### PR TITLE
Implement preview->certificate owner reference

### DIFF
--- a/.werft/jobs/build/deploy-to-preview-environment.ts
+++ b/.werft/jobs/build/deploy-to-preview-environment.ts
@@ -505,6 +505,7 @@ export async function issueMetaCerts(
     certName: string,
     certsNamespace: string,
     domain: string,
+    branch: string,
     slice: string,
 ): Promise<boolean> {
     const additionalSubdomains: string[] = ["", "*.", `*.ws.`];
@@ -513,6 +514,7 @@ export async function issueMetaCerts(
     metaClusterCertParams.gcpSaPath = GCLOUD_SERVICE_ACCOUNT_PATH;
     metaClusterCertParams.certName = certName;
     metaClusterCertParams.certNamespace = certsNamespace;
+    metaClusterCertParams.previewName = previewNameFromBranchName(branch)
     metaClusterCertParams.dnsZoneDomain = "gitpod-dev.com";
     metaClusterCertParams.domain = domain;
     metaClusterCertParams.ip = getCoreDevIngressIP();

--- a/.werft/jobs/build/prepare.ts
+++ b/.werft/jobs/build/prepare.ts
@@ -81,7 +81,7 @@ async function issueCertificate(werft: Werft, config: JobConfig): Promise<boolea
     const domain = `${config.previewEnvironment.destname}.preview.gitpod-dev.com`;
 
     werft.log(prepareSlices.ISSUE_CERTIFICATES, prepareSlices.ISSUE_CERTIFICATES);
-    var certReady = await issueMetaCerts(werft, certName, "certs", domain, prepareSlices.ISSUE_CERTIFICATES);
+    var certReady = await issueMetaCerts(werft, certName, "certs", domain, config.repository.branch, prepareSlices.ISSUE_CERTIFICATES);
     werft.done(prepareSlices.ISSUE_CERTIFICATES);
     return certReady
 }

--- a/.werft/platform-delete-preview-environments-cron.ts
+++ b/.werft/platform-delete-preview-environments-cron.ts
@@ -1,7 +1,6 @@
 import { Werft } from "./util/werft";
 import * as Tracing from "./observability/tracing";
 import { SpanStatusCode } from "@opentelemetry/api";
-import { wipePreviewEnvironmentAndNamespace, helmInstallName, listAllPreviewNamespaces } from "./util/kubectl";
 import { exec } from "./util/shell";
 import { previewNameFromBranchName } from "./util/preview";
 import { CORE_DEV_KUBECONFIG_PATH, HARVESTER_KUBECONFIG_PATH, PREVIEW_K3S_KUBECONFIG_PATH } from "./jobs/build/const";
@@ -10,7 +9,7 @@ import * as VM from "./vm/vm";
 
 // for testing purposes
 // if set to 'true' it shows only previews that would be deleted
-const DRY_RUN = false;
+const DRY_RUN = true;
 
 const SLICES = {
     CONFIGURE_ACCESS: "Configuring access to relevant resources",
@@ -21,6 +20,7 @@ const SLICES = {
     CHECKING_FOR_DB_ACTIVITY: "Checking for DB activity",
     DETERMINING_STALE_PREVIEW_ENVIRONMENTS: "Determining stale preview environments",
     DELETING_PREVIEW_ENVIRONMNETS: "Deleting preview environments",
+    DELETING_ORPHAN_CERTIFICATES: "Deleting certificates without a matching preview environment",
 };
 
 // Will be set once tracing has been initialized
@@ -32,6 +32,7 @@ Tracing.initialize()
     })
     .then(() => deletePreviewEnvironments())
     .then(() => cleanLoadbalancer())
