### PR TITLE
Add spending limit notifications

### DIFF
--- a/components/dashboard/src/App.tsx
+++ b/components/dashboard/src/App.tsx
@@ -49,6 +49,7 @@ import SelectIDEModal from "./settings/SelectIDEModal";
 import { StartPage, StartPhase } from "./start/StartPage";
 import { isGitpodIo } from "./utils";
 import { BlockedRepositories } from "./admin/BlockedRepositories";
+import { AppNotifications } from "./AppNotifications";
 
 const Setup = React.lazy(() => import(/* webpackPrefetch: true */ "./Setup"));
 const Workspaces = React.lazy(() => import(/* webpackPrefetch: true */ "./workspaces/Workspaces"));
@@ -346,6 +347,7 @@ function App() {
         <Route>
             <div className="container">
                 <Menu />
+                <AppNotifications />
                 <Switch>
                     <Route path={projectsPathNew} exact component={NewProject} />
                     <Route path="/open" exact component={Open} />

--- a/components/dashboard/src/AppNotifications.tsx
+++ b/components/dashboard/src/AppNotifications.tsx
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { useEffect, useState } from "react";
+import Alert from "./components/Alert";
+import { getGitpodService } from "./service/service";
+
+const KEY_APP_NOTIFICATIONS = "KEY_APP_NOTIFICATIONS";
+
+export function AppNotifications() {
+    const [notifications, setNotifications] = useState<string[]>([]);
+
+    useEffect(() => {
+        let localState = getLocalStorageObject(KEY_APP_NOTIFICATIONS);
+        if (Array.isArray(localState)) {
+            setNotifications(localState);
+            return;
+        }
+        (async () => {
+            const serverState = await getGitpodService().server.getNotifications();
+            setNotifications(serverState);
+            setLocalStorageObject(KEY_APP_NOTIFICATIONS, serverState);
+        })();
+    }, []);
+
+    const topNotification = notifications[0];
+    if (topNotification === undefined) {
+        return null;
+    }
+
+    const dismissNotification = () => {
+        removeLocalStorageObject(KEY_APP_NOTIFICATIONS);
+        setNotifications([]);
+    };
+
+    return (
+        <div className="app-container pt-2">
+            <Alert
+                type={"warning"}
+                closable={true}
+                onClose={() => dismissNotification()}
+                showIcon={true}
+                className="flex rounded mb-2 w-full"
+            >
+                <span>{topNotification}</span>
+            </Alert>
+        </div>
+    );
+}
+
+function getLocalStorageObject(key: string): any {
+    try {
+        const string = window.localStorage.getItem(key);
+        if (!string) {
+            return;
+        }
+        return JSON.parse(string);
+    } catch (error) {
+        return;
+    }
+}
+
+function removeLocalStorageObject(key: string): void {
+    window.localStorage.removeItem(key);
+}
+
+function setLocalStorageObject(key: string, object: Object): void {
+    try {
+        window.localStorage.setItem(key, JSON.stringify(object));
+    } catch (error) {
+        console.error("Setting localstorage item failed", key, object, error);
+    }
+}

--- a/components/dashboard/src/components/Alert.tsx
+++ b/components/dashboard/src/components/Alert.tsx
@@ -26,6 +26,7 @@ export interface AlertProps {
     // Without background color, default false
     light?: boolean;
     closable?: boolean;
+    onClose?: () => void;
     showIcon?: boolean;
     icon?: React.ReactNode;
     children?: React.ReactNode;
@@ -80,7 +81,15 @@ export default function Alert(props: AlertProps) {
             <span className="flex-1 text-left">{props.children}</span>
             {props.closable && (
                 <span className={`mt-1 ml-4 h-4 w-4`}>
-                    <XSvg onClick={() => setVisible(false)} className="w-3 h-4 cursor-pointer"></XSvg>
+                    <XSvg
+                        onClick={() => {
+                            setVisible(false);
+                            if (props.onClose) {
+                                props.onClose();
+                            }
+                        }}
+                        className="w-3 h-4 cursor-pointer"
+                    ></XSvg>
                 </span>
             )}
         </div>

--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -302,6 +302,11 @@ export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, 
     trackEvent(event: RemoteTrackMessage): Promise<void>;
     trackLocation(event: RemotePageMessage): Promise<void>;
     identifyUser(event: RemoteIdentifyMessage): Promise<void>;
+
+    /**
+     * Frontend notifications
+     */
+    getNotifications(): Promise<string[]>;
 }
 
 export interface RateLimiterError {

--- a/components/server/src/auth/rate-limiter.ts
+++ b/components/server/src/auth/rate-limiter.ts
@@ -219,6 +219,7 @@ function getConfig(config: RateLimiterConfig): RateLimiterConfig {
         setUsageAttribution: { group: "default", points: 1 },
         getSpendingLimitForTeam: { group: "default", points: 1 },
         setSpendingLimitForTeam: { group: "default", points: 1 },
+        getNotifications: { group: "default", points: 1 },
     };
 
     return {

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -3243,4 +3243,9 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
             return this.imagebuilderClientProvider.getClient(user, workspace, instance);
         }
     }
+
+    async getNotifications(ctx: TraceContext): Promise<string[]> {
+        this.checkAndBlockUser("getNotifications");
+        return [];
+    }
 }


### PR DESCRIPTION
## Description
This PR add the basic notification to signal reaching of spending limits as described in https://github.com/gitpod-io/gitpod/issues/11404. The static message is provided by the server API.

**Screenshot** shows a notification when a spending limit of **1** is reached.

The notification is dismissible, but will reappear on reload until the condition is resolved. 

<img width="1457" alt="Screen Shot 2022-07-22 at 14 51 36" src="https://user-images.githubusercontent.com/914497/180444523-e0e703b6-880a-4521-9583-8b3026da9981.png">

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Relates to #11404

## How to test
* setting up proper refresh rate for `usage` component
* setting up a spending limit on a team with billing enabled
* starting a workspace and waiting for the usage to reach 80% or more
* reloading the dashboard

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Notify when spending limit is reached.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
- [x] /werft with-payment
