### PR TITLE
[code] update stable code for 1.69 with in-product changelog and port…

### DIFF
--- a/install/installer/pkg/components/workspace/ide/constants.go
+++ b/install/installer/pkg/components/workspace/ide/constants.go
@@ -6,7 +6,7 @@ package ide
 
 const (
 	CodeIDEImage                = "ide/code"
-	CodeIDEImageStableVersion   = "commit-050c611f28564c6c7b1e58db470f07997dfb4730" // stable version that will be updated manually on demand
+	CodeIDEImageStableVersion   = "commit-079f161f0aaf95d6b5e28f0709b3e629337291e9" // stable version that will be updated manually on demand
 	CodeDesktopIDEImage         = "ide/code-desktop"
 	CodeDesktopInsidersIDEImage = "ide/code-desktop-insiders"
 	IntelliJDesktopIDEImage     = "ide/intellij"


### PR DESCRIPTION
…s view improvement

## Description
<!-- Describe your changes in detail -->

Commit hash from previous PR https://github.com/gitpod-io/gitpod/pull/11753 job https://werft.gitpod-dev.com/job/gitpod-build-hw-vs-b.1/results

With first three commits in [gp-code/release/1.69](https://github.com/gitpod-io/openvscode-server/commits/gp-code/release/1.69) branch

- Improve ports view https://github.com/gitpod-io/openvscode-server/commit/69d2355b6368945da2f6dadf22427dbcd82fa271
- Add in product changelog https://github.com/gitpod-io/openvscode-server/commit/e6232db3143b88e6b05b2a2cd1f9d22e6ee85f3c
- Hide code show release notes command https://github.com/gitpod-io/openvscode-server/commit/9a4dbcf1367331cdd6a840be0c3ca351849ec5a2

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
- Open workspace with stable browser code
- Check if new features applied

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Update stable Browser VSCode image with in-product changelog and experimental `Ports` view improvement
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
