### PR TITLE
[ws-daemon] Fix wait until workspace is stop

### DIFF
--- a/components/ws-daemon/pkg/dispatch/dispatch.go
+++ b/components/ws-daemon/pkg/dispatch/dispatch.go
@@ -234,7 +234,7 @@ func (d *Dispatch) handlePodUpdate(oldPod, newPod *corev1.Pod) {
 		go func() {
 			// no matter if the container was deleted or not - we've lost our guard that was waiting for that to happen.
 			// Hence, we must stop listening for it to come into existence and cancel the context.
-			err := d.Runtime.WaitForContainerStop(waitForPodCtx, workspaceInstanceID)
+			err := d.Runtime.WaitForContainerStop(context.Background(), workspaceInstanceID)
 			if err != nil && !errors.Is(err, context.DeadlineExceeded) {
 				log.WithError(err).WithFields(owi).Error("unexpected waiting for container to stop")
 			}


### PR DESCRIPTION
## Description

Use a background context instead one with a timeout. We cannot rely on a fixed time to wait for the disposal of the workspace.

![Screenshot from 2022-07-26 20-01-27](https://user-images.githubusercontent.com/161571/181132910-e5f7af02-f105-4259-bc2a-caa13e37c05d.png)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
