### PR TITLE
[kots]: collect the user config in support bundles

### DIFF
--- a/install/kots/manifests/kots-redactor.yaml
+++ b/install/kots/manifests/kots-redactor.yaml
@@ -1,0 +1,29 @@
+# Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+# Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
+apiVersion: troubleshoot.sh/v1beta2
+kind: Redactor
+metadata:
+  name: gitpod
+spec:
+  redactors:
+    - name: kots-config
+      fileSelector:
+        file: kots-config/*/*/*
+      removals:
+        yamlPath:
+          - "spec.values.reg_incluster_storage_s3_accesskey"
+          - "spec.values.reg_incluster_storage_s3_secretkey"
+          - "spec.values.reg_password"
+          - "spec.values.db_encryption_keys"
+          - "spec.values.db_password"
+          - "spec.values.db_gcp_credentials"
+          - "spec.values.store_azure_account_name"
+          - "spec.values.store_azure_access_key"
+          - "spec.values.store_gcp_project"
+          - "spec.values.store_gcp_credentials"
+          - "spec.values.store_s3_access_key_id"
+          - "spec.values.store_s3_secret_access_key"
+          - "spec.values.tls_ca_crt"
+          - "spec.values.tls_crt"
+          - "spec.values.tls_key"

--- a/install/kots/manifests/kots-support-bundle.yaml
+++ b/install/kots/manifests/kots-support-bundle.yaml
@@ -106,3 +106,17 @@ spec:
         selector:
           - app=gitpod
         namespace: '{{repl Namespace }}'
+    - exec:
+        name: kots-config
+        selector:
+          - app=kotsadm
+        namespace: '{{repl Namespace }}'
+        command:
+          - /kots
+        args:
+          - get
+          - config
+          - --appslug
+          - '{{repl LicenseFieldValue "numSeats" }}'
+          - --namespace
+          - '{{repl Namespace }}'


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This is redacted to ensure that sensitive data is not included in the support bundles. Example from [Fernando at Replicated](https://community.replicated.com/t/how-can-i-export-config-options-into-a-support-bundle/879/4)

## How to test
<!-- Provide steps to test this PR -->
Deploy via KOTS and run a support bundle. Inspect files and look in `kots-config/gitpod/kotsadm-*/stdout.txt`. Anything sensitive will be replaces with `***HIDDEN***`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[kots]: collect the user config in support bundles
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
