### PR TITLE
[supervisor]: gitpod config changed analytics

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,6 +45,11 @@ repos:
 
   - repo: local
     hooks:
+      - id: generate-gitpod-config-types
+        name: generate-gitpod-config-types
+        entry: ./components/gitpod-protocol/hack/generate-config.sh
+        language: script
+        pass_filenames: false
       - id: license-header
         name: license-header
         entry: leeway run components:update-license-header

--- a/.werft/jobs/build/deploy-to-preview-environment.ts
+++ b/.werft/jobs/build/deploy-to-preview-environment.ts
@@ -334,7 +334,7 @@ async function deployToDevWithInstaller(
     }
     werft.done(installerSlices.IMAGE_PULL_SECRET);
 
-    let analytics: Analytics;
+    let analytics: Analytics | undefined;
     if ((deploymentConfig.analytics || "").startsWith("segment|")) {
         analytics = {
             type: "segment",

--- a/.werft/jobs/build/installer/post-process.sh
+++ b/.werft/jobs/build/installer/post-process.sh
@@ -276,9 +276,6 @@ while [ "$documentIndex" -le "$DOCS" ]; do
       LABEL="gitpod.io/workspace_$NODE_POOL_INDEX"
       yq w -i /tmp/"$NAME"overrides.yaml spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key "$LABEL"
       yq w -i /tmp/"$NAME"overrides.yaml spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].operator Exists
-      yq w -i /tmp/"$NAME"overrides.yaml spec.containers[+].name workspace
-      yq w -i /tmp/"$NAME"overrides.yaml "spec.containers.(name==workspace).env[+].name" GITPOD_PREVENT_METADATA_ACCESS
-      yq w -i /tmp/"$NAME"overrides.yaml "spec.containers.(name==workspace).env.(name==GITPOD_PREVENT_METADATA_ACCESS).value" "true"
 
       yq w -i k8s.yaml -d "$documentIndex" "data.[default.yaml]" -- "$(< /tmp/"$NAME"overrides.yaml)"
    fi

--- a/components/common-go/analytics/analytics.go
+++ b/components/common-go/analytics/analytics.go
@@ -41,10 +41,13 @@ type TrackMessage struct {
 func NewFromEnvironment() Writer {
 	switch os.Getenv("GITPOD_ANALYTICS_WRITER") {
 	case "log":
+		log.Debug("log analytics")
 		return &logAnalyticsWriter{}
 	case "segment":
+		log.Debug("segment analytics")
 		return &segmentAnalyticsWriter{Client: segment.New(os.Getenv("GITPOD_ANALYTICS_SEGMENT_KEY"))}
 	default:
+		log.Debug("no analytics")
 		return &noAnalyticsWriter{}
 	}
 }

--- a/components/gitpod-protocol/data/gitpod-schema.json
+++ b/components/gitpod-protocol/data/gitpod-schema.json
@@ -261,140 +261,20 @@
                     }
                 },
                 "intellij": {
-                    "type": "object",
-                    "description": "Configure IntelliJ integration",
-                    "additionalProperties": false,
-                    "properties": {
-                        "plugins": {
-                            "type": "array",
-                            "description": "List of plugins which should be installed for users of this workspace. From the JetBrains Marketplace page, find a page of the required plugin, select 'Versions' tab, click any version to copy pluginId (short name such as org.rust.lang) of the plugin you want to install.",
-                            "items": {
-                                "type": "string"
-                            }
-                        },
-                        "prebuilds": {
-                            "type": "object",
-                            "description": "Enable warming up of IntelliJ in prebuilds.",
-                            "additionalProperties": false,
-                            "properties": {
-                                "version": {
-                                    "type": "string",
-                                    "enum": [
-                                        "stable",
-                                        "latest",
-                                        "both"
-                                    ],
-                                    "description": "Whether only stable, latest or both versions should be warmed up. Default is stable only."
-                                }
-                            }
-                        },
-                        "vmoptions": {
-                            "type": "string",
-                            "description": "Configure JVM options, for instance '-Xmx=4096m'."
-                        }
-                    }
+                    "$ref": "#/definitions/jetbrainsProduct",
+                    "description": "Configure IntelliJ integration"
                 },
                 "goland": {
-                    "type": "object",
-                    "description": "Configure GoLand integration",
-                    "additionalProperties": false,
-                    "properties": {
-                        "plugins": {
-                            "type": "array",
-                            "description": "List of plugins which should be installed for users of this workspace. From the JetBrains Marketplace page, find a page of the required plugin, select 'Versions' tab, click any version to copy pluginId (short name such as org.rust.lang) of the plugin you want to install.",
-                            "items": {
-                                "type": "string"
-                            }
-                        },
-                        "prebuilds": {
-                            "type": "object",
-                            "description": "Enable warming up of GoLand in prebuilds.",
-                            "additionalProperties": false,
-                            "properties": {
-                                "version": {
-                                    "type": "string",
-                                    "enum": [
-                                        "stable",
-                                        "latest",
-                                        "both"
-                                    ],
-                                    "description": "Whether only stable, latest or both versions should be warmed up. Default is stable only."
-                                }
-                            }
-                        },
-                        "vmoptions": {
-                            "type": "string",
-                            "description": "Configure JVM options, for instance '-Xmx=4096m'."
-                        }
-                    }
+                    "$ref": "#/definitions/jetbrainsProduct",
+                    "description": "Configure GoLand integration"
                 },
                 "pycharm": {
-                    "type": "object",
-                    "description": "Configure PyCharm integration",
-                    "additionalProperties": false,
-                    "properties": {
-                        "plugins": {
-                            "type": "array",
-                            "description": "List of plugins which should be installed for users of this workspace. From the JetBrains Marketplace page, find a page of the required plugin, select 'Versions' tab, click any version to copy pluginId (short name such as org.rust.lang) of the plugin you want to install.",
-                            "items": {
-                                "type": "string"
-                            }
-                        },
-                        "prebuilds": {
-                            "type": "object",
-                            "description": "Enable warming up of PyCharm in prebuilds.",
-                            "additionalProperties": false,
-                            "properties": {
-                                "version": {
-                                    "type": "string",
-                                    "enum": [
-                                        "stable",
-                                        "latest",
-                                        "both"
-                                    ],
-                                    "description": "Whether only stable, latest or both versions should be warmed up. Default is stable only."
-                                }
-                            }
-                        },
-                        "vmoptions": {
-                            "type": "string",
-                            "description": "Configure JVM options, for instance '-Xmx=4096m'."
-                        }
-                    }
+                    "$ref": "#/definitions/jetbrainsProduct",
+                    "description": "Configure PyCharm integration"
                 },
                 "phpstorm": {
-                    "type": "object",
-                    "description": "Configure PhpStorm integration",
-                    "additionalProperties": false,
-                    "properties": {
-                        "plugins": {
-                            "type": "array",
-                            "description": "List of plugins which should be installed for users of this workspace. From the JetBrains Marketplace page, find a page of the required plugin, select 'Versions' tab, click any version to copy pluginId (short name such as org.rust.lang) of the plugin you want to install.",
-                            "items": {
-                                "type": "string"
-                            }
-                        },
-                        "prebuilds": {
-                            "type": "object",
-                            "description": "Enable warming up of PhpStorm in prebuilds.",
-                            "additionalProperties": false,
-                            "properties": {
-                                "version": {
-                                    "type": "string",
-                                    "enum": [
-                                        "stable",
-                                        "latest",
-                                        "both"
-                                    ],
-                                    "description": "Whether only stable, latest or both versions should be warmed up. Default is stable only."
-                                }
-                            }
-                        },
-                        "vmoptions": {
-                            "type": "string",
-                            "description": "Configure JVM options, for instance '-Xmx=4096m'."
-                        }
-                    }
+                    "$ref": "#/definitions/jetbrainsProduct",
+                    "description": "Configure PhpStorm integration"
                 }
             }
         },
