### PR TITLE
Check the pod label to determine the PVC feature flag is set

### DIFF
--- a/components/ws-manager/pkg/manager/create.go
+++ b/components/ws-manager/pkg/manager/create.go
@@ -29,6 +29,7 @@ import (
 	"github.com/gitpod-io/gitpod/common-go/kubernetes"
 	wsk8s "github.com/gitpod-io/gitpod/common-go/kubernetes"
 	"github.com/gitpod-io/gitpod/common-go/tracing"
+	"github.com/gitpod-io/gitpod/common-go/util"
 	csapi "github.com/gitpod-io/gitpod/content-service/api"
 	regapi "github.com/gitpod-io/gitpod/registry-facade/api"
 	"github.com/gitpod-io/gitpod/ws-manager/api"
@@ -570,7 +571,7 @@ func (m *Manager) createDefiniteWorkspacePod(startContext *startWorkspaceContext
 		case api.WorkspaceFeatureFlag_NOOP:
 
 		case api.WorkspaceFeatureFlag_PERSISTENT_VOLUME_CLAIM:
-			pod.Labels[pvcWorkspaceFeatureAnnotation] = "true"
+			pod.Labels[pvcWorkspaceFeatureAnnotation] = util.BooleanTrueString
 
 			// update volume to use persistent volume claim, and name of it is the same as pod's name
 			pvcName := pod.ObjectMeta.Name

--- a/components/ws-manager/pkg/manager/manager.go
+++ b/components/ws-manager/pkg/manager/manager.go
@@ -240,12 +240,8 @@ func (m *Manager) StartWorkspace(_ context.Context, req *api.StartWorkspaceReque
 		pvc                *corev1.PersistentVolumeClaim
 		startTime, endTime time.Time // the start time and end time of PVC restoring from VolumeSnapshot
 	)
-	for _, feature := range startContext.Request.Spec.FeatureFlags {
-		if feature == api.WorkspaceFeatureFlag_PERSISTENT_VOLUME_CLAIM {
-			createPVC = true
-			break
-		}
-	}
+	_, createPVC = pod.Labels[pvcWorkspaceFeatureAnnotation]
+
 	if createPVC {
 		if startContext.VolumeSnapshot != nil && startContext.VolumeSnapshot.VolumeSnapshotName != "" {
 			var volumeSnapshot volumesnapshotv1.VolumeSnapshot


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Check the pod label to determine the PVC feature flag is set

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
1. Enable the feature flag PVC, launch the workspace and the PVC object created
2. Disable the feature flag PVC, launch the workspace and no PVC object be created

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
None

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
