### PR TITLE
[UBP] Use a realistic event payload in Stripe webhook automated tests

### DIFF
--- a/components/usage/pkg/apiv1/billing.go
+++ b/components/usage/pkg/apiv1/billing.go
@@ -48,6 +48,12 @@ func (s *BillingService) UpdateInvoices(ctx context.Context, in *v1.UpdateInvoic
 	return &v1.UpdateInvoicesResponse{}, nil
 }
 
+func (s *BillingService) FinalizeInvoice(ctx context.Context, in *v1.FinalizeInvoiceRequest) (*v1.FinalizeInvoiceResponse, error) {
+	log.Infof("Finalizing invoice for invoice %q", in.GetInvoiceId())
+
+	return &v1.FinalizeInvoiceResponse{}, nil
+}
+
 func (s *BillingService) creditSummaryForTeams(sessions []*v1.BilledSession) (map[string]int64, error) {
 	creditsPerTeamID := map[string]float64{}
 

--- a/components/usage/pkg/apiv1/billing_test.go
+++ b/components/usage/pkg/apiv1/billing_test.go
@@ -5,6 +5,7 @@
 package apiv1
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -114,4 +115,12 @@ func TestCreditSummaryForTeams(t *testing.T) {
 			require.Equal(t, s.Expected, actual)
 		})
 	}
+}
+
+func TestFinalizeInvoice(t *testing.T) {
+	b := BillingService{}
+
+	_, err := b.FinalizeInvoice(context.Background(), &v1.FinalizeInvoiceRequest{})
+
+	require.NoError(t, err)
 }


### PR DESCRIPTION
## Description

When Stripe invoices finalize, the webhook is `POST`ed to with an `invoice.finalized` payload indicating the invoice id that was finalized. The exact shape of the payload for each event type is described in the [Stripe docs](https://stripe.com/docs/api/events/types).

This PR make the Stripe webhook extract the invoice id from the event payload. Most of the changes are to the test code that exercises the webhook to ensure that a realistic payload is attached to the `invoice.finalized` event.

## Related Issue(s)
Part of #10937 

## How to test

Automated tests for the webhook handler.

For an end to end test:

* Run the webhook handler locally:
```
cd components/public-api-server/
go run . run
```
* Download the [Stripe CLI](https://github.com/stripe/stripe-cli/releases) and run:
```
stripe listen --skip-verify --forward-to localhost:9002/stripe/invoices/webhook
```
* Trigger some Stripe events:
```
stripe trigger invoice.finalized
```

This should start a series of Stripe events (setting up a customer and payment methods), the last of which (the `invoice.finalized` event) should receive a `200 OK` response.

* You should see the following in the public api server logs:
```
{"level":"info","message":"finalizing invoice for invoice id: in_1LUlkzGadRXm50o3jqXq7mgh","serviceContext":{"service":"public-api-server","version":""},"severity":"INFO","time":"2022-08-09T06:17:39Z"}
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
