### PR TITLE
[usage] Add alert on failed reconciliations

### DIFF
--- a/operations/observability/mixins/meta/rules/components/components.libsonnet
+++ b/operations/observability/mixins/meta/rules/components/components.libsonnet
@@ -6,4 +6,5 @@
 (import './nodes/alerts.libsonnet') +
 (import './nodes/rules.libsonnet') +
 (import './server/alerts.libsonnet') +
-(import './messagebus/alerts.libsonnet')
+(import './messagebus/alerts.libsonnet') +
+(import './usage/alerts.libsonnet')

--- a/operations/observability/mixins/meta/rules/components/usage/alerts.libsonnet
+++ b/operations/observability/mixins/meta/rules/components/usage/alerts.libsonnet
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+ * Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+ */
+
+{
+  prometheusAlerts+:: {
+    groups+: [
+      {
+        name: 'gitpod-component-webapp-usage-alerts',
+        rules: [
+          {
+            alert: 'ScheduledReconciliationFailures',
+            expr: 'sum(increase(gitpod_usage_reconcile_completed_duration_seconds_count[1h])) > 1',
+            'for': '30m',
+            labels: {
+              severity: 'warning',
+              team: 'webapp'
+            },
+            annotations: {
+              runbook_url: 'TODO',
+              summary: 'WIP, do not action yet. There are failed scheduled reconciliations in the usage component.',
+              description: 'We have accumulated {{ printf "%.2f" $value }} failures. This affects how stale usage data is and/or updating invoices in Stripe.',
+            },
+          },
+        ],
+      },
+    ],
+  },
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Alert is a warning for now, and goes directly to team webapp. Runbook will be added in tandem and this alert updated.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
