### PR TITLE
[installer] Ensure stable ordering of rendered K8s objects

### DIFF
--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -1,4 +1,23 @@
 ---
+# networking.k8s.io/v1/NetworkPolicy agent-smith
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: agent-smith
+  name: agent-smith
+  namespace: default
+spec:
+  podSelector:
+    matchLabels:
+      app: gitpod
+      component: agent-smith
+  policyTypes:
+    - Ingress
+
+---
 # networking.k8s.io/v1/NetworkPolicy blobserve
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -32,70 +51,15 @@ spec:
     - Ingress
 
 ---
-# networking.k8s.io/v1/NetworkPolicy ws-daemon
+# networking.k8s.io/v1/NetworkPolicy content-service
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   creationTimestamp: null
   labels:
     app: gitpod
-    component: ws-daemon
-  name: ws-daemon
-  namespace: default
-spec:
-  ingress:
-    - from:
-        - podSelector:
-            matchLabels:
-              app: gitpod
-              component: ws-manager
-      ports:
-        - port: 8080
-          protocol: TCP
-    - from:
-        - podSelector:
-            matchLabels:
-              app: prometheus
-              component: server
-      ports:
-        - port: 9500
-          protocol: TCP
-  podSelector:
-    matchLabels:
-      app: gitpod
-      component: ws-daemon
-  policyTypes:
-    - Ingress
-
----
-# networking.k8s.io/v1/NetworkPolicy agent-smith
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  creationTimestamp: null
-  labels:
-    app: gitpod
-    component: agent-smith
-  name: agent-smith
-  namespace: default
-spec:
-  podSelector:
-    matchLabels:
-      app: gitpod
-      component: agent-smith
-  policyTypes:
-    - Ingress
-
----
-# networking.k8s.io/v1/NetworkPolicy ws-manager
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  creationTimestamp: null
-  labels:
-    app: gitpod
-    component: ws-manager
-  name: ws-manager
+    component: content-service
+  name: content-service
   namespace: default
 spec:
   ingress:
@@ -103,7 +67,124 @@ spec:
   podSelector:
     matchLabels:
       app: gitpod
-      component: ws-manager
+      component: content-service
+  policyTypes:
+    - Ingress
+
+---
+# networking.k8s.io/v1/NetworkPolicy dashboard-deny-all-allow-explicit
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: dashboard
+  name: dashboard-deny-all-allow-explicit
+  namespace: default
+spec:
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              component: proxy
+      ports:
+        - port: 80
+          protocol: TCP
+  podSelector:
+    matchLabels:
+      app: gitpod
+      component: dashboard
+  policyTypes:
+    - Ingress
+
+---
+# networking.k8s.io/v1/NetworkPolicy image-builder-mk3
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: image-builder-mk3
+  name: image-builder-mk3
+  namespace: default
+spec:
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              component: server
+        - podSelector:
+            matchLabels:
+              component: ws-manager
+  podSelector:
+    matchLabels:
+      app: gitpod
+      component: image-builder-mk3
+  policyTypes:
+    - Ingress
+
+---
+# networking.k8s.io/v1/NetworkPolicy messagebus
+# Source: rabbitmq/charts/rabbitmq/templates/networkpolicy.yaml
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: messagebus
+  namespace: "default"
+  labels:
+    app.kubernetes.io/name: rabbitmq
+    helm.sh/chart: rabbitmq-10.1.1
+    app.kubernetes.io/instance: RabbitMQ
+    app.kubernetes.io/managed-by: Helm
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: rabbitmq
+      app.kubernetes.io/instance: RabbitMQ
+  ingress:
+    # Allow inbound connections
+    - ports:
+        - port: 4369 # EPMD
+        - port: 5672
+        - port: 5671
+        - port: 25672
+        - port: 15672
+    # Allow prometheus scrapes
+    - ports:
+        - port: 9419
+
+---
+# networking.k8s.io/v1/NetworkPolicy openvsx-proxy
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: openvsx-proxy
+  name: openvsx-proxy
+  namespace: default
+spec:
+  ingress:
+    - ports:
+        - port: 8080
+          protocol: TCP
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              chart: monitoring
+          podSelector:
+            matchLabels:
+              component: server
+      ports:
+        - port: 8080
+          protocol: TCP
+  podSelector:
+    matchLabels:
+      app: gitpod
+      component: openvsx-proxy
   policyTypes:
     - Ingress
 
@@ -145,34 +226,69 @@ spec:
     - Ingress
 
 ---
-# networking.k8s.io/v1/NetworkPolicy messagebus
-# Source: rabbitmq/charts/rabbitmq/templates/networkpolicy.yaml
-kind: NetworkPolicy
+# networking.k8s.io/v1/NetworkPolicy registry-facade
 apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
 metadata:
-  name: messagebus
-  namespace: "default"
+  creationTimestamp: null
   labels:
-    app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
-    app.kubernetes.io/instance: RabbitMQ
-    app.kubernetes.io/managed-by: Helm
+    app: gitpod
+    component: registry-facade
+  name: registry-facade
+  namespace: default
 spec:
+  ingress:
+    - {}
   podSelector:
     matchLabels:
-      app.kubernetes.io/name: rabbitmq
-      app.kubernetes.io/instance: RabbitMQ
+      app: gitpod
+      component: registry-facade
+  policyTypes:
+    - Ingress
+
+---
+# networking.k8s.io/v1/NetworkPolicy server
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: server
+  name: server
+  namespace: default
+spec:
   ingress:
-    # Allow inbound connections
-    - ports:
-        - port: 4369 # EPMD
-        - port: 5672
-        - port: 5671
-        - port: 25672
-        - port: 15672
-    # Allow prometheus scrapes
-    - ports:
-        - port: 9419
+    - from:
+        - podSelector:
+            matchLabels:
+              component: proxy
+      ports:
+        - port: 3000
+          protocol: TCP
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              chart: monitoring
+          podSelector:
+            matchLabels:
+              component: proxy
+      ports:
+        - port: 9500
+          protocol: TCP
+    - from:
+        - podSelector:
+            matchLabels:
+              component: gitpod
+      ports:
+        - port: 9000
+          protocol: TCP
+  podSelector:
+    matchLabels:
+      app: gitpod
+      component: server
+  policyTypes:
+    - Ingress
 
 ---
 # networking.k8s.io/v1/NetworkPolicy workspace-default
@@ -253,6 +369,63 @@ spec:
     - Egress
 
 ---
+# networking.k8s.io/v1/NetworkPolicy ws-daemon
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ws-daemon
+  name: ws-daemon
+  namespace: default
+spec:
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: gitpod
+              component: ws-manager
+      ports:
+        - port: 8080
+          protocol: TCP
+    - from:
+        - podSelector:
+            matchLabels:
+              app: prometheus
+              component: server
+      ports:
+        - port: 9500
+          protocol: TCP
+  podSelector:
+    matchLabels:
+      app: gitpod
+      component: ws-daemon
+  policyTypes:
+    - Ingress
+
+---
+# networking.k8s.io/v1/NetworkPolicy ws-manager
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ws-manager
+  name: ws-manager
+  namespace: default
+spec:
+  ingress:
+    - {}
+  podSelector:
+    matchLabels:
+      app: gitpod
+      component: ws-manager
+  policyTypes:
+    - Ingress
+
+---
 # networking.k8s.io/v1/NetworkPolicy ws-proxy
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -276,179 +449,6 @@ spec:
     matchLabels:
       app: gitpod
       component: ws-proxy
-  policyTypes:
-    - Ingress
-
----
-# networking.k8s.io/v1/NetworkPolicy server
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  creationTimestamp: null
-  labels:
-    app: gitpod
-    component: server
-  name: server
-  namespace: default
-spec:
-  ingress:
-    - from:
-        - podSelector:
-            matchLabels:
-              component: proxy
-      ports:
-        - port: 3000
-          protocol: TCP
-    - from:
-        - namespaceSelector:
-            matchLabels:
-              chart: monitoring
-          podSelector:
-            matchLabels:
-              component: proxy
-      ports:
-        - port: 9500
-          protocol: TCP
-    - from:
-        - podSelector:
-            matchLabels:
-              component: gitpod
-      ports:
-        - port: 9000
-          protocol: TCP
-  podSelector:
-    matchLabels:
-      app: gitpod
-      component: server
-  policyTypes:
-    - Ingress
-
----
-# networking.k8s.io/v1/NetworkPolicy openvsx-proxy
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  creationTimestamp: null
-  labels:
-    app: gitpod
-    component: openvsx-proxy
-  name: openvsx-proxy
-  namespace: default
-spec:
-  ingress:
-    - ports:
-        - port: 8080
-          protocol: TCP
-    - from:
-        - namespaceSelector:
-            matchLabels:
-              chart: monitoring
-          podSelector:
-            matchLabels:
-              component: server
-      ports:
-        - port: 8080
-          protocol: TCP
-  podSelector:
-    matchLabels:
-      app: gitpod
-      component: openvsx-proxy
-  policyTypes:
-    - Ingress
-
----
-# networking.k8s.io/v1/NetworkPolicy registry-facade
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  creationTimestamp: null
-  labels:
-    app: gitpod
-    component: registry-facade
-  name: registry-facade
-  namespace: default
-spec:
-  ingress:
-    - {}
-  podSelector:
-    matchLabels:
-      app: gitpod
-      component: registry-facade
-  policyTypes:
-    - Ingress
-
----
-# networking.k8s.io/v1/NetworkPolicy dashboard-deny-all-allow-explicit
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  creationTimestamp: null
-  labels:
-    app: gitpod
-    component: dashboard
-  name: dashboard-deny-all-allow-explicit
-  namespace: default
-spec:
-  ingress:
-    - from:
-        - podSelector:
-            matchLabels:
-              component: proxy
-      ports:
-        - port: 80
-          protocol: TCP
-  podSelector:
-    matchLabels:
-      app: gitpod
-      component: dashboard
-  policyTypes:
-    - Ingress
-
----
-# networking.k8s.io/v1/NetworkPolicy image-builder-mk3
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  creationTimestamp: null
-  labels:
-    app: gitpod
-    component: image-builder-mk3
-  name: image-builder-mk3
-  namespace: default
-spec:
-  ingress:
-    - from:
-        - podSelector:
-            matchLabels:
-              component: server
-        - podSelector:
-            matchLabels:
-              component: ws-manager
-  podSelector:
-    matchLabels:
-      app: gitpod
-      component: image-builder-mk3
-  policyTypes:
-    - Ingress
-
----
-# networking.k8s.io/v1/NetworkPolicy content-service
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  creationTimestamp: null
-  labels:
-    app: gitpod
-    component: content-service
-  name: content-service
-  namespace: default
-spec:
-  ingress:
-    - {}
-  podSelector:
-    matchLabels:
-      app: gitpod
-      component: content-service
   policyTypes:
     - Ingress
 
@@ -525,33 +525,29 @@ spec:
       component: docker-registry
 status: {}
 ---
-# cert-manager.io/v1/Certificate ws-manager
+# cert-manager.io/v1/Certificate builtin-registry-facade-cert
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   creationTimestamp: null
   labels:
     app: gitpod
-    component: ws-manager
-  name: ws-manager
+    component: registry-facade
+  name: builtin-registry-facade-cert
   namespace: default
 spec:
   dnsNames:
-  - registry-facade
-  - server
-  - ws-manager-bridge
-  - ws-proxy
-  - ws-manager
+  - reg.minimal-test.gitpod.com
   duration: 2160h0m0s
   issuerRef:
     group: cert-manager.io
     kind: Issuer
     name: ca-issuer
-  secretName: ws-manager-client-tls
+  secretName: builtin-registry-facade-cert
   secretTemplate:
     labels:
       app: gitpod
-      component: ws-manager
+      component: registry-facade
 status: {}
 ---
 # cert-manager.io/v1/Certificate ca-issuer-ca
@@ -582,31 +578,6 @@ spec:
       component: cluster
 status: {}
 ---
-# cert-manager.io/v1/Certificate builtin-registry-facade-cert
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  creationTimestamp: null
-  labels:
-    app: gitpod
-    component: registry-facade
-  name: builtin-registry-facade-cert
-  namespace: default
-spec:
-  dnsNames:
-  - reg.minimal-test.gitpod.com
-  duration: 2160h0m0s
-  issuerRef:
-    group: cert-manager.io
-    kind: Issuer
-    name: ca-issuer
-  secretName: builtin-registry-facade-cert
-  secretTemplate:
-    labels:
-      app: gitpod
-      component: registry-facade
-status: {}
----
 # cert-manager.io/v1/Certificate ws-daemon-tls
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -633,6 +604,35 @@ spec:
     labels:
       app: gitpod
       component: ws-daemon
+status: {}
+---
+# cert-manager.io/v1/Certificate ws-manager
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ws-manager
+  name: ws-manager
+  namespace: default
+spec:
+  dnsNames:
+  - registry-facade
+  - server
+  - ws-manager-bridge
+  - ws-proxy
+  - ws-manager
+  duration: 2160h0m0s
+  issuerRef:
+    group: cert-manager.io
+    kind: Issuer
+    name: ca-issuer
+  secretName: ws-manager-client-tls
+  secretTemplate:
+    labels:
+      app: gitpod
+      component: ws-manager
 status: {}
 ---
 # cert-manager.io/v1/Certificate ws-manager-tls
@@ -663,155 +663,6 @@ spec:
       component: ws-manager
 status: {}
 ---
-# policy/v1beta1/PodSecurityPolicy default-ns-unprivileged
-apiVersion: policy/v1beta1
-kind: PodSecurityPolicy
-metadata:
-  annotations:
-    apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
-    apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
-    seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
-    seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
-  creationTimestamp: null
-  name: default-ns-unprivileged
-  namespace: default
-spec:
-  allowPrivilegeEscalation: false
-  fsGroup:
-    ranges:
-    - max: 65535
-      min: 1
-    rule: MustRunAs
-  requiredDropCapabilities:
-  - ALL
-  runAsUser:
-    rule: MustRunAsNonRoot
-  seLinux:
-    rule: RunAsAny
-  supplementalGroups:
-    ranges:
-    - max: 65535
-      min: 1
-    rule: MustRunAs
-  volumes:
-  - configMap
-  - emptyDir
-  - projected
-  - secret
-  - persistentVolumeClaim
----
-# policy/v1beta1/PodSecurityPolicy default-ns-privileged-unconfined
-apiVersion: policy/v1beta1
-kind: PodSecurityPolicy
-metadata:
-  annotations:
-    apparmor.security.beta.kubernetes.io/allowedProfileNames: unconfined
-    apparmor.security.beta.kubernetes.io/defaultProfileName: unconfined
-    seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default,unconfined
-    seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
-  creationTimestamp: null
-  name: default-ns-privileged-unconfined
-  namespace: default
-spec:
-  allowPrivilegeEscalation: true
-  allowedCapabilities:
-  - '*'
-  fsGroup:
-    rule: RunAsAny
-  hostPID: true
-  hostPorts:
-  - max: 65535
-    min: 0
-  privileged: true
-  runAsUser:
-    rule: RunAsAny
-  seLinux:
-    rule: RunAsAny
-  supplementalGroups:
-    rule: RunAsAny
-  volumes:
-  - '*'
----
-# policy/v1beta1/PodSecurityPolicy default-ns-workspace
-apiVersion: policy/v1beta1
-kind: PodSecurityPolicy
-metadata:
-  annotations:
-    apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default,unconfined
-    apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
-    seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
-    seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
-  creationTimestamp: null
-  name: default-ns-workspace
-  namespace: default
-spec:
-  allowPrivilegeEscalation: true
-  allowedCapabilities:
-  - AUDIT_WRITE
-  - FSETID
-  - KILL
-  - NET_BIND_SERVICE
-  - SYS_PTRACE
-  fsGroup:
-    ranges:
-    - max: 65535
-      min: 1
-    rule: MustRunAs
-  runAsUser:
-    rule: RunAsAny
-  seLinux:
-    rule: RunAsAny
-  supplementalGroups:
-    ranges:
-    - max: 65535
-      min: 1
-    rule: MustRunAs
-  volumes:
-  - configMap
-  - projected
-  - secret
-  - hostPath
----
-# policy/v1beta1/PodSecurityPolicy default-ns-restricted-root-user
-apiVersion: policy/v1beta1
-kind: PodSecurityPolicy
-metadata:
-  annotations:
-    apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
-    apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
-    seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
-    seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
-  creationTimestamp: null
-  name: default-ns-restricted-root-user
-  namespace: default
-spec:
-  fsGroup:
-    ranges:
-    - max: 65535
-      min: 1
-    rule: MustRunAs
-  hostNetwork: true
-  hostPorts:
-  - max: 33000
-    min: 30000
-  privileged: true
-  runAsUser:
-    rule: RunAsAny
-  seLinux:
-    rule: RunAsAny
-  supplementalGroups:
-    ranges:
-    - max: 65535
-      min: 1
-    rule: MustRunAs
-  volumes:
-  - configMap
-  - projected
-  - secret
-  - emptyDir
-  - persistentVolumeClaim
-  - hostPath
----
 # policy/v1beta1/PodSecurityPolicy default-ns-privileged
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
@@ -832,6 +683,38 @@ spec:
     rule: RunAsAny
   hostIPC: true
   hostNetwork: true
+  hostPID: true
+  hostPorts:
+  - max: 65535
+    min: 0
+  privileged: true
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - '*'
+---
+# policy/v1beta1/PodSecurityPolicy default-ns-privileged-unconfined
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  annotations:
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: unconfined
+    apparmor.security.beta.kubernetes.io/defaultProfileName: unconfined
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default,unconfined
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+  creationTimestamp: null
+  name: default-ns-privileged-unconfined
+  namespace: default
+spec:
+  allowPrivilegeEscalation: true
+  allowedCapabilities:
+  - '*'
+  fsGroup:
+    rule: RunAsAny
   hostPID: true
   hostPorts:
   - max: 65535
@@ -885,6 +768,123 @@ spec:
   - emptyDir
   - hostPath
 ---
+# policy/v1beta1/PodSecurityPolicy default-ns-restricted-root-user
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  annotations:
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
+    apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+  creationTimestamp: null
+  name: default-ns-restricted-root-user
+  namespace: default
+spec:
+  fsGroup:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  hostNetwork: true
+  hostPorts:
+  - max: 33000
+    min: 30000
+  privileged: true
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  volumes:
+  - configMap
+  - projected
+  - secret
+  - emptyDir
+  - persistentVolumeClaim
+  - hostPath
+---
+# policy/v1beta1/PodSecurityPolicy default-ns-unprivileged
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  annotations:
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
+    apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+  creationTimestamp: null
+  name: default-ns-unprivileged
+  namespace: default
+spec:
+  allowPrivilegeEscalation: false
+  fsGroup:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  requiredDropCapabilities:
+  - ALL
+  runAsUser:
+    rule: MustRunAsNonRoot
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  volumes:
+  - configMap
+  - emptyDir
+  - projected
+  - secret
+  - persistentVolumeClaim
+---
+# policy/v1beta1/PodSecurityPolicy default-ns-workspace
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  annotations:
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default,unconfined
+    apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+  creationTimestamp: null
+  name: default-ns-workspace
+  namespace: default
+spec:
+  allowPrivilegeEscalation: true
+  allowedCapabilities:
+  - AUDIT_WRITE
+  - FSETID
+  - KILL
+  - NET_BIND_SERVICE
+  - SYS_PTRACE
+  fsGroup:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  volumes:
+  - configMap
+  - projected
+  - secret
+  - hostPath
+---
 # policy/v1/PodDisruptionBudget messagebus
 # Source: rabbitmq/charts/rabbitmq/templates/pdb.yaml
 apiVersion: policy/v1
@@ -904,6 +904,42 @@ spec:
       app.kubernetes.io/name: rabbitmq
       app.kubernetes.io/instance: RabbitMQ
 ---
+# v1/ServiceAccount agent-smith
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: agent-smith
+  name: agent-smith
+  namespace: default
+---
+# v1/ServiceAccount blobserve
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: blobserve
+  name: blobserve
+  namespace: default
+---
+# v1/ServiceAccount content-service
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: content-service
+  name: content-service
+  namespace: default
+---
 # v1/ServiceAccount dashboard
 apiVersion: v1
 automountServiceAccountToken: true
@@ -914,6 +950,78 @@ metadata:
     app: gitpod
     component: dashboard
   name: dashboard
+  namespace: default
+---
+# v1/ServiceAccount db
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: db
+  name: db
+  namespace: default
+---
+# v1/ServiceAccount docker-registry
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: docker-registry
+  name: docker-registry
+  namespace: default
+---
+# v1/ServiceAccount gitpod
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: gitpod
+  name: gitpod
+  namespace: default
+---
+# v1/ServiceAccount ide-proxy
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ide-proxy
+  name: ide-proxy
+  namespace: default
+---
+# v1/ServiceAccount image-builder-mk3
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: image-builder-mk3
+  name: image-builder-mk3
+  namespace: default
+---
+# v1/ServiceAccount migrations
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: migrations
+  name: migrations
   namespace: default
 ---
 # v1/ServiceAccount minio
@@ -932,18 +1040,6 @@ automountServiceAccountToken: true
 secrets:
   - name: minio
 ---
-# v1/ServiceAccount image-builder-mk3
-apiVersion: v1
-automountServiceAccountToken: true
-kind: ServiceAccount
-metadata:
-  creationTimestamp: null
-  labels:
-    app: gitpod
-    component: image-builder-mk3
-  name: image-builder-mk3
-  namespace: default
----
 # v1/ServiceAccount nobody
 apiVersion: v1
 automountServiceAccountToken: true
@@ -956,7 +1052,7 @@ metadata:
   name: nobody
   namespace: default
 ---
-# v1/ServiceAccount content-service
+# v1/ServiceAccount openvsx-proxy
 apiVersion: v1
 automountServiceAccountToken: true
 kind: ServiceAccount
@@ -964,20 +1060,8 @@ metadata:
   creationTimestamp: null
   labels:
     app: gitpod
-    component: content-service
-  name: content-service
-  namespace: default
----
-# v1/ServiceAccount workspace
-apiVersion: v1
-automountServiceAccountToken: true
-kind: ServiceAccount
-metadata:
-  creationTimestamp: null
-  labels:
-    app: gitpod
-    component: workspace
-  name: workspace
+    component: openvsx-proxy
+  name: openvsx-proxy
   namespace: default
 ---
 # v1/ServiceAccount proxy
@@ -990,66 +1074,6 @@ metadata:
     app: gitpod
     component: proxy
   name: proxy
-  namespace: default
----
-# v1/ServiceAccount ws-proxy
-apiVersion: v1
-automountServiceAccountToken: true
-kind: ServiceAccount
-metadata:
-  creationTimestamp: null
-  labels:
-    app: gitpod
-    component: ws-proxy
-  name: ws-proxy
-  namespace: default
----
-# v1/ServiceAccount migrations
-apiVersion: v1
-automountServiceAccountToken: true
-kind: ServiceAccount
-metadata:
-  creationTimestamp: null
-  labels:
-    app: gitpod
-    component: migrations
-  name: migrations
-  namespace: default
----
-# v1/ServiceAccount registry-facade
-apiVersion: v1
-automountServiceAccountToken: true
-kind: ServiceAccount
-metadata:
-  creationTimestamp: null
-  labels:
-    app: gitpod
-    component: registry-facade
-  name: registry-facade
-  namespace: default
----
-# v1/ServiceAccount gitpod
-apiVersion: v1
-automountServiceAccountToken: true
-kind: ServiceAccount
-metadata:
-  creationTimestamp: null
-  labels:
-    app: gitpod
-    component: gitpod
-  name: gitpod
-  namespace: default
----
-# v1/ServiceAccount ws-daemon
-apiVersion: v1
-automountServiceAccountToken: true
-kind: ServiceAccount
-metadata:
-  creationTimestamp: null
-  labels:
-    app: gitpod
-    component: ws-daemon
-  name: ws-daemon
   namespace: default
 ---
 # v1/ServiceAccount rabbitmq
@@ -1068,6 +1092,18 @@ automountServiceAccountToken: true
 secrets:
   - name: messagebus
 ---
+# v1/ServiceAccount registry-facade
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: registry-facade
+  name: registry-facade
+  namespace: default
+---
 # v1/ServiceAccount server
 apiVersion: v1
 automountServiceAccountToken: true
@@ -1080,7 +1116,7 @@ metadata:
   name: server
   namespace: default
 ---
-# v1/ServiceAccount agent-smith
+# v1/ServiceAccount workspace
 apiVersion: v1
 automountServiceAccountToken: true
 kind: ServiceAccount
@@ -1088,11 +1124,11 @@ metadata:
   creationTimestamp: null
   labels:
     app: gitpod
-    component: agent-smith
-  name: agent-smith
+    component: workspace
+  name: workspace
   namespace: default
 ---
-# v1/ServiceAccount db
+# v1/ServiceAccount ws-daemon
 apiVersion: v1
 automountServiceAccountToken: true
 kind: ServiceAccount
