### PR TITLE
[server] Tie protected_secrets to ConfigCag

### DIFF
--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -749,6 +749,12 @@ export class WorkspaceStarter {
                 );
             }
 
+            if (await getExperimentsClientForBackend().getValueAsync("protected_secrets", false, { user })) {
+                // We roll out the protected secrets feature using a ConfigCat feature flag, to ensure
+                // a smooth, gradual roll out without breaking users.
+                featureFlags = featureFlags.concat(["protected_secrets"]);
+            }
+
             featureFlags = featureFlags.filter((f) => !excludeFeatureFlags.includes(f));
 
             if (forcePVC === true) {


### PR DESCRIPTION
## Description
This PR ties protected_secrets to a ConfigCat feature flag (on server) so that we can roll this out in production. This is the next step for https://github.com/gitpod-io/gitpod/issues/10134.

I've added the `protected_secrets` flag to ConfigCat and enabled it for non-prod environments.

## How to test
1. Start a workspace
2. Observe that the workspace was started with the `protected_secrets` flag, and that its secrets were fed from a Kubernetes secret.
    <img width="859" alt="image" src="https://user-images.githubusercontent.com/3210701/182134338-2dcc8678-a343-4fdd-b43c-b84b4304b568.png">

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
