### PR TITLE
Move usageAttributionId

### DIFF
--- a/components/dashboard/src/settings/Billing.tsx
+++ b/components/dashboard/src/settings/Billing.tsx
@@ -42,9 +42,8 @@ export default function Billing() {
         if (!user) {
             return;
         }
-        const additionalData = user.additionalData || {};
-        additionalData.usageAttributionId = team ? `team:${team.id}` : `user:${user.id}`;
-        await getGitpodService().server.updateLoggedInUser({ additionalData });
+        const usageAttributionId = team ? `team:${team.id}` : `user:${user.id}`;
+        await getGitpodService().server.setUsageAttribution(usageAttributionId);
     };
 
     return (
@@ -73,9 +72,7 @@ export default function Billing() {
                         <span>Bill all my usage to:</span>
                         <DropDown
                             activeEntry={
-                                teamsWithBillingEnabled.find(
-                                    (t) => `team:${t.id}` === user?.additionalData?.usageAttributionId,
-                                )?.name
+                                teamsWithBillingEnabled.find((t) => `team:${t.id}` === user?.usageAttributionId)?.name
                             }
                             customClasses="w-32"
                             renderAsLink={true}

--- a/components/gitpod-db/src/typeorm/migration/1658394096656-UsageAttributionId.ts
+++ b/components/gitpod-db/src/typeorm/migration/1658394096656-UsageAttributionId.ts
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { columnExists } from "./helper/helper";
+
+const TABLE_NAME = "d_b_user";
+const COLUMN_NAME = "usageAttributionId";
+
+export class UsageAttributionId1658394096656 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        if (!(await columnExists(queryRunner, TABLE_NAME, COLUMN_NAME))) {
+            await queryRunner.query(
+                `ALTER TABLE ${TABLE_NAME} ADD COLUMN ${COLUMN_NAME} varchar(60) NOT NULL DEFAULT '', ALGORITHM=INPLACE, LOCK=NONE `,
+            );
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {}
+}

--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -292,6 +292,7 @@ export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, 
     getStripePortalUrlForTeam(teamId: string): Promise<string>;
 
     listBilledUsage(attributionId: string): Promise<BillableSession[]>;
+    setUsageAttribution(usageAttribution: string): Promise<void>;
 
     /**
      * Analytics

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -45,6 +45,9 @@ export interface User {
     markedDeleted?: boolean;
 
     additionalData?: AdditionalUserData;
+
+    // Identifies an explicit team or user ID to which all the user's workspace usage should be attributed to (e.g. for billing purposes)
+    usageAttributionId?: string;
 }
 
 export namespace User {
@@ -199,8 +202,6 @@ export interface AdditionalUserData {
     knownGitHubOrgs?: string[];
     // Git clone URL pointing to the user's dotfile repo
     dotfileRepo?: string;
-    // Identifies an explicit team or user ID to which all the user's workspace usage should be attributed to (e.g. for billing purposes)
-    usageAttributionId?: string;
     // preferred workspace classes
     workspaceClasses?: WorkspaceClasses;
     // additional user profile data

--- a/components/server/src/auth/rate-limiter.ts
+++ b/components/server/src/auth/rate-limiter.ts
@@ -216,6 +216,7 @@ function getConfig(config: RateLimiterConfig): RateLimiterConfig {
         identifyUser: { group: "default", points: 1 },
         getIDEOptions: { group: "default", points: 1 },
         getPrebuildEvents: { group: "default", points: 1 },
+        setUsageAttribution: { group: "default", points: 1 },
     };
 
     return {

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -3195,6 +3195,16 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         throw new ResponseError(ErrorCodes.SAAS_FEATURE, `Not implemented in this version`);
     }
 
+    async setUsageAttribution(ctx: TraceContext, usageAttributionId: string): Promise<void> {
+        const user = this.checkAndBlockUser("setUsageAttribution");
+        try {
+            await this.userService.setUsageAttribution(user, usageAttributionId);
+        } catch (error) {
+            log.error("cannot set usage attribution", error, { userId: user.id, usageAttributionId });
+            throw new ResponseError(ErrorCodes.PERMISSION_DENIED, `cannot set usage attribution`);
+        }
+    }
+
     //
     //#endregion
 


### PR DESCRIPTION
## Description
This PR implements validations for `setUsageAttribution` in `UserServer`.
Also `usageAttributionId` is moved to be a field of `User` entity.

A follow-up to https://github.com/gitpod-io/gitpod/pull/10893


## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
- [x] /werft with-payment