@@ -1100,8 +1136,8 @@ metadata:
   creationTimestamp: null
   labels:
     app: gitpod
-    component: db
-  name: db
+    component: ws-daemon
+  name: ws-daemon
   namespace: default
 ---
 # v1/ServiceAccount ws-manager
@@ -1116,18 +1152,6 @@ metadata:
   name: ws-manager
   namespace: default
 ---
-# v1/ServiceAccount docker-registry
-apiVersion: v1
-automountServiceAccountToken: true
-kind: ServiceAccount
-metadata:
-  creationTimestamp: null
-  labels:
-    app: gitpod
-    component: docker-registry
-  name: docker-registry
-  namespace: default
----
 # v1/ServiceAccount ws-manager-bridge
 apiVersion: v1
 automountServiceAccountToken: true
@@ -1140,7 +1164,7 @@ metadata:
   name: ws-manager-bridge
   namespace: default
 ---
-# v1/ServiceAccount ide-proxy
+# v1/ServiceAccount ws-proxy
 apiVersion: v1
 automountServiceAccountToken: true
 kind: ServiceAccount
@@ -1148,99 +1172,8 @@ metadata:
   creationTimestamp: null
   labels:
     app: gitpod
-    component: ide-proxy
-  name: ide-proxy
-  namespace: default
----
-# v1/ServiceAccount blobserve
-apiVersion: v1
-automountServiceAccountToken: true
-kind: ServiceAccount
-metadata:
-  creationTimestamp: null
-  labels:
-    app: gitpod
-    component: blobserve
-  name: blobserve
-  namespace: default
----
-# v1/ServiceAccount openvsx-proxy
-apiVersion: v1
-automountServiceAccountToken: true
-kind: ServiceAccount
-metadata:
-  creationTimestamp: null
-  labels:
-    app: gitpod
-    component: openvsx-proxy
-  name: openvsx-proxy
-  namespace: default
----
-# v1/Secret minio
-# Source: minio/charts/minio/templates/secrets.yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: minio
-  namespace: "default"
-  labels:
-    app.kubernetes.io/name: minio
-    helm.sh/chart: minio-11.6.3
-    app.kubernetes.io/instance: Minio
-    app.kubernetes.io/managed-by: Helm
-type: Opaque
-data:
-  root-user: "OC1XR3F3Mm9UbnNQZlVETlNrMFk="
-  root-password: "RHBDLmFTQXhrV0JQdTJfYkpfQUU="
-  key.json: ""
----
-# v1/Secret rabbitmq
-# Source: rabbitmq/charts/rabbitmq/templates/secrets.yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: rabbitmq
-  namespace: "default"
-  labels:
-    app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
-    app.kubernetes.io/instance: RabbitMQ
-    app.kubernetes.io/managed-by: Helm
-type: Opaque
-stringData:
-  password: uq4KxOLtrA-QsDTfuwQ-
-  username: gitpod
----
-# v1/Secret db-password
-apiVersion: v1
-data:
-  mysql-password: akJ6Vk1lMnc0WWk3R2FnYWRzeUI=
-  mysql-root-password: UEhlak1mc0x2ZkxjRzFEcnM0MGg=
-kind: Secret
-metadata:
-  creationTimestamp: null
-  labels:
-    app: gitpod
-    component: db
-  name: db-password
-  namespace: default
----
-# v1/Secret mysql
-apiVersion: v1
-data:
-  database: Z2l0cG9k
-  encryptionKeys: WwogIHsKICAgICJuYW1lIjogImdlbmVyYWwiLAogICAgInZlcnNpb24iOiAxLAogICAgInByaW1hcnkiOiB0cnVlLAogICAgIm1hdGVyaWFsIjogIjR1R2gxcTh5MkRZcnlKd3JWTUhzMGtXWEpscXZIV1d0L0tKdU5pMDRlZEk9IgogIH0KXQ==
-  host: ZGI=
-  password: akJ6Vk1lMnc0WWk3R2FnYWRzeUI=
-  port: MzMwNg==
-  username: Z2l0cG9k
-kind: Secret
-metadata:
-  creationTimestamp: null
-  labels:
-    app: gitpod
-    component: db
-  name: mysql
+    component: ws-proxy
+  name: ws-proxy
   namespace: default
 ---
 # v1/Secret builtin-registry-auth
@@ -1258,6 +1191,20 @@ metadata:
   name: builtin-registry-auth
   namespace: default
 type: kubernetes.io/dockerconfigjson
+---
+# v1/Secret db-password
+apiVersion: v1
+data:
+  mysql-password: akJ6Vk1lMnc0WWk3R2FnYWRzeUI=
+  mysql-root-password: UEhlak1mc0x2ZkxjRzFEcnM0MGg=
+kind: Secret
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: db
+  name: db-password
+  namespace: default
 ---
 # v1/Secret load-definition
 # Source: rabbitmq/charts/rabbitmq/templates/secrets.yaml
@@ -1290,24 +1237,6 @@ metadata:
 type: Opaque
 data:
   rabbitmq-password: "dXE0S3hPTHRyQS1Rc0RUZnV3US0="
----
-# v1/Secret registry-secret
-# Source: docker-registry/charts/docker-registry/templates/secret.yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: registry-secret
-  namespace: default
-  labels:
-    app: docker-registry
-    chart: docker-registry-1.16.0
-    heritage: Helm
-    release: docker-registry
-type: Opaque
-data:
-  haSharedSecret: "a2pjcXpkdHRjd3BRY3Brcw=="
-  proxyUsername: ""
-  proxyPassword: ""
 ---
 # v1/Secret messagebus-certificates-secret-core
 apiVersion: v1
@@ -1354,200 +1283,102 @@ metadata:
   name: messagebus-erlang-cookie
   namespace: default
 ---
-# v1/ConfigMap ws-manager
+# v1/Secret minio
+# Source: minio/charts/minio/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: minio
+  namespace: "default"
+  labels:
+    app.kubernetes.io/name: minio
+    helm.sh/chart: minio-11.6.3
+    app.kubernetes.io/instance: Minio
+    app.kubernetes.io/managed-by: Helm
+type: Opaque
+data:
+  root-user: "OC1XR3F3Mm9UbnNQZlVETlNrMFk="
+  root-password: "RHBDLmFTQXhrV0JQdTJfYkpfQUU="
+  key.json: ""
+---
+# v1/Secret mysql
 apiVersion: v1
 data:
-  config.json: |-
-    {
-      "manager": {
-        "namespace": "default",
-        "schedulerName": "",
-        "seccompProfile": "localhost/workspace_default_main.4110.json",
-        "timeouts": {
-          "startup": "1h0m0s",
-          "initialization": "30m0s",
-          "regularWorkspace": "30m0s",
-          "maxLifetime": "36h0m0s",
-          "headlessWorkspace": "1h0m0s",
-          "afterClose": "2m0s",
-          "contentFinalization": "1h0m0s",
-          "stopping": "1h0m0s",
-          "interrupted": "5m0s"
-        },
-        "initProbe": {
-          "timeout": "1s"
-        },
-        "urlTemplate": "https://{{ .Prefix }}.ws.minimal-test.gitpod.com",
-        "portUrlTemplate": "https://{{ .WorkspacePort }}-{{ .Prefix }}.ws.minimal-test.gitpod.com",
-        "workspaceHostPath": "/var/gitpod/workspaces",
-        "heartbeatInterval": "30s",
-        "hostURL": "https://minimal-test.gitpod.com",
-        "reconnectionInterval": "30s",
-        "wsdaemon": {
-          "port": 8080,
-          "tls": {
-            "ca": "/ws-daemon-tls-certs/ca.crt",
-            "crt": "/ws-daemon-tls-certs/tls.crt",
-            "key": "/ws-daemon-tls-certs/tls.key"
-          }
-        },
-        "registryFacadeHost": "reg.minimal-test.gitpod.com:20000",
-        "workspaceClusterHost": "ws.minimal-test.gitpod.com",
-        "workspaceClass": {
-          "default": {
-            "name": "default",
-            "container": {
-              "requests": {
-                "cpu": "1",
-                "memory": "2Gi",
-                "ephemeral-storage": ""
-              },
-              "limits": {
-                "cpu": "",
-                "memory": "",
-                "ephemeral-storage": ""
-              }
-            },
-            "templates": {},
-            "pvc": {
-              "size": "30Gi",
-              "storageClass": "",
-              "snapshotClass": ""
-            }
-          }
-        }
-      },
-      "content": {
-        "storage": {
-          "stage": "",
-          "kind": "minio",
-          "gcloud": {
-            "credentialsFile": "",
-            "region": "",
-            "projectId": ""
-          },
-          "minio": {
-            "endpoint": "minio.default.svc.cluster.local:9000",
-            "accessKey": "8-WGqw2oTnsPfUDNSk0Y",
-            "accessKeyFile": "",
-            "secretKey": "DpC.aSAxkWBPu2_bJ_AE",
-            "secretKeyFile": "",
-            "region": "local",
-            "parallelUpload": 6
-          },
-          "blobQuota": 5368709120
-        }
-      },
-      "rpcServer": {
-        "addr": ":8080",
-        "tls": {
-          "ca": "/certs/ca.crt",
-          "crt": "/certs/tls.crt",
-          "key": "/certs/tls.key"
-        },
-        "ratelimits": {}
-      },
-      "imageBuilderProxy": {
-        "targetAddr": "image-builder-mk3.default.svc.cluster.local:8080"
-      },
-      "pprof": {
-        "addr": "127.0.0.1:6060"
-      },
-      "prometheus": {
-        "addr": "127.0.0.1:9500"
-      }
-    }
-kind: ConfigMap
+  database: Z2l0cG9k
+  encryptionKeys: WwogIHsKICAgICJuYW1lIjogImdlbmVyYWwiLAogICAgInZlcnNpb24iOiAxLAogICAgInByaW1hcnkiOiB0cnVlLAogICAgIm1hdGVyaWFsIjogIjR1R2gxcTh5MkRZcnlKd3JWTUhzMGtXWEpscXZIV1d0L0tKdU5pMDRlZEk9IgogIH0KXQ==
+  host: ZGI=
+  password: akJ6Vk1lMnc0WWk3R2FnYWRzeUI=
+  port: MzMwNg==
+  username: Z2l0cG9k
+kind: Secret
 metadata:
   creationTimestamp: null
   labels:
     app: gitpod
-    component: ws-manager
-  name: ws-manager
+    component: db
+  name: mysql
   namespace: default
 ---
-# v1/ConfigMap mysql
-# Source: mysql/charts/mysql/templates/primary/configmap.yaml
+# v1/Secret rabbitmq
+# Source: rabbitmq/charts/rabbitmq/templates/secrets.yaml
 apiVersion: v1
-kind: ConfigMap
+kind: Secret
 metadata:
-  name: mysql
+  name: rabbitmq
   namespace: "default"
   labels:
-    app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
-    app.kubernetes.io/instance: MySQL
+    app.kubernetes.io/name: rabbitmq
+    helm.sh/chart: rabbitmq-10.1.1
+    app.kubernetes.io/instance: RabbitMQ
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: primary
-data:
-  my.cnf: |-
-    [mysqld]
-    default_authentication_plugin=mysql_native_password
-    skip-name-resolve
-    explicit_defaults_for_timestamp
-    basedir=/opt/bitnami/mysql
-    plugin_dir=/opt/bitnami/mysql/lib/plugin
-    port=3306
-    socket=/opt/bitnami/mysql/tmp/mysql.sock
-    datadir=/bitnami/mysql/data
-    tmpdir=/opt/bitnami/mysql/tmp
-    max_allowed_packet=16M
-    bind-address=0.0.0.0
-    pid-file=/opt/bitnami/mysql/tmp/mysqld.pid
-    log-error=/opt/bitnami/mysql/logs/mysqld.log
-    character-set-server=UTF8
-    collation-server=utf8_general_ci
-    slow_query_log=0
-    slow_query_log_file=/opt/bitnami/mysql/logs/mysqld.log
-    long_query_time=10.0
-    
-    [client]
-    port=3306
-    socket=/opt/bitnami/mysql/tmp/mysql.sock
-    default-character-set=UTF8
-    plugin_dir=/opt/bitnami/mysql/lib/plugin
-    
-    [manager]
-    port=3306
-    socket=/opt/bitnami/mysql/tmp/mysql.sock
-    pid-file=/opt/bitnami/mysql/tmp/mysqld.pid
+type: Opaque
+stringData:
+  password: uq4KxOLtrA-QsDTfuwQ-
+  username: gitpod
 ---
-# v1/ConfigMap registry-config
-# Source: docker-registry/charts/docker-registry/templates/configmap.yaml
+# v1/Secret registry-secret
+# Source: docker-registry/charts/docker-registry/templates/secret.yaml
 apiVersion: v1
-kind: ConfigMap
+kind: Secret
 metadata:
-  name: registry-config
+  name: registry-secret
   namespace: default
   labels:
     app: docker-registry
     chart: docker-registry-1.16.0
     heritage: Helm
     release: docker-registry
+type: Opaque
 data:
-  config.yml: |-
-    health:
-      storagedriver:
-        enabled: true
-        interval: 10s
-        threshold: 3
-    http:
-      addr: :5000
-      debug:
-        addr: :5001
-        prometheus:
-          enabled: false
-          path: /metrics
-      headers:
-        X-Content-Type-Options:
-        - nosniff
-    log:
-      fields:
-        service: registry
-    storage:
-      cache:
-        blobdescriptor: inmemory
-    version: 0.1
+  haSharedSecret: "a2pjcXpkdHRjd3BRY3Brcw=="
+  proxyUsername: ""
+  proxyPassword: ""
+---
+# v1/ConfigMap agent-smith
+apiVersion: v1
+data:
+  config.json: |-
+    {
+      "gitpodAPI": {
+        "hostURL": "https://minimal-test.gitpod.com",
+        "apiToken": ""
+      },
+      "enforcement": {},
+      "kubernetes": {
+        "enabled": true
+      },
+      "namespace": "default",
+      "pprofAddr": "127.0.0.1:6060",
+      "prometheusAddr": "127.0.0.1:9500"
+    }
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: agent-smith
+  name: agent-smith
+  namespace: default
 ---
 # v1/ConfigMap blobserve
 apiVersion: v1
@@ -1639,50 +1470,99 @@ metadata:
   name: blobserve
   namespace: default
 ---
-# v1/ConfigMap ws-manager-bridge-config
+# v1/ConfigMap content-service
 apiVersion: v1
 data:
