### PR TITLE
[ws-manager] Only build snapshots of initialized/ready workspaces

### DIFF
--- a/components/ws-manager/pkg/manager/monitor.go
+++ b/components/ws-manager/pkg/manager/monitor.go
@@ -1040,6 +1040,16 @@ func (m *Monitor) finalizeWorkspaceContent(ctx context.Context, wso *workspaceOb
 			return true, nil, err
 		}
 
+		// only build prebuild snapshots of initialized/ready workspaces.
+		if tpe == api.WorkspaceType_PREBUILD {
+			_, err = snc.WaitForInit(ctx, &wsdaemon.WaitForInitRequest{Id: workspaceID})
+			if st, ok := grpc_status.FromError(err); ok && st.Code() == codes.FailedPrecondition &&
+				(st.Message() == "workspace is not initializing or ready" || st.Message() == "workspace is not ready") {
+				log.Warn("skipping snapshot creation because content-initializer never finished or the workspace reached a ready state")
+				doSnapshot = false
+			}
+		}
+
 		ctx, cancelReq := context.WithTimeout(ctx, time.Duration(m.manager.Config.Timeouts.ContentFinalization))
 		m.finalizerMap[workspaceID] = cancelReq
 		m.finalizerMapLock.Unlock()


### PR DESCRIPTION
## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Address some of the issues found in logs https://cloudlogging.app.goo.gl/JFjbmUaMZiHCeBmW6

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
