### PR TITLE
[installer] Support configuration of the public API HTTP port

### DIFF
--- a/install/installer/pkg/components/public-api-server/configmap.go
+++ b/install/installer/pkg/components/public-api-server/configmap.go
@@ -28,6 +28,9 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 				GRPC: &baseserver.ServerConfiguration{
 					Address: fmt.Sprintf(":%d", GRPCContainerPort),
 				},
+				HTTP: &baseserver.ServerConfiguration{
+					Address: fmt.Sprintf(":%d", HTTPContainerPort),
+				},
 			},
 		},
 	}

--- a/install/installer/pkg/components/public-api-server/configmap_test.go
+++ b/install/installer/pkg/components/public-api-server/configmap_test.go
@@ -29,6 +29,9 @@ func TestConfigMap(t *testing.T) {
 				GRPC: &baseserver.ServerConfiguration{
 					Address: fmt.Sprintf(":%d", GRPCContainerPort),
 				},
+				HTTP: &baseserver.ServerConfiguration{
+					Address: fmt.Sprintf(":%d", HTTPContainerPort),
+				},
 			},
 		},
 	}

--- a/install/installer/pkg/components/public-api-server/constants.go
+++ b/install/installer/pkg/components/public-api-server/constants.go
@@ -10,4 +10,7 @@ const (
 	GRPCPortName      = "grpc"
 	GRPCContainerPort = 9001
 	GRPCServicePort   = 9001
+	HTTPContainerPort = 9002
+	HTTPServicePort   = 9002
+	HTTPPortName      = "http"
 )

--- a/install/installer/pkg/components/public-api-server/service.go
+++ b/install/installer/pkg/components/public-api-server/service.go
@@ -9,11 +9,18 @@ import (
 )
 
 func service(ctx *common.RenderContext) ([]runtime.Object, error) {
-	return common.GenerateService(Component, []common.ServicePort{
+	servicePorts := []common.ServicePort{
 		{
 			Name:          GRPCPortName,
 			ContainerPort: GRPCContainerPort,
 			ServicePort:   GRPCServicePort,
 		},
-	})(ctx)
+		{
+			Name:          HTTPPortName,
+			ContainerPort: HTTPContainerPort,
+			ServicePort:   HTTPServicePort,
+		},
+	}
+
+	return common.GenerateService(Component, servicePorts)(ctx)
 }


### PR DESCRIPTION
## Description

As of https://github.com/gitpod-io/gitpod/pull/11806, the public api exposes an HTTP port for a Stripe webhook handler. This handler should be present on Gitpod SaaS but absent on self hosted installations.

This PR adds experimental config for the public api component to allow an HTTP port to be configured. If the port is not present in the configuration, `baseserver` ensures that HTTP is not served.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of https://github.com/gitpod-io/gitpod/issues/10937 and #9036 .

## How to test

Installer unit tests to check the rendered public api configmap.

## Release Notes

```release-note
NONE
```

## Documentation


## Werft options:

- [ ] /werft with-preview
