### PR TITLE
[installer]: rename the CA

### DIFF
--- a/install/installer/pkg/common/constants.go
+++ b/install/installer/pkg/common/constants.go
@@ -15,7 +15,7 @@ import (
 const (
 	AppName                     = "gitpod"
 	BlobServeServicePort        = 4000
-	CertManagerCAIssuer         = "ca-issuer"
+	CertManagerCAIssuer         = AppName
 	DockerRegistryURL           = "docker.io"
 	DockerRegistryName          = "registry"
 	GitpodContainerRegistry     = "eu.gcr.io/gitpod-core-dev/build"

--- a/install/kots/manifests/gitpod-certificate.yaml
+++ b/install/kots/manifests/gitpod-certificate.yaml
@@ -13,7 +13,7 @@ metadata:
 spec:
   secretName: https-certificates
   issuerRef:
-    name: '{{repl if (ConfigOptionEquals "tls_self_signed_enabled" "1" ) }}ca-issuer{{repl else }}{{repl ConfigOption "cert_manager_issuer_name" }}{{repl end }}'
+    name: '{{repl if (ConfigOptionEquals "tls_self_signed_enabled" "1" ) }}gitpod{{repl else }}{{repl ConfigOption "cert_manager_issuer_name" }}{{repl end }}'
     kind: '{{repl if (ConfigOptionEquals "tls_self_signed_enabled" "1" ) }}Issuer{{repl else }}{{repl ConfigOption "cert_manager_issuer" }}{{repl end }}'
   dnsNames:
     - '{{repl ConfigOption "domain" }}'

--- a/install/kots/manifests/gitpod-installation-status.yaml
+++ b/install/kots/manifests/gitpod-installation-status.yaml
@@ -30,7 +30,7 @@ spec:
       containers:
         - name: installation-status
           # This will normally be the release tag
-          image: "eu.gcr.io/gitpod-core-dev/build/installer:nvn-fix-11408.15"
+          image: "eu.gcr.io/gitpod-core-dev/build/installer:sje-installer-ca-name.0"
           command:
             - /bin/sh
             - -c

--- a/install/kots/manifests/gitpod-installer-job.yaml
+++ b/install/kots/manifests/gitpod-installer-job.yaml
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: installer
           # This will normally be the release tag
-          image: "eu.gcr.io/gitpod-core-dev/build/installer:nvn-fix-11408.15"
+          image: "eu.gcr.io/gitpod-core-dev/build/installer:sje-installer-ca-name.0"
           volumeMounts:
             - mountPath: /config-patch
               name: config-patch
@@ -241,7 +241,7 @@ spec:
               then
                 echo "Gitpod: Generating a self-signed certificate with the internal CA"
                 yq e -i '.customCACert.kind = "secret"' "${CONFIG_FILE}"
-                yq e -i '.customCACert.name = "ca-issuer-ca"' "${CONFIG_FILE}"
+                yq e -i '.customCACert.name = "gitpod-ca"' "${CONFIG_FILE}"
               elif [ '{{repl and (ConfigOptionEquals "tls_self_signed_enabled" "0") (ConfigOptionEquals "cert_manager_enabled" "0") (ConfigOptionNotEquals "tls_ca_crt" "") }}' = "true" ];
               then
                 echo "Gitpod: Setting CA to be used for certificate"

--- a/install/kots/manifests/kots-config.yaml
+++ b/install/kots/manifests/kots-config.yaml
@@ -292,7 +292,7 @@ spec:
             certificate and install it to your browser.
 
             To download the certificate, run
-            `kubectl get secrets -n {{repl Namespace }}  ca-issuer-ca -o jsonpath='{.data.ca\.crt}' | base64 -d > ./ca.crt`
+            `kubectl get secrets -n {{repl Namespace }}  gitpod-ca -o jsonpath='{.data.ca\.crt}' | base64 -d > ./ca.crt`
 
         - name: cert_manager_enabled
           title: Use cert-manager


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
As we're now supporting self-signed certs and making the CA more prominent, we should have it named Gitpod

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[installer]: rename the CA
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
