### PR TITLE
[usage] Upload usage reports to cloud storage

### DIFF
--- a/components/usage/pkg/contentservice/client.go
+++ b/components/usage/pkg/contentservice/client.go
@@ -7,14 +7,17 @@ package contentservice
 import (
 	"context"
 	"fmt"
+	"io"
+	"net/http"
 
+	"github.com/gitpod-io/gitpod/common-go/log"
 	"github.com/gitpod-io/gitpod/content-service/api"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 )
 
 type Interface interface {
-	GetSignedUploadUrl(ctx context.Context) (string, error)
+	UploadFile(ctx context.Context, filename string, body io.Reader) error
 }
 
 type Client struct {
@@ -25,7 +28,33 @@ func New(url string) *Client {
 	return &Client{url: url}
 }
 
-func (c *Client) GetSignedUploadUrl(ctx context.Context) (string, error) {
+func (c *Client) UploadFile(ctx context.Context, filename string, body io.Reader) error {
+	url, err := c.getSignedUploadUrl(ctx, filename)
+	if err != nil {
+		return fmt.Errorf("failed to obtain signed upload URL: %w", err)
+	}
+
+	req, err := http.NewRequest(http.MethodPut, url, body)
+	if err != nil {
+		return fmt.Errorf("failed to construct http request: %w", err)
+	}
+
+	req.Header.Set("Content-Encoding", "gzip")
+
+	log.Infof("Uploading %q to object storage...", filename)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to make http request: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected http response code: %s", resp.Status)
+	}
+	log.Info("Upload complete")
+
+	return nil
+}
+
+func (c *Client) getSignedUploadUrl(ctx context.Context, key string) (string, error) {
 	conn, err := grpc.Dial(c.url, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return "", fmt.Errorf("failed to dial content-service gRPC server: %w", err)
@@ -34,9 +63,9 @@ func (c *Client) GetSignedUploadUrl(ctx context.Context) (string, error) {
 
 	uc := api.NewUsageReportServiceClient(conn)
 
-	resp, err := uc.UploadURL(ctx, &api.UsageReportUploadURLRequest{Name: "some-name"})
+	resp, err := uc.UploadURL(ctx, &api.UsageReportUploadURLRequest{Name: key})
 	if err != nil {
-		return "", fmt.Errorf("failed to obtain signed upload URL: %w", err)
+		return "", fmt.Errorf("failed RPC to content service: %w", err)
 	}
 
 	return resp.Url, nil

--- a/components/usage/pkg/contentservice/noop.go
+++ b/components/usage/pkg/contentservice/noop.go
@@ -4,8 +4,13 @@
 
 package contentservice
 
-import "context"
+import (
+	"context"
+	"io"
+)
 
 type NoOpClient struct{}
 
-func (c *NoOpClient) GetSignedUploadUrl(ctx context.Context) (string, error) { return "", nil }
+func (c *NoOpClient) UploadFile(ctx context.Context, filename string, body io.Reader) error {
+	return nil
+}

--- a/components/usage/pkg/contentservice/noop.go
+++ b/components/usage/pkg/contentservice/noop.go
@@ -6,11 +6,12 @@ package contentservice
 
 import (
 	"context"
-	"io"
+
+	"github.com/gitpod-io/gitpod/usage/pkg/db"
 )
 
 type NoOpClient struct{}
 
-func (c *NoOpClient) UploadFile(ctx context.Context, filename string, body io.Reader) error {
+func (c *NoOpClient) UploadUsageReport(ctx context.Context, filename string, report map[db.AttributionID][]db.WorkspaceInstanceForUsage) error {
 	return nil
 }


### PR DESCRIPTION
## Description

As part of the move towards usage based pricing (https://github.com/gitpod-io/gitpod/issues/9036), we'd like for the usage aggregator (`components/usage`) to be able to upload its usage reports to cloud storage. This will provide an audit trail of usage reports, allowing us to cross reference usage entries in the database with the usage reports that provided the data. In future, we may also allow access to these reports to users directly.

This is the third part of the PR stack:

https://github.com/gitpod-io/gitpod/pull/11474: Add a means of getting signed S3 upload URLs from content-service.
https://github.com/gitpod-io/gitpod/pull/11493: Request the signed upload URLs from the usage component.
This PR: Use the upload URL to upload compressed usage reports to object storage and stop writing the reports to the container filesystem.

## Related Issue(s)
Part of #9036 

## How to test

* Port forward to minio in the preview environment:
```
kubectl port-forward svc/minio 9000:9000
```
* Get the access key and secret key for the preview minio instance:
```
kubectl exec deploy/content-service -- cat /config/config.json
```
* [Download the minio client](https://min.io/download#/kubernetes) `mc`, then add server credentials for the preview minio:
```
mc alias set mm http://localhost:9000
```
* Change the usage component to run reconciliation every 30 seconds or so:
```
kubectl edit cm usage
 # edit the `controllerSchedule` field
```
* Tail the logs of the usage component:
```
kubectl logs -f deploy/usage
```
* See that when the usage component runs reconciliation, the resulting usage report will be uploaded to minio in-cluster storage:
```
mc ls mm/usage-reports
```
* Download and unzip the usage report to see that it has the expected contents:
```
mc cp mm/usage-reports/<some report file> .
gunzip <filename>.gz
cat <filename>
```


## Release Notes
```release-note
NONE
```

## Werft options:

- [x] /werft with-preview
