### PR TITLE
[usage] Implement markWorkspaceInstanceSessionAsBilled

### DIFF
--- a/components/server/ee/src/billing/billing-mode.ts
+++ b/components/server/ee/src/billing/billing-mode.ts
@@ -46,7 +46,7 @@ export class BillingModesImpl implements BillingModes {
     @inject(TeamDB) protected readonly teamDB: TeamDB;
     @inject(UserDB) protected readonly userDB: UserDB;
 
-    async getBillingMode(attributionId: AttributionId, now: Date): Promise<BillingMode> {
+    public async getBillingMode(attributionId: AttributionId, now: Date): Promise<BillingMode> {
         switch (attributionId.kind) {
             case "team":
                 const team = await this.teamDB.findTeamById(attributionId.teamId);

--- a/components/server/src/container-module.ts
+++ b/components/server/src/container-module.ts
@@ -102,9 +102,12 @@ import { LicenseEvaluator } from "@gitpod/licensor/lib";
 import { WorkspaceClusterImagebuilderClientProvider } from "./workspace/workspace-cluster-imagebuilder-client-provider";
 import {
     CachingUsageServiceClientProvider,
+    CachingBillingServiceClientProvider,
     UsageServiceClientCallMetrics,
     UsageServiceClientConfig,
     UsageServiceClientProvider,
+    BillingServiceClientCallMetrics,
+    BillingServiceClientConfig,
 } from "@gitpod/usage-api/lib/usage/v1/sugar";
 import { CommunityEntitlementService, EntitlementService } from "./billing/entitlement-service";
 import {
@@ -266,6 +269,13 @@ export const productionContainerModule = new ContainerModule((bind, unbind, isBo
     bind(CachingUsageServiceClientProvider).toSelf().inSingletonScope();
     bind(UsageServiceClientProvider).toService(CachingImageBuilderClientProvider);
     bind(UsageServiceClientCallMetrics).toService(IClientCallMetrics);
+
+    bind(CachingBillingServiceClientProvider).toSelf().inSingletonScope();
+    bind(BillingServiceClientCallMetrics).toService(IClientCallMetrics);
+    bind(BillingServiceClientConfig).toDynamicValue((ctx) => {
+        const config = ctx.container.get<Config>(Config);
+        return { address: config.usageServiceAddr };
+    });
 
     bind(EntitlementService).to(CommunityEntitlementService).inSingletonScope();
 

--- a/components/usage-api/typescript/src/usage/v1/sugar.ts
+++ b/components/usage-api/typescript/src/usage/v1/sugar.ts
@@ -10,6 +10,7 @@ import { TraceContext } from "@gitpod/gitpod-protocol/lib/util/tracing";
 import * as opentracing from "opentracing";
 import { Metadata } from "@grpc/grpc-js";
 import { BilledSession, ListBilledUsageRequest, ListBilledUsageResponse } from "./usage_pb";
+import { SetBilledSessionRequest, SetBilledSessionResponse } from "./billing_pb";
 import { injectable, inject, optional } from "inversify";
 import { createClientCallMetricsInterceptor, IClientCallMetrics } from "@gitpod/gitpod-protocol/lib/util/grpc";
 import * as grpc from "@grpc/grpc-js";
@@ -224,6 +225,28 @@ export class PromisifiedBillingServiceClient {
             cs == grpc.connectivityState.IDLE ||
             cs == grpc.connectivityState.READY
         );
+    }
+
+    public async setBilledSession(instanceId: string, instanceCreationTime: Timestamp, system: string) {
+        const req = new SetBilledSessionRequest();
+        req.setInstanceId(instanceId);
+        req.setFrom(instanceCreationTime);
+        req.setSystem(system);
+
+
+        const response = await new Promise<SetBilledSessionResponse>((resolve, reject) => {
+        this.client.setBilledSession(
+            req,
+            (err: grpc.ServiceError | null, response: SetBilledSessionResponse) => {
+            if (err) {
+                reject(err);
+                return;
+            }
+            resolve(response);
+        },
+        )}
+        )
+        return response;
     }
 
     public dispose() {

--- a/components/usage/pkg/apiv1/billing_test.go
+++ b/components/usage/pkg/apiv1/billing_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
+	"gorm.io/gorm"
 )
 
 func TestCreditSummaryForTeams(t *testing.T) {
@@ -109,7 +110,7 @@ func TestCreditSummaryForTeams(t *testing.T) {
 
 	for _, s := range scenarios {
 		t.Run(s.Name, func(t *testing.T) {
-			svc := NewBillingService(&stripe.Client{}, s.BillSessionsAfter)
+			svc := NewBillingService(&stripe.Client{}, s.BillSessionsAfter, &gorm.DB{})
 			actual, err := svc.creditSummaryForTeams(s.Sessions)
 			require.NoError(t, err)
 			require.Equal(t, s.Expected, actual)

--- a/components/usage/pkg/apiv1/size_test.go
+++ b/components/usage/pkg/apiv1/size_test.go
@@ -16,6 +16,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
+	"gorm.io/gorm"
 )
 
 func TestServerCanReceiveLargeMessages(t *testing.T) {
@@ -23,7 +24,7 @@ func TestServerCanReceiveLargeMessages(t *testing.T) {
 		baseserver.WithGRPC(baseserver.MustUseRandomLocalAddress(t)),
 	)
 
-	v1.RegisterBillingServiceServer(srv.GRPC(), NewBillingService(&stripe.Client{}, time.Time{}))
+	v1.RegisterBillingServiceServer(srv.GRPC(), NewBillingService(&stripe.Client{}, time.Time{}, &gorm.DB{}))
 	baseserver.StartServerForTests(t, srv)
 
 	conn, err := grpc.Dial(srv.GRPCAddress(), grpc.WithTransportCredentials(insecure.NewCredentials()))

--- a/components/usage/pkg/server/server.go
+++ b/components/usage/pkg/server/server.go
@@ -156,7 +156,7 @@ func registerGRPCServices(srv *baseserver.Server, conn *gorm.DB, stripeClient *s
 	if stripeClient == nil {
 		v1.RegisterBillingServiceServer(srv.GRPC(), &apiv1.BillingServiceNoop{})
 	} else {
-		v1.RegisterBillingServiceServer(srv.GRPC(), apiv1.NewBillingService(stripeClient, billInstancesAfter))
+		v1.RegisterBillingServiceServer(srv.GRPC(), apiv1.NewBillingService(stripeClient, billInstancesAfter, conn))
 	}
 	return nil
 }


### PR DESCRIPTION
## Description
Implements setBilledSession and calls it during workspace start.

## Related Issue(s)
Depends on #11999
Fixes #11884

## How to test
1. Do NOT create a "Gitpod" team to ensure that you are still under the Chargebee billing mode.
2. Run workspaces either as personal or in a team's project.
3. Check in the DB (I can also check it) that the session is added into `d_b_billed_session`. 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
- [x]  /werft with-payment
