### PR TITLE
Fetch workspace classes from server

### DIFF
--- a/components/dashboard/src/service/service-mock.ts
+++ b/components/dashboard/src/service/service-mock.ts
@@ -210,6 +210,59 @@ const gitpodServiceMock = createServiceMock({
     onDidCloseConnection: Event.None,
     trackEvent: async (event) => {},
     trackLocation: async (event) => {},
+    getSupportedWorkspaceClasses: async () => {
+        return [
+            {
+                id: "g1-standard",
+                category: "GENERAL PURPOSE",
+                displayName: "Standard",
+                description: "Up to 4 vCPU, 8GB memory, 30GB disk",
+                powerups: 1,
+            },
+            {
+                id: "g1-large",
+                category: "GENERAL PURPOSE",
+                displayName: "Large",
+                description: "Up to 8 vCPU, 16GB memory, 50GB disk",
+                powerups: 2,
+            },
+        ];
+    },
+    getShowPaymentUI: async () => {
+        return false;
+    },
+    getClientRegion: async () => {
+        return "europe-west-1";
+    },
+    isStudent: async () => {
+        return false;
+    },
+    isChargebeeCustomer: async () => {
+        return false;
+    },
+    getSuggestedContextURLs: async () => {
+        return [];
+    },
+    getIDEOptions: async () => {
+        return {
+            defaultDesktopIde: "code-desktop",
+            defaultIde: "code",
+            options: {
+                code: {
+                    title: "VS Code",
+                    type: "browser",
+                    logo: "",
+                    image: "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-050c611f28564c6c7b1e58db470f07997dfb4730",
+                },
+                "code-desktop": {
+                    title: "VS Code",
+                    type: "desktop",
+                    logo: "",
+                    image: "eu.gcr.io/gitpod-core-dev/build/ide/code-desktop:commit-9b29fc94cc1f0c776ef74f60dc3a7ce68d41bdbe",
+                },
+            },
+        };
+    },
 });
 
 export { gitpodServiceMock };

--- a/components/dashboard/src/service/service-mock.ts
+++ b/components/dashboard/src/service/service-mock.ts
@@ -218,6 +218,7 @@ const gitpodServiceMock = createServiceMock({
                 displayName: "Standard",
                 description: "Up to 4 vCPU, 8GB memory, 30GB disk",
                 powerups: 1,
+                isDefault: true,
             },
             {
                 id: "g1-large",
@@ -225,6 +226,7 @@ const gitpodServiceMock = createServiceMock({
                 displayName: "Large",
                 description: "Up to 8 vCPU, 16GB memory, 50GB disk",
                 powerups: 2,
+                isDefault: false,
             },
         ];
     },

--- a/components/dashboard/src/settings/selectClass.tsx
+++ b/components/dashboard/src/settings/selectClass.tsx
@@ -43,10 +43,14 @@ export default function SelectWorkspaceClass(props: SelectWorkspaceClassProps) {
         const fetchClasses = async () => {
             const classes = await getGitpodService().server.getSupportedWorkspaceClasses();
             setSupportedClasses(classes);
+
+            if (!workspaceClass) {
+                setWorkspaceClass(supportedClasses.find((c) => c.isDefault)?.id || "");
+            }
         };
 
         fetchClasses().catch(console.error);
-    }, []);
+    });
 
     if (!props.enabled) {
         return <div></div>;

--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -62,6 +62,7 @@ import { IDEServer } from "./ide-protocol";
 import { InstallationAdminSettings, TelemetryData } from "./installation-admin-protocol";
 import { Currency } from "./plans";
 import { BillableSession } from "./usage";
+import { SupportedWorkspaceClass } from "./workspace-class";
 
 export interface GitpodClient {
     onInstanceUpdate(instance: WorkspaceInstance): void;
@@ -307,6 +308,8 @@ export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, 
      * Frontend notifications
      */
     getNotifications(): Promise<string[]>;
+    
+    getSupportedWorkspaceClasses(): Promise<SupportedWorkspaceClass[]>;
 }
 
 export interface RateLimiterError {

--- a/components/gitpod-protocol/src/workspace-class.ts
+++ b/components/gitpod-protocol/src/workspace-class.ts
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+export interface SupportedWorkspaceClass {
+    id: string;
+    category: string;
+    displayName: string;
+    description: string;
+    powerups: number;
+}

--- a/components/gitpod-protocol/src/workspace-class.ts
+++ b/components/gitpod-protocol/src/workspace-class.ts
@@ -10,4 +10,5 @@ export interface SupportedWorkspaceClass {
     displayName: string;
     description: string;
     powerups: number;
+    isDefault: boolean;
 }

--- a/components/server/src/auth/rate-limiter.ts
+++ b/components/server/src/auth/rate-limiter.ts
@@ -220,6 +220,7 @@ function getConfig(config: RateLimiterConfig): RateLimiterConfig {
         getSpendingLimitForTeam: { group: "default", points: 1 },
         setSpendingLimitForTeam: { group: "default", points: 1 },
         getNotifications: { group: "default", points: 1 },
+        getSupportedWorkspaceClasses: { group: "default", points: 1 },
     };
 
     return {

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -3052,6 +3052,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
                 displayName: c.displayName,
                 description: c.description,
                 powerups: c.powerups,
+                isDefault: c.isDefault,
             }));
 
         return classes;

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -115,6 +115,7 @@ import {
     RemotePageMessage,
     RemoteTrackMessage,
 } from "@gitpod/gitpod-protocol/lib/analytics";