-  ws-manager-bridge.json: |-
+  config.json: |-
     {
-      "installation": "default",
-      "staticBridges": [
-        {
-          "name": "default",
-          "url": "dns:///ws-manager:8080",
-          "tls": {
-            "ca": "/ws-manager-client-tls-certs/ca.crt",
-            "crt": "/ws-manager-client-tls-certs/tls.crt",
-            "key": "/ws-manager-client-tls-certs/tls.key"
-          },
-          "state": "available",
-          "maxScore": 100,
-          "score": 50,
-          "govern": true,
-          "admissionConstraints": null
-        }
-      ],
-      "clusterService": {
-        "port": 8080,
-        "host": "localhost"
+      "service": {
+        "address": ":8080"
       },
-      "wsClusterDBReconcileIntervalSeconds": 60,
-      "controllerIntervalSeconds": 60,
-      "controllerMaxDisconnectSeconds": 150,
-      "emulatePreparingIntervalSeconds": 10,
-      "timeouts": {
-        "preparingPhaseSeconds": 3600,
-        "buildingPhaseSeconds": 3600,
-        "unknownPhaseSeconds": 600
+      "storage": {
+        "stage": "",
+        "kind": "minio",
+        "gcloud": {
+          "credentialsFile": "",
+          "region": "",
+          "projectId": ""
+        },
+        "minio": {
+          "endpoint": "minio.default.svc.cluster.local:9000",
+          "accessKey": "8-WGqw2oTnsPfUDNSk0Y",
+          "accessKeyFile": "",
+          "secretKey": "DpC.aSAxkWBPu2_bJ_AE",
+          "secretKeyFile": "",
+          "region": "local",
+          "parallelUpload": 6
+        },
+        "blobQuota": 5368709120
       },
-      "clusterSyncIntervalSeconds": 60
+      "usageReport": {
+        "bucketName": "gitpod-usage-reports"
+      }
     }
 kind: ConfigMap
 metadata:
   creationTimestamp: null
   labels:
     app: gitpod
-    component: ws-manager-bridge
-  name: ws-manager-bridge-config
+    component: content-service
+  name: content-service
+  namespace: default
+---
+# v1/ConfigMap db-init-scripts
+apiVersion: v1
+data:
+  init.sql: |
+    -- 01-create-and-init-sessions-db.sql
+
+    -- Copyright (c) 2020 Gitpod GmbH. All rights reserved.
+    -- Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
+    -- must be idempotent
+
+    CREATE DATABASE IF NOT EXISTS `gitpod-sessions` CHARSET utf8mb4;
+
+    USE `gitpod-sessions`;
+
+    CREATE TABLE IF NOT EXISTS sessions (
+       `session_id` varchar(128) COLLATE utf8mb4_bin NOT NULL,
+       `expires` int(11) unsigned NOT NULL,
+       `data` text COLLATE utf8mb4_bin,
+       `_lastModified` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+       PRIMARY KEY (`session_id`)
+    );
+
+    -- Grant privileges
+    GRANT ALL ON `gitpod-sessions`.* TO "gitpod"@"%";
+    -- 02-recreate-gitpod-db.sql
+
+    -- Copyright (c) 2020 Gitpod GmbH. All rights reserved.
+    -- Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
+    -- must be idempotent
+
+    -- @gitpodDB contains name of the DB the script manipulates, and is replaced by the file reader
+    SET
+    @gitpodDB = IFNULL(@gitpodDB, '`gitpod`');
+
+    SET
+    @statementStr = CONCAT('DROP DATABASE IF EXISTS ', @gitpodDB);
+    PREPARE statement FROM @statementStr;
+    EXECUTE statement;
+
+    SET
+    @statementStr = CONCAT('CREATE DATABASE ', @gitpodDB, ' CHARSET utf8mb4');
+    PREPARE statement FROM @statementStr;
+    EXECUTE statement;
+  tuneMysql.sql: SET GLOBAL innodb_lru_scan_depth=256;
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: db
+  name: db-init-scripts
   namespace: default
 ---
 # v1/ConfigMap gitpod
@@ -1876,776 +1756,6 @@ metadata:
     app: gitpod
     component: gitpod
   name: gitpod
-  namespace: default
----
-# v1/ConfigMap content-service
-apiVersion: v1
-data:
-  config.json: |-
-    {
-      "service": {
-        "address": ":8080"
-      },
-      "storage": {
-        "stage": "",
-        "kind": "minio",
-        "gcloud": {
-          "credentialsFile": "",
-          "region": "",
-          "projectId": ""
-        },
-        "minio": {
-          "endpoint": "minio.default.svc.cluster.local:9000",
-          "accessKey": "8-WGqw2oTnsPfUDNSk0Y",
-          "accessKeyFile": "",
-          "secretKey": "DpC.aSAxkWBPu2_bJ_AE",
-          "secretKeyFile": "",
-          "region": "local",
-          "parallelUpload": 6
-        },
-        "blobQuota": 5368709120
-      },
-      "usageReport": {
-        "bucketName": "gitpod-usage-reports"
-      }
-    }
-kind: ConfigMap
-metadata:
-  creationTimestamp: null
-  labels:
-    app: gitpod
-    component: content-service
-  name: content-service
-  namespace: default
----
-# v1/ConfigMap proxy-config
-apiVersion: v1
-data:
-  vhost.docker-registry: |-
-    https://registry.minimal-test.gitpod.com {
-        import enable_log
-        import remove_server_header
-        import ssl_configuration
-
-        basicauth bcrypt "Docker Registry" {
-            xSedJiDgJQQg4BkW5xKu JDJhJDEwJFFTRGRRMHZZY2pIS2JqUC9aMDNnVC5HbEg2Z1dOQm5TL0pySnpYSm5iNy9DeVh0ZUw2cFM2
-        }
-
-        reverse_proxy https://registry.default.svc.cluster.local {
-            flush_interval -1
-            transport http {
-                tls_trusted_ca_certs /etc/caddy/registry-certs/ca.crt
-            }
-        }
-    }
-  vhost.empty: '# Placeholder to avoid errors loading files using a glob pattern'
-  vhost.ide-proxy: |-
-    https://ide.minimal-test.gitpod.com {
-        import enable_log_debug
-        import remove_server_header
-        import ssl_configuration
-
-        reverse_proxy  {
-            to ide-proxy.default.svc.cluster.local:80
-        }
-    }
-  vhost.minio: |-
-    https://minio.minimal-test.gitpod.com {
-        import enable_log
-        import remove_server_header
-        import ssl_configuration
-
-        reverse_proxy minio.default.svc.cluster.local:9001 {
-            flush_interval -1
-        }
-    }
-  vhost.open-vsx: |-
-    https://open-vsx.minimal-test.gitpod.com {
-        import enable_log_debug
-        import remove_server_header
-        import ssl_configuration
-
-        reverse_proxy  {
-            to openvsx-proxy.default.svc.cluster.local:8080
-        }
-    }
-  vhost.payment-endpoint: |
-    https://payment.minimal-test.gitpod.com {
-        import enable_log
-        import remove_server_header
-        import ssl_configuration
-        import debug_headers
-
-        reverse_proxy payment-endpoint.default.svc.cluster.local:3002 {
-            import upstream_headers
-            import upstream_connection
-        }
-
-        @backend path /stripe/invoices/webhook
-        handle @backend {
-            reverse_proxy public-api-server.{$KUBE_NAMESPACE}.{$KUBE_DOMAIN}:9002 {
-                import upstream_headers
-                import upstream_connection
-            }
-        }
-
-        handle_errors {
-            respond "Internal Server Error" 500
-        }
-    }
-kind: ConfigMap
-metadata:
-  creationTimestamp: null
-  labels:
-    app: gitpod
-    component: proxy
-  name: proxy-config
-  namespace: default
----
-# v1/ConfigMap server-config
-apiVersion: v1
-data:
-  config.json: |-
-    {
-      "version": "main.4110",
-      "hostUrl": "https://minimal-test.gitpod.com",
-      "installationShortname": "default",
-      "devBranch": "",
-      "insecureNoDomain": false,
-      "license": "",
-      "licenseFile": "",
-      "definitelyGpDisabled": true,
-      "enableLocalApp": true,
-      "disableDynamicAuthProviderLogin": false,
-      "maxEnvvarPerUserCount": 4048,
-      "maxConcurrentPrebuildsPerRef": 10,
-      "makeNewUsersAdmin": false,
-      "defaultBaseImageRegistryWhitelist": [],
-      "runDbDeleter": true,
-      "contentServiceAddr": "content-service:8080",
-      "imageBuilderAddr": "image-builder-mk3:8080",
-      "usageServiceAddr": "usage:9001",
-      "vsxRegistryUrl": "https://open-vsx.minimal-test.gitpod.com",
-      "chargebeeProviderOptionsFile": "/chargebee/providerOptions",
-      "stripeSecretsFile": "/stripe-secret/apikeys",
-      "stripeConfigFile": "/stripe-config/config",
-      "enablePayment": false,
-      "workspaceHeartbeat": {
-        "intervalSeconds": 60,
-        "timeoutSeconds": 300
-      },
-      "workspaceDefaults": {
-        "workspaceImage": "docker.io/gitpod/workspace-full:latest",
-        "previewFeatureFlags": [],
-        "defaultFeatureFlags": []
-      },
-      "session": {
-        "maxAgeMs": 259200000,
-        "secret": "Important!Really-Change-This-Key!"
-      },
-      "githubApp": {
-        "enabled": false,
-        "appId": 0,
-        "baseUrl": "",
-        "webhookSecret": "",
-        "authProviderId": "",
-        "certPath": "",
-        "marketplaceName": "",
-        "logLevel": "",
-        "certSecretName": ""
-      },
-      "workspaceGarbageCollection": {
-        "disabled": false,
-        "startDate": 0,
-        "chunkLimit": 1000,
-        "minAgeDays": 14,
-        "minAgePrebuildDays": 7,
-        "contentRetentionPeriodDays": 21,
-        "contentChunkLimit": 1000
-      },
-      "authProviderConfigFiles": [],
-      "incrementalPrebuilds": {
-        "repositoryPasslist": [],
-        "commitHistory": 100
-      },
-      "blockNewUsers": {
-        "enabled": false,
-        "passlist": []
-      },
-      "oauthServer": {
-        "enabled": true,
-        "jwtSecret": "8QMIxwyCGe5U0NAj6Uei"
-      },
-      "rateLimiter": {
-        "groups": {
-          "inWorkspaceUserAction": {
-            "points": 10,
-            "durationsSec": 2
-          }
-        },
-        "functions": {
-          "closePort": {
-            "group": "inWorkspaceUserAction",
-            "points": 0
-          },
-          "controlAdmission": {
-            "group": "inWorkspaceUserAction",
-            "points": 0
-          },
-          "openPort": {
-            "group": "inWorkspaceUserAction",
-            "points": 0
-          },
-          "shareSnapshot": {
-            "group": "inWorkspaceUserAction",
-            "points": 0
-          }
-        }
-      },
-      "codeSync": {
-        "revLimit": 0,
-        "contentLimit": 0,
-        "resources": null
-      },
-      "prebuildLimiter": {
-        "*": 50
-      },
-      "workspaceClasses": [
-        {
-          "id": "default",
-          "category": "GENERAL PURPOSE",
-          "displayName": "Default",
-          "description": "Default workspace class",
-          "powerups": 1,
-          "isDefault": true,
-          "deprecated": false
-        }
-      ]
-    }
-kind: ConfigMap
-metadata:
-  creationTimestamp: null
-  labels:
-    app: gitpod
-    component: server
-  name: server-config
-  namespace: default
----
-# v1/ConfigMap registry-facade
-apiVersion: v1
-data:
-  config.json: |-
-    {
-      "registry": {
-        "port": 32223,
-        "prefix": "",
-        "staticLayer": [
-          {
-            "ref": "eu.gcr.io/gitpod-core-dev/build/supervisor:test",
-            "type": "image"
-          },
-          {
-            "ref": "eu.gcr.io/gitpod-core-dev/build/workspacekit:test",
-            "type": "image"
-          },
-          {
-            "ref": "eu.gcr.io/gitpod-core-dev/build/docker-up:test",
-            "type": "image"
-          }
-        ],
-        "remoteSpecProvider": {
-          "addr": "dns:///ws-manager:8080",
-          "tls": {
-            "ca": "/ws-manager-client-tls-certs/ca.crt",
-            "crt": "/ws-manager-client-tls-certs/tls.crt",
-            "key": "/ws-manager-client-tls-certs/tls.key"
-          }
-        },
-        "store": "/mnt/cache/registry",
-        "requireAuth": false,
-        "tls": {
-          "ca": "",
-          "crt": "/mnt/certificates/tls.crt",
-          "key": "/mnt/certificates/tls.key"
-        }
-      },
-      "dockerAuth": "/mnt/pull-secret.json",
-      "pprofAddr": "127.0.0.1:6060",
-      "prometheusAddr": "127.0.0.1:9500",
-      "readinessProbeAddr": ":8086"
-    }
-kind: ConfigMap
-metadata:
-  creationTimestamp: null
-  labels:
-    app: gitpod
-    component: registry-facade
-  name: registry-facade
-  namespace: default
----
-# v1/ConfigMap server-ide-config
-apiVersion: v1
-data:
-  config.json: |-
-    {
-      "supervisorImage": "eu.gcr.io/gitpod-core-dev/build/supervisor:test",
-      "ideOptions": {
-        "options": {
-          "code": {
-            "orderKey": "00",
-            "title": "VS Code",
-            "type": "browser",
-            "logo": "https://ide.minimal-test.gitpod.com/image/ide-logo/vscode.svg",
-            "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-ce3e2bc5edd1cf37d66ef0b37c38645543021831",
-            "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
-          },
-          "code-desktop": {
-            "orderKey": "02",
-            "title": "VS Code",
-            "type": "desktop",
-            "logo": "https://ide.minimal-test.gitpod.com/image/ide-logo/vscode.svg",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code-desktop:test",
-            "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code-desktop-insiders:test"
-          },
-          "goland": {
-            "orderKey": "05",
-            "title": "GoLand",
-            "type": "desktop",
-            "logo": "https://ide.minimal-test.gitpod.com/image/ide-logo/golandLogo.svg",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/goland:test",
-            "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/goland:latest"
-          },
-          "intellij": {
-            "orderKey": "04",
-            "title": "IntelliJ IDEA",
-            "type": "desktop",
-            "logo": "https://ide.minimal-test.gitpod.com/image/ide-logo/intellijIdeaLogo.svg",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/intellij:test",
-            "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/intellij:latest"
-          },
-          "phpstorm": {
-            "orderKey": "07",
-            "title": "PhpStorm",
-            "type": "desktop",
-            "logo": "https://ide.minimal-test.gitpod.com/image/ide-logo/phpstormLogo.svg",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/phpstorm:test",
-            "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/phpstorm:latest"
-          },
-          "pycharm": {
-            "orderKey": "06",
-            "title": "PyCharm",
-            "type": "desktop",
-            "logo": "https://ide.minimal-test.gitpod.com/image/ide-logo/pycharmLogo.svg",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/pycharm:test",
-            "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/pycharm:latest"
-          }
-        },
-        "defaultIde": "code",
-        "defaultDesktopIde": "code-desktop",
-        "clients": {
-          "jetbrains-gateway": {
-            "defaultDesktopIDE": "intellij",
-            "desktopIDEs": [
-              "intellij",
-              "goland",
-              "pycharm",
-              "phpstorm"
-            ],
-            "installationSteps": [
-              "If you don't see an open dialog in your browser, make sure you have the \u003ca target='_blank' class='gp-link' href='https://www.gitpod.io/docs/ides-and-editors/jetbrains-gateway#getting-started-jetbrains-gateway'\u003eJetBrains Gateway with Gitpod Plugin\u003c/a\u003e installed on your machine, and then click \u003cb\u003e${OPEN_LINK_LABEL}\u003c/b\u003e below."
-            ]
-          },
-          "vscode": {
-            "defaultDesktopIDE": "code-desktop",
-            "desktopIDEs": [
-              "code-desktop"
-            ],
-            "installationSteps": [
-              "If you don't see an open dialog in your browser, make sure you have \u003ca target='_blank' class='gp-link' href='https://code.visualstudio.com/download'\u003eVS Code\u003c/a\u003e installed on your machine, and then click \u003cb\u003e${OPEN_LINK_LABEL}\u003c/b\u003e below."
-            ]
-          },
-          "vscode-insiders": {
-            "defaultDesktopIDE": "code-desktop",
-            "desktopIDEs": [
-              "code-desktop"
-            ],
-            "installationSteps": [
-              "If you don't see an open dialog in your browser, make sure you have \u003ca target='_blank' class='gp-link' href='https://code.visualstudio.com/insiders'\u003eVS Code Insiders\u003c/a\u003e installed on your machine, and then click \u003cb\u003e${OPEN_LINK_LABEL}\u003c/b\u003e below."
-            ]
-          }
-        }
-      }
-    }
-kind: ConfigMap
-metadata:
-  creationTimestamp: null
-  labels:
-    app: gitpod
-    component: server
-  name: server-ide-config
-  namespace: default
----
-# v1/ConfigMap image-builder-mk3-config
-apiVersion: v1
-data:
-  image-builder.json: |-
-    {
-      "orchestrator": {
-        "wsman": {
-          "address": "ws-manager:8080",
-          "tls": {
-            "ca": "/wsman-certs/ca.crt",
-            "crt": "/wsman-certs/tls.crt",
-            "key": "/wsman-certs/tls.key"
-          }
-        },
-        "pullSecret": "builtin-registry-auth",
-        "pullSecretFile": "/config/pull-secret.json",
-        "baseImageRepository": "registry.minimal-test.gitpod.com/base-images",
-        "workspaceImageRepository": "registry.minimal-test.gitpod.com/workspace-images",
-        "builderImage": "eu.gcr.io/gitpod-core-dev/build/image-builder-mk3/bob:test"
-      },
-      "refCache": {
-        "interval": "6h0m0s",
-        "refs": [
-          "docker.io/gitpod/workspace-full:latest"
-        ]
-      },
-      "service": {
-        "address": ":8080",
-        "tls": {
-          "ca": "",
-          "crt": "",
-          "key": ""
-        }
-      },
-      "prometheus": {
-        "address": "127.0.0.1:9500",
-        "tls": {
-          "ca": "",
-          "crt": "",
-          "key": ""
-        }
-      },
-      "pprof": {
-        "address": "127.0.0.1:6060"
-      }
-    }
-kind: ConfigMap
-metadata:
-  creationTimestamp: null
-  labels:
-    app: gitpod
-    component: image-builder-mk3
-  name: image-builder-mk3-config
-  namespace: default
----
-# v1/ConfigMap ws-daemon
-apiVersion: v1
-data:
-  config.json: |-
-    {
-      "daemon": {
-        "runtime": {
-          "containerRuntime": {
-            "mounts": {
-              "proc": "/mnt/mounts"
-            },
-            "nodeToContainerMapping": {
-              "/var/lib/containerd/io.containerd.runtime.v2.task/k8s.io": "/mnt/node0"
-            },
-            "runtime": "containerd",
-            "containerd": {
-              "socket": "/mnt/containerd.sock"
-            }
-          },
-          "kubeconfig": "",
-          "namespace": "default"
-        },
-        "content": {
-          "workingArea": "/mnt/workingarea",
-          "workingAreaNode": "/var/gitpod/workspaces",
-          "tempDir": "/tmp",
-          "storage": {
-            "stage": "",
-            "kind": "minio",
-            "gcloud": {
-              "credentialsFile": "",
-              "region": "",
-              "projectId": ""
-            },
-            "minio": {
-              "endpoint": "minio.default.svc.cluster.local:9000",
-              "accessKey": "8-WGqw2oTnsPfUDNSk0Y",
-              "accessKeyFile": "",
-              "secretKey": "DpC.aSAxkWBPu2_bJ_AE",
-              "secretKeyFile": "",
-              "region": "local",
-              "parallelUpload": 6
-            },
-            "blobQuota": 5368709120
-          },
-          "backup": {
-            "timeout": "5m0s",
-            "attempts": 3,
-            "period": "0s"
-          },
-          "userNamespaces": {
-            "fsShift": "FUSE"
-          },
-          "initializer": {
-            "command": "/app/content-initializer",
-            "args": null
-          }
-        },
-        "uidmapper": {
-          "procLocation": "/proc",
-          "rootUIDRange": {
-            "start": 33333,
-            "size": 1
-          },
-          "userUIDRange": [
-            {
-              "start": 100000,
-              "size": 70000
-            }
-          ]
-        },
-        "cpulimit": {
-          "enabled": false,
-          "totalBandwidth": "0",
-          "limit": "0",
-          "burstLimit": "0",
-          "controlPeriod": "15s",
-          "cgroupBasePath": "/mnt/node-cgroups"
-        },
-        "ioLimit": {
-          "writeBandwidthPerSecond": "0",
-          "readBandwidthPerSecond": "0",
-          "writeIOPS": 0,
-          "readIOPS": 0
-        },
-        "procLimit": 0,
-        "hosts": {
-          "enabled": true,
-          "nodeHostsFile": "/mnt/hosts",
-          "fixedHosts": {
-            "registryFacade": [
-              {
-                "addr": "127.0.0.1",
-                "name": "reg.minimal-test.gitpod.com"
-              }
-            ]
-          }
-        },
-        "disk": {
-          "enabled": true,
-          "interval": "5m0s",
-          "locations": [
-            {
-              "path": "/mnt/workingarea",
-              "minBytesAvail": 21474836480
-            }
-          ]
-        }
-      },
-      "service": {
-        "address": ":8080",
-        "tls": {
-          "caPath": "/certs/ca.crt",
-          "certPath": "/certs/tls.crt",
-          "keyPath": "/certs/tls.key"
-        }
-      }
-    }
-kind: ConfigMap
-metadata:
-  creationTimestamp: null
-  labels:
-    app: gitpod
-    component: ws-daemon
-  name: ws-daemon
-  namespace: default
----
-# v1/ConfigMap ws-proxy
-apiVersion: v1
-data:
-  config.json: |-
-    {
-      "ingress": {
-        "httpAddress": ":8080",
-        "httpsAddress": ":9090",
-        "header": "x-wsproxy-host"
-      },
-      "proxy": {
-        "https": {
-          "key": "/mnt/certificates/tls.key",
-          "crt": "/mnt/certificates/tls.crt"
-        },
-        "transportConfig": {
-          "connectTimeout": "10s",
-          "idleConnTimeout": "1m0s",
-          "maxIdleConns": 0,
-          "maxIdleConnsPerHost": 100
-        },
-        "blobServer": {
-          "scheme": "https",
-          "host": "ide.minimal-test.gitpod.com",
-          "pathPrefix": "/blobserve"
-        },
-        "gitpodInstallation": {
-          "scheme": "https",
-          "hostName": "minimal-test.gitpod.com",
-          "workspaceHostSuffix": ".ws.minimal-test.gitpod.com",
-          "workspaceHostSuffixRegex": "\\.ws[^\\.]*\\.minimal-test.gitpod.com"
-        },
-        "workspacePodConfig": {
-          "theiaPort": 23000,
-          "supervisorPort": 22999,
-          "supervisorImage": "eu.gcr.io/gitpod-core-dev/build/supervisor:test"
-        },
-        "builtinPages": {
-          "location": "/app/public"
-        }
-      },
-      "pprofAddr": "127.0.0.1:6060",
-      "prometheusAddr": "127.0.0.1:9500",
-      "readinessProbeAddr": ":8086",
-      "namespace": "default",
-      "wsManager": {
-        "addr": "ws-manager:8080",
-        "tls": {
-          "ca": "/ws-manager-client-tls-certs/ca.crt",
-          "crt": "/ws-manager-client-tls-certs/tls.crt",
-          "key": "/ws-manager-client-tls-certs/tls.key"
-        }
-      }
-    }
-kind: ConfigMap
-metadata:
-  creationTimestamp: null
-  labels:
-    app: gitpod
-    component: ws-proxy
-  name: ws-proxy
-  namespace: default
----
-# v1/ConfigMap openvsx-proxy-config
-apiVersion: v1
-data:
-  config.json: |-
-    {
-      "log_debug": false,
-      "cache_duration_regular": "5m0s",
-      "cache_duration_backup": "72h0m0s",
-      "url_upstream": "https://open-vsx.org",
-      "url_local": "https://open-vsx.minimal-test.gitpod.com",
-      "max_idle_conns": 1000,
-      "max_idle_conns_per_host": 1000,
-      "redis_addr": "localhost:6379",
-      "prometheusAddr": "127.0.0.1:9500"
-    }
-  redis.conf: "\nmaxmemory 100mb\nmaxmemory-policy allkeys-lfu\n\t"
-kind: ConfigMap
-metadata:
-  creationTimestamp: null
-  labels:
-    app: gitpod
-    component: openvsx-proxy
-  name: openvsx-proxy-config
-  namespace: default
----
-# v1/ConfigMap agent-smith
-apiVersion: v1
-data:
-  config.json: |-
-    {
-      "gitpodAPI": {
-        "hostURL": "https://minimal-test.gitpod.com",
-        "apiToken": ""
-      },
-      "enforcement": {},
-      "kubernetes": {
-        "enabled": true
-      },
-      "namespace": "default",
-      "pprofAddr": "127.0.0.1:6060",
-      "prometheusAddr": "127.0.0.1:9500"
-    }
-kind: ConfigMap
-metadata:
-  creationTimestamp: null
-  labels:
-    app: gitpod
-    component: agent-smith
-  name: agent-smith
-  namespace: default
----
-# v1/ConfigMap workspace-templates
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  creationTimestamp: null
-  labels:
-    app: gitpod
-    component: ws-manager
-  name: workspace-templates
-  namespace: default
----
-# v1/ConfigMap db-init-scripts
-apiVersion: v1
-data:
-  init.sql: |
-    -- 01-create-and-init-sessions-db.sql
-
-    -- Copyright (c) 2020 Gitpod GmbH. All rights reserved.
-    -- Licensed under the MIT License. See License-MIT.txt in the project root for license information.
-
-    -- must be idempotent
-
-    CREATE DATABASE IF NOT EXISTS `gitpod-sessions` CHARSET utf8mb4;
-
-    USE `gitpod-sessions`;
-
-    CREATE TABLE IF NOT EXISTS sessions (
-       `session_id` varchar(128) COLLATE utf8mb4_bin NOT NULL,
-       `expires` int(11) unsigned NOT NULL,
-       `data` text COLLATE utf8mb4_bin,
-       `_lastModified` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
-       PRIMARY KEY (`session_id`)
-    );
-
-    -- Grant privileges
-    GRANT ALL ON `gitpod-sessions`.* TO "gitpod"@"%";
-    -- 02-recreate-gitpod-db.sql
-
-    -- Copyright (c) 2020 Gitpod GmbH. All rights reserved.
-    -- Licensed under the MIT License. See License-MIT.txt in the project root for license information.
-
-    -- must be idempotent
-
-    -- @gitpodDB contains name of the DB the script manipulates, and is replaced by the file reader
-    SET
-    @gitpodDB = IFNULL(@gitpodDB, '`gitpod`');
-
-    SET
-    @statementStr = CONCAT('DROP DATABASE IF EXISTS ', @gitpodDB);
-    PREPARE statement FROM @statementStr;
-    EXECUTE statement;
-
-    SET
-    @statementStr = CONCAT('CREATE DATABASE ', @gitpodDB, ' CHARSET utf8mb4');
-    PREPARE statement FROM @statementStr;
-    EXECUTE statement;
-  tuneMysql.sql: SET GLOBAL innodb_lru_scan_depth=256;
-kind: ConfigMap
-metadata:
-  creationTimestamp: null
-  labels:
-    app: gitpod
-    component: db
-  name: db-init-scripts
   namespace: default
 ---
 # v1/ConfigMap gitpod-app
@@ -4449,6 +3559,896 @@ metadata:
   namespace: default
 
 ---
