### PR TITLE
Replace workspace search alert

### DIFF
--- a/components/dashboard/src/admin/WorkspacesSearch.tsx
+++ b/components/dashboard/src/admin/WorkspacesSearch.tsx
@@ -22,8 +22,8 @@ import { Link } from "react-router-dom";
 import { getGitpodService } from "../service/service";
 import { getProject, WorkspaceStatusIndicator } from "../workspaces/WorkspaceEntry";
 import WorkspaceDetail from "./WorkspaceDetail";
-import info from "../images/info.svg";
 import { PageWithAdminSubMenu } from "./PageWithAdminSubMenu";
+import Alert from "../components/Alert";
 
 interface Props {
     user?: User;
@@ -138,14 +138,9 @@ export function WorkspaceSearch(props: Props) {
                     </button>
                 </div>
             </div>
-            <div
-                className={
-                    "flex rounded-xl bg-gray-200 dark:bg-gray-800 text-gray-600 dark:text-gray-400 p-2 w-2/3 mb-2 w-full"
-                }
-            >
-                <img className="w-4 h-4 m-1 ml-2 mr-4" alt="info" src={info} />
-                <span>Please enter complete IDs - this search does not perform partial-matching.</span>
-            </div>
+            <Alert type={"info"} closable={false} showIcon={true} className="flex rounded p-2 mb-2 w-full">
+                <span>Search workspaces using workspace ID.</span>
+            </Alert>
             <div className="flex flex-col space-y-2">
                 <div className="px-6 py-3 flex justify-between text-sm text-gray-400 border-t border-b border-gray-200 dark:border-gray-800 mb-2">
                     <div className="w-8"></div>


### PR DESCRIPTION
## Description

This will replace the custom alert component added in https://github.com/gitpod-io/gitpod/pull/8632 for searching workspaces only by their IDs.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/8701

## How to test
1. Go to **/admin/workspaces**
2. Breathe and enjoy the hidden power of components

## Screenshots

| BEFORE | AFTER |
|-|-|
| <img width="1440" alt="Screenshot 2022-07-23 at 12 41 08 AM (2)" src="https://user-images.githubusercontent.com/120486/180572700-e08ea515-1460-4823-a190-f4b3b7cc3efe.png"> | <img width="1440" alt="Screenshot 2022-07-23 at 12 41 27 AM (2)" src="https://user-images.githubusercontent.com/120486/180572703-edec9cf6-1bd2-412b-b6c7-e85ee21e8abd.png"> |

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Replce workspace search alert
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
