### PR TITLE
previewctl: install-context honors the branch name

### DIFF
--- a/dev/preview/previewctl/cmd/install_context.go
+++ b/dev/preview/previewctl/cmd/install_context.go
@@ -23,7 +23,7 @@ func installContextCmd(logger *logrus.Logger) *cobra.Command {
 	var lastSuccessfulPreviewEnvironment *preview.Preview = nil
 
 	install := func(timeout time.Duration) error {
-		p, err := preview.New("", logger)
+		p, err := preview.New(branch, logger)
 
 		if err != nil {
 			return err


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
`previewctl install-context --branch <branch-name>` does not use the branch name flag.
It keeps using the result of `git rev-parse --abbrev-ref HEAD`.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
`previewctl install-context -branch <branch-name>` should branch name input.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
None

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
