### PR TITLE
Detach dangling base mounts

### DIFF
--- a/components/ws-daemon/pkg/iws/iws.go
+++ b/components/ws-daemon/pkg/iws/iws.go
@@ -761,6 +761,10 @@ func cleanupMaskedMount(owi map[string]interface{}, base string, paths []string)
 	err := unix.Unmount(base, 0)
 	if err != nil {
 		log.WithError(err).WithField("fn", base).WithFields(owi).Warn("cannot unmount dangling base mount")
+		err = unix.Unmount(base, syscall.MNT_DETACH)
+		if err != nil {
+			log.WithError(err).WithField("fn", base).WithFields(owi).Warn("cannot detach dangling base mount")
+		}
 		return
 	}
 


### PR DESCRIPTION
## Description
As a last ditch effort detach base mounts if they cannot be unmounted. That way new accesses are denied and it will be unmounted once all processes are done using it.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related to https://github.com/gitpod-io/gitpod/issues/11369


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```
## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
