### PR TITLE
[installer] updating the refCache image in image-builder-mk3

### DIFF
--- a/install/installer/pkg/components/image-builder-mk3/configmap.go
+++ b/install/installer/pkg/components/image-builder-mk3/configmap.go
@@ -53,12 +53,17 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		WorkspaceImageRepository: fmt.Sprintf("%s/workspace-images", registryName),
 	}
 
+	workspaceImage := ctx.Config.Workspace.WorkspaceImage
+	if workspaceImage == "" {
+		workspaceImage = ctx.ImageName(common.ThirdPartyContainerRepo(ctx.Config.Repository, ""), workspace.DefaultWorkspaceImage, workspace.DefaultWorkspaceImageVersion)
+	}
+
 	imgcfg := config.ServiceConfig{
 		Orchestrator: orchestrator,
 		RefCache: config.RefCacheConfig{
 			Interval: util.Duration(time.Hour * 6).String(),
 			Refs: []string{
-				ctx.ImageName(common.ThirdPartyContainerRepo(ctx.Config.Repository, ""), workspace.DefaultWorkspaceImage, workspace.DefaultWorkspaceImageVersion),
+				workspaceImage,
 			},
 		},
 		Service: config.Service{


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PR updates the workspace image name in the `refCache` of `image-builder-mk3-config` configmap when a custom workspace base image is provided in the installer config file. This means the correct base images are not cached, slightly slowing the image build.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #11684

## How to test
<!-- Provide steps to test this PR -->
Create a Gitpod self hosted instance by opening a Gitpod workspace from main, making sure you have access to `core-dev` cluster and running: (you can read more about this preview setup [here](https://www.notion.so/gitpod/WIP-Self-hosted-automated-nightly-pipelines-fdc5a202e67b4197aa00d93b98d57927)) 
```
werft run github -j .werft/self-hosted-installer-tests.yaml -a skipTests=true -a preview=true -a deps=external
```
When the job is finished, you will get the URL and `KUBECONFIG` details under the `get-results` phase tab of the werft job.

Connect to KOTS UI by running `kubectl kots admin-console -n gitpod`, go to the `config` tab, tick the `Enable advanced options` and upload config patch with the following content:
```
workspace:
  workspaceImage: "gcr.io/sh-automated-tests/busybox:latest"
containerRegistry:
  privateBaseImageAllowList:
    - "gcr.io"
```
Redeploy as prompted. Once the setup is ready, check the `refCache` field in the configmap `image-builder-mk3-config` under gitpod namespace. You will see that it still shows `workspace-full` image.

Now update to the changes corresponding to this branch by doing the following(I have updated the changes to the `dev-nan` channel):
- Go to replicated.com -> Customers -> `dev-nan` -> Download all licenses
- In the KOTS UI, update the license to the downloaded file and redeploy.
- You will now see the correct image in the `refCache` field
 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
