### PR TITLE
Ensure workspace is only deleted once

### DIFF
--- a/components/ws-daemon/pkg/internal/session/store.go
+++ b/components/ws-daemon/pkg/internal/session/store.go
@@ -137,13 +137,13 @@ func (s *Store) Delete(ctx context.Context, name string) (err error) {
 	if !exists {
 		return nil
 	}
+	defer delete(s.workspaces, name)
 
 	err = session.Dispose(ctx)
 	if err != nil {
-		return xerrors.Errorf("cannot delete session: %w", err)
+		return xerrors.Errorf("cannot delete session for workspace %s: %w", session.InstanceID, err)
 	}
 
-	delete(s.workspaces, name)
 	return nil
 }
 


### PR DESCRIPTION
## Description
Takes care of the following problem:
- We attempt to delete the workspace and delete the workspace.json file
- Workspace deletion fails at a later step for some reason
- We do not remove the session
- We reattempt deletion but because the workspace.json has already been deleted we fail again due to the missing workspace.json file.

So lets remove the workspace session even if deleting the workspace from disk fails because we will definitely fail the second time and it just generates noise. We need to focus on why it fails in the first place.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/11715

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
