### PR TITLE
[dashboard] Remove showUsageBasedUI from PaymentContext

### DIFF
--- a/components/dashboard/src/payment-context.tsx
+++ b/components/dashboard/src/payment-context.tsx
@@ -10,8 +10,6 @@ import { Currency } from "@gitpod/gitpod-protocol/lib/plans";
 const PaymentContext = createContext<{
     showPaymentUI?: boolean;
     setShowPaymentUI: React.Dispatch<boolean>;
-    showUsageBasedUI?: boolean;
-    setShowUsageBasedUI: React.Dispatch<boolean>;
     currency: Currency;
     setCurrency: React.Dispatch<Currency>;
     isStudent?: boolean;
@@ -20,7 +18,6 @@ const PaymentContext = createContext<{
     setIsChargebeeCustomer: React.Dispatch<boolean>;
 }>({
     setShowPaymentUI: () => null,
-    setShowUsageBasedUI: () => null,
     currency: "USD",
     setCurrency: () => null,
     setIsStudent: () => null,
@@ -29,7 +26,6 @@ const PaymentContext = createContext<{
 
 const PaymentContextProvider: React.FC = ({ children }) => {
     const [showPaymentUI, setShowPaymentUI] = useState<boolean>();
-    const [showUsageBasedUI, setShowUsageBasedUI] = useState<boolean>();
     const [currency, setCurrency] = useState<Currency>("USD");
     const [isStudent, setIsStudent] = useState<boolean>();
     const [isChargebeeCustomer, setIsChargebeeCustomer] = useState<boolean>();
@@ -39,8 +35,6 @@ const PaymentContextProvider: React.FC = ({ children }) => {
             value={{
                 showPaymentUI,
                 setShowPaymentUI,
-                showUsageBasedUI,
-                setShowUsageBasedUI,
                 currency,
                 setCurrency,
                 isStudent,

--- a/components/dashboard/src/teams/TeamUsage.tsx
+++ b/components/dashboard/src/teams/TeamUsage.tsx
@@ -7,7 +7,6 @@
 import { useContext, useEffect, useState } from "react";
 import { Redirect, useLocation } from "react-router";
 import { getCurrentTeam, TeamsContext } from "./teams-context";
-import { PaymentContext } from "../payment-context";
 import { getGitpodService, gitpodHostUrl } from "../service/service";
 import { BillableSession, BillableWorkspaceType } from "@gitpod/gitpod-protocol/lib/usage";
 import { AttributionId } from "@gitpod/gitpod-protocol/lib/attribution";
@@ -16,10 +15,11 @@ import moment from "moment";
 import Pagination from "../components/Pagination";
 import Header from "../components/Header";
 import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
+import { FeatureFlagContext } from "../contexts/FeatureFlagContext";
 
 function TeamUsage() {
     const { teams } = useContext(TeamsContext);
-    const { showUsageBasedUI } = useContext(PaymentContext);
+    const { showUsageBasedPricingUI } = useContext(FeatureFlagContext);
     const location = useLocation();
     const team = getCurrentTeam(location, teams);
     const [billedUsage, setBilledUsage] = useState<BillableSession[]>([]);
@@ -44,7 +44,7 @@ function TeamUsage() {
         })();
     }, [team]);
 
-    if (!showUsageBasedUI) {
+    if (!showUsageBasedPricingUI) {
         return <Redirect to="/" />;
     }
 

--- a/components/dashboard/src/teams/TeamUsageBasedBilling.tsx
+++ b/components/dashboard/src/teams/TeamUsageBasedBilling.tsx
@@ -14,6 +14,7 @@ import { ReactComponent as Spinner } from "../icons/Spinner.svg";
 import { PaymentContext } from "../payment-context";
 import { getGitpodService } from "../service/service";
 import { ThemeContext } from "../theme-context";
+import { FeatureFlagContext } from "../contexts/FeatureFlagContext";
 
 type PendingStripeSubscription = { pendingSince: number };
 
@@ -21,7 +22,8 @@ export default function TeamUsageBasedBilling() {
     const { teams } = useContext(TeamsContext);
     const location = useLocation();
     const team = getCurrentTeam(location, teams);
-    const { showUsageBasedUI, currency } = useContext(PaymentContext);
+    const { currency } = useContext(PaymentContext);
+    const { showUsageBasedPricingUI } = useContext(FeatureFlagContext);
     const [stripeSubscriptionId, setStripeSubscriptionId] = useState<string | undefined>();
     const [isLoading, setIsLoading] = useState<boolean>(true);
     const [showBillingSetupModal, setShowBillingSetupModal] = useState<boolean>(false);
@@ -135,7 +137,7 @@ export default function TeamUsageBasedBilling() {
         }
     }, [pendingStripeSubscription, pollStripeSubscriptionTimeout, stripeSubscriptionId, team]);
 
-    if (!showUsageBasedUI) {
+    if (!showUsageBasedPricingUI) {
         return <></>;
     }
 


### PR DESCRIPTION
## Description

Follow up to https://github.com/gitpod-io/gitpod/pull/11613 to clean up the `PaymentContext` and it's usages now that the feature flag is provided by the `FeatureFlagContext`.

## Related Issue(s)

Part of https://github.com/gitpod-io/gitpod/issues/11609

## How to test

Team usage view is once again visible:

<img width="1305" alt="image" src="https://user-images.githubusercontent.com/8225907/180763998-5d0a89c2-73c3-45ef-b957-fd67ed5b1071.png">

As is the widget to enable billing for a team:

<img width="1247" alt="image" src="https://user-images.githubusercontent.com/8225907/180764104-f8a5a247-95de-49a3-bfa9-f1f620eb9177.png">

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
- [x] /werft with-payment
