### PR TITLE
[installer]: refactor yq to run against arbitrary strings

### DIFF
--- a/install/installer/pkg/postprocess/postprocess.go
+++ b/install/installer/pkg/postprocess/postprocess.go
@@ -4,15 +4,9 @@
 package postprocess
 
 import (
-	"bytes"
-	"fmt"
-	"os"
-	"strings"
-
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 	openvsxproxy "github.com/gitpod-io/gitpod/installer/pkg/components/openvsx-proxy"
-	"github.com/mikefarah/yq/v4/pkg/yqlib"
-	logging "gopkg.in/op/go-logging.v1"
+	"github.com/gitpod-io/gitpod/installer/pkg/yq"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
 )
@@ -38,52 +32,6 @@ type Processor struct {
 	Name       *string // Optional
 }
 
-// process emulates how YQ parsers the file
-func process(expression string, obj *common.RuntimeObject) error {
-	// Stop the logging to Stderr
-	var format = logging.MustStringFormatter(
-		`%{color}%{time:15:04:05} %{shortfunc} [%{level:.4s}]%{color:reset} %{message}`,
-	)
-	var backend = logging.AddModuleLevel(
-		logging.NewBackendFormatter(logging.NewLogBackend(os.Stderr, "", 0), format))
-
-	backend.SetLevel(logging.ERROR, "")
-	logging.SetBackend(backend)
-	// End of logger config
-
-	yqlib.InitExpressionParser()
-
-	var writer bytes.Buffer
-	printerWriter := yqlib.NewSinglePrinterWriter(&writer)
-	encoder := yqlib.NewYamlEncoder(2, false, false, true)
-
-	printer := yqlib.NewPrinter(encoder, printerWriter)
-
-	decoder := yqlib.NewYamlDecoder()
-
-	streamEvaluator := yqlib.NewStreamEvaluator()
-
-	reader := strings.NewReader(obj.Content)
-
-	node, err := yqlib.ExpressionParser.ParseExpression(expression)
-	if err != nil {
-		return err
-	}
-
-	// This is used for debugging
-	filename := fmt.Sprintf("%s %s %s", obj.APIVersion, obj.Kind, obj.Metadata.Name)
-
-	_, err = streamEvaluator.Evaluate(filename, reader, node, printer, "", decoder)
-	if err != nil {
-		return err
-	}
-
-	// Overwrite the content with the parsed data
-	obj.Content = writer.String()
-
-	return nil
-}
-
 func useProcessor(object common.RuntimeObject, processor Processor) bool {
 	if object.APIVersion == processor.Type.APIVersion && object.Kind == processor.Type.Kind {
 		// Name is optional
@@ -105,10 +53,11 @@ func Run(objects []common.RuntimeObject) ([]common.RuntimeObject, error) {
 	for _, o := range objects {
 		for _, p := range Processors {
 			if useProcessor(o, p) {
-				err := process(p.Expression, &o)
+				output, err := yq.Process(o.Content, p.Expression)
 				if err != nil {
 					return nil, err
 				}
+				o.Content = *output
 			}
 		}
 

--- a/install/installer/pkg/yq/yq.go
+++ b/install/installer/pkg/yq/yq.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
+package yq
+
+import (
+	"bytes"
+	"os"
+	"strings"
+
+	"github.com/mikefarah/yq/v4/pkg/yqlib"
+	logging "gopkg.in/op/go-logging.v1"
+	"k8s.io/utils/pointer"
+)
+
+func Process(input string, expression string) (*string, error) {
+	// Stop the logging to Stderr
+	var format = logging.MustStringFormatter(
+		`%{color}%{time:15:04:05} %{shortfunc} [%{level:.4s}]%{color:reset} %{message}`,
+	)
+	var backend = logging.AddModuleLevel(
+		logging.NewBackendFormatter(logging.NewLogBackend(os.Stderr, "", 0), format))
+
+	backend.SetLevel(logging.ERROR, "")
+	logging.SetBackend(backend)
+	// End of logger config
+
+	yqlib.InitExpressionParser()
+
+	var writer bytes.Buffer
+	printerWriter := yqlib.NewSinglePrinterWriter(&writer)
+	encoder := yqlib.NewYamlEncoder(2, false, false, true)
+
+	printer := yqlib.NewPrinter(encoder, printerWriter)
+
+	decoder := yqlib.NewYamlDecoder()
+
+	streamEvaluator := yqlib.NewStreamEvaluator()
+
+	reader := strings.NewReader(input)
+
+	node, err := yqlib.ExpressionParser.ParseExpression(expression)
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = streamEvaluator.Evaluate("gitpod-installer.tmp.yaml", reader, node, printer, "", decoder)
+	if err != nil {
+		return nil, err
+	}
+
+	return pointer.String(writer.String()), nil
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Refactor `yq` into its own standalone library in the Installer.

Also changes the way the `apiVersion` is removed from the `config.yaml` to use `yq` so it's not dependent upon the regex. This is a problem when using the input as a JSON object (it's unlikely, but as YAML is a superset of JSON, it is something we should probably support).

Originally I thought this was required to #9926 (it's not), but I thought it had merit so spun off to its own PR.

No changes in the rendered output prove this hasn't introduced any regressions

## How to test
<!-- Provide steps to test this PR -->
Install via KOTS

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[installer]: refactor yq to run against arbitrary strings
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
