### PR TITLE
ws-manager: Provide more detail of DiposalStatus.

### DIFF
--- a/components/ws-manager/pkg/manager/annotations.go
+++ b/components/ws-manager/pkg/manager/annotations.go
@@ -183,13 +183,14 @@ func (m *Manager) markDisposalStatus(ctx context.Context, workspaceID string, di
 type DisposalStatus string
 
 const (
+	DisposalEmpty    DisposalStatus = ""
 	DisposalStarted  DisposalStatus = "started"
 	DisposalRetrying DisposalStatus = "retrying"
 	DisposalFinished DisposalStatus = "finished"
 )
 
 func (ds DisposalStatus) IsDisposing() bool {
-	return !(ds == "" || ds == DisposalFinished)
+	return !(ds == DisposalEmpty || ds == DisposalFinished)
 }
 
 // workspaceVolumeSnapshotStatus stores the status of volume snapshot

--- a/components/ws-manager/pkg/manager/annotations.go
+++ b/components/ws-manager/pkg/manager/annotations.go
@@ -177,11 +177,7 @@ func (m *Manager) markDisposalStatus(ctx context.Context, workspaceID string, di
 		return err
 	}
 
-	err = m.markWorkspace(ctx, workspaceID, addMark(disposalStatusAnnotation, string(b)))
-	if err != nil {
-		return err
-	}
-	return nil
+	return m.markWorkspace(ctx, workspaceID, addMark(disposalStatusAnnotation, string(b)))
 }
 
 type DisposalStatus string

--- a/components/ws-manager/pkg/manager/monitor.go
+++ b/components/ws-manager/pkg/manager/monitor.go
@@ -514,9 +514,11 @@ func actOnPodEvent(ctx context.Context, m actingManager, manager *Manager, statu
 				}
 				return m.modifyFinalizer(ctx, workspaceID, gitpodFinalizerName, false)
 			} else {
-				// We start finalizing the workspace content only after the container is gone. This way we ensure there's
-				// no process modifying the workspace content as we create the backup.
-				go m.finalizeWorkspaceContent(ctx, wso)
+				if ds == nil || ds.Status != DisposalFinished {
+					// We start finalizing the workspace content only after the container is gone. This way we ensure there's
+					// no process modifying the workspace content as we create the backup.
+					go m.finalizeWorkspaceContent(ctx, wso)
+				}
 			}
 		}
 

--- a/components/ws-manager/pkg/manager/testdata/actOnPodEvent_workspace_startup_failed.golden
+++ b/components/ws-manager/pkg/manager/testdata/actOnPodEvent_workspace_startup_failed.golden
@@ -11,27 +11,6 @@
             "Params": {
                 "podName": "ws-7b26a643-d588-4346-bc9e-b46e70831078"
             }
-        },
-        {
-            "Func": "markWorkspace",
-            "Params": {
-                "annotations": [
-                    {
-                        "Name": "gitpod/explicitFail",
-                        "Value": "workspace failed to start.",
-                        "Delete": false
-                    }
-                ],
-                "workspaceID": "7b26a643-d588-4346-bc9e-b46e70831078"
-            }
-        },
-        {
-            "Func": "modifyFinalizer",
-            "Params": {
-                "add": false,
-                "finalizer": "gitpod.io/finalizer",
-                "workspaceID": "7b26a643-d588-4346-bc9e-b46e70831078"
-            }
         }
     ]
 }

--- a/components/ws-manager/pkg/manager/testdata/actOnPodEvent_workspace_startup_failed.golden
+++ b/components/ws-manager/pkg/manager/testdata/actOnPodEvent_workspace_startup_failed.golden
@@ -11,6 +11,27 @@
             "Params": {
                 "podName": "ws-7b26a643-d588-4346-bc9e-b46e70831078"
             }
+        },
+        {
+            "Func": "markWorkspace",
+            "Params": {
+                "annotations": [
+                    {
+                        "Name": "gitpod/explicitFail",
+                        "Value": "workspace failed to start.",
+                        "Delete": false
+                    }
+                ],
+                "workspaceID": "7b26a643-d588-4346-bc9e-b46e70831078"
+            }
+        },
+        {
+            "Func": "modifyFinalizer",
+            "Params": {
+                "add": false,
+                "finalizer": "gitpod.io/finalizer",
+                "workspaceID": "7b26a643-d588-4346-bc9e-b46e70831078"
+            }
         }
     ]
 }


### PR DESCRIPTION
## Description

The `StartDisposal` annotation so far has only shown that it has started, so we will provide more detailed information.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
1. Open a workspace
2. Stop a workspace with monitoring workspace pod's annotation


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
