### PR TITLE
Replace with sorting icon

### DIFF
--- a/components/dashboard/src/images/sort-arrow.svg
+++ b/components/dashboard/src/images/sort-arrow.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 16 16"><path fill="#A8A29E" fill-rule="evenodd" d="M13.366 8.234a.8.8 0 0 1 0 1.132l-4.8 4.8a.8.8 0 0 1-1.132 0l-4.8-4.8a.8.8 0 1 1 1.132-1.132L7.2 11.67V2.4a.8.8 0 1 1 1.6 0v9.269l3.434-3.435a.8.8 0 0 1 1.132 0z" clip-rule="evenodd"/></svg>

--- a/components/dashboard/src/teams/TeamUsage.tsx
+++ b/components/dashboard/src/teams/TeamUsage.tsx
@@ -23,7 +23,7 @@ import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
 import { FeatureFlagContext } from "../contexts/FeatureFlagContext";
 import { ReactComponent as CreditsSvg } from "../images/credits.svg";
 import { ReactComponent as Spinner } from "../icons/Spinner.svg";
-import Arrow from "../components/Arrow";
+import { ReactComponent as SortArrow } from "../images/sort-arrow.svg";
 
 function TeamUsage() {
     const { teams } = useContext(TeamsContext);
@@ -202,9 +202,16 @@ function TeamUsage() {
                                             <span>Credits</span>
                                         </ItemField>
                                         <ItemField className="my-auto cursor-pointer">
-                                            <span onClick={() => setIsStartedTimeDescending(!isStartedTimeDescending)}>
+                                            <span
+                                                className="flex my-auto"
+                                                onClick={() => setIsStartedTimeDescending(!isStartedTimeDescending)}
+                                            >
                                                 Started
-                                                <Arrow direction={isStartedTimeDescending ? "down" : "up"} />
+                                                <SortArrow
+                                                    className={`h-4 w-4 my-auto ${
+                                                        isStartedTimeDescending ? "" : " transform rotate-180"
+                                                    }`}
+                                                />
                                             </span>
                                         </ItemField>
                                     </Item>


### PR DESCRIPTION
## Description
Uses the correct arrow icon.

<img width="279" alt="Screenshot 2022-08-03 at 18 33 14" src="https://user-images.githubusercontent.com/8015191/182661697-a9eb4d93-8ecd-4034-894b-2455a2abf0b1.png">


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #11783

## How to test
1. [Join this team](https://laushinka-3f2ec393c7.preview.gitpod-dev.com/teams/join?inviteId=47ce2625-e4d3-4c42-bb74-e6ab80c86621).
2. I will set you as owner.
3. Go to the [usage](https://laushinka-3f2ec393c7.preview.gitpod-dev.com/t/gitpod/usage) tab.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
