### PR TITLE
[installer] Small render test improvements

### DIFF
--- a/install/installer/cmd/render_test.go
+++ b/install/installer/cmd/render_test.go
@@ -19,7 +19,6 @@ var (
 func init() {
 	// Ensure that the randomisation always returns the same values
 	rootOpts.SeedValue = 42
-	setSeed()
 }
 
 func TestMain(m *testing.M) {
@@ -45,6 +44,10 @@ func TestRender(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.Name, func(t *testing.T) {
+
+			// reset seed for each test case
+			setSeed()
+
 			rootOpts.VersionMF = "testdata/render/versions.yaml"
 			renderOpts.ConfigFN = "testdata/render/" + testCase.Name + "/config.yaml"
 			goldenPath := "testdata/render/" + testCase.Name + "/output.golden"

--- a/install/installer/cmd/render_test.go
+++ b/install/installer/cmd/render_test.go
@@ -52,10 +52,6 @@ func TestRender(t *testing.T) {
 			renderOpts.ConfigFN = "testdata/render/" + testCase.Name + "/config.yaml"
 			goldenPath := "testdata/render/" + testCase.Name + "/output.golden"
 
-			f, err := os.OpenFile(goldenPath, os.O_RDWR, 0644)
-			defer f.Close()
-			require.NoError(t, err)
-
 			// Generate the YAML from the render function
 			yaml, err := renderFn()
 			require.NoError(t, err)
@@ -73,6 +69,10 @@ func TestRender(t *testing.T) {
 			}
 
 			// Get the expected output from the golden file
+			f, err := os.OpenFile(goldenPath, os.O_RDWR, 0644)
+			defer f.Close()
+			require.NoError(t, err)
+
 			content, err := ioutil.ReadAll(f)
 			if err != nil {
 				require.NoError(t, err)


### PR DESCRIPTION
## Description
This PR updates the installer render tests:
- It resets the seed for every test case. Otherwise, adding a test case would lead to changes in other tests because the pseudo-random generator starts with a different state.
- It allows to create a golden file even when there is not file yet.


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```


## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
