### PR TITLE
[installer] Disable integration tests during upgrade tests

### DIFF
--- a/.werft/jobs/build/self-hosted-upgrade-tests.ts
+++ b/.werft/jobs/build/self-hosted-upgrade-tests.ts
@@ -39,7 +39,7 @@ export async function triggerUpgradeTests(werft: Werft, config: JobConfig, usern
     const channel: string = config.replicatedChannel || "beta";
 
     exec(`git config --global user.name "${username}"`);
-    var annotation = `-a version=${config.fromVersion} -a upgrade=true -a channel=${channel} -a preview=true`;
+    var annotation = `-a version=${config.fromVersion} -a upgrade=true -a channel=${channel} -a preview=true -a skipTests=true`;
 
     for (let phase in phases) {
         const upgradeConfig = phases[phase];


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PR temporarily disables integration tests during upgrade test pipeline. Since the main point of running these tests is to get a self-hosted preview of the upgraded version of Gitpod during release test, having the installation messed up due to integration tests cause problems. This PR disables the tests from this phase, assuming the crons run tests every night anyway we don't necessarily need this.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [X] /werft with-preview
