### PR TITLE
[observability] - warn Team Workspace in Slack when node connections are high

### DIFF
--- a/operations/observability/mixins/cross-teams/rules/components/nodes/alerts.libsonnet
+++ b/operations/observability/mixins/cross-teams/rules/components/nodes/alerts.libsonnet
@@ -30,6 +30,23 @@
               |||,
           },
           {
+            alert: 'GitpodSuspiciouslyHighConntrackEntries',
+            labels: {
+              severity: 'warning',
+              team: 'workspace',
+            },
+            'for': '5m',
+            annotations: {
+              runbook_url: 'https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodNodeConntrackTableIsFull.md',
+              summary: 'Node conntrack count is very high, probably too high',
+              description: 'Node {{ $labels.node }} conntrack entries are high, check the node for abuse.',
+            },
+            expr:
+              |||
+                node_nf_conntrack_entries > 10000
+              |||,
+          },
+          {
             alert: 'GitpodNodeConntrackTableIsFull',
             labels: {
               severity: 'critical',


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
An experiment to test warnings that route to Slack for Team Workspace.

note: will try to test/trigger in preview environment, hence draft.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes # n/a

## How to test
<!-- Provide steps to test this PR -->
In preview:
https://www.notion.so/gitpod/Creating-an-Alert-Manually-3463b7f615ba4ccb8a92d83d9e8cad50

In production:
1. Push this to a workspace cluster via the enable monitoring werft job.
2. Wait for it to trigger, it'll do so a few times a day.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
