### PR TITLE
[public-api] Add a placeholder Stripe webhook

### DIFF
--- a/components/public-api-server/config.json
+++ b/components/public-api-server/config.json
@@ -4,6 +4,9 @@
     "services": {
       "grpc": {
         "address": ":9001"
+      },
+      "http": {
+        "address": ":9002"
       }
     }
   }

--- a/components/public-api-server/go.mod
+++ b/components/public-api-server/go.mod
@@ -24,7 +24,9 @@ require (
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/cyphar/filepath-securejoin v0.2.3 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/felixge/httpsnoop v1.0.1 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/gorilla/handlers v1.5.1 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
 	github.com/hashicorp/golang-lru v0.5.1 // indirect

--- a/components/public-api-server/go.mod
+++ b/components/public-api-server/go.mod
@@ -38,6 +38,7 @@ require (
 	github.com/prometheus/procfs v0.7.3 // indirect
 	github.com/sourcegraph/jsonrpc2 v0.0.0-20200429184054-15c2290dcb37 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/stripe/stripe-go/v72 v72.122.0 // indirect
 	golang.org/x/net v0.0.0-20211209124913-491a49abca63 // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	golang.org/x/sys v0.0.0-20220114195835-da31bd327af9 // indirect

--- a/components/public-api-server/go.sum
+++ b/components/public-api-server/go.sum
@@ -243,6 +243,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stripe/stripe-go/v72 v72.122.0 h1:eRXWqnEwGny6dneQ5BsxGzUCED5n180u8n665JHlut8=
+github.com/stripe/stripe-go/v72 v72.122.0/go.mod h1:QwqJQtduHubZht9mek5sds9CtQcKFdsykV9ZepRWwo0=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/components/public-api-server/go.sum
+++ b/components/public-api-server/go.sum
@@ -72,6 +72,8 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.mod h1:AFq3mo9L8Lqqiid3OhADV3RfLJnjiw63cSpi+fDTRC0=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+github.com/felixge/httpsnoop v1.0.1 h1:lvB5Jl89CsZtGIWuTcDM1E/vkVs49/Ml7JJe07l8SPQ=
+github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
@@ -143,6 +145,8 @@ github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm4
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
+github.com/gorilla/handlers v1.5.1 h1:9lRY6j8DEeeBT10CvO9hGW0gmky0BprnvDI5vfhUHH4=
+github.com/gorilla/handlers v1.5.1/go.mod h1:t8XrUpc4KVXb7HGyJ4/cEnwQiaxrX/hz1Zv/4g96P1Q=
 github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=

--- a/components/public-api-server/pkg/server/server.go
+++ b/components/public-api-server/pkg/server/server.go
@@ -6,12 +6,15 @@ package server
 
 import (
 	"fmt"
-	"github.com/gitpod-io/gitpod/public-api/config"
 	"net/url"
+
+	"github.com/gitpod-io/gitpod/public-api/config"
+	"github.com/gorilla/handlers"
 
 	"github.com/gitpod-io/gitpod/common-go/baseserver"
 	"github.com/gitpod-io/gitpod/public-api-server/pkg/apiv1"
 	"github.com/gitpod-io/gitpod/public-api-server/pkg/proxy"
+	"github.com/gitpod-io/gitpod/public-api-server/pkg/webhooks"
 	v1 "github.com/gitpod-io/gitpod/public-api/v1"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
@@ -35,6 +38,10 @@ func Start(logger *logrus.Entry, cfg *config.Configuration) error {
 	if err != nil {
 		return fmt.Errorf("failed to initialize public api server: %w", err)
 	}
+
+	srv.HTTPMux().Handle("/stripe/invoices/webhook",
+		handlers.ContentTypeHandler(webhooks.NewStripeWebhookHandler(), "application/json"),
+	)
 
 	if registerErr := register(srv, gitpodAPI, registry); registerErr != nil {
 		return fmt.Errorf("failed to register services: %w", registerErr)

--- a/components/public-api-server/pkg/webhooks/stripe.go
+++ b/components/public-api-server/pkg/webhooks/stripe.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package webhooks
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/gitpod-io/gitpod/common-go/log"
+	"github.com/stripe/stripe-go/v72"
+)
+
+type webhookHandler struct{}
+
+func NewStripeWebhookHandler() *webhookHandler {
+	return &webhookHandler{}
+}
+
+func (h *webhookHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	const maxBodyBytes = int64(65536)
+
+	req.Body = http.MaxBytesReader(w, req.Body, maxBodyBytes)
+
+	event := stripe.Event{}
+	err := json.NewDecoder(req.Body).Decode(&event)
+	if err != nil {
+		log.WithError(err).Error("Stripe webhook error while parsing event payload")
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	// TODO: verify webhook signature.
+	// Conditional on there being a secret configured.
+
+	fmt.Fprintf(w, "event type: %s", event.Type)
+}


### PR DESCRIPTION
## Description

Add a placeholder [Stripe webhook](https://stripe.com/docs/webhooks) to the `public-api` component. 

In later PRs, the webhook will:
* receive `invoice.finalized` events from Stripe.
* invoke RPCs on the `usage` component to update usage records to show that they have been included in a particular invoice.

This PR is a re-do of https://github.com/gitpod-io/gitpod/pull/11776, which added the webhook to the `usage` component directly.

After some discussion on that PR and [internally](https://gitpod.slack.com/archives/C02EN94AEPL/p1659427332329269), it was decided to move it to the public API and have the pubilc API invoke RPCs on `usage` instead.

## Related Issue(s)

Part of #9036 and https://github.com/gitpod-io/gitpod/issues/10937

## How to test

* Install the[ `stripe` CLI](https://stripe.com/docs/stripe-cli) into the workspace and run `stripe login`.
* Port forward to the database in the preview environment:
```
kubectl port-forward svc/mysql 3306:3306
```
* Run the `public-api-server` component locally:
```
cd components/public-api-server
go run . run  
```
* Forward `stripe` events to the local webhook endpoint:
```
stripe listen --skip-verify --forward-to localhost:9002/webhook
```
* Trigger a series of Stripe events:
```
stripe trigger invoice.finalized
```
This should start a series of Stripe events (setting up a customer and payment methods), each of which should be handled with a `200 OK`  by the webhook:

<img width="907" alt="image" src="https://user-images.githubusercontent.com/8225907/182176787-6abcd5a2-2869-44d9-a7e2-00088aba911b.png">

## Release Notes

```release-note
NONE
```

## Documentation


## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
