### PR TITLE
[docker-up] Update docker compose to v2.8.0

### DIFF
--- a/components/docker-up/BUILD.yaml
+++ b/components/docker-up/BUILD.yaml
@@ -45,8 +45,8 @@ packages:
         - ["mv", "components-docker-up--bin-runc-facade/docker-up", "runc-facade"]
         - ["rm", "-r", "components-docker-up--bin-runc-facade"]
         # Override docker-compose with custom version https://github.com/gitpod-io/compose/pull/1
-        - ["curl", "--fail", "-sSL", "https://github.com/gitpod-io/compose/releases/download/2.7.0-gitpod.0/docker-compose-linux-x86_64", "-o", "docker-compose-linux-x86_64"]
-        - ["curl", "--fail", "-sSL", "https://github.com/gitpod-io/compose/releases/download/2.7.0-gitpod.0/checksums.txt", "-o", "checksums.txt"]
+        - ["curl", "--fail", "-sSL", "https://github.com/gitpod-io/compose/releases/download/2.8.0-gitpod.0/docker-compose-linux-x86_64", "-o", "docker-compose-linux-x86_64"]
+        - ["curl", "--fail", "-sSL", "https://github.com/gitpod-io/compose/releases/download/2.8.0-gitpod.0/checksums.txt", "-o", "checksums.txt"]
         - ["sha256sum", "-c", "checksums.txt"]
         - ["mv", "docker-compose-linux-x86_64", "docker-compose"]
         - ["chmod", "+x", "docker-compose"]


### PR DESCRIPTION
## Description

Sync fork https://github.com/gitpod-io/compose/compare/v2.7.0...v2.8.0

## How to test
- Start a workspace
- Run `docker-compose --version`, should return `Docker Compose version 2.8.0-gitpod.0`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Update docker compose to v2.8.0
```

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
