### PR TITLE
[werft] Set publicApi.httpPort

### DIFF
--- a/.werft/jobs/build/installer/installer.ts
+++ b/.werft/jobs/build/installer/installer.ts
@@ -231,6 +231,9 @@ EOF`);
         exec(`yq w -i ${this.options.installerConfigPath} experimental.webapp.publicApi.enabled true`, {
             slice: slice,
         });
+        exec(`yq w -i ${this.options.installerConfigPath} experimental.webapp.publicApi.httpPort 9002`, {
+            slice: slice,
+        });
     }
 
     private configureUsage(slice: string) {

--- a/install/installer/pkg/components/public-api-server/configmap.go
+++ b/install/installer/pkg/components/public-api-server/configmap.go
@@ -32,6 +32,12 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		},
 	}
 
+	if exp := getExperimentalPublicAPIConfig(ctx); exp != nil && exp.HttpPort != 0 {
+		cfg.Server.Services.HTTP = &baseserver.ServerConfiguration{
+			Address: fmt.Sprintf(":%d", exp.HttpPort),
+		}
+	}
+
 	fc, err := common.ToJSONString(cfg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal config: %w", err)

--- a/install/installer/pkg/components/public-api-server/configmap_test.go
+++ b/install/installer/pkg/components/public-api-server/configmap_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gitpod-io/gitpod/common-go/baseserver"
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
+	"github.com/gitpod-io/gitpod/installer/pkg/config/v1/experimental"
 	"github.com/gitpod-io/gitpod/public-api/config"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -28,6 +29,46 @@ func TestConfigMap(t *testing.T) {
 			Services: baseserver.ServicesConfiguration{
 				GRPC: &baseserver.ServerConfiguration{
 					Address: fmt.Sprintf(":%d", GRPCContainerPort),
+				},
+			},
+		},
+	}
+
+	expectedJSON, err := common.ToJSONString(expectedConfiguration)
+	require.NoError(t, err)
+
+	cm := objs[0].(*corev1.ConfigMap)
+	require.Equal(t, &corev1.ConfigMap{
+		TypeMeta: common.TypeMetaConfigmap,
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        Component,
+			Namespace:   ctx.Namespace,
+			Labels:      common.CustomizeLabel(ctx, Component, common.TypeMetaConfigmap),
+			Annotations: common.CustomizeAnnotation(ctx, Component, common.TypeMetaConfigmap),
+		},
+		Data: map[string]string{
+			"config.json": string(expectedJSON),
+		},
+	}, cm)
+}
+
+func TestConfigMapWithHttpConfiguration(t *testing.T) {
+	ctx := renderContextWithPublicAPIConfig(t, &experimental.PublicAPIConfig{Enabled: true, HttpPort: 9002})
+
+	objs, err := configmap(ctx)
+	require.NoError(t, err)
+
+	require.Len(t, objs, 1, "must only render one configmap")
+
+	expectedConfiguration := config.Configuration{
+		GitpodServiceURL: "wss://test.domain.everything.awesome.is/api/v1",
+		Server: &baseserver.Configuration{
+			Services: baseserver.ServicesConfiguration{
+				GRPC: &baseserver.ServerConfiguration{
+					Address: fmt.Sprintf(":%d", GRPCContainerPort),
+				},
+				HTTP: &baseserver.ServerConfiguration{
+					Address: ":9002",
 				},
 			},
 		},

--- a/install/installer/pkg/components/public-api-server/constants.go
+++ b/install/installer/pkg/components/public-api-server/constants.go
@@ -10,4 +10,6 @@ const (
 	GRPCPortName      = "grpc"
 	GRPCContainerPort = 9001
 	GRPCServicePort   = 9001
+	HTTPServicePort   = 9002
+	HTTPPortName      = "http"
 )

--- a/install/installer/pkg/components/public-api-server/objects_test.go
+++ b/install/installer/pkg/components/public-api-server/objects_test.go
@@ -30,11 +30,15 @@ func TestObjects_RenderedWhenExperimentalConfigSet(t *testing.T) {
 }
 
 func renderContextWithPublicAPIEnabled(t *testing.T) *common.RenderContext {
+	return renderContextWithPublicAPIConfig(t, &experimental.PublicAPIConfig{Enabled: true})
+}
+
+func renderContextWithPublicAPIConfig(t *testing.T, cfg *experimental.PublicAPIConfig) *common.RenderContext {
 	ctx, err := common.NewRenderContext(config.Config{
 		Domain: "test.domain.everything.awesome.is",
 		Experimental: &experimental.Config{
 			WebApp: &experimental.WebAppConfig{
-				PublicAPI: &experimental.PublicAPIConfig{Enabled: true},
+				PublicAPI: cfg,
 			},
 		},
 	}, versions.Manifest{

--- a/install/installer/pkg/components/public-api-server/service.go
+++ b/install/installer/pkg/components/public-api-server/service.go
@@ -9,11 +9,21 @@ import (
 )
 
 func service(ctx *common.RenderContext) ([]runtime.Object, error) {
-	return common.GenerateService(Component, []common.ServicePort{
+	servicePorts := []common.ServicePort{
 		{
 			Name:          GRPCPortName,
 			ContainerPort: GRPCContainerPort,
 			ServicePort:   GRPCServicePort,
 		},
-	})(ctx)
+	}
+
+	if exp := getExperimentalPublicAPIConfig(ctx); exp != nil && exp.HttpPort != 0 {
+		servicePorts = append(servicePorts, common.ServicePort{
+			Name:          HTTPPortName,
+			ContainerPort: exp.HttpPort,
+			ServicePort:   HTTPServicePort,
+		})
+	}
+
+	return common.GenerateService(Component, servicePorts)(ctx)
 }

--- a/install/installer/pkg/config/v1/experimental/experimental.go
+++ b/install/installer/pkg/config/v1/experimental/experimental.go
@@ -205,7 +205,8 @@ type ProxyConfig struct {
 }
 
 type PublicAPIConfig struct {
-	Enabled bool `json:"enabled"`
+	Enabled  bool  `json:"enabled"`
+	HttpPort int32 `json:"httpPort"`
 }
 
 type UsageConfig struct {


### PR DESCRIPTION
## Description

Configure the HTTP port on which the public API server listens in preview environments.

See https://github.com/gitpod-io/gitpod/pull/11832 for a description of what this port is for. 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of https://github.com/gitpod-io/gitpod/issues/10937

## How to test

In the preview environment for this branch run `kubectl describe cm public-api-server`.

See that the following section is present in the config:
```yaml
"http": {
   "address": ":9002"
}
```

## Release Notes

```release-note
NONE
```

## Documentation


## Werft options:
- [x] /werft with-preview
