### PR TITLE
[usage] Allow marshalling of VarCharTime to JSON

### DIFF
--- a/components/usage/pkg/db/types.go
+++ b/components/usage/pkg/db/types.go
@@ -92,6 +92,14 @@ func (n VarcharTime) String() string {
 	return ""
 }
 
+func (u VarcharTime) MarshalJSON() ([]byte, error) {
+	if !u.IsSet() {
+		return []byte(""), nil
+	}
+
+	return u.Time().MarshalJSON()
+}
+
 const ISO8601Format = "2006-01-02T15:04:05.000Z"
 
 func TimeToISO8601(t time.Time) string {

--- a/components/usage/pkg/db/types_test.go
+++ b/components/usage/pkg/db/types_test.go
@@ -5,6 +5,7 @@
 package db
 
 import (
+	"encoding/json"
 	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
@@ -114,4 +115,12 @@ func TestVarcharTime_String_ISO8601(t *testing.T) {
 	} {
 		require.Equal(t, scenario.Expected, scenario.Time.String())
 	}
+}
+
+func TestVarCharTime_ToJSON(t *testing.T) {
+	vt := NewVarcharTime(time.Date(2022, 7, 25, 11, 17, 23, 300, time.UTC))
+
+	serialized, err := json.Marshal(vt)
+	require.NoError(t, err)
+	require.JSONEq(t, `"2022-07-25T11:17:23.0000003Z"`, string(serialized))
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
The report generated by usage would not have properly serialized timestamps, it would come out as:
```json
{
...
"user:some-user-ID": [
        {
            "id": "1f62df2f-4248-4b5f-a947-ce9df115bc14",
            "workspaceId": "csweichel-testrepo-z4qnprx42vk",
            "ownerId": "someOwnerID",
            "projectId": {
                "String": "",
                "Valid": true
            },
            "workspaceClass": "default",
            "workspaceType": "regular",
            "usageAttributionId": "user:userAttributionID",
            "creationTime": {},
            "stoppedTime": {}
        }
    ]
}
```


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
Unit tests

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
