### PR TITLE
[installer] Support setting `billInstancesAfter`

### DIFF
--- a/components/usage/cmd/run.go
+++ b/components/usage/cmd/run.go
@@ -8,11 +8,13 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"os"
+	"path"
+	"time"
+
 	"github.com/gitpod-io/gitpod/common-go/log"
 	"github.com/gitpod-io/gitpod/usage/pkg/server"
 	"github.com/spf13/cobra"
-	"os"
-	"path"
 )
 
 func init() {
@@ -64,6 +66,10 @@ func parseConfig(path string) (server.Config, error) {
 	err = dec.Decode(&cfg)
 	if err != nil {
 		return server.Config{}, fmt.Errorf("failed to parse config from %s: %w", path, err)
+	}
+
+	if cfg.BillInstancesAfter == nil {
+		cfg.BillInstancesAfter = &time.Time{}
 	}
 
 	return cfg, nil

--- a/install/installer/pkg/components/usage/configmap.go
+++ b/install/installer/pkg/components/usage/configmap.go
@@ -38,6 +38,9 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		if expConfig.Schedule != "" {
 			cfg.ControllerSchedule = expConfig.Schedule
 		}
+		if expConfig.BillInstancesAfter != nil {
+			cfg.BillInstancesAfter = expConfig.BillInstancesAfter
+		}
 
 		cfg.CreditsPerMinuteByWorkspaceClass = expConfig.CreditsPerMinuteByWorkspaceClass
 	}

--- a/install/installer/pkg/components/usage/configmap_test.go
+++ b/install/installer/pkg/components/usage/configmap_test.go
@@ -5,6 +5,7 @@ package usage
 
 import (
 	"testing"
+	"time"
 
 	"github.com/gitpod-io/gitpod/installer/pkg/config/v1/experimental"
 	"github.com/stretchr/testify/require"
@@ -23,6 +24,34 @@ func TestConfigMap_ContainsSchedule(t *testing.T) {
 	require.JSONEq(t,
 		`{
        "controllerSchedule": "2m",
+       "contentServiceAddress": "content-service:8080",
+       "stripeCredentialsFile": "stripe-secret/apikeys",
+       "server": {
+         "services": {
+           "grpc": {
+             "address": ":9001"
+           }
+         }
+       }
+     }`,
+		cfgmap.Data[configJSONFilename],
+	)
+}
+
+func TestConfigMap_ContainsBillInstancesAfter(t *testing.T) {
+	afterTime := time.Date(2022, 8, 4, 0, 0, 0, 0, time.UTC)
+	ctx := renderContextWithUsageConfig(t, &experimental.UsageConfig{Enabled: true, BillInstancesAfter: &afterTime})
+
+	objs, err := configmap(ctx)
+	require.NoError(t, err)
+
+	cfgmap, ok := objs[0].(*corev1.ConfigMap)
+	require.True(t, ok)
+
+	require.JSONEq(t,
+		`{
+       "controllerSchedule": "1h0m0s",
+       "billInstancesAfter": "2022-08-04T00:00:00Z",
        "contentServiceAddress": "content-service:8080",
        "stripeCredentialsFile": "stripe-secret/apikeys",
        "server": {

--- a/install/installer/pkg/config/v1/experimental/experimental.go
+++ b/install/installer/pkg/config/v1/experimental/experimental.go
@@ -11,6 +11,8 @@
 package experimental
 
 import (
+	"time"
+
 	agentSmith "github.com/gitpod-io/gitpod/agent-smith/pkg/config"
 	"github.com/gitpod-io/gitpod/common-go/grpc"
 	corev1 "k8s.io/api/core/v1"
@@ -211,6 +213,7 @@ type PublicAPIConfig struct {
 type UsageConfig struct {
 	Enabled                          bool               `json:"enabled"`
 	Schedule                         string             `json:"schedule"`
+	BillInstancesAfter               *time.Time         `json:"billInstancesAfter"`
 	CreditsPerMinuteByWorkspaceClass map[string]float64 `json:"creditsPerMinuteByWorkspaceClass"`
 }
 


### PR DESCRIPTION
## Description

In https://github.com/gitpod-io/gitpod/pull/11882 the `usage` component gained a `billInstancesAfter` config setting, to better support the rollout of usage based pricing.

This PR adds the ability to set `billInstancesAfter` through the installer. 

## Related Issue(s)

Part of https://github.com/gitpod-io/gitpod/issues/10937

## How to test

Automated installer tests.

## Release Notes

```release-note
NONE
```

## Documentation

## Werft options:

- [ ] /werft with-preview
