### PR TITLE
[usage] Make workspace class non-mandatory

### DIFF
--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -2159,7 +2159,7 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
             workspaceId: mandatory(s.getWorkspaceId()),
             instanceId: mandatory(s.getInstanceId()),
             workspaceType: mandatory(s.getWorkspaceType()) as WorkspaceType,
-            workspaceClass: mandatory(s.getWorkspaceClass()),
+            workspaceClass: s.getWorkspaceClass(),
             startTime: mandatory(s.getStartTime(), (t) => t!.toDate().toISOString()),
             endTime: s.getEndTime()?.toDate().toISOString(),
             credits: s.getCredits(), // optional


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Workspace classes look not to be stable enough to be always present on the records, see [internal conversation](https://gitpod.slack.com/archives/C02F19UUW6S/p1658744227235839)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
