### PR TITLE
Automatically create Pull Requests for updating the Platform Version from JetBrains Plugins when available

### DIFF
--- a/.github/workflows/jetbrains-update-plugin-platform-template.yml
+++ b/.github/workflows/jetbrains-update-plugin-platform-template.yml
@@ -1,0 +1,130 @@
+on:
+    workflow_call:
+        inputs:
+            pluginName:
+                description: Name of the plugin.
+                type: string
+                required: true
+            pluginId:
+                description: ID of the plugin in lowercase and without spaces.
+                type: string
+                required: true
+            xpath:
+                description: Xpath for the latest platform version in https://www.jetbrains.com/intellij-repository/snapshots
+                type: string
+                required: true
+            gradlePropertiesPath:
+                description: Path for the gradle.properties file of the plugin.
+                type: string
+                required: true
+        secrets:
+            slackWebhook:
+                required: true
+jobs:
+    update-plugin-platform:
+        name: Update Platform Version from ${{ inputs.pluginName }}
+        runs-on: ubuntu-latest
+        env:
+            SNAPSHOTS_HTML_FILENAME: snapshots.html
+        steps:
+            - name: Checkout Repository
+              uses: actions/checkout@v3
+            - name: Save the snapshots page to an HTML file
+              run: curl -sL https://www.jetbrains.com/intellij-repository/snapshots > ${{ env.SNAPSHOTS_HTML_FILENAME }}
+            - name: Get Current Platform Version
+              id: current-version
+              run: |
+                  CURRENT_VERSION=$(cat ${{ inputs.gradlePropertiesPath }} | grep platformVersion= | sed 's/platformVersion=//')
+                  echo "::set-output name=result::$CURRENT_VERSION"
+            - name: Extract Major Version from Current Platform Version
+              id: major-version
+              run: |
+                  MAJOR_VERSION=$(cut -c 1-3 <<< ${{ steps.current-version.outputs.result }})
+                  echo "Major Version from Current Platform Version: $MAJOR_VERSION"
+                  echo "::set-output name=result::$MAJOR_VERSION"
+            - name: Replace Major Version Placeholder
+              id: update-xpath
+              run: |
+                  UPDATED_XPATH=$(echo "${{ inputs.xpath }}" | sed 's/MAJOR_VERSION_PLACEHOLDER/${{ steps.major-version.outputs.result }}/')
+                  echo "Updated xpath: $UPDATED_XPATH"
+                  echo "::set-output name=result::$UPDATED_XPATH"
+            - name: Get Latest Platform Version
+              uses: QwerMike/xpath-action@v1
+              id: latest-version
+              with:
+                  filename: ${{ env.SNAPSHOTS_HTML_FILENAME }}
+                  expression: ${{ steps.update-xpath.outputs.result }}
+            - run: rm ${{ env.SNAPSHOTS_HTML_FILENAME }}
+            - name: Print Result
+              run: |
+                  echo "Current platform version: ${{ steps.current-version.outputs.result }}"
+                  echo "Latest platform version:  ${{ steps.latest-version.outputs.result }}"
+            - name: Update ${{ inputs.gradlePropertiesPath }}
+              if: ${{ steps.latest-version.outputs.result != steps.current-version.outputs.result }}
+              run: |
+                  sed -i 's/platformVersion=${{ steps.current-version.outputs.result }}/platformVersion=${{ steps.latest-version.outputs.result }}/' ${{ inputs.gradlePropertiesPath }}
+                  git diff
+            - name: Create Pull Request for Gateway Plugin
+              if: ${{ inputs.pluginId == 'gateway-plugin' && steps.latest-version.outputs.result != steps.current-version.outputs.result }}
+              uses: peter-evans/create-pull-request@v4
+              with:
+                  title: "Update Platform Version from ${{ inputs.pluginName }}"
+                  body: |
+                      ## Description
+                      This PR updates the Platform Version from ${{ inputs.pluginName }} to the latest version.
+
+                      ## How to test
+                      1. Ensure you have the [latest JetBrains Gateway](https://www.jetbrains.com/remote-development/gateway/) installed.
+                      2. Download the plugin build related to this branch in [Dev Versions](https://plugins.jetbrains.com/plugin/18438-gitpod-gateway/versions/dev), and install it on the Gateway following [these instructions](https://www.jetbrains.com/help/idea/managing-plugins.html#install_plugin_from_disk).
+                      3. Change the "Gitpod Host" (in JetBrains Gateway Preferences >> Tools >> Gitpod) to the preview environment hostname, so you can see the list of workspaces running on it.
+                      4. Create a new workspace from JetBrains Gateway (it's ok to use the pre-selected IDE and Repository) and confirm if JetBrains Client can connect to it.
+
+                      ## Release Notes
+                      ```release-note
+                      NONE
+                      ```
+
+                      ## Werft options:
+                      - [ ] /werft with-preview
+
+                      _This PR was created automatically with GitHub Actions using [this](https://github.com/gitpod-io/gitpod/blob/main/.github/workflows/jetbrains-update-plugin-platform-template.yml) template._
+                  commit-message: "Update Platform Version of ${{ inputs.pluginName }} to ${{ steps.latest-version.outputs.version }}"
+                  branch: "jetbrains/update-${{ inputs.pluginId }}-platform-version-to-${{ steps.latest-version.outputs.version }}"
+                  labels: "team: IDE"
+                  team-reviewers: "engineering-ide"
+            - name: Create Pull Request for Backend Plugin
+              if: ${{ inputs.pluginId == 'backend-plugin' && steps.latest-version.outputs.result != steps.current-version.outputs.result }}
+              uses: peter-evans/create-pull-request@v4
+              with:
+                  title: "Update Platform Version from ${{ inputs.pluginName }}"
+                  body: |
+                      ## Description
+                      This PR updates the Platform Version from ${{ inputs.pluginName }} to the latest version.
+
+                      ## How to test
+                      1. Open the preview environment generated for this branch
+                      2. Choose the stable version of IntelliJ IDEA as your preferred editor
+                      3. Start a workspace using this repository: https://github.com/gitpod-io/spring-petclinic
+                      4. Verify that the workspace starts successfully
+                      5. Verify that the IDE opens successfully
+
+                      ## Release Notes
+                      ```release-note
+                      NONE
+                      ```
+
+                      ## Werft options:
+                      - [x] /werft with-preview
+
+                      _This PR was created automatically with GitHub Actions using [this](https://github.com/gitpod-io/gitpod/blob/main/.github/workflows/jetbrains-update-plugin-platform-template.yml) template._
+                  commit-message: "Update Platform Version of ${{ inputs.pluginName }} to ${{ steps.latest-version.outputs.version }}"
+                  branch: "jetbrains/update-${{ inputs.pluginId }}-platform-version-to-${{ steps.latest-version.outputs.version }}"
+                  labels: "team: IDE"
+                  team-reviewers: "engineering-ide"
+            - name: Slack Notification
+              if: always()
+              uses: rtCamp/action-slack-notify@v2
+              env:
+                  SLACK_WEBHOOK: ${{ secrets.slackWebhook }}
+                  SLACK_COLOR: ${{ job.status }}
+                  SLACK_TITLE: ${{ inputs.productName }}

--- a/.github/workflows/jetbrains-update-plugin-platform.yml
+++ b/.github/workflows/jetbrains-update-plugin-platform.yml
@@ -1,0 +1,25 @@
+name: JB Plugins Platform Update
+on:
+    workflow_dispatch:
+    schedule:
+        # At 11:00 on every day-of-week from Monday through Friday.
+        - cron: "0 11 * * 1-5"
+jobs:
+    update-backend-plugin-platform:
+        uses: ./.github/workflows/jetbrains-update-plugin-platform-template.yml
+        with:
+            pluginName: JetBrains Backend Plugin
+            pluginId: backend-plugin
+            xpath: "(/html/body/table[preceding::h2/text()='com.jetbrains.intellij.idea'][1]/tbody/tr/td[contains(text(),'-EAP-CANDIDATE-SNAPSHOT') and starts-with(text(),'MAJOR_VERSION_PLACEHOLDER')]/text())[1]"
+            gradlePropertiesPath: components/ide/jetbrains/backend-plugin/gradle-latest.properties
+        secrets:
+            slackWebhook: ${{ secrets.IDE_SLACK_WEBHOOK }}
+    update-gateway-plugin-platform:
+        uses: ./.github/workflows/jetbrains-update-plugin-platform-template.yml
+        with:
+            pluginName: JetBrains Gateway Plugin
+            pluginId: gateway-plugin
+            xpath: "(/html/body/table[preceding::h2/text()='com.jetbrains.gateway'][1]/tbody/tr/td[contains(text(),'-CUSTOM-SNAPSHOT') and starts-with(text(),'MAJOR_VERSION_PLACEHOLDER') and not(contains(text(),'-NIGHTLY'))]/text())[1]"
+            gradlePropertiesPath: components/ide/jetbrains/gateway-plugin/gradle.properties
+        secrets:
+            slackWebhook: ${{ secrets.IDE_SLACK_WEBHOOK }}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Add a GitHub Action that runs every day checking if there's some update the Platform Version from JetBrains Plugins. If so, it create a Pull Request.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Resolves #11120

## How to test
<!-- Provide steps to test this PR -->
- It won't be able to be tested manually, but I've ran it once by setting it to run on this PR, and from it we can see it's working as expected: When the version is up to date, nothing happens, but if it's outdated, a PR will be created:
  - https://github.com/gitpod-io/gitpod/runs/7546306836?check_suite_focus=true
    <img width="580" alt="image" src="https://user-images.githubusercontent.com/418083/181342931-f2c50e53-ab00-47db-b1b5-463cc9b2c246.png">
  - https://github.com/gitpod-io/gitpod/runs/7546306657?check_suite_focus=true (You can ignore the red icon in this case, as it just failed because it can't create a PR from another PR without specific configuration)
    <img width="564" alt="image" src="https://user-images.githubusercontent.com/418083/181343093-b75f8fa9-5c1b-4214-ae93-c30e2cb0453d.png">
- But you can read the PR changes and confirm if the code looks good.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
None.

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