+    .then(() => removeOrphanCertificates())
     .catch((err) => {
         werft.rootSpan.setStatus({
             code: SpanStatusCode.ERROR,
@@ -413,7 +414,6 @@ async function removePreviewEnvironment(previewEnvironment: PreviewEnvironment) 
     werft.log(sliceID, `Starting deletion of all resources related to ${previewEnvironment.name}`);
     try {
         // We're running these promises sequentially to make it easier to read the log output.
-        await removeCertificate(previewEnvironment.name, CORE_DEV_KUBECONFIG_PATH, sliceID);
         await previewEnvironment.removeDNSRecords(sliceID);
         await previewEnvironment.delete();
         werft.done(sliceID);
@@ -422,11 +422,67 @@ async function removePreviewEnvironment(previewEnvironment: PreviewEnvironment) 
     }
 }
 
-async function removeCertificate(preview: string, kubectlConfig: string, slice: string) {
-    return exec(
-        `kubectl --kubeconfig ${kubectlConfig} -n certs delete --ignore-not-found=true cert harvester-${preview} ${preview}`,
-        { slice: slice, async: true },
-    );
+async function removeOrphanCertificates() {
+    const certificatesNamespace = "certs"
+    werft.phase(SLICES.DELETING_ORPHAN_CERTIFICATES);
+
+    try {
+        const GCLOUD_SERVICE_ACCOUNT_PATH = "/mnt/secrets/gcp-sa/service-account.json";
+        exec(`gcloud auth activate-service-account --key-file "${GCLOUD_SERVICE_ACCOUNT_PATH}"`, {
+            slice: SLICES.CONFIGURE_ACCESS,
+        });
+        exec(
+            `KUBECONFIG=${CORE_DEV_KUBECONFIG_PATH} gcloud container clusters get-credentials core-dev --zone europe-west1-b --project gitpod-core-dev`,
+            { slice: SLICES.CONFIGURE_ACCESS },
+        );
+        werft.done(SLICES.CONFIGURE_ACCESS);
+    } catch (err) {
+        werft.fail(SLICES.CONFIGURE_ACCESS, err);
+    }
+
+    try {
+        exec(`cp /mnt/secrets/harvester-kubeconfig/harvester-kubeconfig.yml ${HARVESTER_KUBECONFIG_PATH}`, {
+            slice: SLICES.INSTALL_HARVESTER_KUBECONFIG,
+        });
+        werft.done(SLICES.INSTALL_HARVESTER_KUBECONFIG);
+    } catch (err) {
+        werft.fail(SLICES.INSTALL_HARVESTER_KUBECONFIG, err);
+    }
+
+    const certificates = exec(
+        `kubectl --kubeconfig ${CORE_DEV_KUBECONFIG_PATH} get certificates -n ${certificatesNamespace} -o=custom-columns=:metadata.name | grep harvester-`,
+        { slice: SLICES.DELETING_ORPHAN_CERTIFICATES, silent: true, async: false },
+    )
+    .stdout.trim()
+    .split("\n");
+
+    const previews = exec(
+        `kubectl --kubeconfig ${HARVESTER_KUBECONFIG_PATH} get ns -o=custom-columns=:metadata.name | grep preview-`,
+        { slice: SLICES.DELETING_ORPHAN_CERTIFICATES, silent: true, async: false },
+    )
+    .stdout.trim()
+    .replace(/preview-/g, "")
+    .split("\n");
+
+    certificates.forEach(certificate => {
+        const owner = exec(
+            `kubectl --kubeconfig ${CORE_DEV_KUBECONFIG_PATH} get certificates -n ${certificatesNamespace} -o=custom-columns=:metadata.annotations.preview/owner`,
+            { slice: SLICES.DELETING_ORPHAN_CERTIFICATES, silent: true, async: false },
+        ).stdout.trim()
+
+        if (!previews.includes(owner)) {
+            if (!DRY_RUN) {
+                exec(
+                    `kubectl --kubeconfig ${CORE_DEV_KUBECONFIG_PATH} -n ${certificatesNamespace} delete --ignore-not-found=true cert ${certificate}`,
+                    { slice: SLICES.DELETING_ORPHAN_CERTIFICATES, async: true },
+                );
+            } else {
+                werft.log(SLICES.DELETING_ORPHAN_CERTIFICATES, `Certificate ${certificate} would have been deleted`)
+            }
+        }
+    });
+
+    werft.done(SLICES.DELETING_ORPHAN_CERTIFICATES)
 }
 
 async function cleanLoadbalancer() {

--- a/.werft/util/certs.ts
+++ b/.werft/util/certs.ts
@@ -14,6 +14,7 @@ export class IssueCertificateParams {
     bucketPrefixTail: string;
     certName: string;
     certNamespace: string;
+    previewName: string
 }
 
 export class InstallCertificateParams {
@@ -107,6 +108,7 @@ function createCertificateResource(
     && yq w -i cert.yaml spec.secretName '${params.certName}' \
     && yq w -i cert.yaml metadata.namespace '${params.certNamespace}' \
     && yq w -i cert.yaml spec.issuerRef.name 'letsencrypt-issuer-gitpod-core-dev' \
+    && yq w -i cert.yaml metadata.annotations.preview/owner '${params.previewName}' \
     ${subdomains.map((s) => `&& yq w -i cert.yaml spec.dnsNames[+] '${s + params.domain}'`).join("  ")} \
     && kubectl --kubeconfig ${CORE_DEV_KUBECONFIG_PATH} apply -f cert.yaml`;
 


### PR DESCRIPTION
Signed-off-by: ArthurSens <arthursens2005@gmail.com>

## Description
<!-- Describe your changes in detail -->
A lot of certificates are left hanging around because it heavily ties preview and certificate deletion. In case for some random reason a preview is deleted and the certificate isn't, the certificate will stay in our cluster forever.

This PR aims to refactor the certificate deletion, adopting something similar to Kubernetes Owner references.

1. To delete a certificate the cron first deletes a certain preview and the certificate is left there untouched. 
2. A following cron will be responsible for checking that we now have a orphan certificate, and it should be deleted.


Opening it as a draft because I have no idea how to test that 😅 

## How to test
<!-- Provide steps to test this PR -->
I'm not sure, and open to ideas 😅 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
