### PR TITLE
[usage] Enable sorting in the UI

### DIFF
--- a/components/dashboard/src/teams/TeamUsage.tsx
+++ b/components/dashboard/src/teams/TeamUsage.tsx
@@ -23,6 +23,7 @@ import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
 import { FeatureFlagContext } from "../contexts/FeatureFlagContext";
 import { ReactComponent as CreditsSvg } from "../images/credits.svg";
 import { ReactComponent as Spinner } from "../icons/Spinner.svg";
+import Arrow from "../components/Arrow";
 
 function TeamUsage() {
     const { teams } = useContext(TeamsContext);
@@ -39,7 +40,7 @@ function TeamUsage() {
     const [startDateOfBillMonth, setStartDateOfBillMonth] = useState(timestampStartOfCurrentMonth);
     const [endDateOfBillMonth, setEndDateOfBillMonth] = useState(Date.now());
     const [isLoading, setIsLoading] = useState<boolean>(true);
-    const [startedTimeOrder] = useState<SortOrder>(SortOrder.Descending);
+    const [isStartedTimeDescending, setIsStartedTimeDescending] = useState<boolean>(true);
 
     useEffect(() => {
         if (!team) {
@@ -49,7 +50,7 @@ function TeamUsage() {
             const attributionId = AttributionId.render({ kind: "team", teamId: team.id });
             const request: BillableSessionRequest = {
                 attributionId,
-                startedTimeOrder,
+                startedTimeOrder: isStartedTimeDescending ? SortOrder.Descending : SortOrder.Ascending,
                 from: startDateOfBillMonth,
                 to: endDateOfBillMonth,
             };
@@ -64,7 +65,7 @@ function TeamUsage() {
                 setIsLoading(false);
             }
         })();
-    }, [team, startDateOfBillMonth, endDateOfBillMonth, startedTimeOrder]);
+    }, [team, startDateOfBillMonth, endDateOfBillMonth, isStartedTimeDescending]);
 
     if (!showUsageBasedPricingUI) {
         return <Redirect to="/" />;
@@ -200,7 +201,12 @@ function TeamUsage() {
                                             <CreditsSvg className="my-auto mr-1" />
                                             <span>Credits</span>
                                         </ItemField>
-                                        <ItemField className="my-auto" />
+                                        <ItemField className="my-auto cursor-pointer">
+                                            <span onClick={() => setIsStartedTimeDescending(!isStartedTimeDescending)}>
+                                                Started
+                                                <Arrow direction={isStartedTimeDescending ? "down" : "up"} />
+                                            </span>
+                                        </ItemField>
                                     </Item>
                                     {currentPaginatedResults &&
                                         currentPaginatedResults.map((usage) => (


### PR DESCRIPTION
## Description
This allows the started time to be sorted in descending and ascending orders.

<img width="705" alt="Screenshot 2022-08-01 at 16 29 24" src="https://user-images.githubusercontent.com/8015191/182173713-6d9b5c4f-15dc-4e41-9f1f-091daf2ca597.png">


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #11706 

## How to test
1. [Join this team](https://lau-sorting-ui-11706.preview.gitpod-dev.com/teams/join?inviteId=11a4f51d-4eb6-4f51-b171-a5c747ab1357).
2. See the usage.
3. Click on the sorting in the "Started" column. The list should be re-rendered accordingly.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
