### PR TITLE
[dashboard] Fix rendering of the redirect URI on Git Integrations page

### DIFF
--- a/components/dashboard/src/settings/Integrations.tsx
+++ b/components/dashboard/src/settings/Integrations.tsx
@@ -643,6 +643,12 @@ export function GitIntegrationModal(
                 newHostValue = host.replace("https://", "");
             }
 
+            // Negative Lookahead (?!\/)
+            // `\/` matches the character `/`
+            // "https://foobar:80".replace(/:(?!\/)/, "_")
+            // => 'https://foobar_80'
+            newHostValue = host.replace(/:(?!\/)/, "_");
+
             setHost(newHostValue);
             setRedirectURL(callbackUrl(newHostValue));
             setErrorMessage(undefined);


### PR DESCRIPTION
## Description
Redirect URI is used to be copy-pasted into OAuth applications of GHE/GL/BBS. When port numbers are included in host names, this was not handled properly in #11409.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #11795

## How to test
Try to create a Git Integration with port number in hostname and see the value of the redirect URI is rendered with colon before the port number.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Fix rendering of the redirect URI on Git Integrations page
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
