### PR TITLE
[ws-daemon] Log update of resource limits

### DIFF
--- a/components/ws-daemon/pkg/cgroup/plugin_iolimit_v1.go
+++ b/components/ws-daemon/pkg/cgroup/plugin_iolimit_v1.go
@@ -76,8 +76,8 @@ func (c *IOLimiterV1) Update(writeBytesPerSecond, readBytesPerSecond, writeIOPs,
 	c.cond.L.Lock()
 	defer c.cond.L.Unlock()
 
-	log.WithField("limits", c.limits).Info("updating I/O cgroups v1 limits")
 	c.limits = buildLimits(writeBytesPerSecond, readBytesPerSecond, writeIOPs, readIOPs)
+	log.WithField("limits", c.limits).Info("updating I/O cgroups v1 limits")
 
 	c.cond.Broadcast()
 }

--- a/components/ws-daemon/pkg/cgroup/plugin_iolimit_v2.go
+++ b/components/ws-daemon/pkg/cgroup/plugin_iolimit_v2.go
@@ -92,8 +92,8 @@ func (c *IOLimiterV2) Update(writeBytesPerSecond, readBytesPerSecond, writeIOPs,
 	c.cond.L.Lock()
 	defer c.cond.L.Unlock()
 
-	log.WithField("limits", c.limits).Info("updating I/O cgroups v2 limits")
 	c.limits = buildV2Limits(writeBytesPerSecond, readBytesPerSecond, writeIOPs, readIOPs, c.devices)
+	log.WithField("limits", c.limits.IO).Info("updating I/O cgroups v2 limits")
 
 	c.cond.Broadcast()
 }

--- a/components/ws-daemon/pkg/cgroup/plugin_proc_limit_v2.go
+++ b/components/ws-daemon/pkg/cgroup/plugin_proc_limit_v2.go
@@ -86,5 +86,6 @@ func (c *ProcLimiterV2) Update(processes int64) {
 		},
 	}
 
+	log.WithField("limits", c.limits.Pids).Info("updating proc cgroups v2 limits")
 	c.cond.Broadcast()
 }


### PR DESCRIPTION
## Description
Log that resource limits have been updated. 

## Related Issue(s)
n.a.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