@@ -404,5 +284,40 @@
             "description": "Experimental network configuration in workspaces (deprecated). Enabled by default"
         }
     },
-    "additionalProperties": false
+    "additionalProperties": false,
+    "definitions": {
+        "jetbrainsProduct": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "plugins": {
+                    "type": "array",
+                    "description": "List of plugins which should be installed for users of this workspace. From the JetBrains Marketplace page, find a page of the required plugin, select 'Versions' tab, click any version to copy pluginId (short name such as org.rust.lang) of the plugin you want to install.",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "prebuilds": {
+                    "type": "object",
+                    "description": "Enable warming up of JetBrains backend in prebuilds.",
+                    "additionalProperties": false,
+                    "properties": {
+                        "version": {
+                            "type": "string",
+                            "enum": [
+                                "stable",
+                                "latest",
+                                "both"
+                            ],
+                            "description": "Whether only stable, latest or both versions should be warmed up. Default is stable only."
+                        }
+                    }
+                },
+                "vmoptions": {
+                    "type": "string",
+                    "description": "Configure JVM options, for instance '-Xmx=4096m'."
+                }
+            }
+        }
+    }
 }

--- a/components/gitpod-protocol/hack/generate-config.sh
+++ b/components/gitpod-protocol/hack/generate-config.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
 
