### PR TITLE
Revert add annotation gitpod.io/startedDisposal earlier

### DIFF
--- a/components/ws-manager/pkg/manager/monitor.go
+++ b/components/ws-manager/pkg/manager/monitor.go
@@ -984,12 +984,6 @@ func (m *Monitor) finalizeWorkspaceContent(ctx context.Context, wso *workspaceOb
 		return
 	}
 
-	err := m.manager.markWorkspace(ctx, workspaceID, addMark(startedDisposalAnnotation, util.BooleanTrueString))
-	if err != nil {
-		tracing.LogError(span, err)
-		log.WithError(err).Error("was unable to update pod's start disposal state - this might cause an incorrect disposal state")
-	}
-
 	var disposalStatus *workspaceDisposalStatus
 	defer func() {
 		if disposalStatus == nil {
@@ -1095,6 +1089,12 @@ func (m *Monitor) finalizeWorkspaceContent(ctx context.Context, wso *workspaceOb
 			cancelReq := val.(context.CancelFunc)
 			cancelReq()
 		}()
+
+		err = m.manager.markWorkspace(ctx, workspaceID, addMark(startedDisposalAnnotation, util.BooleanTrueString))
+		if err != nil {
+			tracing.LogError(span, err)
+			log.WithError(err).Error("was unable to update pod's start disposal state - this might cause an incorrect disposal state")
+		}
 
 		if pvcFeatureEnabled {
 			// pvc was created with the name of the pod. see createDefiniteWorkspacePod()


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Address PR comment https://github.com/gitpod-io/gitpod/pull/11826#issuecomment-1204384417

This reverts commit e40e43d76120e5de702522e6b816f28b86a219c6.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related https://github.com/gitpod-io/gitpod/issues/11710

## How to test
<!-- Provide steps to test this PR -->
None

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
None

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
