### PR TITLE
Add openvsx alert

### DIFF
--- a/operations/observability/mixins/IDE/rules/components/openvsx-proxy/alerts.libsonnet
+++ b/operations/observability/mixins/IDE/rules/components/openvsx-proxy/alerts.libsonnet
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+ * Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+ */
+
+{
+  prometheusAlerts+:: {
+    groups+: [
+      {
+        name: 'gitpod-component-openvsx-proxy-alerts',
+        rules: [
+          {
+            alert: 'GitpodOpenVSXRegistryDown',
+            labels: {
+              severity: 'critical',
+            },
+            'for': '20m',
+            annotations: {
+              runbook_url: 'https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodOpenVsxRegistryDown.md',
+              summary: 'Open-VSX registry is possibly down',
+              description: 'Open-VSX registry is possibly down. We cannot pull VSCode extensions we don\'t have in our caches',
+            },
+            expr:
+              |||
+                sum(rate(gitpod_openvsx_proxy_requests_total{status=~"5..|error"}[5m])) / sum(rate(gitpod_openvsx_proxy_requests_total[5m])) > 0.01
+              |||,
+          },
+        ],
+      },
+    ],
+  },
+}

--- a/operations/observability/mixins/IDE/rules/components/openvsx-proxy/rules.libsonnet
+++ b/operations/observability/mixins/IDE/rules/components/openvsx-proxy/rules.libsonnet
@@ -3,5 +3,9 @@
  * Licensed under the MIT License. See License-MIT.txt in the project root for license information.
  */
 
-(import './openvsx-proxy/alerts.libsonnet') +
-(import './openvsx-proxy/rules.libsonnet')
+{
+  prometheusRules+:: {
+    groups+: [],
+    // There is no recording rules for this component.
+  },
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Add alert when openvsx registry is down

runbook: https://github.com/gitpod-io/runbooks/pull/292

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
