### PR TITLE
[usage] Delay gRPC self connection

### DIFF
--- a/components/usage/pkg/server/dialer.go
+++ b/components/usage/pkg/server/dialer.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package server
+
+import (
+	"context"
+	"net"
+	"time"
+
+	"google.golang.org/grpc"
+)
+
+func grpcDialerWithInitialDelay(delay time.Duration) grpc.DialOption {
+	return grpc.WithContextDialer(func(_ context.Context, addr string) (net.Conn, error) {
+		<-time.After(delay)
+
+		conn, err := net.Dial("tcp", addr)
+		if err != nil {
+			return nil, err
+		}
+		return conn, nil
+	})
+}

--- a/components/usage/pkg/server/server.go
+++ b/components/usage/pkg/server/server.go
@@ -6,11 +6,12 @@ package server
 
 import (
 	"fmt"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 	"net"
 	"os"
 	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/gitpod-io/gitpod/common-go/baseserver"
 	"github.com/gitpod-io/gitpod/common-go/log"
@@ -58,7 +59,8 @@ func Start(cfg Config) error {
 		return fmt.Errorf("failed to initialize usage server: %w", err)
 	}
 
-	selfConnection, err := grpc.Dial(srv.GRPCAddress(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	dialerOpt := grpcDialerWithInitialDelay(1 * time.Second)
+	selfConnection, err := grpc.Dial(srv.GRPCAddress(), grpc.WithTransportCredentials(insecure.NewCredentials()), dialerOpt)
 	if err != nil {
 		return fmt.Errorf("failed to create self-connection to grpc server: %w", err)
 	}


### PR DESCRIPTION
## Description

The billing client tries to connect to the usage component gRPC server before the gRPC server is ready. This is a non-fatal error as gRPC dialing has built-in backoff/retry logic but it does produce ugly warnings in the usage component logs.

Here we use a simple solution to delay the self-connection attempt for a short period to give the gRPC server time to start.

## Related Issue(s)
Fixes https://github.com/gitpod-io/gitpod/issues/11743

## How to test

Warning messages at `usage` component startup (as described in #11743) are no longer present.

## Release Notes
```release-note
NONE
```

## Documentation

## Werft options:
- [ ] /werft with-preview
