### PR TITLE
[dashboard] Extract `PageWithSettingsSubMenu` component

### DIFF
--- a/components/dashboard/src/settings/Account.tsx
+++ b/components/dashboard/src/settings/Account.tsx
@@ -6,17 +6,14 @@
 
 import { User } from "@gitpod/gitpod-protocol";
 import { useContext, useState } from "react";
-import { PageWithSubMenu } from "../components/PageWithSubMenu";
 import { getGitpodService, gitpodHostUrl } from "../service/service";
 import { UserContext } from "../user-context";
-import getSettingsMenu from "./settings-menu";
 import ConfirmationModal from "../components/ConfirmationModal";
-import { PaymentContext } from "../payment-context";
 import ProfileInformation, { ProfileState } from "./ProfileInformation";
+import { PageWithSettingsSubMenu } from "./PageWithSettingsSubMenu";
 
 export default function Account() {
     const { user, setUser } = useContext(UserContext);
-    const { showPaymentUI, showUsageBasedUI } = useContext(PaymentContext);
     const [modal, setModal] = useState(false);
     const primaryEmail = User.getPrimaryEmail(user!) || "";
     const [typedEmail, setTypedEmail] = useState("");
@@ -69,11 +66,7 @@ export default function Account() {
                 <input autoFocus className="w-full" type="text" onChange={(e) => setTypedEmail(e.target.value)}></input>
             </ConfirmationModal>
 
-            <PageWithSubMenu
-                subMenu={getSettingsMenu({ showPaymentUI, showUsageBasedUI })}
-                title="Account"
-                subtitle="Manage account and Git configuration."
-            >
+            <PageWithSettingsSubMenu title="Account" subtitle="Manage account and Git configuration.">
                 <h3>Profile</h3>
                 <form
                     onSubmit={(e) => {
@@ -104,7 +97,7 @@ export default function Account() {
                 <button className="danger secondary" onClick={() => setModal(true)}>
                     Delete Account
                 </button>
-            </PageWithSubMenu>
+            </PageWithSettingsSubMenu>
         </div>
     );
 }

--- a/components/dashboard/src/settings/Billing.tsx
+++ b/components/dashboard/src/settings/Billing.tsx
@@ -7,18 +7,15 @@
 import { Team } from "@gitpod/gitpod-protocol";
 import { useContext, useEffect, useState } from "react";
 import { Link } from "react-router-dom";
-import getSettingsMenu from "./settings-menu";
 import { ReactComponent as Spinner } from "../icons/Spinner.svg";
 import DropDown from "../components/DropDown";
-import { PageWithSubMenu } from "../components/PageWithSubMenu";
-import { PaymentContext } from "../payment-context";
 import { getGitpodService } from "../service/service";
 import { TeamsContext } from "../teams/teams-context";
 import { UserContext } from "../user-context";
+import { PageWithSettingsSubMenu } from "./PageWithSettingsSubMenu";
 
 export default function Billing() {
     const { user } = useContext(UserContext);
-    const { showPaymentUI, showUsageBasedUI } = useContext(PaymentContext);
     const { teams } = useContext(TeamsContext);
     const [teamsWithBillingEnabled, setTeamsWithBillingEnabled] = useState<Team[] | undefined>();
 
@@ -47,11 +44,7 @@ export default function Billing() {
     };
 
     return (
-        <PageWithSubMenu
-            subMenu={getSettingsMenu({ showPaymentUI, showUsageBasedUI })}
-            title="Billing"
-            subtitle="Usage-Based Billing."
-        >
+        <PageWithSettingsSubMenu title="Billing" subtitle="Usage-Based Billing.">
             <h3>Usage-Based Billing</h3>
             <h2 className="text-gray-500">Manage usage-based billing, spending limit, and payment method.</h2>
             <div className="mt-8">
@@ -91,6 +84,6 @@ export default function Billing() {
                     </div>
                 )}
             </div>
-        </PageWithSubMenu>
+        </PageWithSettingsSubMenu>
     );
 }

--- a/components/dashboard/src/settings/EnvironmentVariables.tsx
+++ b/components/dashboard/src/settings/EnvironmentVariables.tsx
@@ -5,15 +5,13 @@
  */
 
 import { UserEnvVar, UserEnvVarValue } from "@gitpod/gitpod-protocol";
-import { useContext, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import ConfirmationModal from "../components/ConfirmationModal";
 import { Item, ItemField, ItemFieldContextMenu, ItemsList } from "../components/ItemsList";
 import Modal from "../components/Modal";
-import { PageWithSubMenu } from "../components/PageWithSubMenu";
 import { getGitpodService } from "../service/service";
-import getSettingsMenu from "./settings-menu";
 import CodeText from "../components/CodeText";
-import { PaymentContext } from "../payment-context";
+import { PageWithSettingsSubMenu } from "./PageWithSettingsSubMenu";
 
 interface EnvVarModalProps {
     envVar: UserEnvVarValue;
@@ -146,7 +144,6 @@ function sortEnvVars(a: UserEnvVarValue, b: UserEnvVarValue) {
 }
 
 export default function EnvVars() {
-    const { showPaymentUI, showUsageBasedUI } = useContext(PaymentContext);
     const [envVars, setEnvVars] = useState([] as UserEnvVarValue[]);
     const [currentEnvVar, setCurrentEnvVar] = useState({
         name: "",
@@ -207,11 +204,7 @@ export default function EnvVars() {
     };
 
     return (
-        <PageWithSubMenu
-            subMenu={getSettingsMenu({ showPaymentUI, showUsageBasedUI })}
-            title="Variables"
-            subtitle="Configure environment variables for all workspaces."
-        >
+        <PageWithSettingsSubMenu title="Variables" subtitle="Configure environment variables for all workspaces.">
             {isAddEnvVarModalVisible && (
                 <AddEnvVarModal
                     save={save}
@@ -292,6 +285,6 @@ export default function EnvVars() {
                     })}
                 </ItemsList>
             )}
-        </PageWithSubMenu>
+        </PageWithSettingsSubMenu>
     );
 }

--- a/components/dashboard/src/settings/Integrations.tsx
+++ b/components/dashboard/src/settings/Integrations.tsx
@@ -14,31 +14,26 @@ import { ContextMenuEntry } from "../components/ContextMenu";
 import InfoBox from "../components/InfoBox";
 import { Item, ItemField, ItemFieldContextMenu, ItemFieldIcon, ItemsList } from "../components/ItemsList";
 import Modal from "../components/Modal";
-import { PageWithSubMenu } from "../components/PageWithSubMenu";
 import copy from "../images/copy.svg";
 import exclamation from "../images/exclamation.svg";
-import { PaymentContext } from "../payment-context";
 import { openAuthorizeWindow } from "../provider-utils";
 import { getGitpodService, gitpodHostUrl } from "../service/service";
 import { UserContext } from "../user-context";
 import { isGitpodIo } from "../utils";
+import { PageWithSettingsSubMenu } from "./PageWithSettingsSubMenu";
 import { SelectAccountModal } from "./SelectAccountModal";
-import getSettingsMenu from "./settings-menu";
 
 export default function Integrations() {
-    const { showPaymentUI, showUsageBasedUI } = useContext(PaymentContext);
-
     return (
         <div>
-            <PageWithSubMenu
-                subMenu={getSettingsMenu({ showPaymentUI, showUsageBasedUI })}
+            <PageWithSettingsSubMenu
                 title="Integrations"
                 subtitle="Manage permissions for Git providers and integrations."
             >
                 <GitProviders />
                 <div className="h-12"></div>
                 <GitIntegrations />
-            </PageWithSubMenu>
+            </PageWithSettingsSubMenu>
         </div>
     );
 }

--- a/components/dashboard/src/settings/Notifications.tsx
+++ b/components/dashboard/src/settings/Notifications.tsx
@@ -8,14 +8,11 @@ import { useContext, useState } from "react";
 import { getGitpodService } from "../service/service";
 import { UserContext } from "../user-context";
 import CheckBox from "../components/CheckBox";
-import { PageWithSubMenu } from "../components/PageWithSubMenu";
-import getSettingsMenu from "./settings-menu";
 import { identifyUser } from "../Analytics";
-import { PaymentContext } from "../payment-context";
+import { PageWithSettingsSubMenu } from "./PageWithSettingsSubMenu";
 
 export default function Notifications() {
     const { user, setUser } = useContext(UserContext);
-    const { showPaymentUI, showUsageBasedUI } = useContext(PaymentContext);
     const [isOnboardingMail, setOnboardingMail] = useState(
         !!user?.additionalData?.emailNotificationSettings?.allowsOnboardingMail,
     );
@@ -83,11 +80,7 @@ export default function Notifications() {
 
     return (
         <div>
-            <PageWithSubMenu
-                subMenu={getSettingsMenu({ showPaymentUI, showUsageBasedUI })}
-                title="Notifications"
-                subtitle="Choose when to be notified."
-            >
+            <PageWithSettingsSubMenu title="Notifications" subtitle="Choose when to be notified.">
                 <h3>Email Notification Preferences</h3>
                 <CheckBox
                     title="Account Notifications [required]"
@@ -113,7 +106,7 @@ export default function Notifications() {
                     checked={isDevXMail}
                     onChange={toggleDevXMail}
                 />
-            </PageWithSubMenu>
+            </PageWithSettingsSubMenu>
         </div>
     );
 }

--- a/components/dashboard/src/settings/PageWithSettingsSubMenu.tsx
+++ b/components/dashboard/src/settings/PageWithSettingsSubMenu.tsx
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { useContext } from "react";
+import { PageWithSubMenu } from "../components/PageWithSubMenu";
+import { PaymentContext } from "../payment-context";
+import getSettingsMenu from "./settings-menu";
+
+export interface PageWithAdminSubMenuProps {
+    title: string;
+    subtitle: string;
+    children: React.ReactNode;
+}
+
+export function PageWithSettingsSubMenu({ title, subtitle, children }: PageWithAdminSubMenuProps) {
+    const { showPaymentUI, showUsageBasedUI } = useContext(PaymentContext);
+
+    return (
+        <PageWithSubMenu
+            subMenu={getSettingsMenu({ showPaymentUI, showUsageBasedUI })}
+            title={title}
+            subtitle={subtitle}
+        >
+            {children}
+        </PageWithSubMenu>
+    );
+}

--- a/components/dashboard/src/settings/Plans.tsx
+++ b/components/dashboard/src/settings/Plans.tsx
@@ -22,10 +22,9 @@ import Modal from "../components/Modal";
 import SelectableCard from "../components/SelectableCard";
 import { getGitpodService } from "../service/service";
 import { UserContext } from "../user-context";
-import { PageWithSubMenu } from "../components/PageWithSubMenu";
 import Tooltip from "../components/Tooltip";
-import getSettingsMenu from "./settings-menu";
 import { PaymentContext } from "../payment-context";
+import { PageWithSettingsSubMenu } from "./PageWithSettingsSubMenu";
 
 type PlanWithOriginalPrice = Plan & { originalPrice?: number };
 type Pending = { pendingSince: number };
@@ -45,8 +44,7 @@ type TeamClaimModal =
 
 export default function () {
     const { user } = useContext(UserContext);
-    const { showPaymentUI, showUsageBasedUI, currency, setCurrency, isStudent, isChargebeeCustomer } =
-        useContext(PaymentContext);
+    const { showPaymentUI, currency, setCurrency, isStudent, isChargebeeCustomer } = useContext(PaymentContext);
     const [accountStatement, setAccountStatement] = useState<AccountStatement>();
     const [availableCoupons, setAvailableCoupons] = useState<PlanCoupon[]>();
     const [appliedCoupons, setAppliedCoupons] = useState<PlanCoupon[]>();
@@ -636,11 +634,7 @@ export default function () {
 
     return (
         <div>
-            <PageWithSubMenu
-                subMenu={getSettingsMenu({ showPaymentUI, showUsageBasedUI })}
-                title="Plans"
-                subtitle="Manage account usage and billing."
-            >
+            <PageWithSettingsSubMenu title="Plans" subtitle="Manage account usage and billing.">
                 {showPaymentUI && (
                     <div className="w-full text-center">
                         <p className="text-xl text-gray-500">
@@ -858,7 +852,7 @@ export default function () {
                         </div>
                     </Modal>
                 )}
-            </PageWithSubMenu>
+            </PageWithSettingsSubMenu>
         </div>
     );
 }

--- a/components/dashboard/src/settings/Preferences.tsx
+++ b/components/dashboard/src/settings/Preferences.tsx
@@ -5,23 +5,20 @@
  */
 
 import { useContext, useState } from "react";
-import { PageWithSubMenu } from "../components/PageWithSubMenu";
 import SelectableCardSolid from "../components/SelectableCardSolid";
 import { getGitpodService } from "../service/service";
 import { ThemeContext } from "../theme-context";
 import { UserContext } from "../user-context";
-import getSettingsMenu from "./settings-menu";
 import { trackEvent } from "../Analytics";
-import { PaymentContext } from "../payment-context";
 import SelectIDE from "./SelectIDE";
 import { getExperimentsClient } from "../experiments/client";
 import SelectWorkspaceClass from "./selectClass";
+import { PageWithSettingsSubMenu } from "./PageWithSettingsSubMenu";
 
 type Theme = "light" | "dark" | "system";
 
 export default function Preferences() {
     const { user } = useContext(UserContext);
-    const { showPaymentUI, showUsageBasedUI } = useContext(PaymentContext);
     const { setIsDark } = useContext(ThemeContext);
 
     const [theme, setTheme] = useState<Theme>(localStorage.theme || "system");
@@ -65,11 +62,7 @@ export default function Preferences() {
 
     return (
         <div>
-            <PageWithSubMenu
-                subMenu={getSettingsMenu({ showPaymentUI, showUsageBasedUI })}
-                title="Preferences"
-                subtitle="Configure user preferences."
-            >
+            <PageWithSettingsSubMenu title="Preferences" subtitle="Configure user preferences.">
                 <h3>Editor</h3>
                 <p className="text-base text-gray-500 dark:text-gray-400">Choose the editor for opening workspaces.</p>
                 <SelectIDE location="preferences" />
@@ -153,7 +146,7 @@ export default function Preferences() {
                         </p>
                     </div>
                 </div>
-            </PageWithSubMenu>
+            </PageWithSettingsSubMenu>
         </div>
     );
 }

--- a/components/dashboard/src/settings/SSHKeys.tsx
+++ b/components/dashboard/src/settings/SSHKeys.tsx
@@ -4,10 +4,7 @@
  * See License-AGPL.txt in the project root for license information.
  */
 
-import { useContext, useEffect, useState } from "react";
-import { PageWithSubMenu } from "../components/PageWithSubMenu";
-import getSettingsMenu from "./settings-menu";
-import { PaymentContext } from "../payment-context";
+import { useEffect, useState } from "react";
 import Modal from "../components/Modal";
 import Alert from "../components/Alert";
 import { Item, ItemField, ItemFieldContextMenu } from "../components/ItemsList";
@@ -15,6 +12,7 @@ import ConfirmationModal from "../components/ConfirmationModal";
 import { SSHPublicKeyValue, UserSSHPublicKeyValue } from "@gitpod/gitpod-protocol";
 import { getGitpodService } from "../service/service";
 import moment from "moment";
+import { PageWithSettingsSubMenu } from "./PageWithSettingsSubMenu";
 
 interface AddModalProps {
     value: SSHPublicKeyValue;
@@ -147,8 +145,6 @@ export function DeleteSSHKeyModal(props: DeleteModalProps) {
 }
 
 export default function SSHKeys() {
-    const { showPaymentUI, showUsageBasedUI } = useContext(PaymentContext);
-
     const [dataList, setDataList] = useState<UserSSHPublicKeyValue[]>([]);
     const [currentData, setCurrentData] = useState<SSHPublicKeyValue>({ name: "", key: "" });
     const [currentDelData, setCurrentDelData] = useState<UserSSHPublicKeyValue>();
@@ -178,11 +174,7 @@ export default function SSHKeys() {
     };
 
     return (
-        <PageWithSubMenu
-            subMenu={getSettingsMenu({ showPaymentUI, showUsageBasedUI })}
-            title="SSH Keys"
-            subtitle="Connect securely to workspaces."
-        >
+        <PageWithSettingsSubMenu title="SSH Keys" subtitle="Connect securely to workspaces.">
             {showAddModal && (
                 <AddSSHKeyModal value={currentData} onSave={loadData} onClose={() => setShowAddModal(false)} />
             )}
@@ -239,7 +231,7 @@ export default function SSHKeys() {
                     })}
                 </div>
             )}
-        </PageWithSubMenu>
+        </PageWithSettingsSubMenu>
     );
 }
 

--- a/components/dashboard/src/settings/Teams.tsx
+++ b/components/dashboard/src/settings/Teams.tsx
@@ -6,7 +6,6 @@
 
 import React, { useContext, useEffect, useRef, useState } from "react";
 import ContextMenu, { ContextMenuEntry } from "../components/ContextMenu";
-import { PageWithSubMenu } from "../components/PageWithSubMenu";
 import { getGitpodService } from "../service/service";
 import AlertBox from "../components/AlertBox";
 import Modal from "../components/Modal";
@@ -21,22 +20,19 @@ import copy from "../images/copy.svg";
 import exclamation from "../images/exclamation.svg";
 import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
 import { poll, PollOptions } from "../utils";
-import getSettingsMenu from "./settings-menu";
 import { Disposable } from "@gitpod/gitpod-protocol";
 import { PaymentContext } from "../payment-context";
+import { PageWithSettingsSubMenu } from "./PageWithSettingsSubMenu";
 
 export default function Teams() {
-    const { showPaymentUI, showUsageBasedUI } = useContext(PaymentContext);
-
     return (
         <div>
-            <PageWithSubMenu
-                subMenu={getSettingsMenu({ showPaymentUI, showUsageBasedUI })}
+            <PageWithSettingsSubMenu
                 title="Team Plans"
                 subtitle="View and manage subscriptions for your team with one centralized billing."
             >
                 <AllTeams />
-            </PageWithSubMenu>
+            </PageWithSettingsSubMenu>
         </div>
     );
 }


### PR DESCRIPTION
## Description

Create and use a new `PageWithSettingsSubMenu` component to move all the many calls to `getSettingsMenu` into one place. 

Previously all the various settings pages would call `getSettingsMenu` individually to draw the menu.

This is a refactoring step towards moving all feature flags into the `FeatureFlagContext` (#11609)

## Related Issue(s)

Part of https://github.com/gitpod-io/gitpod/issues/11609.

## How to test

- [x] Settings menu in the UI still renders correctly, with and without payment enabled.

## Release Notes

```release-note
NONE
```

## Documentation


## Werft options:

- [x] /werft with-preview
