### PR TITLE
gpctl: support all workspace types.

### DIFF
--- a/dev/gpctl/cmd/workspaces-list.go
+++ b/dev/gpctl/cmd/workspaces-list.go
@@ -49,6 +49,10 @@ var workspacesListCmd = &cobra.Command{
 				pod = fmt.Sprintf("ws-%s", w.GetId())
 			case api.WorkspaceType_PREBUILD:
 				pod = fmt.Sprintf("prebuild-%s", w.GetId())
+			case api.WorkspaceType_IMAGEBUILD:
+				pod = fmt.Sprintf("imagebuild-%s", w.GetId())
+			case api.WorkspaceType_PROBE:
+				pod = fmt.Sprintf("probe-%s", w.GetId())
 			}
 			out = append(out, PrintWorkspace{
 				Owner:       w.GetMetadata().GetOwner(),


### PR DESCRIPTION
## Description

following https://github.com/gitpod-io/gitpod/pull/11870/

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
1. Run cd dev/gpctl && go run main.go workspaces list
1. Observe the output columns containing type and pod.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
`gpctl workspaces list` shows all workspace types
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
