### PR TITLE
[code] update stable code image to 1.70

### DIFF
--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -2197,7 +2197,7 @@ data:
             "type": "browser",
             "logo": "https://ide.minimal-test.gitpod.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-8cdc51634e84dfb0f66df6c66186c90ce5ed0c80",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-ce3e2bc5edd1cf37d66ef0b37c38645543021831",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/pkg/components/workspace/ide/constants.go
+++ b/install/installer/pkg/components/workspace/ide/constants.go
@@ -6,7 +6,7 @@ package ide
 
 const (
 	CodeIDEImage                = "ide/code"
-	CodeIDEImageStableVersion   = "commit-8cdc51634e84dfb0f66df6c66186c90ce5ed0c80" // stable version that will be updated manually on demand
+	CodeIDEImageStableVersion   = "commit-ce3e2bc5edd1cf37d66ef0b37c38645543021831" // stable version that will be updated manually on demand
 	CodeDesktopIDEImage         = "ide/code-desktop"
 	CodeDesktopInsidersIDEImage = "ide/code-desktop-insiders"
 	IntelliJDesktopIDEImage     = "ide/intellij"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Commit sha in PR comes from previous PR https://github.com/gitpod-io/gitpod/pull/11899 build result https://werft.gitpod-dev.com/job/gitpod-build-hw-vs-170-build.3/results

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #
Relates https://github.com/gitpod-io/gitpod/issues/11638

## How to test
<!-- Provide steps to test this PR -->

Tested in https://github.com/gitpod-io/gitpod/pull/11899. So we can check version and commit hash here

- Open workspace in prev env with stable code
- Check if version and commit sha in `About`, sha should be `a2d4f1655c40b19dbc5c989a00af9184bfd93940`, version should be `1.70.0`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[code] update stable VSCode Browser to 1.70.0
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
