### PR TITLE
[installer-tests] Add slack webhook for test failures

### DIFF
--- a/.werft/aks-installer-tests.yaml
+++ b/.werft/aks-installer-tests.yaml
@@ -58,6 +58,21 @@ pod:
       valueFrom:
         fieldRef:
           fieldPath: spec.nodeName
+    - name: IDE_SLACK_NOTIFICATION_PATH
+      valueFrom:
+        secretKeyRef:
+          name: slack-webhook-urls
+          key: ide_jobs
+    - name: WS_SLACK_NOTIFICATION_PATH
+      valueFrom:
+        secretKeyRef:
+          name: slack-webhook-urls
+          key: workspace_jobs
+    - name: SH_SLACK_NOTIFICATION_PATH
+      valueFrom:
+        secretKeyRef:
+          name: slack-webhook-urls
+          key: self_hosted_jobs
     command:
       - bash
       - -c

--- a/.werft/cleanup-installer-setups.yaml
+++ b/.werft/cleanup-installer-setups.yaml
@@ -83,6 +83,21 @@ pod:
         secretKeyRef:
           name: aws-credentials
           key: aws-region
+    - name: IDE_SLACK_NOTIFICATION_PATH
+      valueFrom:
+        secretKeyRef:
+          name: slack-webhook-urls
+          key: ide_jobs
+    - name: WS_SLACK_NOTIFICATION_PATH
+      valueFrom:
+        secretKeyRef:
+          name: slack-webhook-urls
+          key: workspace_jobs
+    - name: SH_SLACK_NOTIFICATION_PATH
+      valueFrom:
+        secretKeyRef:
+          name: slack-webhook-urls
+          key: self_hosted_jobs
     command:
       - bash
       - -c

--- a/.werft/eks-installer-tests.yaml
+++ b/.werft/eks-installer-tests.yaml
@@ -53,6 +53,21 @@ pod:
       valueFrom:
         fieldRef:
           fieldPath: spec.nodeName
+    - name: IDE_SLACK_NOTIFICATION_PATH
+      valueFrom:
+        secretKeyRef:
+          name: slack-webhook-urls
+          key: ide_jobs
+    - name: WS_SLACK_NOTIFICATION_PATH
+      valueFrom:
+        secretKeyRef:
+          name: slack-webhook-urls
+          key: workspace_jobs
+    - name: SH_SLACK_NOTIFICATION_PATH
+      valueFrom:
+        secretKeyRef:
+          name: slack-webhook-urls
+          key: self_hosted_jobs
     command:
       - bash
       - -c

--- a/.werft/gke-installer-tests.yaml
+++ b/.werft/gke-installer-tests.yaml
@@ -40,6 +40,21 @@ pod:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: IDE_SLACK_NOTIFICATION_PATH
+          valueFrom:
+            secretKeyRef:
+              name: slack-webhook-urls
+              key: ide_jobs
+        - name: WS_SLACK_NOTIFICATION_PATH
+          valueFrom:
+            secretKeyRef:
+              name: slack-webhook-urls
+              key: workspace_jobs
+        - name: SH_SLACK_NOTIFICATION_PATH
+          valueFrom:
+            secretKeyRef:
+              name: slack-webhook-urls
+              key: self_hosted_jobs
       command:
         - bash
         - -c

--- a/.werft/k3s-installer-tests.yaml
+++ b/.werft/k3s-installer-tests.yaml
@@ -45,6 +45,21 @@ pod:
           secretKeyRef:
             name: integration-test-user
             key: token
+      - name: IDE_SLACK_NOTIFICATION_PATH
+        valueFrom:
+          secretKeyRef:
+            name: slack-webhook-urls
+            key: ide_jobs
+      - name: WS_SLACK_NOTIFICATION_PATH
+        valueFrom:
+          secretKeyRef:
+            name: slack-webhook-urls
+            key: workspace_jobs
+      - name: SH_SLACK_NOTIFICATION_PATH
+        valueFrom:
+          secretKeyRef:
+            name: slack-webhook-urls
+            key: self_hosted_jobs
     command:
       - bash
       - -c

--- a/.werft/self-hosted-installer-tests.yaml
+++ b/.werft/self-hosted-installer-tests.yaml
@@ -54,12 +54,17 @@ pod:
   - name: sh-aks-perm
     secret:
       secretName: aks-credentials
+  - name: self-hosted-github-oauth
+    secret:
+      secretName: self-hosted-github-oauth
   containers:
   - name: nightly-test
     image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:sje-kots-latest-img.2
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:
+    - name: self-hosted-github-oauth
+      mountPath: /mnt/secrets/self-hosted-github-oauth
     - name: sh-playground-sa-perm
       mountPath: /mnt/secrets/sh-playground-sa-perm
     - name: sh-playground-dns-perm # this sa is used for the DNS management
@@ -115,6 +120,21 @@ pod:
         secretKeyRef:
           name: aws-credentials
           key: aws-region
