### PR TITLE
[usage] Extend method call with order arg

### DIFF
--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -61,7 +61,7 @@ import { RemotePageMessage, RemoteTrackMessage, RemoteIdentifyMessage } from "./
 import { IDEServer } from "./ide-protocol";
 import { InstallationAdminSettings, TelemetryData } from "./installation-admin-protocol";
 import { Currency } from "./plans";
-import { BillableSession } from "./usage";
+import { BillableSession, BillableSessionRequest } from "./usage";
 import { SupportedWorkspaceClass } from "./workspace-class";
 
 export interface GitpodClient {
@@ -294,7 +294,8 @@ export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, 
     getSpendingLimitForTeam(teamId: string): Promise<number | undefined>;
     setSpendingLimitForTeam(teamId: string, spendingLimit: number): Promise<void>;
 
-    listBilledUsage(attributionId: string, from?: number, to?: number): Promise<BillableSession[]>;
+    listBilledUsage(req: BillableSessionRequest): Promise<BillableSession[]>;
+
     setUsageAttribution(usageAttribution: string): Promise<void>;
 
     /**
@@ -308,7 +309,7 @@ export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, 
      * Frontend notifications
      */
     getNotifications(): Promise<string[]>;
-    
+
     getSupportedWorkspaceClasses(): Promise<SupportedWorkspaceClass[]>;
 }
 

--- a/components/gitpod-protocol/src/usage.ts
+++ b/components/gitpod-protocol/src/usage.ts
@@ -35,4 +35,16 @@ export interface BillableSession {
     projectId?: string;
 }
 
+export interface BillableSessionRequest {
+    attributionId: string;
+    startedTimeOrder: SortOrder;
+    from?: number;
+    to?: number;
+}
+
 export type BillableWorkspaceType = WorkspaceType;
+
+export enum SortOrder {
+    Descending = 0,
+    Ascending = 1,
+}

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -169,7 +169,7 @@ import { LicenseEvaluator } from "@gitpod/licensor/lib";
 import { Feature } from "@gitpod/licensor/lib/api";
 import { Currency } from "@gitpod/gitpod-protocol/lib/plans";
 import { getExperimentsClientForBackend } from "@gitpod/gitpod-protocol/lib/experiments/configcat-server";
-import { BillableSession } from "@gitpod/gitpod-protocol/lib/usage";
+import { BillableSession, BillableSessionRequest } from "@gitpod/gitpod-protocol/lib/usage";
 import { WorkspaceClusterImagebuilderClientProvider } from "./workspace-cluster-imagebuilder-client-provider";
 
 // shortcut
@@ -3207,12 +3207,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         throw new ResponseError(ErrorCodes.SAAS_FEATURE, `Not implemented in this version`);
     }
 
-    async listBilledUsage(
-        ctx: TraceContext,
-        attributionId: string,
-        from?: number,
-        to?: number,
-    ): Promise<BillableSession[]> {
+    async listBilledUsage(ctx: TraceContext, req: BillableSessionRequest): Promise<BillableSession[]> {
         throw new ResponseError(ErrorCodes.SAAS_FEATURE, `Not implemented in this version`);
     }
     async getSpendingLimitForTeam(ctx: TraceContext, teamId: string): Promise<number | undefined> {

--- a/components/usage-api/typescript/src/usage/v1/sugar.ts
+++ b/components/usage-api/typescript/src/usage/v1/sugar.ts
@@ -91,7 +91,7 @@ export class PromisifiedUsageServiceClient {
         );
     }
 
-    public async listBilledUsage(_ctx: TraceContext, attributionId: string, from?: Timestamp, to?: Timestamp): Promise<ListBilledUsageResponse> {
+    public async listBilledUsage(_ctx: TraceContext, attributionId: string, order: ListBilledUsageRequest.Ordering, from?: Timestamp, to?: Timestamp): Promise<ListBilledUsageResponse> {
         const ctx = TraceContext.childContext(`/usage-service/listBilledUsage`, _ctx);
 
         try {
@@ -99,6 +99,7 @@ export class PromisifiedUsageServiceClient {
             req.setAttributionId(attributionId);
             req.setFrom(from);
             req.setTo(to);
+            req.setOrder(order);
 
             const response = await new Promise<ListBilledUsageResponse>((resolve, reject) => {
                 this.client.listBilledUsage(


### PR DESCRIPTION
## Description
Adds the ordering argument to `listBilledUsage` calls.
View implementation will be in a separate issue and PR.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #11691

## How to test
1. Join [team](https://laushinka-1e1c9f7bce.preview.gitpod-dev.com/teams/join?inviteId=5e187f1c-c628-4741-b4b0-3ad9d15cde44)
2. Go to [/usage](https://laushinka-1e1c9f7bce.preview.gitpod-dev.com/t/gitpod/usage)
3. Check the network call - `listBilledUsage` should be called with the additional param '0'.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
