### PR TITLE
[usage] Ensure `Content-Type` headers are set for GCP object storage uploads

### DIFF
--- a/components/content-service/pkg/service/usage-report-service.go
+++ b/components/content-service/pkg/service/usage-report-service.go
@@ -48,7 +48,7 @@ func (us *UsageReportService) UploadURL(ctx context.Context, req *api.UsageRepor
 	}
 
 	info, err := us.s.SignUpload(ctx, us.bucketName, req.Name, &storage.SignedURLOptions{
-		ContentType: "*/*",
+		ContentType: "application/json",
 	})
 	if err != nil {
 		log.WithField("name", req.Name).

--- a/components/usage/pkg/contentservice/client.go
+++ b/components/usage/pkg/contentservice/client.go
@@ -53,6 +53,7 @@ func (c *Client) UploadUsageReport(ctx context.Context, filename string, report 
 		return fmt.Errorf("failed to construct http request: %w", err)
 	}
 
+	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Content-Encoding", "gzip")
 
 	log.Infof("Uploading %q to object storage...", filename)


### PR DESCRIPTION
## Description

As part of the move towards usage based pricing (https://github.com/gitpod-io/gitpod/issues/9036), we'd like for the usage aggregator (`components/usage`) to be able to upload its usage reports to cloud storage. This will provide an audit trail of usage reports, allowing us to cross reference usage entries in the database with the usage reports that provided the data. In future, we may also allow access to these reports to users directly.

In order to be able to upload these reports to GCP Cloud Storage, the signed URL can be created for a specific `Content-Type`; only `PUT` requests to that URL that set the same `Content-Type` header will be accepted.

This PR sets the `Content-Type` header when generating the signed URL and sets it on the `usage` component `PUT` to that URL.

Minio object storage has no such requirements on the `Content-Type` header which is why we only hit this problem in staging/production.

## Related Issue(s)

Fixes https://github.com/gitpod-io/gitpod/issues/11688

## How to test

This is difficult to test as preview uses minio for object storage, not GCP.

Tested by taking the images built for this branch and hot-patching the images for `content-service` and `usage` in staging.

Reports are uploaded to the bucket:

<img width="1536" alt="image" src="https://user-images.githubusercontent.com/8225907/181597669-6d678485-5aa8-4720-a7f6-f2bc44a3341c.png">

## Release Notes
```release-note
NONE
```

## Documentation


## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
