### PR TITLE
[usage] Fix arguments to the listBilledUsage call

### DIFF
--- a/components/dashboard/src/teams/TeamUsage.tsx
+++ b/components/dashboard/src/teams/TeamUsage.tsx
@@ -8,7 +8,12 @@ import { useContext, useEffect, useState } from "react";
 import { Redirect, useLocation } from "react-router";
 import { getCurrentTeam, TeamsContext } from "./teams-context";
 import { getGitpodService, gitpodHostUrl } from "../service/service";
-import { BillableSession, BillableWorkspaceType, SortOrder } from "@gitpod/gitpod-protocol/lib/usage";
+import {
+    BillableSession,
+    BillableSessionRequest,
+    BillableWorkspaceType,
+    SortOrder,
+} from "@gitpod/gitpod-protocol/lib/usage";
 import { AttributionId } from "@gitpod/gitpod-protocol/lib/attribution";
 import { Item, ItemField, ItemsList } from "../components/ItemsList";
 import moment from "moment";
@@ -42,11 +47,11 @@ function TeamUsage() {
         }
         (async () => {
             const attributionId = AttributionId.render({ kind: "team", teamId: team.id });
-            const request = {
+            const request: BillableSessionRequest = {
                 attributionId,
                 startedTimeOrder,
-                startDateOfBillMonth,
-                endDateOfBillMonth,
+                from: startDateOfBillMonth,
+                to: endDateOfBillMonth,
             };
             try {
                 const billedUsageResult = await getGitpodService().server.listBilledUsage(request);


### PR DESCRIPTION
## Description
The wrong param names were sent, causing the API to compute default values.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
