### PR TITLE
Use prebuild workspace class for regular workspaces

### DIFF
--- a/components/server/package.json
+++ b/components/server/package.json
@@ -43,6 +43,7 @@
     "@jmondi/oauth2-server": "^2.2.2",
     "@octokit/rest": "18.6.1",
     "@probot/get-private-key": "^1.1.1",
+    "@types/jaeger-client": "^3.18.3",
     "amqplib": "^0.8.0",
     "base-64": "^1.0.0",
     "bitbucket": "^2.7.0",

--- a/components/server/src/workspace/workspace-classes.spec.ts
+++ b/components/server/src/workspace/workspace-classes.spec.ts
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { WorkspaceClassesConfig, WorkspaceClasses } from "./workspace-classes";
+import * as chai from "chai";
+const expect = chai.expect;
+
+let config: WorkspaceClassesConfig = [
+    {
+        id: "g1-standard",
+        isDefault: true,
+        category: "GENERAL PURPOSE",
+        displayName: "Standard",
+        description: "Up to 4 vCPU, 8 GB memory, 30GB storage",
+        powerups: 1,
+        deprecated: false,
+        resources: {
+            cpu: 4,
+            memory: 8,
+            storage: 30,
+        },
+    },
+];
+
+config.push({
+    id: "g1-large",
+    isDefault: false,
+    category: "GENERAL PURPOSE",
+    displayName: "Large",
+    description: "Up to 8 vCPU, 16 GB memory, 50GB storage",
+    powerups: 2,
+    deprecated: false,
+    marker: {
+        moreResources: true,
+    },
+    resources: {
+        cpu: 8,
+        memory: 16,
+        storage: 50,
+    },
+});
+
+config.push({
+    id: "g1-deprecated",
+    isDefault: false,
+    category: "GENERAL PURPOSE",
+    displayName: "Large",
+    description: "Up to 8 vCPU, 16 GB memory, 50GB storage",
+    powerups: 2,
+    deprecated: true,
+    resources: {
+        cpu: 8,
+        memory: 16,
+        storage: 50,
+    },
+});
+
+describe("workspace-classes", function () {
+    describe("can substitute", function () {
+        it("classes are the same", function () {
+            const classId = WorkspaceClasses.canSubstitute("g1-large", "g1-large", config);
+            expect(classId).to.be.equal("g1-large");
+        });
+
+        it("substitute is acceptable", function () {
+            const classId = WorkspaceClasses.canSubstitute("g1-standard", "g1-large", config);
+            expect(classId).to.be.equal("g1-large");
+        });
+
+        it("substitute is deprecated", function () {
+            const classId = WorkspaceClasses.canSubstitute("g1-standard", "g1-deprecated", config);
+            expect(classId).to.be.equal("g1-large");
+        });
+
+        it("current is deprecated, substitute not acceptable", function () {
+            const classId = WorkspaceClasses.canSubstitute("g1-deprecated", "g1-standard", config);
+            expect(classId).to.be.equal("g1-large");
+        });
+
+        it("substitute is not acceptable", function () {
+            const classId = WorkspaceClasses.canSubstitute("g1-large", "g1-standard", config);
+            expect(classId).to.be.equal("g1-large");
+        });
+    });
+});

--- a/components/server/src/workspace/workspace-classes.spec.ts
+++ b/components/server/src/workspace/workspace-classes.spec.ts
@@ -17,11 +17,6 @@ let config: WorkspaceClassesConfig = [
         description: "Up to 4 vCPU, 8 GB memory, 30GB storage",
         powerups: 1,
         deprecated: false,
-        resources: {
-            cpu: 4,
-            memory: 8,
-            storage: 30,
-        },
     },
 ];
 
