### PR TITLE
We use the install-values.yaml to attach the node affinity

### DIFF
--- a/components/ws-manager/pkg/manager/create.go
+++ b/components/ws-manager/pkg/manager/create.go
@@ -466,36 +466,6 @@ func (m *Manager) createDefiniteWorkspacePod(startContext *startWorkspaceContext
 		)
 	}
 
-	workloadType := "regular"
-	if startContext.Headless {
-		workloadType = "headless"
-	}
-
-	affinity := &corev1.Affinity{
-		NodeAffinity: &corev1.NodeAffinity{
-			RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
-				NodeSelectorTerms: []corev1.NodeSelectorTerm{
-					{
-						MatchExpressions: []corev1.NodeSelectorRequirement{
-							{
-								Key:      "gitpod.io/workload_workspace_" + workloadType,
-								Operator: corev1.NodeSelectorOpExists,
-							},
-							{
-								Key:      "gitpod.io/ws-daemon_ready_ns_" + m.Config.Namespace,
-								Operator: corev1.NodeSelectorOpExists,
-							},
-							{
-								Key:      "gitpod.io/registry-facade_ready_ns_" + m.Config.Namespace,
-								Operator: corev1.NodeSelectorOpExists,
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-
 	pod := corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        podName(req),
@@ -510,7 +480,6 @@ func (m *Manager) createDefiniteWorkspacePod(startContext *startWorkspaceContext
 			ServiceAccountName:           "workspace",
 			SchedulerName:                m.Config.SchedulerName,
 			EnableServiceLinks:           &boolFalse,
-			Affinity:                     affinity,
 			SecurityContext:              &corev1.PodSecurityContext{},
 			Containers: []corev1.Container{
 				*workspaceContainer,

--- a/components/ws-manager/pkg/manager/testdata/cdwp_admission.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_admission.golden
@@ -220,30 +220,6 @@
             "automountServiceAccountToken": false,
             "securityContext": {},
             "hostname": "foobar",
-            "affinity": {
-                "nodeAffinity": {
-                    "requiredDuringSchedulingIgnoredDuringExecution": {
-                        "nodeSelectorTerms": [
-                            {
-                                "matchExpressions": [
-                                    {
-                                        "key": "gitpod.io/workload_workspace_regular",
-                                        "operator": "Exists"
-                                    },
-                                    {
-                                        "key": "gitpod.io/ws-daemon_ready_ns_default",
-                                        "operator": "Exists"
-                                    },
-                                    {
-                                        "key": "gitpod.io/registry-facade_ready_ns_default",
-                                        "operator": "Exists"
-                                    }
-                                ]
-                            }
-                        ]
-                    }
-                }
-            },
             "tolerations": [
                 {
                     "key": "node.kubernetes.io/disk-pressure",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_affinity.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_affinity.golden
@@ -212,30 +212,6 @@
             "automountServiceAccountToken": false,
             "securityContext": {},
             "hostname": "foobar",
-            "affinity": {
-                "nodeAffinity": {
-                    "requiredDuringSchedulingIgnoredDuringExecution": {
-                        "nodeSelectorTerms": [
-                            {
-                                "matchExpressions": [
-                                    {
-                                        "key": "gitpod.io/workload_workspace_regular",
-                                        "operator": "Exists"
-                                    },
-                                    {
-                                        "key": "gitpod.io/ws-daemon_ready_ns_default",
-                                        "operator": "Exists"
-                                    },
-                                    {
-                                        "key": "gitpod.io/registry-facade_ready_ns_default",
-                                        "operator": "Exists"
-                                    }
-                                ]
-                            }
-                        ]
-                    }
-                }
-            },
             "tolerations": [
                 {
                     "key": "node.kubernetes.io/disk-pressure",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_class.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_class.golden
@@ -234,18 +234,6 @@
                             {
                                 "matchExpressions": [
                                     {
-                                        "key": "gitpod.io/workload_workspace_regular",
-                                        "operator": "Exists"
-                                    },
-                                    {
-                                        "key": "gitpod.io/ws-daemon_ready_ns_default",
-                                        "operator": "Exists"
-                                    },
-                                    {
-                                        "key": "gitpod.io/registry-facade_ready_ns_default",
-                                        "operator": "Exists"
-                                    },
-                                    {
                                         "key": "gitpod.io/workspaceClass",
                                         "operator": "In",
                                         "values": [

--- a/components/ws-manager/pkg/manager/testdata/cdwp_class_notfound.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_class_notfound.golden
@@ -216,30 +216,6 @@
             "automountServiceAccountToken": false,
             "securityContext": {},
             "hostname": "foobar",
-            "affinity": {
-                "nodeAffinity": {
-                    "requiredDuringSchedulingIgnoredDuringExecution": {
-                        "nodeSelectorTerms": [
-                            {
-                                "matchExpressions": [
-                                    {
-                                        "key": "gitpod.io/workload_workspace_regular",
-                                        "operator": "Exists"
-                                    },
-                                    {
-                                        "key": "gitpod.io/ws-daemon_ready_ns_default",
-                                        "operator": "Exists"
-                                    },
-                                    {
-                                        "key": "gitpod.io/registry-facade_ready_ns_default",
-                                        "operator": "Exists"
-                                    }
-                                ]
-                            }
-                        ]
-                    }
-                }
-            },
             "tolerations": [
                 {
                     "key": "node.kubernetes.io/disk-pressure",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_customcerts.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_customcerts.golden
@@ -234,30 +234,6 @@
             "automountServiceAccountToken": false,
             "securityContext": {},
             "hostname": "foobar",
-            "affinity": {
-                "nodeAffinity": {
-                    "requiredDuringSchedulingIgnoredDuringExecution": {
-                        "nodeSelectorTerms": [
-                            {
-                                "matchExpressions": [
-                                    {
-                                        "key": "gitpod.io/workload_workspace_regular",
-                                        "operator": "Exists"
-                                    },
-                                    {
-                                        "key": "gitpod.io/ws-daemon_ready_ns_default",
-                                        "operator": "Exists"
-                                    },
-                                    {
-                                        "key": "gitpod.io/registry-facade_ready_ns_default",
-                                        "operator": "Exists"
-                                    }
-                                ]
-                            }
-                        ]
-                    }
-                }
-            },
             "tolerations": [
                 {
                     "key": "node.kubernetes.io/disk-pressure",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_debug_workspace_pod.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_debug_workspace_pod.golden
@@ -213,30 +213,6 @@
             "automountServiceAccountToken": false,
             "securityContext": {},
             "hostname": "foobar",
-            "affinity": {
-                "nodeAffinity": {
-                    "requiredDuringSchedulingIgnoredDuringExecution": {
-                        "nodeSelectorTerms": [
-                            {
-                                "matchExpressions": [
-                                    {
-                                        "key": "gitpod.io/workload_workspace_regular",
-                                        "operator": "Exists"
-                                    },
-                                    {
-                                        "key": "gitpod.io/ws-daemon_ready_ns_default",
-                                        "operator": "Exists"
-                                    },
-                                    {
-                                        "key": "gitpod.io/registry-facade_ready_ns_default",
-                                        "operator": "Exists"
-                                    }
-                                ]
-                            }
-                        ]
-                    }
-                }
-            },
             "tolerations": [
                 {
                     "key": "node.kubernetes.io/disk-pressure",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_empty_resource_req.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_empty_resource_req.golden
@@ -210,30 +210,6 @@
             "automountServiceAccountToken": false,
             "securityContext": {},
             "hostname": "foobar",
-            "affinity": {
-                "nodeAffinity": {
-                    "requiredDuringSchedulingIgnoredDuringExecution": {
-                        "nodeSelectorTerms": [
-                            {
-                                "matchExpressions": [
-                                    {
-                                        "key": "gitpod.io/workload_workspace_regular",
-                                        "operator": "Exists"
-                                    },
-                                    {
-                                        "key": "gitpod.io/ws-daemon_ready_ns_default",
-                                        "operator": "Exists"
-                                    },
-                                    {
-                                        "key": "gitpod.io/registry-facade_ready_ns_default",
-                                        "operator": "Exists"
-                                    }
-                                ]
-                            }
-                        ]
-                    }
-                }
-            },
             "tolerations": [
                 {
                     "key": "node.kubernetes.io/disk-pressure",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_envvars.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_envvars.golden
@@ -249,30 +249,6 @@
             "automountServiceAccountToken": false,
             "securityContext": {},
             "hostname": "foobar",
-            "affinity": {
-                "nodeAffinity": {
-                    "requiredDuringSchedulingIgnoredDuringExecution": {
-                        "nodeSelectorTerms": [
-                            {
-                                "matchExpressions": [
-                                    {
-                                        "key": "gitpod.io/workload_workspace_regular",
-                                        "operator": "Exists"
-                                    },
-                                    {
-                                        "key": "gitpod.io/ws-daemon_ready_ns_default",
-                                        "operator": "Exists"
-                                    },
-                                    {
-                                        "key": "gitpod.io/registry-facade_ready_ns_default",
-                                        "operator": "Exists"
-                                    }
-                                ]
-                            }
-                        ]
-                    }
-                }
-            },
             "tolerations": [
                 {
                     "key": "node.kubernetes.io/disk-pressure",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_fixedresources.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_fixedresources.golden
@@ -217,30 +217,6 @@
             "automountServiceAccountToken": false,
             "securityContext": {},
             "hostname": "foobar",
-            "affinity": {
-                "nodeAffinity": {
-                    "requiredDuringSchedulingIgnoredDuringExecution": {
-                        "nodeSelectorTerms": [
-                            {
-                                "matchExpressions": [
-                                    {
-                                        "key": "gitpod.io/workload_workspace_regular",
-                                        "operator": "Exists"
-                                    },
-                                    {
-                                        "key": "gitpod.io/ws-daemon_ready_ns_default",
-                                        "operator": "Exists"
-                                    },
-                                    {
-                                        "key": "gitpod.io/registry-facade_ready_ns_default",
-                                        "operator": "Exists"
-                                    }
-                                ]
-                            }
-                        ]
-                    }
-                }
-            },
             "tolerations": [
                 {
                     "key": "node.kubernetes.io/disk-pressure",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_fullworkspacebackup.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_fullworkspacebackup.golden
@@ -206,30 +206,6 @@
             "automountServiceAccountToken": false,
             "securityContext": {},
             "hostname": "foobar",
-            "affinity": {
-                "nodeAffinity": {
-                    "requiredDuringSchedulingIgnoredDuringExecution": {
-                        "nodeSelectorTerms": [
-                            {
-                                "matchExpressions": [
-                                    {
-                                        "key": "gitpod.io/workload_workspace_regular",
-                                        "operator": "Exists"
-                                    },
-                                    {
-                                        "key": "gitpod.io/ws-daemon_ready_ns_default",
-                                        "operator": "Exists"
-                                    },
-                                    {
-                                        "key": "gitpod.io/registry-facade_ready_ns_default",
-                                        "operator": "Exists"
-                                    }
-                                ]
-                            }
-                        ]
-                    }
-                }
-            },
             "tolerations": [
                 {
                     "key": "node.kubernetes.io/disk-pressure",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_imagebuild.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_imagebuild.golden
@@ -238,30 +238,6 @@
             "automountServiceAccountToken": false,
             "securityContext": {},
             "hostname": "foobar",
-            "affinity": {
-                "nodeAffinity": {
-                    "requiredDuringSchedulingIgnoredDuringExecution": {
-                        "nodeSelectorTerms": [
-                            {
-                                "matchExpressions": [
-                                    {
-                                        "key": "gitpod.io/workload_workspace_headless",
-                                        "operator": "Exists"
-                                    },
-                                    {
-                                        "key": "gitpod.io/ws-daemon_ready_ns_default",
-                                        "operator": "Exists"
-                                    },
-                                    {
-                                        "key": "gitpod.io/registry-facade_ready_ns_default",
-                                        "operator": "Exists"
-                                    }
-                                ]
-                            }
-                        ]
-                    }
-                }
-            },
             "tolerations": [
                 {
                     "key": "node.kubernetes.io/disk-pressure",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_imagebuild_template.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_imagebuild_template.golden
@@ -238,30 +238,6 @@
             "automountServiceAccountToken": false,
             "securityContext": {},
             "hostname": "foobar",
-            "affinity": {
-                "nodeAffinity": {
-                    "requiredDuringSchedulingIgnoredDuringExecution": {
-                        "nodeSelectorTerms": [
-                            {
-                                "matchExpressions": [
-                                    {
-                                        "key": "gitpod.io/workload_workspace_headless",
-                                        "operator": "Exists"
-                                    },
-                                    {
-                                        "key": "gitpod.io/ws-daemon_ready_ns_default",
-                                        "operator": "Exists"
-                                    },
-                                    {
-                                        "key": "gitpod.io/registry-facade_ready_ns_default",
-                                        "operator": "Exists"
-                                    }
-                                ]
-                            }
-                        ]
-                    }
-                }
-            },
             "tolerations": [
                 {
                     "key": "node.kubernetes.io/disk-pressure",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_no_ideimage.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_no_ideimage.golden
@@ -210,30 +210,6 @@
             "automountServiceAccountToken": false,
             "securityContext": {},
             "hostname": "foobar",
-            "affinity": {
-                "nodeAffinity": {
-                    "requiredDuringSchedulingIgnoredDuringExecution": {
-                        "nodeSelectorTerms": [
-                            {
-                                "matchExpressions": [
-                                    {
-                                        "key": "gitpod.io/workload_workspace_regular",
-                                        "operator": "Exists"
-                                    },
-                                    {
-                                        "key": "gitpod.io/ws-daemon_ready_ns_default",
-                                        "operator": "Exists"
-                                    },
-                                    {
-                                        "key": "gitpod.io/registry-facade_ready_ns_default",
-                                        "operator": "Exists"
-                                    }
-                                ]
-                            }
-                        ]
-                    }
-                }
-            },
             "tolerations": [
                 {
                     "key": "node.kubernetes.io/disk-pressure",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_prebuild.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_prebuild.golden
@@ -220,30 +220,6 @@
             "automountServiceAccountToken": false,
             "securityContext": {},
             "hostname": "foobar",
-            "affinity": {
-                "nodeAffinity": {
-                    "requiredDuringSchedulingIgnoredDuringExecution": {
-                        "nodeSelectorTerms": [
-                            {
-                                "matchExpressions": [
-                                    {
-                                        "key": "gitpod.io/workload_workspace_headless",
-                                        "operator": "Exists"
-                                    },
-                                    {
-                                        "key": "gitpod.io/ws-daemon_ready_ns_default",
-                                        "operator": "Exists"
-                                    },
-                                    {
-                                        "key": "gitpod.io/registry-facade_ready_ns_default",
-                                        "operator": "Exists"
-                                    }
-                                ]
-                            }
-                        ]
-                    }
-                }
-            },
             "tolerations": [
                 {
                     "key": "node.kubernetes.io/disk-pressure",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_prebuild_template.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_prebuild_template.golden
@@ -220,30 +220,6 @@
             "automountServiceAccountToken": false,
             "securityContext": {},
             "hostname": "foobar",
-            "affinity": {
-                "nodeAffinity": {
-                    "requiredDuringSchedulingIgnoredDuringExecution": {
-                        "nodeSelectorTerms": [
-                            {
-                                "matchExpressions": [
-                                    {
-                                        "key": "gitpod.io/workload_workspace_headless",
-                                        "operator": "Exists"
-                                    },
-                                    {
-                                        "key": "gitpod.io/ws-daemon_ready_ns_default",
-                                        "operator": "Exists"
-                                    },
-                                    {
-                                        "key": "gitpod.io/registry-facade_ready_ns_default",
-                                        "operator": "Exists"
-                                    }
-                                ]
-                            }
-                        ]
-                    }
-                }
-            },
             "tolerations": [
                 {
                     "key": "node.kubernetes.io/disk-pressure",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_prebuild_template.json
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_prebuild_template.json
@@ -26,29 +26,6 @@
             ]
         }
     },
-    "prebuildTemplate": {
-        "spec": {
-            "affinity": {
-                "nodeAffinity": {
-                    "requiredDuringSchedulingIgnoredDuringExecution": {
-                        "nodeSelectorTerms": [
-                            {
-                                "matchExpressions": [
-                                    {
-                                        "key": "gitpod.io/workload_prebuild",
-                                        "operator": "In",
-                                        "values": [
-                                            "true"
-                                        ]
-                                    }
-                                ]
-                            }
-                        ]
-                    }
-                }
-            }
-        }
-    },
     "request": {
         "id": "foobar",
         "type": 1,

--- a/components/ws-manager/pkg/manager/testdata/cdwp_prebuild_template_override_resources.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_prebuild_template_override_resources.golden
@@ -220,30 +220,6 @@
             "automountServiceAccountToken": false,
             "securityContext": {},
             "hostname": "foobar",
-            "affinity": {
-                "nodeAffinity": {
-                    "requiredDuringSchedulingIgnoredDuringExecution": {
-                        "nodeSelectorTerms": [
-                            {
-                                "matchExpressions": [
-                                    {
-                                        "key": "gitpod.io/workload_workspace_headless",
-                                        "operator": "Exists"
-                                    },
-                                    {
-                                        "key": "gitpod.io/ws-daemon_ready_ns_default",
-                                        "operator": "Exists"
-                                    },
-                                    {
-                                        "key": "gitpod.io/registry-facade_ready_ns_default",
-                                        "operator": "Exists"
-                                    }
-                                ]
-                            }
-                        ]
-                    }
-                }
-            },
             "tolerations": [
                 {
                     "key": "node.kubernetes.io/disk-pressure",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_probe.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_probe.golden
@@ -220,30 +220,6 @@
             "automountServiceAccountToken": false,
             "securityContext": {},
             "hostname": "foobar",
-            "affinity": {
-                "nodeAffinity": {
-                    "requiredDuringSchedulingIgnoredDuringExecution": {
-                        "nodeSelectorTerms": [
-                            {
-                                "matchExpressions": [
-                                    {
-                                        "key": "gitpod.io/workload_workspace_headless",
-                                        "operator": "Exists"
-                                    },
-                                    {
-                                        "key": "gitpod.io/ws-daemon_ready_ns_default",
-                                        "operator": "Exists"
-                                    },
-                                    {
-                                        "key": "gitpod.io/registry-facade_ready_ns_default",
-                                        "operator": "Exists"
-                                    }
-                                ]
-                            }
-                        ]
-                    }
-                }
-            },
             "tolerations": [
                 {
                     "key": "node.kubernetes.io/disk-pressure",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_readinessprobe.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_readinessprobe.golden
@@ -216,30 +216,6 @@
             "automountServiceAccountToken": false,
             "securityContext": {},
             "hostname": "foobar",
-            "affinity": {
-                "nodeAffinity": {
-                    "requiredDuringSchedulingIgnoredDuringExecution": {
-                        "nodeSelectorTerms": [
-                            {
-                                "matchExpressions": [
-                                    {
-                                        "key": "gitpod.io/workload_workspace_regular",
-                                        "operator": "Exists"
-                                    },
-                                    {
-                                        "key": "gitpod.io/ws-daemon_ready_ns_default",
-                                        "operator": "Exists"
-                                    },
-                                    {
-                                        "key": "gitpod.io/registry-facade_ready_ns_default",
-                                        "operator": "Exists"
-                                    }
-                                ]
-                            }
-                        ]
-                    }
-                }
-            },
             "tolerations": [
                 {
                     "key": "node.kubernetes.io/disk-pressure",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_secrets.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_secrets.golden
@@ -230,30 +230,6 @@
             "automountServiceAccountToken": false,
             "securityContext": {},
             "hostname": "foobar",
-            "affinity": {
-                "nodeAffinity": {
-                    "requiredDuringSchedulingIgnoredDuringExecution": {
-                        "nodeSelectorTerms": [
-                            {
-                                "matchExpressions": [
-                                    {
-                                        "key": "gitpod.io/workload_workspace_regular",
-                                        "operator": "Exists"
-                                    },
-                                    {
-                                        "key": "gitpod.io/ws-daemon_ready_ns_default",
-                                        "operator": "Exists"
-                                    },
-                                    {
-                                        "key": "gitpod.io/registry-facade_ready_ns_default",
-                                        "operator": "Exists"
-                                    }
-                                ]
-                            }
-                        ]
-                    }
-                }
-            },
             "tolerations": [
                 {
                     "key": "node.kubernetes.io/disk-pressure",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_sshkeys.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_sshkeys.golden
@@ -217,30 +217,6 @@
             "automountServiceAccountToken": false,
             "securityContext": {},
             "hostname": "foobar",
-            "affinity": {
-                "nodeAffinity": {
-                    "requiredDuringSchedulingIgnoredDuringExecution": {
-                        "nodeSelectorTerms": [
-                            {
-                                "matchExpressions": [
-                                    {
-                                        "key": "gitpod.io/workload_workspace_regular",
-                                        "operator": "Exists"
-                                    },
-                                    {
-                                        "key": "gitpod.io/ws-daemon_ready_ns_default",
-                                        "operator": "Exists"
-                                    },
-                                    {
-                                        "key": "gitpod.io/registry-facade_ready_ns_default",
-                                        "operator": "Exists"
-                                    }
-                                ]
-                            }
-                        ]
-                    }
-                }
-            },
             "tolerations": [
                 {
                     "key": "node.kubernetes.io/disk-pressure",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_sshkeys.json
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_sshkeys.json
@@ -16,25 +16,6 @@
                     "name": "eu.gcr.io-gitpod"
                 }
             ],
-            "affinity": {
-                "nodeAffinity": {
-                    "requiredDuringSchedulingIgnoredDuringExecution": {
-                        "nodeSelectorTerms": [
-                            {
-                                "matchExpressions": [
-                                    {
-                                        "key": "gitpod.io/workload_workspace_regular",
-                                        "operator": "In",
-                                        "values": [
-                                            "true"
-                                        ]
-                                    }
-                                ]
-                            }
-                        ]
-                    }
-                }
-            },
             "containers": [
               {
                 "name": "workspace",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_tasks.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_tasks.golden
@@ -220,30 +220,6 @@
             "automountServiceAccountToken": false,
             "securityContext": {},
             "hostname": "foobar",
-            "affinity": {
-                "nodeAffinity": {
-                    "requiredDuringSchedulingIgnoredDuringExecution": {
-                        "nodeSelectorTerms": [
-                            {
-                                "matchExpressions": [
-                                    {
-                                        "key": "gitpod.io/workload_workspace_regular",
-                                        "operator": "Exists"
-                                    },
-                                    {
-                                        "key": "gitpod.io/ws-daemon_ready_ns_default",
-                                        "operator": "Exists"
-                                    },
-                                    {
-                                        "key": "gitpod.io/registry-facade_ready_ns_default",
-                                        "operator": "Exists"
-                                    }
-                                ]
-                            }
-                        ]
-                    }
-                }
-            },
             "tolerations": [
                 {
                     "key": "node.kubernetes.io/disk-pressure",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_template.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_template.golden
@@ -216,30 +216,6 @@
             "automountServiceAccountToken": false,
             "securityContext": {},
             "hostname": "foobar",
-            "affinity": {
-                "nodeAffinity": {
-                    "requiredDuringSchedulingIgnoredDuringExecution": {
-                        "nodeSelectorTerms": [
-                            {
-                                "matchExpressions": [
-                                    {
-                                        "key": "gitpod.io/workload_workspace_regular",
-                                        "operator": "Exists"
-                                    },
-                                    {
-                                        "key": "gitpod.io/ws-daemon_ready_ns_default",
-                                        "operator": "Exists"
-                                    },
-                                    {
-                                        "key": "gitpod.io/registry-facade_ready_ns_default",
-                                        "operator": "Exists"
-                                    }
-                                ]
-                            }
-                        ]
-                    }
-                }
-            },
             "tolerations": [
                 {
                     "key": "node.kubernetes.io/disk-pressure",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_template.json
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_template.json
@@ -16,25 +16,6 @@
                     "name": "eu.gcr.io-gitpod"
                 }
             ],
-            "affinity": {
-                "nodeAffinity": {
-                    "requiredDuringSchedulingIgnoredDuringExecution": {
-                        "nodeSelectorTerms": [
-                            {
-                                "matchExpressions": [
-                                    {
-                                        "key": "gitpod.io/workload_workspace_regular",
-                                        "operator": "In",
-                                        "values": [
-                                            "true"
-                                        ]
-                                    }
-                                ]
-                            }
-                        ]
-                    }
-                }
-            },
             "containers": [
               {
                 "name": "workspace",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_timeout.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_timeout.golden
@@ -221,30 +221,6 @@
             "automountServiceAccountToken": false,
             "securityContext": {},
             "hostname": "foobar",
-            "affinity": {
-                "nodeAffinity": {
-                    "requiredDuringSchedulingIgnoredDuringExecution": {
-                        "nodeSelectorTerms": [
-                            {
-                                "matchExpressions": [
-                                    {
-                                        "key": "gitpod.io/workload_workspace_regular",
-                                        "operator": "Exists"
-                                    },
-                                    {
-                                        "key": "gitpod.io/ws-daemon_ready_ns_default",
-                                        "operator": "Exists"
-                                    },
-                                    {
-                                        "key": "gitpod.io/registry-facade_ready_ns_default",
-                                        "operator": "Exists"
-                                    }
-                                ]
-                            }
-                        ]
-                    }
-                }
-            },
             "tolerations": [
                 {
                     "key": "node.kubernetes.io/disk-pressure",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_userns.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_userns.golden
@@ -216,30 +216,6 @@
             "automountServiceAccountToken": false,
             "securityContext": {},
             "hostname": "foobar",
-            "affinity": {
-                "nodeAffinity": {
-                    "requiredDuringSchedulingIgnoredDuringExecution": {
-                        "nodeSelectorTerms": [
-                            {
-                                "matchExpressions": [
-                                    {
-                                        "key": "gitpod.io/workload_workspace_regular",
-                                        "operator": "Exists"
-                                    },
-                                    {
-                                        "key": "gitpod.io/ws-daemon_ready_ns_default",
-                                        "operator": "Exists"
-                                    },
-                                    {
-                                        "key": "gitpod.io/registry-facade_ready_ns_default",
-                                        "operator": "Exists"
-                                    }
-                                ]
-                            }
-                        ]
-                    }
-                }
-            },
             "tolerations": [
                 {
                     "key": "node.kubernetes.io/disk-pressure",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_with_ephemeral_storage.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_with_ephemeral_storage.golden
@@ -235,30 +235,6 @@
             "automountServiceAccountToken": false,
             "securityContext": {},
             "hostname": "foobar",
-            "affinity": {
-                "nodeAffinity": {
-                    "requiredDuringSchedulingIgnoredDuringExecution": {
-                        "nodeSelectorTerms": [
-                            {
-                                "matchExpressions": [
-                                    {
-                                        "key": "gitpod.io/workload_workspace_headless",
-                                        "operator": "Exists"
-                                    },
-                                    {
-                                        "key": "gitpod.io/ws-daemon_ready_ns_default",
-                                        "operator": "Exists"
-                                    },
-                                    {
-                                        "key": "gitpod.io/registry-facade_ready_ns_default",
-                                        "operator": "Exists"
-                                    }
-                                ]
-                            }
-                        ]
-                    }
-                }
-            },
             "tolerations": [
                 {
                     "key": "node.kubernetes.io/disk-pressure",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_withaffinity_regular.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_withaffinity_regular.golden
@@ -216,30 +216,6 @@
             "automountServiceAccountToken": false,
             "securityContext": {},
             "hostname": "foobar",
-            "affinity": {
-                "nodeAffinity": {
-                    "requiredDuringSchedulingIgnoredDuringExecution": {
-                        "nodeSelectorTerms": [
-                            {
-                                "matchExpressions": [
-                                    {
-                                        "key": "gitpod.io/workload_workspace_regular",
-                                        "operator": "Exists"
-                                    },
-                                    {
-                                        "key": "gitpod.io/ws-daemon_ready_ns_default",
-                                        "operator": "Exists"
-                                    },
-                                    {
-                                        "key": "gitpod.io/registry-facade_ready_ns_default",
-                                        "operator": "Exists"
-                                    }
-                                ]
-                            }
-                        ]
-                    }
-                }
-            },
             "tolerations": [
                 {
                     "key": "node.kubernetes.io/disk-pressure",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_withaffinityheadless.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_withaffinityheadless.golden
@@ -238,30 +238,6 @@
             "automountServiceAccountToken": false,
             "securityContext": {},
             "hostname": "foobar",
-            "affinity": {
-                "nodeAffinity": {
-                    "requiredDuringSchedulingIgnoredDuringExecution": {
-                        "nodeSelectorTerms": [
-                            {
-                                "matchExpressions": [
-                                    {
-                                        "key": "gitpod.io/workload_workspace_headless",
-                                        "operator": "Exists"
-                                    },
-                                    {
-                                        "key": "gitpod.io/ws-daemon_ready_ns_default",
-                                        "operator": "Exists"
-                                    },
-                                    {
-                                        "key": "gitpod.io/registry-facade_ready_ns_default",
-                                        "operator": "Exists"
-                                    }
-                                ]
-                            }
-                        ]
-                    }
-                }
-            },
             "tolerations": [
                 {
                     "key": "node.kubernetes.io/disk-pressure",

--- a/components/ws-manager/pkg/manager/testdata/status_brokenScheduler_UNKNOWN00.json
+++ b/components/ws-manager/pkg/manager/testdata/status_brokenScheduler_UNKNOWN00.json
@@ -208,25 +208,6 @@
                     "name": "eu.gcr.io-gitpod"
                 }
             ],
-            "affinity": {
-                "nodeAffinity": {
-                    "requiredDuringSchedulingIgnoredDuringExecution": {
-                        "nodeSelectorTerms": [
-                            {
-                                "matchExpressions": [
-                                    {
-                                        "key": "gitpod.io/workload_workspace_regular",
-                                        "operator": "In",
-                                        "values": [
-                                            "true"
-                                        ]
-                                    }
-                                ]
-                            }
-                        ]
-                    }
-                }
-            },
             "tolerations": [
                 {
                     "key": "node.kubernetes.io/not-ready",

--- a/components/ws-manager/pkg/manager/testdata/status_cannotPull_004_CREATING00.json
+++ b/components/ws-manager/pkg/manager/testdata/status_cannotPull_004_CREATING00.json
@@ -782,22 +782,6 @@
         ]
       },
       "dnsPolicy": "None",
-      "affinity": {
-        "nodeAffinity": {
-          "requiredDuringSchedulingIgnoredDuringExecution": {
-            "nodeSelectorTerms": [
-              {
-                "matchExpressions": [
-                  {
-                    "operator": "Exists",
-                    "key": "gitpod.io/workload_workspace_regular"
-                  }
-                ]
-              }
-            ]
-          }
-        }
-      },
       "imagePullSecrets": [
         {
           "name": "workspace-registry-pull-secret"

--- a/components/ws-manager/pkg/manager/testdata/status_cannotPull_005_STOPPED00.json
+++ b/components/ws-manager/pkg/manager/testdata/status_cannotPull_005_STOPPED00.json
@@ -666,22 +666,6 @@
           "name": "workspace-registry-pull-secret"
         }
       ],
-      "affinity": {
-        "nodeAffinity": {
-          "requiredDuringSchedulingIgnoredDuringExecution": {
-            "nodeSelectorTerms": [
-              {
-                "matchExpressions": [
-                  {
-                    "key": "gitpod.io/workload_workspace_regular",
-                    "operator": "Exists"
-                  }
-                ]
-              }
-            ]
-          }
-        }
-      },
       "volumes": [
         {
           "name": "vol-this-workspace",

--- a/components/ws-manager/pkg/manager/testdata/status_containerd4214_STOPPING00.json
+++ b/components/ws-manager/pkg/manager/testdata/status_containerd4214_STOPPING00.json
@@ -268,22 +268,6 @@
           "name": "gcp-sa-registry-auth"
         }
       ],
-      "affinity": {
-        "nodeAffinity": {
-          "requiredDuringSchedulingIgnoredDuringExecution": {
-            "nodeSelectorTerms": [
-              {
-                "matchExpressions": [
-                  {
-                    "key": "gitpod.io/workload_workspace_regular",
-                    "operator": "Exists"
-                  }
-                ]
-              }
-            ]
-          }
-        }
-      },
       "tolerations": [
         {
           "key": "node.kubernetes.io/disk-pressure",

--- a/components/ws-manager/pkg/manager/testdata/status_disposal_STOPPED01.json
+++ b/components/ws-manager/pkg/manager/testdata/status_disposal_STOPPED01.json
@@ -238,22 +238,6 @@
           "name": "gcp-sa-registry-auth"
         }
       ],
-      "affinity": {
-        "nodeAffinity": {
-          "requiredDuringSchedulingIgnoredDuringExecution": {
-            "nodeSelectorTerms": [
-              {
-                "matchExpressions": [
-                  {
-                    "key": "gitpod.io/workload_workspace_regular",
-                    "operator": "Exists"
-                  }
-                ]
-              }
-            ]
-          }
-        }
-      },
       "tolerations": [
         {
           "key": "node.kubernetes.io/disk-pressure",

--- a/components/ws-manager/pkg/manager/testdata/status_disposal_STOPPED02.json
+++ b/components/ws-manager/pkg/manager/testdata/status_disposal_STOPPED02.json
@@ -238,22 +238,6 @@
           "name": "gcp-sa-registry-auth"
         }
       ],
-      "affinity": {
-        "nodeAffinity": {
-          "requiredDuringSchedulingIgnoredDuringExecution": {
-            "nodeSelectorTerms": [
-              {
-                "matchExpressions": [
-                  {
-                    "key": "gitpod.io/workload_workspace_regular",
-                    "operator": "Exists"
-                  }
-                ]
-              }
-            ]
-          }
-        }
-      },
       "tolerations": [
         {
           "key": "node.kubernetes.io/disk-pressure",

--- a/components/ws-manager/pkg/manager/testdata/status_disposal_STOPPED03.json
+++ b/components/ws-manager/pkg/manager/testdata/status_disposal_STOPPED03.json
@@ -239,22 +239,6 @@
           "name": "gcp-sa-registry-auth"
         }
       ],
-      "affinity": {
-        "nodeAffinity": {
-          "requiredDuringSchedulingIgnoredDuringExecution": {
-            "nodeSelectorTerms": [
-              {
-                "matchExpressions": [
-                  {
-                    "key": "gitpod.io/workload_workspace_regular",
-                    "operator": "Exists"
-                  }
-                ]
-              }
-            ]
-          }
-        }
-      },
       "tolerations": [
         {
           "key": "node.kubernetes.io/disk-pressure",

--- a/components/ws-manager/pkg/manager/testdata/status_disposal_STOPPING01.json
+++ b/components/ws-manager/pkg/manager/testdata/status_disposal_STOPPING01.json
@@ -242,22 +242,6 @@
           "name": "gcp-sa-registry-auth"
         }
       ],
-      "affinity": {
-        "nodeAffinity": {
-          "requiredDuringSchedulingIgnoredDuringExecution": {
-            "nodeSelectorTerms": [
-              {
-                "matchExpressions": [
-                  {
-                    "key": "gitpod.io/workload_workspace_regular",
-                    "operator": "Exists"
-                  }
-                ]
-              }
-            ]
-          }
-        }
-      },
       "tolerations": [
         {
           "key": "node.kubernetes.io/disk-pressure",

--- a/components/ws-manager/pkg/manager/testdata/status_disposal_STOPPING02.json
+++ b/components/ws-manager/pkg/manager/testdata/status_disposal_STOPPING02.json
@@ -241,22 +241,6 @@
           "name": "gcp-sa-registry-auth"
         }
       ],
-      "affinity": {
-        "nodeAffinity": {
-          "requiredDuringSchedulingIgnoredDuringExecution": {
-            "nodeSelectorTerms": [
-              {
-                "matchExpressions": [
-                  {
-                    "key": "gitpod.io/workload_workspace_regular",
-                    "operator": "Exists"
-                  }
-                ]
-              }
-            ]
-          }
-        }
-      },
       "tolerations": [
         {
           "key": "node.kubernetes.io/disk-pressure",

--- a/components/ws-manager/pkg/manager/testdata/status_failedBeforeStopping_explicitFail.json
+++ b/components/ws-manager/pkg/manager/testdata/status_failedBeforeStopping_explicitFail.json
@@ -207,25 +207,6 @@
           "name": "eu.gcr.io-gitpod"
         }
       ],
-      "affinity": {
-        "nodeAffinity": {
-          "requiredDuringSchedulingIgnoredDuringExecution": {
-            "nodeSelectorTerms": [
-              {
-                "matchExpressions": [
-                  {
-                    "key": "gitpod.io/workload_workspace_regular",
-                    "operator": "In",
-                    "values": [
-                      "true"
-                    ]
-                  }
-                ]
-              }
-            ]
-          }
-        }
-      },
       "schedulerName": "default-scheduler",
       "tolerations": [
         {

--- a/components/ws-manager/pkg/manager/testdata/status_failedWorkspaceMount_PENDING00.json
+++ b/components/ws-manager/pkg/manager/testdata/status_failedWorkspaceMount_PENDING00.json
@@ -204,25 +204,6 @@
           "name": "eu.gcr.io-gitpod"
         }
       ],
-      "affinity": {
-        "nodeAffinity": {
-          "requiredDuringSchedulingIgnoredDuringExecution": {
-            "nodeSelectorTerms": [
-              {
-                "matchExpressions": [
-                  {
-                    "key": "gitpod.io/workload_workspace_regular",
-                    "operator": "In",
-                    "values": [
-                      "true"
-                    ]
-                  }
-                ]
-              }
-            ]
-          }
-        }
-      },
       "schedulerName": "default-scheduler",
       "tolerations": [
         {

--- a/components/ws-manager/pkg/manager/testdata/status_headlessTaskFailed_STOPPING00.json
+++ b/components/ws-manager/pkg/manager/testdata/status_headlessTaskFailed_STOPPING00.json
@@ -617,22 +617,6 @@
           "name": "gcp-sa-registry-auth"
         }
       ],
-      "affinity": {
-        "nodeAffinity": {
-          "requiredDuringSchedulingIgnoredDuringExecution": {
-            "nodeSelectorTerms": [
-              {
-                "matchExpressions": [
-                  {
-                    "key": "gitpod.io/workload_workspace_regular",
-                    "operator": "Exists"
-                  }
-                ]
-              }
-            ]
-          }
-        }
-      },
       "tolerations": [
         {
           "key": "node.kubernetes.io/disk-pressure",

--- a/components/ws-manager/pkg/manager/testdata/status_prebuildFail_STOPPED00.json
+++ b/components/ws-manager/pkg/manager/testdata/status_prebuildFail_STOPPED00.json
@@ -258,22 +258,6 @@
           "name": "gcp-sa-registry-auth"
         }
       ],
-      "affinity": {
-        "nodeAffinity": {
-          "requiredDuringSchedulingIgnoredDuringExecution": {
-            "nodeSelectorTerms": [
-              {
-                "matchExpressions": [
-                  {
-                    "key": "gitpod.io/workload_workspace_regular",
-                    "operator": "Exists"
-                  }
-                ]
-              }
-            ]
-          }
-        }
-      },
       "schedulerName": "workspace-scheduler",
       "tolerations": [
         {

--- a/components/ws-manager/pkg/manager/testdata/status_prebuildFail_STOPPING00.json
+++ b/components/ws-manager/pkg/manager/testdata/status_prebuildFail_STOPPING00.json
@@ -253,22 +253,6 @@
           "name": "gcp-sa-registry-auth"
         }
       ],
-      "affinity": {
-        "nodeAffinity": {
-          "requiredDuringSchedulingIgnoredDuringExecution": {
-            "nodeSelectorTerms": [
-              {
-                "matchExpressions": [
-                  {
-                    "key": "gitpod.io/workload_workspace_regular",
-                    "operator": "Exists"
-                  }
-                ]
-              }
-            ]
-          }
-        }
-      },
       "tolerations": [
         {
           "key": "node.kubernetes.io/disk-pressure",

--- a/components/ws-manager/pkg/manager/testdata/status_stuckInStopping_RUNNING00.json
+++ b/components/ws-manager/pkg/manager/testdata/status_stuckInStopping_RUNNING00.json
@@ -1027,22 +1027,6 @@
                     "tolerationSeconds": 300
                 }
             ],
-            "affinity": {
-                "nodeAffinity": {
-                    "requiredDuringSchedulingIgnoredDuringExecution": {
-                        "nodeSelectorTerms": [
-                            {
-                                "matchExpressions": [
-                                    {
-                                        "key": "gitpod.io/workload_workspace_regular",
-                                        "operator": "Exists"
-                                    }
-                                ]
-                            }
-                        ]
-                    }
-                }
-            },
             "securityContext": {
                 "fsGroup": 1,
                 "seccompProfile": {

--- a/components/ws-manager/pkg/manager/testdata/status_stuckInStopping_STOPPING00.json
+++ b/components/ws-manager/pkg/manager/testdata/status_stuckInStopping_STOPPING00.json
@@ -641,22 +641,6 @@
                     "8.8.8.8"
                 ]
             },
-            "affinity": {
-                "nodeAffinity": {
-                    "requiredDuringSchedulingIgnoredDuringExecution": {
-                        "nodeSelectorTerms": [
-                            {
-                                "matchExpressions": [
-                                    {
-                                        "key": "gitpod.io/workload_workspace_regulars",
-                                        "operator": "Exists"
-                                    }
-                                ]
-                            }
-                        ]
-                    }
-                }
-            },
             "tolerations": [
                 {
                     "effect": "NoExecute",


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
We see in the production cluster, the rebuild and workspace pod with duplicate node affinity rule.
```yaml
spec:
  affinity:
    nodeAffinity:
      requiredDuringSchedulingIgnoredDuringExecution:
        nodeSelectorTerms:
        - matchExpressions:
          - key: gitpod.io/workload_workspace_headless
            operator: Exists
          - key: gitpod.io/ws-daemon_ready_ns_default
            operator: Exists
          - key: gitpod.io/registry-facade_ready_ns_default
            operator: Exists
          - key: gitpod.io/workspace-class
            operator: In
            values:
            - default
          - key: gitpod.io/workload_workspace_headless
            operator: Exists
          - key: gitpod.io/ws-daemon_ready_ns_default
            operator: Exists
          - key: gitpod.io/registry-facade_ready_ns_default
            operator: Exists
```

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
None

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
