### PR TITLE
Fix openvsx-proxy metrics

### DIFF
--- a/install/installer/pkg/components/openvsx-proxy/statefulset.go
+++ b/install/installer/pkg/components/openvsx-proxy/statefulset.go
@@ -132,7 +132,7 @@ func statefulset(ctx *common.RenderContext) ([]runtime.Object, error) {
 							Name:      "redis-data",
 							MountPath: "/data",
 						}},
-					},
+					}, *common.KubeRBACProxyContainer(ctx),
 					},
 				},
 			},


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This adds the `kube-rbac-proxy` to the `openvxs-proxy` statefulset, exposing the metrics endpoint through it, so prometheus is able to scrape it correctly.

## How to test
<!-- Provide steps to test this PR -->
[Before and after updating the address](https://grafana.gitpod.io/d/HNOvmGpxgd/openvsx-proxy?orgId=1&from=1658913689599&to=1658925254366&query=ws-proxy&var-datasource=VictoriaMetrics&var-cluster=All&var-node=All&var-pod=All&var-pod_instance=All&var-container_instance=All)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