@@ -36,11 +31,6 @@ config.push({
     marker: {
         moreResources: true,
     },
-    resources: {
-        cpu: 8,
-        memory: 16,
-        storage: 50,
-    },
 });
 
 config.push({
@@ -51,37 +41,50 @@ config.push({
     description: "Up to 8 vCPU, 16 GB memory, 50GB storage",
     powerups: 2,
     deprecated: true,
-    resources: {
-        cpu: 8,
-        memory: 16,
-        storage: 50,
+    marker: {
+        moreResources: true,
     },
 });
 
 describe("workspace-classes", function () {
     describe("can substitute", function () {
         it("classes are the same", function () {
-            const classId = WorkspaceClasses.canSubstitute("g1-large", "g1-large", config);
+            const classId = WorkspaceClasses.selectClassForRegular("g1-large", "g1-large", config);
             expect(classId).to.be.equal("g1-large");
         });
 
-        it("substitute is acceptable", function () {
-            const classId = WorkspaceClasses.canSubstitute("g1-standard", "g1-large", config);
+        it("prebuild has more resources, substitute has not", function () {
+            const classId = WorkspaceClasses.selectClassForRegular("g1-large", "g1-standard", config);
             expect(classId).to.be.equal("g1-large");
         });
 
-        it("substitute is deprecated", function () {
-            const classId = WorkspaceClasses.canSubstitute("g1-standard", "g1-deprecated", config);
+        it("prebuild has more resources, substitute also has more resources", function () {
+            const classId = WorkspaceClasses.selectClassForRegular("g1-large", "g1-large", config);
             expect(classId).to.be.equal("g1-large");
         });
 
-        it("current is deprecated, substitute not acceptable", function () {
-            const classId = WorkspaceClasses.canSubstitute("g1-deprecated", "g1-standard", config);
+        it("prebuild has more resources, substitute has not, prebuild is deprecated", function () {
+            const classId = WorkspaceClasses.selectClassForRegular("g1-deprecated", "g1-standard", config);
             expect(classId).to.be.equal("g1-large");
+        });
+
+        it("prebuild has more resources, substitute has not, prebuild not deprecated", function () {
+            const classId = WorkspaceClasses.selectClassForRegular("g1-large", "g1-standard", config);
+            expect(classId).to.be.equal("g1-large");
+        });
+
+        it("prebuild does not have more resources, return substitute", function () {
+            const classId = WorkspaceClasses.selectClassForRegular("g1-standard", "g1-large", config);
+            expect(classId).to.be.equal("g1-large");
+        });
+
+        it("prebuild does not have more resources, substitute unknown", function () {
+            const classId = WorkspaceClasses.selectClassForRegular("g1-standard", "g1-unknown", config);
+            expect(classId).to.be.equal("g1-standard");
         });
 
         it("substitute is not acceptable", function () {
-            const classId = WorkspaceClasses.canSubstitute("g1-large", "g1-standard", config);
+            const classId = WorkspaceClasses.selectClassForRegular("g1-large", "g1-standard", config);
             expect(classId).to.be.equal("g1-large");
         });
     });

--- a/components/server/src/workspace/workspace-starter.spec.ts
+++ b/components/server/src/workspace/workspace-starter.spec.ts
@@ -4,10 +4,17 @@
  * See License-AGPL.txt in the project root for license information.
  */
 
-import { User } from "@gitpod/gitpod-protocol";
+import { DBWithTracing, MaybeWorkspaceInstance, WorkspaceDB } from "@gitpod/gitpod-db/lib";
+import { WorkspaceClassesConfig } from "./workspace-classes";
+import { PrebuiltWorkspace, User, Workspace, WorkspaceInstance, WorkspaceType } from "@gitpod/gitpod-protocol";
 import { IDEOption, IDEOptions } from "@gitpod/gitpod-protocol/lib/ide-protocol";
 import * as chai from "chai";
-import { migrationIDESettings, chooseIDE } from "./workspace-starter";
+import { migrationIDESettings, chooseIDE, getWorkspaceClassForInstance } from "./workspace-starter";
+import { MockTracer } from "opentracing";
+import { CustomTracerOpts, TraceContext, TracingManager } from "@gitpod/gitpod-protocol/lib/util/tracing";
+import { JaegerTracer } from "jaeger-client";
+import { EntitlementService } from "../billing/entitlement-service";
+import { EntitlementServiceChargebee } from "../../ee/src/billing/entitlement-service-chargebee";
 const expect = chai.expect;
 
 describe("workspace-starter", function () {
@@ -264,4 +271,256 @@ describe("workspace-starter", function () {
             expect(result.ideImage).to.equal(ideOptions.options["code"].latestImage);
         });
     });
+    describe("selectWorkspaceClass", function () {
+        it("new regular workspace, without prebuild, regular class configured", async function () {
+            const builder = new WorkspaceClassTestBuilder("regular").withRegularClassConfigured("g1-standard");
+            await execute(builder, "g1-standard");
+        });
+        it("new regular workspace, without prebuild, class not configured, has more resources", async function () {
+            const builder = new WorkspaceClassTestBuilder("regular").withHasMoreResources();
+            await execute(builder, "g1-large");
+        });
+
+        it("new regular workspace, without prebuild, class not configured, does not have more resources", async function () {
+            const builder = new WorkspaceClassTestBuilder("regular");
+            await execute(builder, "g1-standard");
+        });
+
+        it("restarted workspace", async function () {
+            const builder = new WorkspaceClassTestBuilder("regular").withPreviousInstance("g1-large");
+            await execute(builder, "g1-large");
+        });
+
+        it("restarted workspace, class does not exist, fallback to default class", async function () {
+            const builder = new WorkspaceClassTestBuilder("regular").withPreviousInstance("g1-unknown");
+            await execute(builder, "g1-standard");
+        });
+
+        it("restarted workspace, class is deprecated, fallback to default class", async function () {
+            const builder = new WorkspaceClassTestBuilder("regular").withPreviousInstance("g1-deprecated");
+            await execute(builder, "g1-standard");
+        });
+
+        it("new prebuild workspace, prebuild class configured", async function () {
+            const builder = new WorkspaceClassTestBuilder("prebuild").withPrebuildClassConfigured("g1-large");
+            await execute(builder, "g1-large");
+        });
+
+        it("new prebuild workspace, prebuild class not configured, has more resources", async function () {
+            const builder = new WorkspaceClassTestBuilder("prebuild").withHasMoreResources();
+            await execute(builder, "g1-large");
+        });
+
+        it("new prebuild workspace, prebuild class not configured, does not have more resources", async function () {
+            const builder = new WorkspaceClassTestBuilder("prebuild");
+            await execute(builder, "g1-standard");
+        });
+    });
 });
+
+async function execute(builder: WorkspaceClassTestBuilder, expectedClass: string) {
+    let [ctx, workspace, previousInstance, user, entitlementService, config, workspaceDb] = builder.build();
+
+    let actualClass = await getWorkspaceClassForInstance(
+        ctx,
+        workspace,
+        previousInstance,
+        user,
+        entitlementService,
+        config,
+        workspaceDb,
+    );
+    expect(actualClass).to.equal(expectedClass);
+}
+
+class WorkspaceClassTestBuilder {
+    // Type of the workspace that is being created e.g. regular or prebuild
+    workspaceType: WorkspaceType;
+
+    // The workspace class of the previous instance of the workspace
+    previousInstanceClass: string;
+
+    // The class configured by the user for a regular workspace
+    configuredRegularClass: string;
+
+    // The class configured by the user for a prebuild workspace
+    configuredPrebuildClass: string;
+
+    // Workspace is based on a prebuild
+    basedOnPrebuild: string;
+
+    // User has more resources
+    hasMoreResources: boolean;
+
+    constructor(workspaceType: WorkspaceType) {
+        this.workspaceType = workspaceType;
+    }
+
+    public withPreviousInstance(classId: string): WorkspaceClassTestBuilder {
+        this.previousInstanceClass = classId;
+        return this;
+    }
+
+    public withPrebuild(): WorkspaceClassTestBuilder {
+        this.basedOnPrebuild = "0kaks09j";
+        return this;
+    }
+
+    public withRegularClassConfigured(classId: string): WorkspaceClassTestBuilder {
+        this.configuredRegularClass = classId;
+        return this;
+    }
+
+    public withPrebuildClassConfigured(classId: string): WorkspaceClassTestBuilder {
+        this.configuredPrebuildClass = classId;
+        return this;
+    }
+
+    public withHasMoreResources(): WorkspaceClassTestBuilder {
+        this.hasMoreResources = true;
+        return this;
+    }
+
+    public build(): [
+        TraceContext,
+        Workspace,
+        WorkspaceInstance,
+        User,
+        EntitlementService,
+        WorkspaceClassesConfig,
+        DBWithTracing<WorkspaceDB>,
+    ] {
+        const tracer = new MockTracer();
+        const span = tracer.startSpan("testspan");
+        const ctx = {
+            span,
+        };
+
+        const workspace: Workspace = {
+            basedOnPrebuildId: this.basedOnPrebuild,
+            type: this.workspaceType,
+        } as Workspace;
+
+        const previousInstance: WorkspaceInstance = {
+            workspaceClass: this.previousInstanceClass,
+        } as WorkspaceInstance;
+
+        let user: User = {
+            id: "string",
+            creationDate: "string",
+            identities: [],
+            additionalData: {
+                workspaceClasses: {
+                    regular: this.configuredRegularClass,
+                    prebuild: this.configuredPrebuildClass,
+                },
+            },
+        };
+
+        const entitlementService: EntitlementService = new MockEntitlementService(this.hasMoreResources);
+
+        let config: WorkspaceClassesConfig = [
+            {
+                id: "g1-standard",
+                isDefault: true,
+                category: "GENERAL PURPOSE",
+                displayName: "Standard",
+                description: "Up to 4 vCPU, 8 GB memory, 30GB storage",
+                powerups: 1,
+                deprecated: false,
+                resources: {
+                    cpu: 4,
+                    memory: 8,
+                    storage: 30,
+                },
+            },
+        ];
+
+        config.push({
+            id: "g1-large",
+            isDefault: false,
+            category: "GENERAL PURPOSE",
+            displayName: "Large",
+            description: "Up to 8 vCPU, 16 GB memory, 50GB storage",
+            powerups: 2,
+            deprecated: false,
+            marker: {
+                moreResources: this.hasMoreResources,
+            },
+            resources: {
+                cpu: 8,
+                memory: 16,
+                storage: 50,
+            },
+        });
+
+        config.push({
+            id: "g1-deprecated",
+            isDefault: false,
+            category: "GENERAL PURPOSE",
+            displayName: "Large",
+            description: "Up to 8 vCPU, 16 GB memory, 50GB storage",
+            powerups: 2,
+            deprecated: true,
+            resources: {
+                cpu: 8,
+                memory: 16,
+                storage: 50,
+            },
+        });
+
+        const workspaceDb = new MockWorkspaceDb(!!this.basedOnPrebuild);
+        const workspaceDbWithTracing: DBWithTracing<WorkspaceDB> = new DBWithTracing(
+            workspaceDb,
+            new MockTracingManager(),
+        );
+
+        return [ctx, workspace, previousInstance, user, entitlementService, config, workspaceDbWithTracing];
+    }
+}
+
+class MockEntitlementService extends EntitlementServiceChargebee {
+    constructor(protected hasMoreResources: boolean) {
+        super();
+    }
+
+    userGetsMoreResources(user: User): Promise<boolean> {
+        return new Promise((resolve) => {
+            resolve(this.hasMoreResources);
+        });
+    }
+}
+
+class MockWorkspaceDb {
+    constructor(protected hasPrebuild: boolean) {}
+
+    findPrebuildByID(pwsid: string): Promise<PrebuiltWorkspace | undefined> {
+        return new Promise((resolve) => {
+            if (this.hasPrebuild) {
+                resolve({
+                    buildWorkspaceId: "string",
+                } as PrebuiltWorkspace);
+            } else {
+                resolve(undefined);
+            }
+        });
+    }
+
+    findCurrentInstance(workspaceId: string): Promise<MaybeWorkspaceInstance> {
+        return new Promise((resolve) => {
+            if (this.hasPrebuild) {
+                resolve({
+                    id: "string",
+                } as MaybeWorkspaceInstance);
+            } else {
+                resolve(undefined);
+            }
+        });
+    }
+}
+
+class MockTracingManager extends TracingManager {
+    getTracerForService(serviceName: string, opts?: CustomTracerOpts | undefined): JaegerTracer {
+        return {} as JaegerTracer;
+    }
+}

--- a/components/server/src/workspace/workspace-starter.spec.ts
+++ b/components/server/src/workspace/workspace-starter.spec.ts
@@ -428,11 +428,6 @@ class WorkspaceClassTestBuilder {
                 description: "Up to 4 vCPU, 8 GB memory, 30GB storage",
                 powerups: 1,
                 deprecated: false,
-                resources: {
-                    cpu: 4,
-                    memory: 8,
-                    storage: 30,
-                },
             },
         ];
 
@@ -447,11 +442,6 @@ class WorkspaceClassTestBuilder {
             marker: {
                 moreResources: this.hasMoreResources,
             },
-            resources: {
-                cpu: 8,
-                memory: 16,
-                storage: 50,
-            },
         });
 
         config.push({
@@ -462,11 +452,6 @@ class WorkspaceClassTestBuilder {
             description: "Up to 8 vCPU, 16 GB memory, 50GB storage",
             powerups: 2,
             deprecated: true,
-            resources: {
-                cpu: 8,
-                memory: 16,
-                storage: 50,
-            },
         });
 
         const workspaceDb = new MockWorkspaceDb(!!this.basedOnPrebuild);

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -203,7 +203,7 @@ export async function getWorkspaceClassForInstance(
         let workspaceClass = "";
         if (!previousInstance?.workspaceClass) {
             if (workspace.type == "regular") {
-                const prebuildClass = await WorkspaceClasses.getFromPrebuild(ctx, workspace, workspaceDb, config);
+                const prebuildClass = await WorkspaceClasses.getFromPrebuild(ctx, workspace, workspaceDb.trace(ctx));
                 if (prebuildClass) {
                     const userClass = await WorkspaceClasses.getConfiguredOrUpgradeFromLegacy(
                         user,

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -775,7 +775,19 @@ export class WorkspaceStarter {
                 // before workspace classes and does not have a class yet
                 if (!previousInstance?.workspaceClass) {
                     if (workspace.type == "regular") {
-                        if (user.additionalData?.workspaceClasses?.regular) {
+                        const prebuildClass = await WorkspaceClasses.getFromPrebuild(
+                            ctx,
+                            workspace,
+                            this.workspaceDb,
+                            this.config.workspaceClasses,
+                        );
+                        if (prebuildClass) {
+                            workspaceClass = WorkspaceClasses.canSubstitute(
+                                prebuildClass,
+                                user.additionalData?.workspaceClasses?.regular,
+                                this.config.workspaceClasses,
+                            );
+                        } else if (user.additionalData?.workspaceClasses?.regular) {
                             workspaceClass = user.additionalData?.workspaceClasses?.regular;
                         }
                     }

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -210,7 +210,7 @@ export async function getWorkspaceClassForInstance(
                         config,
                         entitlementService,
                     );
-                    workspaceClass = WorkspaceClasses.canSubstitute(prebuildClass, userClass, config);
+                    workspaceClass = WorkspaceClasses.selectClassForRegular(prebuildClass, userClass, config);
                 } else if (user.additionalData?.workspaceClasses?.regular) {
                     workspaceClass = user.additionalData?.workspaceClasses?.regular;
                 }


### PR DESCRIPTION
## Description
Ensure that if a prebuild is used to create a workspace a class is used that is appropriate for the workspace; meaning if the prebuild has a workspace class greater than the currently configured one by the customer the prebuild class is used, otherwise the class configured by the customer is used. 

## Related Issue(s)
Fixes #https://github.com/gitpod-io/gitpod/issues/11972
Needs https://github.com/gitpod-io/ops/pull/3728

## How to test
- Select workspace class g1-large
- Start a prebuild 
- Select workspace class g1-standard
- Create a regular workspace from prebuild
- The workspace should have g1-large 
--
- Start a prebuild for another repository (with g1-standard)
- Select workspace class g1-large
- Create a regular workspace from prebuild
- The workspace should have g1-large

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
