### PR TITLE
[terraform] update the disk size in eks module

### DIFF
--- a/install/infra/terraform/eks/kubernetes.tf
+++ b/install/infra/terraform/eks/kubernetes.tf
@@ -54,7 +54,6 @@ module "eks" {
   }
 
   eks_managed_node_group_defaults = {
-    disk_size                  = 150
     ami_type                   = "CUSTOM"
     iam_role_attach_cni_policy = true
     ami_id                     = var.image_id
@@ -71,6 +70,13 @@ module "eks" {
       min_size     = 1
       max_size     = 10
       desired_size = 1
+      block_device_mappings =  [{
+        device_name = "/dev/sda1"
+
+        ebs =  [{
+          volume_size = 150
+        }]
+      }]
       labels = {
         "gitpod.io/workload_meta" = true
         "gitpod.io/workload_ide"  = true
@@ -93,6 +99,13 @@ module "eks" {
       subnet_ids   = module.vpc.public_subnets
       min_size     = 1
       max_size     = 10
+      block_device_mappings =  [{
+        device_name = "/dev/sda1"
+
+        ebs =  [{
+          volume_size = 150
+        }]
+      }]
       desired_size = 1
       enable_bootstrap_user_data = true
       labels = {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Currently, when using the EKS module, the `disk_size` field set doesn't change the value. This is because templates are getting created for both the node pools. To change the disk size in the template as well, we define `block_device_mappings` for both the managed node pools

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Partly fixes #11533 (not to be closed)

## How to test
<!-- Provide steps to test this PR -->
Documentation task is still TODO for terraform modules.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [X] /werft with-preview
