### PR TITLE
[IDE jobs] only post interesting notifications to Slack

### DIFF
--- a/.github/workflows/code-nightly.yaml
+++ b/.github/workflows/code-nightly.yaml
@@ -37,8 +37,6 @@ jobs:
       - name: Get previous job's status
         id: lastrun
         uses: filiptronicek/get-last-job-status@main
-        with:
-          workflow-id: 15751907
       - name: Slack Notification
         if: ${{ (success() && steps.lastrun.outputs.status == 'failed') || failure() }}
         uses: rtCamp/action-slack-notify@v2

--- a/.github/workflows/code-nightly.yaml
+++ b/.github/workflows/code-nightly.yaml
@@ -34,8 +34,13 @@ jobs:
           headCommit=$(curl -H 'Accept: application/vnd.github.VERSION.sha' https://api.github.com/repos/gitpod-io/openvscode-server/commits/gp-code/main)
           cd components/ide/code
           leeway build -Dversion=nightly -DimageRepoBase=eu.gcr.io/gitpod-core-dev/build -DcodeCommit=$headCommit -DcodeQuality=insider .:docker
+      - name: Get previous job's status
+        id: lastrun
+        uses: filiptronicek/get-last-job-status@main
+        with:
+          workflow-id: 15751907
       - name: Slack Notification
-        if: always()
+        if: ${{ (success() && steps.lastrun.outputs.status == 'failed') || failure() }}
         uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_WEBHOOK: ${{ secrets.IDE_SLACK_WEBHOOK }}

--- a/.github/workflows/jetbrains-auto-update-template.yml
+++ b/.github/workflows/jetbrains-auto-update-template.yml
@@ -47,8 +47,13 @@ jobs:
           export LEEWAY_WORKSPACE_ROOT=$(pwd)
           cd components/ide/jetbrains/image
           leeway build -Dversion=latest -DimageRepoBase=eu.gcr.io/gitpod-core-dev/build .:${{ inputs.productId }}-latest
+      - name: Get previous job's status
+        id: lastrun
+        uses: filiptronicek/get-last-job-status@main
+        with:
+          workflow-id: 18268462
       - name: Slack Notification
-        if: always()
+        if: ${{ (success() && steps.lastrun.outputs.status == 'failed') || failure() }}
         uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_WEBHOOK: ${{ secrets.slackWebhook }}

--- a/.github/workflows/jetbrains-auto-update-template.yml
+++ b/.github/workflows/jetbrains-auto-update-template.yml
@@ -50,8 +50,6 @@ jobs:
       - name: Get previous job's status
         id: lastrun
         uses: filiptronicek/get-last-job-status@main
-        with:
-          workflow-id: 18268462
       - name: Slack Notification
         if: ${{ (success() && steps.lastrun.outputs.status == 'failed') || failure() }}
         uses: rtCamp/action-slack-notify@v2

--- a/.github/workflows/jetbrains-update-plugin-platform-template.yml
+++ b/.github/workflows/jetbrains-update-plugin-platform-template.yml
@@ -120,10 +120,15 @@ jobs:
                   branch: "jetbrains/${{ inputs.pluginId }}-platform-${{ steps.latest-version.outputs.result }}"
                   labels: "team: IDE"
                   team-reviewers: "engineering-ide"
+            - name: Get previous job's status
+              id: lastrun
+              uses: filiptronicek/get-last-job-status@main
+              with:
+                workflow-id: 31174155
             - name: Slack Notification
-              if: always()
+              if: ${{ (success() && steps.lastrun.outputs.status == 'failed') || failure() }}
               uses: rtCamp/action-slack-notify@v2
               env:
-                  SLACK_WEBHOOK: ${{ secrets.slackWebhook }}
-                  SLACK_COLOR: ${{ job.status }}
-                  SLACK_TITLE: ${{ inputs.productName }}
+                SLACK_WEBHOOK: ${{ secrets.slackWebhook }}
+                SLACK_COLOR: ${{ job.status }}
+                SLACK_TITLE: ${{ inputs.productName }}

--- a/.github/workflows/jetbrains-update-plugin-platform-template.yml
+++ b/.github/workflows/jetbrains-update-plugin-platform-template.yml
@@ -123,8 +123,6 @@ jobs:
             - name: Get previous job's status
               id: lastrun
               uses: filiptronicek/get-last-job-status@main
-              with:
-                workflow-id: 31174155
             - name: Slack Notification
               if: ${{ (success() && steps.lastrun.outputs.status == 'failed') || failure() }}
               uses: rtCamp/action-slack-notify@v2

--- a/.github/workflows/jetbrains-updates-template.yml
+++ b/.github/workflows/jetbrains-updates-template.yml
@@ -91,8 +91,13 @@ jobs:
           branch: "jetbrains/${{ inputs.productId }}-${{ steps.latest-release.outputs.version2 }}"
           labels: "team: IDE"
           team-reviewers: "engineering-ide"
+      - name: Get previous job's status
+        id: lastrun
+        uses: filiptronicek/get-last-job-status@main
+        with:
+          workflow-id: 15883329
       - name: Slack Notification
-        if: always()
+        if: ${{ (success() && steps.lastrun.outputs.status == 'failed') || failure() }}
         uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_WEBHOOK: ${{ secrets.slackWebhook }}

--- a/.github/workflows/jetbrains-updates-template.yml
+++ b/.github/workflows/jetbrains-updates-template.yml
@@ -94,8 +94,6 @@ jobs:
       - name: Get previous job's status
         id: lastrun
         uses: filiptronicek/get-last-job-status@main
-        with:
-          workflow-id: 15883329
       - name: Slack Notification
         if: ${{ (success() && steps.lastrun.outputs.status == 'failed') || failure() }}
         uses: rtCamp/action-slack-notify@v2


### PR DESCRIPTION
## Description
This PR changes all IDE jobs which have previously posted a message to Slack every time they were run to now only post when they are interesting to us. 
This includes them failing or being fixed (going from failing to passing).

This is all achieved by this little snippet:
```yaml
- name: Get previous job's status
  id: lastrun
  uses: filiptronicek/get-last-job-status@main
  with:
    workflow-id: 18268462
- name: Slack Notification
  if: always()
  if: ${{ (success() && steps.lastrun.outputs.status == 'failed') || failure() }}
  ...
```

### Progress
- [x] https://github.com/gitpod-io/gitpod/blob/main/.github/workflows/code-nightly.yaml
- [x] https://github.com/gitpod-io/gitpod/blob/main/.github/workflows/jetbrains-auto-update-template.yml
- [x] https://github.com/gitpod-io/gitpod/blob/main/.github/workflows/jetbrains-update-plugin-platform-template.yml
- [x] https://github.com/gitpod-io/gitpod/blob/main/.github/workflows/jetbrains-updates-template.yml


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #11771

## How to test
For the workflows that have manual triggers (can be run by a `Run Workflow` button on the [Actions page](https://github.com/gitpod-io/gitpod/actions)), you can just trigger it and wait for it to finish. If it succeeds then it should not output anything to the Slack channel and the Action step should be skipped.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
