### PR TITLE
[registry] allow insecure TLS for self signed cert

### DIFF
--- a/components/image-builder-api/go/config/config.go
+++ b/components/image-builder-api/go/config/config.go
@@ -82,6 +82,9 @@ type Configuration struct {
 
 	// BuilderImage is an image ref to the workspace builder image
 	BuilderImage string `json:"builderImage"`
+
+	// SkipTLSVerify skips TLS verification in case if using self-signed certificate.
+	SkipTLSVerify bool `json:"skipTLSVerify,omitempty"`
 }
 
 type TLS struct {

--- a/components/image-builder-mk3/pkg/orchestrator/orchestrator.go
+++ b/components/image-builder-mk3/pkg/orchestrator/orchestrator.go
@@ -111,7 +111,7 @@ func NewOrchestratingBuilder(cfg config.Configuration) (res *Orchestrator, err e
 		censorship:    make(map[string][]string),
 		metrics:       newMetrics(),
 	}
-	o.monitor = newBuildMonitor(o, o.wsman)
+	o.monitor = newBuildMonitor(o, o.wsman, cfg.SkipTLSVerify)
 
 	return o, nil
 }
@@ -535,7 +535,7 @@ func (o *Orchestrator) checkImageExists(ctx context.Context, ref string, authent
 	defer tracing.FinishSpan(span, &err)
 	span.SetTag("ref", ref)
 
-	_, err = o.RefResolver.Resolve(ctx, ref, resolve.WithAuthentication(authentication))
+	_, err = o.RefResolver.Resolve(ctx, ref, resolve.WithAuthentication(authentication), resolve.WithSkipTLSVerify(o.Config.SkipTLSVerify))
 	if errors.Is(err, resolve.ErrNotFound) {
 		return false, nil
 	}
@@ -556,7 +556,7 @@ func (o *Orchestrator) getAbsoluteImageRef(ctx context.Context, ref string, allo
 		return "", status.Errorf(codes.InvalidArgument, "cannt resolve base image ref: %v", err)
 	}
 
-	ref, err = o.RefResolver.Resolve(ctx, ref, resolve.WithAuthentication(auth))
+	ref, err = o.RefResolver.Resolve(ctx, ref, resolve.WithAuthentication(auth), resolve.WithSkipTLSVerify(o.Config.SkipTLSVerify))
 	if xerrors.Is(err, resolve.ErrNotFound) {
 		return "", status.Error(codes.NotFound, "cannot resolve image")
 	}

--- a/install/installer/pkg/components/image-builder-mk3/configmap.go
+++ b/install/installer/pkg/components/image-builder-mk3/configmap.go
@@ -51,6 +51,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		BaseImageRepository:      fmt.Sprintf("%s/base-images", registryName),
 		BuilderImage:             ctx.ImageName(ctx.Config.Repository, BuilderImage, ctx.VersionManifest.Components.ImageBuilderMk3.BuilderImage.Version),
 		WorkspaceImageRepository: fmt.Sprintf("%s/workspace-images", registryName),
+		SkipTLSVerify:            pointer.BoolDeref(ctx.Config.ContainerRegistry.SkipTLSVerify, false),
 	}
 
 	imgcfg := config.ServiceConfig{

--- a/install/installer/pkg/config/v1/config.go
+++ b/install/installer/pkg/config/v1/config.go
@@ -269,6 +269,7 @@ type ContainerRegistry struct {
 	External                  *ContainerRegistryExternal `json:"external,omitempty" validate:"required_if=InCluster false"`
 	S3Storage                 *S3Storage                 `json:"s3storage,omitempty"`
 	PrivateBaseImageAllowList []string                   `json:"privateBaseImageAllowList"`
+	SkipTLSVerify             *bool                      `json:"skipTLSVerify,omitempty"`
 }
 
 type ContainerRegistryExternal struct {

--- a/install/kots/manifests/gitpod-installation-status.yaml
+++ b/install/kots/manifests/gitpod-installation-status.yaml
@@ -30,7 +30,7 @@ spec:
       containers:
         - name: installation-status
           # This will normally be the release tag
-          image: "eu.gcr.io/gitpod-core-dev/build/installer:nvn-fix-11408.15"
+          image: "eu.gcr.io/gitpod-core-dev/build/installer:pavel-11005.7"
           command:
             - /bin/sh
             - -c

--- a/install/kots/manifests/gitpod-installer-job.yaml
+++ b/install/kots/manifests/gitpod-installer-job.yaml
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: installer
           # This will normally be the release tag
-          image: "eu.gcr.io/gitpod-core-dev/build/installer:nvn-fix-11408.15"
+          image: "eu.gcr.io/gitpod-core-dev/build/installer:pavel-11005.7"
           volumeMounts:
             - mountPath: /config-patch
               name: config-patch
@@ -242,11 +242,13 @@ spec:
                 echo "Gitpod: Generating a self-signed certificate with the internal CA"
                 yq e -i '.customCACert.kind = "secret"' "${CONFIG_FILE}"
                 yq e -i '.customCACert.name = "ca-issuer-ca"' "${CONFIG_FILE}"
+                yq e -i '.containerRegistry.skipTLSVerify = true' "${CONFIG_FILE}"
               elif [ '{{repl and (ConfigOptionEquals "tls_self_signed_enabled" "0") (ConfigOptionEquals "cert_manager_enabled" "0") (ConfigOptionNotEquals "tls_ca_crt" "") }}' = "true" ];
               then
                 echo "Gitpod: Setting CA to be used for certificate"
                 yq e -i '.customCACert.kind = "secret"' "${CONFIG_FILE}"
                 yq e -i '.customCACert.name = "ca-certificate"' "${CONFIG_FILE}"
+                yq e -i '.containerRegistry.skipTLSVerify = true' "${CONFIG_FILE}"
               fi
 
               if [ '{{repl ConfigOptionEquals "user_management_block_enabled" "1" }}' = "true" ];


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Allows registry and image builder to use insecure TLS when using self signed certs whose CA cannot be verified.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #11005 

## How to test
<!-- Provide steps to test this PR -->
Update your installer.yaml with:
Specify valid 'customCACert` field in your installer yaml file, as well as:
```
containerRegistry:
  skipTLSVerify: true
```
Deploy your gitpod and verify that it is using self signed cert and that you are able to open the workspace, see image builder logs, and workspace can be shutdown. 
(you might need to wrangle with your browser to let it use insecure site)

## How I tested
Using workspace preview environment, I deployed gitpod using self signed cert (via cert manager) and verified that above test instructions succeed.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[registry] allow to use insecure TLS for self signed certs
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
