### PR TITLE
Hotfix release for `local-preview`

### DIFF
--- a/components/dashboard/src/App.tsx
+++ b/components/dashboard/src/App.tsx
@@ -47,7 +47,8 @@ import { StartWorkspaceModal } from "./workspaces/StartWorkspaceModal";
 import { parseProps } from "./start/StartWorkspace";
 import SelectIDEModal from "./settings/SelectIDEModal";
 import { StartPage, StartPhase } from "./start/StartPage";
-import { isGitpodIo } from "./utils";
+import { isGitpodIo, isLocalPreview } from "./utils";
+import Alert from "./components/Alert";
 import { BlockedRepositories } from "./admin/BlockedRepositories";
 import { AppNotifications } from "./AppNotifications";
 
@@ -347,6 +348,28 @@ function App() {
         <Route>
             <div className="container">
                 <Menu />
+                {isLocalPreview() && (
+                    <div className="app-container mt-2">
+                        <Alert type="warning" className="app-container rounded-md">
+                            You are using a <b>local preview</b> installation, intended for exploring the product on a
+                            single machine without requiring a Kubernetes cluster.{" "}
+                            <a
+                                className="gp-link hover:text-gray-600"
+                                href="https://www.gitpod.io/community-license?utm_source=local-preview"
+                            >
+                                Request a community license
+                            </a>{" "}
+                            or{" "}
+                            <a
+                                className="gp-link hover:text-gray-600"
+                                href="https://www.gitpod.io/contact/sales?utm_source=local-preview"
+                            >
+                                contact sales
+                            </a>{" "}
+                            to get a professional license for running Gitpod in production.
+                        </Alert>
+                    </div>
+                )}
                 <AppNotifications />
                 <Switch>
                     <Route path={projectsPathNew} exact component={NewProject} />

--- a/components/dashboard/src/utils.ts
+++ b/components/dashboard/src/utils.ts
@@ -58,8 +58,12 @@ export function isGitpodIo() {
     );
 }
 
+export function isLocalPreview() {
+    return window.location.hostname === "preview.gitpod-self-hosted.com";
+}
+
 function trimResource(resource: string): string {
-    return resource.split('/').filter(Boolean).join('/');
+    return resource.split("/").filter(Boolean).join("/");
 }
 
 // Returns 'true' if a 'pathname' is a part of 'resources' provided.
