### PR TITLE
previews: Implement certificate garbage collection

### DIFF
--- a/.werft/platform-delete-preview-environments-cron.ts
+++ b/.werft/platform-delete-preview-environments-cron.ts
@@ -9,7 +9,7 @@ import * as VM from "./vm/vm";
 
 // for testing purposes
 // if set to 'true' it shows only previews that would be deleted
-const DRY_RUN = true;
+const DRY_RUN = false;
 
 const SLICES = {
     CONFIGURE_ACCESS: "Configuring access to relevant resources",


### PR DESCRIPTION
Signed-off-by: ArthurSens <arthursens2005@gmail.com>

## Description
<!-- Describe your changes in detail -->
A follow-up from #11855.

This PR aims to refactor the certificate deletion, adopting something similar to Kubernetes Owner references.

1. To delete a certificate the cron first deletes a certain preview and the certificate is left there untouched.
2. A following cron will be responsible for checking that we now have an orphan certificate, and it should be deleted.

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview

## Noteworthy mentions

We should merge #11855 first and wait a few days to merge this one.

The reason is that the garbage collection will delete certificates without owners, and we still have preview environments that don't have such reference. 

Once all active previews have the owner reference, then it is safe to merge this one.