### PR TITLE
BillingMode: add Json RPC API methods (2/4)

### DIFF
--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -63,6 +63,7 @@ import { InstallationAdminSettings, TelemetryData } from "./installation-admin-p
 import { Currency } from "./plans";
 import { BillableSession, BillableSessionRequest } from "./usage";
 import { SupportedWorkspaceClass } from "./workspace-class";
+import { BillingMode } from "./billing-mode";
 
 export interface GitpodClient {
     onInstanceUpdate(instance: WorkspaceInstance): void;
@@ -297,6 +298,9 @@ export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, 
     listBilledUsage(req: BillableSessionRequest): Promise<BillableSession[]>;
 
     setUsageAttribution(usageAttribution: string): Promise<void>;
+
+    getBillingModeForUser(): Promise<BillingMode>;
+    getBillingModeForTeam(teamId: string): Promise<BillingMode>;
 
     /**
      * Analytics

--- a/components/server/src/auth/rate-limiter.ts
+++ b/components/server/src/auth/rate-limiter.ts
@@ -211,6 +211,9 @@ function getConfig(config: RateLimiterConfig): RateLimiterConfig {
         subscribeTeamToStripe: { group: "default", points: 1 },
         getStripePortalUrlForTeam: { group: "default", points: 1 },
         listBilledUsage: { group: "default", points: 1 },
+        getBillingModeForTeam: { group: "default", points: 1 },
+        getBillingModeForUser: { group: "default", points: 1 },
+
         trackEvent: { group: "default", points: 1 },
         trackLocation: { group: "default", points: 1 },
         identifyUser: { group: "default", points: 1 },


### PR DESCRIPTION
## Description
Introduces JSON RPC API to retrieve the current BillingModes for a given user/team.

## Related Issue(s)

Context: https://github.com/gitpod-io/gitpod/issues/11402

## How to test
 - see [previous PR](https://github.com/gitpod-io/gitpod/pull/11812)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
