### PR TITLE
Stop sign on "out of credits"

### DIFF
--- a/components/dashboard/src/start/StartWorkspace.tsx
+++ b/components/dashboard/src/start/StartWorkspace.tsx
@@ -528,7 +528,7 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
                                         try {
                                             const desktopLink = new URL(openLink);
                                             redirect =
-                                                desktopLink.protocol != "http:" && desktopLink.protocol != "https:";
+                                                desktopLink.protocol !== "http:" && desktopLink.protocol !== "https:";
                                         } catch {}
                                         if (redirect) {
                                             window.location.href = openLink;

--- a/components/gitpod-protocol/src/messaging/error.ts
+++ b/components/gitpod-protocol/src/messaging/error.ts
@@ -35,6 +35,9 @@ export namespace ErrorCodes {
     // 450 Payment error
     export const PAYMENT_ERROR = 450;
 
+    // 451 Out of credits
+    export const PAYMENT_SPENDING_LIMIT_REACHED = 451;
+
     // 455 Invalid cost center (custom status code)
     export const INVALID_COST_CENTER = 455;
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Partially resolves #11404

Very limited UI 🛹  of a modal shown when you've reached the configured spending limit.

<img width="755" alt="Screen Shot 2022-08-03 at 14 07 02" src="https://user-images.githubusercontent.com/914497/182604959-b5f9364f-2589-43bf-a0ef-481381334b04.png">


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related to #11404

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Add Spending Limit Reached modal on workspace creation.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
- [x] /werft with-payment