### PR TITLE
Remove backup trail

### DIFF
--- a/.werft/jobs/build/helm/values.dev.gcp-storage.yaml
+++ b/.werft/jobs/build/helm/values.dev.gcp-storage.yaml
@@ -2,9 +2,6 @@ components:
   contentService:
     remoteStorage:
       kind: gcloud
-      backupTrail:
-        enabled: true
-        maxLength: 2
       gcloud:
         credentialsFile: /credentials/service-account.json
         projectId: gitpod-core-dev

--- a/components/content-service-api/go/config/config.go
+++ b/components/content-service-api/go/config/config.go
@@ -24,12 +24,6 @@ type StorageConfig struct {
 	// MinIOConfig configures the MinIO remote storage
 	MinIOConfig MinIOConfig `json:"minio,omitempty"`
 
-	// BackupTrail maintains a number of backups for the same workspace
-	BackupTrail struct {
-		Enabled   bool `json:"enabled"`
-		MaxLength int  `json:"maxLength"`
-	} `json:"backupTrail"`
-
 	BlobQuota int64 `json:"blobQuota"`
 }
 
@@ -91,8 +85,6 @@ type GCPConfig struct {
 	CredentialsFile string `json:"credentialsFile"`
 	Region          string `json:"region"`
 	Project         string `json:"projectId"`
-
-	MaximumBackupCount int `json:"maximumBackupCount"`
 }
 
 // MinIOConfig MinIOconfigures the MinIO remote storage backend

