### PR TITLE
[werft] support large vm

### DIFF
--- a/.werft/jobs/build/job-config.ts
+++ b/.werft/jobs/build/job-config.ts
@@ -30,6 +30,7 @@ export interface JobConfig {
     previewEnvironment: PreviewEnvironmentConfig;
     repository: Repository;
     observability: Observability;
+    withLargeVM: boolean;
 }
 
 export interface PreviewEnvironmentConfig {
@@ -89,6 +90,7 @@ export function jobConfig(werft: Werft, context: any): JobConfig {
     const installEELicense = !("without-ee-license" in buildConfig) || mainBuild;
     const withPayment = "with-payment" in buildConfig && !mainBuild;
     const withObservability = "with-observability" in buildConfig && !mainBuild;
+    const withLargeVM = "with-large-vm" in buildConfig && !mainBuild;
     const repository: Repository = {
         owner: context.Repository.owner,
         repo: context.Repository.repo,
@@ -139,6 +141,7 @@ export function jobConfig(werft: Werft, context: any): JobConfig {
         withPayment,
         withUpgradeTests,
         workspaceFeatureFlags,
+        withLargeVM,
     };
 
     werft.log("job config", JSON.stringify(jobConfig));

--- a/.werft/jobs/build/prepare.ts
+++ b/.werft/jobs/build/prepare.ts
@@ -110,7 +110,9 @@ function createVM(werft: Werft, config: JobConfig) {
     }
 
     werft.log(prepareSlices.BOOT_VM, "Creating  VM");
-    VM.startVM({ name: config.previewEnvironment.destname });
+    const cpu = config.withLargeVM ? 12 : 6;
+    const memory = config.withLargeVM ? 24 : 12;
+    VM.startVM({ name: config.previewEnvironment.destname, cpu, memory });
     werft.currentPhaseSpan.setAttribute("preview.created_vm", true);
 }
 

--- a/.werft/vm/manifests.ts
+++ b/.werft/vm/manifests.ts
@@ -19,6 +19,8 @@ type VirtualMachineManifestArguments = {
     claimName: string;
     storageClaimName: string;
     userDataSecretName: string;
+    cpu: number;
+    memory: number;
 };
 
 export function VirtualMachineManifest({
@@ -27,6 +29,8 @@ export function VirtualMachineManifest({
     claimName,
     storageClaimName,
     userDataSecretName,
+    cpu,
+    memory
 }: VirtualMachineManifestArguments) {
     return `
 apiVersion: kubevirt.io/v1
@@ -63,7 +67,7 @@ spec:
         machine:
           type: q35
         cpu:
-          cores: 6
+          cores: ${cpu}
           sockets: 1
           threads: 1
         devices:
@@ -84,8 +88,8 @@ spec:
                 bus: virtio
         resources:
           limits:
-            memory: 12Gi
-            cpu: 6
+            memory: ${memory}Gi
+            cpu: ${cpu}
       evictionStrategy: LiveMigrate
       networks:
         - pod: {}

--- a/.werft/vm/vm.ts
+++ b/.werft/vm/vm.ts
@@ -31,7 +31,7 @@ EOF
  * Start a VM
  * Does not wait for the VM to be ready.
  */
-export function startVM(options: { name: string }) {
+export function startVM(options: { name: string, cpu: number, memory: number }) {
     const namespace = `preview-${options.name}`;
     const userDataSecretName = `userdata-${options.name}`;
 
@@ -56,6 +56,8 @@ export function startVM(options: { name: string }) {
             claimName: `${options.name}-${Date.now()}`,
             storageClaimName: `${options.name}-storage-${Date.now()}`,
             userDataSecretName,
+            cpu: options.cpu,
+            memory: options.memory
         }),
         { validate: false },
     );
@@ -97,6 +99,8 @@ export function deleteVM(options: { name: string }) {
             claimName: `${options.name}-${Date.now()}`,
             storageClaimName: `${options.name}-storage-${Date.now()}`,
             userDataSecretName,
+            cpu: 0,
+            memory: 0,
         }),
     );
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
In ide integration test, we need run many workspace in the same time, this PR introduces a werft annotation `with-large-vm`, if job with this annotation, it will create a vm that use 12 cpu, and 24GB memory.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
