### PR TITLE
Add a delete rety and fail into the certificate issue function

### DIFF
--- a/.werft/util/certs.ts
+++ b/.werft/util/certs.ts
@@ -47,6 +47,7 @@ export async function issueCertificate(werft: Werft, params: IssueCertificatePar
     }
     if (!certReady) {
         retrieveFailedCertDebug(params.certName, shellOpts.slice)
+        werft.fail(shellOpts.slice, `Certificate ${params.certName} never reached the Ready state`)
     }
     return certReady
 }

--- a/.werft/util/certs.ts
+++ b/.werft/util/certs.ts
@@ -44,6 +44,7 @@ export async function issueCertificate(werft: Werft, params: IssueCertificatePar
             certReady = true;
             break;
         }
+        deleteCertificateResource(werft, shellOpts, params)
     }
     if (!certReady) {
         retrieveFailedCertDebug(params.certName, shellOpts.slice)
@@ -113,7 +114,22 @@ function createCertificateResource(
     const rc = exec(cmd, { slice: shellOpts.slice, dontCheckRc: true }).code;
 
     if (rc != 0) {
-        werft.fail(shellOpts.slice, "Failed to create the certificate Custom Resource");
+        werft.fail(shellOpts.slice, `Failed to create the certificate (${params.certName}) Custom Resource`);
+    }
+}
+
+function deleteCertificateResource(
+    werft: Werft,
+    shellOpts: ExecOptions,
+    params: IssueCertificateParams,
+) {
+    const rc = exec(
+        `kubectl --kubeconfig ${CORE_DEV_KUBECONFIG_PATH} -n ${params.certNamespace} delete ${params.certName}`,
+        { slice: shellOpts.slice, dontCheckRc: true }
+    ).code;
+
+    if (rc != 0) {
+        werft.fail(shellOpts.slice, `Failed to delete the certificate (${params.certName}) Custom Resource`);
     }
 }
 


### PR DESCRIPTION
## Description
Delete the certificate if it fails and recreate it. When certificate issues do occur, we want to fail immediately

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