+# v1/ConfigMap image-builder-mk3-config
+apiVersion: v1
+data:
+  image-builder.json: |-
+    {
+      "orchestrator": {
+        "wsman": {
+          "address": "ws-manager:8080",
+          "tls": {
+            "ca": "/wsman-certs/ca.crt",
+            "crt": "/wsman-certs/tls.crt",
+            "key": "/wsman-certs/tls.key"
+          }
+        },
+        "pullSecret": "builtin-registry-auth",
+        "pullSecretFile": "/config/pull-secret.json",
+        "baseImageRepository": "registry.minimal-test.gitpod.com/base-images",
+        "workspaceImageRepository": "registry.minimal-test.gitpod.com/workspace-images",
+        "builderImage": "eu.gcr.io/gitpod-core-dev/build/image-builder-mk3/bob:test"
+      },
+      "refCache": {
+        "interval": "6h0m0s",
+        "refs": [
+          "docker.io/gitpod/workspace-full:latest"
+        ]
+      },
+      "service": {
+        "address": ":8080",
+        "tls": {
+          "ca": "",
+          "crt": "",
+          "key": ""
+        }
+      },
+      "prometheus": {
+        "address": "127.0.0.1:9500",
+        "tls": {
+          "ca": "",
+          "crt": "",
+          "key": ""
+        }
+      },
+      "pprof": {
+        "address": "127.0.0.1:6060"
+      }
+    }
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: image-builder-mk3
+  name: image-builder-mk3-config
+  namespace: default
+---
+# v1/ConfigMap mysql
+# Source: mysql/charts/mysql/templates/primary/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mysql
+  namespace: "default"
+  labels:
+    app.kubernetes.io/name: mysql
+    helm.sh/chart: mysql-9.1.2
+    app.kubernetes.io/instance: MySQL
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: primary
+data:
+  my.cnf: |-
+    [mysqld]
+    default_authentication_plugin=mysql_native_password
+    skip-name-resolve
+    explicit_defaults_for_timestamp
+    basedir=/opt/bitnami/mysql
+    plugin_dir=/opt/bitnami/mysql/lib/plugin
+    port=3306
+    socket=/opt/bitnami/mysql/tmp/mysql.sock
+    datadir=/bitnami/mysql/data
+    tmpdir=/opt/bitnami/mysql/tmp
+    max_allowed_packet=16M
+    bind-address=0.0.0.0
+    pid-file=/opt/bitnami/mysql/tmp/mysqld.pid
+    log-error=/opt/bitnami/mysql/logs/mysqld.log
+    character-set-server=UTF8
+    collation-server=utf8_general_ci
+    slow_query_log=0
+    slow_query_log_file=/opt/bitnami/mysql/logs/mysqld.log
+    long_query_time=10.0
+    
+    [client]
+    port=3306
+    socket=/opt/bitnami/mysql/tmp/mysql.sock
+    default-character-set=UTF8
+    plugin_dir=/opt/bitnami/mysql/lib/plugin
+    
+    [manager]
+    port=3306
+    socket=/opt/bitnami/mysql/tmp/mysql.sock
+    pid-file=/opt/bitnami/mysql/tmp/mysqld.pid
+---
+# v1/ConfigMap openvsx-proxy-config
+apiVersion: v1
+data:
+  config.json: |-
+    {
+      "log_debug": false,
+      "cache_duration_regular": "5m0s",
+      "cache_duration_backup": "72h0m0s",
+      "url_upstream": "https://open-vsx.org",
+      "url_local": "https://open-vsx.minimal-test.gitpod.com",
+      "max_idle_conns": 1000,
+      "max_idle_conns_per_host": 1000,
+      "redis_addr": "localhost:6379",
+      "prometheusAddr": "127.0.0.1:9500"
+    }
+  redis.conf: "\nmaxmemory 100mb\nmaxmemory-policy allkeys-lfu\n\t"
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: openvsx-proxy
+  name: openvsx-proxy-config
+  namespace: default
+---
+# v1/ConfigMap proxy-config
+apiVersion: v1
+data:
+  vhost.docker-registry: |-
+    https://registry.minimal-test.gitpod.com {
+        import enable_log
+        import remove_server_header
+        import ssl_configuration
+
+        basicauth bcrypt "Docker Registry" {
+            xSedJiDgJQQg4BkW5xKu JDJhJDEwJFFTRGRRMHZZY2pIS2JqUC9aMDNnVC5HbEg2Z1dOQm5TL0pySnpYSm5iNy9DeVh0ZUw2cFM2
+        }
+
+        reverse_proxy https://registry.default.svc.cluster.local {
+            flush_interval -1
+            transport http {
+                tls_trusted_ca_certs /etc/caddy/registry-certs/ca.crt
+            }
+        }
+    }
+  vhost.empty: '# Placeholder to avoid errors loading files using a glob pattern'
+  vhost.ide-proxy: |-
+    https://ide.minimal-test.gitpod.com {
+        import enable_log_debug
+        import remove_server_header
+        import ssl_configuration
+
+        reverse_proxy  {
+            to ide-proxy.default.svc.cluster.local:80
+        }
+    }
+  vhost.minio: |-
+    https://minio.minimal-test.gitpod.com {
+        import enable_log
+        import remove_server_header
+        import ssl_configuration
+
+        reverse_proxy minio.default.svc.cluster.local:9001 {
+            flush_interval -1
+        }
+    }
+  vhost.open-vsx: |-
+    https://open-vsx.minimal-test.gitpod.com {
+        import enable_log_debug
+        import remove_server_header
+        import ssl_configuration
+
+        reverse_proxy  {
+            to openvsx-proxy.default.svc.cluster.local:8080
+        }
+    }
+  vhost.payment-endpoint: |
+    https://payment.minimal-test.gitpod.com {
+        import enable_log
+        import remove_server_header
+        import ssl_configuration
+        import debug_headers
+
+        reverse_proxy payment-endpoint.default.svc.cluster.local:3002 {
+            import upstream_headers
+            import upstream_connection
+        }
+
+        @backend path /stripe/invoices/webhook
+        handle @backend {
+            reverse_proxy public-api-server.{$KUBE_NAMESPACE}.{$KUBE_DOMAIN}:9002 {
+                import upstream_headers
+                import upstream_connection
+            }
+        }
+
+        handle_errors {
+            respond "Internal Server Error" 500
+        }
+    }
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: proxy
+  name: proxy-config
+  namespace: default
+---
+# v1/ConfigMap registry-config
+# Source: docker-registry/charts/docker-registry/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: registry-config
+  namespace: default
+  labels:
+    app: docker-registry
+    chart: docker-registry-1.16.0
+    heritage: Helm
+    release: docker-registry
+data:
+  config.yml: |-
+    health:
+      storagedriver:
+        enabled: true
+        interval: 10s
+        threshold: 3
+    http:
+      addr: :5000
+      debug:
+        addr: :5001
+        prometheus:
+          enabled: false
+          path: /metrics
+      headers:
+        X-Content-Type-Options:
+        - nosniff
+    log:
+      fields:
+        service: registry
+    storage:
+      cache:
+        blobdescriptor: inmemory
+    version: 0.1
+---
+# v1/ConfigMap registry-facade
+apiVersion: v1
+data:
+  config.json: |-
+    {
+      "registry": {
+        "port": 32223,
+        "prefix": "",
+        "staticLayer": [
+          {
+            "ref": "eu.gcr.io/gitpod-core-dev/build/supervisor:test",
+            "type": "image"
+          },
+          {
+            "ref": "eu.gcr.io/gitpod-core-dev/build/workspacekit:test",
+            "type": "image"
+          },
+          {
+            "ref": "eu.gcr.io/gitpod-core-dev/build/docker-up:test",
+            "type": "image"
+          }
+        ],
+        "remoteSpecProvider": {
+          "addr": "dns:///ws-manager:8080",
+          "tls": {
+            "ca": "/ws-manager-client-tls-certs/ca.crt",
+            "crt": "/ws-manager-client-tls-certs/tls.crt",
+            "key": "/ws-manager-client-tls-certs/tls.key"
+          }
+        },
+        "store": "/mnt/cache/registry",
+        "requireAuth": false,
+        "tls": {
+          "ca": "",
+          "crt": "/mnt/certificates/tls.crt",
+          "key": "/mnt/certificates/tls.key"
+        }
+      },
+      "dockerAuth": "/mnt/pull-secret.json",
+      "pprofAddr": "127.0.0.1:6060",
+      "prometheusAddr": "127.0.0.1:9500",
+      "readinessProbeAddr": ":8086"
+    }
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: registry-facade
+  name: registry-facade
+  namespace: default
+---
+# v1/ConfigMap server-config
+apiVersion: v1
+data:
+  config.json: |-
+    {
+      "version": "main.4110",
+      "hostUrl": "https://minimal-test.gitpod.com",
+      "installationShortname": "default",
+      "devBranch": "",
+      "insecureNoDomain": false,
+      "license": "",
+      "licenseFile": "",
+      "definitelyGpDisabled": true,
+      "enableLocalApp": true,
+      "disableDynamicAuthProviderLogin": false,
+      "maxEnvvarPerUserCount": 4048,
+      "maxConcurrentPrebuildsPerRef": 10,
+      "makeNewUsersAdmin": false,
+      "defaultBaseImageRegistryWhitelist": [],
+      "runDbDeleter": true,
+      "contentServiceAddr": "content-service:8080",
+      "imageBuilderAddr": "image-builder-mk3:8080",
+      "usageServiceAddr": "usage:9001",
+      "vsxRegistryUrl": "https://open-vsx.minimal-test.gitpod.com",
+      "chargebeeProviderOptionsFile": "/chargebee/providerOptions",
+      "stripeSecretsFile": "/stripe-secret/apikeys",
+      "stripeConfigFile": "/stripe-config/config",
+      "enablePayment": false,
+      "workspaceHeartbeat": {
+        "intervalSeconds": 60,
+        "timeoutSeconds": 300
+      },
+      "workspaceDefaults": {
+        "workspaceImage": "docker.io/gitpod/workspace-full:latest",
+        "previewFeatureFlags": [],
+        "defaultFeatureFlags": []
+      },
+      "session": {
+        "maxAgeMs": 259200000,
+        "secret": "Important!Really-Change-This-Key!"
+      },
+      "githubApp": {
+        "enabled": false,
+        "appId": 0,
+        "baseUrl": "",
+        "webhookSecret": "",
+        "authProviderId": "",
+        "certPath": "",
+        "marketplaceName": "",
+        "logLevel": "",
+        "certSecretName": ""
+      },
+      "workspaceGarbageCollection": {
+        "disabled": false,
+        "startDate": 0,
+        "chunkLimit": 1000,
+        "minAgeDays": 14,
+        "minAgePrebuildDays": 7,
+        "contentRetentionPeriodDays": 21,
+        "contentChunkLimit": 1000
+      },
+      "authProviderConfigFiles": [],
+      "incrementalPrebuilds": {
+        "repositoryPasslist": [],
+        "commitHistory": 100
+      },
+      "blockNewUsers": {
+        "enabled": false,
+        "passlist": []
+      },
+      "oauthServer": {
+        "enabled": true,
+        "jwtSecret": "8QMIxwyCGe5U0NAj6Uei"
+      },
+      "rateLimiter": {
+        "groups": {
+          "inWorkspaceUserAction": {
+            "points": 10,
+            "durationsSec": 2
+          }
+        },
+        "functions": {
+          "closePort": {
+            "group": "inWorkspaceUserAction",
+            "points": 0
+          },
+          "controlAdmission": {
+            "group": "inWorkspaceUserAction",
+            "points": 0
+          },
+          "openPort": {
+            "group": "inWorkspaceUserAction",
+            "points": 0
+          },
+          "shareSnapshot": {
+            "group": "inWorkspaceUserAction",
+            "points": 0
+          }
+        }
+      },
+      "codeSync": {
+        "revLimit": 0,
+        "contentLimit": 0,
+        "resources": null
+      },
+      "prebuildLimiter": {
+        "*": 50
+      },
+      "workspaceClasses": [
+        {
+          "id": "default",
+          "category": "GENERAL PURPOSE",
+          "displayName": "Default",
+          "description": "Default workspace class",
+          "powerups": 1,
+          "isDefault": true,
+          "deprecated": false
+        }
+      ]
+    }
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: server
+  name: server-config
+  namespace: default
+---
+# v1/ConfigMap server-ide-config
+apiVersion: v1
+data:
+  config.json: |-
+    {
+      "supervisorImage": "eu.gcr.io/gitpod-core-dev/build/supervisor:test",
+      "ideOptions": {
+        "options": {
+          "code": {
+            "orderKey": "00",
+            "title": "VS Code",
+            "type": "browser",
+            "logo": "https://ide.minimal-test.gitpod.com/image/ide-logo/vscode.svg",
+            "label": "Browser",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-ce3e2bc5edd1cf37d66ef0b37c38645543021831",
+            "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
+          },
+          "code-desktop": {
+            "orderKey": "02",
+            "title": "VS Code",
+            "type": "desktop",
+            "logo": "https://ide.minimal-test.gitpod.com/image/ide-logo/vscode.svg",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code-desktop:test",
+            "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code-desktop-insiders:test"
+          },
+          "goland": {
+            "orderKey": "05",
+            "title": "GoLand",
+            "type": "desktop",
+            "logo": "https://ide.minimal-test.gitpod.com/image/ide-logo/golandLogo.svg",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/goland:test",
+            "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/goland:latest"
+          },
+          "intellij": {
+            "orderKey": "04",
+            "title": "IntelliJ IDEA",
+            "type": "desktop",
+            "logo": "https://ide.minimal-test.gitpod.com/image/ide-logo/intellijIdeaLogo.svg",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/intellij:test",
+            "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/intellij:latest"
+          },
+          "phpstorm": {
+            "orderKey": "07",
+            "title": "PhpStorm",
+            "type": "desktop",
+            "logo": "https://ide.minimal-test.gitpod.com/image/ide-logo/phpstormLogo.svg",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/phpstorm:test",
+            "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/phpstorm:latest"
+          },
+          "pycharm": {
+            "orderKey": "06",
+            "title": "PyCharm",
+            "type": "desktop",
+            "logo": "https://ide.minimal-test.gitpod.com/image/ide-logo/pycharmLogo.svg",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/pycharm:test",
+            "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/pycharm:latest"
+          }
+        },
+        "defaultIde": "code",
+        "defaultDesktopIde": "code-desktop",
+        "clients": {
+          "jetbrains-gateway": {
+            "defaultDesktopIDE": "intellij",
+            "desktopIDEs": [
+              "intellij",
+              "goland",
+              "pycharm",
+              "phpstorm"
+            ],
+            "installationSteps": [
+              "If you don't see an open dialog in your browser, make sure you have the \u003ca target='_blank' class='gp-link' href='https://www.gitpod.io/docs/ides-and-editors/jetbrains-gateway#getting-started-jetbrains-gateway'\u003eJetBrains Gateway with Gitpod Plugin\u003c/a\u003e installed on your machine, and then click \u003cb\u003e${OPEN_LINK_LABEL}\u003c/b\u003e below."
+            ]
+          },
+          "vscode": {
+            "defaultDesktopIDE": "code-desktop",
+            "desktopIDEs": [
+              "code-desktop"
+            ],
+            "installationSteps": [
+              "If you don't see an open dialog in your browser, make sure you have \u003ca target='_blank' class='gp-link' href='https://code.visualstudio.com/download'\u003eVS Code\u003c/a\u003e installed on your machine, and then click \u003cb\u003e${OPEN_LINK_LABEL}\u003c/b\u003e below."
+            ]
+          },
+          "vscode-insiders": {
+            "defaultDesktopIDE": "code-desktop",
+            "desktopIDEs": [
+              "code-desktop"
+            ],
+            "installationSteps": [
+              "If you don't see an open dialog in your browser, make sure you have \u003ca target='_blank' class='gp-link' href='https://code.visualstudio.com/insiders'\u003eVS Code Insiders\u003c/a\u003e installed on your machine, and then click \u003cb\u003e${OPEN_LINK_LABEL}\u003c/b\u003e below."
+            ]
+          }
+        }
+      }
+    }
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: server
+  name: server-ide-config
+  namespace: default
+---
+# v1/ConfigMap workspace-templates
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ws-manager
+  name: workspace-templates
+  namespace: default
+---
+# v1/ConfigMap ws-daemon
+apiVersion: v1
+data:
+  config.json: |-
+    {
+      "daemon": {
+        "runtime": {
+          "containerRuntime": {
+            "mounts": {
+              "proc": "/mnt/mounts"
+            },
+            "nodeToContainerMapping": {
+              "/var/lib/containerd/io.containerd.runtime.v2.task/k8s.io": "/mnt/node0"
+            },
+            "runtime": "containerd",
+            "containerd": {
+              "socket": "/mnt/containerd.sock"
+            }
+          },
+          "kubeconfig": "",
+          "namespace": "default"
+        },
+        "content": {
+          "workingArea": "/mnt/workingarea",
+          "workingAreaNode": "/var/gitpod/workspaces",
+          "tempDir": "/tmp",
+          "storage": {
+            "stage": "",
+            "kind": "minio",
+            "gcloud": {
+              "credentialsFile": "",
+              "region": "",
+              "projectId": ""
+            },
+            "minio": {
+              "endpoint": "minio.default.svc.cluster.local:9000",
+              "accessKey": "8-WGqw2oTnsPfUDNSk0Y",
+              "accessKeyFile": "",
+              "secretKey": "DpC.aSAxkWBPu2_bJ_AE",
+              "secretKeyFile": "",
+              "region": "local",
+              "parallelUpload": 6
+            },
+            "blobQuota": 5368709120
+          },
+          "backup": {
+            "timeout": "5m0s",
+            "attempts": 3,
+            "period": "0s"
+          },
+          "userNamespaces": {
+            "fsShift": "FUSE"
+          },
+          "initializer": {
+            "command": "/app/content-initializer",
+            "args": null
+          }
+        },
+        "uidmapper": {
+          "procLocation": "/proc",
+          "rootUIDRange": {
+            "start": 33333,
+            "size": 1
+          },
+          "userUIDRange": [
+            {
+              "start": 100000,
+              "size": 70000
+            }
+          ]
+        },
+        "cpulimit": {
+          "enabled": false,
+          "totalBandwidth": "0",
+          "limit": "0",
+          "burstLimit": "0",
+          "controlPeriod": "15s",
+          "cgroupBasePath": "/mnt/node-cgroups"
+        },
+        "ioLimit": {
+          "writeBandwidthPerSecond": "0",
+          "readBandwidthPerSecond": "0",
+          "writeIOPS": 0,
+          "readIOPS": 0
+        },
+        "procLimit": 0,
+        "hosts": {
+          "enabled": true,
+          "nodeHostsFile": "/mnt/hosts",
+          "fixedHosts": {
+            "registryFacade": [
+              {
+                "addr": "127.0.0.1",
+                "name": "reg.minimal-test.gitpod.com"
+              }
+            ]
+          }
+        },
+        "disk": {
+          "enabled": true,
+          "interval": "5m0s",
+          "locations": [
+            {
+              "path": "/mnt/workingarea",
+              "minBytesAvail": 21474836480
+            }
+          ]
+        }
+      },
+      "service": {
+        "address": ":8080",
+        "tls": {
+          "caPath": "/certs/ca.crt",
+          "certPath": "/certs/tls.crt",
+          "keyPath": "/certs/tls.key"
+        }
+      }
+    }
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ws-daemon
+  name: ws-daemon
+  namespace: default
+---
+# v1/ConfigMap ws-manager
+apiVersion: v1
+data:
+  config.json: |-
+    {
+      "manager": {
+        "namespace": "default",
+        "schedulerName": "",
+        "seccompProfile": "localhost/workspace_default_main.4110.json",
+        "timeouts": {
+          "startup": "1h0m0s",
+          "initialization": "30m0s",
+          "regularWorkspace": "30m0s",
+          "maxLifetime": "36h0m0s",
+          "headlessWorkspace": "1h0m0s",
+          "afterClose": "2m0s",
+          "contentFinalization": "1h0m0s",
+          "stopping": "1h0m0s",
+          "interrupted": "5m0s"
+        },
+        "initProbe": {
+          "timeout": "1s"
+        },
+        "urlTemplate": "https://{{ .Prefix }}.ws.minimal-test.gitpod.com",
+        "portUrlTemplate": "https://{{ .WorkspacePort }}-{{ .Prefix }}.ws.minimal-test.gitpod.com",
+        "workspaceHostPath": "/var/gitpod/workspaces",
+        "heartbeatInterval": "30s",
+        "hostURL": "https://minimal-test.gitpod.com",
+        "reconnectionInterval": "30s",
+        "wsdaemon": {
+          "port": 8080,
+          "tls": {
+            "ca": "/ws-daemon-tls-certs/ca.crt",
+            "crt": "/ws-daemon-tls-certs/tls.crt",
+            "key": "/ws-daemon-tls-certs/tls.key"
+          }
+        },
+        "registryFacadeHost": "reg.minimal-test.gitpod.com:20000",
+        "workspaceClusterHost": "ws.minimal-test.gitpod.com",
+        "workspaceClass": {
+          "default": {
+            "name": "default",
+            "container": {
+              "requests": {
+                "cpu": "1",
+                "memory": "2Gi",
+                "ephemeral-storage": ""
+              },
+              "limits": {
+                "cpu": "",
+                "memory": "",
+                "ephemeral-storage": ""
+              }
+            },
+            "templates": {},
+            "pvc": {
+              "size": "30Gi",
+              "storageClass": "",
+              "snapshotClass": ""
+            }
+          }
+        }
+      },
+      "content": {
+        "storage": {
+          "stage": "",
+          "kind": "minio",
+          "gcloud": {
+            "credentialsFile": "",
+            "region": "",
+            "projectId": ""
+          },
+          "minio": {
+            "endpoint": "minio.default.svc.cluster.local:9000",
+            "accessKey": "8-WGqw2oTnsPfUDNSk0Y",
+            "accessKeyFile": "",
+            "secretKey": "DpC.aSAxkWBPu2_bJ_AE",
+            "secretKeyFile": "",
+            "region": "local",
+            "parallelUpload": 6
+          },
+          "blobQuota": 5368709120
+        }
+      },
+      "rpcServer": {
+        "addr": ":8080",
+        "tls": {
+          "ca": "/certs/ca.crt",
+          "crt": "/certs/tls.crt",
+          "key": "/certs/tls.key"
+        },
+        "ratelimits": {}
+      },
+      "imageBuilderProxy": {
+        "targetAddr": "image-builder-mk3.default.svc.cluster.local:8080"
+      },
+      "pprof": {
+        "addr": "127.0.0.1:6060"
+      },
+      "prometheus": {
+        "addr": "127.0.0.1:9500"
+      }
+    }
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ws-manager
+  name: ws-manager
+  namespace: default
+---
+# v1/ConfigMap ws-manager-bridge-config
+apiVersion: v1
+data:
+  ws-manager-bridge.json: |-
+    {
+      "installation": "default",
+      "staticBridges": [
+        {
+          "name": "default",
+          "url": "dns:///ws-manager:8080",
+          "tls": {
+            "ca": "/ws-manager-client-tls-certs/ca.crt",
+            "crt": "/ws-manager-client-tls-certs/tls.crt",
+            "key": "/ws-manager-client-tls-certs/tls.key"
+          },
+          "state": "available",
+          "maxScore": 100,
+          "score": 50,
+          "govern": true,
+          "admissionConstraints": null
+        }
+      ],
+      "clusterService": {
+        "port": 8080,
+        "host": "localhost"
+      },
+      "wsClusterDBReconcileIntervalSeconds": 60,
+      "controllerIntervalSeconds": 60,
+      "controllerMaxDisconnectSeconds": 150,
+      "emulatePreparingIntervalSeconds": 10,
+      "timeouts": {
+        "preparingPhaseSeconds": 3600,
+        "buildingPhaseSeconds": 3600,
+        "unknownPhaseSeconds": 600
+      },
+      "clusterSyncIntervalSeconds": 60
+    }
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ws-manager-bridge
+  name: ws-manager-bridge-config
+  namespace: default
+---
+# v1/ConfigMap ws-proxy
+apiVersion: v1
+data:
+  config.json: |-
+    {
+      "ingress": {
+        "httpAddress": ":8080",
+        "httpsAddress": ":9090",
+        "header": "x-wsproxy-host"
+      },
+      "proxy": {
+        "https": {
+          "key": "/mnt/certificates/tls.key",
+          "crt": "/mnt/certificates/tls.crt"
+        },
+        "transportConfig": {
+          "connectTimeout": "10s",
+          "idleConnTimeout": "1m0s",
+          "maxIdleConns": 0,
+          "maxIdleConnsPerHost": 100
+        },
+        "blobServer": {
+          "scheme": "https",
+          "host": "ide.minimal-test.gitpod.com",
+          "pathPrefix": "/blobserve"
+        },
+        "gitpodInstallation": {
+          "scheme": "https",
+          "hostName": "minimal-test.gitpod.com",
+          "workspaceHostSuffix": ".ws.minimal-test.gitpod.com",
+          "workspaceHostSuffixRegex": "\\.ws[^\\.]*\\.minimal-test.gitpod.com"
+        },
+        "workspacePodConfig": {
+          "theiaPort": 23000,
+          "supervisorPort": 22999,
+          "supervisorImage": "eu.gcr.io/gitpod-core-dev/build/supervisor:test"
+        },
+        "builtinPages": {
+          "location": "/app/public"
+        }
+      },
+      "pprofAddr": "127.0.0.1:6060",
+      "prometheusAddr": "127.0.0.1:9500",
+      "readinessProbeAddr": ":8086",
+      "namespace": "default",
+      "wsManager": {
+        "addr": "ws-manager:8080",
+        "tls": {
+          "ca": "/ws-manager-client-tls-certs/ca.crt",
+          "crt": "/ws-manager-client-tls-certs/tls.crt",
+          "key": "/ws-manager-client-tls-certs/tls.key"
+        }
+      }
+    }
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ws-proxy
+  name: ws-proxy
+  namespace: default
+---
 # v1/PersistentVolumeClaim minio
 # Source: minio/charts/minio/templates/pvc.yaml
 kind: PersistentVolumeClaim
@@ -4487,6 +4487,93 @@ spec:
     requests:
       storage: "10Gi"
 ---
+# rbac.authorization.k8s.io/v1/ClusterRole default-kube-rbac-proxy
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: default-kube-rbac-proxy
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+---
+# rbac.authorization.k8s.io/v1/ClusterRole default-ns-image-builder-mk3
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: image-builder-mk3
+  name: default-ns-image-builder-mk3
+rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - default-ns-privileged-unconfined
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+---
+# rbac.authorization.k8s.io/v1/ClusterRole default-ns-psp:privileged
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: default-ns-psp:privileged
+rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - default-ns-privileged
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+---
+# rbac.authorization.k8s.io/v1/ClusterRole default-ns-psp:restricted-root-user
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: default-ns-psp:restricted-root-user
+rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - default-ns-restricted-root-user
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+---
+# rbac.authorization.k8s.io/v1/ClusterRole default-ns-psp:unprivileged
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: default-ns-psp:unprivileged
+rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - default-ns-unprivileged
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+---
 # rbac.authorization.k8s.io/v1/ClusterRole default-ns-registry-facade
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -4514,76 +4601,6 @@ rules:
   - list
   - update
   - patch
----
-# rbac.authorization.k8s.io/v1/ClusterRole default-kube-rbac-proxy
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  creationTimestamp: null
-  name: default-kube-rbac-proxy
-rules:
-- apiGroups:
-  - authentication.k8s.io
-  resources:
-  - tokenreviews
-  verbs:
-  - create
-- apiGroups:
-  - authorization.k8s.io
-  resources:
-  - subjectaccessreviews
-  verbs:
-  - create
----
-# rbac.authorization.k8s.io/v1/ClusterRole default-ns-psp:restricted-root-user
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  creationTimestamp: null
-  name: default-ns-psp:restricted-root-user
-rules:
-- apiGroups:
-  - policy
-  resourceNames:
-  - default-ns-restricted-root-user
-  resources:
-  - podsecuritypolicies
-  verbs:
-  - use
----
-# rbac.authorization.k8s.io/v1/ClusterRole ws-manager
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  creationTimestamp: null
-  labels:
-    app: gitpod
-    component: ws-manager
-  name: ws-manager
-  namespace: default
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - snapshot.storage.k8s.io
-  resources:
-  - volumesnapshotcontents
-  - volumesnapshotclasses
-  verbs:
-  - get
-  - list
-  - create
-  - update
-  - patch
-  - watch
-  - delete
-  - deletecollection
 ---
 # rbac.authorization.k8s.io/v1/ClusterRole default-ns-ws-daemon
 apiVersion: rbac.authorization.k8s.io/v1
@@ -4630,74 +4647,39 @@ rules:
   - update
   - patch
 ---
-# rbac.authorization.k8s.io/v1/ClusterRole default-ns-psp:unprivileged
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  creationTimestamp: null
-  name: default-ns-psp:unprivileged
-rules:
-- apiGroups:
-  - policy
-  resourceNames:
-  - default-ns-unprivileged
-  resources:
-  - podsecuritypolicies
-  verbs:
-  - use
----
-# rbac.authorization.k8s.io/v1/ClusterRole default-ns-image-builder-mk3
+# rbac.authorization.k8s.io/v1/ClusterRole ws-manager
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
   labels:
     app: gitpod
-    component: image-builder-mk3
-  name: default-ns-image-builder-mk3
-rules:
-- apiGroups:
-  - policy
-  resourceNames:
-  - default-ns-privileged-unconfined
-  resources:
-  - podsecuritypolicies
-  verbs:
-  - use
----
-# rbac.authorization.k8s.io/v1/ClusterRole default-ns-psp:privileged
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  creationTimestamp: null
-  name: default-ns-psp:privileged
-rules:
-- apiGroups:
-  - policy
-  resourceNames:
-  - default-ns-privileged
-  resources:
-  - podsecuritypolicies
-  verbs:
-  - use
----
-# rbac.authorization.k8s.io/v1/ClusterRoleBinding default-server-rb-kube-rbac-proxy
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  creationTimestamp: null
-  labels:
-    app: gitpod
-    component: server
-  name: default-server-rb-kube-rbac-proxy
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: default-kube-rbac-proxy
-subjects:
-- kind: ServiceAccount
-  name: server
+    component: ws-manager
+  name: ws-manager
   namespace: default
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotcontents
+  - volumesnapshotclasses
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - patch
+  - watch
+  - delete
+  - deletecollection
 ---
 # rbac.authorization.k8s.io/v1/ClusterRoleBinding default-agent-smith-rb-kube-rbac-proxy
 apiVersion: rbac.authorization.k8s.io/v1
@@ -4753,76 +4735,22 @@ subjects:
   name: image-builder-mk3
   namespace: default
 ---
-# rbac.authorization.k8s.io/v1/ClusterRoleBinding default-ws-daemon-rb
+# rbac.authorization.k8s.io/v1/ClusterRoleBinding default-openvsx-proxy-kube-rbac-proxy
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   creationTimestamp: null
   labels:
     app: gitpod
-    component: ws-daemon
-  name: default-ws-daemon-rb
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: default-ns-ws-daemon
-subjects:
-- kind: ServiceAccount
-  name: ws-daemon
-  namespace: default
----
-# rbac.authorization.k8s.io/v1/ClusterRoleBinding default-ws-manager-kube-rbac-proxy
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  creationTimestamp: null
-  labels:
-    app: gitpod
-    component: ws-manager
-  name: default-ws-manager-kube-rbac-proxy
+    component: openvsx-proxy
+  name: default-openvsx-proxy-kube-rbac-proxy
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: default-kube-rbac-proxy
 subjects:
 - kind: ServiceAccount
-  name: ws-manager
-  namespace: default
----
-# rbac.authorization.k8s.io/v1/ClusterRoleBinding default-registry-facade-rb
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  creationTimestamp: null
-  labels:
-    app: gitpod
-    component: registry-facade
-  name: default-registry-facade-rb
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: default-ns-registry-facade
-subjects:
-- kind: ServiceAccount
-  name: registry-facade
-  namespace: default
----
-# rbac.authorization.k8s.io/v1/ClusterRoleBinding default-registry-facade-kube-rbac-proxy
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  creationTimestamp: null
-  labels:
-    app: gitpod
-    component: registry-facade
-  name: default-registry-facade-kube-rbac-proxy
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: default-kube-rbac-proxy
-subjects:
-- kind: ServiceAccount
-  name: registry-facade
+  name: openvsx-proxy
   namespace: default
 ---
 # rbac.authorization.k8s.io/v1/ClusterRoleBinding default-proxy-kube-rbac-proxy
@@ -4843,22 +4771,76 @@ subjects:
   name: proxy
   namespace: default
 ---
