### PR TITLE
BillingMode: Use BillingMode to restrict API access (3/4)

### DIFF
--- a/components/dashboard/src/Menu.tsx
+++ b/components/dashboard/src/Menu.tsx
@@ -155,10 +155,13 @@ export default function Menu() {
 
         // Refresh billing mode
         refreshUserBillingMode();
-        if (team) {
-            server.getBillingModeForTeam(team.id).then(setTeamBillingMode);
-        }
     }, []);
+
+    useEffect(() => {
+        if (team) {
+            getGitpodService().server.getBillingModeForTeam(team.id).then(setTeamBillingMode);
+        }
+    }, [team]);
 
     const teamOrUserSlug = !!team ? "/t/" + team.slug : "/projects";
     const leftMenu: Entry[] = (() => {

--- a/components/dashboard/src/contexts/FeatureFlagContext.tsx
+++ b/components/dashboard/src/contexts/FeatureFlagContext.tsx
@@ -16,11 +16,9 @@ interface FeatureFlagConfig {
 }
 
 const FeatureFlagContext = createContext<{
-    showUsageBasedPricingUI: boolean;
     showWorkspaceClassesUI: boolean;
     showPersistentVolumeClaimUI: boolean;
 }>({
-    showUsageBasedPricingUI: false,
     showWorkspaceClassesUI: false,
     showPersistentVolumeClaimUI: false,
 });
@@ -31,12 +29,10 @@ const FeatureFlagContextProvider: React.FC = ({ children }) => {
     const { project } = useContext(ProjectContext);
     const location = useLocation();
     const team = getCurrentTeam(location, teams);
-    const [showUsageBasedPricingUI, setShowUsageBasedPricingUI] = useState<boolean>(false);
     const [showWorkspaceClassesUI, setShowWorkspaceClassesUI] = useState<boolean>(false);
     const [showPersistentVolumeClaimUI, setShowPersistentVolumeClaimUI] = useState<boolean>(false);
 
     const featureFlags: FeatureFlagConfig = {
-        isUsageBasedBillingEnabled: { defaultValue: false, setter: setShowUsageBasedPricingUI },
         workspace_classes: { defaultValue: true, setter: setShowWorkspaceClassesUI },
         persistent_volume_claim: { defaultValue: true, setter: setShowPersistentVolumeClaimUI },
     };
@@ -58,9 +54,7 @@ const FeatureFlagContextProvider: React.FC = ({ children }) => {
     }, [user, teams, team, project]);
 
     return (
-        <FeatureFlagContext.Provider
-            value={{ showUsageBasedPricingUI, showWorkspaceClassesUI, showPersistentVolumeClaimUI }}
-        >
+        <FeatureFlagContext.Provider value={{ showWorkspaceClassesUI, showPersistentVolumeClaimUI }}>
             {children}
         </FeatureFlagContext.Provider>
     );

--- a/components/dashboard/src/payment-context.tsx
+++ b/components/dashboard/src/payment-context.tsx
@@ -8,8 +8,6 @@ import React, { createContext, useState } from "react";
 import { Currency } from "@gitpod/gitpod-protocol/lib/plans";
 
 const PaymentContext = createContext<{
-    showPaymentUI?: boolean;
-    setShowPaymentUI: React.Dispatch<boolean>;
     currency: Currency;
     setCurrency: React.Dispatch<Currency>;
     isStudent?: boolean;
@@ -17,7 +15,6 @@ const PaymentContext = createContext<{
     isChargebeeCustomer?: boolean;
     setIsChargebeeCustomer: React.Dispatch<boolean>;
 }>({
-    setShowPaymentUI: () => null,
     currency: "USD",
     setCurrency: () => null,
     setIsStudent: () => null,
@@ -25,7 +22,6 @@ const PaymentContext = createContext<{
 });
 
 const PaymentContextProvider: React.FC = ({ children }) => {
-    const [showPaymentUI, setShowPaymentUI] = useState<boolean>();
     const [currency, setCurrency] = useState<Currency>("USD");
     const [isStudent, setIsStudent] = useState<boolean>();
     const [isChargebeeCustomer, setIsChargebeeCustomer] = useState<boolean>();
@@ -33,8 +29,6 @@ const PaymentContextProvider: React.FC = ({ children }) => {
     return (
         <PaymentContext.Provider
             value={{
-                showPaymentUI,
-                setShowPaymentUI,
                 currency,
                 setCurrency,
                 isStudent,

--- a/components/dashboard/src/settings/PageWithSettingsSubMenu.tsx
+++ b/components/dashboard/src/settings/PageWithSettingsSubMenu.tsx
@@ -6,8 +6,7 @@
 
 import { useContext } from "react";
 import { PageWithSubMenu } from "../components/PageWithSubMenu";
-import { FeatureFlagContext } from "../contexts/FeatureFlagContext";
-import { PaymentContext } from "../payment-context";
+import { UserContext } from "../user-context";
 import getSettingsMenu from "./settings-menu";
 
 export interface PageWithAdminSubMenuProps {
@@ -17,15 +16,10 @@ export interface PageWithAdminSubMenuProps {
 }
 
 export function PageWithSettingsSubMenu({ title, subtitle, children }: PageWithAdminSubMenuProps) {
-    const { showUsageBasedPricingUI } = useContext(FeatureFlagContext);
-    const { showPaymentUI } = useContext(PaymentContext);
+    const { userBillingMode } = useContext(UserContext);
 
     return (
-        <PageWithSubMenu
-            subMenu={getSettingsMenu({ showPaymentUI, showUsageBasedPricingUI })}
-            title={title}
-            subtitle={subtitle}
-        >
+        <PageWithSubMenu subMenu={getSettingsMenu({ userBillingMode })} title={title} subtitle={subtitle}>
             {children}
         </PageWithSubMenu>
     );

--- a/components/dashboard/src/settings/Plans.tsx
+++ b/components/dashboard/src/settings/Plans.tsx
@@ -43,8 +43,8 @@ type TeamClaimModal =
       };
 
 export default function () {
-    const { user } = useContext(UserContext);
-    const { showPaymentUI, currency, setCurrency, isStudent, isChargebeeCustomer } = useContext(PaymentContext);
+    const { user, userBillingMode } = useContext(UserContext);
+    const { currency, setCurrency, isStudent, isChargebeeCustomer } = useContext(PaymentContext);
     const [accountStatement, setAccountStatement] = useState<AccountStatement>();
     const [availableCoupons, setAvailableCoupons] = useState<PlanCoupon[]>();
     const [appliedCoupons, setAppliedCoupons] = useState<PlanCoupon[]>();
@@ -632,10 +632,11 @@ export default function () {
         );
     }
 
+    const showPlans = userBillingMode && userBillingMode.mode === "chargebee";
     return (
         <div>
             <PageWithSettingsSubMenu title="Plans" subtitle="Manage account usage and billing.">
-                {showPaymentUI && (
+                {showPlans && (
                     <div className="w-full text-center">
                         <p className="text-xl text-gray-500">
                             You are currently using the{" "}

--- a/components/dashboard/src/settings/Teams.tsx
+++ b/components/dashboard/src/settings/Teams.tsx
@@ -23,6 +23,7 @@ import { poll, PollOptions } from "../utils";
 import { Disposable } from "@gitpod/gitpod-protocol";
 import { PaymentContext } from "../payment-context";
 import { PageWithSettingsSubMenu } from "./PageWithSettingsSubMenu";
+import { UserContext } from "../user-context";
 
 export default function Teams() {
     return (
@@ -43,8 +44,8 @@ interface Slot extends TeamSubscriptionSlotResolved {
 }
 
 function AllTeams() {
-    const { showPaymentUI, currency, isStudent, isChargebeeCustomer, setIsChargebeeCustomer } =
-        useContext(PaymentContext);
+    const { userBillingMode } = useContext(UserContext);
+    const { currency, isStudent, isChargebeeCustomer, setIsChargebeeCustomer } = useContext(PaymentContext);
 
     const [slots, setSlots] = useState<Slot[]>([]);
     const [teamSubscriptions, setTeamSubscriptions] = useState<TeamSubscription[]>([]);
@@ -603,9 +604,13 @@ function AllTeams() {
         </React.Fragment>
     );
 
+    const showTeamPlans =
+        userBillingMode &&
+        (userBillingMode.mode === "chargebee" ||
+            (userBillingMode.mode === "usage-based" && !!userBillingMode.hasChargebeeTeamPlan));
     return (
         <div>
-            {showPaymentUI ? (
+            {showTeamPlans ? (
                 renderTeams()
             ) : (
                 <div className="flex flex-row">

--- a/components/dashboard/src/settings/settings-menu.ts
+++ b/components/dashboard/src/settings/settings-menu.ts
@@ -68,6 +68,10 @@ function renderBillingMenuEntries(billingMode?: BillingMode) {
             ];
         case "usage-based":
             return [
+                {
+                    title: "Billing",
+                    link: [settingsPathBilling],
+                },
                 // We need to allow access to "Team Plans" here, at least for owners.
                 ...(billingMode.hasChargebeeTeamSubscription
                     ? [
@@ -77,10 +81,6 @@ function renderBillingMenuEntries(billingMode?: BillingMode) {
                           },
                       ]
                     : []),
-                {
-                    title: "Billing",
-                    link: [settingsPathBilling],
-                },
             ];
     }
 }

--- a/components/dashboard/src/user-context.tsx
+++ b/components/dashboard/src/user-context.tsx
@@ -5,18 +5,33 @@
  */
 
 import { User } from "@gitpod/gitpod-protocol";
+import { BillingMode } from "@gitpod/gitpod-protocol/lib/billing-mode";
 import React, { createContext, useState } from "react";
+import { getGitpodService } from "./service/service";
 
 const UserContext = createContext<{
     user?: User;
     setUser: React.Dispatch<User>;
+    userBillingMode?: BillingMode;
+    refreshUserBillingMode: () => void;
 }>({
     setUser: () => null,
+    refreshUserBillingMode: () => null,
 });
 
 const UserContextProvider: React.FC = ({ children }) => {
     const [user, setUser] = useState<User>();
-    return <UserContext.Provider value={{ user, setUser }}>{children}</UserContext.Provider>;
+    const [billingMode, setBillingMode] = useState<BillingMode>();
+    function refreshUserBillingMode() {
+        getGitpodService()
+            .server.getBillingModeForUser()
+            .then((bm) => setBillingMode);
+    }
+    return (
+        <UserContext.Provider value={{ user, setUser, userBillingMode: billingMode, refreshUserBillingMode }}>
+            {children}
+        </UserContext.Provider>
+    );
 };
 
 export { UserContext, UserContextProvider };

--- a/components/dashboard/src/user-context.tsx
+++ b/components/dashboard/src/user-context.tsx
@@ -23,9 +23,7 @@ const UserContextProvider: React.FC = ({ children }) => {
     const [user, setUser] = useState<User>();
     const [billingMode, setBillingMode] = useState<BillingMode>();
     function refreshUserBillingMode() {
-        getGitpodService()
-            .server.getBillingModeForUser()
-            .then((bm) => setBillingMode);
+        getGitpodService().server.getBillingModeForUser().then(setBillingMode);
     }
     return (
         <UserContext.Provider value={{ user, setUser, userBillingMode: billingMode, refreshUserBillingMode }}>

--- a/components/gitpod-protocol/src/billing-mode.ts
+++ b/components/gitpod-protocol/src/billing-mode.ts
@@ -16,23 +16,11 @@ export namespace BillingMode {
         mode: "none",
     };
 
-    export function showChargebeeBilling(billingMode: BillingMode): boolean {
-        if (billingMode.mode === "chargebee") {
-            return true;
-        }
-        return false;
-    }
-
-    export function showChargebeeInvoices(billingMode: BillingMode): boolean {
-        if (showChargebeeBilling(billingMode)) {
-            return true;
-        }
-        // TODO(gpl) or hasBeenCustomer, so they can access invoices (edge case?)
-        return false;
-    }
-
     /** Incl. upgrade and status */
-    export function showStripeBilling(billingMode: BillingMode): boolean {
+    export function showUsageBasedBilling(billingMode?: BillingMode): boolean {
+        if (!billingMode) {
+            return false;
+        }
         return (
             billingMode.mode === "usage-based" || (billingMode.mode === "chargebee" && !!billingMode.canUpgradeToUBB)
         );
@@ -63,4 +51,10 @@ interface Chargebee {
 /** Session is handld with new usage-based logic */
 interface UsageBased {
     mode: "usage-based";
+
+    /** User is already converted, but is member with at least one Chargebee-based "Team Plan" */
+    hasChargebeeTeamPlan?: boolean;
+
+    /** User is already converted, but is member in at least one Chargebee-based "Team Subscription" */
+    hasChargebeeTeamSubscription?: boolean;
 }

--- a/components/server/ee/src/billing/billing-mode.spec.db.ts
+++ b/components/server/ee/src/billing/billing-mode.spec.db.ts
@@ -73,10 +73,10 @@ class StripeServiceMock extends StripeService {
 }
 
 class ConfigCatClientMock implements Client {
-    constructor(protected readonly usageBasedPricingEnabled: boolean) {}
+    constructor(protected readonly featureFlags: { [key: string]: boolean }) {}
 
     async getValueAsync<T>(experimentName: string, defaultValue: T, attributes: Attributes): Promise<T> {
-        return this.usageBasedPricingEnabled as any as T;
+        return !!this.featureFlags[experimentName] as any as T;
     }
 
     dispose() {}
@@ -431,7 +431,11 @@ class BillingModeSpec {
 
                     bind(StripeService).toConstantValue(new StripeServiceMock(test.config.stripeSubscription));
                     bind(ConfigCatClientFactory).toConstantValue(
-                        () => new ConfigCatClientMock(test.config.usageBasedPricingEnabled),
+                        () =>
+                            new ConfigCatClientMock({
+                                isUsageBasedBillingEnabled: test.config.usageBasedPricingEnabled,
+                                isBillingModeEnabled: true,
+                            }),
                     );
                 }),
             );

--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -1230,8 +1230,6 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
     async createPortalSession(ctx: TraceContext): Promise<{}> {
         const user = this.checkUser("createPortalSession");
         const logContext = { userId: user.id };
-        // TODO(gpl) This _might_ lock out people from their invoices (test). But if we wanted to keep it, we'd have to explicitly disabled/deny upgrading from the portal, first!
-        await this.ensureChargebeeApiIsAllowed({ user });
 
         return await new Promise((resolve, reject) => {
             this.chargebeeProvider.portal_session
@@ -1261,8 +1259,6 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
         if (!team) {
             throw new ResponseError(ErrorCodes.NOT_FOUND, "Team not found");
         }
-        // TODO(gpl) This _might_ lock out people from their invoices (test). But if we wanted to keep it, we'd have to explicitly disabled/deny upgrading from the portal, first!
-        await this.ensureChargebeeApiIsAllowed({ team });
         const members = await this.teamDB.findMembersByTeam(team.id);
         await this.guardAccess({ kind: "team", subject: team, members }, "update");
 


### PR DESCRIPTION
## Description
This PR introduces the usage of the `getBillindMode` calculation across the code base.
It turned out quite big in terms of lines of code, but can be either reviewed commit-by-commit, or even split into multiple PRs if that increases confidence. It contains four main changes:
 - Guard calculation of BillingMode by new FF "isBillingModeEnabled": if false, getBillingMode always returns "chargebee" (in SaaS). This is meant to de-risk the rollout of "BillingModes", prior to even thinking about enabling "usage-based pricing" Feature Flag. This is meant to go away short-term (end of next week?) once we see that calling the actual impl does not break prod
 - some improvements and fixes to getBillingMode
 - Enforce that Chargebee/Stripe API is only usable with the respective BillingMode: There is one TODO: We currently guard access to the "Portal" as well, because it allows people to perform checkouts and upgrades as well, which we want to prohibit. This might block people from accessing their invoices, though. If this is a problem we should investigate in a follow-up issue.
 - Use BillingMode to guide what components are shown in the UI: here I might be wrong in some details, but the commit should convey the idea of how to use the BIllingMode for these decisions
 
### ToDos for follow-up PRs:
   - [ ] Align access to configuring WorkspaceClasses with `BillingMode.canSetWorkspaceClass`
   ~- [ ] Find a way to display "SpendingLimit" independent of "Billing" component ([here](https://github.com/gitpod-io/gitpod/blob/1e909bab0e075c2816118a001a435326bb1888f5/components/dashboard/src/settings/Billing.tsx#L14))~
   - [ ] Cleanup: Introduce a `TeamContext` and use it across dashboard
   - [ ] Allow access to old Chargebee invoices _without_ allowing them ti upgrade (Portal access)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
- `(cd components/server && leeway build .:dbtest)` : verify that all BillingMode tests are still running

### isBillingModeEnabled: false
- go to preview environment, sign up with test user 1 (U1) and see that Chargebee integration works as expected:
   1. start workspace and try to increase timeout: :x: 
   2. Upgrade to "Unleashed", start workspace and try to increase timeout: :heavy_check_mark:  
- however, you do _not_ see any usage-based UI

### isBillingModeEnabled: true
- repeat the test from above, with a new user (U2)
- notice how everything still works (now with more expensive computation, maybe)

:information_source:  Testing `isUsageBaseBilling` is actually out-of-scope for this PR

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
- [x] /werft with-payment
