### PR TITLE
[usage] Extend server args with time-filtering

### DIFF
--- a/components/dashboard/src/teams/TeamUsage.tsx
+++ b/components/dashboard/src/teams/TeamUsage.tsx
@@ -26,6 +26,10 @@ function TeamUsage() {
     const [currentPage, setCurrentPage] = useState(1);
     const [resultsPerPage] = useState(10);
     const [errorMessage, setErrorMessage] = useState("");
+    const today = new Date();
+    const startOfCurrentMonth = new Date(today.getFullYear(), today.getMonth(), 1);
+    const timestampOfStart = startOfCurrentMonth.getTime();
+    const [startDateOfBillMonth] = useState(timestampOfStart);
 
     useEffect(() => {
         if (!team) {
@@ -34,7 +38,11 @@ function TeamUsage() {
         (async () => {
             const attributionId = AttributionId.render({ kind: "team", teamId: team.id });
             try {
-                const billedUsageResult = await getGitpodService().server.listBilledUsage(attributionId);
+                const billedUsageResult = await getGitpodService().server.listBilledUsage(
+                    attributionId,
+                    startDateOfBillMonth, // TODO: set based on selected month
+                    Date.now(), // TODO: set based on selected month
+                );
                 setBilledUsage(billedUsageResult);
             } catch (error) {
                 if (error.code === ErrorCodes.PERMISSION_DENIED) {
@@ -90,7 +98,10 @@ function TeamUsage() {
                             <div className="space-y-8 mb-6" style={{ width: "max-content" }}>
                                 <div className="flex flex-col truncate">
                                     <div className="text-base text-gray-500 truncate">Period</div>
-                                    <div className="text-lg text-gray-600 font-semibold truncate">June 2022</div>
+                                    <div className="text-lg text-gray-600 font-semibold truncate">
+                                        {startOfCurrentMonth.toLocaleString("default", { month: "long" })}{" "}
+                                        {startOfCurrentMonth.getFullYear()}
+                                    </div>
                                 </div>
                                 <div className="flex flex-col truncate">
                                     <div className="text-base text-gray-500">Total usage</div>

--- a/components/gitpod-protocol/package.json
+++ b/components/gitpod-protocol/package.json
@@ -22,6 +22,7 @@
         "@types/random-number-csprng": "^1.0.0",
         "@types/uuid": "^8.3.1",
         "@types/ws": "^5.1.2",
+        "@types/google-protobuf": "^3.15.5",
         "chai": "^4.3.4",
         "chai-subset": "^1.6.0",
         "mocha": "^5.0.0",
@@ -62,6 +63,7 @@
         "vscode-languageserver-types": "3.17.0",
         "vscode-uri": "^3.0.3",
         "vscode-ws-jsonrpc": "^0.2.0",
-        "ws": "^7.4.6"
+        "ws": "^7.4.6",
+        "google-protobuf": "^3.18.0-rc.2"
     }
 }

--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -293,7 +293,7 @@ export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, 
     getSpendingLimitForTeam(teamId: string): Promise<number | undefined>;
     setSpendingLimitForTeam(teamId: string, spendingLimit: number): Promise<void>;
 
-    listBilledUsage(attributionId: string): Promise<BillableSession[]>;
+    listBilledUsage(attributionId: string, from?: number, to?: number): Promise<BillableSession[]>;
     setUsageAttribution(usageAttribution: string): Promise<void>;
 
     /**

--- a/components/server/package.json
+++ b/components/server/package.json
@@ -99,6 +99,7 @@
     "@types/express-mysql-session": "^2.1.3",
     "@types/express-session": "1.17.4",
     "@types/fs-extra": "^9.0.12",
+    "@types/google-protobuf": "^3.15.5",
     "@types/heapdump": "^0.3.1",
     "@types/http-proxy": "^1.17.7",
     "@types/js-yaml": "^4.0.3",

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -3191,7 +3191,12 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         throw new ResponseError(ErrorCodes.SAAS_FEATURE, `Not implemented in this version`);
     }
 
-    async listBilledUsage(ctx: TraceContext, attributionId: string): Promise<BillableSession[]> {
+    async listBilledUsage(
+        ctx: TraceContext,
+        attributionId: string,
+        from?: number,
+        to?: number,
+    ): Promise<BillableSession[]> {
         throw new ResponseError(ErrorCodes.SAAS_FEATURE, `Not implemented in this version`);
     }
     async getSpendingLimitForTeam(ctx: TraceContext, teamId: string): Promise<number | undefined> {

--- a/components/usage-api/typescript/src/usage/v1/sugar.ts
+++ b/components/usage-api/typescript/src/usage/v1/sugar.ts
@@ -12,6 +12,7 @@ import { ListBilledUsageRequest, ListBilledUsageResponse } from "./usage_pb";
 import { injectable, inject, optional } from "inversify";
 import { createClientCallMetricsInterceptor, IClientCallMetrics } from "@gitpod/gitpod-protocol/lib/util/grpc";
 import * as grpc from "@grpc/grpc-js";
+import { Timestamp } from "google-protobuf/google/protobuf/timestamp_pb";
 
 export const UsageServiceClientProvider = Symbol("UsageServiceClientProvider");
 
@@ -90,12 +91,14 @@ export class PromisifiedUsageServiceClient {
         );
     }
 
-    public async listBilledUsage(_ctx: TraceContext, attributionId: string): Promise<ListBilledUsageResponse> {
+    public async listBilledUsage(_ctx: TraceContext, attributionId: string, from?: Timestamp, to?: Timestamp): Promise<ListBilledUsageResponse> {
         const ctx = TraceContext.childContext(`/usage-service/listBilledUsage`, _ctx);
 
         try {
             const req = new ListBilledUsageRequest();
             req.setAttributionId(attributionId);
+            req.setFrom(from);
+            req.setTo(to);
 
             const response = await new Promise<ListBilledUsageResponse>((resolve, reject) => {
                 this.client.listBilledUsage(


### PR DESCRIPTION
## Description
Extends the server with time-filtering args.
The client sends `number` and then it gets converted in the server to `google.protobuf.Timestamp`.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Relates #11526

## How to test
[Preview](https://laushinka-c45de4dc15.preview.gitpod-dev.com/t/gitpod/usage) still renders and calls `listBilledUsage` with the time params (the websocket connection in the network tab).

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
