### PR TITLE
Adjust the Workspace Start URL the in JetBrains Gateway workspaces list

### DIFF
--- a/components/ide/jetbrains/gateway-plugin/README.md
+++ b/components/ide/jetbrains/gateway-plugin/README.md
@@ -14,5 +14,19 @@ This project is not yet Gitpodified as testing it requires running the local Gat
 
 **Note**: Gradle should run with Java 11.
 
----
-Plugin based on the [IntelliJ Platform Plugin Template][template].
+This plugin is based on the [IntelliJ Platform Plugin Template](https://github.com/JetBrains/intellij-platform-plugin-template).
+
+## How to test from a Pull Request
+
+- Ensure you have the latest JetBrains Gateway installed: https://www.jetbrains.com/remote-development/gateway/
+- Download this Gateway Plugin build, from Gitpod's Plugin Dev Channel: https://plugins.jetbrains.com/plugin/18438-gitpod-gateway/versions/dev
+- Install it on the Gateway following these instructions: https://www.jetbrains.com/help/idea/managing-plugins.html#install_plugin_from_disk
+- Do the checks requested by the pull request creator or do a full manual test as instructed below.
+
+## Checklist for a Full Manual Test
+
+- Check if you can create a new workspace
+- Check if you can connect to a running workspace
+- Check if you can connect to a stopped workspace
+- Check if changing the "Gitpod Host" in Preferences >> Tools >> Gitpod takes effect
+- Check if the info displayed in the workspaces list is matching what you see on the Web App Dashboard

--- a/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodWorkspacesView.kt
+++ b/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodWorkspacesView.kt
@@ -37,6 +37,7 @@ import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.future.await
 import kotlinx.coroutines.launch
+import org.apache.http.client.utils.URIBuilder
 import java.time.OffsetDateTime
 import java.time.ZonedDateTime
 import java.time.temporal.ChronoUnit
@@ -276,7 +277,7 @@ class GitpodWorkspacesView(
                                         browserLink(info.workspace.id, info.latestInstance.ideUrl)
                                     }
                                     info.workspace.context.normalizedContextURL.ifPresent {
-                                        contextUrlRow.rowComment("<a href='${it}'>${it}</a>")
+                                        contextUrlRow.rowComment("<a href='$it'>$it</a>")
                                     }
                                 }
                                 label("").resizableColumn().horizontalAlign(HorizontalAlign.FILL)
@@ -286,7 +287,7 @@ class GitpodWorkspacesView(
                                         it.totalUncommitedFiles + it.totalUntrackedFiles + it.totalUnpushedCommits
                                     } ?: 0
                                     row {
-                                        info.workspace.context.ref.ifPresentOrElse({ label(it) },{ label("(detached)") })
+                                        info.workspace.context.ref.ifPresentOrElse({ label(it) }, { label("(detached)") })
                                     }.rowComment(
                                         when {
                                             changes == 1 -> "<b>$changes Change</b>"
@@ -298,7 +299,14 @@ class GitpodWorkspacesView(
                                 label(getRelativeTimeSpan(info.latestInstance.creationTime))
                                 button("Connect") {
                                     if (!canConnect) {
-                                        BrowserUtil.browse(info.latestInstance.ideUrl)
+                                        val startUrl = URIBuilder()
+                                                .setScheme("https")
+                                                .setHost(gitpodHost)
+                                                .setPath("start")
+                                                .setFragment(info.workspace.id)
+                                                .build()
+                                                .toString()
+                                        BrowserUtil.browse(startUrl)
                                     } else {
                                         GatewayUI.getInstance().connect(
                                             mapOf(


### PR DESCRIPTION
## Description

Adjust the Workspace Start URL the in JetBrains Gateway workspaces list.
This is now aligned with the URL used in WebApp workspaces list.

It's aligned with the URL used in the workspaces list from Gitpod Dashboard:
https://github.com/gitpod-io/gitpod/blob/05ae248a7c4e2527dac6f23fab9ba89d9f3ac6b8/components/dashboard/src/workspaces/WorkspaceEntry.tsx#L56-L59
https://github.com/gitpod-io/gitpod/blob/05ae248a7c4e2527dac6f23fab9ba89d9f3ac6b8/components/dashboard/src/workspaces/WorkspaceEntry.tsx#L66-L69

## Related Issue(s)

Fixes #11284

## How to test

- Follow the instructions from [how to test it from a Pull Request](https://github.com/gitpod-io/gitpod/blob/bebfb53a007d14269d8d9383073f7bf15d4dc49c/components/ide/jetbrains/gateway-plugin/README.md#how-to-test-from-a-pull-request).
- Check if when clicking the "Connect" button from a workspace that is not running opens `https://gitpod.io/start/#<WORKSPACE_ID>` in the browser.

## Release Notes

```release-note
Fixed the Connect Button on JetBrains Gateway workspaces list to avoid opening an invalid URL in case the workspace was not running.
```

## Documentation

None.

## Werft options:

- [ ] /werft with-preview