+import { SupportedWorkspaceClass } from "@gitpod/gitpod-protocol/lib/workspace-class";
 import { ImageBuilderClientProvider, LogsRequest } from "@gitpod/image-builder/lib";
 import { WorkspaceManagerClientProvider } from "@gitpod/ws-manager/lib/client-provider";
 import {
@@ -3040,6 +3041,20 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
     async getIDEOptions(ctx: TraceContext): Promise<IDEOptions> {
         const ideConfig = await this.ideConfigService.config;
         return ideConfig.ideOptions;
+    }
+
+    async getSupportedWorkspaceClasses(ctx: TraceContext): Promise<SupportedWorkspaceClass[]> {
+        let classes = this.config.workspaceClasses
+            .filter((c) => !c.deprecated)
+            .map((c) => ({
+                id: c.id,
+                category: c.category,
+                displayName: c.displayName,
+                description: c.description,
+                powerups: c.powerups,
+            }));
+
+        return classes;
     }
 
     //#region gitpod.io concerns

--- a/components/server/src/workspace/workspace-classes.ts
+++ b/components/server/src/workspace/workspace-classes.ts
@@ -15,8 +15,17 @@ export interface WorkspaceClassConfig {
     // Is the "default" class. The config is validated to only every have exactly _one_ default class.
     isDefault: boolean;
 
+    // Identifies which category this class belongs to e.g. general purpose
+    category: string;
+
     // The string we display to users in the UI
     displayName: string;
+
+    // The description for the workspace class
+    description: string;
+
+    // The "power level" of the workspace class
+    powerups: number;
 
     // Whether or not to:
     //  - offer users this Workspace class for selection

--- a/install/installer/pkg/components/server/configmap.go
+++ b/install/installer/pkg/components/server/configmap.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net"
 	"strconv"
+	"strings"
 
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 	"github.com/gitpod-io/gitpod/installer/pkg/components/usage"
@@ -137,7 +138,10 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 	workspaceClasses := []WorkspaceClass{
 		{
 			Id:          config.DefaultWorkspaceClass,
-			DisplayName: config.DefaultWorkspaceClass,
+			Category:    GeneralPurpose,
+			DisplayName: strings.Title(config.DefaultWorkspaceClass),
+			Description: "Default workspace class",
+			PowerUps:    1,
 			IsDefault:   true,
 			Deprecated:  false,
 		},
@@ -148,7 +152,10 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 			for _, cl := range cfg.WebApp.WorkspaceClasses {
 				class := WorkspaceClass{
 					Id:          cl.Id,
+					Category:    WorkspaceClassCategory(cl.Category),
 					DisplayName: cl.DisplayName,
+					Description: cl.Description,
+					PowerUps:    cl.PowerUps,
 					IsDefault:   cl.IsDefault,
 					Deprecated:  cl.Deprecated,
 					Marker:      cl.Marker,

--- a/install/installer/pkg/components/server/types.go
+++ b/install/installer/pkg/components/server/types.go
@@ -129,11 +129,14 @@ type WorkspaceDefaults struct {
 }
 
 type WorkspaceClass struct {
-	Id          string          `json:"id"`
-	DisplayName string          `json:"displayName"`
-	IsDefault   bool            `json:"isDefault"`
-	Deprecated  bool            `json:"deprecated"`
-	Marker      map[string]bool `json:"marker,omitempty"`
+	Id          string                 `json:"id"`
+	Category    WorkspaceClassCategory `json:"category"`
+	DisplayName string                 `json:"displayName"`
+	Description string                 `json:"description"`
+	PowerUps    uint32                 `json:"powerups"`
+	IsDefault   bool                   `json:"isDefault"`
+	Deprecated  bool                   `json:"deprecated"`
+	Marker      map[string]bool        `json:"marker,omitempty"`
 }
 
 type NamedWorkspaceFeatureFlag string
@@ -141,4 +144,10 @@ type NamedWorkspaceFeatureFlag string
 const (
 	NamedWorkspaceFeatureFlagFullWorkspaceBackup NamedWorkspaceFeatureFlag = "full_workspace_backup"
 	NamedWorkspaceFeatureFlagFixedResources      NamedWorkspaceFeatureFlag = "fixed_resources"
+)
+
+type WorkspaceClassCategory string
+
+const (
+	GeneralPurpose WorkspaceClassCategory = "GENERAL PURPOSE"
 )

--- a/install/installer/pkg/config/v1/experimental/experimental.go
+++ b/install/installer/pkg/config/v1/experimental/experimental.go
@@ -209,7 +209,10 @@ type UsageConfig struct {
 
 type WebAppWorkspaceClass struct {
 	Id          string          `json:"id"`
+	Category    string          `json:"category"`
 	DisplayName string          `json:"displayName"`
+	Description string          `json:"description"`
+	PowerUps    uint32          `json:"powerups"`
 	IsDefault   bool            `json:"isDefault"`
 	Deprecated  bool            `json:"deprecated"`
 	Marker      map[string]bool `json:"marker,omitempty"`


### PR DESCRIPTION
## Description
Source the workspace classes that should be displayed in the settings dialog from the server instead of hard coding them.

## Related Issue(s)
Fixes #https://github.com/gitpod-io/gitpod/issues/11583

## How to test
- Open dashboard in preview environment
- Check that workspace classes configured in the server config map are dispalyed

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
