### PR TITLE
[ws-daemon] Enable workspace content housekeeping

### DIFF
--- a/components/ws-daemon/pkg/internal/session/store_test.go
+++ b/components/ws-daemon/pkg/internal/session/store_test.go
@@ -1,0 +1,118 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package session
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestDoHousekeeping(t *testing.T) {
+	type File struct {
+		Name  string
+		IsDir bool
+		Age   time.Duration
+	}
+	type Expectation struct {
+		Error string
+		Files []string
+	}
+	tests := []struct {
+		Name        string
+		Files       []File
+		Expectation Expectation
+	}{
+		{
+			Name: "empty store",
+		},
+		{
+			Name: "with state file",
+			Files: []File{
+				{Name: "foo.workspace.json", IsDir: false},
+				{Name: "foo", IsDir: true},
+			},
+			Expectation: Expectation{
+				Files: []string{"foo", "foo.workspace.json"},
+			},
+		},
+		{
+			Name: "no state file",
+			Files: []File{
+				{Name: "foo", IsDir: true, Age: 4 * time.Hour},
+				{Name: "foo-daemon", IsDir: true, Age: 4 * time.Hour},
+			},
+		},
+		{
+			Name: "daemon dir with state file",
+			Files: []File{
+				{Name: "foo.workspace.json", IsDir: false},
+				{Name: "foo-daemon", IsDir: true},
+			},
+			Expectation: Expectation{
+				Files: []string{"foo-daemon", "foo.workspace.json"},
+			},
+		},
+		{
+			Name: "daemon dir no state file",
+			Files: []File{
+				{Name: "foo-daemon", IsDir: true, Age: 4 * time.Hour},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			store, err := getTestStore()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			for _, f := range test.Files {
+				loc := filepath.Join(store.Location, f.Name)
+				var err error
+				if f.IsDir {
+					err = os.MkdirAll(loc, 0644)
+				} else {
+					err = ioutil.WriteFile(loc, nil, 0644)
+				}
+				if err != nil {
+					t.Fatalf("cannot prepare file %s: %v", f.Name, err)
+				}
+				if f.Age > 0 {
+					modtime := time.Now().Add(-f.Age)
+					err = os.Chtimes(loc, modtime, modtime)
+				}
+				if err != nil {
+					t.Fatalf("cannot prepare file %s: %v", f.Name, err)
+				}
+			}
+
+			errs := store.doHousekeeping(context.Background())
+			var act Expectation
+			for _, err := range errs {
+				if act.Error != "" {
+					act.Error += "; "
+				}
+				act.Error = err.Error()
+			}
+			res, err := ioutil.ReadDir(store.Location)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, f := range res {
+				act.Files = append(act.Files, f.Name())
+			}
+
+			if diff := cmp.Diff(test.Expectation, act); diff != "" {
+				t.Errorf("unexpected doHousekeeping result (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description
This PR re-instates ws-daemon's content garbage collection which removes workspace content from disk once the state file is gone. We had originally disabled this behaviour because it interfered with the ws-daemon/ws-sync migration three years ago.

There's a grace period for content built-in which ensures we only delete content older than two hours. The motivation is to guard against accidental state mishaps.

>**Warning**
> This PR carries the risk that it might delete workspace content unintentionally. 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #11369

## How to test
- see unit test
- start a workspace, produce a file in the workspace content directory which cannot be deleted and stop the workspace
- make the workspace content directory deletable again and see it being deleted

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
