### PR TITLE
[code] update stable code image to fix changelog related url not works

### DIFF
--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -2197,7 +2197,7 @@ data:
             "type": "browser",
             "logo": "https://ide.minimal-test.gitpod.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-079f161f0aaf95d6b5e28f0709b3e629337291e9",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-8cdc51634e84dfb0f66df6c66186c90ce5ed0c80",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/pkg/components/workspace/ide/constants.go
+++ b/install/installer/pkg/components/workspace/ide/constants.go
@@ -6,7 +6,7 @@ package ide
 
 const (
 	CodeIDEImage                = "ide/code"
-	CodeIDEImageStableVersion   = "commit-079f161f0aaf95d6b5e28f0709b3e629337291e9" // stable version that will be updated manually on demand
+	CodeIDEImageStableVersion   = "commit-8cdc51634e84dfb0f66df6c66186c90ce5ed0c80" // stable version that will be updated manually on demand
 	CodeDesktopIDEImage         = "ide/code-desktop"
 	CodeDesktopInsidersIDEImage = "ide/code-desktop-insiders"
 	IntelliJDesktopIDEImage     = "ide/intellij"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
commit hash in PR is from this PR https://github.com/gitpod-io/gitpod/pull/11875 job https://werft.gitpod-dev.com/job/gitpod-build-hw-vs-build.0

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
- Open workspace in preview env with stable vscode
- Check if the commit hash is https://github.com/gitpod-io/openvscode-server/commit/e59b2689b5dcd7e5618baf76b111b87a20e36aac

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Fix in-product changelog relative URLs not working problem
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
