### PR TITLE
[code] build code image to fix changelog related url not works

### DIFF
--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -7,7 +7,7 @@ defaultArgs:
   jbMarketplacePublishTrigger: "false"
   publishToJBMarketplace: true
   localAppVersion: unknown
-  codeCommit: 9a4dbcf1367331cdd6a840be0c3ca351849ec5a2
+  codeCommit: e59b2689b5dcd7e5618baf76b111b87a20e36aac
   codeQuality: stable
   intellijDownloadUrl: "https://download.jetbrains.com/idea/ideaIU-2022.2.tar.gz"
   golandDownloadUrl: "https://download.jetbrains.com/go/goland-2022.2.tar.gz"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Commit hash is from branch [gp-code/release/1.69](https://github.com/gitpod-io/openvscode-server/tree/gp-code/release/1.69) changes https://github.com/gitpod-io/openvscode-server/commit/e59b2689b5dcd7e5618baf76b111b87a20e36aac

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
- Open workspace in prev env with latest code
- Open changelog with command
- See if header image works

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
