### PR TITLE
[dashboard] Hide PVC feature section when feat flag not set

### DIFF
--- a/components/dashboard/src/projects/ProjectSettings.tsx
+++ b/components/dashboard/src/projects/ProjectSettings.tsx
@@ -94,22 +94,25 @@ export default function () {
                 checked={!project.settings?.keepOutdatedPrebuildsRunning}
                 onChange={({ target }) => updateProjectSettings({ keepOutdatedPrebuildsRunning: !target.checked })}
             />
-            <br></br>
-            <h3 className="mt-12">Workspace Persistence</h3>
-            <CheckBox
-                title={
-                    <span>
-                        Enable Persistent Volume Claim{" "}
-                        <PillLabel type="warn" className="font-semibold mt-2 ml-2 py-0.5 px-2 self-center">
-                            Experimental
-                        </PillLabel>
-                    </span>
-                }
-                desc={<span>Experimental feature that is still under development.</span>}
-                checked={project.settings?.usePersistentVolumeClaim ?? false}
-                disabled={!showPersistentVolumeClaimUI}
-                onChange={({ target }) => updateProjectSettings({ usePersistentVolumeClaim: target.checked })}
-            />
+            {showPersistentVolumeClaimUI && (
+                <>
+                    <br></br>
+                    <h3 className="mt-12">Workspace Persistence</h3>
+                    <CheckBox
+                        title={
+                            <span>
+                                Enable Persistent Volume Claim{" "}
+                                <PillLabel type="warn" className="font-semibold mt-2 ml-2 py-0.5 px-2 self-center">
+                                    Experimental
+                                </PillLabel>
+                            </span>
+                        }
+                        desc={<span>Experimental feature that is still under development.</span>}
+                        checked={project.settings?.usePersistentVolumeClaim ?? false}
+                        onChange={({ target }) => updateProjectSettings({ usePersistentVolumeClaim: target.checked })}
+                    />
+                </>
+            )}
         </ProjectSettingsPage>
     );
 }


### PR DESCRIPTION
## Description

Hide the PVC feature section on the project settings page when the PVC feature flag is not set.

<img width="1313" alt="image" src="https://user-images.githubusercontent.com/8225907/181182254-82292ea3-631b-4590-8d58-fc391964b786.png">

Previously, the section would always be visible but the checkbox would be disabled if the feature flag was not set.

## Related Issue(s)

## How to test

Disable the feature flag for users in non-production (via configcat) and reload a project settings page. 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation


## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
