### PR TITLE
Provide better error message for HTTP 524

### DIFF
--- a/components/content-service/pkg/initializer/prebuild.go
+++ b/components/content-service/pkg/initializer/prebuild.go
@@ -129,9 +129,11 @@ func runGitInit(ctx context.Context, gInit *GitInitializer) (err error) {
 		didStash := !strings.Contains(string(out), "No local changes to save")
 
 		err = gInit.Fetch(ctx)
+		err = checkGitStatus(err)
 		if err != nil {
 			return xerrors.Errorf("prebuild initializer: %w", err)
 		}
+
 		err = gInit.realizeCloneTarget(ctx)
 		if err != nil {
 			return xerrors.Errorf("prebuild initializer: %w", err)


### PR DESCRIPTION
## Description
Provide a better error message when we receive a HTTP 524 status code.
![ErrorMessageHttp524](https://user-images.githubusercontent.com/24721048/182386168-5ef34dfd-6f76-4ee1-aa3d-8263df451d5c.png)



## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #https://github.com/gitpod-io/gitpod/issues/11712

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
