### PR TITLE
[dashboard] Move usage based pricing feature flag into feature flag context

### DIFF
--- a/components/dashboard/src/Menu.tsx
+++ b/components/dashboard/src/Menu.tsx
@@ -26,7 +26,7 @@ import { ProjectContext } from "./projects/project-context";
 import { PaymentContext } from "./payment-context";
 import FeedbackFormModal from "./feedback-form/FeedbackModal";
 import { inResource, isGitpodIo } from "./utils";
-import { getExperimentsClient } from "./experiments/client";
+import { FeatureFlagContext } from "./contexts/FeatureFlagContext";
 
 interface Entry {
     title: string;
@@ -39,15 +39,9 @@ export default function Menu() {
     const { teams } = useContext(TeamsContext);
     const location = useLocation();
     const team = getCurrentTeam(location, teams);
-    const {
-        showPaymentUI,
-        setShowPaymentUI,
-        showUsageBasedUI,
-        setShowUsageBasedUI,
-        setCurrency,
-        setIsStudent,
-        setIsChargebeeCustomer,
-    } = useContext(PaymentContext);
+    const { showPaymentUI, setShowPaymentUI, setCurrency, setIsStudent, setIsChargebeeCustomer } =
+        useContext(PaymentContext);
+    const { showUsageBasedPricingUI } = useContext(FeatureFlagContext);
     const { project, setProject } = useContext(ProjectContext);
     const [isFeedbackFormVisible, setFeedbackFormVisible] = useState<boolean>(false);
 
@@ -162,26 +156,6 @@ export default function Menu() {
         ]).then((setters) => setters.forEach((s) => s()));
     }, []);
 
-    useEffect(() => {
-        if (!user) {
-            return;
-        }
-        (async () => {
-            const isUsageBasedBillingEnabled = await getExperimentsClient().getValueAsync(
-                "isUsageBasedBillingEnabled",
-                false,
-                {
-                    user,
-                    projectId: project?.id,
-                    teamId: team?.id,
-                    teamName: team?.name,
-                    teams,
-                },
-            );
-            setShowUsageBasedUI(isUsageBasedBillingEnabled);
-        })();
-    }, [user, teams, team, project]);
-
     const teamOrUserSlug = !!team ? "/t/" + team.slug : "/projects";
     const leftMenu: Entry[] = (() => {
         // Project menu
@@ -217,7 +191,7 @@ export default function Menu() {
                     link: `/t/${team.slug}/members`,
                 },
             ];
-            if (showUsageBasedUI) {
+            if (showUsageBasedPricingUI) {
                 teamSettingsList.push({
                     title: "Usage",
                     link: `/t/${team.slug}/usage`,
@@ -242,7 +216,7 @@ export default function Menu() {
             {
                 title: "Settings",
                 link: "/settings",
-                alternatives: getSettingsMenu({ showPaymentUI, showUsageBasedUI }).flatMap((e) => e.link),
+                alternatives: getSettingsMenu({ showPaymentUI, showUsageBasedPricingUI }).flatMap((e) => e.link),
             },
         ];
     })();

--- a/components/dashboard/src/index.tsx
+++ b/components/dashboard/src/index.tsx
@@ -24,23 +24,23 @@ ReactDOM.render(
     <React.StrictMode>
         <UserContextProvider>
             <AdminContextProvider>
-                <FeatureFlagContextProvider>
-                    <PaymentContextProvider>
-                        <LicenseContextProvider>
-                            <TeamsContextProvider>
-                                <ProjectContextProvider>
-                                    <ThemeContextProvider>
-                                        <StartWorkspaceModalContextProvider>
-                                            <BrowserRouter>
+                <PaymentContextProvider>
+                    <LicenseContextProvider>
+                        <TeamsContextProvider>
+                            <ProjectContextProvider>
+                                <ThemeContextProvider>
+                                    <StartWorkspaceModalContextProvider>
+                                        <BrowserRouter>
+                                            <FeatureFlagContextProvider>
                                                 <App />
-                                            </BrowserRouter>
-                                        </StartWorkspaceModalContextProvider>
-                                    </ThemeContextProvider>
-                                </ProjectContextProvider>
-                            </TeamsContextProvider>
-                        </LicenseContextProvider>
-                    </PaymentContextProvider>
-                </FeatureFlagContextProvider>
+                                            </FeatureFlagContextProvider>
+                                        </BrowserRouter>
+                                    </StartWorkspaceModalContextProvider>
+                                </ThemeContextProvider>
+                            </ProjectContextProvider>
+                        </TeamsContextProvider>
+                    </LicenseContextProvider>
+                </PaymentContextProvider>
             </AdminContextProvider>
         </UserContextProvider>
     </React.StrictMode>,

--- a/components/dashboard/src/settings/PageWithSettingsSubMenu.tsx
+++ b/components/dashboard/src/settings/PageWithSettingsSubMenu.tsx
@@ -6,6 +6,7 @@
 
 import { useContext } from "react";
 import { PageWithSubMenu } from "../components/PageWithSubMenu";
+import { FeatureFlagContext } from "../contexts/FeatureFlagContext";
 import { PaymentContext } from "../payment-context";
 import getSettingsMenu from "./settings-menu";
 
@@ -16,11 +17,12 @@ export interface PageWithAdminSubMenuProps {
 }
 
 export function PageWithSettingsSubMenu({ title, subtitle, children }: PageWithAdminSubMenuProps) {
-    const { showPaymentUI, showUsageBasedUI } = useContext(PaymentContext);
+    const { showUsageBasedPricingUI } = useContext(FeatureFlagContext);
+    const { showPaymentUI } = useContext(PaymentContext);
 
     return (
         <PageWithSubMenu
-            subMenu={getSettingsMenu({ showPaymentUI, showUsageBasedUI })}
+            subMenu={getSettingsMenu({ showPaymentUI, showUsageBasedPricingUI })}
             title={title}
             subtitle={subtitle}
         >

--- a/components/dashboard/src/settings/settings-menu.ts
+++ b/components/dashboard/src/settings/settings-menu.ts
@@ -17,7 +17,7 @@ import {
     settingsPathSSHKeys,
 } from "./settings.routes";
 
-export default function getSettingsMenu(params: { showPaymentUI?: boolean; showUsageBasedUI?: boolean }) {
+export default function getSettingsMenu(params: { showPaymentUI?: boolean; showUsageBasedPricingUI?: boolean }) {
     return [
         {
             title: "Account",
@@ -29,7 +29,7 @@ export default function getSettingsMenu(params: { showPaymentUI?: boolean; showU
         },
         ...(params.showPaymentUI
             ? [
-                  ...(params.showUsageBasedUI
+                  ...(params.showUsageBasedPricingUI
                       ? [
                             {
                                 title: "Billing",


### PR DESCRIPTION
## Description

Move the UBP feature flag into the `FeatureFlagContext`. We want to consolidate all setting of feature flags in this context.

Stacked on:
* https://github.com/gitpod-io/gitpod/pull/11610

## Related Issue(s)
Part of https://github.com/gitpod-io/gitpod/issues/11609

## How to test

- [x] Usage based billing UI is still displayed/hidden correctly according to the value of the feature flag.

## Release Notes

```release-note
NONE
```

## Documentation


## Werft options:

- [x] /werft with-preview
- [x] /werft with-payment
