### PR TITLE
[preview-env] Use ceph v17.2.1 instead of latest v17

### DIFF
--- a/.werft/vm/manifests/rook-ceph/cluster-test.yaml
+++ b/.werft/vm/manifests/rook-ceph/cluster-test.yaml
@@ -28,7 +28,7 @@ metadata:
 spec:
   dataDirHostPath: /var/lib/rook
   cephVersion:
-    image: quay.io/ceph/ceph:v17
+    image: quay.io/ceph/ceph:v17.2.1
     allowUnsupported: true
   mon:
     count: 1


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
The rook-ceph-mgr-a pod keeps in CrashLoopBackOff state.
<img width="845" alt="image" src="https://user-images.githubusercontent.com/49380831/180917803-00529990-8560-4ebe-8f98-c2a458d32c39.png">

There could be something breaking with the latest ceph. So, let's stick to v17.2.1.
https://github.com/rook/rook/commit/4501cc25c6534a2fa66233812fe79f0a3382e07e

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
1. Create a preview environment
2. Check all the pods under rook-ceph namespace are in Running state
   ```console
   kubectl get pod -n rook-ceph
   ```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
None

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
