### PR TITLE
[public-api] Allow unknown fields in public-api-server config

### DIFF
--- a/components/public-api-server/cmd/root.go
+++ b/components/public-api-server/cmd/root.go
@@ -60,7 +60,6 @@ func getConfig() *config.Configuration {
 
 	var cfg config.Configuration
 	dec := json.NewDecoder(bytes.NewReader(ctnt))
-	dec.DisallowUnknownFields()
 	err = dec.Decode(&cfg)
 	if err != nil {
 		log.WithError(err).Fatal("Cannot decode configuration. Maybe missing --config?")


### PR DESCRIPTION
## Description

Allow unknown fields in the `public-api-server` config file.

Disallowing unknown fields guards against typos in the config file but makes it harder to deploy config changes independently of code changes. IMO the latter is worth more than the former.

## Related Issue(s)

## How to test

## Release Notes

```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
