### PR TITLE
[usage] Fix max call send message size

### DIFF
--- a/components/usage/pkg/server/server.go
+++ b/components/usage/pkg/server/server.go
@@ -62,7 +62,10 @@ func Start(cfg Config) error {
 	selfConnection, err := grpc.Dial(srv.GRPCAddress(),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpcDialerWithInitialDelay(1*time.Second),
-		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(30*1024*1024)),
+		grpc.WithDefaultCallOptions(
+			grpc.MaxCallRecvMsgSize(30*1024*1024),
+			grpc.MaxCallSendMsgSize(30*1024*1024),
+		),
 	)
 	if err != nil {
 		return fmt.Errorf("failed to create self-connection to grpc server: %w", err)


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Reconciler fails with:
```
failed to update invoices: rpc error: code = ResourceExhausted desc = grpc: received message larger than max (19548617 vs. 16777216)"
```

That's because we're sending the BilledSessions to the UpdateInvoices RPC. For now, we increase the size.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
