### PR TITLE
[usage] Add `billInstancesAfter` config setting

### DIFF
--- a/components/usage/cmd/run.go
+++ b/components/usage/cmd/run.go
@@ -8,11 +8,13 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"os"
+	"path"
+	"time"
+
 	"github.com/gitpod-io/gitpod/common-go/log"
 	"github.com/gitpod-io/gitpod/usage/pkg/server"
 	"github.com/spf13/cobra"
-	"os"
-	"path"
 )
 
 func init() {
@@ -64,6 +66,10 @@ func parseConfig(path string) (server.Config, error) {
 	err = dec.Decode(&cfg)
 	if err != nil {
 		return server.Config{}, fmt.Errorf("failed to parse config from %s: %w", path, err)
+	}
+
+	if cfg.BillInstancesAfter == nil {
+		cfg.BillInstancesAfter = &time.Time{}
 	}
 
 	return cfg, nil


### PR DESCRIPTION
## Description

Add a new config setting to the usage component config setting to better support the rollout of usage based pricing.

The `billInstancesAfter` setting defines the date after which instances should be considered for billing - instances started before `billInstancesAfter` will never be considered by the billing controller.

## Related Issue(s)
Part of https://github.com/gitpod-io/gitpod/issues/10937

## How to test

Unit tests for the billing controller.

For an end-to-end test do this in the preview environment:

* Join the Gitpod team: https://af-no-bill390c0e761d.preview.gitpod-dev.com/teams/join?inviteId=f35adc3b-720f-4406-85ec-101628b587bc

* Edit the usage configmap to change `billInstancesAfter`:
```yaml
{
  "billInstancesAfter": "2022-08-06T00:00:00Z",
  ...
}
```
By changing the date, restarting the `usage` pod and starting workspaces you can see that workspaces are either included or not in the Stripe invoice for the Gitpod team (find it in the Stripe dashboard).

## Release Notes

```release-note
NONE
```

## Documentation

## Werft options:

- [x] /werft with-preview
- [x] /werft with-payment
