### PR TITLE
[server] GH: Send 401 with message on failed webhook

### DIFF
--- a/components/server/ee/src/prebuilds/github-enterprise-app.ts
+++ b/components/server/ee/src/prebuilds/github-enterprise-app.ts
@@ -57,7 +57,7 @@ export class GitHubEnterpriseApp {
                 }
                 if (!user) {
                     res.statusCode = 401;
-                    res.send();
+                    res.send("Unauthorized: Cannot find user.");
                     span.finish();
                     await this.webhookEvents.updateEvent(event.id, { status: "dismissed_unauthorized" });
                     return;


### PR DESCRIPTION
## Description
[server] GH: Send 401 with message on failed webhook

## Related Issue(s)

Requested in a customer call

## How to test

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NNE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
