### PR TITLE
[usage] Remove pricer dependency from billing controller

### DIFF
--- a/components/usage/pkg/contentservice/client.go
+++ b/components/usage/pkg/contentservice/client.go
@@ -20,7 +20,7 @@ import (
 )
 
 type Interface interface {
-	UploadUsageReport(ctx context.Context, filename string, report map[db.AttributionID][]db.WorkspaceInstanceForUsage) error
+	UploadUsageReport(ctx context.Context, filename string, report []db.WorkspaceInstanceUsage) error
 }
 
 type Client struct {
@@ -31,7 +31,7 @@ func New(url string) *Client {
 	return &Client{url: url}
 }
 
-func (c *Client) UploadUsageReport(ctx context.Context, filename string, report map[db.AttributionID][]db.WorkspaceInstanceForUsage) error {
+func (c *Client) UploadUsageReport(ctx context.Context, filename string, report []db.WorkspaceInstanceUsage) error {
 	url, err := c.getSignedUploadUrl(ctx, filename)
 	if err != nil {
 		return fmt.Errorf("failed to obtain signed upload URL: %w", err)

--- a/components/usage/pkg/contentservice/noop.go
+++ b/components/usage/pkg/contentservice/noop.go
@@ -12,6 +12,6 @@ import (
 
 type NoOpClient struct{}
 
-func (c *NoOpClient) UploadUsageReport(ctx context.Context, filename string, report map[db.AttributionID][]db.WorkspaceInstanceForUsage) error {
+func (c *NoOpClient) UploadUsageReport(ctx context.Context, filename string, report []db.WorkspaceInstanceUsage) error {
 	return nil
 }

--- a/components/usage/pkg/controller/billing.go
+++ b/components/usage/pkg/controller/billing.go
@@ -14,29 +14,27 @@ import (
 )
 
 type BillingController interface {
-	Reconcile(ctx context.Context, now time.Time, report UsageReport) error
+	Reconcile(ctx context.Context, report UsageReport) error
 }
 
 type NoOpBillingController struct{}
 
-func (b *NoOpBillingController) Reconcile(_ context.Context, _ time.Time, _ UsageReport) error {
+func (b *NoOpBillingController) Reconcile(_ context.Context, _ UsageReport) error {
 	return nil
 }
 
 type StripeBillingController struct {
-	pricer *WorkspacePricer
-	sc     *stripe.Client
+	sc *stripe.Client
 }
 
-func NewStripeBillingController(sc *stripe.Client, pricer *WorkspacePricer) *StripeBillingController {
+func NewStripeBillingController(sc *stripe.Client) *StripeBillingController {
 	return &StripeBillingController{
-		sc:     sc,
-		pricer: pricer,
+		sc: sc,
 	}
 }
 
-func (b *StripeBillingController) Reconcile(_ context.Context, now time.Time, report UsageReport) error {
-	runtimeReport := report.CreditSummaryForTeams(b.pricer, now)
+func (b *StripeBillingController) Reconcile(_ context.Context, report UsageReport) error {
+	runtimeReport := report.CreditSummaryForTeams()
 
 	err := b.sc.UpdateUsage(runtimeReport)
 	if err != nil {

--- a/components/usage/pkg/server/server.go
+++ b/components/usage/pkg/server/server.go
@@ -65,7 +65,7 @@ func Start(cfg Config) error {
 			return fmt.Errorf("failed to initialize stripe client: %w", err)
 		}
 
-		billingController = controller.NewStripeBillingController(c, pricer)
+		billingController = controller.NewStripeBillingController(c)
 	}
 
 	schedule, err := time.ParseDuration(cfg.ControllerSchedule)


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This wasn't needed any more, as we already compute the CreditsUsed in the usage controller
This also fixes a bug where the pricer was using a different `now` timestamp to what the usage controller used.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Relates to https://github.com/gitpod-io/gitpod/issues/10785

## How to test
<!-- Provide steps to test this PR -->
Unit tests

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
