### PR TITLE
Add clone3 to seccomp profile syscalls

### DIFF
--- a/components/docker-up/dependencies.sh
+++ b/components/docker-up/dependencies.sh
@@ -5,10 +5,10 @@
 
 set -euo pipefail
 
-DOCKER_VERSION=19.03.15
-DOCKER_COMPOSE_VERSION=1.29.2
-RUNC_VERSION=v1.1.0
+DOCKER_VERSION=20.10.17
+DOCKER_COMPOSE_VERSION=2.8.0-gitpod.0
+RUNC_VERSION=v1.1.3
 
 curl -o docker.tgz      -fsSL https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz
-curl -o docker-compose  -fsSL https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-Linux-x86_64
+curl -o docker-compose  -fsSL https://github.com/gitpod-io/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-linux-x86_64
 curl -o runc            -fsSL https://github.com/opencontainers/runc/releases/download/${RUNC_VERSION}/runc.amd64

--- a/components/docker-up/docker-up/main.go
+++ b/components/docker-up/docker-up/main.go
@@ -468,7 +468,7 @@ func needInstallRunc() bool {
 		return true
 	}
 
-	return major < 1 || major == 1 && minor < 1
+	return major < 1 || major == 1 && minor < 3
 }
 
 func detectRuncVersion(output string) (major, minor int, err error) {

--- a/components/docker-up/go.mod
+++ b/components/docker-up/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/gitpod-io/gitpod/common-go v0.0.0-00010101000000-000000000000
-	github.com/opencontainers/runtime-spec v1.0.2
+	github.com/opencontainers/runtime-spec v1.0.3-0.20220601164019-72c1f0b44f79
 	github.com/rootless-containers/rootlesskit v1.0.1
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/pflag v1.0.5

--- a/components/docker-up/go.sum
+++ b/components/docker-up/go.sum
@@ -24,8 +24,8 @@ github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfn
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/opencontainers/runtime-spec v1.0.2 h1:UfAcuLBJB9Coz72x1hgl8O5RVzTdNiaglX6v2DM6FI0=
-github.com/opencontainers/runtime-spec v1.0.2/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
+github.com/opencontainers/runtime-spec v1.0.3-0.20220601164019-72c1f0b44f79 h1:JeJNHMISqkHIT50baRp6X+m6ZCd7QVpP5cW9ReVxjQk=
+github.com/opencontainers/runtime-spec v1.0.3-0.20220601164019-72c1f0b44f79/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rootless-containers/rootlesskit v1.0.1 h1:jepqW1txFSowKSMAEkVhWH3Oa1TCY9S400MVYe/6Iro=

--- a/components/ws-daemon/seccomp-profile-installer/main.go
+++ b/components/ws-daemon/seccomp-profile-installer/main.go
@@ -31,6 +31,7 @@ func main() {
 		specs.LinuxSyscall{
 			Names: []string{
 				"clone",
+				"clone3",
 				"mount",
 				"umount2",
 				"chroot",


### PR DESCRIPTION
## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #10703
Fixes #11963
Fixes #11964

## How to test
- Open a workspace and run
``` 
git clone https://github.com/ComplianceAsCode/content/
cd content/Dockerfiles
docker build -t test -f ubuntu .
```

- Test command `docker run -it gitpod/workspace-full:latest bash` do not ends with `SIGABRT`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
