### PR TITLE
[dashboard] Fix displaying of logs for finished Prebuilds

### DIFF
--- a/components/dashboard/src/components/PrebuildLogs.tsx
+++ b/components/dashboard/src/components/PrebuildLogs.tsx
@@ -121,14 +121,16 @@ export default function PrebuildLogs(props: PrebuildLogsProps) {
                 disposables.push(retryWatchWorkspaceImageBuildLogs(workspaceId));
                 break;
             // When we're "running" we want to switch to the logs from the actual prebuild workspace, instead
+            // When the prebuild has "stopped", we still want to go for the logs
             case "running":
+            case "stopped":
                 disposables.push(
                     watchHeadlessLogs(
                         workspaceInstance.id,
                         (chunk) => {
                             logsEmitter.emit("logs", chunk);
                         },
-                        async () => workspaceInstance?.status.phase === "stopped",
+                        async () => false,
                     ),
                 );
         }


### PR DESCRIPTION
## Description
Fix a bug where we do not load Prebuild logs when the prebuild has already finished.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #11755 

## How to test
 - join [this team](https://gpl-11755-logs.preview.gitpod-dev.com/teams/join?inviteId=439d46d2-f218-4752-a96c-1f566a2fe637)
 - modify [this line](https://github.com/geropl/gitpod-test-repo/blob/gpl/docker-build-2mins/.gitpod.yml#L4)
 - [check](https://gpl-11755-logs.preview.gitpod-dev.com/t/superhumans/gitpod-test-repo) that the prebuild is executed
 - once it's "READY", go to the PrebuildDetails page (click the status) and notice how the logs are shown as well

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
