### PR TITLE
[usage] Have spinner while loading

### DIFF
--- a/components/dashboard/src/teams/TeamUsage.tsx
+++ b/components/dashboard/src/teams/TeamUsage.tsx
@@ -17,6 +17,7 @@ import Header from "../components/Header";
 import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
 import { FeatureFlagContext } from "../contexts/FeatureFlagContext";
 import { ReactComponent as CreditsSvg } from "../images/credits.svg";
+import { ReactComponent as Spinner } from "../icons/Spinner.svg";
 
 function TeamUsage() {
     const { teams } = useContext(TeamsContext);
@@ -32,6 +33,7 @@ function TeamUsage() {
     const timestampStartOfCurrentMonth = startOfCurrentMonth.getTime();
     const [startDateOfBillMonth, setStartDateOfBillMonth] = useState(timestampStartOfCurrentMonth);
     const [endDateOfBillMonth, setEndDateOfBillMonth] = useState(Date.now());
+    const [isLoading, setIsLoading] = useState<boolean>(true);
 
     useEffect(() => {
         if (!team) {
@@ -50,6 +52,8 @@ function TeamUsage() {
                 if (error.code === ErrorCodes.PERMISSION_DENIED) {
                     setErrorMessage("Access to usage details is restricted to team owners.");
                 }
+            } finally {
+                setIsLoading(false);
             }
         })();
     }, [team, startDateOfBillMonth, endDateOfBillMonth]);
@@ -146,7 +150,7 @@ function TeamUsage() {
                                 </div>
                             </div>
                         </div>
-                        {billedUsage.length === 0 && !errorMessage && (
+                        {billedUsage.length === 0 && !errorMessage && !isLoading && (
                             <div className="flex flex-col w-full mb-8">
                                 <h3 className="text-center text-gray-500 mt-8">No sessions found.</h3>
                                 <p className="text-center text-gray-500 mt-1">
@@ -163,7 +167,15 @@ function TeamUsage() {
                                 </p>
                             </div>
                         )}
-                        {billedUsage.length > 0 && (
+                        {isLoading && (
+                            <div className="flex flex-col place-items-center align-center w-full">
+                                <div className="uppercase text-sm text-gray-400 dark:text-gray-500 mb-5">
+                                    Fetching usage...
+                                </div>
+                                <Spinner className="m-2 h-5 w-5 animate-spin" />
+                            </div>
+                        )}
+                        {billedUsage.length > 0 && !isLoading && (
                             <div className="flex flex-col w-full mb-8">
                                 <ItemsList className="mt-2 text-gray-500">
                                     <Item header={false} className="grid grid-cols-5 bg-gray-100 mb-5">


### PR DESCRIPTION
## Description
This introduces a spinner when the data is being fetched.

<img width="575" alt="Screenshot 2022-07-27 at 13 56 41" src="https://user-images.githubusercontent.com/8015191/181241089-d505cac0-93da-4119-863e-38c80949df76.png">


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #11677

## How to test
1. Join https://lau-loading-11677.preview.gitpod-dev.com/teams/join?inviteId=6dd143f5-9997-4e43-a1ef-1ba9edd2169b
2. Set network conditions to Slow 3G
3. Go to https://lau-loading-11677.preview.gitpod-dev.com/t/gitpod/usage

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
