### PR TITLE
[ws-daemon] Refactor Dispatch AddEventHandler

### DIFF
--- a/components/ws-manager/pkg/manager/manager.go
+++ b/components/ws-manager/pkg/manager/manager.go
@@ -215,9 +215,12 @@ func (m *Manager) StartWorkspace(ctx context.Context, req *api.StartWorkspaceReq
 	}
 	span.LogKV("event", "validated workspace start request")
 	// create the objects required to start the workspace pod/service
-	startContext, err := m.newStartWorkspaceContext(ctx, req)
+	var startContext *startWorkspaceContext
+	startContext, err = m.newStartWorkspaceContext(ctx, req)
+	clog.WithError(err).Debug("starting new workspace")
 	if err != nil {
-		return nil, xerrors.Errorf("cannot create context: %w", err)
+		err = xerrors.Errorf("cannot create context: %w", err)
+		return
 	}
 	span.LogKV("event", "created start workspace context")
 	clog.Debug("starting new workspace")

--- a/components/ws-manager/pkg/manager/manager.go
+++ b/components/ws-manager/pkg/manager/manager.go
@@ -164,10 +164,10 @@ func (m *Manager) Close() {
 }
 
 // StartWorkspace creates a new running workspace within the manager's cluster
-func (m *Manager) StartWorkspace(ctx context.Context, req *api.StartWorkspaceRequest) (res *api.StartWorkspaceResponse, err error) {
+func (m *Manager) StartWorkspace(_ context.Context, req *api.StartWorkspaceRequest) (res *api.StartWorkspaceResponse, err error) {
 	owi := log.LogContext(req.Metadata.Owner, req.Metadata.MetaId, req.Id, req.Metadata.GetProject(), req.Metadata.GetTeam())
 	clog := log.WithFields(owi)
-	span, ctx := tracing.FromContext(ctx, "StartWorkspace")
+	span, ctx := tracing.FromContext(context.Background(), "StartWorkspace")
 	tracing.LogRequestSafe(span, req)
 	tracing.ApplyOWI(span, owi)
 	defer tracing.FinishSpan(span, &err)
@@ -356,6 +356,7 @@ func (m *Manager) StartWorkspace(ctx context.Context, req *api.StartWorkspaceReq
 		}
 	}
 
+	clog.Info("DEBUG About to remove attemptingToCreatePodAnnotation")
 	// remove annotation to signal that workspace pod was indeed created and scheduled on the node
 	err = m.markWorkspace(ctx, req.Id, deleteMark(attemptingToCreatePodAnnotation))
 	if err != nil {

--- a/components/ws-manager/pkg/manager/monitor.go
+++ b/components/ws-manager/pkg/manager/monitor.go
@@ -798,6 +798,7 @@ func (m *Monitor) initializeWorkspaceContent(ctx context.Context, pod *corev1.Po
 
 		_, alreadyInitializing := m.initializerMap[pod.Name]
 		if alreadyInitializing {
+			log.Info("DEBUG -> alreadyInitializing")
 			return nil
 		}
 
@@ -861,6 +862,7 @@ func (m *Monitor) initializeWorkspaceContent(ctx context.Context, pod *corev1.Po
 	}
 	if err == nil && snc == nil {
 		// we are already initialising
+		log.Info("DEBUG -> err == nil && snc == nil")
 		return nil
 	}
 	t := time.Now()
@@ -878,6 +880,7 @@ func (m *Monitor) initializeWorkspaceContent(ctx context.Context, pod *corev1.Po
 			RemoteStorageDisabled: shouldDisableRemoteStorage(pod),
 			StorageQuotaBytes:     storage.Value(),
 		})
+		log.WithError(err).Info("DEBUG -> InitWorkspace")
 		return err
 	})
 	if st, ok := grpc_status.FromError(err); ok && st.Code() == codes.AlreadyExists {
@@ -886,6 +889,7 @@ func (m *Monitor) initializeWorkspaceContent(ctx context.Context, pod *corev1.Po
 	} else {
 		err = handleGRPCError(ctx, err)
 	}
+	log.WithError(err).Info("DEBUG -> retryIfUnavailable")
 	wsType := strings.ToUpper(pod.Labels[wsk8s.TypeLabel])
 	wsClass := pod.Labels[workspaceClassLabel]
 	hist, errHist := m.manager.metrics.initializeTimeHistVec.GetMetricWithLabelValues(wsType, wsClass)

--- a/components/ws-manager/pkg/manager/monitor.go
+++ b/components/ws-manager/pkg/manager/monitor.go
@@ -207,6 +207,7 @@ func (m *Monitor) onVolumesnapshotEvent(evt watch.Event) error {
 
 // onPodEvent interpretes Kubernetes events, translates and broadcasts them, and acts based on them
 func (m *Monitor) onPodEvent(evt watch.Event) error {
+	log.Infof("onPodEvent(evt watch.Event)")
 	// Beware: we patch running pods to add annotations. At the moment this is not a problem as do not attach
 	//         state to pods from which we did not want events to be created. However, we might have to filter out
 	//         some MODIFIED events here if that ever changes. Otherwise the monitor clients will receive multiple
@@ -282,6 +283,7 @@ func (m *Monitor) onPodEvent(evt watch.Event) error {
 // actOnPodEvent performs actions when a kubernetes event comes in. For example we shut down failed workspaces or start
 // polling the ready state of initializing ones.
 func actOnPodEvent(ctx context.Context, m actingManager, manager *Manager, status *api.WorkspaceStatus, wso *workspaceObjects) (err error) {
+	log.Infof(" actOnPodEvent(ctx context.Context")
 	pod := wso.Pod
 
 	span, ctx := tracing.FromContext(ctx, "actOnPodEvent")

--- a/components/ws-manager/pkg/manager/pod_controller.go
+++ b/components/ws-manager/pkg/manager/pod_controller.go
@@ -42,6 +42,8 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		return ctrl.Result{}, nil
 	}
 
+	r.Log.Info("DEBUG Event", "pod", pod)
+
 	r.Monitor.eventpool.Add(queue, watch.Event{
 		Type:   watch.Modified,
 		Object: &pod,

--- a/components/ws-manager/pkg/manager/pod_controller.go
+++ b/components/ws-manager/pkg/manager/pod_controller.go
@@ -42,8 +42,6 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		return ctrl.Result{}, nil
 	}
 
-	r.Log.Info("DEBUG Event", "pod", pod)
-
 	r.Monitor.eventpool.Add(queue, watch.Event{
 		Type:   watch.Modified,
 		Object: &pod,

--- a/components/ws-manager/pkg/manager/status.go
+++ b/components/ws-manager/pkg/manager/status.go
@@ -408,6 +408,8 @@ func (m *Manager) extractStatusFromPod(result *api.WorkspaceStatus, wso workspac
 	}
 
 	status := pod.Status
+	log.WithField("status", status).WithField("pod", pod.Name).Info("DEBUG workspace pod status")
+
 	if status.Phase == corev1.PodPending {
 		// check if any container is still pulling images
 		for _, cs := range status.ContainerStatuses {
@@ -427,12 +429,15 @@ func (m *Manager) extractStatusFromPod(result *api.WorkspaceStatus, wso workspac
 				result.Phase = api.WorkspacePhase_CREATING
 				result.Conditions.PullingImages = api.WorkspaceConditionBool_TRUE
 				result.Message = "containers are being created"
+				log.WithField("result", result).WithField("pod", pod.Name).Info("DEBUG WorkspacePhase_CREATING")
+
 				return nil
 			}
 		}
 
 		result.Phase = api.WorkspacePhase_PENDING
 		result.Message = "pod is pending"
+		log.WithField("result", result).WithField("pod", pod.Name).Info("DEBUG WorkspacePhase_PENDING")
 		return nil
 	} else if status.Phase == corev1.PodRunning {
 		if firstUserActivity, ok := wso.Pod.Annotations[firstUserActivityAnnotation]; ok {


### PR DESCRIPTION
## Description

Pending pods due to a scale-up event are not updated creating an scenario where ws-daemon never will try to run the hooks, and more importantly, create the unix socket required by workspacekit ring0.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/11513

## Release Notes
```release-note
NONE
```

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
