### PR TITLE
Delete PVC once the VolumeSnapshot is ready to use

### DIFF
--- a/components/ws-manager/pkg/manager/annotations.go
+++ b/components/ws-manager/pkg/manager/annotations.go
@@ -108,6 +108,9 @@ func (m *Manager) markWorkspace(ctx context.Context, workspaceID string, annotat
 	err := retry.RetryOnConflict(backoff, func() error {
 		pod, err := m.findWorkspacePod(ctx, workspaceID)
 		if err != nil {
+			if isKubernetesObjNotFoundError(err) {
+				return nil
+			}
 			return fmt.Errorf("cannot find workspace %s: %w", workspaceID, err)
 		}
 		if pod == nil {

--- a/components/ws-manager/pkg/manager/annotations.go
+++ b/components/ws-manager/pkg/manager/annotations.go
@@ -111,7 +111,7 @@ func (m *Manager) markWorkspace(ctx context.Context, workspaceID string, annotat
 			if isKubernetesObjNotFoundError(err) {
 				return nil
 			}
-			return fmt.Errorf("cannot find workspace %s: %w", workspaceID, err)
+			return fmt.Errorf("cannot mark workspace %s: %w", workspaceID, err)
 		}
 		if pod == nil {
 			return fmt.Errorf("workspace %s does not exist", workspaceID)

--- a/components/ws-manager/pkg/manager/monitor.go
+++ b/components/ws-manager/pkg/manager/monitor.go
@@ -778,7 +778,7 @@ func (m *Monitor) initializeWorkspaceContent(ctx context.Context, pod *corev1.Po
 
 	class, ok := m.manager.Config.WorkspaceClasses[pod.Labels[workspaceClassLabel]]
 	if !ok {
-		return xerrors.Errorf("pod %s has unknown workspace class", pod.Name, pod.Labels[workspaceClassLabel])
+		return xerrors.Errorf("pod %s has unknown workspace class %s", pod.Name, pod.Labels[workspaceClassLabel])
 	}
 	storage, err := class.Container.Limits.StorageQuantity()
 	if !ok {

--- a/components/ws-manager/pkg/manager/monitor.go
+++ b/components/ws-manager/pkg/manager/monitor.go
@@ -183,7 +183,10 @@ func (m *Monitor) onVolumesnapshotEvent(evt watch.Event) error {
 
 	// get the pod resource
 	var pod corev1.Pod
-	_ = m.manager.Clientset.Get(context.Background(), types.NamespacedName{Namespace: vs.Namespace, Name: podName}, &pod)
+	err := m.manager.Clientset.Get(context.Background(), types.NamespacedName{Namespace: vs.Namespace, Name: podName}, &pod)
+	if err != nil && !k8serr.IsNotFound(err) {
+		log.WithError(err).Warnf("cannot get pod")
+	}
 
 	if vs.Status == nil || vs.Status.ReadyToUse == nil || !*vs.Status.ReadyToUse || vs.Status.BoundVolumeSnapshotContentName == nil {
 		if !pod.CreationTimestamp.IsZero() {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Directly delete the workspace Pod and remove the finalizer before the VolumeSnapshot is ready, the VolumeSnapshot is created, and the workspace Pod is removed as well. However, the PVC does not be removed after that.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Partially #10531

## How to test
<!-- Provide steps to test this PR -->
1. Create a workspace-preview environment
2. Enable feature flag `persistent_volume_claim`.
3. Launch a workspace.
4. Manually delete the workspace pod `kubectl delete pod <pod-name>`.
5. Before the VolumeSnapshot is ready to use, remove the workspace pod finalizer `kubectl patch pod <pod-name> -p '{"metadata":{"finalizers":null}}' --type=merge`.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
None

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
