### PR TITLE
[db][usage] Add d_b_billed_session table migration and Go definitions

### DIFF
--- a/components/gitpod-db/src/typeorm/migration/1659601647550-BilledSession.ts
+++ b/components/gitpod-db/src/typeorm/migration/1659601647550-BilledSession.ts
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class BilledSession1659601647550 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            "CREATE TABLE IF NOT EXISTS `d_b_billed_session` (`instanceId` char(36) NOT NULL, `from` varchar(255) NOT NULL, `to` varchar(255) NOT NULL DEFAULT '', `system` ENUM('chargebee','stripe') NOT NULL, `invoiceId` varchar(255) NOT NULL DEFAULT '', `deleted` tinyint(4) NOT NULL DEFAULT '0', `_lastModified` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6), PRIMARY KEY (`instanceId`, `from`), KEY `ind_dbsync` (`_lastModified`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;",
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {}
+}

--- a/components/usage/pkg/db/billed_session.go
+++ b/components/usage/pkg/db/billed_session.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package db
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// BilledSession represents the underlying DB object
+type BilledSession struct {
+	InstanceID   uuid.UUID   `gorm:"primary_key;column:instanceId;type:char;size:36;" json:"instanceId"`
+	From         VarcharTime `gorm:"primary_key;column:from;type:varchar;size:255;" json:"from"`
+	To           VarcharTime `gorm:"column:to;type:varchar;size:255;" json:"to"`
+	System       string      `gorm:"column:system;type:varchar;size:255;" json:"system"`
+	InvoiceID    string      `gorm:"column:invoiceId;type:varchar;size:255;" json:"invoiceId"`
+	LastModified time.Time   `gorm:"column:_lastModified;type:timestamp;default:CURRENT_TIMESTAMP(6);" json:"_lastModified"`
+
+	// deleted is restricted for use by db-sync
+	_ bool `gorm:"column:deleted;type:tinyint;default:0;" json:"deleted"`
+}
+
+// TableName sets the insert table name for this struct type
+func (d *BilledSession) TableName() string {
+	return "d_b_billed_session"
+}

--- a/components/usage/pkg/db/billed_session_test.go
+++ b/components/usage/pkg/db/billed_session_test.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package db_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gitpod-io/gitpod/usage/pkg/db"
+	"github.com/gitpod-io/gitpod/usage/pkg/db/dbtest"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBilledSession_WriteRead(t *testing.T) {
+	conn := dbtest.ConnectForTests(t)
+
+	billedSession := &db.BilledSession{
+		InstanceID: uuid.New(),
+		From:       db.NewVarcharTime(time.Date(2022, 8, 04, 12, 00, 00, 00, time.UTC)),
+		To:         db.NewVarcharTime(time.Date(2022, 9, 04, 12, 00, 00, 00, time.UTC)),
+		System:     "chargebee",
+		InvoiceID:  "some-invoice-ID",
+	}
+
+	tx := conn.Create(billedSession)
+	require.NoError(t, tx.Error)
+
+	read := &db.BilledSession{InstanceID: billedSession.InstanceID}
+	tx = conn.First(read)
+	require.NoError(t, tx.Error)
+	require.Equal(t, billedSession.InstanceID, read.InstanceID)
+	require.Equal(t, billedSession.From, read.From)
+	require.Equal(t, billedSession.To, read.To)
+	require.Equal(t, billedSession.System, read.System)
+	require.Equal(t, billedSession.InvoiceID, read.InvoiceID)
+
+	t.Cleanup(func() {
+		conn.Model(&db.BilledSession{}).Delete(billedSession)
+	})
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Add d_b_billed_session table migration and Go definitions

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #11867 

## How to test
In `/components/usage/pkg/db` run `go test`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
