### PR TITLE
[usage] stripe.UpdateUsage uses context

### DIFF
--- a/components/usage/pkg/controller/billing.go
+++ b/components/usage/pkg/controller/billing.go
@@ -33,10 +33,10 @@ func NewStripeBillingController(sc *stripe.Client) *StripeBillingController {
 	}
 }
 
-func (b *StripeBillingController) Reconcile(_ context.Context, report UsageReport) error {
+func (b *StripeBillingController) Reconcile(ctx context.Context, report UsageReport) error {
 	runtimeReport := report.CreditSummaryForTeams()
 
-	err := b.sc.UpdateUsage(runtimeReport)
+	err := b.sc.UpdateUsage(ctx, runtimeReport)
 	if err != nil {
 		return fmt.Errorf("failed to update usage: %w", err)
 	}

--- a/components/usage/pkg/stripe/stripe.go
+++ b/components/usage/pkg/stripe/stripe.go
@@ -5,6 +5,7 @@
 package stripe
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -46,7 +47,7 @@ func New(config ClientConfig) (*Client, error) {
 
 // UpdateUsage updates teams' Stripe subscriptions with usage data
 // `usageForTeam` is a map from team name to total workspace seconds used within a billing period.
-func (c *Client) UpdateUsage(creditsPerTeam map[string]int64) error {
+func (c *Client) UpdateUsage(ctx context.Context, creditsPerTeam map[string]int64) error {
 	teamIds := make([]string, 0, len(creditsPerTeam))
 	for k := range creditsPerTeam {
 		teamIds = append(teamIds, k)
@@ -57,8 +58,9 @@ func (c *Client) UpdateUsage(creditsPerTeam map[string]int64) error {
 		log.Infof("about to make query %q", query)
 		params := &stripe.CustomerSearchParams{
 			SearchParams: stripe.SearchParams{
-				Query:  query,
-				Expand: []*string{stripe.String("data.subscriptions")},
+				Query:   query,
+				Expand:  []*string{stripe.String("data.subscriptions")},
+				Context: ctx,
 			},
 		}
 		iter := c.sc.Customers.Search(params)


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Propagating context ensures that requests get cancelled when the parent context is cancelled, and generally help with tracing. They are a standard golang practice.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
