### PR TITLE
Add kube-rbac-proxy to content-service

### DIFF
--- a/install/installer/pkg/components/content-service/deployment.go
+++ b/install/installer/pkg/components/content-service/deployment.go
@@ -79,7 +79,8 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 				MountPath: "/config",
 				ReadOnly:  true,
 			}},
-		}},
+		}, *common.KubeRBACProxyContainer(ctx),
+		},
 	}
 
 	err = common.AddStorageMounts(ctx, &podSpec, Component)


### PR DESCRIPTION
Signed-off-by: ArthurSens <arthursens2005@gmail.com>

## Description
<!-- Describe your changes in detail -->
Recently we added a [new alert](https://github.com/gitpod-io/gitpod/pull/11745) for whenever Prometheus fails to scrape a component, and we immediately got alerted about content-service being unreachable. After some debugging, we traced down #11591 which introduced a breaking change for many `/metrics` endpoints. 

This PR adds kube-rbac-proxy to content-service, which will make the metrics endpoint reachable again.


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Resolves alerts such as [this one](https://gitpod.slack.com/archives/C03MWBB5MP1/p1659380032576119).

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [X] /werft with-preview
