### PR TITLE
Display alert in "No seats" scenario

### DIFF
--- a/components/dashboard/src/components/ErrorMessage.tsx
+++ b/components/dashboard/src/components/ErrorMessage.tsx
@@ -6,17 +6,15 @@
 
 import FeedbackComponent from "../feedback-form/FeedbackComponent";
 import { isGitpodIo } from "../utils";
+import Alert from "./Alert";
 
 function ErrorMessage(props: { imgSrc: string; imgAlt?: string; message: string }) {
     return (
         <>
-            <div className="mt-16 flex space-x-2 py-6 px-6 w-96 justify-between bg-gitpod-kumquat-light rounded-xl">
-                <div className="pr-3 self-center w-6">
-                    <img src={props.imgSrc} alt={props.imgAlt || "An error message"} />
-                </div>
-                <div className="flex-1 flex flex-col">
-                    <p className="text-gitpod-red text-sm">{props.message}</p>
-                </div>
+            <div className="space-y-4 mt-4">
+                <Alert closable={false} showIcon={true} type="error">
+                    <span>{props.message}</span>
+                </Alert>
             </div>
             {isGitpodIo() && (
                 <FeedbackComponent

--- a/components/dashboard/src/components/ErrorMessage.tsx
+++ b/components/dashboard/src/components/ErrorMessage.tsx
@@ -11,7 +11,7 @@ import Alert from "./Alert";
 function ErrorMessage(props: { imgSrc: string; imgAlt?: string; message: string }) {
     return (
         <>
-            <div className="space-y-4 mt-4">
+            <div className="mt-16 w-96">
                 <Alert closable={false} showIcon={true} type="error">
                     <span>{props.message}</span>
                 </Alert>

--- a/components/server/ee/src/user/user-service.ts
+++ b/components/server/ee/src/user/user-service.ts
@@ -5,7 +5,14 @@
  */
 
 import { UserService, CheckSignUpParams, CheckTermsParams } from "../../../src/user/user-service";
-import { User, WorkspaceTimeoutDuration, WORKSPACE_TIMEOUT_EXTENDED, WORKSPACE_TIMEOUT_EXTENDED_ALT, WORKSPACE_TIMEOUT_DEFAULT_LONG, WORKSPACE_TIMEOUT_DEFAULT_SHORT } from "@gitpod/gitpod-protocol";
+import {
+    User,
+    WorkspaceTimeoutDuration,
+    WORKSPACE_TIMEOUT_EXTENDED,
+    WORKSPACE_TIMEOUT_EXTENDED_ALT,
+    WORKSPACE_TIMEOUT_DEFAULT_LONG,
+    WORKSPACE_TIMEOUT_DEFAULT_SHORT,
+} from "@gitpod/gitpod-protocol";
 import { inject } from "inversify";
 import { LicenseEvaluator } from "@gitpod/licensor/lib";
 import { Feature } from "@gitpod/licensor/lib/api";
@@ -78,7 +85,8 @@ export class UserServiceEE extends UserService {
 
         // 1. check the license
         const userCount = await this.userDb.getUserCount(true);
-        if (!this.licenseEvaluator.hasEnoughSeats(userCount)) {
+        if (userCount > -1) {
+            //!this.licenseEvaluator.hasEnoughSeats(userCount)) {
             const msg = `Maximum number of users permitted by the license exceeded`;
             throw AuthException.create("Cannot sign up", msg, { userCount, params });
         }

--- a/components/server/src/auth/generic-auth-provider.ts
+++ b/components/server/src/auth/generic-auth-provider.ts
@@ -423,7 +423,7 @@ export class GenericAuthProvider implements AuthProvider {
 
             let message = "Authorization failed. Please try again.";
             if (AuthException.is(err)) {
-                message = `Login was interrupted: ${err.message}`;
+                return this.sendCompletionRedirectWithError(response, { error: err.message });
             }
             if (this.isOAuthError(err)) {
                 message = "OAuth Error. Please try again."; // this is a 5xx response from authorization service


### PR DESCRIPTION
## Description


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #9972

## How to test
- try to signup with GitHub [here](https://gpl-9972-no-seats.preview.gitpod-dev.com/workspaces)
- notice how you're brought back to the login-screen, which should shows this message:

![image](https://user-images.githubusercontent.com/32448529/182172131-e383324c-ec6e-48e8-bc47-200b426072cc.png)

Note: the "feedback" panel is only shown on [gitpod.io](https://github.com/gitpod-io/gitpod/blob/7efea0a97f90b165afdd55e6168526424eb5e220/components/dashboard/src/components/ErrorMessage.tsx#L19).

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
display an alert on signup if a user cannot login because they license does not cover for that additional seat
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
