### PR TITLE
[experiment] A way todifferente btw `self-hosted` & `SAAS`

### DIFF
--- a/components/dashboard/src/Menu.tsx
+++ b/components/dashboard/src/Menu.tsx
@@ -28,6 +28,8 @@ import FeedbackFormModal from "./feedback-form/FeedbackModal";
 import { inResource, isGitpodIo } from "./utils";
 import { FeatureFlagContext } from "./contexts/FeatureFlagContext";
 import { getExperimentsClient } from "./experiments/client";
+import Alert from "./components/Alert";
+import { isLocalPreview } from "./utils";
 
 interface Entry {
     title: string;
@@ -111,6 +113,8 @@ export default function Menu() {
     const isMinimalUI = inResource(location.pathname, ["new", "teams/new", "open"]);
     const isWorkspacesUI = inResource(location.pathname, ["workspaces"]);
     const isAdminUI = inResource(window.location.pathname, ["admin"]);
+
+    const isLP = isLocalPreview();
 
     const [teamMembers, setTeamMembers] = useState<Record<string, TeamMemberInfo[]>>({});
     useEffect(() => {
@@ -488,6 +492,18 @@ export default function Menu() {
                             />
                         ))}
                     </nav>
+                )}
+                {isLP && (
+                    <Alert type="warning" className="app-container rounded-md">
+                        This is a local-preview instance. Visit{" "}
+                        <a
+                            className="gp-link hover:text-gray-600"
+                            href="https://www.gitpod.io/community-license?utm_source=local-preview"
+                        >
+                            the community license page
+                        </a>{" "}
+                        for next steps on running a production version of Gitpod.
+                    </Alert>
                 )}
             </header>
             <Separator />

--- a/components/dashboard/src/utils.ts
+++ b/components/dashboard/src/utils.ts
@@ -58,8 +58,12 @@ export function isGitpodIo() {
     );
 }
 
+export function isLocalPreview() {
+    return true;
+}
+
 function trimResource(resource: string): string {
-    return resource.split('/').filter(Boolean).join('/');
+    return resource.split("/").filter(Boolean).join("/");
 }
 
 // Returns 'true' if a 'pathname' is a part of 'resources' provided.
