### PR TITLE
Add alert for target down

### DIFF
--- a/operations/observability/mixins/platform/rules.libsonnet
+++ b/operations/observability/mixins/platform/rules.libsonnet
@@ -3,5 +3,4 @@
  * Licensed under the MIT License. See License-MIT.txt in the project root for license information.
  */
 
-(import './dashboards.libsonnet') +
-(import './rules.libsonnet')
+(import './rules/scrape.libsonnet')

--- a/operations/observability/mixins/platform/rules/scrape.libsonnet
+++ b/operations/observability/mixins/platform/rules/scrape.libsonnet
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+ */
+
+{
+  prometheusAlerts+:: {
+    groups+: [
+      {
+        name: 'prometheus-scraping-rules',
+        rules: [
+          {
+            alert: 'TargetDownOrFailedScrape',
+            labels: {
+              severity: 'warning',
+              team: 'platform',
+            },
+            'for': '10m',
+            annotations: {
+              summary: 'Prometheus failed to scrape {{ $labels.job }}',
+              description: 'Prometheus couldn\'t scrape {{ printf "%.4g" $value }}% of the {{ $labels.job }} targets. Components could be unnavailable or we have some scraping misconfiguration.',
+            },
+            expr: '100 * (count(up{container!="workspace"} == 0) BY (job) / count(up{container!="workspace"}) BY (job)) > 0',
+          },
+        ],
+      },
+    ],
+  },
+}


### PR DESCRIPTION
Signed-off-by: ArthurSens <arthursens2005@gmail.com>

## Description
<!-- Describe your changes in detail -->
Add an alert for when Prometheus fails to scrape metrics from any target. (Actually, it ignores workspaces)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
