### PR TITLE
Revert the ws-daemon max unavailable back to wsdaemonMaxAttempts

### DIFF
--- a/components/ws-manager/pkg/manager/monitor.go
+++ b/components/ws-manager/pkg/manager/monitor.go
@@ -1244,10 +1244,7 @@ func (m *Monitor) finalizeWorkspaceContent(ctx context.Context, wso *workspaceOb
 	)
 	t := time.Now()
 
-	// since we're within the content backup loop, the maximum retry time should
-	// rely on the content finalization configuration
-	maxRetry := int(m.manager.Config.Timeouts.ContentFinalization / util.Duration(wsdaemonRetryInterval))
-	for i := 0; i < maxRetry; i++ {
+	for i := 0; i < wsdaemonMaxAttempts; i++ {
 		span.LogKV("attempt", i)
 		didSometing, gs, err := doFinalize()
 		if !didSometing {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Give the ws-daemon unavailable retry maximum be 2 mins.
We see in the production cluster, that once the ws-daemon is gone, probably due to the underlying node being gone.
We don't need to waste time to keep retrying it for 1 hour in such a case.

Somehow, the finalizeWorkspaceContent executes takes 3h14m, it not what we expected within 1 hour.
<img width="1493" alt="image" src="https://user-images.githubusercontent.com/49380831/181468179-925b5889-1746-4a8f-bc92-90eb6d53e607.png">

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
None

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
