### PR TITLE
[usage] Configure ingress for Stripe webhook

### DIFF
--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -1969,7 +1969,7 @@ data:
             to openvsx-proxy.default.svc.cluster.local:8080
         }
     }
-  vhost.payment-endpoint: |-
+  vhost.payment-endpoint: |
     https://payment.minimal-test.gitpod.com {
         import enable_log
         import remove_server_header
@@ -1979,6 +1979,14 @@ data:
         reverse_proxy payment-endpoint.default.svc.cluster.local:3002 {
             import upstream_headers
             import upstream_connection
+        }
+
+        @backend path /stripe/invoices/webhook
+        handle @backend {
+            reverse_proxy public-api-server.{$KUBE_NAMESPACE}.{$KUBE_DOMAIN}:9002 {
+                import upstream_headers
+                import upstream_connection
+            }
         }
 
         handle_errors {
@@ -8505,7 +8513,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 376f6713002e46d8ebff894855ecd010de87d856d5c4c412c2a2649847f2017a
+        gitpod.io/checksum_config: 926e623fd161e557fe9ebb5f2dc7f2e31ed391fb5a3fb1308cefc8b76945401a
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/pkg/components/proxy/templates/configmap/vhost.payment-endpoint.tpl
+++ b/install/installer/pkg/components/proxy/templates/configmap/vhost.payment-endpoint.tpl
@@ -9,6 +9,14 @@ https://payment.{{.Domain}} {
         import upstream_connection
     }
 
+    @backend path /stripe/invoices/webhook
+    handle @backend {
+        reverse_proxy public-api-server.{$KUBE_NAMESPACE}.{$KUBE_DOMAIN}:9002 {
+            import upstream_headers
+            import upstream_connection
+        }
+    }
+
     handle_errors {
         respond "Internal Server Error" 500
     }

--- a/install/installer/pkg/components/public-api-server/networkpolicy.go
+++ b/install/installer/pkg/components/public-api-server/networkpolicy.go
@@ -33,6 +33,10 @@ func networkpolicy(ctx *common.RenderContext) ([]runtime.Object, error) {
 								Protocol: common.TCPProtocol,
 								Port:     &intstr.IntOrString{IntVal: GRPCContainerPort},
 							},
+							{
+								Protocol: common.TCPProtocol,
+								Port:     &intstr.IntOrString{IntVal: HTTPContainerPort},
+							},
 						},
 						From: []networkingv1.NetworkPolicyPeer{
 							{

--- a/install/installer/pkg/components/public-api-server/networkpolicy_test.go
+++ b/install/installer/pkg/components/public-api-server/networkpolicy_test.go
@@ -30,6 +30,10 @@ func TestNetworkPolicy(t *testing.T) {
 				Protocol: common.TCPProtocol,
 				Port:     &intstr.IntOrString{IntVal: GRPCContainerPort},
 			},
+			{
+				Protocol: common.TCPProtocol,
+				Port:     &intstr.IntOrString{IntVal: HTTPContainerPort},
+			},
 		},
 		From: []networkingv1.NetworkPolicyPeer{
 			{


### PR DESCRIPTION
## Description

Configures ingress between `proxy` and the public API server to allow external access to the Stripe webhook (added in https://github.com/gitpod-io/gitpod/pull/11806).

* Add a new `backend` section to the `payment-ingress` section in the proxy `Caddyfile` and 
* Update a `networkpolicy` to allow `proxy` to reach the `public-api-server`.

## Related Issue(s)

Part of https://github.com/gitpod-io/gitpod/issues/10937

## How to test

* Hit the webhook handler using its external URL:
```
brew install httpie
http POST https://payment.af-ingressf994192aa3.preview.gitpod-dev.com/stripe/invoices/webhook type=foo
```
Expected output:

```http
HTTP/1.1 200 OK
Content-Length: 15
Content-Type: text/plain; charset=utf-8
Date: Thu, 04 Aug 2022 08:05:21 GMT
X-Gitpod-Region: local.

event type: foo
```

## Release Notes
```release-note
NONE
```

## Documentation

## Werft options:
- [x] /werft with-preview
