### PR TITLE
Add support for HTTP_PROXY, HTTPS_PROXY and NO_PROXY in probes

### DIFF
--- a/components/common-go/kubernetes/probes.go
+++ b/components/common-go/kubernetes/probes.go
@@ -21,6 +21,7 @@ func NetworkIsReachableProbe(url string) func() error {
 	return func() error {
 		tr := &http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			Proxy:           http.ProxyFromEnvironment,
 		}
 		client := &http.Client{
 			Transport: tr,


### PR DESCRIPTION
## Description

Use defined env variables to use proxies.

## Release Notes
```release-note
NONE
```

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
