### PR TITLE
Set KOTS/Replicated dependencies to latest

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
-image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-go.18
+image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:sje-kots-latest-img.2
 workspaceLocation: gitpod/gitpod-ws.code-workspace
 checkoutLocation: gitpod
 ports:

--- a/.werft/aks-installer-tests.yaml
+++ b/.werft/aks-installer-tests.yaml
@@ -21,7 +21,7 @@ pod:
       secretName: sh-playground-dns-perm
   containers:
   - name: nightly-test
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-go.18
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:sje-kots-latest-img.2
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/build.yaml
+++ b/.werft/build.yaml
@@ -75,7 +75,7 @@ pod:
     - name: MYSQL_TCP_PORT
       value: 23306
   - name: build
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-go.18
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:sje-kots-latest-img.2
     workingDir: /workspace
     imagePullPolicy: IfNotPresent
     resources:

--- a/.werft/debug.yaml
+++ b/.werft/debug.yaml
@@ -53,7 +53,7 @@ pod:
     - name: MYSQL_TCP_PORT
       value: 23306
   - name: build
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-go.18
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:sje-kots-latest-img.2
     workingDir: /workspace
     imagePullPolicy: IfNotPresent
     volumeMounts:

--- a/.werft/eks-installer-tests.yaml
+++ b/.werft/eks-installer-tests.yaml
@@ -21,7 +21,7 @@ pod:
       secretName: sh-playground-dns-perm
   containers:
   - name: nightly-test
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-go.18
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:sje-kots-latest-img.2
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/gke-installer-tests.yaml
+++ b/.werft/gke-installer-tests.yaml
@@ -21,7 +21,7 @@ pod:
         secretName: sh-playground-dns-perm
   containers:
     - name: nightly-test
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-go.18
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:sje-kots-latest-img.2
       workingDir: /workspace
       imagePullPolicy: Always
       volumeMounts:

--- a/.werft/ide-integration-tests-startup.yaml
+++ b/.werft/ide-integration-tests-startup.yaml
@@ -16,7 +16,7 @@ pod:
         secretName: github-token-gitpod-bot
   containers:
     - name: gcloud
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-go.18
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:sje-kots-latest-img.2
       workingDir: /workspace
       imagePullPolicy: IfNotPresent
       env:

--- a/.werft/k3s-installer-tests.yaml
+++ b/.werft/k3s-installer-tests.yaml
@@ -21,7 +21,7 @@ pod:
       secretName: sh-playground-dns-perm
   containers:
   - name: nightly-test
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-go.18
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:sje-kots-latest-img.2
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/platform-delete-preview-environments-cron.yaml
+++ b/.werft/platform-delete-preview-environments-cron.yaml
@@ -24,7 +24,7 @@ pod:
         secretName: harvester-vm-ssh-keys
   containers:
     - name: build
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-go.18
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:sje-kots-latest-img.2
       workingDir: /workspace
       imagePullPolicy: IfNotPresent
       volumeMounts:

--- a/.werft/platform-trigger-werft-cleanup.yaml
+++ b/.werft/platform-trigger-werft-cleanup.yaml
@@ -21,7 +21,7 @@ pod:
         secretName: gcp-sa-gitpod-dev-deployer
   containers:
     - name: build
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-go.18
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:sje-kots-latest-img.2
       workingDir: /workspace
       imagePullPolicy: IfNotPresent
       volumeMounts:

--- a/.werft/run-integration-tests.yaml
+++ b/.werft/run-integration-tests.yaml
@@ -22,7 +22,7 @@ pod:
       emptyDir: {}
   initContainers:
     - name: gcloud
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-go.18
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:sje-kots-latest-img.2
       workingDir: /workspace
       imagePullPolicy: IfNotPresent
       volumeMounts:

--- a/.werft/self-hosted-installer-tests.yaml
+++ b/.werft/self-hosted-installer-tests.yaml
@@ -56,7 +56,7 @@ pod:
       secretName: aks-credentials
   containers:
   - name: nightly-test
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-go.18
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:sje-kots-latest-img.2
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/wipe-devstaging.yaml
+++ b/.werft/wipe-devstaging.yaml
@@ -14,7 +14,7 @@ pod:
         secretName: gcp-sa-gitpod-dev-deployer
   containers:
     - name: wipe-devstaging
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-go.18
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:sje-kots-latest-img.2
       workingDir: /workspace
       imagePullPolicy: IfNotPresent
       volumeMounts:

--- a/.werft/workspace-run-integration-tests.yaml
+++ b/.werft/workspace-run-integration-tests.yaml
@@ -16,7 +16,7 @@ pod:
         secretName: github-token-gitpod-bot
   containers:
     - name: gcloud
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-go.18
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:sje-kots-latest-img.2
       workingDir: /workspace
       imagePullPolicy: IfNotPresent
       env:

--- a/dev/image/Dockerfile
+++ b/dev/image/Dockerfile
@@ -248,8 +248,9 @@ RUN curl -fsSLO https://github.com/brancz/gojsontoyaml/releases/download/v${GOJS
     rm -f gojsontoyaml_${GOJSONTOYAML_VERSION}_linux_amd64.tar.gz
 
 # Install Replicated and KOTS
-RUN curl https://raw.githubusercontent.com/replicatedhq/replicated/v0.38.0/install.sh | sudo bash && \
-    curl https://kots.io/install/1.65.0 | bash
+RUN curl https://raw.githubusercontent.com/replicatedhq/replicated/$(curl -s https://api.github.com/repos/replicatedhq/replicated/releases/latest | jq -r '.name')/install.sh | sudo bash && \
+    curl https://kots.io/install | bash && \
+    bash -c "echo . \<\(kubectl kots completion bash\) >> ~/.bashrc"
 
 # Copy our own tools
 ENV NEW_KUBECDL=1


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
These have become very outdated. As a way of avoiding this in future, these are set to the latest. 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
