### PR TITLE
[dashboard] fix arbitrary useEffect

### DIFF
--- a/components/dashboard/src/App.tsx
+++ b/components/dashboard/src/App.tsx
@@ -234,7 +234,7 @@ function App() {
             // Choose which experiments to run for this session/user
             Experiment.set(Experiment.seed(true));
         }
-    });
+    }, []);
 
     useEffect(() => {
         return history.listen((location: any) => {

--- a/components/dashboard/src/components/ConfirmationModal.tsx
+++ b/components/dashboard/src/components/ConfirmationModal.tsx
@@ -60,7 +60,7 @@ export default function ConfirmationModal(props: {
     const buttonDisabled = useRef(props.buttonDisabled);
     useEffect(() => {
         buttonDisabled.current = props.buttonDisabled;
-    });
+    }, []);
 
     return (
         <Modal

--- a/components/dashboard/src/settings/selectClass.tsx
+++ b/components/dashboard/src/settings/selectClass.tsx
@@ -50,7 +50,7 @@ export default function SelectWorkspaceClass(props: SelectWorkspaceClassProps) {
         };
 
         fetchClasses().catch(console.error);
-    });
+    }, []);
 
     if (!props.enabled) {
         return <div></div>;


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Randomly checking webapp dashboards after recent deployment shows excessive calls to newly `getSupportedWorkspaceClasses` operations caused by `useEffect` without dependency specification, thus causing evaluation without need. 

<img width="747" alt="Screen Shot 2022-08-05 at 14 40 16" src="https://user-images.githubusercontent.com/914497/183079229-8d645660-ade7-45f5-8940-ed5ca4c6844f.png">


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Relates to #11571

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
