### PR TITLE
[blobserve] Fix lint issues

### DIFF
--- a/components/blobserve/pkg/blobserve/blobserve.go
+++ b/components/blobserve/pkg/blobserve/blobserve.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"html"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"path/filepath"
 	"regexp"
@@ -294,7 +293,7 @@ func inlineVars(req *http.Request, r io.ReadSeeker, inlineReplacements []InlineR
 		return r, xerrors.Errorf("cannot parse inline vars: %w: %s", err, inlineVars)
 	}
 
-	content, err := ioutil.ReadAll(r)
+	content, err := io.ReadAll(r)
 	if err != nil {
 		return r, xerrors.Errorf("cannot read index.html: %w", err)
 	}

--- a/components/blobserve/pkg/blobserve/blobspace.go
+++ b/components/blobserve/pkg/blobserve/blobspace.go
@@ -10,7 +10,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/exec"
@@ -180,7 +179,7 @@ func (b *diskBlobspace) Get(name string) (fs http.FileSystem, state blobstate) {
 		return nil, blobUnready
 	}
 
-	os.WriteFile(fmt.Sprintf("%s.used", fn), nil, 0644)
+	_ = os.WriteFile(fmt.Sprintf("%s.used", fn), nil, 0644)
 	return http.Dir(fn), blobReady
 }
 
@@ -205,7 +204,7 @@ func (b *diskBlobspace) AddFromTar(ctx context.Context, name string, in io.Reade
 	cmd.Stdin = cin
 	go func() {
 		<-ctx.Done()
-		cmd.Process.Kill()
+		_ = cmd.Process.Kill()
 	}()
 
 	out, err := cmd.CombinedOutput()
@@ -220,9 +219,9 @@ func (b *diskBlobspace) AddFromTar(ctx context.Context, name string, in io.Reade
 		}
 	}
 
-	os.WriteFile(fmt.Sprintf("%s.size", fn), []byte(fmt.Sprintf("%d", cw.C)), 0644)
-	os.WriteFile(fmt.Sprintf("%s.used", fn), nil, 0644)
-	os.WriteFile(fmt.Sprintf("%s.ready", fn), nil, 0644)
+	_ = os.WriteFile(fmt.Sprintf("%s.size", fn), []byte(fmt.Sprintf("%d", cw.C)), 0644)
+	_ = os.WriteFile(fmt.Sprintf("%s.used", fn), nil, 0644)
+	_ = os.WriteFile(fmt.Sprintf("%s.ready", fn), nil, 0644)
 
 	return nil
 }
@@ -252,12 +251,12 @@ func (b *diskBlobspace) modifyFile(blobName, filename string, mod FileModifier) 
 		return errdefs.ErrInvalidArgument
 	}
 
-	input, err := ioutil.ReadFile(fn)
+	input, err := os.ReadFile(fn)
 	if err != nil {
 		return err
 	}
 	f, err := os.OpenFile(fn, os.O_TRUNC|os.O_WRONLY, 0644)
-	f.Seek(0, 0)
+	_, _ = f.Seek(0, 0)
 	if err != nil {
 		return err
 	}

--- a/components/blobserve/pkg/blobserve/blobspace_test.go
+++ b/components/blobserve/pkg/blobserve/blobspace_test.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -43,14 +42,21 @@ func Test_diskBlobspace_modifyFile(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
-			tmp, err := ioutil.TempDir("", "")
+			tmp, err := os.MkdirTemp("", "")
 			if err != nil {
 				t.Fatal(err)
 			}
 			defer os.RemoveAll(tmp)
 
-			os.MkdirAll(filepath.Join(tmp, "b1"), 0755)
-			ioutil.WriteFile(filepath.Join(tmp, "b1", "f1"), []byte("hello world"), 0600)
+			err = os.MkdirAll(filepath.Join(tmp, "b1"), 0755)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			err = os.WriteFile(filepath.Join(tmp, "b1", "f1"), []byte("hello world"), 0600)
+			if err != nil {
+				t.Fatal(err)
+			}
 
 			b := &diskBlobspace{
 				Location: tmp,
@@ -60,7 +66,7 @@ func Test_diskBlobspace_modifyFile(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			ctnt, err := ioutil.ReadFile(filepath.Join(tmp, "b1", "f1"))
+			ctnt, err := os.ReadFile(filepath.Join(tmp, "b1", "f1"))
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/components/blobserve/pkg/blobserve/refstore_test.go
+++ b/components/blobserve/pkg/blobserve/refstore_test.go
@@ -52,7 +52,12 @@ func TestBlobFor(t *testing.T) {
 			out := bytes.NewBuffer(nil)
 			gz := gzip.NewWriter(out)
 			tr := tar.NewWriter(gz)
-			tr.WriteHeader(&tar.Header{Typeflag: tar.TypeReg, Name: "foo.txt", Size: 0})
+
+			err := tr.WriteHeader(&tar.Header{Typeflag: tar.TypeReg, Name: "foo.txt", Size: 0})
+			if err != nil {
+				return nil, err
+			}
+
 			tr.Close()
 			gz.Close()
 			return out.Bytes(), nil


### PR DESCRIPTION
## Related Issue(s)
```
pkg/blobserve/blobspace.go:183:14: Error return value of `os.WriteFile` is not checked (errcheck)
	os.WriteFile(fmt.Sprintf("%s.used", fn), nil, 0644)
	            ^
pkg/blobserve/blobspace.go:208:19: Error return value of `cmd.Process.Kill` is not checked (errcheck)
		cmd.Process.Kill()
		                ^
pkg/blobserve/blobspace.go:223:14: Error return value of `os.WriteFile` is not checked (errcheck)
	os.WriteFile(fmt.Sprintf("%s.size", fn), []byte(fmt.Sprintf("%d", cw.C)), 0644)
	            ^
pkg/blobserve/blobspace.go:224:14: Error return value of `os.WriteFile` is not checked (errcheck)
	os.WriteFile(fmt.Sprintf("%s.used", fn), nil, 0644)
	            ^
pkg/blobserve/blobspace.go:260:8: Error return value of `f.Seek` is not checked (errcheck)
	f.Seek(0, 0)
	      ^
pkg/blobserve/blobspace_test.go:52:15: Error return value of `os.MkdirAll` is not checked (errcheck)
			os.MkdirAll(filepath.Join(tmp, "b1"), 0755)
			           ^
pkg/blobserve/blobspace_test.go:53:20: Error return value of `ioutil.WriteFile` is not checked (errcheck)
			ioutil.WriteFile(filepath.Join(tmp, "b1", "f1"), []byte("hello world"), 0600)
			                ^
pkg/blobserve/refstore_test.go:55:18: Error return value of `tr.WriteHeader` is not checked (errcheck)
			tr.WriteHeader(&tar.Header{Typeflag: tar.TypeReg, Name: "foo.txt", Size: 0})
``` 


## How to test

- Running `golangci-lint run ./...` in the blobserve directorio should return no errors

## Release Notes
```release-note
NONE
```

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
