### PR TITLE
[kots]: only add to base image allow list in airgapped mode

### DIFF
--- a/install/kots/manifests/gitpod-installer-job.yaml
+++ b/install/kots/manifests/gitpod-installer-job.yaml
@@ -144,19 +144,20 @@ spec:
 
               if [ '{{repl HasLocalRegistry }}' = "true" ];
               then
-                echo "Gitpod: configuring mirrored container registry"
+                echo "Gitpod: configuring mirrored container registry for airgapped installation"
 
                 yq e -i ".repository = \"{{repl LocalRegistryAddress }}\"" "${CONFIG_FILE}"
                 yq e -i ".imagePullSecrets[0].kind = \"secret\"" "${CONFIG_FILE}"
                 yq e -i ".imagePullSecrets[0].name = \"{{repl ImagePullSecretName }}\"" "${CONFIG_FILE}"
                 yq e -i '.dropImageRepo = true' "${CONFIG_FILE}"
+
+                # Add the registry to the server allowlist - keep docker.io in case it's just using the mirrored registry functionality without being airgapped
+                yq e -i ".containerRegistry.privateBaseImageAllowList += \"{{repl LocalRegistryHost }}\"" "${CONFIG_FILE}"
+                yq e -i ".containerRegistry.privateBaseImageAllowList += \"docker.io\"" "${CONFIG_FILE}"
               fi
 
               # Output the local registry secret - this is proxy.replicated.com if user hasn't set their own
               echo "{{repl LocalRegistryImagePullSecret }}" | base64 -d > /tmp/kotsregistry.json
-
-              # Add the registries to the server allowlist
-              yq e -i ".containerRegistry.privateBaseImageAllowList += $(cat /tmp/kotsregistry.json | jq '.auths' | jq -rc 'keys')" "${CONFIG_FILE}"
 
               if [ '{{repl ConfigOptionEquals "reg_incluster" "0" }}' = "true" ];
               then


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Change the allowlist so it only amends the `privateBaseImageAllowList` in airgapped mode. As the Replicated proxy URLs were getting added (pointlessly - the base image is never them), this only needs adding for airgapped mode.

`docker.io` is still added in when in "airgapped mode" as this would be activated if someone is just mirroring their container images (this is possible in KOTS even if the license doesn't allow for airgapped installations).

The [codebase in question](https://github.com/gitpod-io/gitpod/blob/main/components/image-builder-mk3/pkg/auth/auth.go#L120-L153)

## How to test
<!-- Provide steps to test this PR -->
### Non Airgapped
- Deploy via KOTS in non-airgapped mode
- Run `kubectl get configmaps -n gitpod gitpod -o jsonpath='{.data.config\.yaml}'`
- Should see the following:
```yaml
containerRegistry:
  privateBaseImageAllowList: []
```

### Airgapped
- Deploy via KOTS in airgapped mode
- Run `kubectl get configmaps -n gitpod gitpod -o jsonpath='{.data.config\.yaml}'`
- Should see the following:
```yaml
containerRegistry:
  privateBaseImageAllowList:
  - <airgapped-hostname>
  - docker.io
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[kots]: add docker.io to registry allowlist
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
