### PR TITLE
[codeowners] Allow all teams to approve installer testdata changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -26,6 +26,7 @@
 /components/installation-telemetry @gitpod-io/engineering-self-hosted
 /install @gitpod-io/engineering-self-hosted
 /install/installer @gitpod-io/engineering-self-hosted
+/install/installer/cmd/testdata @gitpod-io/engineering-self-hosted @gitpod-io/engineering-ide @gitpod-io/engineering-webapp @gitpod-io/engineering-workspace
 /install/installer/pkg/components/agent-smith @gitpod-io/engineering-workspace
 /install/installer/pkg/components/blobserve @gitpod-io/engineering-ide
 /install/installer/pkg/components/components-webapp @gitpod-io/engineering-webapp


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
When Team Self-Hosted is the only codeowner of the testdata, we need to approve nearly every change of the installer. This would defacto cancel out the codeowner properties of the individual packages. Which would not make much sense, IMO.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
