### PR TITLE
[usage] Add a placeholder Stripe webhook

### DIFF
--- a/components/usage/config.json
+++ b/components/usage/config.json
@@ -8,6 +8,9 @@
     "services": {
       "grpc": {
         "address": ":9001"
+      },
+      "http": {
+        "address": ":9002"
       }
     }
   }

--- a/components/usage/go.mod
+++ b/components/usage/go.mod
@@ -27,7 +27,9 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/felixge/httpsnoop v1.0.1 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/gorilla/handlers v1.5.1 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
 	github.com/hashicorp/golang-lru v0.5.1 // indirect

--- a/components/usage/go.sum
+++ b/components/usage/go.sum
@@ -78,6 +78,8 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/go-control-plane v0.10.2-0.20220325020618-49ff273808a1/go.mod h1:KJwIaB5Mv44NWtYuAOFCVOjcI94vtpEz2JU/D2v6IjE=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+github.com/felixge/httpsnoop v1.0.1 h1:lvB5Jl89CsZtGIWuTcDM1E/vkVs49/Ml7JJe07l8SPQ=
+github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
@@ -157,6 +159,8 @@ github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
+github.com/gorilla/handlers v1.5.1 h1:9lRY6j8DEeeBT10CvO9hGW0gmky0BprnvDI5vfhUHH4=
+github.com/gorilla/handlers v1.5.1/go.mod h1:t8XrUpc4KVXb7HGyJ4/cEnwQiaxrX/hz1Zv/4g96P1Q=
 github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 h1:+9834+KizmvFV7pXQGSXQTsaWhq2GjuNUt0aUU0YBYw=
 github.com/grpc-ecosystem/go-grpc-middleware v1.3.0/go.mod h1:z0ButlSOZa5vEBq9m2m2hlwIgKw+rp3sdCBRoJY+30Y=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 h1:Ovs26xHkKqVztRpIrF/92BcuyuQ/YW4NSIpoGtfXNho=

--- a/components/usage/pkg/server/server.go
+++ b/components/usage/pkg/server/server.go
@@ -138,5 +138,5 @@ func registerGRPCServices(srv *baseserver.Server, conn *gorm.DB, stripeClient *s
 }
 
 func registerHttpHandlers(srv *baseserver.Server, h *stripe.WebhookHandler) {
-	srv.HTTPMux().HandleFunc("/webhook", h.Handle)
+	srv.HTTPMux().HandleFunc("/stripe/invoices/webhook", h.Handle)
 }

--- a/components/usage/pkg/server/server.go
+++ b/components/usage/pkg/server/server.go
@@ -111,6 +111,9 @@ func Start(cfg Config) error {
 		return fmt.Errorf("failed to register gRPC services: %w", err)
 	}
 
+	h := stripe.NewWebhookHandler()
+	registerHttpHandlers(srv, h)
+
 	err = controller.RegisterMetrics(srv.MetricsRegistry())
 	if err != nil {
 		return fmt.Errorf("failed to register controller metrics: %w", err)
@@ -132,4 +135,8 @@ func registerGRPCServices(srv *baseserver.Server, conn *gorm.DB, stripeClient *s
 		v1.RegisterBillingServiceServer(srv.GRPC(), apiv1.NewBillingService(stripeClient))
 	}
 	return nil
+}
+
+func registerHttpHandlers(srv *baseserver.Server, h *stripe.WebhookHandler) {
+	srv.HTTPMux().HandleFunc("/webhook", h.Handle)
 }

--- a/components/usage/pkg/server/server.go
+++ b/components/usage/pkg/server/server.go
@@ -21,6 +21,7 @@ import (
 	"github.com/gitpod-io/gitpod/usage/pkg/controller"
 	"github.com/gitpod-io/gitpod/usage/pkg/db"
 	"github.com/gitpod-io/gitpod/usage/pkg/stripe"
+	"github.com/gorilla/handlers"
 	"gorm.io/gorm"
 )
 
@@ -138,5 +139,5 @@ func registerGRPCServices(srv *baseserver.Server, conn *gorm.DB, stripeClient *s
 }
 
 func registerHttpHandlers(srv *baseserver.Server, h *stripe.WebhookHandler) {
-	srv.HTTPMux().HandleFunc("/stripe/invoices/webhook", h.Handle)
+	srv.HTTPMux().Handle("/stripe/invoices/webhook", handlers.ContentTypeHandler(h, "application/json"))
 }

