### PR TITLE
Pass `--branches` to git log command

### DIFF
--- a/components/content-service/pkg/git/git.go
+++ b/components/content-service/pkg/git/git.go
@@ -300,7 +300,7 @@ func (c *Client) Status(ctx context.Context) (res *Status, err error) {
 	}
 
 	latestCommit := ""
-	gitout, err = c.GitWithOutput(ctx, "log", "--pretty=%H", "-n", "1")
+	gitout, err = c.GitWithOutput(ctx, "log", "--pretty=%H", "--branches", "-n", "1")
 	if err != nil && !strings.Contains(err.Error(), errNoCommitsYet) {
 		return nil, err
 	}

--- a/components/content-service/pkg/git/git_test.go
+++ b/components/content-service/pkg/git/git_test.go
@@ -153,7 +153,6 @@ func TestGitStatus(t *testing.T) {
 			},
 			nil,
 		},
-
 		{
 			"pending in sub-dir files",
 			func(ctx context.Context, c *Client) error {
@@ -205,7 +204,7 @@ func TestGitStatus(t *testing.T) {
 
 			if status != nil {
 				if test.Result.BranchOID == notEmpty && status.LatestCommit != "" {
-					test.Result.BranchOID = status.LatestCommit
+					test.Result.BranchOID = status.BranchOID
 				}
 				if test.Result.LatestCommit == notEmpty && status.LatestCommit != "" {
 					test.Result.LatestCommit = status.LatestCommit
@@ -454,7 +453,7 @@ func TestGitStatusFromFiles(t *testing.T) {
 
 			if status != nil {
 				if test.Result.BranchOID == notEmpty && status.LatestCommit != "" {
-					test.Result.BranchOID = status.LatestCommit
+					test.Result.BranchOID = status.BranchOID
 				}
 				if test.Result.LatestCommit == notEmpty && status.LatestCommit != "" {
 					test.Result.LatestCommit = status.LatestCommit

--- a/components/content-service/pkg/layer/provider.go
+++ b/components/content-service/pkg/layer/provider.go
@@ -498,7 +498,7 @@ cd ${GITPOD_REPO_ROOT}
 git config --global --add safe.directory ${GITPOD_REPO_ROOT}
 git status --porcelain=v2 --branch -uall > /.workspace/prestophookdata/git_status.txt
 git log --pretty='%h: %s' --branches --not --remotes > /.workspace/prestophookdata/git_log_1.txt
-git log --pretty=%H -n 1 > /.workspace/prestophookdata/git_log_2.txt
+git log --pretty=%H --branches -n 1 > /.workspace/prestophookdata/git_log_2.txt
 cp /workspace/.gitpod/prebuild-log* /.workspace/prestophookdata/
 `
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Pass the `--branches` flag to prevent the git log displays the error message `fatal: your current branch 'main' does not have any commits yet`.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #11789

## How to test
<!-- Provide steps to test this PR -->
1. Install Jaeger in preview env.
2. Launch workspace https://github.com/gitpod-io/empty and close it.
3. Query Jaeger with tag `error=true`, to verify that the error `git log --pretty=%H -n 1 failed (exit status 128): fatal: your current branch 'main' does not have any commits yet` no longer exists.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
None

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