--- a/components/content-service/pkg/service/headless-log-service_test.go
+++ b/components/content-service/pkg/service/headless-log-service_test.go
@@ -20,16 +20,9 @@ import (
 
 func TestListLogs(t *testing.T) {
 	cfg := config.StorageConfig{
-		Stage: config.StageProduction,
-		Kind:  config.GCloudStorage, // dummy, mocked away
-		BackupTrail: struct {
-			Enabled   bool "json:\"enabled\""
-			MaxLength int  "json:\"maxLength\""
-		}{
-			Enabled:   false,
-			MaxLength: 3,
-		},
-		BlobQuota: 1073741824, // 1Gi
+		Stage:     config.StageProduction,
+		Kind:      config.GCloudStorage, // dummy, mocked away
+		BlobQuota: 1073741824,           // 1Gi
 	}
 
 	OwnerId := "1234"

--- a/components/content-service/pkg/storage/storage.go
+++ b/components/content-service/pkg/storage/storage.go
@@ -165,12 +165,6 @@ type DirectAccess interface {
 
 // UploadOptions configure remote storage upload
 type UploadOptions struct {
-	BackupTrail struct {
-		Enabled      bool
-		ThisBackupID string
-		TrailLength  int
-	}
-
 	// Annotations are generic metadata atteched to a storage object
 	Annotations map[string]string
 
@@ -179,24 +173,6 @@ type UploadOptions struct {
 
 // UploadOption configures a particular aspect of remote storage upload
 type UploadOption func(*UploadOptions) error
-
-// WithBackupTrail enables backup trailing for this upload
-func WithBackupTrail(thisBackupID string, trailLength int) UploadOption {
-	return func(opts *UploadOptions) error {
-		if thisBackupID == "" {
-			return xerrors.Errorf("backup ID is missing")
-		}
-		if trailLength < 1 {
-			return xerrors.Errorf("backup trail length must be greater zero")
-		}
-
-		opts.BackupTrail.Enabled = true
-		opts.BackupTrail.ThisBackupID = thisBackupID
-		opts.BackupTrail.TrailLength = trailLength
-
-		return nil
-	}
-}
 
 // WithAnnotations adds arbitrary metadata to a storage object
 func WithAnnotations(md map[string]string) UploadOption {

--- a/components/ws-daemon/example-config.json
+++ b/components/ws-daemon/example-config.json
@@ -13,8 +13,7 @@
                 "region": "europe-west1",
                 "project": "gitpod-dev",
                 "parallelUpload": 4,
-                "maximumBackupSize": 32212254720,
-                "maximumBackupCount": 20
+                "maximumBackupSize": 32212254720
             },
             "minio": {
                 "endpoint": "127.0.0.1:9000",

--- a/components/ws-daemon/pkg/content/service.go
+++ b/components/ws-daemon/pkg/content/service.go
@@ -500,10 +500,6 @@ func (s *WorkspaceService) uploadWorkspaceContent(ctx context.Context, sess *ses
 		log.WithError(err).WithFields(sess.OWI()).Warn("cannot remove workspace ready file")
 	}
 
-	if s.config.Storage.BackupTrail.Enabled && !sess.FullWorkspaceBackup {
-		opts = append(opts, storage.WithBackupTrail("trail", s.config.Storage.BackupTrail.MaxLength))
-	}
-
 	rs, ok := sess.NonPersistentAttrs[session.AttrRemoteStorage].(storage.DirectAccess)
 	if rs == nil || !ok {
 		return xerrors.Errorf("no remote storage configured")

--- a/components/ws-manager/pkg/manager/testdata/status_metadata.json
+++ b/components/ws-manager/pkg/manager/testdata/status_metadata.json
@@ -156,7 +156,7 @@
           "env": [
             {
               "name": "WSSYNCD",
-              "value": "{\"workspace\":{\"location\":\"/workspace\",\"name\":\"foobas\",\"cleanup\":true},\"remoteStorage\":{\"kind\":\"\"},\"gcloud\":{\"credentialsFile\":\"\",\"region\":\"\",\"project\":\"\",\"tmpdir\":\"\",\"maximumBackupSize\":0,\"maximumBackupCount\":0},\"initializer\":{\"kind\":\"\",\"git\":{\"remoteURI\":\"\",\"targetMode\":\"\"}},\"notification\":{\"url\":\"http://localhost:23000/gitpod/syncd\"},\"syncDisabled\":true,\"apiserver\":{\"enabled\":true,\"host\":\"127.0.0.1\",\"port\":44444,\"apitoken\":\"c17a7eaf-e5de-4e9d-815a-7919379e2bf8\"}}"
+              "value": "{\"workspace\":{\"location\":\"/workspace\",\"name\":\"foobas\",\"cleanup\":true},\"remoteStorage\":{\"kind\":\"\"},\"gcloud\":{\"credentialsFile\":\"\",\"region\":\"\",\"project\":\"\",\"tmpdir\":\"\",\"maximumBackupSize\":0},\"initializer\":{\"kind\":\"\",\"git\":{\"remoteURI\":\"\",\"targetMode\":\"\"}},\"notification\":{\"url\":\"http://localhost:23000/gitpod/syncd\"},\"syncDisabled\":true,\"apiserver\":{\"enabled\":true,\"host\":\"127.0.0.1\",\"port\":44444,\"apitoken\":\"c17a7eaf-e5de-4e9d-815a-7919379e2bf8\"}}"
             }
           ],
           "resources": {

--- a/install/installer/pkg/common/storage.go
+++ b/install/installer/pkg/common/storage.go
@@ -34,18 +34,12 @@ func useMinio(context *RenderContext) bool {
 func StorageConfig(context *RenderContext) storageconfig.StorageConfig {
 	var res *storageconfig.StorageConfig
 	if context.Config.ObjectStorage.CloudStorage != nil {
-		maximumBackupCount := 3
-		if context.Config.ObjectStorage.MaximumBackupCount != nil {
-			maximumBackupCount = *context.Config.ObjectStorage.MaximumBackupCount
-		}
-
 		res = &storageconfig.StorageConfig{
 			Kind: storageconfig.GCloudStorage,
 			GCloudConfig: storageconfig.GCPConfig{
-				Region:             context.Config.Metadata.Region,
-				Project:            context.Config.ObjectStorage.CloudStorage.Project,
-				CredentialsFile:    filepath.Join(storageMount, "service-account.json"),
-				MaximumBackupCount: maximumBackupCount,
+				Region:          context.Config.Metadata.Region,
+				Project:         context.Config.ObjectStorage.CloudStorage.Project,
+				CredentialsFile: filepath.Join(storageMount, "service-account.json"),
 			},
 		}
 	}
@@ -84,14 +78,6 @@ func StorageConfig(context *RenderContext) storageconfig.StorageConfig {
 		panic("no valid storage configuration set")
 	}
 
-	// todo(sje): create exportable type
-	res.BackupTrail = struct {
-		Enabled   bool `json:"enabled"`
-		MaxLength int  `json:"maxLength"`
-	}{
-		Enabled:   true,
-		MaxLength: 3,
-	}
 	// 5 GiB
 	res.BlobQuota = 5 * 1024 * 1024 * 1024
 	if context.Config.ObjectStorage.BlobQuota != nil {

--- a/install/installer/pkg/config/v1/config.go
+++ b/install/installer/pkg/config/v1/config.go
@@ -128,6 +128,10 @@ func (v version) CheckDeprecated(rawCfg interface{}) (map[string]interface{}, []
 		}
 	}
 
+	if cfg.ObjectStorage.MaximumBackupCount != nil {
+		warnings["objectStorage.maximumBackupCount"] = cfg.ObjectStorage.MaximumBackupCount
+	}
+
 	return warnings, conflicts
 }
 
@@ -222,8 +226,10 @@ type ObjectStorage struct {
 	S3           *ObjectStorageS3           `json:"s3,omitempty"`
 	CloudStorage *ObjectStorageCloudStorage `json:"cloudStorage,omitempty"`
 	Azure        *ObjectStorageAzure        `json:"azure,omitempty"`
-	BlobQuota    *int64                     `json:"blobQuota,omitempty"`
-	Resources    *Resources                 `json:"resources,omitempty"`
+	// DEPRECATED
+	MaximumBackupCount *int       `json:"maximumBackupCount,omitempty"`
+	BlobQuota          *int64     `json:"blobQuota,omitempty"`
+	Resources          *Resources `json:"resources,omitempty"`
 }
 
 type ObjectStorageS3 struct {

--- a/install/installer/pkg/config/v1/config.go
+++ b/install/installer/pkg/config/v1/config.go
@@ -218,13 +218,12 @@ type DatabaseCloudSQL struct {
 }
 
 type ObjectStorage struct {
-	InCluster          *bool                      `json:"inCluster,omitempty"`
-	S3                 *ObjectStorageS3           `json:"s3,omitempty"`
-	CloudStorage       *ObjectStorageCloudStorage `json:"cloudStorage,omitempty"`
-	Azure              *ObjectStorageAzure        `json:"azure,omitempty"`
-	MaximumBackupCount *int                       `json:"maximumBackupCount,omitempty"`
-	BlobQuota          *int64                     `json:"blobQuota,omitempty"`
-	Resources          *Resources                 `json:"resources,omitempty"`
+	InCluster    *bool                      `json:"inCluster,omitempty"`
+	S3           *ObjectStorageS3           `json:"s3,omitempty"`
+	CloudStorage *ObjectStorageCloudStorage `json:"cloudStorage,omitempty"`
+	Azure        *ObjectStorageAzure        `json:"azure,omitempty"`
+	BlobQuota    *int64                     `json:"blobQuota,omitempty"`
+	Resources    *Resources                 `json:"resources,omitempty"`
 }
 
 type ObjectStorageS3 struct {

--- a/install/installer/pkg/config/v1/config.md
+++ b/install/installer/pkg/config/v1/config.md
@@ -32,7 +32,6 @@ Config defines the v1 version structure of the gitpod config file
 |`objectStorage.cloudStorage.project`|string|Y|  ||
 |`objectStorage.azure.credentials.kind`|string|N| `secret` ||
 |`objectStorage.azure.credentials.name`|string|Y|  ||
-|`objectStorage.maximumBackupCount`|int|N|  ||
 |`objectStorage.blobQuota`|int64|N|  ||
 |`objectStorage.resources.requests`||Y|  |  todo(sje): add custom validation to corev1.ResourceList|
 |`objectStorage.resources.limits`||N|  ||


### PR DESCRIPTION
## Description

Remove the backup trail feature. The feature is present only on GCP. 
The reason for the removal is consistency with other providers and also to align it with PVC.

In traces, we see the error `Maximum number of snapshots (%d of %d) reached` meaning we are not going to upload a backup for the workspace and the next time it is open, it will contain the previous state, not the last one.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #11709

## Release Notes
```release-note
NONE
```

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
