### PR TITLE
[kots]: put the "run" collectors into the active namespace

### DIFF
--- a/install/kots/manifests/kots-preflight.yaml
+++ b/install/kots/manifests/kots-preflight.yaml
@@ -11,6 +11,7 @@ spec:
         collectorName: database
         image: eu.gcr.io/gitpod-core-dev/build/kots-config-check/database:sje-kots-config-check.9
         name: database
+        namespace: '{{repl Namespace }}'
         args:
           - '{{repl ConfigOption "db_incluster" }}' # DB_IN_CLUSTER_ENABLED
           - '{{repl ConfigOption "db_cloudsql_enabled" }}' # DB_CLOUDSQL_ENABLED
@@ -24,6 +25,7 @@ spec:
         collectorName: "kernel"
         image: alpine/semver
         name: kernel
+        namespace: '{{repl Namespace }}'
         command:
           - /bin/sh
           - -c
@@ -33,6 +35,7 @@ spec:
         collectorName: registry
         image: eu.gcr.io/gitpod-core-dev/build/kots-config-check/registry:sje-kots-registry-check.16
         name: registry
+        namespace: '{{repl Namespace }}'
         args:
           - '{{repl ConfigOption "reg_incluster" }}' # REG_IN_CLUSTER_ENABLED
           - '{{repl ConfigOption "reg_username" }}' # REG_USERNAME
@@ -49,6 +52,7 @@ spec:
         collectorName: storage
         image: eu.gcr.io/gitpod-core-dev/build/kots-config-check/storage:sje-kots-storage-check.9
         name: storage
+        namespace: '{{repl Namespace }}'
         args:
           - '{{repl ConfigOption "store_provider" }}' # STORE_PROVIDER
           - '{{repl ConfigOption "store_region" }}' # STORE_LOCATION
@@ -65,6 +69,7 @@ spec:
         collectorName: ping-registry
         image: alpine/curl
         name: ping-registry
+        namespace: '{{repl Namespace }}'
         command:
           - /bin/sh
           - -c

--- a/install/kots/manifests/kots-support-bundle.yaml
+++ b/install/kots/manifests/kots-support-bundle.yaml
@@ -11,6 +11,7 @@ spec:
         collectorName: database
         image: eu.gcr.io/gitpod-core-dev/build/kots-config-check/database:sje-kots-config-check.9
         name: database
+        namespace: '{{repl Namespace }}'
         args:
           - '{{repl ConfigOption "db_incluster" }}' # DB_IN_CLUSTER_ENABLED
           - '{{repl ConfigOption "db_cloudsql_enabled" }}' # DB_CLOUDSQL_ENABLED
@@ -24,6 +25,7 @@ spec:
         collectorName: registry
         image: eu.gcr.io/gitpod-core-dev/build/kots-config-check/registry:sje-kots-registry-check.16
         name: registry
+        namespace: '{{repl Namespace }}'
         args:
           - '{{repl ConfigOption "reg_incluster" }}' # REG_IN_CLUSTER_ENABLED
           - '{{repl ConfigOption "reg_username" }}' # REG_USERNAME
@@ -40,6 +42,7 @@ spec:
         collectorName: storage
         image: eu.gcr.io/gitpod-core-dev/build/kots-config-check/storage:sje-kots-storage-check.9
         name: storage
+        namespace: '{{repl Namespace }}'
         args:
           - '{{repl ConfigOption "store_provider" }}' # STORE_PROVIDER
           - '{{repl ConfigOption "store_region" }}' # STORE_LOCATION
@@ -55,6 +58,7 @@ spec:
         collectorName: ping-registry
         image: alpine/curl
         name: ping-registry
+        namespace: '{{repl Namespace }}'
         command:
           - /bin/sh
           - -c


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
The KOTS `run` collectors previously ran in the `default` namespace. This puts them in the namespace where the application is stored

## How to test
<!-- Provide steps to test this PR -->
Deploy via KOTS

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[kots]: put the "run" collectors into the active namespace
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
