### PR TITLE
Remove the PVC object if the workspace pod is never been ready

### DIFF
--- a/components/ws-manager/pkg/manager/manager.go
+++ b/components/ws-manager/pkg/manager/manager.go
@@ -724,6 +724,23 @@ func (m *Manager) stopWorkspace(ctx context.Context, workspaceID string, gracePe
 	return nil
 }
 
+func (m *Manager) deleteWorkspacePVC(ctx context.Context, pvcName string) error {
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      pvcName,
+			Namespace: m.Config.Namespace,
+		},
+	}
+	err := m.Clientset.Delete(ctx, pvc)
+	if k8serr.IsNotFound(err) {
+		err = nil
+	}
+	if err != nil {
+		return xerrors.Errorf("cannot delete workspace pvc: %w", err)
+	}
+	return nil
+}
+
 func (m *Manager) deleteWorkspaceSecrets(ctx context.Context, podName string) error {
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{

--- a/components/ws-manager/pkg/manager/monitor.go
+++ b/components/ws-manager/pkg/manager/monitor.go
@@ -498,6 +498,11 @@ func actOnPodEvent(ctx context.Context, m actingManager, manager *Manager, statu
 					}
 				}
 
+				// delete PVC because the workspace pod is never ready
+				if err = manager.deleteWorkspacePVC(ctx, pod.Name); err != nil {
+					log.Error(err)
+					return err
+				}
 				return m.modifyFinalizer(ctx, workspaceID, gitpodFinalizerName, false)
 			} else {
 				// We start finalizing the workspace content only after the container is gone. This way we ensure there's
@@ -1183,16 +1188,10 @@ func (m *Monitor) finalizeWorkspaceContent(ctx context.Context, wso *workspaceOb
 			// backup is done and we are ready to kill the pod, mark PVC for deletion
 			if readyVolumeSnapshot && !deletedPVC {
 				// todo: once we add snapshot objects, this will be changed to create snapshot object first
-				pvcErr := m.manager.Clientset.Delete(ctx,
-					&corev1.PersistentVolumeClaim{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      pvcName,
-							Namespace: m.manager.Config.Namespace,
-						},
-					},
-				)
-				if pvcErr != nil && !k8serr.IsNotFound(pvcErr) {
-					log.WithError(pvcErr).Errorf("failed to delete pvc `%s`", pvcName)
+				err = m.manager.deleteWorkspacePVC(ctx, pvcName)
+				if err != nil {
+					log.Error(err)
+					return true, nil, err
 				}
 				deletedPVC = true
 			}

--- a/components/ws-manager/pkg/manager/status.go
+++ b/components/ws-manager/pkg/manager/status.go
@@ -349,14 +349,6 @@ func (m *Manager) extractStatusFromPod(result *api.WorkspaceStatus, wso workspac
 	if isPodBeingDeleted(pod) {
 		result.Phase = api.WorkspacePhase_STOPPING
 
-		_, podFailedBeforeBeingStopped := pod.Annotations[workspaceFailedBeforeStoppingAnnotation]
-		if podFailedBeforeBeingStopped {
-			if _, ok := pod.Annotations[workspaceNeverReadyAnnotation]; ok {
-				// The workspace is never ready, so there is no need for a stopping phase.
-				result.Phase = api.WorkspacePhase_STOPPED
-			}
-		}
-
 		var hasFinalizer bool
 		for _, f := range wso.Pod.Finalizers {
 			if f == gitpodFinalizerName {

--- a/components/ws-manager/pkg/manager/testdata/actOnPodEvent_workspace_startup_failed.golden
+++ b/components/ws-manager/pkg/manager/testdata/actOnPodEvent_workspace_startup_failed.golden
@@ -13,6 +13,19 @@
             }
         },
         {
+            "Func": "markWorkspace",
+            "Params": {
+                "annotations": [
+                    {
+                        "Name": "gitpod/explicitFail",
+                        "Value": "workspace failed to start.",
+                        "Delete": false
+                    }
+                ],
+                "workspaceID": "7b26a643-d588-4346-bc9e-b46e70831078"
+            }
+        },
+        {
             "Func": "modifyFinalizer",
             "Params": {
                 "add": false,

--- a/components/ws-manager/pkg/manager/testdata/status_workspace_startup_failed.golden
+++ b/components/ws-manager/pkg/manager/testdata/status_workspace_startup_failed.golden
@@ -20,7 +20,7 @@
             },
             "class": "default"
         },
-        "phase": 6,
+        "phase": 5,
         "conditions": {
             "volume_snapshot": {}
         },


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Remove the PVC object if the workspace pod is never been ready; we still go through the stopping phase even if the workspace is not ready. However, we don't perform backup but we just remove the finalizer in the end (and remove the PVC object if it existed).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #11635

## How to test
<!-- Provide steps to test this PR -->
I have no idea how to make the workspace pod has never been in a ready state. 🤔 
But you could use this cluster for testing this PR https://jenting-10531.preview.gitpod-dev.com/workspaces, and open the workspace ID `gitpodio-templatenix-kzpw34u`. This workspace always hits the ErrImagePull error which belongs to the workspace pod that has never been in a ready state.

<img width="594" alt="image" src="https://user-images.githubusercontent.com/49380831/180968055-61be3620-8fa6-4c48-adfd-5194a24931af.png">
<img width="400" alt="image" src="https://user-images.githubusercontent.com/49380831/180968143-01207a00-4299-4687-8dd5-d1f9fa1feb58.png">


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
None

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
