### PR TITLE
[installer-tests] Support tests against multiple version of k8s and ubuntu images

### DIFF
--- a/.werft/jobs/build/self-hosted-upgrade-tests.ts
+++ b/.werft/jobs/build/self-hosted-upgrade-tests.ts
@@ -46,7 +46,7 @@ export async function triggerUpgradeTests(werft: Werft, config: JobConfig, usern
 
         werft.phase(upgradeConfig.phase, upgradeConfig.description);
 
-        annotation = `${annotation} -a cluster=${phase}`
+        annotation = `${annotation} -a cluster=${phase} -a updateGitHubStatus=gitpod-io/gitpod`
 
         const testFile: string = ".werft/self-hosted-installer-tests.yaml";
 

--- a/install/infra/terraform/aks/variables.tf
+++ b/install/infra/terraform/aks/variables.tf
@@ -1,8 +1,12 @@
 // Common variables
 variable "kubeconfig" {
-    default = "./kubeconfig"
-
+  default = "./kubeconfig"
 }
+
+variable "cluster_version" {
+  description = "kubernetes version of to create the cluster with"
+}
+
 variable "dns_enabled" {}
 variable "domain_name" {}
 variable "enable_airgapped" {}
@@ -14,6 +18,5 @@ variable "workspace_name" {
 
 // Azure-specific variables
 variable "location" {
-    default = "northeurope"
-
+  default = "northeurope"
 }

--- a/install/infra/terraform/eks/kubernetes.tf
+++ b/install/infra/terraform/eks/kubernetes.tf
@@ -2,30 +2,30 @@ module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
   version = "3.12.0"
 
-  name               = "vpc-${var.cluster_name}"
-  cidr               = var.vpc_cidr
-  azs                = var.vpc_availability_zones
-  private_subnets    = [var.private_primary_subnet_cidr, var.private_secondary_subnet_cidr]
-  public_subnets     = [var.public_primary_subnet_cidr, var.public_secondary_subnet_cidr, var.public_db_subnet_cidr_1, var.public_db_subnet_cidr_2]
-  enable_nat_gateway = true
+  name                 = "vpc-${var.cluster_name}"
+  cidr                 = var.vpc_cidr
+  azs                  = var.vpc_availability_zones
+  private_subnets      = [var.private_primary_subnet_cidr, var.private_secondary_subnet_cidr]
+  public_subnets       = [var.public_primary_subnet_cidr, var.public_secondary_subnet_cidr, var.public_db_subnet_cidr_1, var.public_db_subnet_cidr_2]
+  enable_nat_gateway   = true
   enable_dns_hostnames = true
 }
 
 resource "aws_security_group" "nodes" {
-  name = "nodes-sg-${var.cluster_name}"
+  name   = "nodes-sg-${var.cluster_name}"
   vpc_id = module.vpc.vpc_id
 
   ingress {
-    from_port = 0
-    to_port = 0
-    protocol = "-1"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
   }
 
   egress {
-    from_port = 0
-    to_port = 0
-    protocol = "-1"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
   }
 }
@@ -34,10 +34,10 @@ module "eks" {
   source  = "terraform-aws-modules/eks/aws"
   version = "18.8.1"
 
-  cluster_name                    = var.cluster_name
-  cluster_version                 = "1.22"
+  cluster_name    = var.cluster_name
+  cluster_version = var.cluster_version
 
-  cluster_endpoint_public_access  = true
+  cluster_endpoint_public_access = true
 
   vpc_id     = module.vpc.vpc_id
   subnet_ids = module.vpc.public_subnets
@@ -58,7 +58,7 @@ module "eks" {
     iam_role_attach_cni_policy = true
     ami_id                     = var.image_id
     enable_bootstrap_user_data = true
-    vpc_security_group_ids = [aws_security_group.nodes.id]
+    vpc_security_group_ids     = [aws_security_group.nodes.id]
   }
 
   eks_managed_node_groups = {
@@ -144,7 +144,7 @@ module "vpc_cni_irsa" {
 }
 
 resource "null_resource" "kubeconfig" {
-  depends_on = [ module.eks ]
+  depends_on = [module.eks]
   provisioner "local-exec" {
     command = "aws eks update-kubeconfig --region ${var.region} --name ${var.cluster_name} --kubeconfig ${var.kubeconfig}"
   }

--- a/install/infra/terraform/eks/variables.tf
+++ b/install/infra/terraform/eks/variables.tf
@@ -2,6 +2,13 @@ variable "cluster_name" {
   type        = string
   description = "EKS cluster name."
 }
+
+variable "cluster_version" {
+  type        = string
+  description = "Kubernetes version to create the cluster with"
+  default     = "1.22"
+}
+
 variable "kubeconfig" {
   type        = string
   description = "Path to the kubeconfig file"
@@ -9,31 +16,31 @@ variable "kubeconfig" {
 }
 
 variable "image_id" {
-  type = string
+  type        = string
   description = "AMI Image ID specific to the region"
   // latest ubuntu image for 1.22 k8s for eu-west-1 region, refer https://cloud-images.ubuntu.com/docs/aws/eks/
   default = "ami-0793b4124359a6ad7"
 }
 
 variable "service_machine_type" {
-  type = string
+  type        = string
   description = "Machine type for service workload node pool"
-  default = "m6i.xlarge"
+  default     = "m6i.xlarge"
 }
 
 variable "workspace_machine_type" {
-  type = string
+  type        = string
   description = "Machine type for workspace workload node pool"
-  default = "m6i.2xlarge"
+  default     = "m6i.2xlarge"
 }
 
 variable "region" {
-  type = string
+  type    = string
   default = "eu-west-1"
 }
 
 variable "vpc_availability_zones" {
-  type = list(string)
+  type    = list(string)
   default = ["eu-west-1c", "eu-west-1b"]
 }
 

--- a/install/infra/terraform/gke/variables.tf
+++ b/install/infra/terraform/gke/variables.tf
@@ -20,7 +20,7 @@ variable "zone" {
   default     = null
 }
 
-variable "kubernetes_version" {
+variable "cluster_version" {
   type        = string
   description = "Kubernetes version to be setup"
   default     = "1.22.8-gke.201"

--- a/install/infra/terraform/k3s/variables.tf
+++ b/install/infra/terraform/k3s/variables.tf
@@ -27,6 +27,16 @@ variable "name" {
   default     = "k3s"
 }
 
+variable "image_id" {
+  description = "Node image ID to be used to provision EC2 instances"
+  default     = "ubuntu-2004-focal-v20220419"
+}
+
+variable "cluster_version" {
+  description = "Kubernetes version to use to provision the cluster"
+  default     = "v1.22.12+k3s1"
+}
+
 variable "dns_sa_creds" {
   description = "Credentials with DNS admin rights to the project with managed DNS record"
   default     = ""

--- a/install/tests/Makefile
+++ b/install/tests/Makefile
@@ -17,6 +17,11 @@ ifndef cloud
 	$(error cloud is not defined)
 endif
 
+check-env-cluster-version:
+ifndef TF_VAR_cluster_version
+	$(error TF_VAR_cluster_version is not defined)
+endif
+
 .PHONY: help
 all: help
 help: Makefile
@@ -41,12 +46,13 @@ k3s-kubeconfig: sync-kubeconfig
 gcp-kubeconfig:
 	gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS} --project=sh-automated-tests
 	export KUBECONFIG=${KUBECONFIG} && \
-	gcloud container clusters get-credentials c${TF_VAR_TEST_ID} --zone europe-west1-d --project sh-automated-tests || $(MAKE) sync-kubeconfig || echo "No cluster present"
+	gcloud container clusters get-credentials gitpod-${TF_VAR_TEST_ID} --zone europe-west1-d --project sh-automated-tests || $(MAKE) sync-kubeconfig || echo "No cluster present"
 
 ## azure-kubeconfig: Get the kubeconfig configuration for Azure AKS
 azure-kubeconfig:
 	export KUBECONFIG=${KUBECONFIG} && \
-	az aks get-credentials --name gitpod-test-nor-primary-${TF_VAR_TEST_ID} --resource-group gitpod-test-nor-${TF_VAR_TEST_ID} --file ${KUBECONFIG} || echo "No cluster present"
+	export resource=$$(echo "$$TF_VAR_TEST_ID" | sed "s/[\\W\\-]//") && \
+	az aks get-credentials --name gitpod-test-nor-primary-$$resource --resource-group gitpod-test-nor-$$resource --file ${KUBECONFIG} || echo "No cluster present"
 
 ## aws-kubeconfig: Get the kubeconfig configuration for AWS EKS
 aws-kubeconfig:
@@ -56,23 +62,30 @@ aws-kubeconfig:
 
 .PHONY:
 ## gke-standard-cluster: Creates a zonal GKE cluster
-gke-standard-cluster:
+gke-standard-cluster: check-env-cluster-version
 	terraform init --upgrade && \
 	terraform workspace new $(TF_VAR_TEST_ID) || $(MAKE) select-workspace && \
 	terraform apply -target=module.gke -var kubeconfig=${KUBECONFIG} --auto-approve
 	@echo "Done creating GKE cluster"
 
+ami_id_120 := "ami-0ecb917eb4fbf4387"
+
+ami_id_121 := "ami-0d57fb01036fac543"
+
+ami_id_122 := "ami-0b306cb7e98db98e4"
+
 .PHONY:
 ## eks-standard-cluster: Creates an EKS cluster
-eks-standard-cluster:
+eks-standard-cluster: ami_id = $(if $(ami_id_${TF_VAR_cluster_version//.}),$(ami_id_${TF_VAR_cluster_version//.}),$(ami_id_122))
+eks-standard-cluster: check-env-cluster-version
 	terraform init --upgrade && \
 	terraform workspace new $(TF_VAR_TEST_ID) || $(MAKE) select-workspace && \
-	terraform apply -target=module.eks -var kubeconfig=${KUBECONFIG} --auto-approve
+	terraform apply -target=module.eks -var kubeconfig=${KUBECONFIG} -var eks_node_image_id=${ami_id} --auto-approve
 	@echo "Done creating EKS cluster"
 
 .PHONY:
 ## aks-standard-cluster: Creates an AKS cluster
-aks-standard-cluster:
+aks-standard-cluster: check-env-cluster-version
 	terraform init --upgrade && \
 	terraform workspace new $(TF_VAR_TEST_ID) || $(MAKE) select-workspace && \
 	terraform apply -target=module.aks -var kubeconfig=${KUBECONFIG} --auto-approve
@@ -94,12 +107,20 @@ cluster-issuer: check-env-cloud
 	terraform apply -target=module.$(cloud)-issuer  -var kubeconfig=${KUBECONFIG} --auto-approve
 	@echo "Done creating cluster issuer"
 
+image_id_1804 := "ubuntu-1804-bionic-v20220712"
+
+image_id_2004 := "ubuntu-2004-focal-v20220712"
+
+image_id_2204 := "ubuntu-2204-jammy-v20220712a"
+
+os_version ?= "2004"
 .PHONY:
 ## k3s-standard-cluster: Creates a K3S cluster on GCP with one master and 1 worker node
-k3s-standard-cluster:
+k3s-standard-cluster: image_id = $(if $(image_id_$(os_version)),$(image_id_$(os_version)),$(image_id_2004))
+k3s-standard-cluster: check-env-cluster-version
 	terraform init --upgrade && \
 	terraform workspace new $(TF_VAR_TEST_ID) || $(MAKE) select-workspace && \
-	terraform apply -target=module.k3s -var kubeconfig=${KUBECONFIG} --auto-approve && \
+	terraform apply -target=module.k3s -var kubeconfig=${KUBECONFIG} -var k3s_node_image_id=${image_id} --auto-approve && \
 	$(MAKE) upload-kubeconfig-to-gcp # we upload the file to GCP since we cannot retrieve the file against without SSHing to the master
 	@echo "Done creating k3s cluster"
 
@@ -241,8 +262,13 @@ delete-cm-setup: sleeptime=$(if $(time_to_sleep_$(cloud)),$(time_to_sleep_$(clou
 delete-cm-setup:
 	sleep 180 && kubectl --kubeconfig=${KUBECONFIG} delete pods --all -n cert-manager && sleep ${sleeptime};
 
+gitpod-debug-info:
+	@echo "Gitpod is not ready"
+	@kubectl get pods -n gitpod
+	@kubectl get certificate -n gitpod
+
 check-kots-app:
-	kubectl kots get --kubeconfig=${KUBECONFIG} app gitpod -n gitpod | grep gitpod  | awk '{print $$2}' | grep "ready" || { echo "Gitpod is not ready"; exit 1; }
+	kubectl kots get --kubeconfig=${KUBECONFIG} app gitpod -n gitpod | grep gitpod  | awk '{print $$2}' | grep "ready" || { $(MAKE) gitpod-debug-info; exit 1; }
 
 check-gitpod-installation: delete-cm-setup check-kots-app check-env-sub-domain
 	@echo "Curling http://${TF_VAR_TEST_ID}.tests.gitpod-self-hosted.com/api/version"
@@ -293,7 +319,7 @@ destroy-cluster: destroy-gcp destroy-aws destroy-azure
 destroy-kubeconfig:
 	gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS} --project=sh-automated-tests
 	gsutil rm gs://nightly-tests/tf-state/${TF_VAR_TEST_ID}-kubeconfig || echo "No kubeconfig"
-	rm ${KUBECONFIG}
+	rm ${KUBECONFIG} || echo "No kubeconfig"
 
 select-workspace:
 	terraform workspace select $(TF_VAR_TEST_ID)

--- a/install/tests/main.tf
+++ b/install/tests/main.tf
@@ -1,4 +1,4 @@
-variable "kubeconfig" { }
+variable "kubeconfig" {}
 variable "TEST_ID" { default = "nightly" }
 
 # We store the state always in a GCS bucket
@@ -11,18 +11,31 @@ terraform {
 
 variable "project" { default = "sh-automated-tests" }
 variable "sa_creds" { default = null }
-variable "dns_sa_creds" {default = null }
+variable "dns_sa_creds" { default = null }
+
+variable "eks_node_image_id" {
+  default = "ami-0793b4124359a6ad7" // this AMI is regional
+}
+
+variable "k3s_node_image_id" {
+  default = null
+}
+
+variable "cluster_version" {
+  default = "1.22"
+}
 
 module "gke" {
   # source = "github.com/gitpod-io/gitpod//install/infra/terraform/gke?ref=main" # we can later use tags here
   source = "../infra/terraform/gke" # we can later use tags here
 
-  name        = var.TEST_ID
-  project     = var.project
-  credentials = var.sa_creds
-  kubeconfig  = var.kubeconfig
-  region      = "europe-west1"
-  zone        = "europe-west1-d"
+  name            = var.TEST_ID
+  project         = var.project
+  credentials     = var.sa_creds
+  kubeconfig      = var.kubeconfig
+  region          = "europe-west1"
+  zone            = "europe-west1-d"
+  cluster_version = var.cluster_version
 }
 
 module "k3s" {
@@ -37,17 +50,19 @@ module "k3s" {
   dns_project      = "dns-for-playgrounds"
   managed_dns_zone = "tests-gitpod-self-hosted-com"
   domain_name      = "${var.TEST_ID}.tests.gitpod-self-hosted.com"
+  cluster_version  = var.cluster_version
+  image_id         = var.k3s_node_image_id
 }
 
 module "gcp-issuer" {
-  source              = "../infra/terraform/tools/issuer"
-  kubeconfig          = var.kubeconfig
-  issuer_name         = "cloudDNS"
+  source      = "../infra/terraform/tools/issuer"
+  kubeconfig  = var.kubeconfig
+  issuer_name = "cloudDNS"
   cert_manager_issuer = {
-    project  = "dns-for-playgrounds"
+    project = "dns-for-playgrounds"
     serviceAccountSecretRef = {
       name = "clouddns-dns01-solver"
-      key = "keys.json"
+      key  = "keys.json"
     }
   }
 }
@@ -55,7 +70,7 @@ module "gcp-issuer" {
 
 module "aks" {
   # source = "github.com/gitpod-io/gitpod//install/infra/terraform/aks?ref=main" # we can later use tags here
-  source                   = "../infra/terraform/aks"
+  source = "../infra/terraform/aks"
 
   domain_name              = "${var.TEST_ID}.tests.gitpod-self-hosted.com"
   enable_airgapped         = false
@@ -65,6 +80,7 @@ module "aks" {
   dns_enabled              = true
   workspace_name           = var.TEST_ID
   kubeconfig               = var.kubeconfig
+  cluster_version          = var.cluster_version
 }
 
 module "eks" {
@@ -73,13 +89,14 @@ module "eks" {
   cluster_name           = var.TEST_ID
   region                 = "eu-west-1"
   vpc_availability_zones = ["eu-west-1c", "eu-west-1b"]
-  image_id               = "ami-0793b4124359a6ad7" // this AMI is regional
+  image_id               = var.eks_node_image_id
   kubeconfig             = var.kubeconfig
+  cluster_version        = var.cluster_version
 }
 
 module "certmanager" {
   # source = "github.com/gitpod-io/gitpod//install/infra/terraform/tools/cert-manager?ref=main"
-  source      = "../infra/terraform/tools/cert-manager"
+  source = "../infra/terraform/tools/cert-manager"
 
   kubeconfig  = var.kubeconfig
   credentials = var.dns_sa_creds


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PR parameterize  the version of node image when possible and version of kubernetes. The node images are not configurable easily on managed self-hosted instances. We can only use the supported images corresponding to the Kubernetes version we are using. Hence the all supported ubuntu versions are tested only in the k3s setup.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #11349 
Fixes #11272 

## How to test
<!-- Provide steps to test this PR -->
One can use any of the suggested commands in this [internal document](https://www.notion.so/gitpod/Self-hosted-automated-nightly-test-pipelines-fdc5a202e67b4197aa00d93b98d57927) to test.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
