### PR TITLE
[installer] registry-facade: Fix render bug

### DIFF
--- a/install/installer/pkg/components/registry-facade/daemonset.go
+++ b/install/installer/pkg/components/registry-facade/daemonset.go
@@ -306,7 +306,7 @@ func daemonset(ctx *common.RenderContext) ([]runtime.Object, error) {
 						*common.KubeRBACProxyContainer(ctx),
 						{
 							Name:  "node-labeler",
-							Image: ctx.ImageName(ctx.Config.Repository, Component, ctx.VersionManifest.Components.WSDaemon.Version),
+							Image: ctx.ImageName(ctx.Config.Repository, Component, ctx.VersionManifest.Components.RegistryFacade.Version),
 							Command: []string{
 								"/app/ready-probe-labeler",
 								fmt.Sprintf("--label=gitpod.io/registry-facade_ready_ns_%v", ctx.Namespace),


### PR DESCRIPTION
## Description

During a refactor the wrong component/version combination [got introduced](https://github.com/gitpod-io/gitpod/commit/316b4930575a22af53e15550e89e67d34cabb66e). The `/app/ready-probe-labeler` is present in the `registry-facade` image (cmp. [here](https://github.com/gitpod-io/gitpod/blob/316b4930575a22af53e15550e89e67d34cabb66e/components/registry-facade/leeway.Dockerfile#L14)).

This _sometimes_ results in failing Gitpod installations when `registry-facade` and `ws-daemon` are _not_ last change within the same commit.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
 - check `registry-facade` deamonset and check it has the "registr-facade" same image just like the "registry-facade" 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
