### PR TITLE
Fix "how to test" instructions, commit message, and branch name of Pull Requests created by the GitHub Action

### DIFF
--- a/.github/workflows/jetbrains-update-plugin-platform-template.yml
+++ b/.github/workflows/jetbrains-update-plugin-platform-template.yml
@@ -75,9 +75,8 @@ jobs:
 
                       ## How to test
                       1. Ensure you have the [latest JetBrains Gateway](https://www.jetbrains.com/remote-development/gateway/) installed.
-                      2. Download the plugin build related to this branch in [Dev Versions](https://plugins.jetbrains.com/plugin/18438-gitpod-gateway/versions/dev), and install it on the Gateway following [these instructions](https://www.jetbrains.com/help/idea/managing-plugins.html#install_plugin_from_disk).
-                      3. Change the "Gitpod Host" (in JetBrains Gateway Preferences >> Tools >> Gitpod) to the preview environment hostname, so you can see the list of workspaces running on it.
-                      4. Create a new workspace from JetBrains Gateway (it's ok to use the pre-selected IDE and Repository) and confirm if JetBrains Client can connect to it.
+                      2. Download the plugin build related to this branch in [Dev Versions](https://plugins.jetbrains.com/plugin/18438-gitpod-gateway/versions/dev), and [install it on the Gateway](https://www.jetbrains.com/help/idea/managing-plugins.html#install_plugin_from_disk).
+                      3. Create a new workspace from the Gateway (it's ok to use the pre-selected IDE and Repository) and confirm if JetBrains Client can connect to it.
 
                       ## Release Notes
                       ```release-note
@@ -88,8 +87,8 @@ jobs:
                       - [ ] /werft with-preview
 
                       _This PR was created automatically with GitHub Actions using [this](https://github.com/gitpod-io/gitpod/blob/main/.github/workflows/jetbrains-update-plugin-platform-template.yml) template._
-                  commit-message: "Update Platform Version of ${{ inputs.pluginName }} to ${{ steps.latest-version.outputs.version }}"
-                  branch: "jetbrains/update-${{ inputs.pluginId }}-platform-version-to-${{ steps.latest-version.outputs.version }}"
+                  commit-message: "Update Platform Version of ${{ inputs.pluginName }} to ${{ steps.latest-version.outputs.result }}"
+                  branch: "jetbrains/${{ inputs.pluginId }}-platform-${{ steps.latest-version.outputs.result }}"
                   labels: "team: IDE"
                   team-reviewers: "engineering-ide"
             - name: Create Pull Request for Backend Plugin
@@ -117,8 +116,8 @@ jobs:
                       - [x] /werft with-preview
 
                       _This PR was created automatically with GitHub Actions using [this](https://github.com/gitpod-io/gitpod/blob/main/.github/workflows/jetbrains-update-plugin-platform-template.yml) template._
-                  commit-message: "Update Platform Version of ${{ inputs.pluginName }} to ${{ steps.latest-version.outputs.version }}"
-                  branch: "jetbrains/update-${{ inputs.pluginId }}-platform-version-to-${{ steps.latest-version.outputs.version }}"
+                  commit-message: "Update Platform Version of ${{ inputs.pluginName }} to ${{ steps.latest-version.outputs.result }}"
+                  branch: "jetbrains/${{ inputs.pluginId }}-platform-${{ steps.latest-version.outputs.result }}"
                   labels: "team: IDE"
                   team-reviewers: "engineering-ide"
             - name: Slack Notification


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Fix "how to test" instructions, commit message, and branch name of Pull Requests created by [this GitHub Action]
(https://github.com/gitpod-io/gitpod/blob/main/.github/workflows/jetbrains-update-plugin-platform.yml).

These are issues noticed after its first run: https://github.com/gitpod-io/gitpod/pull/11720
Notice the incomplete branch name and commit message.
Notice also that the 3rd instruction of "How to test" was unnecessary, as the PR doesn't create a Preview Environment.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
None.

## How to test
<!-- Provide steps to test this PR -->
Don't need to test. Just check the strings changed in the files.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
None.

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
