### PR TITLE
[usage] Fix conversion of from and to pb.Timestamp

### DIFF
--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -2110,10 +2110,10 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
         await this.guardCostCenterAccess(ctx, user.id, attributionId, "get");
 
         if (from) {
-            timestampFrom = new Timestamp().setSeconds(from);
+            timestampFrom = Timestamp.fromDate(new Date(from));
         }
         if (to) {
-            timestampTo = new Timestamp().setSeconds(to);
+            timestampTo = Timestamp.fromDate(new Date(to));
         }
         const usageClient = this.usageServiceClientProvider.getDefault();
         const response = await usageClient.listBilledUsage(ctx, attributionId, timestampFrom, timestampTo);


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Because setSeconds doesn't work the same for ts Date and pb.Timestamp

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
