### PR TITLE
[kots]: fix typo which meant wasn't using the appSlug in config collect

### DIFF
--- a/install/kots/manifests/kots-support-bundle.yaml
+++ b/install/kots/manifests/kots-support-bundle.yaml
@@ -117,6 +117,6 @@ spec:
           - get
           - config
           - --appslug
-          - '{{repl LicenseFieldValue "numSeats" }}'
+          - '{{repl LicenseFieldValue "appSlug" }}'
           - --namespace
           - '{{repl Namespace }}'


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Genuinely no idea how this got in. Assume it was during the "hold" process and a copied the wrong thing across.

## How to test
<!-- Provide steps to test this PR -->
As per #11943

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[kots]: fix typo which meant wasn't using the appSlug in config collect
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
