### PR TITLE
previews: Add preview owner reference to certificates

### DIFF
--- a/.werft/jobs/build/deploy-to-preview-environment.ts
+++ b/.werft/jobs/build/deploy-to-preview-environment.ts
@@ -505,6 +505,7 @@ export async function issueMetaCerts(
     certName: string,
     certsNamespace: string,
     domain: string,
+    branch: string,
     slice: string,
 ): Promise<boolean> {
     const additionalSubdomains: string[] = ["", "*.", `*.ws.`];
@@ -513,6 +514,7 @@ export async function issueMetaCerts(
     metaClusterCertParams.gcpSaPath = GCLOUD_SERVICE_ACCOUNT_PATH;
     metaClusterCertParams.certName = certName;
     metaClusterCertParams.certNamespace = certsNamespace;
+    metaClusterCertParams.previewName = previewNameFromBranchName(branch)
     metaClusterCertParams.dnsZoneDomain = "gitpod-dev.com";
     metaClusterCertParams.domain = domain;
     metaClusterCertParams.ip = getCoreDevIngressIP();

--- a/.werft/jobs/build/prepare.ts
+++ b/.werft/jobs/build/prepare.ts
@@ -81,7 +81,7 @@ async function issueCertificate(werft: Werft, config: JobConfig): Promise<boolea
     const domain = `${config.previewEnvironment.destname}.preview.gitpod-dev.com`;
 
     werft.log(prepareSlices.ISSUE_CERTIFICATES, prepareSlices.ISSUE_CERTIFICATES);
-    var certReady = await issueMetaCerts(werft, certName, "certs", domain, prepareSlices.ISSUE_CERTIFICATES);
+    var certReady = await issueMetaCerts(werft, certName, "certs", domain, config.repository.branch, prepareSlices.ISSUE_CERTIFICATES);
     werft.done(prepareSlices.ISSUE_CERTIFICATES);
     return certReady
 }

--- a/.werft/util/certs.ts
+++ b/.werft/util/certs.ts
@@ -14,6 +14,7 @@ export class IssueCertificateParams {
     bucketPrefixTail: string;
     certName: string;
     certNamespace: string;
+    previewName: string
 }
 
 export class InstallCertificateParams {
@@ -107,6 +108,7 @@ function createCertificateResource(
     && yq w -i cert.yaml spec.secretName '${params.certName}' \
     && yq w -i cert.yaml metadata.namespace '${params.certNamespace}' \
     && yq w -i cert.yaml spec.issuerRef.name 'letsencrypt-issuer-gitpod-core-dev' \
+    && yq w -i cert.yaml metadata.annotations.preview/owner '${params.previewName}' \
     ${subdomains.map((s) => `&& yq w -i cert.yaml spec.dnsNames[+] '${s + params.domain}'`).join("  ")} \
     && kubectl --kubeconfig ${CORE_DEV_KUBECONFIG_PATH} apply -f cert.yaml`;
 


### PR DESCRIPTION
Signed-off-by: ArthurSens <arthursens2005@gmail.com>

## Description
<!-- Describe your changes in detail -->
The same thing as https://github.com/gitpod-io/gitpod/pull/11844, but more carefully. I'm splitting adding owner reference to the certificate and the garbage collection logic into separate PRs. 

The main reason for this separation is that the garbage collection will delete any certificate without an owner's reference.

A chained PR will implement the garbage collection logic(https://github.com/gitpod-io/gitpod/pull/11856)

## How to test
<!-- Provide steps to test this PR -->
Open a workspace from this PR and run:
```
werft run github -a with-preview -f
```

Check if the generated certificate has an owner annotation referencing the correct preview.
```
kubectl --context dev describe certificate -n certs <certificate-name>
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