@@ -69,9 +73,9 @@ function trimResource(resource: string): string {
 // 'pathname' arg can be provided via `location.pathname`.
 export function inResource(pathname: string, resources: string[]): boolean {
     // Removes leading and trailing '/'
-    const trimmedResource = trimResource(pathname)
+    const trimmedResource = trimResource(pathname);
 
     // Checks if a path is part of a resource.
     // E.g. "api/userspace/resource" path is a part of resource "api/userspace"
-    return resources.map(res => trimmedResource.startsWith(trimResource(res))).some(Boolean)
+    return resources.map((res) => trimmedResource.startsWith(trimResource(res))).some(Boolean);
 }

--- a/install/preview/BUILD.yaml
+++ b/install/preview/BUILD.yaml
@@ -3,14 +3,12 @@ packages:
     type: docker
     deps:
       - install/installer:app
+      - install/preview/prettylog:app
     argdeps:
       - imageRepoBase
     srcs:
       - "entrypoint.sh"
       - "manifests/*.yaml"
-      - "prettylog/main.go"
-      - "prettylog/go.sum"
-      - "prettylog/go.mod"
     config:
       dockerfile: leeway.Dockerfile
       image:

--- a/install/preview/entrypoint.sh
+++ b/install/preview/entrypoint.sh
@@ -9,6 +9,10 @@ if [ -z "${DOMAIN}" ]; then
   export DOMAIN="127-0-0-1.nip.io"
 fi
 
+# Create a USER_ID to be used everywhere
+USER_ID="$(od -x /dev/urandom | head -1 | awk '{OFS="-"; print $2$3,$4,$5,$6,$7$8$9}')"
+export USER_ID
+
 if [ "$1" != "logging" ]; then
   $0 logging 2>&1 | /prettylog
   exit

--- a/install/preview/entrypoint.sh
+++ b/install/preview/entrypoint.sh
@@ -4,9 +4,9 @@
 
 set -e
 
-# Set Domain to `127-0-0-1.nip.io` if not set
+# Set Domain to `preview.gitpod-self-hosted.com` if not set
 if [ -z "${DOMAIN}" ]; then
-  export DOMAIN="127-0-0-1.nip.io"
+  export DOMAIN="preview.gitpod-self-hosted.com"
 fi
 
 # Create a USER_ID to be used everywhere

--- a/install/preview/leeway.Dockerfile
+++ b/install/preview/leeway.Dockerfile
@@ -1,12 +1,6 @@
 # Copyright (c) 2022 Gitpod GmbH. All rights reserved.
 # Licensed under the MIT License. See License-MIT.txt in the project root for license information.
 
-FROM golang:1.18 as prettylog
-
-WORKDIR /app
-COPY prettylog/* ./
-RUN CGO_ENABLED=0 go build .
-
 FROM rancher/k3s:v1.21.12-k3s1
 
 ADD https://github.com/FiloSottile/mkcert/releases/download/v1.4.4/mkcert-v1.4.4-linux-amd64 /bin/mkcert
@@ -20,7 +14,7 @@ RUN chmod +x /bin/yq
 
 COPY manifests/* /app/manifests/
 COPY install-installer--app/installer /gitpod-installer
-COPY --from=prettylog /app/prettylog /prettylog
+COPY install-preview-prettylog--app/prettylog /prettylog
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/install/preview/manifests/coredns.yaml
+++ b/install/preview/manifests/coredns.yaml
@@ -56,18 +56,18 @@ metadata:
   namespace: kube-system
 data:
   gitpod.db: |
-    ; 127-0-0-1.nip.io test file
-    127-0-0-1.nip.io.       IN      SOA    sns.dns.icann.org. noc.dns.icann.org. 2015082541 7200 3600 1209600 3600
-    127-0-0-1.nip.io.       IN      CNAME  proxy.default.svc.cluster.local.
-    *.127-0-0-1.nip.io.     IN      CNAME  proxy.default.svc.cluster.local.
-    *.ws.127-0-0-1.nip.io.  IN      CNAME  proxy.default.svc.cluster.local.
+    ; preview.gitpod-self-hosted.com test file
+    preview.gitpod-self-hosted.com.       IN      SOA    sns.dns.icann.org. noc.dns.icann.org. 2015082541 7200 3600 1209600 3600
+    preview.gitpod-self-hosted.com.       IN      CNAME  proxy.default.svc.cluster.local.
+    *.preview.gitpod-self-hosted.com.     IN      CNAME  proxy.default.svc.cluster.local.
+    *.ws.preview.gitpod-self-hosted.com.  IN      CNAME  proxy.default.svc.cluster.local.
   Corefile: |
     .:53 {
         errors
         health
         ready
-        # extra configuration for `127-0-0-1.nip.io`
-        file /etc/coredns/gitpod.db 127-0-0-1.nip.io
+        # extra configuration for `preview.gitpod-self-hosted.com`
+        file /etc/coredns/gitpod.db preview.gitpod-self-hosted.com
         kubernetes cluster.local in-addr.arpa ip6.arpa {
           pods insecure
           fallthrough in-addr.arpa ip6.arpa

--- a/install/preview/prettylog/BUILD.yaml
+++ b/install/preview/prettylog/BUILD.yaml
@@ -1,0 +1,25 @@
+# Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+# Licensed under the GNU Affero General Public License (AGPL).
+# See License-AGPL.txt in the project root for license information.
+
+packages:
+  - name: app
+    type: go
+    argdeps:
+      - SEGMENT_IO_TOKEN
+    srcs:
+      - "main.go"
+      - "go.sum"
+      - "go.mod"
+    env:
+      - CGO_ENABLED=0
+    config:
+      packaging: app
+      buildCommand:
+        [
+          "go",
+          "build",
+          "-trimpath",
+          "-ldflags",
+          "-buildid= -w -s -X 'main.segmentIOToken=${SEGMENT_IO_TOKEN}'",
+        ]

--- a/install/preview/prettylog/go.mod
+++ b/install/preview/prettylog/go.mod
@@ -1,10 +1,9 @@
-module github.com/gitpod-io/gitpod/olpi/prettylog
+module github.com/gitpod-io/gitpod/install/preview/prettylog
 
 go 1.18
 
-require github.com/pterm/pterm v0.12.41
-
 require (
+	github.com/pterm/pterm v0.12.41
 	github.com/atomicgo/cursor v0.0.1 // indirect
 	github.com/gookit/color v1.5.0 // indirect
 	github.com/mattn/go-runewidth v0.0.13 // indirect
@@ -12,4 +11,11 @@ require (
 	github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778 // indirect
 	golang.org/x/sys v0.0.0-20220319134239-a9b59b0215f8 // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
+	gopkg.in/segmentio/analytics-go.v3 v3.1.0
+)
+
+require (
+	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect
+	github.com/segmentio/backo-go v1.0.1 // indirect
+	github.com/xtgo/uuid v0.0.0-20140804021211-a0b114877d4c // indirect
 )

--- a/install/preview/prettylog/go.sum
+++ b/install/preview/prettylog/go.sum
@@ -8,6 +8,8 @@ github.com/MarvinJWendt/testza v0.3.5 h1:g9krITRRlIsF1eO9sUKXtiTw670gZIIk6T08Kee
 github.com/MarvinJWendt/testza v0.3.5/go.mod h1:ExbTpWmA1z2E9HSskvrNcwApoX4F9bID692s10nuHRY=
 github.com/atomicgo/cursor v0.0.1 h1:xdogsqa6YYlLfM+GyClC/Lchf7aiMerFiZQn7soTOoU=
 github.com/atomicgo/cursor v0.0.1/go.mod h1:cBON2QmmrysudxNBFthvMtN32r3jxVRIvzkUiF/RuIk=
+github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4YnC6+E63dPcxHo2sUxDIu8g3QgEJdRY=
+github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -18,8 +20,10 @@ github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa02
 github.com/klauspost/cpuid/v2 v2.0.10/go.mod h1:g2LTdtYhdyuGPqyWyv7qRAmj1WBqxuObKfj5c0PQa7c=
 github.com/klauspost/cpuid/v2 v2.0.12 h1:p9dKCg8i4gmOxtv35DvrYoWqYzQrvEVdjQ762Y0OqZE=
 github.com/klauspost/cpuid/v2 v2.0.12/go.mod h1:g2LTdtYhdyuGPqyWyv7qRAmj1WBqxuObKfj5c0PQa7c=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/mattn/go-runewidth v0.0.13 h1:lTGmDsbAYt5DmK6OnoV7EuIF1wEIFAcxld6ypU4OSgU=
 github.com/mattn/go-runewidth v0.0.13/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
@@ -36,6 +40,8 @@ github.com/pterm/pterm v0.12.41 h1:e2BRfFo1H9nL8GY0S3ImbZqfZ/YimOk9XtkhoobKJVs=
 github.com/pterm/pterm v0.12.41/go.mod h1:LW/G4J2A42XlTaPTAGRPvbBfF4UXvHWhC6SN7ueU4jU=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
+github.com/segmentio/backo-go v1.0.1 h1:68RQccglxZeyURy93ASB/2kc9QudzgIDexJ927N++y4=
+github.com/segmentio/backo-go v1.0.1/go.mod h1:9/Rh6yILuLysoQnZ2oNooD2g7aBnvM7r/fNVxRNWfBc=
 github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=
 github.com/sergi/go-diff v1.2.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -45,6 +51,8 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778 h1:QldyIu/L63oPpyvQmHgvgickp1Yw510KJOqX7H24mg8=
 github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778/go.mod h1:2MuV+tbUrU1zIOPMxZ5EncGwgmMJsa+9ucAQZXxsObs=
+github.com/xtgo/uuid v0.0.0-20140804021211-a0b114877d4c h1:3lbZUMbMiGUW/LMkfsEABsc5zNT9+b1CvsJx47JzJ8g=
+github.com/xtgo/uuid v0.0.0-20140804021211-a0b114877d4c/go.mod h1:UrdRz5enIKZ63MEE3IF9l2/ebyx59GyGgPi+tICQdmM=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -57,6 +65,8 @@ golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 h1:JGgROgKl9N8DuW20oFS5gxc+
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/segmentio/analytics-go.v3 v3.1.0 h1:UzxH1uaGZRpMKDhJyBz0pexz6yUoBU3x8bJsRk/HV6U=
+gopkg.in/segmentio/analytics-go.v3 v3.1.0/go.mod h1:4QqqlTlSSpVlWA9/9nDcPw+FkM2yv1NQoYjUbL9/JAw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/install/preview/prettylog/main.go
+++ b/install/preview/prettylog/main.go
@@ -12,21 +12,30 @@ import (
 	"strings"
 
 	"github.com/pterm/pterm"
+	"gopkg.in/segmentio/analytics-go.v3"
 )
 
-var msgs = []struct {
-	Fail    string
-	Success string
+const (
+	telemetryEvent = "localpreview_status"
+)
 
-	Msg string
-}{
-	{Msg: "checking prerequisites", Fail: "requires a system with at least", Success: "Gitpod Domain:"},
-	{Msg: "preparing system", Success: "extracting images to download ahead"},
-	{Msg: "downloading images", Success: "--output-split-files"},
-	{Msg: "preparing Gitpod preview installation", Success: "rm -rf /var/lib/rancher/k3s/server/manifests/gitpod"},
-	{Msg: "starting Gitpod", Success: "Gitpod pods are ready"},
-	{Msg: fmt.Sprintf("Gitpod is running. Visit https://%s to access the dashboard", os.Getenv("DOMAIN"))},
-}
+var (
+	segmentIOToken string
+	msgs           = []struct {
+		Fail    string
+		Success string
+		Status  string
+
+		Msg string
+	}{
+		{Msg: "checking prerequisites", Fail: "requires a system with at least", Success: "Gitpod Domain:", Status: "checking prerequisites"},
+		{Msg: "preparing system", Success: "extracting images to download ahead"},
+		{Msg: "downloading images", Success: "--output-split-files"},
+		{Msg: "preparing Gitpod preview installation", Success: "rm -rf /var/lib/rancher/k3s/server/manifests/gitpod"},
+		{Msg: "starting Gitpod", Success: "Gitpod pods are ready", Status: "starting gitpod"},
+		{Msg: fmt.Sprintf("Gitpod is running. Visit https://%s to access the dashboard", os.Getenv("DOMAIN")), Status: "gitpod ready"},
+	}
+)
 
 func main() {
 	dmp, err := os.OpenFile("logs.txt", os.O_WRONLY|os.O_TRUNC|os.O_CREATE, 0644)
@@ -40,10 +49,11 @@ func main() {
 	scan := bufio.NewScanner(r)
 	var msgIdx int
 	lastSpinner, _ := pterm.DefaultSpinner.Start(msgs[msgIdx].Msg)
+	// send Telemetry update for the first phase
+	send_telemetry(msgs[msgIdx].Status)
 	for scan.Scan() {
 		line := scan.Text()
 		msg := msgs[msgIdx]
-
 		var next bool
 		switch {
 		case msg.Fail != "" && strings.Contains(line, msg.Fail):
@@ -63,6 +73,9 @@ func main() {
 			return
 		}
 		lastSpinner, _ = pterm.DefaultSpinner.Start(msgs[msgIdx].Msg)
+		// send Telemetry for phase update
+		send_telemetry(msgs[msgIdx].Status)
+
 	}
 	err = scan.Err()
 	if errors.Is(err, io.EOF) {
@@ -70,5 +83,27 @@ func main() {
 	}
 	if err != nil {
 		panic(err)
+	}
+}
+
+func send_telemetry(status string) {
+	if os.Getenv("DO_NOT_TRACK") != "1" && status != "" {
+		if segmentIOToken == "" {
+			panic("No segmentIOToken set during build")
+		}
+
+		client, _ := analytics.NewWithConfig(segmentIOToken, analytics.Config{})
+		defer func() {
+			client.Close()
+
+		}()
+
+		telemetry := analytics.Track{
+			UserId: os.Getenv("USER_ID"),
+			Event:  telemetryEvent,
+			Properties: analytics.NewProperties().
+				Set("status", status),
+		}
+		client.Enqueue(telemetry)
 	}
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This PR creates a hot-fix release for `local-preview` that includes the
following 2 commits:
- [[local-preview] Send telemetry for each event](https://github.com/gitpod-io/gitpod/commit/747f7ab6c8214804fd5be432c06e2d745afd578f)
- [[dashboard] Next steps nudge for local-preview](https://github.com/gitpod-io/gitpod/commit/333fada5380479fea60b8b9aa6a5fa9da8340662)

on top of the `2022-07-0` release.

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
