### PR TITLE
[supervisor-frontend] use beacon to send heartbeat to avoid data loss

### DIFF
--- a/components/supervisor/frontend/src/ide/gitpod-server-compatibility.ts
+++ b/components/supervisor/frontend/src/ide/gitpod-server-compatibility.ts
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { serverUrl } from '../shared/urls';
+
+const currentHost = new URL(serverUrl.toString()).hostname;
+
+export const isSaaS = currentHost === 'gitpod.io'
+
+const versionRegex = new RegExp('main\.(\\d+)')
+
+function getVersionInfo(version: string) {
+    const result = versionRegex.exec(version);
+    if (!result) {
+        return;
+    }
+    return Number(result[1]);
+}
+
+const serverVersion = (async () => {
+    const url = serverUrl.withApi({ pathname: '/version' }).toString();
+    const fetchVersion = async (retry: number) => {
+        try {
+            const resp = await fetch(url);
+            const currentVersionStr = await resp.text();
+            return getVersionInfo(currentVersionStr);
+        } catch (e) {
+            if (retry - 1 <= 0) {
+                throw e;
+            }
+            fetchVersion(retry - 1)
+        }
+    }
+    try {
+        return await fetchVersion(3)
+    } catch (e) {
+        console.error('failed to fetch server verson:', e)
+    }
+})();
+
+export async function isSaaSServerGreaterThan (version: string) {
+    if (!isSaaS) {
+        return false;
+    }
+    const serverVersionNum = await serverVersion;
+    const versionNum = getVersionInfo(version);
+    return !!serverVersionNum  && !!versionNum  && serverVersionNum >= versionNum;
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

In the current implementation of supervisor-frontend, we will send some requests before/during browser unload, which may cause some data loss since requests will be canceled after 1 second once user close the tab. 

We will move those requests to use [Navigator.sendBeacon](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/sendBeacon) to avoid data loss.

So this PR is going to add HTTP post endpoint for sendBeacon

see also https://github.com/gitpod-io/gitpod/pull/11643 and [internal chat](https://gitpod.slack.com/archives/C01KGM9BH54/p1658742853684919?thread_ts=1658720614.040559&cid=C01KGM9BH54)

👉 The first commit is cherry-picked from prev PR https://github.com/gitpod-io/gitpod/pull/11643

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

### With prepared env (part of code changed)

- Use preview env https://hw-hb-t.preview.gitpod-dev.com/workspaces which change `main` to `hw-hb-t` as SaaS verify condition
- Use desktop code as IDE
- Search chrome devTool log with `unloadListener` should only get `handleUnload.unloadListener.Beacon` according to code below
- Check with [segment](https://app.segment.com/gitpod/sources/staging_untrusted/debugger) should shown `ide_close_signal` if you close or refresh the tab

https://github.com/gitpod-io/gitpod/blob/a72f0a0873c087ee4845d78eb4e2374d0191e6cc/components/supervisor/frontend/src/ide/heart-beat.ts#L67-L83

![image](https://user-images.githubusercontent.com/20944364/182430823-8888b965-754f-4c69-8606-e389a6be8694.png)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
- [x] /werft analytics=segment|TEZnsG4QbLSxLfHfNieLYGF4cDwyFWoe
