### PR TITLE
Fix team reviews in Jetbrains auto updates

### DIFF
--- a/.github/workflows/jetbrains-updates-template.yml
+++ b/.github/workflows/jetbrains-updates-template.yml
@@ -90,7 +90,7 @@ jobs:
           commit-message: "[${{ inputs.productId }}] Update IDE image to build version ${{ steps.latest-release.outputs.version }}"
           branch: "jetbrains/${{ inputs.productId }}-${{ steps.latest-release.outputs.version2 }}"
           labels: "team: IDE"
-          team-reviewers: "gitpod-io/engineering-ide"
+          team-reviewers: "engineering-ide"
       - name: Slack Notification
         if: always()
         uses: rtCamp/action-slack-notify@v2


### PR DESCRIPTION
## Description
Fixes the incorrect behavior described in https://github.com/gitpod-io/gitpod/pull/11496#issuecomment-1191220663.

## How to test
Sadly, this can't be tested easily, **but** the way I tested is I tried using the GitHub API and when I didn't provide `gitpod-io/` it worked for requesting reviews.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
