### PR TITLE
Ignore git error message `does not have any commits yet`

### DIFF
--- a/components/content-service/pkg/git/git_test.go
+++ b/components/content-service/pkg/git/git_test.go
@@ -416,7 +416,7 @@ func TestGitStatusFromFiles(t *testing.T) {
 				return
 			}
 
-			gitout, err := client.GitWithOutput(ctx, "status", "--porcelain=v2", "--branch", "-uall")
+			gitout, err := client.GitWithOutput(ctx, nil, "status", "--porcelain=v2", "--branch", "-uall")
 			if err != nil {
 				t.Errorf("error calling GitWithOutput: %v", err)
 				return
@@ -426,7 +426,7 @@ func TestGitStatusFromFiles(t *testing.T) {
 				return
 			}
 
-			gitout, err = client.GitWithOutput(ctx, "log", "--pretty=%h: %s", "--branches", "--not", "--remotes")
+			gitout, err = client.GitWithOutput(ctx, &errNoCommitsYet, "log", "--pretty=%h: %s", "--branches", "--not", "--remotes")
 			if err != nil {
 				t.Errorf("error calling GitWithOutput: %v", err)
 				return
@@ -436,7 +436,7 @@ func TestGitStatusFromFiles(t *testing.T) {
 				return
 			}
 
-			gitout, err = client.GitWithOutput(ctx, "log", "--pretty=%H", "-n", "1")
+			gitout, err = client.GitWithOutput(ctx, &errNoCommitsYet, "log", "--pretty=%H", "-n", "1")
 			if err != nil && !strings.Contains(err.Error(), "fatal: your current branch 'master' does not have any commits yet") {
 				t.Errorf("error calling GitWithOutput: %v", err)
 				return

--- a/components/content-service/pkg/initializer/git.go
+++ b/components/content-service/pkg/initializer/git.go
@@ -178,7 +178,7 @@ func (ws *GitInitializer) realizeCloneTarget(ctx context.Context) (err error) {
 		}
 	} else {
 		// update to remote HEAD
-		if _, err := ws.GitWithOutput(ctx, "reset", "--hard", "origin/HEAD"); err != nil {
+		if _, err := ws.GitWithOutput(ctx, nil, "reset", "--hard", "origin/HEAD"); err != nil {
 			var giterr git.OpFailedError
 			if errors.As(err, &giterr) && strings.Contains(giterr.Output, "unknown revision or path not in the working tree") {
 				// 'git reset --hard origin/HEAD' returns a non-zero exit code if origin does not have a single commit (empty repository).

--- a/components/content-service/pkg/initializer/prebuild.go
+++ b/components/content-service/pkg/initializer/prebuild.go
@@ -114,7 +114,7 @@ func runGitInit(ctx context.Context, gInit *GitInitializer) (err error) {
 	)
 	defer tracing.FinishSpan(span, &err)
 	if git.IsWorkingCopy(gInit.Location) {
-		out, err := gInit.GitWithOutput(ctx, "stash", "push", "--no-include-untracked")
+		out, err := gInit.GitWithOutput(ctx, nil, "stash", "push", "--no-include-untracked")
 		if err != nil {
 			var giterr git.OpFailedError
 			if errors.As(err, &giterr) && strings.Contains(giterr.Output, "You do not have the initial commit yet") {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
If the git repo has no commits, the git log displays `does not have any
commits yet`. We ignore it in tracing.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #11789

## How to test
<!-- Provide steps to test this PR -->
1. Open repo github.com/gitpod-io/emtpy
2. Check jaeger tracing, making sure there is no tracing error in `git.log` span.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
None

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
