### PR TITLE
Add Spending Limit to Billing page

### DIFF
--- a/components/dashboard/src/teams/TeamUsageBasedBilling.tsx
+++ b/components/dashboard/src/teams/TeamUsageBasedBilling.tsx
@@ -28,6 +28,8 @@ export default function TeamUsageBasedBilling() {
     const [pendingStripeSubscription, setPendingStripeSubscription] = useState<PendingStripeSubscription | undefined>();
     const [pollStripeSubscriptionTimeout, setPollStripeSubscriptionTimeout] = useState<NodeJS.Timeout | undefined>();
     const [stripePortalUrl, setStripePortalUrl] = useState<string | undefined>();
+    const [showUpdateLimitModal, setShowUpdateLimitModal] = useState<boolean>(false);
+    const [spendingLimit, setSpendingLimit] = useState<number | undefined>();
 
     useEffect(() => {
         if (!team) {
@@ -54,6 +56,8 @@ export default function TeamUsageBasedBilling() {
         (async () => {
             const portalUrl = await getGitpodService().server.getStripePortalUrlForTeam(team.id);
             setStripePortalUrl(portalUrl);
+            const spendingLimit = await getGitpodService().server.getSpendingLimitForTeam(team.id);
+            setSpendingLimit(spendingLimit);
         })();
     }, [team, stripeSubscriptionId]);
 
@@ -135,30 +139,50 @@ export default function TeamUsageBasedBilling() {
         return <></>;
     }
 
+    const showSpinner = isLoading || pendingStripeSubscription;
+    const showUpgradeBilling = !showSpinner && !stripeSubscriptionId;
+    const showManageBilling = !showSpinner && !!stripeSubscriptionId;
+
+    const doUpdateLimit = async (newLimit: number) => {
+        if (!team) {
+            return;
+        }
+        const oldLimit = spendingLimit;
+        setSpendingLimit(newLimit);
+        try {
+            await getGitpodService().server.setSpendingLimitForTeam(team.id, newLimit);
+        } catch (error) {
+            setSpendingLimit(oldLimit);
+            console.error(error);
+            alert(error?.message || "Failed to update spending limit. See console for error message.");
+        }
+        setShowUpdateLimitModal(false);
+    };
+
     return (
         <div className="mb-16">
             <h3>Usage-Based Billing</h3>
             <h2 className="text-gray-500">Manage usage-based billing, spending limit, and payment method.</h2>
-            <div className="max-w-xl">
-                <div className="mt-4 h-32 p-4 flex flex-col rounded-xl bg-gray-100 dark:bg-gray-800">
-                    <div className="uppercase text-sm text-gray-400 dark:text-gray-500">Billing</div>
-                    {(isLoading || pendingStripeSubscription) && (
-                        <>
-                            <Spinner className="m-2 h-5 w-5 animate-spin" />
-                        </>
-                    )}
-                    {!isLoading && !pendingStripeSubscription && !stripeSubscriptionId && (
-                        <>
-                            <div className="text-xl font-semibold flex-grow text-gray-600 dark:text-gray-400">
-                                Inactive
-                            </div>
-                            <button className="self-end" onClick={() => setShowBillingSetupModal(true)}>
-                                Upgrade Billing
-                            </button>
-                        </>
-                    )}
-                    {!isLoading && !pendingStripeSubscription && !!stripeSubscriptionId && (
-                        <>
+            <div className="max-w-xl flex flex-col">
+                {showSpinner && (
+                    <div className="flex flex-col mt-4 h-32 p-4 rounded-xl bg-gray-100 dark:bg-gray-800">
+                        <div className="uppercase text-sm text-gray-400 dark:text-gray-500">Billing</div>
+                        <Spinner className="m-2 h-5 w-5 animate-spin" />
+                    </div>
+                )}
+                {showUpgradeBilling && (
+                    <div className="flex flex-col mt-4 h-32 p-4 rounded-xl bg-gray-100 dark:bg-gray-800">
+                        <div className="uppercase text-sm text-gray-400 dark:text-gray-500">Billing</div>
+                        <div className="text-xl font-semibold flex-grow text-gray-600 dark:text-gray-400">Inactive</div>
+                        <button className="self-end" onClick={() => setShowBillingSetupModal(true)}>
+                            Upgrade Billing
+                        </button>
+                    </div>
+                )}
+                {showManageBilling && (
+                    <div className="max-w-xl flex space-x-4">
+                        <div className="flex flex-col w-72 mt-4 h-32 p-4 rounded-xl bg-gray-100 dark:bg-gray-800">
+                            <div className="uppercase text-sm text-gray-400 dark:text-gray-500">Billing</div>
                             <div className="text-xl font-semibold flex-grow text-gray-600 dark:text-gray-400">
                                 Active
                             </div>
@@ -167,11 +191,27 @@ export default function TeamUsageBasedBilling() {
                                     Manage Billing →
                                 </button>
                             </a>
-                        </>
-                    )}
-                </div>
+                        </div>
+                        <div className="flex flex-col w-72 mt-4 h-32 p-4 rounded-xl bg-gray-100 dark:bg-gray-800">
+                            <div className="uppercase text-sm text-gray-400 dark:text-gray-500">Spending Limit</div>
+                            <div className="text-xl font-semibold flex-grow text-gray-600 dark:text-gray-400">
+                                {spendingLimit || "–"}
+                            </div>
+                            <button className="self-end" onClick={() => setShowUpdateLimitModal(true)}>
+                                Update Limit
+                            </button>
+                        </div>
+                    </div>
+                )}
             </div>
             {showBillingSetupModal && <BillingSetupModal onClose={() => setShowBillingSetupModal(false)} />}
+            {showUpdateLimitModal && (
+                <UpdateLimitModal
+                    currentValue={spendingLimit}
+                    onClose={() => setShowUpdateLimitModal(false)}
+                    onUpdate={(newLimit) => doUpdateLimit(newLimit)}
+                />
+            )}
         </div>
     );
 }
@@ -180,6 +220,49 @@ function getStripeAppearance(isDark?: boolean): Appearance {
     return {
         theme: isDark ? "night" : "stripe",
     };
+}
+
+function UpdateLimitModal(props: {
+    currentValue: number | undefined;
+    onClose: () => void;
+    onUpdate: (newLimit: number) => {};
+}) {
+    const [newLimit, setNewLimit] = useState<number | undefined>(props.currentValue);
+
+    return (
+        <Modal visible={true} onClose={props.onClose}>
+            <h3 className="flex">Update Limit</h3>
+            <div className="border-t border-b border-gray-200 dark:border-gray-800 -mx-6 px-6 py-4 flex flex-col">
+                <p className="pb-4 text-gray-500 text-base">Set up a spending limit on a monthly basis.</p>
+
+                <label htmlFor="newLimit" className="font-medium">
+                    Limit
+                </label>
+                <div className="w-full">
+                    <input
+                        name="newLimit"
+                        type="number"
+                        min={0}
+                        value={newLimit}
+                        className="rounded-md w-full truncate overflow-x-scroll pr-8"
+                        onChange={(e) => setNewLimit(parseInt(e.target.value || "1", 10))}
+                    />
+                </div>
+            </div>
+            <div className="flex justify-end mt-6 space-x-2">
+                <button
+                    className="secondary"
+                    onClick={() => {
+                        if (typeof newLimit === "number") {
+                            props.onUpdate(newLimit);
+                        }
+                    }}
+                >
+                    Update
+                </button>
+            </div>
+        </Modal>
+    );
 }
 
 function BillingSetupModal(props: { onClose: () => void }) {
@@ -243,7 +326,7 @@ function CreditCardInputForm() {
             }
         } catch (error) {
             console.error(error);
-            alert(error);
+            alert(error?.message || "Failed to submit form. See console for error message.");
         } finally {
             setIsLoading(false);
         }

--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -290,6 +290,8 @@ export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, 
     findStripeSubscriptionIdForTeam(teamId: string): Promise<string | undefined>;
     subscribeTeamToStripe(teamId: string, setupIntentId: string, currency: Currency): Promise<void>;
     getStripePortalUrlForTeam(teamId: string): Promise<string>;
+    getSpendingLimitForTeam(teamId: string): Promise<number | undefined>;
+    setSpendingLimitForTeam(teamId: string, spendingLimit: number): Promise<void>;
 
     listBilledUsage(attributionId: string): Promise<BillableSession[]>;
     setUsageAttribution(usageAttribution: string): Promise<void>;

--- a/components/server/src/auth/rate-limiter.ts
+++ b/components/server/src/auth/rate-limiter.ts
@@ -217,6 +217,8 @@ function getConfig(config: RateLimiterConfig): RateLimiterConfig {
         getIDEOptions: { group: "default", points: 1 },
         getPrebuildEvents: { group: "default", points: 1 },
         setUsageAttribution: { group: "default", points: 1 },
+        getSpendingLimitForTeam: { group: "default", points: 1 },
+        setSpendingLimitForTeam: { group: "default", points: 1 },
     };
 
     return {

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -3194,6 +3194,12 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
     async listBilledUsage(ctx: TraceContext, attributionId: string): Promise<BillableSession[]> {
         throw new ResponseError(ErrorCodes.SAAS_FEATURE, `Not implemented in this version`);
     }
+    async getSpendingLimitForTeam(ctx: TraceContext, teamId: string): Promise<number | undefined> {
+        throw new ResponseError(ErrorCodes.SAAS_FEATURE, `Not implemented in this version`);
+    }
+    async setSpendingLimitForTeam(ctx: TraceContext, teamId: string, spendingLimit: number): Promise<void> {
+        throw new ResponseError(ErrorCodes.SAAS_FEATURE, `Not implemented in this version`);
+    }
 
     async setUsageAttribution(ctx: TraceContext, usageAttributionId: string): Promise<void> {
         const user = this.checkAndBlockUser("setUsageAttribution");


### PR DESCRIPTION
## Description
🛹  PR to configure spending limit on a team's Billing page.

This PR does not include setting unlimited spending on a team.

<img width="685" alt="Screen Shot 2022-07-21 at 12 33 39" src="https://user-images.githubusercontent.com/914497/180193793-35746b64-b021-4d06-b729-cef19a0e96c9.png">
<img width="657" alt="Screen Shot 2022-07-21 at 12 33 48" src="https://user-images.githubusercontent.com/914497/180193807-40188815-a807-4406-aed1-ca2e14f15716.png">


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Partial fix for  #11401

## How to test
Configure spending limit on the preview environment.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Configure team's spending limit on its Billing page.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
- [x] /werft with-payment