### PR TITLE
Route GitpodWorkspaceStuckOnStarting to #t_workspace_alerts

### DIFF
--- a/operations/observability/mixins/workspace/rules/components/workspaces/alerts.libsonnet
+++ b/operations/observability/mixins/workspace/rules/components/workspaces/alerts.libsonnet
@@ -12,7 +12,8 @@
           {
             alert: 'GitpodWorkspaceStuckOnStarting',
             labels: {
-              severity: 'critical',
+              severity: 'warning',
+              team: 'workspace',
             },
             'for': '20m',
             annotations: {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Updates `GitpodWorkspaceStuckOnStarting` to #t_workspace_alerts.

Since alerts with no user impact should never go to PagerDuty, what is written in the runbook is already clear enough:
* [This issue has little to no user impact, but will result in on-call being paged regularly due to stuck nodes.](https://github.com/gitpod-io/runbooks/blob/e24540d28700262a4b8e8331640c1d2cea449c02/runbooks/GitpodWorkspaceStuckOnStarting.md?plain=1#L26)

Hey @kylos101, I'm coming back to your suggestion to re-classify the alert to something less severe.
https://github.com/gitpod-io/runbooks/pull/373#discussion_r929248324

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
