### PR TITLE
[usage] Add metrics for number of usage records

### DIFF
--- a/components/usage/pkg/controller/reconciler.go
+++ b/components/usage/pkg/controller/reconciler.go
@@ -58,6 +58,7 @@ func (r *UsageAndBillingReconciler) Reconcile() (err error) {
 	}
 
 	sessions := usageResp.GetSessions()
+	reportSessionsRetrievedTotal(len(sessions))
 
 	_, err = r.billingClient.UpdateInvoices(ctx, &v1.UpdateInvoicesRequest{
 		StartTime: timestamppb.New(startOfCurrentMonth),

--- a/components/usage/pkg/controller/reporter.go
+++ b/components/usage/pkg/controller/reporter.go
@@ -5,6 +5,7 @@
 package controller
 
 import (
+	"fmt"
 	"github.com/prometheus/client_golang/prometheus"
 	"time"
 )
@@ -29,17 +30,26 @@ var (
 		Help:      "Histogram of reconcile duration",
 		Buckets:   prometheus.LinearBuckets(30, 30, 10), // every 30 secs, starting at 30secs
 	}, []string{"outcome"})
+
+	sessionsRetrievedTotal = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: namespace,
+		Subsystem: subsystem,
+		Name:      "usage_records_retrieved_total",
+		Help:      "Number of usage records retrieved during usage collection run",
+	})
 )
 
 func RegisterMetrics(reg *prometheus.Registry) error {
-	err := reg.Register(reconcileStartedTotal)
-	if err != nil {
-		return err
+	metrics := []prometheus.Collector{
+		reconcileStartedTotal,
+		reconcileStartedDurationSeconds,
+		sessionsRetrievedTotal,
 	}
-
-	err = reg.Register(reconcileStartedDurationSeconds)
-	if err != nil {
-		return err
+	for _, metric := range metrics {
+		err := reg.Register(metric)
+		if err != nil {
+			return fmt.Errorf("failed to register metric: %w", err)
+		}
 	}
 
 	return nil
@@ -55,4 +65,8 @@ func reportUsageReconcileFinished(duration time.Duration, err error) {
 		outcome = "error"
 	}
 	reconcileStartedDurationSeconds.WithLabelValues(outcome).Observe(duration.Seconds())
+}
+
+func reportSessionsRetrievedTotal(count int) {
+	sessionsRetrievedTotal.Set(float64(count))
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Expose metrics about number of sessions updated in each run

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Depends on https://github.com/gitpod-io/gitpod/pull/11681

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
