### PR TITLE
[ws-daemon] Replace Workspace mutex with atomic.Value

### DIFF
--- a/components/ws-daemon/pkg/internal/session/store.go
+++ b/components/ws-daemon/pkg/internal/session/store.go
@@ -81,7 +81,7 @@ func NewStore(ctx context.Context, location string, hooks map[WorkspaceState][]W
 }
 
 func (s *Store) runLifecycleHooks(ctx context.Context, ws *Workspace) error {
-	hooks := s.hooks[ws.state]
+	hooks := s.hooks[ws.currentState()]
 	log.WithFields(ws.OWI()).WithField("state", ws.state).WithField("hooks", len(hooks)).Debug("running lifecycle hooks")
 
 	for _, h := range hooks {
@@ -111,7 +111,7 @@ func (s *Store) NewWorkspace(ctx context.Context, instanceID, location string, c
 	if err != nil {
 		return nil, err
 	}
-	res.state = WorkspaceInitializing
+	res.state.Store(WorkspaceInitializing)
 	if res.NonPersistentAttrs == nil {
 		res.NonPersistentAttrs = make(map[string]interface{})
 	}

--- a/components/ws-daemon/pkg/internal/session/workspace_test.go
+++ b/components/ws-daemon/pkg/internal/session/workspace_test.go
@@ -144,7 +144,7 @@ func TestWaitForInit(t *testing.T) {
 			t.Errorf("%s: cannot create test workspace: %v", test.Desc, err)
 			continue
 		}
-		ws.state = test.State
+		ws.state.Store(test.State)
 
 		waitStarted := make(chan struct{})
 		waitComplete := make(chan struct{})
@@ -199,7 +199,7 @@ func TestWaitOrMarkForDisposalRace(t *testing.T) {
 		t.Errorf("cannot create test workspace: %v", err)
 		return
 	}
-	ws.state = WorkspaceReady
+	ws.state.Store(WorkspaceReady)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -222,7 +222,7 @@ func TestWaitOrMarkForDisposalRace(t *testing.T) {
 
 				time.Sleep(1 * time.Second)
 				t.Logf("num go routines: %03d", runtime.NumGoroutine())
-				ws.Dispose(ctx)
+				_ = ws.Dispose(ctx)
 			}
 		}()
 	}
@@ -263,7 +263,7 @@ func TestWaitOrMarkForDisposal(t *testing.T) {
 			t.Errorf("%s: cannot create test workspace: %v", test.Desc, err)
 			continue
 		}
-		ws.state = test.State
+		ws.state.Store(test.State)
 
 		waitStarted := make(chan struct{})
 		waitComplete := make(chan struct{})


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