-go install -u github.com/a-h/generate/...
+COMPONENT_PATH="$(dirname "$0")/.."
+GITPOD_CONFIG_TYPE_PATH="$COMPONENT_PATH/go/gitpod-config-types.go"
 
-schema-generate -p protocol ../data/gitpod-schema.json > ../go/gitpod-config-types.go
+go install github.com/a-h/generate/...@latest
 
-sed -i 's/json:/yaml:/g' ../go/gitpod-config-types.go
-gofmt -w ../go/gitpod-config-types.go
+schema-generate -p protocol "$COMPONENT_PATH/data/gitpod-schema.json" > "$GITPOD_CONFIG_TYPE_PATH"
+
+sed -i 's/json:/yaml:/g' "$GITPOD_CONFIG_TYPE_PATH"
+gofmt -w "$GITPOD_CONFIG_TYPE_PATH"
 
 leeway run components:update-license-header

--- a/components/ide/jetbrains/image/status/main.go
+++ b/components/ide/jetbrains/image/status/main.go
@@ -368,7 +368,7 @@ func updateVMOptions(config *gitpod.GitpodConfig, alias string, content string) 
 	if config != nil {
 		productConfig := getProductConfig(config, alias)
 		if productConfig != nil {
-			projectVMOptions := strings.Fields(productConfig.VMOptions)
+			projectVMOptions := strings.Fields(productConfig.Vmoptions)
 			if len(projectVMOptions) > 0 {
 				vmoptions = deduplicateVMOption(vmoptions, projectVMOptions, filterFunc)
 			}
@@ -492,11 +492,11 @@ func parseGitpodConfig(repoRoot string) (*gitpod.GitpodConfig, error) {
 
 func getPlugins(config *gitpod.GitpodConfig, alias string) ([]string, error) {
 	var plugins []string
-	if config == nil || config.JetBrains == nil {
+	if config == nil || config.Jetbrains == nil {
 		return nil, nil
 	}
-	if config.JetBrains.Plugins != nil {
-		plugins = append(plugins, config.JetBrains.Plugins...)
+	if config.Jetbrains.Plugins != nil {
+		plugins = append(plugins, config.Jetbrains.Plugins...)
 	}
 	productConfig := getProductConfig(config, alias)
 	if productConfig != nil && productConfig.Plugins != nil {
@@ -505,16 +505,16 @@ func getPlugins(config *gitpod.GitpodConfig, alias string) ([]string, error) {
 	return plugins, nil
 }
 
-func getProductConfig(config *gitpod.GitpodConfig, alias string) *gitpod.JetBrainsProduct {
+func getProductConfig(config *gitpod.GitpodConfig, alias string) *gitpod.JetbrainsProduct {
 	defer func() {
 		if err := recover(); err != nil {
 			log.WithField("error", err).WithField("alias", alias).Error("failed to extract JB product config")
 		}
 	}()
-	v := reflect.ValueOf(*config.JetBrains).FieldByNameFunc(func(s string) bool {
+	v := reflect.ValueOf(*config.Jetbrains).FieldByNameFunc(func(s string) bool {
 		return strings.ToLower(s) == alias
 	}).Interface()
-	productConfig, ok := v.(*gitpod.JetBrainsProduct)
+	productConfig, ok := v.(*gitpod.JetbrainsProduct)
 	if !ok {
 		return nil
 	}

--- a/components/ide/jetbrains/image/status/main_test.go
+++ b/components/ide/jetbrains/image/status/main_test.go
@@ -15,10 +15,10 @@ import (
 )
 
 func TestGetProductConfig(t *testing.T) {
-	expectation := &protocol.JetBrainsProduct{}
+	expectation := &protocol.JetbrainsProduct{}
 	actual := getProductConfig(&protocol.GitpodConfig{
-		JetBrains: &protocol.JetBrains{
-			IntelliJ: expectation,
+		Jetbrains: &protocol.Jetbrains{
+			Intellij: expectation,
 		},
 	}, "intellij")
 
@@ -29,10 +29,10 @@ func TestGetProductConfig(t *testing.T) {
 
 func TestParseGitpodConfig(t *testing.T) {
 	gitpodConfig, _ := parseGitpodConfig("testdata")
-	assert.Equal(t, 1, len(gitpodConfig.JetBrains.IntelliJ.Plugins))
-	assert.Equal(t, "both", gitpodConfig.JetBrains.IntelliJ.Prebuilds.Version)
-	assert.Equal(t, "-Xmx3g", gitpodConfig.JetBrains.IntelliJ.VMOptions)
-	assert.Equal(t, "-Xmx4096m -XX:MaxRAMPercentage=75", gitpodConfig.JetBrains.GoLand.VMOptions)
+	assert.Equal(t, 1, len(gitpodConfig.Jetbrains.Intellij.Plugins))
+	assert.Equal(t, "both", gitpodConfig.Jetbrains.Intellij.Prebuilds.Version)
+	assert.Equal(t, "-Xmx3g", gitpodConfig.Jetbrains.Intellij.Vmoptions)
+	assert.Equal(t, "-Xmx4096m -XX:MaxRAMPercentage=75", gitpodConfig.Jetbrains.Goland.Vmoptions)
 }
 
 func TestUpdateVMOptions(t *testing.T) {

--- a/components/supervisor/cmd/run.go
+++ b/components/supervisor/cmd/run.go
@@ -5,6 +5,8 @@
 package cmd
 
 import (
+	"os"
+
 	"github.com/spf13/cobra"
 
 	common_grpc "github.com/gitpod-io/gitpod/common-go/grpc"
@@ -21,7 +23,7 @@ var runCmd = &cobra.Command{
 	Short: "starts the supervisor",
 
 	Run: func(cmd *cobra.Command, args []string) {
-		log.Init(ServiceName, Version, true, false)
+		log.Init(ServiceName, Version, true, os.Getenv("SUPERVISOR_DEBUG_ENABLE") == "true")
 		common_grpc.SetupLogging()
 		supervisor.Version = Version
 		supervisor.Run(supervisor.WithRunGP(runOpts.RunGP))

--- a/components/supervisor/pkg/config/gitpod-config-analytics.go
+++ b/components/supervisor/pkg/config/gitpod-config-analytics.go
@@ -1,0 +1,156 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package config
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"sync"
+	"time"
+
+	gitpod "github.com/gitpod-io/gitpod/gitpod-protocol"
+	"github.com/sirupsen/logrus"
+)
+
+var emptyConfig = &gitpod.GitpodConfig{}
+
+type ConfigAnalyzer struct {
+	log    *logrus.Entry
+	report func(field string)
+	delay  time.Duration
+	prev   *gitpod.GitpodConfig
+	timer  *time.Timer
+	mu     sync.RWMutex
+}
+
+func NewConfigAnalyzer(
+	log *logrus.Entry,
+	delay time.Duration,
+	report func(field string),
+	initial *gitpod.GitpodConfig,
+) *ConfigAnalyzer {
+	prev := emptyConfig
+	if initial != nil {
+		prev = initial
+	}
+	log.WithField("initial", prev).Debug("gitpod config analytics: initialized")
+	return &ConfigAnalyzer{
+		log:    log,
+		delay:  delay,
+		report: report,
+		prev:   prev,
+	}
+}
+
+func (a *ConfigAnalyzer) Analyse(cfg *gitpod.GitpodConfig) <-chan struct{} {
+	current := emptyConfig
+	if cfg != nil {
+		current = cfg
+	}
+
+	a.log.Debug("gitpod config analytics: scheduling")
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if a.timer != nil && !a.timer.Stop() {
+		a.log.WithField("cfg", current).Debug("gitpod config analytics: cancelled")
+		<-a.timer.C
+	}
+
+	done := make(chan struct{})
+	a.timer = time.AfterFunc(a.delay, func() {
+		a.mu.Lock()
+		defer a.mu.Unlock()
+		a.process(current)
+		a.timer = nil
+		close(done)
+	})
+	return done
+}
+
+func (a *ConfigAnalyzer) process(current *gitpod.GitpodConfig) {
+	a.log.Debug("gitpod config analytics: processing")
+
+	fields := a.computeFields(a.prev, current)
+	for _, field := range fields {
+		if a.diffByField(a.prev, current, field) {
+			a.report(field)
+		}
+	}
+
+	a.log.WithField("current", current).
+		WithField("prev", a.prev).
+		WithField("fields", fields).
+		Debug("gitpod config analytics: processed")
+
+	a.prev = current
+}
+
+func (a *ConfigAnalyzer) computeFields(configs ...*gitpod.GitpodConfig) []string {
+	defer func() {
+		if err := recover(); err != nil {
+			a.log.WithField("error", err).Error("gitpod config analytics: failed to compute gitpod config fields")
+		}
+	}()
+	var fields []string
+	uniqueKeys := make(map[string]struct{})
+	for _, cfg := range configs {
+		if cfg == nil {
+			continue
+		}
+		cfgType := reflect.ValueOf(*cfg).Type()
+		if cfgType.Kind() == reflect.Struct {
+			for i := 0; i < cfgType.NumField(); i++ {
+				Name := cfgType.Field(i).Name
+				_, seen := uniqueKeys[Name]
+				if !seen {
+					uniqueKeys[Name] = struct{}{}
+					fields = append(fields, Name)
+				}
+			}
+		}
+	}
+	return fields
+}
+
+func (a *ConfigAnalyzer) valueByField(config *gitpod.GitpodConfig, field string) interface{} {
+	defer func() {
+		if err := recover(); err != nil {
+			a.log.WithField("error", err).WithField("field", field).Error("gitpod config analytics: failed to retrieve value from gitpod config")
+		}
+	}()
+	if config == nil {
+		return nil
+	}
+	return reflect.ValueOf(*config).FieldByName(field).Interface()
+}
+
+func (a *ConfigAnalyzer) computeHash(i interface{}) (string, error) {
+	b, err := json.Marshal(i)
+	if err != nil {
+		return "", err
+	}
+	h := sha256.New()
+	_, err = h.Write(b)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%x", h.Sum(nil)), nil
+}
+
+func (a *ConfigAnalyzer) diffByField(prev *gitpod.GitpodConfig, current *gitpod.GitpodConfig, field string) bool {
+	defer func() {
+		if err := recover(); err != nil {
+			a.log.WithField("error", err).WithField("field", field).Error("gitpod config analytics: failed to compare gitpod configs")
+		}
+	}()
+	prevValue := a.valueByField(prev, field)
+	prevHash, _ := a.computeHash(prevValue)
+	currentValue := a.valueByField(current, field)
+	currHash, _ := a.computeHash(currentValue)
+	return prevHash != currHash
+}

--- a/components/supervisor/pkg/config/gitpod-config_analytics_test.go
+++ b/components/supervisor/pkg/config/gitpod-config_analytics_test.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package config
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+
+	gitpod "github.com/gitpod-io/gitpod/gitpod-protocol"
+)
+
+func TestAnalyzeGitpodConfig(t *testing.T) {
+	tests := []struct {
+		Desc    string
+		Prev    *gitpod.GitpodConfig
+		Current *gitpod.GitpodConfig
+		Fields  []string
+	}{
+		{
+			Desc: "change",
+			Prev: &gitpod.GitpodConfig{
+				CheckoutLocation: "foo",
+			},
+			Current: &gitpod.GitpodConfig{
+				CheckoutLocation: "bar",
+			},
+			Fields: []string{"CheckoutLocation"},
+		},
+		{
+			Desc: "add",
+			Prev: &gitpod.GitpodConfig{},
+			Current: &gitpod.GitpodConfig{
+				CheckoutLocation: "bar",
+			},
+			Fields: []string{"CheckoutLocation"},
+		},
+		{
+			Desc: "remove",
+			Prev: &gitpod.GitpodConfig{
+				CheckoutLocation: "bar",
+			},
+			Current: &gitpod.GitpodConfig{},
+			Fields:  []string{"CheckoutLocation"},
+		},
+		{
+			Desc: "none",
+			Prev: &gitpod.GitpodConfig{
+				CheckoutLocation: "bar",
+			},
+			Current: &gitpod.GitpodConfig{
+				CheckoutLocation: "bar",
+			},
+			Fields: nil,
+		},
+		{
+			Desc:    "fie created",
+			Current: &gitpod.GitpodConfig{},
+			Fields:  nil,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.Desc, func(t *testing.T) {
+			var fields []string
+			analyzer := NewConfigAnalyzer(log, 100*time.Millisecond, func(field string) {
+				fields = append(fields, field)
+			}, test.Prev)
+			<-analyzer.Analyse(test.Current)
+			if diff := cmp.Diff(test.Fields, fields); diff != "" {
+				t.Errorf("unexpected output (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This PR adds analytics for .gitpod.yml changes. We are track when changes are persisted to a disk and debounce them for 5s. After last change we analyse changes to top-level elements and report an event for each. It allows us to gain insights in what users are changing on top-level, e.g `ports` or `tasks`,   and avoid a lot of traffic at the same time. Later we can do more fine grained analysis to see which object properties, like `ports.name`.

I had to resolve couple issues which were discovered during review or were blocking testing:
- enable analytics env inside workspace in preview environments to verify with segment
- don't fire change events for syntactically broken .gitpod.yml files, thank you @andreafalzetti for noticing it
- adding git hook which keeps goland types up to date with gitpod schema, otherwise we will miss new properties, thank you @mustard-mh for brining forward that yaml parser only see properties which are defined in goland

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/6894

## How to test
<!-- Provide steps to test this PR -->

- Open staging untrusted.
- Start a workspace, open .gitpod.yml yet, wait for 5s.
- You should not yet see any `gitpod_config_changed` events.
- Now edit .gitpoy.yml, then you finish wait for 5s.
- Now you should see `gitpod_config_changed` events.
- Edit .gitpod.yml to add some syntax errors and semantic changes, then you finish wait for 5s.
- You should not yet see any `gitpod_config_changed` events.
- Edit .gitpod.yml to fix syntax errors, then you finish wait for 5s.
- Now you should see `gitpod_config_changed` events for semantic changes.

Check for regressions:
- Add new ports and check there are detected in the ports view.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
- [x] /werft analytics=segment|TEZnsG4QbLSxLfHfNieLYGF4cDwyFWoe