### PR TITLE
Update the alert description unit

### DIFF
--- a/operations/observability/mixins/meta/rules/components/server/alerts.libsonnet
+++ b/operations/observability/mixins/meta/rules/components/server/alerts.libsonnet
@@ -32,7 +32,7 @@
             annotations: {
               runbook_url: 'https://github.com/gitpod-io/runbooks/blob/main/runbooks/ServerEventLoopLagTooHigh.md',
               summary: 'Server accumulated too much "event loop lag". The webapp will become unresponsive if we don\'t act here.',
-              description: 'Server has accumulated {{ printf "%.2f" $value }}ms event loop lag.',
+              description: 'Server has accumulated {{ printf "%.2f" $value }}s event loop lag.',
             },
           },
           {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Update the alert description unit, it should be second(s), not millisecond(ms).

https://github.com/gitpod-io/gitpod/blob/9329cb6f33a2105b97c9c8738545f295b5e98bbc/operations/observability/mixins/meta/rules/components/server/alerts.libsonnet#L27
The alert displays `description = Server has accumulated 0.36 ms event loop lag.`
However, the Grafana dashboard max/avg/current is around 2xx ms
<img width="709" alt="image" src="https://user-images.githubusercontent.com/49380831/183551534-14f27b6b-a0de-487d-99e6-206fefd43fd3.png">

Therefore, we change the unit to second.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
N/A

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
N/A
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
