### PR TITLE
EntitlementService Usage-Based Pricing

### DIFF
--- a/components/dashboard/src/start/CreateWorkspace.tsx
+++ b/components/dashboard/src/start/CreateWorkspace.tsx
@@ -372,8 +372,7 @@ function SpendingLimitReachedModal(p: { hints: any }) {
     const [attributedTeam, setAttributedTeam] = useState<Team | undefined>();
 
     useEffect(() => {
-        const attributionId: AttributionId | undefined =
-            p.hints && p.hints.attributionId && AttributionId.parse(p.hints.attributionId);
+        const attributionId: AttributionId | undefined = p.hints && p.hints.attributionId;
         if (attributionId) {
             // setAttributionId(attributionId);
             if (attributionId.kind === "team") {

--- a/components/server/ee/src/billing/billing-service.ts
+++ b/components/server/ee/src/billing/billing-service.ts
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the Gitpod Enterprise Source Code License,
+ * See License.enterprise.txt in the project root folder.
+ */
+
+import { CostCenterDB } from "@gitpod/gitpod-db/lib";
+import { User } from "@gitpod/gitpod-protocol";
+import { AttributionId } from "@gitpod/gitpod-protocol/lib/attribution";
+import { BillableSession, BillableSessionRequest, SortOrder } from "@gitpod/gitpod-protocol/lib/usage";
+import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
+import { UsageService, UsageServiceClientProvider } from "@gitpod/usage-api/lib/usage/v1/sugar";
+import { Timestamp } from "google-protobuf/google/protobuf/timestamp_pb";
+import { inject, injectable } from "inversify";
+import { UserService } from "../../../src/user/user-service";
+
+export interface SpendingLimitReachedResult {
+    reached: boolean;
+    almostReached?: boolean;
+    attributionId: AttributionId;
+}
+
+@injectable()
+export class BillingService {
+    @inject(UserService) protected readonly userService: UserService;
+    @inject(CostCenterDB) protected readonly costCenterDB: CostCenterDB;
+    @inject(UsageServiceClientProvider) protected readonly usageServiceClientProvider: UsageServiceClientProvider;
+
+    async checkSpendingLimitReached(user: User): Promise<SpendingLimitReachedResult> {
+        const attributionId = await this.userService.getWorkspaceUsageAttributionId(user);
+        const costCenter = !!attributionId && (await this.costCenterDB.findById(AttributionId.render(attributionId)));
+        if (!costCenter) {
+            const err = new Error("No CostCenter found");
+            log.error({ userId: user.id }, err.message, err, { attributionId });
+            throw err;
+        }
+
+        const allSessions = await this.listBilledUsage({
+            attributionId: AttributionId.render(attributionId),
+            startedTimeOrder: SortOrder.Descending,
+        });
+        const totalUsage = allSessions.map((s) => s.credits).reduce((a, b) => a + b, 0);
+        if (totalUsage >= costCenter.spendingLimit) {
+            return {
+                reached: true,
+                attributionId,
+            };
+        } else if (totalUsage > costCenter.spendingLimit * 0.8) {
+            return {
+                reached: false,
+                almostReached: true,
+                attributionId,
+            };
+        }
+        return {
+            reached: false,
+            attributionId,
+        };
+    }
+
+    // TODO (gpl): Replace this with call to stripeService.getInvoice()
+    async listBilledUsage(req: BillableSessionRequest): Promise<BillableSession[]> {
+        const { attributionId, startedTimeOrder, from, to } = req;
+        let timestampFrom;
+        let timestampTo;
+
+        if (from) {
+            timestampFrom = Timestamp.fromDate(new Date(from));
+        }
+        if (to) {
+            timestampTo = Timestamp.fromDate(new Date(to));
+        }
+        const usageClient = this.usageServiceClientProvider.getDefault();
+        const response = await usageClient.listBilledUsage(
+            {},
+            attributionId,
+            startedTimeOrder as number,
+            timestampFrom,
+            timestampTo,
+        );
+        const sessions = response.getSessionsList().map((s) => UsageService.mapBilledSession(s));
+        return sessions;
+    }
+}

--- a/components/server/ee/src/billing/billing-service.ts
+++ b/components/server/ee/src/billing/billing-service.ts
@@ -9,7 +9,7 @@ import { User } from "@gitpod/gitpod-protocol";
 import { AttributionId } from "@gitpod/gitpod-protocol/lib/attribution";
 import { BillableSession, BillableSessionRequest, SortOrder } from "@gitpod/gitpod-protocol/lib/usage";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
-import { UsageService, UsageServiceClientProvider } from "@gitpod/usage-api/lib/usage/v1/sugar";
+import { CachingUsageServiceClientProvider, UsageService } from "@gitpod/usage-api/lib/usage/v1/sugar";
 import { Timestamp } from "google-protobuf/google/protobuf/timestamp_pb";
 import { inject, injectable } from "inversify";
 import { UserService } from "../../../src/user/user-service";
@@ -24,7 +24,8 @@ export interface SpendingLimitReachedResult {
 export class BillingService {
     @inject(UserService) protected readonly userService: UserService;
     @inject(CostCenterDB) protected readonly costCenterDB: CostCenterDB;
-    @inject(UsageServiceClientProvider) protected readonly usageServiceClientProvider: UsageServiceClientProvider;
+    @inject(CachingUsageServiceClientProvider)
+    protected readonly usageServiceClientProvider: CachingUsageServiceClientProvider;
 
     async checkSpendingLimitReached(user: User): Promise<SpendingLimitReachedResult> {
         const attributionId = await this.userService.getWorkspaceUsageAttributionId(user);

--- a/components/server/ee/src/billing/entitlement-service-chargebee.ts
+++ b/components/server/ee/src/billing/entitlement-service-chargebee.ts
@@ -17,10 +17,13 @@ import { RemainingHours } from "@gitpod/gitpod-protocol/lib/accounting-protocol"
 import { MAX_PARALLEL_WORKSPACES, Plans } from "@gitpod/gitpod-protocol/lib/plans";
 import { millisecondsToHours } from "@gitpod/gitpod-protocol/lib/util/timeutil";
 import { inject, injectable } from "inversify";
-import { EntitlementService } from "../../../src/billing/entitlement-service";
+import {
+    EntitlementService,
+    HitParallelWorkspaceLimit,
+    MayStartWorkspaceResult,
+} from "../../../src/billing/entitlement-service";
 import { Config } from "../../../src/config";
 import { AccountStatementProvider, CachedAccountStatement } from "../user/account-statement-provider";
-import { HitParallelWorkspaceLimit, MayStartWorkspaceResult } from "../user/eligibility-service";
 
 @injectable()
 export class EntitlementServiceChargebee implements EntitlementService {

--- a/components/server/ee/src/billing/entitlement-service-chargebee.ts
+++ b/components/server/ee/src/billing/entitlement-service-chargebee.ts
@@ -57,8 +57,13 @@ export class EntitlementServiceChargebee implements EntitlementService {
             hasHitParallelWorkspaceLimit(),
         ]);
 
+        const result = enoughCredits && !hitParallelWorkspaceLimit;
+
+        console.log("mayStartWorkspace > hitParallelWorkspaceLimit " + hitParallelWorkspaceLimit);
+
         return {
-            enoughCredits: !!enoughCredits,
+            mayStart: result,
+            oufOfCredits: !enoughCredits,
             hitParallelWorkspaceLimit,
         };
     }
@@ -82,6 +87,7 @@ export class EntitlementServiceChargebee implements EntitlementService {
         const cachedAccountStatement = this.accountStatementProvider.getCachedStatement();
         const lowerBound = this.getRemainingUsageHoursLowerBound(cachedAccountStatement, date.toISOString());
         if (lowerBound && (lowerBound === "unlimited" || lowerBound > Accounting.MINIMUM_CREDIT_FOR_OPEN_IN_HOURS)) {
+            console.log("checkEnoughCreditForWorkspaceStart > unlimited");
             return true;
         }
 
@@ -90,6 +96,7 @@ export class EntitlementServiceChargebee implements EntitlementService {
             date.toISOString(),
             runningInstances,
         );
+        console.log("checkEnoughCreditForWorkspaceStart > remainingUsageHours " + remainingUsageHours);
         return remainingUsageHours > Accounting.MINIMUM_CREDIT_FOR_OPEN_IN_HOURS;
     }
 

--- a/components/server/ee/src/billing/entitlement-service-license.ts
+++ b/components/server/ee/src/billing/entitlement-service-license.ts
@@ -15,9 +15,8 @@ import {
 import { LicenseEvaluator } from "@gitpod/licensor/lib";
 import { Feature } from "@gitpod/licensor/lib/api";
 import { inject, injectable } from "inversify";
-import { EntitlementService } from "../../../src/billing/entitlement-service";
+import { EntitlementService, MayStartWorkspaceResult } from "../../../src/billing/entitlement-service";
 import { Config } from "../../../src/config";
-import { MayStartWorkspaceResult } from "../user/eligibility-service";
 
 @injectable()
 export class EntitlementServiceLicense implements EntitlementService {

--- a/components/server/ee/src/billing/entitlement-service-license.ts
+++ b/components/server/ee/src/billing/entitlement-service-license.ts
@@ -30,7 +30,7 @@ export class EntitlementServiceLicense implements EntitlementService {
         runningInstances: Promise<WorkspaceInstance[]>,
     ): Promise<MayStartWorkspaceResult> {
         // if payment is not enabled users can start as many parallel workspaces as they want
-        return { enoughCredits: true };
+        return { mayStart: true };
     }
 
     async maySetTimeout(user: User, date: Date): Promise<boolean> {

--- a/components/server/ee/src/billing/entitlement-service-ubp.ts
+++ b/components/server/ee/src/billing/entitlement-service-ubp.ts
@@ -57,8 +57,9 @@ export class EntitlementServiceUBP implements EntitlementService {
             this.checkSpendingLimitReached(user, date),
             hasHitParallelWorkspaceLimit(),
         ]);
-
+        const result = !spendingLimitReachedOnCostCenter && !hitParallelWorkspaceLimit;
         return {
+            mayStart: result,
             spendingLimitReachedOnCostCenter,
             hitParallelWorkspaceLimit,
         };

--- a/components/server/ee/src/billing/entitlement-service.ts
+++ b/components/server/ee/src/billing/entitlement-service.ts
@@ -39,17 +39,24 @@ export class EntitlementServiceImpl implements EntitlementService {
     ): Promise<MayStartWorkspaceResult> {
         try {
             const billingMode = await this.billingModes.getBillingModeForUser(user, date);
+            let result;
             switch (billingMode.mode) {
                 case "none":
-                    return this.license.mayStartWorkspace(user, date, runningInstances);
+                    result = await this.license.mayStartWorkspace(user, date, runningInstances);
+                    break;
                 case "chargebee":
-                    return this.chargebee.mayStartWorkspace(user, date, runningInstances);
+                    result = await this.chargebee.mayStartWorkspace(user, date, runningInstances);
+                    break;
                 case "usage-based":
-                    return this.ubp.mayStartWorkspace(user, date, runningInstances);
+                    result = await this.ubp.mayStartWorkspace(user, date, runningInstances);
+                    break;
+                default:
+                    throw new Error("Unsupported billing mode: " + (billingMode as any).mode); // safety net
             }
+            return result;
         } catch (err) {
             log.error({ userId: user.id }, "EntitlementService error: mayStartWorkspace", err);
-            return {};
+            throw err;
         }
     }
 

--- a/components/server/ee/src/container-module.ts
+++ b/components/server/ee/src/container-module.ts
@@ -64,6 +64,7 @@ import { EntitlementServiceChargebee } from "./billing/entitlement-service-charg
 import { BillingModes, BillingModesImpl } from "./billing/billing-mode";
 import { EntitlementServiceLicense } from "./billing/entitlement-service-license";
 import { EntitlementServiceImpl } from "./billing/entitlement-service";
+import { EntitlementServiceUBP } from "./billing/entitlement-service-ubp";
 
 export const productionEEContainerModule = new ContainerModule((bind, unbind, isBound, rebind) => {
     rebind(Server).to(ServerEE).inSingletonScope();
@@ -127,6 +128,7 @@ export const productionEEContainerModule = new ContainerModule((bind, unbind, is
 
     bind(EntitlementServiceChargebee).toSelf().inSingletonScope();
     bind(EntitlementServiceLicense).toSelf().inSingletonScope();
+    bind(EntitlementServiceUBP).toSelf().inSingletonScope();
     bind(EntitlementServiceImpl).toSelf().inSingletonScope();
     rebind(EntitlementService).to(EntitlementServiceImpl).inSingletonScope();
     bind(BillingModes).to(BillingModesImpl).inSingletonScope();

--- a/components/server/ee/src/container-module.ts
+++ b/components/server/ee/src/container-module.ts
@@ -65,6 +65,7 @@ import { BillingModes, BillingModesImpl } from "./billing/billing-mode";
 import { EntitlementServiceLicense } from "./billing/entitlement-service-license";
 import { EntitlementServiceImpl } from "./billing/entitlement-service";
 import { EntitlementServiceUBP } from "./billing/entitlement-service-ubp";
+import { BillingService } from "./billing/billing-service";
 
 export const productionEEContainerModule = new ContainerModule((bind, unbind, isBound, rebind) => {
     rebind(Server).to(ServerEE).inSingletonScope();
@@ -132,4 +133,6 @@ export const productionEEContainerModule = new ContainerModule((bind, unbind, is
     bind(EntitlementServiceImpl).toSelf().inSingletonScope();
     rebind(EntitlementService).to(EntitlementServiceImpl).inSingletonScope();
     bind(BillingModes).to(BillingModesImpl).inSingletonScope();
+
+    bind(BillingService).toSelf().inSingletonScope();
 });

--- a/components/server/ee/src/user/eligibility-service.ts
+++ b/components/server/ee/src/user/eligibility-service.ts
@@ -15,16 +15,6 @@ import { EMailDomainService } from "../auth/email-domain-service";
 import fetch from "node-fetch";
 import { Config } from "../../../src/config";
 
-export interface MayStartWorkspaceResult {
-    hitParallelWorkspaceLimit?: HitParallelWorkspaceLimit;
-    enoughCredits: boolean;
-}
-
-export interface HitParallelWorkspaceLimit {
-    max: number;
-    current: number;
-}
-
 /**
  * Response from the GitHub Education Student Developer / Faculty Member Pack.
  * The flags `student` and `faculty` are mutually exclusive (the cannot both become `true`).

--- a/components/server/ee/src/user/user-service.ts
+++ b/components/server/ee/src/user/user-service.ts
@@ -20,11 +20,9 @@ import { SubscriptionService } from "@gitpod/gitpod-payment-endpoint/lib/account
 import { OssAllowListDB } from "@gitpod/gitpod-db/lib/oss-allowlist-db";
 import { HostContextProvider } from "../../../src/auth/host-context-provider";
 import { Config } from "../../../src/config";
-import { EntitlementService } from "../../../src/billing/entitlement-service";
 
 export class UserServiceEE extends UserService {
     @inject(LicenseEvaluator) protected readonly licenseEvaluator: LicenseEvaluator;
-    @inject(EntitlementService) protected readonly entitlementService: EntitlementService;
     @inject(SubscriptionService) protected readonly subscriptionService: SubscriptionService;
     @inject(OssAllowListDB) protected readonly OssAllowListDb: OssAllowListDB;
     @inject(HostContextProvider) protected readonly hostContextProvider: HostContextProvider;

--- a/components/server/src/billing/entitlement-service.ts
+++ b/components/server/src/billing/entitlement-service.ts
@@ -14,8 +14,11 @@ import { AttributionId } from "@gitpod/gitpod-protocol/lib/attribution";
 import { injectable } from "inversify";
 
 export interface MayStartWorkspaceResult {
+    mayStart: boolean;
+
     hitParallelWorkspaceLimit?: HitParallelWorkspaceLimit;
-    enoughCredits?: boolean;
+
+    oufOfCredits?: boolean;
 
     /** Usage-Based Pricing: AttributionId of the CostCenter that reached it's spending limit */
     spendingLimitReachedOnCostCenter?: AttributionId;
@@ -72,7 +75,7 @@ export class CommunityEntitlementService implements EntitlementService {
         date: Date,
         runningInstances: Promise<WorkspaceInstance[]>,
     ): Promise<MayStartWorkspaceResult> {
-        return { enoughCredits: true };
+        return { mayStart: true };
     }
 
     async maySetTimeout(user: User, date: Date): Promise<boolean> {

--- a/components/server/src/billing/entitlement-service.ts
+++ b/components/server/src/billing/entitlement-service.ts
@@ -11,7 +11,19 @@ import {
     WORKSPACE_TIMEOUT_DEFAULT_SHORT,
 } from "@gitpod/gitpod-protocol";
 import { injectable } from "inversify";
-import { MayStartWorkspaceResult } from "../../ee/src/user/eligibility-service";
+
+export interface MayStartWorkspaceResult {
+    hitParallelWorkspaceLimit?: HitParallelWorkspaceLimit;
+    enoughCredits?: boolean;
+
+    /** Usage-Based Pricing */
+    spendingLimitReached?: boolean;
+}
+
+export interface HitParallelWorkspaceLimit {
+    max: number;
+    current: number;
+}
 
 export const EntitlementService = Symbol("EntitlementService");
 export interface EntitlementService {

--- a/components/server/src/billing/entitlement-service.ts
+++ b/components/server/src/billing/entitlement-service.ts
@@ -10,14 +10,15 @@ import {
     WorkspaceTimeoutDuration,
     WORKSPACE_TIMEOUT_DEFAULT_SHORT,
 } from "@gitpod/gitpod-protocol";
+import { AttributionId } from "@gitpod/gitpod-protocol/lib/attribution";
 import { injectable } from "inversify";
 
 export interface MayStartWorkspaceResult {
     hitParallelWorkspaceLimit?: HitParallelWorkspaceLimit;
     enoughCredits?: boolean;
 
-    /** Usage-Based Pricing */
-    spendingLimitReached?: boolean;
+    /** Usage-Based Pricing: AttributionId of the CostCenter that reached it's spending limit */
+    spendingLimitReachedOnCostCenter?: AttributionId;
 }
 
 export interface HitParallelWorkspaceLimit {

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -1047,7 +1047,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
             // make sure we've checked that the user has enough credit before consuming any resources.
             // Be sure to check this before prebuilds and create workspace, too!
             let context = await contextPromise;
-            await Promise.all([this.mayStartWorkspace(ctx, user, runningInstancesPromise)]);
+            await this.mayStartWorkspace(ctx, user, runningInstancesPromise);
 
             if (SnapshotContext.is(context)) {
                 // TODO(janx): Remove snapshot access tracking once we're certain that enforcing repository read access doesn't disrupt the snapshot UX.

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -119,6 +119,7 @@ import { WorkspaceClusterImagebuilderClientProvider } from "./workspace-cluster-
 import { getExperimentsClientForBackend } from "@gitpod/gitpod-protocol/lib/experiments/configcat-server";
 import { WorkspaceClasses } from "./workspace-classes";
 import { EntitlementService } from "../billing/entitlement-service";
+import { AttributionId } from "@gitpod/gitpod-protocol/lib/attribution";
 
 export interface StartWorkspaceOptions {
     rethrow?: boolean;
@@ -835,7 +836,7 @@ export class WorkspaceStarter {
                     phase: "preparing",
                 },
                 configuration,
-                usageAttributionId,
+                usageAttributionId: usageAttributionId && AttributionId.render(usageAttributionId),
                 workspaceClass,
             };
             if (WithReferrerContext.is(workspace.context)) {


### PR DESCRIPTION
## Description
Based on: https://github.com/gitpod-io/gitpod/pull/11814

 1. Introduce EntitlementServiceUBP
    - [ ] TODO: Implement `hasPaidSubscription`: https://github.com/gitpod-io/gitpod/pull/11936/commits/55c01f7d01df375535df8048bdd4a625699aae91#diff-fd2c4594d5bd9aa04668bdce9e9c810d3c495192a0be434006c7181f4853260bR93
 2. Implement `BillingService.checkSpendingLimitReached ` (based on [usage](https://github.com/gitpod-io/gitpod/pull/11936/commits/b50bc8e9cb449e6574197c3f6b0d2d8766a6f6a3#diff-0caf79924a209df9577c140a9aefa82d74dab19ed1d20bd1f8597259c3d83316R61) until #11692 got merged)#
 3. Wiring, re-use of `BillingService` ([commit](https://github.com/gitpod-io/gitpod/pull/11936/commits/8d35e448211677fa762db3fde2adbef1dc43ff07))

## Related Issue(s)
Fixes #11402

## How to test
Actually, after https://github.com/gitpod-io/gitpod/pull/11814 has been tested thoroughly, this can be tested in prod by enableing `isUsageBasedPricingEnabled`, and testing the rollout flow. :upside_down_face: 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
- [x] /werft with-payment