-# rbac.authorization.k8s.io/v1/ClusterRoleBinding ws-manager
+# rbac.authorization.k8s.io/v1/ClusterRoleBinding default-registry-facade-kube-rbac-proxy
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   creationTimestamp: null
   labels:
     app: gitpod
-    component: ws-manager
-  name: ws-manager
+    component: registry-facade
+  name: default-registry-facade-kube-rbac-proxy
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: ws-manager
+  name: default-kube-rbac-proxy
 subjects:
 - kind: ServiceAccount
-  name: ws-manager
+  name: registry-facade
+  namespace: default
+---
+# rbac.authorization.k8s.io/v1/ClusterRoleBinding default-registry-facade-rb
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: registry-facade
+  name: default-registry-facade-rb
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-ns-registry-facade
+subjects:
+- kind: ServiceAccount
+  name: registry-facade
+  namespace: default
+---
+# rbac.authorization.k8s.io/v1/ClusterRoleBinding default-server-rb-kube-rbac-proxy
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: server
+  name: default-server-rb-kube-rbac-proxy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-kube-rbac-proxy
+subjects:
+- kind: ServiceAccount
+  name: server
+  namespace: default
+---
+# rbac.authorization.k8s.io/v1/ClusterRoleBinding default-ws-daemon-rb
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ws-daemon
+  name: default-ws-daemon-rb
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-ns-ws-daemon
+subjects:
+- kind: ServiceAccount
+  name: ws-daemon
   namespace: default
 ---
 # rbac.authorization.k8s.io/v1/ClusterRoleBinding default-ws-daemon-rb-kube-rbac-proxy
@@ -4879,24 +4861,6 @@ subjects:
   name: ws-daemon
   namespace: default
 ---
-# rbac.authorization.k8s.io/v1/ClusterRoleBinding default-openvsx-proxy-kube-rbac-proxy
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  creationTimestamp: null
-  labels:
-    app: gitpod
-    component: openvsx-proxy
-  name: default-openvsx-proxy-kube-rbac-proxy
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: default-kube-rbac-proxy
-subjects:
-- kind: ServiceAccount
-  name: openvsx-proxy
-  namespace: default
----
 # rbac.authorization.k8s.io/v1/ClusterRoleBinding default-ws-manager-bridge-rb-kube-rbac-proxy
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -4913,6 +4877,24 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: ws-manager-bridge
+  namespace: default
+---
+# rbac.authorization.k8s.io/v1/ClusterRoleBinding default-ws-manager-kube-rbac-proxy
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ws-manager
+  name: default-ws-manager-kube-rbac-proxy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-kube-rbac-proxy
+subjects:
+- kind: ServiceAccount
+  name: ws-manager
   namespace: default
 ---
 # rbac.authorization.k8s.io/v1/ClusterRoleBinding default-ws-proxy-kube-rbac-proxy
@@ -4932,6 +4914,126 @@ subjects:
 - kind: ServiceAccount
   name: ws-proxy
   namespace: default
