### PR TITLE
[usage] Self-connection allows up to 30MB in message response

### DIFF
--- a/components/usage/pkg/server/server.go
+++ b/components/usage/pkg/server/server.go
@@ -59,8 +59,11 @@ func Start(cfg Config) error {
 		return fmt.Errorf("failed to initialize usage server: %w", err)
 	}
 
-	dialerOpt := grpcDialerWithInitialDelay(1 * time.Second)
-	selfConnection, err := grpc.Dial(srv.GRPCAddress(), grpc.WithTransportCredentials(insecure.NewCredentials()), dialerOpt)
+	selfConnection, err := grpc.Dial(srv.GRPCAddress(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpcDialerWithInitialDelay(1*time.Second),
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(30*1024*1024)),
+	)
 	if err != nil {
 		return fmt.Errorf("failed to create self-connection to grpc server: %w", err)
 	}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Allows the reconciler to receive responses up to 30MB in size. Currently it fails with 
```
code = ResourceExhausted desc = grpc: received message larger than max (8500596 vs. 4194304)
```
This is equivalent to ~8MB, so we have some headroom.

If this becomes a problem, we can split the RPC to stop returning All records for everyone, and instead do RPC per Attribution ID or similar.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #11836

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