+    - name: IDE_SLACK_NOTIFICATION_PATH
+      valueFrom:
+        secretKeyRef:
+          name: slack-webhook-urls
+          key: ide_jobs
+    - name: WS_SLACK_NOTIFICATION_PATH
+      valueFrom:
+        secretKeyRef:
+          name: slack-webhook-urls
+          key: workspace_jobs
+    - name: SH_SLACK_NOTIFICATION_PATH
+      valueFrom:
+        secretKeyRef:
+          name: slack-webhook-urls
+          key: self_hosted_jobs
     command:
       - bash
       - -c

--- a/install/tests/Makefile
+++ b/install/tests/Makefile
@@ -147,9 +147,25 @@ external-dns: check-env-cloud select-workspace
 ## get-kubeconfig: Returns KUBECONFIG of a just created cluster
 get-kubeconfig: ${cloud}-kubeconfig
 
+
+get-github-config:
+ifneq ($(GITHUB_SCM_OAUTH),)
+	export SCM_OAUTH=./manifests/github-oauth.yaml && \
+	cat $$GITHUB_SCM_OAUTH/provider > $$SCM_OAUTH && \
+	yq w -i $$SCM_OAUTH 'oauth.callBackUrl' http://${TF_VAR_TEST_ID}.tests.gitpod-self-hosted.com/auth/github.com/callback && \
+	kubectl --kubeconfig=${KUBECONFIG} create namespace gitpod || echo "Gitpod namespace already exist" && \
+	kubectl --kubeconfig=${KUBECONFIG} delete secret github-oauth -n gitpod || echo "gitpod-oauth secret needs to be created" && \
+	kubectl --kubeconfig=${KUBECONFIG} create secret generic "github-oauth" --namespace gitpod --from-literal=provider="$$(cat $$SCM_OAUTH)" && \
+	echo -en  "authProviders:\n  - kind: secret\n    name: github-oauth\n" > ./manifests/config-patch.yaml
+else
+	echo "Skipping github setup since var GITHUB_SCM_OAUTH is not set"
+endif
+
 KOTS_KONFIG := "./manifests/kots-config.yaml"
 
-get-base-config:
+get-base-config: get-github-config
+	export CONFIG_PATCH=./manifests/config-patch.yaml && \
+	export PATCH=$$(cat $$CONFIG_PATCH | base64 -w 0) || export PATCH="" && \
 	envsubst < ${KOTS_KONFIG} > tmp_config.yml
 
 storage-config-gcp:
@@ -264,8 +280,8 @@ delete-cm-setup:
 
 gitpod-debug-info:
 	@echo "Gitpod is not ready"
-	@kubectl get pods -n gitpod
-	@kubectl get certificate -n gitpod
+	@kubectl --kubeconfig=${KUBECONFIG} get pods -n gitpod
+	@kubectl --kubeconfig=${KUBECONFIG} get certificate -n gitpod
 
 check-kots-app:
 	kubectl kots get --kubeconfig=${KUBECONFIG} app gitpod -n gitpod | grep gitpod  | awk '{print $$2}' | grep "ready" || { $(MAKE) gitpod-debug-info; exit 1; }
@@ -297,7 +313,7 @@ run-ib-component-tests:
 	$(call runtests,"test/tests/components/image-builder/")
 
 run-server-component-tests:
-	$(call runtests,"test/tests/components/content-service/")
+	$(call runtests,"test/tests/components/server/")
 
 run-wsd-component-tests:
 	$(call runtests,"test/tests/components/ws-daemon/")
@@ -310,9 +326,12 @@ kots-upgrade:
 	kubectl kots upstream upgrade --kubeconfig=${KUBECONFIG} gitpod -n gitpod --deploy
 
 cloud ?= cluster
-cleanup: $(cloud)-kubeconfig destroy-gitpod destroy-$(cloud) destroy-workspace destroy-kubeconfig
+cleanup: $(cloud)-kubeconfig destroy-gitpod tf-init destroy-$(cloud) destroy-workspace destroy-kubeconfig
 
 cluster-kubeconfig: azure-kubeconfig aws-kubeconfig k3s-kubeconfig gcp-kubeconfig
+
+tf-init:
+	@terraform init
 
 destroy-cluster: destroy-gcp destroy-aws destroy-azure
 

--- a/install/tests/manifests/kots-config.yaml
+++ b/install/tests/manifests/kots-config.yaml
@@ -8,3 +8,9 @@ spec:
       ssh_gateway:
         value: "1"
         data: "ssh_gateway"
+      advanced_mode_enabled:
+        value: "1"
+        data: "advanced_mode_enabled"
+      config_patch:
+        data: "config_patch"
+        value: ${PATCH}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PR adds slack webhook alerting capabilities to the nightly tests. Currently if any of the setup fails, alert goes to #self-hosted-jobs channel on slack and if any of the integration tests fails it goes to the corresponding team's job channel (currently only workspace and IDE). 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #11273 

## How to test
<!-- Provide steps to test this PR -->
You can run any tests like in this [internal doc](https://www.notion.so/gitpod/WIP-Self-hosted-automated-nightly-pipelines-fdc5a202e67b4197aa00d93b98d57927) to  check the alerts

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
