### PR TITLE
Update 'create-pull-request' GitHub Action to v4

### DIFF
--- a/.github/workflows/jetbrains-updates-template.yml
+++ b/.github/workflows/jetbrains-updates-template.yml
@@ -54,7 +54,7 @@ jobs:
           git diff
       - name: Create Pull Request
         if: steps.latest-release.outputs.result != steps.used-release.outputs.result
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v4
         with:
           title: "[${{ inputs.productId }}] Update IDE image to build version ${{ steps.latest-release.outputs.version }}"
           body: |


### PR DESCRIPTION


## Description
<!-- Describe your changes in detail -->
Update 'create-pull-request' GitHub Action to v4.
Because `team-reviewers` is not being set when using v3 (see the [latest PR created with that template](https://github.com/gitpod-io/gitpod/pull/11680)).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
None.

## How to test
<!-- Provide steps to test this PR -->
It has already been tested: see [this PR](https://github.com/gitpod-io/gitpod/pull/11720) created from [this template that uses v4](https://github.com/gitpod-io/gitpod/blob/403ad38fb155da8f525277d01e5ef81f1896866a/.github/workflows/jetbrains-update-plugin-platform-template.yml#L69).

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
None.

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
