### PR TITLE
[UBP] Add placeholder implementation of `FinalizeInvoice`

### DIFF
--- a/components/usage/pkg/apiv1/billing.go
+++ b/components/usage/pkg/apiv1/billing.go
@@ -48,6 +48,12 @@ func (s *BillingService) UpdateInvoices(ctx context.Context, in *v1.UpdateInvoic
 	return &v1.UpdateInvoicesResponse{}, nil
 }
 
+func (s *BillingService) FinalizeInvoice(ctx context.Context, in *v1.FinalizeInvoiceRequest) (*v1.FinalizeInvoiceResponse, error) {
+	log.Infof("Finalizing invoice for invoice %q", in.GetInvoiceId())
+
+	return &v1.FinalizeInvoiceResponse{}, nil
+}
+
 func (s *BillingService) creditSummaryForTeams(sessions []*v1.BilledSession) (map[string]int64, error) {
 	creditsPerTeamID := map[string]float64{}
 

--- a/components/usage/pkg/apiv1/billing_test.go
+++ b/components/usage/pkg/apiv1/billing_test.go
@@ -5,6 +5,7 @@
 package apiv1
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -114,4 +115,12 @@ func TestCreditSummaryForTeams(t *testing.T) {
 			require.Equal(t, s.Expected, actual)
 		})
 	}
+}
+
+func TestFinalizeInvoice(t *testing.T) {
+	b := BillingService{}
+
+	_, err := b.FinalizeInvoice(context.Background(), &v1.FinalizeInvoiceRequest{})
+
+	require.NoError(t, err)
 }


### PR DESCRIPTION
## Description

Add a trivial 'noop' implementation of `FinalizeInvoice` to the billing RPC service.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of #10937 

## How to test

* Unit test for the billing service
or
* Port-forward to the `usage` service gRPC server:
```
kubectl port-forward svc/usage 9001:9001
```
* Use `evans` or `grpcurl` to hit the placeholder `FinalizeInvoice` RPC with an invoice id of e.g: `1234`
* Tail the logs of `deploy/usage` and see:
```
{"level":"info","message":"Finalizing invoice for invoice \"1234\"","serviceContext":{"service":"usage","version":"commit-0aa8abfc2d3b27707a248d3ab285d3561202ceab"},"severity":"INFO","time":"2022-08-08T07:27:39Z"}
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
- [x] /werft with-payment