### PR TITLE
Don't compile previewctl on workspace-startup

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -36,7 +36,6 @@ ports:
 tasks:
   - name: Install Preview Environment kube-context
     command: |
-      (cd dev/preview/previewctl && go install .)
       previewctl install-context --watch
       exit
   - name: Add Harvester kubeconfig


### PR DESCRIPTION
## Description
Improve workspace startup time by not compiling `previewctl` on workspace startup.

This PR removes the compile step for `previewctl` because it's already being added to the workspace here:

https://github.com/gitpod-io/gitpod/blob/81c7aa193fc6f10e015c52ac87a0a355669755f0/dev/image/Dockerfile#L256

## Related Issue(s)
Fixes # https://gitpod.slack.com/archives/C01KGM9AW4W/p1659516801962049?thread_ts=1659513203.668999&cid=C01KGM9AW4W

## How to test
see if `previewctl` is still available in workspaces. 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