--- a/components/usage/pkg/stripe/webhook.go
+++ b/components/usage/pkg/stripe/webhook.go
@@ -19,7 +19,7 @@ func NewWebhookHandler() *WebhookHandler {
 	return &WebhookHandler{}
 }
 
-func (h *WebhookHandler) Handle(w http.ResponseWriter, req *http.Request) {
+func (h *WebhookHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	const maxBodyBytes = int64(65536)
 
 	req.Body = http.MaxBytesReader(w, req.Body, maxBodyBytes)

--- a/components/usage/pkg/stripe/webhook.go
+++ b/components/usage/pkg/stripe/webhook.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package stripe
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/gitpod-io/gitpod/common-go/log"
+	"github.com/stripe/stripe-go/v72"
+)
+
+type WebhookHandler struct{}
+
+func NewWebhookHandler() *WebhookHandler {
+	return &WebhookHandler{}
+}
+
+func (h *WebhookHandler) Handle(w http.ResponseWriter, req *http.Request) {
+	const maxBodyBytes = int64(65536)
+
+	req.Body = http.MaxBytesReader(w, req.Body, maxBodyBytes)
+	payload, err := ioutil.ReadAll(req.Body)
+	if err != nil {
+		log.WithError(err).Error("Stripe webhook error when reading request body")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		return
+	}
+
+	event := stripe.Event{}
+	if err := json.Unmarshal(payload, &event); err != nil {
+		log.WithError(err).Error("Stripe webhook error while parsing event payload")
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	// TODO: verify webhook signature.
+	// Conditional on there being a secret configured.
+
+	fmt.Fprintf(w, "event type: %s", event.Type)
+}

--- a/components/usage/pkg/stripe/webhook.go
+++ b/components/usage/pkg/stripe/webhook.go
@@ -7,7 +7,6 @@ package stripe
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 
 	"github.com/gitpod-io/gitpod/common-go/log"
@@ -24,15 +23,10 @@ func (h *WebhookHandler) Handle(w http.ResponseWriter, req *http.Request) {
 	const maxBodyBytes = int64(65536)
 
 	req.Body = http.MaxBytesReader(w, req.Body, maxBodyBytes)
-	payload, err := ioutil.ReadAll(req.Body)
-	if err != nil {
-		log.WithError(err).Error("Stripe webhook error when reading request body")
-		w.WriteHeader(http.StatusServiceUnavailable)
-		return
-	}
 
 	event := stripe.Event{}
-	if err := json.Unmarshal(payload, &event); err != nil {
+	err := json.NewDecoder(req.Body).Decode(&event)
+	if err != nil {
 		log.WithError(err).Error("Stripe webhook error while parsing event payload")
 		w.WriteHeader(http.StatusBadRequest)
 		return


### PR DESCRIPTION
## Description

Add a placeholder [Stripe webhook](https://stripe.com/docs/webhooks) to the usage component. 

In later PRs, the webhook will receive `invoice.finalized` events from Stripe so that we can update instance usage records to show that they have been included in a particular invoice.


## Related Issue(s)

Part of #9036 and https://github.com/gitpod-io/gitpod/issues/10937

## How to test

* Install the[ `stripe` CLI](https://stripe.com/docs/stripe-cli) into the workspace and run `stripe login`.
* Port forward to the database in the preview environment:
```
kubectl port-forward svc/mysql 3306:3306
```
* Run the `usage` component locally:
```
DB_USERNAME=gitpod DB_HOST=localhost DB_PORT=3306 DB_PASSWORD=<>  go run . run  
```
* Forward `stripe` events to the local webhook endpoint:
```
stripe listen --skip-verify --forward-to localhost:9002/webhook
```
* Trigger a series of Stripe events:
```
stripe trigger invoice.finalized
```
This should start a series of Stripe events (setting up a customer and payment methods), each of which should be handled with a `200 OK`  by the webhook:

<img width="907" alt="image" src="https://user-images.githubusercontent.com/8225907/182176787-6abcd5a2-2869-44d9-a7e2-00088aba911b.png">

## Release Notes

```release-note
NONE
```

## Documentation


## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