+---
+# rbac.authorization.k8s.io/v1/ClusterRoleBinding ws-manager
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ws-manager
+  name: ws-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ws-manager
+subjects:
+- kind: ServiceAccount
+  name: ws-manager
+  namespace: default
+---
+# rbac.authorization.k8s.io/v1/Role agent-smith
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: agent-smith
+  name: agent-smith
+  namespace: default
+rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - default-ns-privileged-unconfined
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - update
+---
+# rbac.authorization.k8s.io/v1/Role messagebus-endpoint-reader
+# Source: rabbitmq/charts/rabbitmq/templates/role.yaml
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: messagebus-endpoint-reader
+  namespace: "default"
+  labels:
+    app.kubernetes.io/name: rabbitmq
+    helm.sh/chart: rabbitmq-10.1.1
+    app.kubernetes.io/instance: RabbitMQ
+    app.kubernetes.io/managed-by: Helm
+rules:
+  - apiGroups: [""]
+    resources: ["endpoints"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create"]
+---
+# rbac.authorization.k8s.io/v1/Role server
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: server
+  name: server
+  namespace: default
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - patch
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - pods/log
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - patch
+  - watch
+---
+# rbac.authorization.k8s.io/v1/Role workspace
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: workspace
+  name: workspace
+  namespace: default
+rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - default-ns-workspace
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
 ---
 # rbac.authorization.k8s.io/v1/Role ws-manager
 apiVersion: rbac.authorization.k8s.io/v1
@@ -5007,29 +5109,187 @@ rules:
   - list
   - watch
 ---
-# rbac.authorization.k8s.io/v1/Role workspace
+# rbac.authorization.k8s.io/v1/RoleBinding agent-smith
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: RoleBinding
 metadata:
   creationTimestamp: null
   labels:
     app: gitpod
-    component: workspace
-  name: workspace
+    component: agent-smith
+  name: agent-smith
   namespace: default
-rules:
-- apiGroups:
-  - policy
-  resourceNames:
-  - default-ns-workspace
-  resources:
-  - podsecuritypolicies
-  verbs:
-  - use
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: agent-smith
+subjects:
+- kind: ServiceAccount
+  name: agent-smith
 ---
-# rbac.authorization.k8s.io/v1/Role messagebus-endpoint-reader
-# Source: rabbitmq/charts/rabbitmq/templates/role.yaml
-kind: Role
+# rbac.authorization.k8s.io/v1/RoleBinding blobserve
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: blobserve
+  name: blobserve
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-ns-psp:restricted-root-user
+subjects:
+- kind: ServiceAccount
+  name: blobserve
+---
+# rbac.authorization.k8s.io/v1/RoleBinding content-service
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: content-service
+  name: content-service
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-ns-psp:restricted-root-user
+subjects:
+- kind: ServiceAccount
+  name: content-service
+---
+# rbac.authorization.k8s.io/v1/RoleBinding dashboard
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: dashboard
+  name: dashboard
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-ns-psp:restricted-root-user
+subjects:
+- kind: ServiceAccount
+  name: dashboard
+---
+# rbac.authorization.k8s.io/v1/RoleBinding db
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: db
+  name: db
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-ns-psp:restricted-root-user
+subjects:
+- kind: ServiceAccount
+  name: db
+---
+# rbac.authorization.k8s.io/v1/RoleBinding default-ns-nobody
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  name: default-ns-nobody
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-ns-psp:unprivileged
+subjects:
+- kind: ServiceAccount
+  name: nobody
+  namespace: default
+---
+# rbac.authorization.k8s.io/v1/RoleBinding docker-registry
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: docker-registry
+  name: docker-registry
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-ns-psp:restricted-root-user
+subjects:
+- kind: ServiceAccount
+  name: docker-registry
+---
+# rbac.authorization.k8s.io/v1/RoleBinding gitpod
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: gitpod
+  name: gitpod
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-ns-psp:restricted-root-user
+subjects:
+- kind: ServiceAccount
+  name: gitpod
+---
+# rbac.authorization.k8s.io/v1/RoleBinding ide-proxy
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ide-proxy
+  name: ide-proxy
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-ns-psp:restricted-root-user
+subjects:
+- kind: ServiceAccount
+  name: ide-proxy
+---
+# rbac.authorization.k8s.io/v1/RoleBinding image-builder-mk3
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: image-builder-mk3
+  name: image-builder-mk3
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-ns-image-builder-mk3
+subjects:
+- kind: ServiceAccount
+  name: image-builder-mk3
+---
+# rbac.authorization.k8s.io/v1/RoleBinding messagebus-endpoint-reader
+# Source: rabbitmq/charts/rabbitmq/templates/rolebinding.yaml
+kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: messagebus-endpoint-reader
@@ -5039,93 +5299,31 @@ metadata:
     helm.sh/chart: rabbitmq-10.1.1
     app.kubernetes.io/instance: RabbitMQ
     app.kubernetes.io/managed-by: Helm
-rules:
-  - apiGroups: [""]
-    resources: ["endpoints"]
-    verbs: ["get"]
-  - apiGroups: [""]
-    resources: ["events"]
-    verbs: ["create"]
+subjects:
+  - kind: ServiceAccount
+    name: rabbitmq
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: messagebus-endpoint-reader
 ---
-# rbac.authorization.k8s.io/v1/Role agent-smith
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  creationTimestamp: null
-  labels:
-    app: gitpod
-    component: agent-smith
-  name: agent-smith
-  namespace: default
-rules:
-- apiGroups:
-  - policy
-  resourceNames:
-  - default-ns-privileged-unconfined
-  resources:
-  - podsecuritypolicies
-  verbs:
-  - use
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  verbs:
-  - get
-  - update
----
-# rbac.authorization.k8s.io/v1/Role server
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  creationTimestamp: null
-  labels:
-    app: gitpod
-    component: server
-  name: server
-  namespace: default
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - services
-  verbs:
-  - get
-  - list
-  - create
-  - update
-  - patch
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - pods/log
-  verbs:
-  - get
-  - list
-  - create
-  - update
-  - patch
-  - watch
----
-# rbac.authorization.k8s.io/v1/RoleBinding ws-proxy-api
+# rbac.authorization.k8s.io/v1/RoleBinding migrations
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   creationTimestamp: null
   labels:
     app: gitpod
-    component: ws-proxy
-  name: ws-proxy-api
+    component: migrations
+  name: migrations
   namespace: default
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: ws-proxy
+  kind: ClusterRole
+  name: default-ns-psp:restricted-root-user
 subjects:
 - kind: ServiceAccount
-  name: ws-proxy
+  name: migrations
 ---
 # rbac.authorization.k8s.io/v1/RoleBinding minio
 apiVersion: rbac.authorization.k8s.io/v1
@@ -5163,134 +5361,6 @@ subjects:
 - kind: ServiceAccount
   name: openvsx-proxy
 ---
-# rbac.authorization.k8s.io/v1/RoleBinding blobserve
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  creationTimestamp: null
-  labels:
-    app: gitpod
-    component: blobserve
-  name: blobserve
-  namespace: default
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: default-ns-psp:restricted-root-user
-subjects:
-- kind: ServiceAccount
-  name: blobserve
----
-# rbac.authorization.k8s.io/v1/RoleBinding migrations
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  creationTimestamp: null
-  labels:
-    app: gitpod
-    component: migrations
-  name: migrations
-  namespace: default
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: default-ns-psp:restricted-root-user
-subjects:
-- kind: ServiceAccount
-  name: migrations
----
-# rbac.authorization.k8s.io/v1/RoleBinding dashboard
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  creationTimestamp: null
-  labels:
-    app: gitpod
-    component: dashboard
-  name: dashboard
-  namespace: default
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: default-ns-psp:restricted-root-user
-subjects:
-- kind: ServiceAccount
-  name: dashboard
----
-# rbac.authorization.k8s.io/v1/RoleBinding messagebus-endpoint-reader
-# Source: rabbitmq/charts/rabbitmq/templates/rolebinding.yaml
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: messagebus-endpoint-reader
-  namespace: "default"
-  labels:
-    app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
-    app.kubernetes.io/instance: RabbitMQ
-    app.kubernetes.io/managed-by: Helm
-subjects:
-  - kind: ServiceAccount
-    name: rabbitmq
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: messagebus-endpoint-reader
----
-# rbac.authorization.k8s.io/v1/RoleBinding docker-registry
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  creationTimestamp: null
-  labels:
-    app: gitpod
-    component: docker-registry
-  name: docker-registry
-  namespace: default
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: default-ns-psp:restricted-root-user
-subjects:
-- kind: ServiceAccount
-  name: docker-registry
----
-# rbac.authorization.k8s.io/v1/RoleBinding ide-proxy
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  creationTimestamp: null
-  labels:
-    app: gitpod
-    component: ide-proxy
-  name: ide-proxy
-  namespace: default
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: default-ns-psp:restricted-root-user
-subjects:
-- kind: ServiceAccount
-  name: ide-proxy
----
-# rbac.authorization.k8s.io/v1/RoleBinding workspace
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  creationTimestamp: null
-  labels:
-    app: gitpod
-    component: workspace
-  name: workspace
-  namespace: default
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: workspace
-subjects:
-- kind: ServiceAccount
-  name: workspace
----
 # rbac.authorization.k8s.io/v1/RoleBinding proxy
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -5308,60 +5378,6 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: proxy
----
-# rbac.authorization.k8s.io/v1/RoleBinding ws-proxy
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  creationTimestamp: null
-  labels:
-    app: gitpod
-    component: ws-proxy
-  name: ws-proxy
-  namespace: default
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: default-ns-psp:unprivileged
-subjects:
-- kind: ServiceAccount
-  name: ws-proxy
----
-# rbac.authorization.k8s.io/v1/RoleBinding image-builder-mk3
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  creationTimestamp: null
-  labels:
-    app: gitpod
-    component: image-builder-mk3
-  name: image-builder-mk3
-  namespace: default
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: default-ns-image-builder-mk3
-subjects:
-- kind: ServiceAccount
-  name: image-builder-mk3
----
-# rbac.authorization.k8s.io/v1/RoleBinding ws-manager
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  creationTimestamp: null
-  labels:
-    app: gitpod
-    component: ws-manager
-  name: ws-manager
-  namespace: default
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: ws-manager
-subjects:
-- kind: ServiceAccount
-  name: ws-manager
 ---
 # rbac.authorization.k8s.io/v1/RoleBinding rabbitmq
 apiVersion: rbac.authorization.k8s.io/v1
@@ -5381,42 +5397,6 @@ subjects:
 - kind: ServiceAccount
   name: rabbitmq
 ---
-# rbac.authorization.k8s.io/v1/RoleBinding content-service
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  creationTimestamp: null
-  labels:
-    app: gitpod
-    component: content-service
-  name: content-service
-  namespace: default
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: default-ns-psp:restricted-root-user
-subjects:
-- kind: ServiceAccount
-  name: content-service
----
-# rbac.authorization.k8s.io/v1/RoleBinding agent-smith
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  creationTimestamp: null
-  labels:
-    app: gitpod
-    component: agent-smith
-  name: agent-smith
-  namespace: default
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: agent-smith
-subjects:
-- kind: ServiceAccount
-  name: agent-smith
----
 # rbac.authorization.k8s.io/v1/RoleBinding server
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -5434,58 +5414,6 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: server
----
-# rbac.authorization.k8s.io/v1/RoleBinding ws-manager-unpriviledged
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  creationTimestamp: null
-  labels:
-    app: gitpod
-    component: ws-manager
-  name: ws-manager-unpriviledged
-  namespace: default
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: default-ns-psp:unprivileged
-subjects:
-- kind: ServiceAccount
-  name: ws-manager
----
-# rbac.authorization.k8s.io/v1/RoleBinding db
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  creationTimestamp: null
-  labels:
-    app: gitpod
-    component: db
-  name: db
-  namespace: default
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: default-ns-psp:restricted-root-user
-subjects:
-- kind: ServiceAccount
-  name: db
----
-# rbac.authorization.k8s.io/v1/RoleBinding default-ns-nobody
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  creationTimestamp: null
-  name: default-ns-nobody
-  namespace: default
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: default-ns-psp:unprivileged
-subjects:
-- kind: ServiceAccount
-  name: nobody
-  namespace: default
 ---
 # rbac.authorization.k8s.io/v1/RoleBinding server-unprivileged
 apiVersion: rbac.authorization.k8s.io/v1
@@ -5505,6 +5433,42 @@ subjects:
 - kind: ServiceAccount
   name: server
 ---
+# rbac.authorization.k8s.io/v1/RoleBinding workspace
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: workspace
+  name: workspace
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: workspace
+subjects:
+- kind: ServiceAccount
+  name: workspace
+---
+# rbac.authorization.k8s.io/v1/RoleBinding ws-manager
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ws-manager
+  name: ws-manager
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ws-manager
+subjects:
+- kind: ServiceAccount
+  name: ws-manager
+---
 # rbac.authorization.k8s.io/v1/RoleBinding ws-manager-bridge
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -5523,203 +5487,80 @@ subjects:
 - kind: ServiceAccount
   name: ws-manager-bridge
 ---
-# rbac.authorization.k8s.io/v1/RoleBinding gitpod
+# rbac.authorization.k8s.io/v1/RoleBinding ws-manager-unpriviledged
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   creationTimestamp: null
   labels:
     app: gitpod
-    component: gitpod
-  name: gitpod
+    component: ws-manager
+  name: ws-manager-unpriviledged
   namespace: default
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: default-ns-psp:restricted-root-user
+  name: default-ns-psp:unprivileged
 subjects:
 - kind: ServiceAccount
-  name: gitpod
+  name: ws-manager
 ---
-# v1/Service openvsx-proxy
-apiVersion: v1
-kind: Service
-metadata:
-  creationTimestamp: null
-  labels:
-    app: gitpod
-    component: openvsx-proxy
-    kind: service
-  name: openvsx-proxy
-  namespace: default
-spec:
-  ports:
-  - name: http
-    port: 8080
-    protocol: TCP
-    targetPort: 8080
-  - name: metrics
-    port: 9500
-    protocol: TCP
-    targetPort: 9500
-  selector:
-    app: gitpod
-    component: openvsx-proxy
-  type: ClusterIP
-status:
-  loadBalancer: {}
----
-# v1/Service dashboard
-apiVersion: v1
-kind: Service
-metadata:
-  creationTimestamp: null
-  labels:
-    app: gitpod
-    component: dashboard
-    kind: service
-  name: dashboard
-  namespace: default
-spec:
-  ports:
-  - name: http
-    port: 3001
-    protocol: TCP
-    targetPort: 80
-  selector:
-    app: gitpod
-    component: dashboard
-  type: ClusterIP
-status:
-  loadBalancer: {}
----
-# v1/Service ws-proxy
-apiVersion: v1
-kind: Service
+# rbac.authorization.k8s.io/v1/RoleBinding ws-proxy
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
 metadata:
   creationTimestamp: null
   labels:
     app: gitpod
     component: ws-proxy
-    kind: service
   name: ws-proxy
   namespace: default
-spec:
-  ports:
-  - name: http-proxy
-    port: 8080
-    protocol: TCP
-    targetPort: 8080
-  - name: https-proxy
-    port: 9090
-    protocol: TCP
-    targetPort: 9090
-  - name: metrics
-    port: 9500
-    protocol: TCP
-    targetPort: 9500
-  - name: ssh
-    port: 22
-    protocol: TCP
-    targetPort: 2200
-  selector:
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-ns-psp:unprivileged
+subjects:
+- kind: ServiceAccount
+  name: ws-proxy
+---
+# rbac.authorization.k8s.io/v1/RoleBinding ws-proxy-api
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
     app: gitpod
     component: ws-proxy
-  type: ClusterIP
-status:
-  loadBalancer: {}
+  name: ws-proxy-api
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ws-proxy
+subjects:
+- kind: ServiceAccount
+  name: ws-proxy
 ---
-# v1/Service minio
-# Source: minio/charts/minio/templates/service.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: minio
-  namespace: "default"
-  labels:
-    app.kubernetes.io/name: minio
-    helm.sh/chart: minio-11.6.3
-    app.kubernetes.io/instance: Minio
-    app.kubernetes.io/managed-by: Helm
-spec:
-  type: ClusterIP
-  ports:
-    - name: minio-api
-      port: 9000
-      targetPort: minio-api
-      nodePort: null
-    - name: minio-console
-      port: 9001
-      targetPort: minio-console
-      nodePort: null
-  selector:
-    app.kubernetes.io/name: minio
-    app.kubernetes.io/instance: Minio
----
-# v1/Service ws-manager
+# v1/Service blobserve
 apiVersion: v1
 kind: Service
 metadata:
   creationTimestamp: null
   labels:
     app: gitpod
-    component: ws-manager
+    component: blobserve
     kind: service
-  name: ws-manager
+  name: blobserve
   namespace: default
 spec:
   ports:
-  - name: rpc
-    port: 8080
+  - name: service
+    port: 4000
     protocol: TCP
-    targetPort: 8080
+    targetPort: 32224
   selector:
     app: gitpod
-    component: ws-manager
-  type: ClusterIP
-status:
-  loadBalancer: {}
----
-# v1/Service ide-proxy
-apiVersion: v1
-kind: Service
-metadata:
-  creationTimestamp: null
-  labels:
-    app: gitpod
-    component: ide-proxy
-    kind: service
-  name: ide-proxy
-  namespace: default
-spec:
-  ports:
-  - name: http
-    port: 80
-    protocol: TCP
-    targetPort: 80
-  selector:
-    app: gitpod
-    component: ide-proxy
-  type: ClusterIP
-status:
-  loadBalancer: {}
----
-# v1/Service ws-daemon
-apiVersion: v1
-kind: Service
-metadata:
-  creationTimestamp: null
-  labels:
-    app: gitpod
-    component: ws-daemon
-    kind: service
-  name: ws-daemon
-  namespace: default
-spec:
-  clusterIP: None
-  selector:
-    app: gitpod
-    component: ws-daemon
+    component: blobserve
   type: ClusterIP
 status:
   loadBalancer: {}
@@ -5752,64 +5593,74 @@ spec:
 status:
   loadBalancer: {}
 ---
-# v1/Service registry-facade
+# v1/Service dashboard
 apiVersion: v1
 kind: Service
 metadata:
   creationTimestamp: null
   labels:
     app: gitpod
-    component: registry-facade
+    component: dashboard
     kind: service
-  name: registry-facade
+  name: dashboard
   namespace: default
 spec:
   ports:
-  - name: registry
-    port: 20000
+  - name: http
+    port: 3001
     protocol: TCP
-    targetPort: 32223
+    targetPort: 80
   selector:
     app: gitpod
-    component: registry-facade
+    component: dashboard
   type: ClusterIP
 status:
   loadBalancer: {}
 ---
-# v1/Service messagebus-headless
-# Source: rabbitmq/charts/rabbitmq/templates/svc-headless.yaml
+# v1/Service db
 apiVersion: v1
 kind: Service
 metadata:
-  name: messagebus-headless
-  namespace: "default"
+  creationTimestamp: null
   labels:
-    app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
-    app.kubernetes.io/instance: RabbitMQ
-    app.kubernetes.io/managed-by: Helm
+    app: gitpod
+    component: db
+  name: db
+  namespace: default
 spec:
-  clusterIP: None
   ports:
-    - name: epmd
-      port: 4369
-      targetPort: epmd
-    - name: amqp
-      port: 5672
-      targetPort: amqp
-    - name: amqp-ssl
-      port: 5671
-      targetPort: amqp-tls
-    - name: dist
-      port: 25672
-      targetPort: dist
-    - name: http-stats
-      port: 15672
-      targetPort: stats
-  selector: 
-    app.kubernetes.io/name: rabbitmq
-    app.kubernetes.io/instance: RabbitMQ
-  publishNotReadyAddresses: true
+  - port: 3306
+    protocol: TCP
+    targetPort: 3306
+  selector:
+    app.kubernetes.io/name: mysql
+  type: ClusterIP
+status:
+  loadBalancer: {}
+---
+# v1/Service ide-proxy
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ide-proxy
+    kind: service
+  name: ide-proxy
+  namespace: default
+spec:
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    app: gitpod
+    component: ide-proxy
+  type: ClusterIP
+status:
+  loadBalancer: {}
 ---
 # v1/Service image-builder-mk3
 apiVersion: v1
@@ -5879,6 +5730,68 @@ spec:
     app.kubernetes.io/name: rabbitmq
     app.kubernetes.io/instance: RabbitMQ
 ---
+# v1/Service messagebus-headless
+# Source: rabbitmq/charts/rabbitmq/templates/svc-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: messagebus-headless
+  namespace: "default"
+  labels:
+    app.kubernetes.io/name: rabbitmq
+    helm.sh/chart: rabbitmq-10.1.1
+    app.kubernetes.io/instance: RabbitMQ
+    app.kubernetes.io/managed-by: Helm
+spec:
+  clusterIP: None
+  ports:
+    - name: epmd
+      port: 4369
+      targetPort: epmd
+    - name: amqp
+      port: 5672
+      targetPort: amqp
+    - name: amqp-ssl
+      port: 5671
+      targetPort: amqp-tls
+    - name: dist
+      port: 25672
+      targetPort: dist
+    - name: http-stats
+      port: 15672
+      targetPort: stats
+  selector: 
+    app.kubernetes.io/name: rabbitmq
+    app.kubernetes.io/instance: RabbitMQ
+  publishNotReadyAddresses: true
+---
+# v1/Service minio
+# Source: minio/charts/minio/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio
+  namespace: "default"
+  labels:
+    app.kubernetes.io/name: minio
+    helm.sh/chart: minio-11.6.3
+    app.kubernetes.io/instance: Minio
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - name: minio-api
+      port: 9000
+      targetPort: minio-api
+      nodePort: null
+    - name: minio-console
+      port: 9001
+      targetPort: minio-console
+      nodePort: null
+  selector:
+    app.kubernetes.io/name: minio
+    app.kubernetes.io/instance: Minio
+---
 # v1/Service mysql
 # Source: mysql/charts/mysql/templates/primary/svc.yaml
 apiVersion: v1
@@ -5907,26 +5820,139 @@ spec:
     app.kubernetes.io/instance: MySQL
     app.kubernetes.io/component: primary
 ---
-# v1/Service blobserve
+# v1/Service mysql-headless
+# Source: mysql/charts/mysql/templates/primary/svc-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: mysql-headless
+  namespace: "default"
+  labels:
+    app.kubernetes.io/name: mysql
+    helm.sh/chart: mysql-9.1.2
+    app.kubernetes.io/instance: MySQL
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: primary
+  annotations:
+spec:
+  type: ClusterIP
+  clusterIP: None
+  publishNotReadyAddresses: true
+  ports:
+    - name: mysql
+      port: 3306
+      targetPort: mysql
+  selector: 
+    app.kubernetes.io/name: mysql
+    app.kubernetes.io/instance: MySQL
+    app.kubernetes.io/component: primary
+---
+# v1/Service openvsx-proxy
 apiVersion: v1
 kind: Service
 metadata:
   creationTimestamp: null
   labels:
     app: gitpod
-    component: blobserve
+    component: openvsx-proxy
     kind: service
-  name: blobserve
+  name: openvsx-proxy
   namespace: default
 spec:
   ports:
-  - name: service
-    port: 4000
+  - name: http
+    port: 8080
     protocol: TCP
-    targetPort: 32224
+    targetPort: 8080
+  - name: metrics
+    port: 9500
+    protocol: TCP
+    targetPort: 9500
   selector:
     app: gitpod
-    component: blobserve
+    component: openvsx-proxy
+  type: ClusterIP
+status:
+  loadBalancer: {}
+---
+# v1/Service proxy
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    cloud.google.com/neg: '{"exposed_ports": {"80":{},"443": {}}}'
+    external-dns.alpha.kubernetes.io/hostname: minimal-test.gitpod.com,*.minimal-test.gitpod.com,*.ws.minimal-test.gitpod.com
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: proxy
+    kind: service
+  name: proxy
+  namespace: default
+spec:
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  - name: https
+    port: 443
+    protocol: TCP
+    targetPort: 443
+  - name: metrics
+    port: 9500
+    protocol: TCP
+    targetPort: 9500
+  selector:
+    app: gitpod
+    component: proxy
+  type: LoadBalancer
+status:
+  loadBalancer: {}
+---
+# v1/Service registry
+# Source: docker-registry/charts/docker-registry/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: registry
+  namespace: default
+  labels:
+    app: docker-registry
+    chart: docker-registry-1.16.0
+    release: docker-registry
+    heritage: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 443
+      protocol: TCP
+      name: https-443
+      targetPort: 5000
+  selector:
+    app: docker-registry
+    release: docker-registry
+---
+# v1/Service registry-facade
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: registry-facade
+    kind: service
+  name: registry-facade
+  namespace: default
+spec:
+  ports:
+  - name: registry
+    port: 20000
+    protocol: TCP
+    targetPort: 32223
+  selector:
+    app: gitpod
+    component: registry-facade
   type: ClusterIP
 status:
   loadBalancer: {}
@@ -5971,111 +5997,405 @@ spec:
 status:
   loadBalancer: {}
 ---
-# v1/Service registry
-# Source: docker-registry/charts/docker-registry/templates/service.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: registry
-  namespace: default
-  labels:
-    app: docker-registry
-    chart: docker-registry-1.16.0
-    release: docker-registry
-    heritage: Helm
-spec:
-  type: ClusterIP
-  ports:
-    - port: 443
-      protocol: TCP
-      name: https-443
-      targetPort: 5000
-  selector:
-    app: docker-registry
-    release: docker-registry
----
-# v1/Service mysql-headless
-# Source: mysql/charts/mysql/templates/primary/svc-headless.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: mysql-headless
-  namespace: "default"
-  labels:
-    app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
-    app.kubernetes.io/instance: MySQL
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: primary
-  annotations:
-spec:
-  type: ClusterIP
-  clusterIP: None
-  publishNotReadyAddresses: true
-  ports:
-    - name: mysql
-      port: 3306
-      targetPort: mysql
-  selector: 
-    app.kubernetes.io/name: mysql
-    app.kubernetes.io/instance: MySQL
-    app.kubernetes.io/component: primary
----
-# v1/Service db
+# v1/Service ws-daemon
 apiVersion: v1
 kind: Service
 metadata:
   creationTimestamp: null
   labels:
     app: gitpod
-    component: db
-  name: db
+    component: ws-daemon
+    kind: service
+  name: ws-daemon
   namespace: default
 spec:
-  ports:
-  - port: 3306
-    protocol: TCP
-    targetPort: 3306
+  clusterIP: None
   selector:
-    app.kubernetes.io/name: mysql
+    app: gitpod
+    component: ws-daemon
   type: ClusterIP
 status:
   loadBalancer: {}
 ---
-# v1/Service proxy
+# v1/Service ws-manager
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    cloud.google.com/neg: '{"exposed_ports": {"80":{},"443": {}}}'
-    external-dns.alpha.kubernetes.io/hostname: minimal-test.gitpod.com,*.minimal-test.gitpod.com,*.ws.minimal-test.gitpod.com
   creationTimestamp: null
   labels:
     app: gitpod
-    component: proxy
+    component: ws-manager
     kind: service
-  name: proxy
+  name: ws-manager
   namespace: default
 spec:
   ports:
-  - name: http
-    port: 80
+  - name: rpc
+    port: 8080
     protocol: TCP
-    targetPort: 80
-  - name: https
-    port: 443
+    targetPort: 8080
+  selector:
+    app: gitpod
+    component: ws-manager
+  type: ClusterIP
+status:
+  loadBalancer: {}
+---
+# v1/Service ws-proxy
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ws-proxy
+    kind: service
+  name: ws-proxy
+  namespace: default
+spec:
+  ports:
+  - name: http-proxy
+    port: 8080
     protocol: TCP
-    targetPort: 443
+    targetPort: 8080
+  - name: https-proxy
+    port: 9090
+    protocol: TCP
+    targetPort: 9090
   - name: metrics
     port: 9500
     protocol: TCP
     targetPort: 9500
+  - name: ssh
+    port: 22
+    protocol: TCP
+    targetPort: 2200
   selector:
     app: gitpod
-    component: proxy
-  type: LoadBalancer
+    component: ws-proxy
+  type: ClusterIP
 status:
   loadBalancer: {}
+---
+# apps/v1/DaemonSet agent-smith
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  annotations:
+    gitpod.io/checksum_config: 6953509cf3cc9e054d55384d788fb0de0bd798b969d752d7e1c40b75de4b4a62
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: agent-smith
+  name: agent-smith
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      app: gitpod
+      component: agent-smith
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: agent-smith
+      name: agent-smith
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: gitpod.io/workload_workspace_regular
+                operator: Exists
+            - matchExpressions:
+              - key: gitpod.io/workload_workspace_headless
+                operator: Exists
+      containers:
+      - args:
+        - run
+        - --config
+        - /config/config.json
+        env:
+        - name: GITPOD_DOMAIN
+          value: minimal-test.gitpod.com
+        - name: GITPOD_INSTALLATION_SHORTNAME
+          value: default
+        - name: GITPOD_REGION
+          value: local
+        - name: HOST_URL
+          value: https://minimal-test.gitpod.com
+        - name: KUBE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: KUBE_DOMAIN
+          value: svc.cluster.local
+        - name: LOG_LEVEL
+          value: info
+        - name: JAEGER_DISABLED
+          value: "true"
+        - name: NODENAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        image: eu.gcr.io/gitpod-core-dev/build/agent-smith:test
+        imagePullPolicy: IfNotPresent
+        name: agent-smith
+        resources:
+          requests:
+            cpu: 100m
+            memory: 32Mi
+        securityContext:
+          privileged: true
+          procMount: Default
+        volumeMounts:
+        - mountPath: /config
+          name: config
+      - args:
+        - --logtostderr
+        - --insecure-listen-address=[$(IP)]:9500
+        - --upstream=http://127.0.0.1:9500/
+        env:
+        - name: IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay.io/brancz/kube-rbac-proxy:v0.12.0
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 9500
+          name: metrics
+        resources:
+          requests:
+            cpu: 1m
+            memory: 30Mi
+        securityContext:
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
+        terminationMessagePolicy: FallbackToLogsOnError
+      dnsPolicy: ClusterFirst
+      enableServiceLinks: false
+      hostPID: true
+      restartPolicy: Always
+      serviceAccountName: agent-smith
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - configMap:
+          name: agent-smith
+        name: config
+  updateStrategy: {}
+status:
+  currentNumberScheduled: 0
+  desiredNumberScheduled: 0
+  numberMisscheduled: 0
+  numberReady: 0
+---
+# apps/v1/DaemonSet registry-facade
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: registry-facade
+  name: registry-facade
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      app: gitpod
+      component: registry-facade
+  template:
+    metadata:
+      annotations:
+        gitpod.io/checksum_config: 1568539df3f78cad79c3dd7b7e3ae3f5cf4fa74ad7263936762f004a8a6af77c
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: registry-facade
+      name: registry-facade
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: gitpod.io/workload_workspace_regular
+                operator: Exists
+            - matchExpressions:
+              - key: gitpod.io/workload_workspace_headless
+                operator: Exists
+      containers:
+      - args:
+        - run
+        - /mnt/config/config.json
+        env:
+        - name: GITPOD_DOMAIN
+          value: minimal-test.gitpod.com
+        - name: GITPOD_INSTALLATION_SHORTNAME
+          value: default
+        - name: GITPOD_REGION
+          value: local
+        - name: HOST_URL
+          value: https://minimal-test.gitpod.com
+        - name: KUBE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: KUBE_DOMAIN
+          value: svc.cluster.local
+        - name: LOG_LEVEL
+          value: info
+        - name: JAEGER_DISABLED
+          value: "true"
+        - name: GRPC_GO_RETRY
+          value: "on"
+        - name: NODENAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        image: eu.gcr.io/gitpod-core-dev/build/registry-facade:test
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /live
+            port: 8086
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: registry-facade
+        ports:
+        - containerPort: 32223
+          hostPort: 20000
+          name: registry
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /ready
+            port: 8086
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          successThreshold: 2
+          timeoutSeconds: 1
+        resources:
+          requests:
+            cpu: 100m
+            memory: 32Mi
+        securityContext:
+          privileged: false
+          runAsUser: 1000
+        volumeMounts:
+        - mountPath: /mnt/cache
+          name: cache
+        - mountPath: /mnt/config
+          name: config
+          readOnly: true
+        - mountPath: /ws-manager-client-tls-certs
+          name: ws-manager-client-tls-certs
+          readOnly: true
+        - mountPath: /mnt/pull-secret.json
+          name: pull-secret
+          subPath: .dockerconfigjson
+        - mountPath: /mnt/certificates
+          name: config-certificates
+      - args:
+        - --logtostderr
+        - --insecure-listen-address=[$(IP)]:9500
+        - --upstream=http://127.0.0.1:9500/
+        env:
+        - name: IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay.io/brancz/kube-rbac-proxy:v0.12.0
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 9500
+          name: metrics
+        resources:
+          requests:
+            cpu: 1m
+            memory: 30Mi
+        securityContext:
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
+        terminationMessagePolicy: FallbackToLogsOnError
+      - command:
+        - /app/ready-probe-labeler
+        - --label=gitpod.io/registry-facade_ready_ns_default
+        - --probe-url=http://localhost:8086/ready
+        env:
+        - name: NODENAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        image: eu.gcr.io/gitpod-core-dev/build/registry-facade:test
+        imagePullPolicy: IfNotPresent
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /app/ready-probe-labeler
+              - --label=gitpod.io/registry-facade_ready_ns_default
+              - --shutdown
+        name: node-labeler
+        resources: {}
+      dnsPolicy: ClusterFirst
+      enableServiceLinks: false
+      initContainers:
+      - command:
+        - bash
+        - -c
+        - set -e; update-ca-certificates -f; cp /etc/ssl/certs/* /ssl-certs; echo
+          'OK'
+        image: eu.gcr.io/gitpod-core-dev/build/ca-updater:test
+        imagePullPolicy: IfNotPresent
+        name: update-ca-certificates
+        resources: {}
+        volumeMounts:
+        - mountPath: /ssl-certs
+          name: cacerts
+        - mountPath: /usr/local/share/ca-certificates/gitpod-ca.crt
+          name: gitpod-ca-certificate
+          subPath: ca.crt
+      priorityClassName: system-node-critical
+      restartPolicy: Always
+      serviceAccountName: registry-facade
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - emptyDir: {}
+        name: cache
+      - configMap:
+          name: registry-facade
+        name: config
+      - name: ws-manager-client-tls-certs
+        secret:
+          secretName: ws-manager-client-tls
+      - name: pull-secret
+        secret:
+          secretName: builtin-registry-auth
+      - hostPath:
+          path: /
+        name: hostfs
+      - emptyDir: {}
+        name: gitpod-ca-certificate
+      - emptyDir: {}
+        name: cacerts
+      - name: config-certificates
+        secret:
+          secretName: https-certificates
+  updateStrategy: {}
+status:
+  currentNumberScheduled: 0
+  desiredNumberScheduled: 0
+  numberMisscheduled: 0
+  numberReady: 0
 ---
 # apps/v1/DaemonSet ws-daemon
 apiVersion: apps/v1
@@ -6354,325 +6674,202 @@ status:
   numberMisscheduled: 0
   numberReady: 0
 ---
-# apps/v1/DaemonSet registry-facade
+# apps/v1/StatefulSet messagebus
+# Source: rabbitmq/charts/rabbitmq/templates/statefulset.yaml
 apiVersion: apps/v1
-kind: DaemonSet
+kind: StatefulSet
 metadata:
-  creationTimestamp: null
+  name: messagebus
+  namespace: "default"
   labels:
-    app: gitpod
-    component: registry-facade
-  name: registry-facade
-  namespace: default
+    app.kubernetes.io/name: rabbitmq
+    helm.sh/chart: rabbitmq-10.1.1
+    app.kubernetes.io/instance: RabbitMQ
+    app.kubernetes.io/managed-by: Helm
 spec:
+  serviceName: messagebus-headless
+  podManagementPolicy: OrderedReady
+  replicas: 1
+  updateStrategy:
+    type: RollingUpdate
   selector:
     matchLabels:
-      app: gitpod
-      component: registry-facade
+      app.kubernetes.io/name: rabbitmq
+      app.kubernetes.io/instance: RabbitMQ
   template:
     metadata:
-      annotations:
-        gitpod.io/checksum_config: 1568539df3f78cad79c3dd7b7e3ae3f5cf4fa74ad7263936762f004a8a6af77c
-      creationTimestamp: null
       labels:
-        app: gitpod
-        component: registry-facade
-      name: registry-facade
+        app.kubernetes.io/name: rabbitmq
+        helm.sh/chart: rabbitmq-10.1.1
+        app.kubernetes.io/instance: RabbitMQ
+        app.kubernetes.io/managed-by: Helm
+      annotations:
+        checksum/config: 57b71edd6161d27a16d419d0a972455d13b77c3e31b641c4f484619042487094
+        checksum/secret: 773b338bdf00459126d415b35270b6bef1889b16ccc4d4d11c3999afa781ccc8
+        prometheus.io/port: '9419'
+        prometheus.io/scrape: "true"
     spec:
+      
+      serviceAccountName: rabbitmq
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: gitpod.io/workload_workspace_regular
+              - key: gitpod.io/workload_meta
                 operator: Exists
-            - matchExpressions:
-              - key: gitpod.io/workload_workspace_headless
-                operator: Exists
+        
+      securityContext:
+        fsGroup: 1001
+      terminationGracePeriodSeconds: 120
+      initContainers:
       containers:
-      - args:
-        - run
-        - /mnt/config/config.json
-        env:
-        - name: GITPOD_DOMAIN
-          value: minimal-test.gitpod.com
-        - name: GITPOD_INSTALLATION_SHORTNAME
-          value: default
-        - name: GITPOD_REGION
-          value: local
-        - name: HOST_URL
-          value: https://minimal-test.gitpod.com
-        - name: KUBE_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: KUBE_DOMAIN
-          value: svc.cluster.local
-        - name: LOG_LEVEL
-          value: info
-        - name: JAEGER_DISABLED
-          value: "true"
-        - name: GRPC_GO_RETRY
-          value: "on"
-        - name: NODENAME
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
-        image: eu.gcr.io/gitpod-core-dev/build/registry-facade:test
-        imagePullPolicy: IfNotPresent
-        livenessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /live
-            port: 8086
-          initialDelaySeconds: 5
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 1
-        name: registry-facade
-        ports:
-        - containerPort: 32223
-          hostPort: 20000
-          name: registry
-        readinessProbe:
-          failureThreshold: 5
-          httpGet:
-            path: /ready
-            port: 8086
-          initialDelaySeconds: 5
-          periodSeconds: 5
-          successThreshold: 2
-          timeoutSeconds: 1
-        resources:
-          requests:
-            cpu: 100m
-            memory: 32Mi
-        securityContext:
-          privileged: false
-          runAsUser: 1000
-        volumeMounts:
-        - mountPath: /mnt/cache
-          name: cache
-        - mountPath: /mnt/config
-          name: config
-          readOnly: true
-        - mountPath: /ws-manager-client-tls-certs
-          name: ws-manager-client-tls-certs
-          readOnly: true
-        - mountPath: /mnt/pull-secret.json
-          name: pull-secret
-          subPath: .dockerconfigjson
-        - mountPath: /mnt/certificates
-          name: config-certificates
-      - args:
-        - --logtostderr
-        - --insecure-listen-address=[$(IP)]:9500
-        - --upstream=http://127.0.0.1:9500/
-        env:
-        - name: IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        image: quay.io/brancz/kube-rbac-proxy:v0.12.0
-        name: kube-rbac-proxy
-        ports:
-        - containerPort: 9500
-          name: metrics
-        resources:
-          requests:
-            cpu: 1m
-            memory: 30Mi
-        securityContext:
-          runAsGroup: 65532
-          runAsNonRoot: true
-          runAsUser: 65532
-        terminationMessagePolicy: FallbackToLogsOnError
-      - command:
-        - /app/ready-probe-labeler
-        - --label=gitpod.io/registry-facade_ready_ns_default
-        - --probe-url=http://localhost:8086/ready
-        env:
-        - name: NODENAME
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
-        image: eu.gcr.io/gitpod-core-dev/build/registry-facade:test
-        imagePullPolicy: IfNotPresent
-        lifecycle:
-          preStop:
+        - name: rabbitmq
+          image: docker.io/bitnami/rabbitmq:3.10.2-debian-10-r7
+          imagePullPolicy: "IfNotPresent"
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1001
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - /bin/bash
+                  - -ec
+                  - |
+                    if [[ -f /opt/bitnami/scripts/rabbitmq/nodeshutdown.sh ]]; then
+                        /opt/bitnami/scripts/rabbitmq/nodeshutdown.sh -t "120" -d "false"
+                    else
+                        rabbitmqctl stop_app
+                    fi
+          env:
+            - name: BITNAMI_DEBUG
+              value: "false"
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: MY_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: K8S_SERVICE_NAME
+              value: messagebus-headless
+            - name: K8S_ADDRESS_TYPE
+              value: hostname
+            - name: RABBITMQ_FORCE_BOOT
+              value: "no"
+            - name: RABBITMQ_NODE_NAME
+              value: "rabbit@$(MY_POD_NAME).$(K8S_SERVICE_NAME).$(MY_POD_NAMESPACE).svc.cluster.local"
+            - name: K8S_HOSTNAME_SUFFIX
+              value: ".$(K8S_SERVICE_NAME).$(MY_POD_NAMESPACE).svc.cluster.local"
+            - name: RABBITMQ_MNESIA_DIR
+              value: "/bitnami/rabbitmq/mnesia/$(RABBITMQ_NODE_NAME)"
+            - name: RABBITMQ_LDAP_ENABLE
+              value: "no"
+            - name: RABBITMQ_LOGS
+              value: "-"
+            - name: RABBITMQ_ULIMIT_NOFILES
+              value: "65536"
+            - name: RABBITMQ_USE_LONGNAME
+              value: "true"
+            - name: RABBITMQ_ERL_COOKIE
+              valueFrom:
+                secretKeyRef:
+                  name: messagebus-erlang-cookie
+                  key: rabbitmq-erlang-cookie
+            - name: RABBITMQ_LOAD_DEFINITIONS
+              value: "yes"
+            - name: RABBITMQ_DEFINITIONS_FILE
+              value: "/app/load_definition.json"
+            - name: RABBITMQ_SECURE_PASSWORD
+              value: "yes"
+            - name: RABBITMQ_USERNAME
+              value: "gitpod"
+            - name: RABBITMQ_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: messagebus
+                  key: rabbitmq-password
+            - name: RABBITMQ_PLUGINS
+              value: "rabbitmq_management, rabbitmq_peer_discovery_k8s, rabbitmq_prometheus"
+            - name: RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS
+              value: +sbwt none +sbwtdcpu none +sbwtdio none
+          envFrom:
+          ports:
+            - name: amqp
+              containerPort: 5672
+            - name: dist
+              containerPort: 25672
+            - name: stats
+              containerPort: 15672
+            - name: epmd
+              containerPort: 4369
+            - name: metrics
+              containerPort: 9419
+            - name: amqp-ssl
+              containerPort: 5671
+          livenessProbe:
+            failureThreshold: 6
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 20
             exec:
               command:
-              - /app/ready-probe-labeler
-              - --label=gitpod.io/registry-facade_ready_ns_default
-              - --shutdown
-        name: node-labeler
-        resources: {}
-      dnsPolicy: ClusterFirst
-      enableServiceLinks: false
-      initContainers:
-      - command:
-        - bash
-        - -c
-        - set -e; update-ca-certificates -f; cp /etc/ssl/certs/* /ssl-certs; echo
-          'OK'
-        image: eu.gcr.io/gitpod-core-dev/build/ca-updater:test
-        imagePullPolicy: IfNotPresent
-        name: update-ca-certificates
-        resources: {}
-        volumeMounts:
-        - mountPath: /ssl-certs
-          name: cacerts
-        - mountPath: /usr/local/share/ca-certificates/gitpod-ca.crt
-          name: gitpod-ca-certificate
-          subPath: ca.crt
-      priorityClassName: system-node-critical
-      restartPolicy: Always
-      serviceAccountName: registry-facade
-      terminationGracePeriodSeconds: 30
+                - /bin/bash
+                - -ec
+                - rabbitmq-diagnostics -q ping
+          readinessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 20
+            exec:
+              command:
+                - /bin/bash
+                - -ec
+                - rabbitmq-diagnostics -q check_running && rabbitmq-diagnostics -q check_local_alarms
+          resources:
+            limits: {}
+            requests: {}
+          volumeMounts:
+            - name: configuration
+              mountPath: /bitnami/rabbitmq/conf
+            - name: data
+              mountPath: /bitnami/rabbitmq/mnesia
+            - name: certs
+              mountPath: /opt/bitnami/rabbitmq/certs
+            - name: load-definition-volume
+              mountPath: /app
+              readOnly: true
       volumes:
-      - emptyDir: {}
-        name: cache
-      - configMap:
-          name: registry-facade
-        name: config
-      - name: ws-manager-client-tls-certs
-        secret:
-          secretName: ws-manager-client-tls
-      - name: pull-secret
-        secret:
-          secretName: builtin-registry-auth
-      - hostPath:
-          path: /
-        name: hostfs
-      - emptyDir: {}
-        name: gitpod-ca-certificate
-      - emptyDir: {}
-        name: cacerts
-      - name: config-certificates
-        secret:
-          secretName: https-certificates
-  updateStrategy: {}
-status:
-  currentNumberScheduled: 0
-  desiredNumberScheduled: 0
-  numberMisscheduled: 0
-  numberReady: 0
----
-# apps/v1/DaemonSet agent-smith
-apiVersion: apps/v1
-kind: DaemonSet
-metadata:
-  annotations:
-    gitpod.io/checksum_config: 6953509cf3cc9e054d55384d788fb0de0bd798b969d752d7e1c40b75de4b4a62
-  creationTimestamp: null
-  labels:
-    app: gitpod
-    component: agent-smith
-  name: agent-smith
-  namespace: default
-spec:
-  selector:
-    matchLabels:
-      app: gitpod
-      component: agent-smith
-  template:
-    metadata:
-      creationTimestamp: null
-      labels:
-        app: gitpod
-        component: agent-smith
-      name: agent-smith
-    spec:
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: gitpod.io/workload_workspace_regular
-                operator: Exists
-            - matchExpressions:
-              - key: gitpod.io/workload_workspace_headless
-                operator: Exists
-      containers:
-      - args:
-        - run
-        - --config
-        - /config/config.json
-        env:
-        - name: GITPOD_DOMAIN
-          value: minimal-test.gitpod.com
-        - name: GITPOD_INSTALLATION_SHORTNAME
-          value: default
-        - name: GITPOD_REGION
-          value: local
-        - name: HOST_URL
-          value: https://minimal-test.gitpod.com
-        - name: KUBE_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: KUBE_DOMAIN
-          value: svc.cluster.local
-        - name: LOG_LEVEL
-          value: info
-        - name: JAEGER_DISABLED
-          value: "true"
-        - name: NODENAME
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
-        image: eu.gcr.io/gitpod-core-dev/build/agent-smith:test
-        imagePullPolicy: IfNotPresent
-        name: agent-smith
-        resources:
-          requests:
-            cpu: 100m
-            memory: 32Mi
-        securityContext:
-          privileged: true
-          procMount: Default
-        volumeMounts:
-        - mountPath: /config
-          name: config
-      - args:
-        - --logtostderr
-        - --insecure-listen-address=[$(IP)]:9500
-        - --upstream=http://127.0.0.1:9500/
-        env:
-        - name: IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        image: quay.io/brancz/kube-rbac-proxy:v0.12.0
-        name: kube-rbac-proxy
-        ports:
-        - containerPort: 9500
-          name: metrics
-        resources:
-          requests:
-            cpu: 1m
-            memory: 30Mi
-        securityContext:
-          runAsGroup: 65532
-          runAsNonRoot: true
-          runAsUser: 65532
-        terminationMessagePolicy: FallbackToLogsOnError
-      dnsPolicy: ClusterFirst
-      enableServiceLinks: false
-      hostPID: true
-      restartPolicy: Always
-      serviceAccountName: agent-smith
-      terminationGracePeriodSeconds: 30
-      volumes:
-      - configMap:
-          name: agent-smith
-        name: config
-  updateStrategy: {}
-status:
-  currentNumberScheduled: 0
-  desiredNumberScheduled: 0
-  numberMisscheduled: 0
-  numberReady: 0
+        - name: certs
+          secret:
+            secretName: messagebus-certificates-secret-core
+            items:
+              - key: tls.crt
+                path: ca_certificate.pem
+              - key: tls.crt
+                path: server_certificate.pem
+              - key: tls.key
+                path: server_key.pem
+        - name: configuration
+          secret:
+            secretName: messagebus-config
+            items:
+              - key: rabbitmq.conf
+                path: rabbitmq.conf
+        - name: load-definition-volume
+          secret:
+            secretName: "load-definition"
+        - name: data
+          emptyDir: {}
 ---
 # apps/v1/StatefulSet mysql
 # Source: mysql/charts/mysql/templates/primary/statefulset.yaml
@@ -6976,202 +7173,143 @@ spec:
       status: {}
 
 ---
-# apps/v1/StatefulSet messagebus
-# Source: rabbitmq/charts/rabbitmq/templates/statefulset.yaml
+# apps/v1/Deployment blobserve
 apiVersion: apps/v1
-kind: StatefulSet
+kind: Deployment
 metadata:
-  name: messagebus
-  namespace: "default"
+  creationTimestamp: null
   labels:
-    app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
-    app.kubernetes.io/instance: RabbitMQ
-    app.kubernetes.io/managed-by: Helm
+    app: gitpod
+    component: blobserve
+  name: blobserve
+  namespace: default
 spec:
-  serviceName: messagebus-headless
-  podManagementPolicy: OrderedReady
   replicas: 1
-  updateStrategy:
-    type: RollingUpdate
   selector:
     matchLabels:
-      app.kubernetes.io/name: rabbitmq
-      app.kubernetes.io/instance: RabbitMQ
+      app: gitpod
+      component: blobserve
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
   template:
     metadata:
-      labels:
-        app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
-        app.kubernetes.io/instance: RabbitMQ
-        app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/config: 57b71edd6161d27a16d419d0a972455d13b77c3e31b641c4f484619042487094
-        checksum/secret: 773b338bdf00459126d415b35270b6bef1889b16ccc4d4d11c3999afa781ccc8
-        prometheus.io/port: '9419'
-        prometheus.io/scrape: "true"
+        gitpod.io/checksum_config: d2c36ebee01aaa9b448075b9c868cbf6abc18874d7cbc537c500683f1b6109ef
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: blobserve
+      name: blobserve
+      namespace: default
     spec:
-      
-      serviceAccountName: rabbitmq
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: gitpod.io/workload_meta
+              - key: gitpod.io/workload_workspace_services
                 operator: Exists
-        
-      securityContext:
-        fsGroup: 1001
-      terminationGracePeriodSeconds: 120
-      initContainers:
       containers:
-        - name: rabbitmq
-          image: docker.io/bitnami/rabbitmq:3.10.2-debian-10-r7
-          imagePullPolicy: "IfNotPresent"
-          securityContext:
-            runAsNonRoot: true
-            runAsUser: 1001
-          lifecycle:
-            preStop:
-              exec:
-                command:
-                  - /bin/bash
-                  - -ec
-                  - |
-                    if [[ -f /opt/bitnami/scripts/rabbitmq/nodeshutdown.sh ]]; then
-                        /opt/bitnami/scripts/rabbitmq/nodeshutdown.sh -t "120" -d "false"
-                    else
-                        rabbitmqctl stop_app
-                    fi
-          env:
-            - name: BITNAMI_DEBUG
-              value: "false"
-            - name: MY_POD_IP
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.podIP
-            - name: MY_POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: MY_POD_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: K8S_SERVICE_NAME
-              value: messagebus-headless
-            - name: K8S_ADDRESS_TYPE
-              value: hostname
-            - name: RABBITMQ_FORCE_BOOT
-              value: "no"
-            - name: RABBITMQ_NODE_NAME
-              value: "rabbit@$(MY_POD_NAME).$(K8S_SERVICE_NAME).$(MY_POD_NAMESPACE).svc.cluster.local"
-            - name: K8S_HOSTNAME_SUFFIX
-              value: ".$(K8S_SERVICE_NAME).$(MY_POD_NAMESPACE).svc.cluster.local"
-            - name: RABBITMQ_MNESIA_DIR
-              value: "/bitnami/rabbitmq/mnesia/$(RABBITMQ_NODE_NAME)"
-            - name: RABBITMQ_LDAP_ENABLE
-              value: "no"
-            - name: RABBITMQ_LOGS
-              value: "-"
-            - name: RABBITMQ_ULIMIT_NOFILES
-              value: "65536"
-            - name: RABBITMQ_USE_LONGNAME
-              value: "true"
-            - name: RABBITMQ_ERL_COOKIE
-              valueFrom:
-                secretKeyRef:
-                  name: messagebus-erlang-cookie
-                  key: rabbitmq-erlang-cookie
-            - name: RABBITMQ_LOAD_DEFINITIONS
-              value: "yes"
-            - name: RABBITMQ_DEFINITIONS_FILE
-              value: "/app/load_definition.json"
-            - name: RABBITMQ_SECURE_PASSWORD
-              value: "yes"
-            - name: RABBITMQ_USERNAME
-              value: "gitpod"
-            - name: RABBITMQ_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: messagebus
-                  key: rabbitmq-password
-            - name: RABBITMQ_PLUGINS
-              value: "rabbitmq_management, rabbitmq_peer_discovery_k8s, rabbitmq_prometheus"
-            - name: RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS
-              value: +sbwt none +sbwtdcpu none +sbwtdio none
-          envFrom:
-          ports:
-            - name: amqp
-              containerPort: 5672
-            - name: dist
-              containerPort: 25672
-            - name: stats
-              containerPort: 15672
-            - name: epmd
-              containerPort: 4369
-            - name: metrics
-              containerPort: 9419
-            - name: amqp-ssl
-              containerPort: 5671
-          livenessProbe:
-            failureThreshold: 6
-            initialDelaySeconds: 30
-            periodSeconds: 30
-            successThreshold: 1
-            timeoutSeconds: 20
-            exec:
-              command:
-                - /bin/bash
-                - -ec
-                - rabbitmq-diagnostics -q ping
-          readinessProbe:
-            failureThreshold: 3
-            initialDelaySeconds: 10
-            periodSeconds: 30
-            successThreshold: 1
-            timeoutSeconds: 20
-            exec:
-              command:
-                - /bin/bash
-                - -ec
-                - rabbitmq-diagnostics -q check_running && rabbitmq-diagnostics -q check_local_alarms
-          resources:
-            limits: {}
-            requests: {}
-          volumeMounts:
-            - name: configuration
-              mountPath: /bitnami/rabbitmq/conf
-            - name: data
-              mountPath: /bitnami/rabbitmq/mnesia
-            - name: certs
-              mountPath: /opt/bitnami/rabbitmq/certs
-            - name: load-definition-volume
-              mountPath: /app
-              readOnly: true
+      - args:
+        - run
+        - /mnt/config/config.json
+        env:
+        - name: GITPOD_DOMAIN
+          value: minimal-test.gitpod.com
+        - name: GITPOD_INSTALLATION_SHORTNAME
+          value: default
+        - name: GITPOD_REGION
+          value: local
+        - name: HOST_URL
+          value: https://minimal-test.gitpod.com
+        - name: KUBE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: KUBE_DOMAIN
+          value: svc.cluster.local
+        - name: LOG_LEVEL
+          value: info
+        - name: JAEGER_DISABLED
+          value: "true"
+        image: eu.gcr.io/gitpod-core-dev/build/blobserve:test
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /live
+            port: 8086
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: blobserve
+        ports:
+        - containerPort: 32224
+          name: service
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /ready
+            port: 8086
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          requests:
+            cpu: 100m
+            memory: 32Mi
+        securityContext:
+          privileged: false
+          runAsUser: 1000
+        volumeMounts:
+        - mountPath: /mnt/config
+          name: config
+          readOnly: true
+        - mountPath: /mnt/cache
+          name: cache
+        - mountPath: /mnt/pull-secret.json
+          name: pull-secret
+          subPath: .dockerconfigjson
+      - args:
+        - --logtostderr
+        - --insecure-listen-address=[$(IP)]:9500
+        - --upstream=http://127.0.0.1:9500/
+        env:
+        - name: IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay.io/brancz/kube-rbac-proxy:v0.12.0
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 9500
+          name: metrics
+        resources:
+          requests:
+            cpu: 1m
+            memory: 30Mi
+        securityContext:
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
+        terminationMessagePolicy: FallbackToLogsOnError
+      enableServiceLinks: false
+      serviceAccountName: blobserve
       volumes:
-        - name: certs
-          secret:
-            secretName: messagebus-certificates-secret-core
-            items:
-              - key: tls.crt
-                path: ca_certificate.pem
-              - key: tls.crt
-                path: server_certificate.pem
-              - key: tls.key
-                path: server_key.pem
-        - name: configuration
-          secret:
-            secretName: messagebus-config
-            items:
-              - key: rabbitmq.conf
-                path: rabbitmq.conf
-        - name: load-definition-volume
-          secret:
-            secretName: "load-definition"
-        - name: data
-          emptyDir: {}
+      - emptyDir: {}
+        name: cache
+      - configMap:
+          name: blobserve
+        name: config
+      - name: pull-secret
+        secret:
+          secretName: builtin-registry-auth
+status: {}
 ---
 # apps/v1/Deployment content-service
 apiVersion: apps/v1
@@ -7290,6 +7428,668 @@ spec:
           name: content-service
         name: config
 status: {}
+---
+# apps/v1/Deployment dashboard
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: dashboard
+  name: dashboard
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gitpod
+      component: dashboard
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: dashboard
+      name: dashboard
+      namespace: default
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: gitpod.io/workload_meta
+                operator: Exists
+      containers:
+      - env:
+        - name: GITPOD_DOMAIN
+          value: minimal-test.gitpod.com
+        - name: GITPOD_INSTALLATION_SHORTNAME
+          value: default
+        - name: GITPOD_REGION
+          value: local
+        - name: HOST_URL
+          value: https://minimal-test.gitpod.com
+        - name: KUBE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: KUBE_DOMAIN
+          value: svc.cluster.local
+        - name: LOG_LEVEL
+          value: info
+        image: eu.gcr.io/gitpod-core-dev/build/dashboard:test
+        imagePullPolicy: IfNotPresent
+        name: dashboard
+        ports:
+        - containerPort: 80
+          name: http
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /ready
+            port: 8080
+            scheme: HTTP
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          requests:
+            cpu: 100m
+            memory: 32Mi
+        securityContext:
+          privileged: false
+      dnsPolicy: ClusterFirst
+      enableServiceLinks: false
+      restartPolicy: Always
+      serviceAccountName: dashboard
+      terminationGracePeriodSeconds: 30
+status: {}
+---
+# apps/v1/Deployment ide-proxy
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ide-proxy
+  name: ide-proxy
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gitpod
+      component: ide-proxy
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ide-proxy
+      name: ide-proxy
+      namespace: default
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: gitpod.io/workload_meta
+                operator: Exists
+      containers:
+      - env:
+        - name: GITPOD_DOMAIN
+          value: minimal-test.gitpod.com
+        - name: GITPOD_INSTALLATION_SHORTNAME
+          value: default
+        - name: GITPOD_REGION
+          value: local
+        - name: HOST_URL
+          value: https://minimal-test.gitpod.com
+        - name: KUBE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: KUBE_DOMAIN
+          value: svc.cluster.local
+        - name: LOG_LEVEL
+          value: info
+        image: eu.gcr.io/gitpod-core-dev/build/ide-proxy:test
+        imagePullPolicy: IfNotPresent
+        name: ide-proxy
+        ports:
+        - containerPort: 80
+          name: http
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /ready
+            port: 8080
+            scheme: HTTP
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          requests:
+            cpu: 100m
+            memory: 32Mi
+        securityContext:
+          privileged: false
+      dnsPolicy: ClusterFirst
+      enableServiceLinks: false
+      restartPolicy: Always
+      serviceAccountName: ide-proxy
+      terminationGracePeriodSeconds: 30
+status: {}
+---
+# apps/v1/Deployment image-builder-mk3
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: image-builder-mk3
+  name: image-builder-mk3
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gitpod
+      component: image-builder-mk3
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        gitpod.io/checksum_config: 02d7698e64b8dddb6eeca7a683b69c5cc8895cebdcfe2c94d80f56526c5cec0a
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: image-builder-mk3
+      name: image-builder-mk3
+      namespace: default
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: gitpod.io/workload_meta
+                operator: Exists
+      containers:
+      - args:
+        - run
+        - --config
+        - /config/image-builder.json
+        env:
+        - name: GITPOD_DOMAIN
+          value: minimal-test.gitpod.com
+        - name: GITPOD_INSTALLATION_SHORTNAME
+          value: default
+        - name: GITPOD_REGION
+          value: local
+        - name: HOST_URL
+          value: https://minimal-test.gitpod.com
+        - name: KUBE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: KUBE_DOMAIN
+          value: svc.cluster.local
+        - name: LOG_LEVEL
+          value: info
+        - name: JAEGER_DISABLED
+          value: "true"
+        image: eu.gcr.io/gitpod-core-dev/build/image-builder-mk3:test
+        imagePullPolicy: IfNotPresent
+        name: image-builder-mk3
+        ports:
+        - containerPort: 8080
+          name: service
+        resources:
+          requests:
+            cpu: 100m
+            memory: 200Mi
+        securityContext:
+          privileged: false
+          runAsUser: 33333
+        volumeMounts:
+        - mountPath: /config/image-builder.json
+          name: configuration
+          subPath: image-builder.json
+        - mountPath: /wsman-certs
+          name: wsman-tls-certs
+          readOnly: true
+        - mountPath: /config/pull-secret.json
+          name: pull-secret
+          subPath: .dockerconfigjson
+      - args:
+        - --logtostderr
+        - --insecure-listen-address=[$(IP)]:9500
+        - --upstream=http://127.0.0.1:9500/
+        env:
+        - name: IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay.io/brancz/kube-rbac-proxy:v0.12.0
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 9500
+          name: metrics
+        resources:
+          requests:
+            cpu: 1m
+            memory: 30Mi
+        securityContext:
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
+        terminationMessagePolicy: FallbackToLogsOnError
+      dnsPolicy: ClusterFirst
+      enableServiceLinks: false
+      initContainers:
+      - command:
+        - bash
+        - -c
+        - set -e; update-ca-certificates -f; cp /etc/ssl/certs/* /ssl-certs; echo
+          'OK'
+        image: eu.gcr.io/gitpod-core-dev/build/ca-updater:test
+        imagePullPolicy: IfNotPresent
+        name: update-ca-certificates
+        resources: {}
+        volumeMounts:
+        - mountPath: /ssl-certs
+          name: cacerts
+        - mountPath: /usr/local/share/ca-certificates/gitpod-ca.crt
+          name: gitpod-ca-certificate
+          subPath: ca.crt
+      restartPolicy: Always
+      serviceAccountName: image-builder-mk3
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - configMap:
+          name: image-builder-mk3-config
+        name: configuration
+      - name: wsman-tls-certs
+        secret:
+          secretName: ws-manager-client-tls
+      - name: pull-secret
+        secret:
+          secretName: builtin-registry-auth
+      - emptyDir: {}
+        name: gitpod-ca-certificate
+      - emptyDir: {}
+        name: cacerts
+status: {}
+---
+# apps/v1/Deployment minio
+# Source: minio/charts/minio/templates/standalone/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio
+  namespace: "default"
+  labels:
+    app.kubernetes.io/name: minio
+    helm.sh/chart: minio-11.6.3
+    app.kubernetes.io/instance: Minio
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: minio
+      app.kubernetes.io/instance: Minio
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: minio
+        helm.sh/chart: minio-11.6.3
+        app.kubernetes.io/instance: Minio
+        app.kubernetes.io/managed-by: Helm
+      annotations:
+        checksum/credentials-secret: 254e39ef7087b8d977946ed0027240eda9a1c7f64ae430fca5644a50b23cece3
+    spec:
+      
+      serviceAccountName: minio
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: gitpod.io/workload_meta
+                operator: Exists
+        
+      securityContext:
+        fsGroup: 1001
+      containers:
+        - name: minio
+          image: docker.io/bitnami/minio:2022.5.26-debian-10-r0
+          imagePullPolicy: "IfNotPresent"
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1001
+          env:
+            - name: BITNAMI_DEBUG
+              value: "false"
+            - name: MINIO_SCHEME
+              value: "http"
+            - name: MINIO_FORCE_NEW_KEYS
+              value: "no"
+            - name: MINIO_ROOT_USER
+              valueFrom:
+                secretKeyRef:
+                  name: minio
+                  key: root-user
+            - name: MINIO_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: minio
+                  key: root-password
+            - name: MINIO_BROWSER
+              value: "on"
+            - name: MINIO_PROMETHEUS_AUTH_TYPE
+              value: "public"
+            - name: MINIO_CONSOLE_PORT_NUMBER
+              value: "9001"
+            - name: MINIO_SKIP_CLIENT
+              value: "yes"
+          envFrom:
+          ports:
+            - name: minio-api
+              containerPort: 9000
+              protocol: TCP
+            - name: minio-console
+              containerPort: 9001
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /minio/health/live
+              port: minio-api
+              scheme: "HTTP"
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 5
+            successThreshold: 1
+            failureThreshold: 5
+          readinessProbe:
+            tcpSocket:
+              port: minio-api
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 5
+          resources:
+            limits: {}
+            requests:
+              memory: 2Gi
+          volumeMounts:
+            - name: data
+              mountPath: /data
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: minio
+---
+# apps/v1/Deployment proxy
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: proxy
+  name: proxy
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gitpod
+      component: proxy
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        gitpod.io/checksum_config: 926e623fd161e557fe9ebb5f2dc7f2e31ed391fb5a3fb1308cefc8b76945401a
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: proxy
+      name: proxy
+      namespace: default
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: gitpod.io/workload_meta
+                operator: Exists
+      containers:
+      - args:
+        - --logtostderr
+        - --insecure-listen-address=[$(IP)]:9500
+        - --upstream=http://127.0.0.1:9545/
+        env:
+        - name: IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.podIP
+        image: quay.io/brancz/kube-rbac-proxy:v0.12.0
+        imagePullPolicy: IfNotPresent
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 9500
+          name: metrics
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 1m
+            memory: 30Mi
+        securityContext:
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
+      - env:
+        - name: GITPOD_DOMAIN
+          value: minimal-test.gitpod.com
+        - name: GITPOD_INSTALLATION_SHORTNAME
+          value: default
+        - name: GITPOD_REGION
+          value: local
+        - name: HOST_URL
+          value: https://minimal-test.gitpod.com
+        - name: KUBE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: KUBE_DOMAIN
+          value: svc.cluster.local
+        - name: LOG_LEVEL
+          value: info
+        - name: PROXY_DOMAIN
+          value: minimal-test.gitpod.com
+        image: eu.gcr.io/gitpod-core-dev/build/proxy:test
+        imagePullPolicy: IfNotPresent
+        name: proxy
+        ports:
+        - containerPort: 80
+          name: http
+        - containerPort: 443
+          name: https
+        - containerPort: 22
+          name: ssh
+          protocol: TCP
+        - containerPort: 9500
+          name: metrics
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /ready
+            port: 8003
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          requests:
+            cpu: 100m
+            memory: 200Mi
+        securityContext:
+          privileged: false
+        volumeMounts:
+        - mountPath: /etc/caddy/vhosts
+          name: vhosts
+        - mountPath: /etc/caddy/certificates
+          name: config-certificates
+        - mountPath: /etc/caddy/registry-auth
+          name: builtin-registry-auth
+        - mountPath: /etc/caddy/registry-certs
+          name: builtin-registry-certs
+      dnsPolicy: ClusterFirst
+      enableServiceLinks: false
+      initContainers:
+      - command:
+        - sh
+        - -c
+        - sysctl -w net.core.somaxconn=32768; sysctl -w net.ipv4.ip_local_port_range='1024
+          65000'
+        image: docker.io/library/alpine:3.16
+        imagePullPolicy: IfNotPresent
+        name: sysctl
+        resources: {}
+        securityContext:
+          privileged: true
+      priorityClassName: system-node-critical
+      restartPolicy: Always
+      securityContext:
+        runAsNonRoot: false
+      serviceAccountName: proxy
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - configMap:
+          name: proxy-config
+        name: vhosts
+      - name: config-certificates
+        secret:
+          secretName: https-certificates
+      - name: builtin-registry-auth
+        secret:
+          secretName: builtin-registry-auth
+      - name: builtin-registry-certs
+        secret:
+          secretName: builtin-registry-certs
+status: {}
+---
+# apps/v1/Deployment registry
+# Source: docker-registry/charts/docker-registry/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: registry
+  namespace: default
+  labels:
+    app: docker-registry
+    chart: docker-registry-1.16.0
+    release: docker-registry
+    heritage: Helm
+spec:
+  selector:
+    matchLabels:
+      app: docker-registry
+      release: docker-registry
+  replicas: 1
+  minReadySeconds: 5
+  template:
+    metadata:
+      labels:
+        app: docker-registry
+        release: docker-registry
+      annotations:
+        checksum/config: 1d22b82e19bbc654e029029c4fb86ad02dc13422dc3ac52f8175ad190e52a0bb
+        gitpod.io/checksum_config: 0ce55d51677cd683df3c7a244542c6aeaaf5dd6dca0f0458e8053a713228f535
+    spec:
+      serviceAccountName: docker-registry
+      securityContext:
+        fsGroup: 1000
+        runAsUser: 1000
+      containers:
+        - name: docker-registry
+          image: "docker.io/library/registry:2.7.1"
+          imagePullPolicy: IfNotPresent
+          command:
+          - /bin/registry
+          - serve
+          - /etc/docker/registry/config.yml
+          ports:
+            - containerPort: 5000
+          livenessProbe:
+            httpGet:
+              scheme: HTTPS
+              path: /
+              port: 5000
+          readinessProbe:
+            httpGet:
+              scheme: HTTPS
+              path: /
+              port: 5000
+          resources:
+            {}
+          env:
+            - name: REGISTRY_HTTP_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: registry-secret
+                  key: haSharedSecret
+            - name: REGISTRY_HTTP_TLS_CERTIFICATE
+              value: /etc/ssl/docker/tls.crt
+            - name: REGISTRY_HTTP_TLS_KEY
+              value: /etc/ssl/docker/tls.key
+            - name: REGISTRY_STORAGE_FILESYSTEM_ROOTDIRECTORY
+              value: "/var/lib/registry"
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/registry/
+            - name: "registry-config"
+              mountPath: "/etc/docker/registry"
+            - mountPath: /etc/ssl/docker
+              name: tls-cert
+              readOnly: true
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: registry
+        - name: registry-config
+          configMap:
+            name: registry-config
+        - name: tls-cert
+          secret:
+            secretName: builtin-registry-certs
 ---
 # apps/v1/Deployment server
 apiVersion: apps/v1
@@ -7552,239 +8352,6 @@ spec:
           secretName: ws-manager-client-tls
 status: {}
 ---
-# apps/v1/Deployment ws-proxy
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  creationTimestamp: null
-  labels:
-    app: gitpod
-    component: ws-proxy
-  name: ws-proxy
-  namespace: default
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: gitpod
-      component: ws-proxy
-  strategy:
-    rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 0
-    type: RollingUpdate
-  template:
-    metadata:
-      annotations:
-        gitpod.io/checksum_config: 877efb2e41ba2a82e0d19c011804fa2bff310f5a5a9cbba236a49bb4cf9ff176
-      creationTimestamp: null
-      labels:
-        app: gitpod
-        component: ws-proxy
-      name: ws-proxy
-      namespace: default
-    spec:
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: gitpod.io/workload_workspace_services
-                operator: Exists
-      containers:
-      - args:
-        - run
-        - /config/config.json
-        env:
-        - name: GITPOD_DOMAIN
-          value: minimal-test.gitpod.com
-        - name: GITPOD_INSTALLATION_SHORTNAME
-          value: default
-        - name: GITPOD_REGION
-          value: local
-        - name: HOST_URL
-          value: https://minimal-test.gitpod.com
-        - name: KUBE_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: KUBE_DOMAIN
-          value: svc.cluster.local
-        - name: LOG_LEVEL
-          value: info
-        - name: JAEGER_DISABLED
-          value: "true"
-        image: eu.gcr.io/gitpod-core-dev/build/ws-proxy:test
-        imagePullPolicy: IfNotPresent
-        livenessProbe:
-          failureThreshold: 10
-          httpGet:
-            path: /healthz
-            port: 8086
-          initialDelaySeconds: 2
-          periodSeconds: 5
-          successThreshold: 1
-          timeoutSeconds: 2
-        name: ws-proxy
-        ports:
-        - containerPort: 8080
-          name: http-proxy
-        - containerPort: 9090
-          name: https-proxy
-        - containerPort: 9500
-          name: metrics
-        readinessProbe:
-          failureThreshold: 10
-          httpGet:
-            path: /readyz
-            port: 8086
-          initialDelaySeconds: 2
-          periodSeconds: 5
-        resources:
-          requests:
-            cpu: 100m
-            memory: 32Mi
-        securityContext:
-          privileged: false
-        volumeMounts:
-        - mountPath: /config
-          name: config
-          readOnly: true
-        - mountPath: /ws-manager-client-tls-certs
-          name: ws-manager-client-tls-certs
-          readOnly: true
-        - mountPath: /mnt/certificates
-          name: config-certificates
-      - args:
-        - --logtostderr
-        - --insecure-listen-address=[$(IP)]:9500
-        - --upstream=http://127.0.0.1:9500/
-        env:
-        - name: IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        image: quay.io/brancz/kube-rbac-proxy:v0.12.0
-        name: kube-rbac-proxy
-        ports:
-        - containerPort: 9500
-          name: metrics
-        resources:
-          requests:
-            cpu: 1m
-            memory: 30Mi
-        securityContext:
-          runAsGroup: 65532
-          runAsNonRoot: true
-          runAsUser: 65532
-        terminationMessagePolicy: FallbackToLogsOnError
-      enableServiceLinks: false
-      priorityClassName: system-node-critical
-      securityContext:
-        runAsUser: 31002
-      serviceAccountName: ws-proxy
-      topologySpreadConstraints:
-      - labelSelector:
-          matchLabels:
-            app: gitpod
-            component: ws-proxy
-        maxSkew: 1
-        topologyKey: kubernetes.io/hostname
-        whenUnsatisfiable: DoNotSchedule
-      volumes:
-      - configMap:
-          name: ws-proxy
-        name: config
-      - name: ws-manager-client-tls-certs
-        secret:
-          secretName: ws-manager-client-tls
-      - name: config-certificates
-        secret:
-          secretName: https-certificates
-status: {}
----
-# apps/v1/Deployment ide-proxy
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  creationTimestamp: null
-  labels:
-    app: gitpod
-    component: ide-proxy
-  name: ide-proxy
-  namespace: default
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: gitpod
-      component: ide-proxy
-  strategy:
-    rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 0
-    type: RollingUpdate
-  template:
-    metadata:
-      creationTimestamp: null
-      labels:
-        app: gitpod
-        component: ide-proxy
-      name: ide-proxy
-      namespace: default
-    spec:
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: gitpod.io/workload_meta
-                operator: Exists
-      containers:
-      - env:
-        - name: GITPOD_DOMAIN
-          value: minimal-test.gitpod.com
-        - name: GITPOD_INSTALLATION_SHORTNAME
-          value: default
-        - name: GITPOD_REGION
-          value: local
-        - name: HOST_URL
-          value: https://minimal-test.gitpod.com
-        - name: KUBE_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: KUBE_DOMAIN
-          value: svc.cluster.local
-        - name: LOG_LEVEL
-          value: info
-        image: eu.gcr.io/gitpod-core-dev/build/ide-proxy:test
-        imagePullPolicy: IfNotPresent
-        name: ide-proxy
-        ports:
-        - containerPort: 80
-          name: http
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /ready
-            port: 8080
-            scheme: HTTP
-          successThreshold: 1
-          timeoutSeconds: 1
-        resources:
-          requests:
-            cpu: 100m
-            memory: 32Mi
-        securityContext:
-          privileged: false
-      dnsPolicy: ClusterFirst
-      enableServiceLinks: false
-      restartPolicy: Always
-      serviceAccountName: ide-proxy
-      terminationGracePeriodSeconds: 30
-status: {}
----
 # apps/v1/Deployment ws-manager
 apiVersion: apps/v1
 kind: Deployment
@@ -7916,337 +8483,6 @@ spec:
       - name: tls-certs
         secret:
           secretName: ws-manager-tls
-status: {}
----
-# apps/v1/Deployment minio
-# Source: minio/charts/minio/templates/standalone/deployment.yaml
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: minio
-  namespace: "default"
-  labels:
-    app.kubernetes.io/name: minio
-    helm.sh/chart: minio-11.6.3
-    app.kubernetes.io/instance: Minio
-    app.kubernetes.io/managed-by: Helm
-spec:
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: minio
-      app.kubernetes.io/instance: Minio
-  strategy:
-    type: Recreate
-  template:
-    metadata:
-      labels:
-        app.kubernetes.io/name: minio
-        helm.sh/chart: minio-11.6.3
-        app.kubernetes.io/instance: Minio
-        app.kubernetes.io/managed-by: Helm
-      annotations:
-        checksum/credentials-secret: 254e39ef7087b8d977946ed0027240eda9a1c7f64ae430fca5644a50b23cece3
-    spec:
-      
-      serviceAccountName: minio
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: gitpod.io/workload_meta
-                operator: Exists
-        
-      securityContext:
-        fsGroup: 1001
-      containers:
-        - name: minio
-          image: docker.io/bitnami/minio:2022.5.26-debian-10-r0
-          imagePullPolicy: "IfNotPresent"
-          securityContext:
-            runAsNonRoot: true
-            runAsUser: 1001
-          env:
-            - name: BITNAMI_DEBUG
-              value: "false"
-            - name: MINIO_SCHEME
-              value: "http"
-            - name: MINIO_FORCE_NEW_KEYS
-              value: "no"
-            - name: MINIO_ROOT_USER
-              valueFrom:
-                secretKeyRef:
-                  name: minio
-                  key: root-user
-            - name: MINIO_ROOT_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: minio
-                  key: root-password
-            - name: MINIO_BROWSER
-              value: "on"
-            - name: MINIO_PROMETHEUS_AUTH_TYPE
-              value: "public"
-            - name: MINIO_CONSOLE_PORT_NUMBER
-              value: "9001"
-            - name: MINIO_SKIP_CLIENT
-              value: "yes"
-          envFrom:
-          ports:
-            - name: minio-api
-              containerPort: 9000
-              protocol: TCP
-            - name: minio-console
-              containerPort: 9001
-              protocol: TCP
-          livenessProbe:
-            httpGet:
-              path: /minio/health/live
-              port: minio-api
-              scheme: "HTTP"
-            initialDelaySeconds: 5
-            periodSeconds: 5
-            timeoutSeconds: 5
-            successThreshold: 1
-            failureThreshold: 5
-          readinessProbe:
-            tcpSocket:
-              port: minio-api
-            initialDelaySeconds: 5
-            periodSeconds: 5
-            timeoutSeconds: 1
-            successThreshold: 1
-            failureThreshold: 5
-          resources:
-            limits: {}
-            requests:
-              memory: 2Gi
-          volumeMounts:
-            - name: data
-              mountPath: /data
-      volumes:
-        - name: data
-          persistentVolumeClaim:
-            claimName: minio
----
-# apps/v1/Deployment dashboard
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  creationTimestamp: null
-  labels:
-    app: gitpod
-    component: dashboard
-  name: dashboard
-  namespace: default
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: gitpod
-      component: dashboard
-  strategy:
-    rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 0
-    type: RollingUpdate
-  template:
-    metadata:
-      creationTimestamp: null
-      labels:
-        app: gitpod
-        component: dashboard
-      name: dashboard
-      namespace: default
-    spec:
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: gitpod.io/workload_meta
-                operator: Exists
-      containers:
-      - env:
-        - name: GITPOD_DOMAIN
-          value: minimal-test.gitpod.com
-        - name: GITPOD_INSTALLATION_SHORTNAME
-          value: default
-        - name: GITPOD_REGION
-          value: local
-        - name: HOST_URL
-          value: https://minimal-test.gitpod.com
-        - name: KUBE_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: KUBE_DOMAIN
-          value: svc.cluster.local
-        - name: LOG_LEVEL
-          value: info
-        image: eu.gcr.io/gitpod-core-dev/build/dashboard:test
-        imagePullPolicy: IfNotPresent
-        name: dashboard
-        ports:
-        - containerPort: 80
-          name: http
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /ready
-            port: 8080
-            scheme: HTTP
-          successThreshold: 1
-          timeoutSeconds: 1
-        resources:
-          requests:
-            cpu: 100m
-            memory: 32Mi
-        securityContext:
-          privileged: false
-      dnsPolicy: ClusterFirst
-      enableServiceLinks: false
-      restartPolicy: Always
-      serviceAccountName: dashboard
-      terminationGracePeriodSeconds: 30
-status: {}
----
-# apps/v1/Deployment blobserve
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  creationTimestamp: null
-  labels:
-    app: gitpod
-    component: blobserve
-  name: blobserve
-  namespace: default
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: gitpod
-      component: blobserve
-  strategy:
-    rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 0
-    type: RollingUpdate
-  template:
-    metadata:
-      annotations:
-        gitpod.io/checksum_config: d2c36ebee01aaa9b448075b9c868cbf6abc18874d7cbc537c500683f1b6109ef
-      creationTimestamp: null
-      labels:
-        app: gitpod
-        component: blobserve
-      name: blobserve
-      namespace: default
-    spec:
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: gitpod.io/workload_workspace_services
-                operator: Exists
-      containers:
-      - args:
-        - run
-        - /mnt/config/config.json
-        env:
-        - name: GITPOD_DOMAIN
-          value: minimal-test.gitpod.com
-        - name: GITPOD_INSTALLATION_SHORTNAME
-          value: default
-        - name: GITPOD_REGION
-          value: local
-        - name: HOST_URL
-          value: https://minimal-test.gitpod.com
-        - name: KUBE_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: KUBE_DOMAIN
-          value: svc.cluster.local
-        - name: LOG_LEVEL
-          value: info
-        - name: JAEGER_DISABLED
-          value: "true"
-        image: eu.gcr.io/gitpod-core-dev/build/blobserve:test
-        imagePullPolicy: IfNotPresent
-        livenessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /live
-            port: 8086
-          initialDelaySeconds: 5
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 1
-        name: blobserve
-        ports:
-        - containerPort: 32224
-          name: service
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /ready
-            port: 8086
-          initialDelaySeconds: 5
-          periodSeconds: 5
-          successThreshold: 1
-          timeoutSeconds: 1
-        resources:
-          requests:
-            cpu: 100m
-            memory: 32Mi
-        securityContext:
-          privileged: false
-          runAsUser: 1000
-        volumeMounts:
-        - mountPath: /mnt/config
-          name: config
-          readOnly: true
-        - mountPath: /mnt/cache
-          name: cache
-        - mountPath: /mnt/pull-secret.json
-          name: pull-secret
-          subPath: .dockerconfigjson
-      - args:
-        - --logtostderr
-        - --insecure-listen-address=[$(IP)]:9500
-        - --upstream=http://127.0.0.1:9500/
-        env:
-        - name: IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        image: quay.io/brancz/kube-rbac-proxy:v0.12.0
-        name: kube-rbac-proxy
-        ports:
-        - containerPort: 9500
-          name: metrics
-        resources:
-          requests:
-            cpu: 1m
-            memory: 30Mi
-        securityContext:
-          runAsGroup: 65532
-          runAsNonRoot: true
-          runAsUser: 65532
-        terminationMessagePolicy: FallbackToLogsOnError
-      enableServiceLinks: false
-      serviceAccountName: blobserve
-      volumes:
-      - emptyDir: {}
-        name: cache
-      - configMap:
-          name: blobserve
-        name: config
-      - name: pull-secret
-        secret:
-          secretName: builtin-registry-auth
 status: {}
 ---
 # apps/v1/Deployment ws-manager-bridge
@@ -8489,22 +8725,22 @@ spec:
           secretName: ws-manager-client-tls
 status: {}
 ---
-# apps/v1/Deployment proxy
+# apps/v1/Deployment ws-proxy
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null
   labels:
     app: gitpod
-    component: proxy
-  name: proxy
+    component: ws-proxy
+  name: ws-proxy
   namespace: default
 spec:
   replicas: 1
   selector:
     matchLabels:
       app: gitpod
-      component: proxy
+      component: ws-proxy
   strategy:
     rollingUpdate:
       maxSurge: 1
@@ -8513,12 +8749,12 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 926e623fd161e557fe9ebb5f2dc7f2e31ed391fb5a3fb1308cefc8b76945401a
+        gitpod.io/checksum_config: 877efb2e41ba2a82e0d19c011804fa2bff310f5a5a9cbba236a49bb4cf9ff176
       creationTimestamp: null
       labels:
         app: gitpod
-        component: proxy
-      name: proxy
+        component: ws-proxy
+      name: ws-proxy
       namespace: default
     spec:
       affinity:
@@ -8526,169 +8762,12 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: gitpod.io/workload_meta
-                operator: Exists
-      containers:
-      - args:
-        - --logtostderr
-        - --insecure-listen-address=[$(IP)]:9500
-        - --upstream=http://127.0.0.1:9545/
-        env:
-        - name: IP
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: status.podIP
-        image: quay.io/brancz/kube-rbac-proxy:v0.12.0
-        imagePullPolicy: IfNotPresent
-        name: kube-rbac-proxy
-        ports:
-        - containerPort: 9500
-          name: metrics
-          protocol: TCP
-        resources:
-          requests:
-            cpu: 1m
-            memory: 30Mi
-        securityContext:
-          runAsGroup: 65532
-          runAsNonRoot: true
-          runAsUser: 65532
-      - env:
-        - name: GITPOD_DOMAIN
-          value: minimal-test.gitpod.com
-        - name: GITPOD_INSTALLATION_SHORTNAME
-          value: default
-        - name: GITPOD_REGION
-          value: local
-        - name: HOST_URL
-          value: https://minimal-test.gitpod.com
-        - name: KUBE_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: KUBE_DOMAIN
-          value: svc.cluster.local
-        - name: LOG_LEVEL
-          value: info
-        - name: PROXY_DOMAIN
-          value: minimal-test.gitpod.com
-        image: eu.gcr.io/gitpod-core-dev/build/proxy:test
-        imagePullPolicy: IfNotPresent
-        name: proxy
-        ports:
-        - containerPort: 80
-          name: http
-        - containerPort: 443
-          name: https
-        - containerPort: 22
-          name: ssh
-          protocol: TCP
-        - containerPort: 9500
-          name: metrics
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /ready
-            port: 8003
-          initialDelaySeconds: 5
-          periodSeconds: 5
-          successThreshold: 1
-          timeoutSeconds: 1
-        resources:
-          requests:
-            cpu: 100m
-            memory: 200Mi
-        securityContext:
-          privileged: false
-        volumeMounts:
-        - mountPath: /etc/caddy/vhosts
-          name: vhosts
-        - mountPath: /etc/caddy/certificates
-          name: config-certificates
-        - mountPath: /etc/caddy/registry-auth
-          name: builtin-registry-auth
-        - mountPath: /etc/caddy/registry-certs
-          name: builtin-registry-certs
-      dnsPolicy: ClusterFirst
-      enableServiceLinks: false
-      initContainers:
-      - command:
-        - sh
-        - -c
-        - sysctl -w net.core.somaxconn=32768; sysctl -w net.ipv4.ip_local_port_range='1024
-          65000'
-        image: docker.io/library/alpine:3.16
-        imagePullPolicy: IfNotPresent
-        name: sysctl
-        resources: {}
-        securityContext:
-          privileged: true
-      priorityClassName: system-node-critical
-      restartPolicy: Always
-      securityContext:
-        runAsNonRoot: false
-      serviceAccountName: proxy
-      terminationGracePeriodSeconds: 30
-      volumes:
-      - configMap:
-          name: proxy-config
-        name: vhosts
-      - name: config-certificates
-        secret:
-          secretName: https-certificates
-      - name: builtin-registry-auth
-        secret:
-          secretName: builtin-registry-auth
-      - name: builtin-registry-certs
-        secret:
-          secretName: builtin-registry-certs
-status: {}
----
-# apps/v1/Deployment image-builder-mk3
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  creationTimestamp: null
-  labels:
-    app: gitpod
-    component: image-builder-mk3
-  name: image-builder-mk3
-  namespace: default
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: gitpod
-      component: image-builder-mk3
-  strategy:
-    rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 0
-    type: RollingUpdate
-  template:
-    metadata:
-      annotations:
-        gitpod.io/checksum_config: 02d7698e64b8dddb6eeca7a683b69c5cc8895cebdcfe2c94d80f56526c5cec0a
-      creationTimestamp: null
-      labels:
-        app: gitpod
-        component: image-builder-mk3
-      name: image-builder-mk3
-      namespace: default
-    spec:
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: gitpod.io/workload_meta
+              - key: gitpod.io/workload_workspace_services
                 operator: Exists
       containers:
       - args:
         - run
-        - --config
-        - /config/image-builder.json
+        - /config/config.json
         env:
         - name: GITPOD_DOMAIN
           value: minimal-test.gitpod.com
@@ -8708,29 +8787,47 @@ spec:
           value: info
         - name: JAEGER_DISABLED
           value: "true"
-        image: eu.gcr.io/gitpod-core-dev/build/image-builder-mk3:test
+        image: eu.gcr.io/gitpod-core-dev/build/ws-proxy:test
         imagePullPolicy: IfNotPresent
-        name: image-builder-mk3
+        livenessProbe:
+          failureThreshold: 10
+          httpGet:
+            path: /healthz
+            port: 8086
+          initialDelaySeconds: 2
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 2
+        name: ws-proxy
         ports:
         - containerPort: 8080
-          name: service
+          name: http-proxy
+        - containerPort: 9090
+          name: https-proxy
+        - containerPort: 9500
+          name: metrics
+        readinessProbe:
+          failureThreshold: 10
+          httpGet:
+            path: /readyz
+            port: 8086
+          initialDelaySeconds: 2
+          periodSeconds: 5
         resources:
           requests:
             cpu: 100m
-            memory: 200Mi
+            memory: 32Mi
         securityContext:
           privileged: false
-          runAsUser: 33333
         volumeMounts:
-        - mountPath: /config/image-builder.json
-          name: configuration
-          subPath: image-builder.json
-        - mountPath: /wsman-certs
-          name: wsman-tls-certs
+        - mountPath: /config
+          name: config
           readOnly: true
-        - mountPath: /config/pull-secret.json
-          name: pull-secret
-          subPath: .dockerconfigjson
+        - mountPath: /ws-manager-client-tls-certs
+          name: ws-manager-client-tls-certs
+          readOnly: true
+        - mountPath: /mnt/certificates
+          name: config-certificates
       - args:
         - --logtostderr
         - --insecure-listen-address=[$(IP)]:9500
@@ -8754,127 +8851,30 @@ spec:
           runAsNonRoot: true
           runAsUser: 65532
         terminationMessagePolicy: FallbackToLogsOnError
-      dnsPolicy: ClusterFirst
       enableServiceLinks: false
-      initContainers:
-      - command:
-        - bash
-        - -c
-        - set -e; update-ca-certificates -f; cp /etc/ssl/certs/* /ssl-certs; echo
-          'OK'
-        image: eu.gcr.io/gitpod-core-dev/build/ca-updater:test
-        imagePullPolicy: IfNotPresent
-        name: update-ca-certificates
-        resources: {}
-        volumeMounts:
-        - mountPath: /ssl-certs
-          name: cacerts
-        - mountPath: /usr/local/share/ca-certificates/gitpod-ca.crt
-          name: gitpod-ca-certificate
-          subPath: ca.crt
-      restartPolicy: Always
-      serviceAccountName: image-builder-mk3
-      terminationGracePeriodSeconds: 30
+      priorityClassName: system-node-critical
+      securityContext:
+        runAsUser: 31002
+      serviceAccountName: ws-proxy
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            app: gitpod
+            component: ws-proxy
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: DoNotSchedule
       volumes:
       - configMap:
-          name: image-builder-mk3-config
-        name: configuration
-      - name: wsman-tls-certs
+          name: ws-proxy
+        name: config
+      - name: ws-manager-client-tls-certs
         secret:
           secretName: ws-manager-client-tls
-      - name: pull-secret
+      - name: config-certificates
         secret:
-          secretName: builtin-registry-auth
-      - emptyDir: {}
-        name: gitpod-ca-certificate
-      - emptyDir: {}
-        name: cacerts
+          secretName: https-certificates
 status: {}
----
-# apps/v1/Deployment registry
-# Source: docker-registry/charts/docker-registry/templates/deployment.yaml
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: registry
-  namespace: default
-  labels:
-    app: docker-registry
-    chart: docker-registry-1.16.0
-    release: docker-registry
-    heritage: Helm
-spec:
-  selector:
-    matchLabels:
-      app: docker-registry
-      release: docker-registry
-  replicas: 1
-  minReadySeconds: 5
-  template:
-    metadata:
-      labels:
-        app: docker-registry
-        release: docker-registry
-      annotations:
-        checksum/config: 1d22b82e19bbc654e029029c4fb86ad02dc13422dc3ac52f8175ad190e52a0bb
-        gitpod.io/checksum_config: 0ce55d51677cd683df3c7a244542c6aeaaf5dd6dca0f0458e8053a713228f535
-    spec:
-      serviceAccountName: docker-registry
-      securityContext:
-        fsGroup: 1000
-        runAsUser: 1000
-      containers:
-        - name: docker-registry
-          image: "docker.io/library/registry:2.7.1"
-          imagePullPolicy: IfNotPresent
-          command:
-          - /bin/registry
-          - serve
-          - /etc/docker/registry/config.yml
-          ports:
-            - containerPort: 5000
-          livenessProbe:
-            httpGet:
-              scheme: HTTPS
-              path: /
-              port: 5000
-          readinessProbe:
-            httpGet:
-              scheme: HTTPS
-              path: /
-              port: 5000
-          resources:
-            {}
-          env:
-            - name: REGISTRY_HTTP_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: registry-secret
-                  key: haSharedSecret
-            - name: REGISTRY_HTTP_TLS_CERTIFICATE
-              value: /etc/ssl/docker/tls.crt
-            - name: REGISTRY_HTTP_TLS_KEY
-              value: /etc/ssl/docker/tls.key
-            - name: REGISTRY_STORAGE_FILESYSTEM_ROOTDIRECTORY
-              value: "/var/lib/registry"
-          volumeMounts:
-            - name: data
-              mountPath: /var/lib/registry/
-            - name: "registry-config"
-              mountPath: "/etc/docker/registry"
-            - mountPath: /etc/ssl/docker
-              name: tls-cert
-              readOnly: true
-      volumes:
-        - name: data
-          persistentVolumeClaim:
-            claimName: registry
-        - name: registry-config
-          configMap:
-            name: registry-config
-        - name: tls-cert
-          secret:
-            secretName: builtin-registry-certs
 ---
 # batch/v1/Job migrations
 apiVersion: batch/v1

--- a/install/installer/pkg/common/display.go
+++ b/install/installer/pkg/common/display.go
@@ -69,9 +69,13 @@ func DependencySortingRenderFunc(objects []RuntimeObject) ([]RuntimeObject, erro
 		sortMap[v] = k
 	}
 
-	sort.Slice(objects, func(i, j int) bool {
+	sort.SliceStable(objects, func(i, j int) bool {
 		scoreI := sortMap[objects[i].Kind]
 		scoreJ := sortMap[objects[j].Kind]
+
+		if scoreI == scoreJ {
+			return objects[i].Metadata.Name < objects[j].Metadata.Name
+		}
 
 		return scoreI < scoreJ
 	})


### PR DESCRIPTION
## Description
This PR ensures that the ordering of the rendered K8s objects is stable. That allows comparing renderings with different configs.


## How to test
<!-- Provide steps to test this PR -->
Render with 2 different configs (e.g. with external registry and with internal registry). Without this change, the ordering is not stable and it is impossible to compare the changes. After this change, the ordering is stable and you can see with a diff what has changed in the rendering.

#11880 has an example where you can compare the golden files with and without an external registry.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