@@ -69,9 +73,9 @@ function trimResource(resource: string): string {
 // 'pathname' arg can be provided via `location.pathname`.
 export function inResource(pathname: string, resources: string[]): boolean {
     // Removes leading and trailing '/'
-    const trimmedResource = trimResource(pathname)
+    const trimmedResource = trimResource(pathname);
 
     // Checks if a path is part of a resource.
     // E.g. "api/userspace/resource" path is a part of resource "api/userspace"
-    return resources.map(res => trimmedResource.startsWith(trimResource(res))).some(Boolean)
+    return resources.map((res) => trimmedResource.startsWith(trimResource(res))).some(Boolean);
 }

--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -90,6 +90,7 @@ export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, 
     getConfiguration(): Promise<Configuration>;
     getToken(query: GitpodServer.GetTokenSearchOptions): Promise<Token | undefined>;
     getGitpodTokenScopes(tokenHash: string): Promise<string[]>;
+    getGitpodInstanceType(): Promise<InstallationType>;
     /**
      * @deprecated
      */

--- a/components/server/src/config.ts
+++ b/components/server/src/config.ts
@@ -55,12 +55,20 @@ export interface WorkspaceGarbageCollection {
     contentChunkLimit: number;
 }
 
+enum InstallationType {
+    selfHosted = "self-hosted",
+    saas = "saas",
+    localPreview = "local-preview",
+}
+
 /**
  * This is the config shape as found in the configuration file, e.g. server-configmap.yaml
  */
 export interface ConfigSerialized {
     version: string;
     hostUrl: string;
+    // Use this to more concretely get the type of Instalaltion
+    installationType?: InstallationType;
     installationShortname: string;
     devBranch?: string;
     insecureNoDomain: boolean;

--- a/install/installer/pkg/components/server/configmap.go
+++ b/install/installer/pkg/components/server/configmap.go
@@ -159,6 +159,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		Version:               ctx.VersionManifest.Version,
 		HostURL:               fmt.Sprintf("https://%s", ctx.Config.Domain),
 		InstallationShortname: ctx.Config.Metadata.InstallationShortname,
+		InstallationType:      string(ctx.Config.Type),
 		LicenseFile:           license,
 		WorkspaceHeartbeat: WorkspaceHeartbeat{
 			IntervalSeconds: 60,

--- a/install/installer/pkg/components/server/types.go
+++ b/install/installer/pkg/components/server/types.go
@@ -16,6 +16,7 @@ type ConfigSerialized struct {
 	Version                           string   `json:"version"`
 	HostURL                           string   `json:"hostUrl"`
 	InstallationShortname             string   `json:"installationShortname"`
+	InstallationType                  string   `json:"installationType"`
 	DevBranch                         string   `json:"devBranch"`
 	InsecureNoDomain                  bool     `json:"insecureNoDomain"`
 	License                           string   `json:"license"`

--- a/install/installer/pkg/config/v1/config.go
+++ b/install/installer/pkg/config/v1/config.go
@@ -40,6 +40,7 @@ func (v version) Defaults(in interface{}) error {
 	}
 
 	cfg.Kind = InstallationFull
+	cfg.Type = InstalaltionSelfHosted
 	cfg.Repository = "eu.gcr.io/gitpod-core-dev/build"
 	cfg.Observability = Observability{
 		LogLevel: LogLevelInfo,
@@ -103,8 +104,10 @@ func (v version) CheckDeprecated(rawCfg interface{}) (map[string]interface{}, []
 
 // Config defines the v1 version structure of the gitpod config file
 type Config struct {
-	// Installation type to run - for most users, this will be Full
+	// Installation type used for rendering - for most users, this will be Full
 	Kind InstallationKind `json:"kind" validate:"required,installation_kind"`
+	// Installation type to be passed down to the *run-time*
+	Type InstallationType `json:"type" validate:"required,installation_type"`
 	// The domain to deploy to
 	Domain     string   `json:"domain" validate:"required,fqdn"`
 	Metadata   Metadata `json:"metadata"`
@@ -221,6 +224,14 @@ const (
 	InstallationMeta      InstallationKind = "Meta"
 	InstallationWorkspace InstallationKind = "Workspace"
 	InstallationFull      InstallationKind = "Full"
+)
+
+type InstallationType string
+
+const (
+	InstallationSAAS         InstallationType = "SAAS"
+	InstalaltionSelfHosted   InstallationType = "self-hosted"
+	InstallationLocalPreview InstallationType = "local-preview"
 )
 
 type ObjectRef struct {

--- a/install/preview/entrypoint.sh
+++ b/install/preview/entrypoint.sh
@@ -95,6 +95,8 @@ EOF
 mkdir -p /var/lib/rancher/k3s/server/manifests/gitpod
 
 /gitpod-installer init > config.yaml
+yq e -i '.installationType = "local-preview"' config.yaml
+yq e -i '.experimental.telemetry.data.platform = "local-preview"' config.yaml
 yq e -i '.domain = "'"${DOMAIN}"'"' config.yaml
 yq e -i '.certificate.name = "https-certificates"' config.yaml
 yq e -i '.certificate.kind = "secret"' config.yaml
@@ -103,7 +105,6 @@ yq e -i '.customCACert.kind = "secret"' config.yaml
 yq e -i '.observability.logLevel = "debug"' config.yaml
 yq e -i '.workspace.runtime.containerdSocket = "/run/k3s/containerd/containerd.sock"' config.yaml
 yq e -i '.workspace.runtime.containerdRuntimeDir = "/var/lib/rancher/k3s/agent/containerd/io.containerd.runtime.v2.task/k8s.io/"' config.yaml
-yq e -i '.experimental.telemetry.data.platform = "local-preview"' config.yaml
 
 echo "extracting images to download ahead..."
 /gitpod-installer render --use-experimental-config --config config.yaml | grep 'image:' | sed 's/ *//g' | sed 's/image://g' | sed 's/\"//g' | sed 's/^-//g' | sort | uniq > /gitpod-images.txt


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
