### PR TITLE
[dashboard] Optimization: Don't wait before fetching a team's spending limit

### DIFF
--- a/components/dashboard/src/teams/TeamUsageBasedBilling.tsx
+++ b/components/dashboard/src/teams/TeamUsageBasedBilling.tsx
@@ -56,9 +56,11 @@ export default function TeamUsageBasedBilling() {
             return;
         }
         (async () => {
-            const portalUrl = await getGitpodService().server.getStripePortalUrlForTeam(team.id);
+            const [portalUrl, spendingLimit] = await Promise.all([
+                getGitpodService().server.getStripePortalUrlForTeam(team.id),
+                getGitpodService().server.getSpendingLimitForTeam(team.id),
+            ]);
             setStripePortalUrl(portalUrl);
-            const spendingLimit = await getGitpodService().server.getSpendingLimitForTeam(team.id);
             setSpendingLimit(spendingLimit);
         })();
     }, [team, stripeSubscriptionId]);


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Optimization: Don't wait for the portal URL before fetching a team's spending limit -- there is no dependency between the two, so they can be fetched in parallel.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

1. Subscribing a team to UBB and setting a spending limit should still work

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
