### PR TITLE
[UBP] Add tests and functionality to the Stripe webhook handler

### DIFF
--- a/components/public-api-server/pkg/webhooks/stripe_test.go
+++ b/components/public-api-server/pkg/webhooks/stripe_test.go
@@ -1,0 +1,117 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package webhooks
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/gitpod-io/gitpod/common-go/baseserver"
+	"github.com/stretchr/testify/require"
+	"github.com/stripe/stripe-go/v72"
+)
+
+// https://stripe.com/docs/api/events/types
+const (
+	invoiceUpdatedEventType   = "invoice.updated"
+	invoiceFinalizedEventType = "invoice.finalized"
+	customerCreatedEventType  = "customer.created"
+)
+
+func TestWebhookAcceptsPostRequests(t *testing.T) {
+	scenarios := []struct {
+		HttpMethod         string
+		ExpectedStatusCode int
+	}{
+		{
+			HttpMethod:         http.MethodPost,
+			ExpectedStatusCode: http.StatusOK,
+		},
+		{
+			HttpMethod:         http.MethodGet,
+			ExpectedStatusCode: http.StatusBadRequest,
+		},
+		{
+			HttpMethod:         http.MethodPut,
+			ExpectedStatusCode: http.StatusBadRequest,
+		},
+	}
+
+	srv := baseServerWithStripeWebhook(t)
+
+	ev := stripe.Event{Type: invoiceFinalizedEventType}
+	payload, err := json.Marshal(ev)
+	require.NoError(t, err)
+
+	url := fmt.Sprintf("%s%s", srv.HTTPAddress(), "/webhook")
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.HttpMethod, func(t *testing.T) {
+			req, err := http.NewRequest(scenario.HttpMethod, url, bytes.NewBuffer(payload))
+			require.NoError(t, err)
+
+			resp, err := http.DefaultClient.Do(req)
+			require.NoError(t, err)
+
+			require.Equal(t, scenario.ExpectedStatusCode, resp.StatusCode)
+		})
+	}
+}
+
+func TestWebhookIgnoresIrrelevantEvents(t *testing.T) {
+	scenarios := []struct {
+		EventType          string
+		ExpectedStatusCode int
+	}{
+		{
+			EventType:          invoiceFinalizedEventType,
+			ExpectedStatusCode: http.StatusOK,
+		},
+		{
+			EventType:          invoiceUpdatedEventType,
+			ExpectedStatusCode: http.StatusBadRequest,
+		},
+		{
+			EventType:          customerCreatedEventType,
+			ExpectedStatusCode: http.StatusBadRequest,
+		},
+	}
+
+	srv := baseServerWithStripeWebhook(t)
+
+	url := fmt.Sprintf("%s%s", srv.HTTPAddress(), "/webhook")
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.EventType, func(t *testing.T) {
+			ev := stripe.Event{Type: scenario.EventType}
+			payload, err := json.Marshal(ev)
+			require.NoError(t, err)
+
+			req, err := http.NewRequest(http.MethodPost, url, bytes.NewBuffer(payload))
+			require.NoError(t, err)
+
+			resp, err := http.DefaultClient.Do(req)
+			require.NoError(t, err)
+
+			require.Equal(t, scenario.ExpectedStatusCode, resp.StatusCode)
+		})
+	}
+}
+
+func baseServerWithStripeWebhook(t *testing.T) *baseserver.Server {
+	t.Helper()
+
+	srv := baseserver.NewForTests(t,
+		baseserver.WithHTTP(baseserver.MustUseRandomLocalAddress(t)),
+	)
+	baseserver.StartServerForTests(t, srv)
+
+	srv.HTTPMux().Handle("/webhook", NewStripeWebhookHandler())
+
+	return srv
+}


### PR DESCRIPTION
## Description

Do some TDD on the Stripe webhook handler.

Add tests to ensure:
* The handler only accepts `POST` requests.
* The handler only responds to `"invoice.finalized"` events.

Add code to the handler to make those tests pass.

## Related Issue(s)
Part of #10937 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
