### PR TITLE
Add alert for OpenVSX-proxy scraping failures

### DIFF
--- a/operations/observability/mixins/IDE/rules/components/openvsx-proxy/alerts.libsonnet
+++ b/operations/observability/mixins/IDE/rules/components/openvsx-proxy/alerts.libsonnet
@@ -18,12 +18,25 @@
             annotations: {
               runbook_url: 'https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodOpenVsxRegistryDown.md',
               summary: 'Open-VSX registry is possibly down',
-              description: 'Open-VSX registry is possibly down. We cannot pull VSCode extensions we don\'t have in our caches',
+              description: "Open-VSX registry is possibly down. We cannot pull VSCode extensions we don't have in our caches",
             },
             expr:
               |||
                 sum(rate(gitpod_openvsx_proxy_requests_total{status=~"5..|error"}[5m])) / sum(rate(gitpod_openvsx_proxy_requests_total[5m])) > 0.01
               |||,
+          },
+          {
+            alert: 'GitpodOpenVSXUnavailable',
+            labels: {
+              severity: 'warning',
+              team: 'ide',
+            },
+            'for': '10m',
+            annotations: {
+              summary: 'Prometheus is failing to scrape OpenVSX-proxy',
+              description: 'OpenVSX-proxy is possibly down, or prometheus is failing to scrape it.',
+            },
+            expr: 'up{job="openvsx-proxy"} == 0 or absent(up{job="openvsx-proxy"}) == 1',
           },
         ],
       },


### PR DESCRIPTION
Signed-off-by: ArthurSens <arthursens2005@gmail.com>

## Description
<!-- Describe your changes in detail -->
Add an alert that triggers when Prometheus fails to scrape OpenVSX-proxy, or when OpenVSX-Proxy completely disappears from Prometheus' target list

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
