### PR TITLE
Sync GCP terraform module to reference architecture

### DIFF
--- a/install/infra/modules/gke/main.tf
+++ b/install/infra/modules/gke/main.tf
@@ -175,6 +175,18 @@ resource "google_sql_user" "users" {
   password = "gitpod"
 }
 
+resource "google_dns_managed_zone" "gitpod-dns-zone" {
+  count = var.domain_name == null ? 0 : 1
+
+  name          = "gitpod-tf-managed-zone"
+  dns_name      = "${var.domain_name}."
+  description   = "Terraform managed DNS zone for ${var.name}"
+  force_destroy = true
+  labels = {
+    app = "gitpod"
+  }
+}
+
 module "gke_auth" {
   depends_on = [google_container_node_pool.workspaces]
 

--- a/install/infra/modules/gke/main.tf
+++ b/install/infra/modules/gke/main.tf
@@ -17,12 +17,12 @@ provider "google" {
 }
 
 resource "google_compute_network" "vpc" {
-  name                    = "vpc-${var.name}"
+  name                    = "vpc-${var.cluster_name}"
   auto_create_subnetworks = "false"
 }
 
 resource "google_compute_subnetwork" "subnet" {
-  name          = "subnet-${var.name}"
+  name          = "subnet-${var.cluster_name}"
   region        = var.region
   network       = google_compute_network.vpc.name
   ip_cidr_range = "10.255.0.0/16"
@@ -39,7 +39,7 @@ resource "google_compute_subnetwork" "subnet" {
 }
 
 resource "google_container_cluster" "gitpod-cluster" {
-  name     = "gitpod-${var.name}"
+  name     = var.cluster_name
   location = var.zone == null ? var.region : var.zone
 
   cluster_autoscaling {
@@ -112,7 +112,7 @@ resource "google_container_cluster" "gitpod-cluster" {
 }
 
 resource "google_container_node_pool" "workspaces" {
-  name               = "workspaces-${var.name}"
+  name               = "workspaces-${var.cluster_name}"
   location           = google_container_cluster.gitpod-cluster.location
   cluster            = google_container_cluster.gitpod-cluster.name
   version            = var.cluster_version // kubernetes version
@@ -153,7 +153,8 @@ resource "google_container_node_pool" "workspaces" {
 }
 
 resource "google_sql_database_instance" "gitpod" {
-  name             = "sql-${var.name}"
+  count            = var.enable_external_database ? 1 : 0
+  name             = "sql-${var.cluster_name}"
   database_version = "MYSQL_5_7"
   region           = var.region
   settings {
@@ -162,29 +163,43 @@ resource "google_sql_database_instance" "gitpod" {
   deletion_protection = false
 }
 
+resource "random_password" "password" {
+  count = var.enable_external_database ? 1 : 0
+
+  length           = 16
+  special          = true
+  override_special = "!#$%&*()-_=+[]{}<>:?"
+}
+
 resource "google_sql_database" "database" {
+  count     = var.enable_external_database ? 1 : 0
   name      = "gitpod"
-  instance  = google_sql_database_instance.gitpod.name
+  instance  = google_sql_database_instance.gitpod[count.index].name
   charset   = "utf8"
   collation = "utf8_general_ci"
 }
 
 resource "google_sql_user" "users" {
-  name     = "gitpod"
-  instance = google_sql_database_instance.gitpod.name
-  password = "gitpod"
+  count    = var.enable_external_database ? 1 : 0
+  name     = "dbuser-${var.cluster_name}-${count.index}"
+  instance = google_sql_database_instance.gitpod[count.index].name
+  password = random_password.password[count.index].result
 }
 
 resource "google_dns_managed_zone" "gitpod-dns-zone" {
   count = var.domain_name == null ? 0 : 1
 
-  name          = "gitpod-tf-managed-zone"
+  name          = "zone-${var.cluster_name}"
   dns_name      = "${var.domain_name}."
-  description   = "Terraform managed DNS zone for ${var.name}"
+  description   = "Terraform managed DNS zone for ${var.cluster_name}"
   force_destroy = true
   labels = {
     app = "gitpod"
   }
+}
+
+data "google_container_registry_repository" "gitpod" {
+  count = var.enable_external_registry ? 1 : 0
 }
 
 module "gke_auth" {
@@ -194,7 +209,7 @@ module "gke_auth" {
 
   project_id   = var.project
   location     = google_container_cluster.gitpod-cluster.location
-  cluster_name = "gitpod-${var.name}"
+  cluster_name = var.cluster_name
 }
 
 resource "local_file" "kubeconfig" {

--- a/install/infra/modules/gke/output.tf
+++ b/install/infra/modules/gke/output.tf
@@ -48,5 +48,5 @@ output "storage" {
     region      = var.region
     project     = var.project
     credentials = "Upload the JSON file corresponding the service account credentials"
-  }, "No s3 bucket created for object storage")
+  }, "No GCS bucket created for object storage")
 }

--- a/install/infra/modules/gke/output.tf
+++ b/install/infra/modules/gke/output.tf
@@ -21,3 +21,32 @@ output "kubeconfig" {
   sensitive = true
   value     = module.gke_auth.kubeconfig_raw
 }
+
+output "database" {
+  sensitive = true
+  value = try({
+    instance            = "${var.project}:${var.region}:${google_sql_database_instance.gitpod[0].name}"
+    username            = "${google_sql_user.users[0].name}"
+    password            = random_password.password[0].result
+    service_account_key = "Upload the JSON file corresponding the service account credentials"
+  }, "No database created")
+}
+
+output "registry" {
+  sensitive = true
+  value = try({
+    url      = data.google_container_registry_repository.gitpod[0].repository_url
+    server   = regex("[^/?#]*", data.google_container_registry_repository.gitpod[0].repository_url)
+    username = "_json_key"
+    password = "Copy paste the content of the service account credentials JSON file"
+  }, "No EKS registry created")
+}
+
+output "storage" {
+  sensitive = true
+  value = try({
+    region      = var.region
+    project     = var.project
+    credentials = "Upload the JSON file corresponding the service account credentials"
+  }, "No s3 bucket created for object storage")
+}

--- a/install/infra/modules/gke/output.tf
+++ b/install/infra/modules/gke/output.tf
@@ -3,6 +3,10 @@ output "kubernetes_endpoint" {
   value     = module.gke_auth.host
 }
 
+output "name_servers" {
+  value = google_dns_managed_zone.gitpod-dns-zone[0].name_servers
+}
+
 output "client_token" {
   sensitive = true
   value     = module.gke_auth.token

--- a/install/infra/modules/gke/output.tf
+++ b/install/infra/modules/gke/output.tf
@@ -39,7 +39,7 @@ output "registry" {
     server   = regex("[^/?#]*", data.google_container_registry_repository.gitpod[0].repository_url)
     username = "_json_key"
     password = "Copy paste the content of the service account credentials JSON file"
-  }, "No EKS registry created")
+  }, "No container registry created")
 }
 
 output "storage" {

--- a/install/infra/modules/gke/variables.tf
+++ b/install/infra/modules/gke/variables.tf
@@ -60,3 +60,8 @@ variable "credentials" {
   description = "Path to the JSON file storing Google service account credentials"
   default     = ""
 }
+
+variable "domain_name" {
+  description = "Domain name register with Cloud DNS, leave empty if you want to manage it yourself"
+  default     = null
+}

--- a/install/infra/modules/gke/variables.tf
+++ b/install/infra/modules/gke/variables.tf
@@ -68,7 +68,7 @@ variable "domain_name" {
 
 variable "enable_external_database" {
   default     = true
-  description = "Set this to false to avoid creating an RDS database to use with Gitpod instead of inclsuter mysql"
+  description = "Set this to false to avoid creating an RDS database to use with Gitpod instead of incluster mysql"
 }
 
 variable "enable_external_storage" {

--- a/install/infra/modules/gke/variables.tf
+++ b/install/infra/modules/gke/variables.tf
@@ -26,7 +26,7 @@ variable "cluster_version" {
   default     = "1.22.8-gke.201"
 }
 
-variable "name" {
+variable "cluster_name" {
   type        = string
   description = "The name of the cluster."
   default     = "gitpod"
@@ -64,4 +64,19 @@ variable "credentials" {
 variable "domain_name" {
   description = "Domain name register with Cloud DNS, leave empty if you want to manage it yourself"
   default     = null
+}
+
+variable "enable_external_database" {
+  default     = true
+  description = "Set this to false to avoid creating an RDS database to use with Gitpod instead of inclsuter mysql"
+}
+
+variable "enable_external_storage" {
+  default     = true
+  description = "Set this to false to avoid creating an s3 storage to use with Gitpod instead of incluster minio"
+}
+
+variable "enable_external_registry" {
+  default     = true
+  description = "Set this to false to create an AWS ECR registry to use with Gitpod(Not officially supported)"
 }

--- a/install/infra/modules/tools/cloud-dns-external-dns/main.tf
+++ b/install/infra/modules/tools/cloud-dns-external-dns/main.tf
@@ -8,9 +8,9 @@ data local_file "gcp_credentials" {
 
 provider "google" {
   credentials = var.credentials
-  project = var.gcp_project
-  region  = var.gcp_region
-  zone    = var.gcp_zone
+  project = var.project
+  region  = var.region
+  zone    = var.zone
 }
 
 provider "helm" {
@@ -57,7 +57,7 @@ resource "helm_release" "external-dns" {
   }
   set {
     name  = "google.project"
-    value = var.gcp_project
+    value = var.project
   }
   set {
     name  = "logFormat"

--- a/install/infra/modules/tools/cloud-dns-external-dns/variables.tf
+++ b/install/infra/modules/tools/cloud-dns-external-dns/variables.tf
@@ -3,17 +3,17 @@ variable "kubeconfig" {
     default = "./kubeconfig"
 }
 
-variable "gcp_project" {
+variable "project" {
     description = "Google cloud Region to perform operations in"
     default = "dns-for-playgrounds"
 }
 
-variable "gcp_region" {
+variable "region" {
     description = "Google cloud Region to perform operations in"
     default = "europe-west1"
 }
 
-variable "gcp_zone" {
+variable "zone" {
     description = "Google cloud Zone to perform operations in"
     default = "europe-west1-d"
 }

--- a/install/infra/single-cluster/aws/README.md
+++ b/install/infra/single-cluster/aws/README.md
@@ -14,7 +14,6 @@ This module will do the following steps:
 
 > 💡 If you would like to create the infrastructure orchestrating the terraform modules by yourself, you can find all the modules we support [here](../../modules/).
 
-
 Since the entire setup requires more than one terraform target to be run due to
 dependencies (eg: helm provider depends on kubernetes cluster config, which is
 not available until the `eks` module finishes), this directory has a `Makefile`
@@ -79,9 +78,6 @@ be used as registry backend. By default `enable_external_storage_for_registry_ba
 is set to `false`. One can re-use the same `S3` bucket for both object storage and registry backend.
 
 The expectation is that you can use the credentials to these setups(provided later
-as terraform outputs) during the setup of Gitpod via UI later in the process.
-Alternatively, one can choose to use incluster dependencies or separately
-created resources of choice.
 
 ### AMI Image ID and Kubernetes version
 

--- a/install/infra/single-cluster/aws/terraform.tfvars
+++ b/install/infra/single-cluster/aws/terraform.tfvars
@@ -1,4 +1,3 @@
-
 # the cluster_name should be of length less than 16 characters
 cluster_name = "nan"
 

--- a/install/infra/single-cluster/gcp/.terraform.lock.hcl
+++ b/install/infra/single-cluster/gcp/.terraform.lock.hcl
@@ -1,0 +1,78 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version = "4.31.0"
+  hashes = [
+    "h1:+X1KG9mnYGMkYD1c/O+uUi72d4kB3kPSDei4yMEDVAQ=",
+    "zh:02a19ed46c2007f6aadfb6ff90aa6063be063194d1f0dd02dc839adc212f7cae",
+    "zh:1046de7e13e81a8f86461f99e9d5ff25d5dabe8465f51efe72084ded426ba771",
+    "zh:209b054685f7364f3f5e8b570ceb62701e5b466d37cce8b7108385fc1feb3683",
+    "zh:717773619a1102748204699974c30aba39dc727baf389b874afcab6e17b63ffa",
+    "zh:7d5f4885cda2ca0ec8cb8bac36ea156aeca7787c01c17e65f7226742b60369d8",
+    "zh:82df57f2df5708441c57045b3e1a9a91ed55abe67d0d2f00705c7a1f512ec6ec",
+    "zh:a0191b194e68dd3c0ac5a26712f95d435839ff20d2b2ad53670374c64946042d",
+    "zh:a95b8358469d6347a5bcf4462ad18efaf80014f07f36bd26019ca039c523ff48",
+    "zh:b62c968f50d3afa8300c9267388d273a90a5be1a4e9a218205a358e6954e7844",
+    "zh:bc11cc9b8defec24831bbd6a73a2fa940659c7c610ea7aa0d8b38c2b1af6689b",
+    "zh:e6ac4c46c3e5a32635fcd27784c189b6cbc6aa9cbf7a3b09e999ec3aa3e2004a",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/helm" {
+  version = "2.6.0"
+  hashes = [
+    "h1:rGVucCeYAqklKupwoLVG5VPQTIkUhO7WGcw3WuHYrm8=",
+    "zh:0ac248c28acc1a4fd11bd26a85e48ab78dd6abf0f7ac842bf1cd7edd05ac6cf8",
+    "zh:3d32c8deae3740d8c5310136cc11c8afeffc350fbf88afaca0c34a223a5246f5",
+    "zh:4055a27489733d19ca7fa2dfce14d323fe99ae9dede7d0fea21ee6db0b9ca74b",
+    "zh:58a8ed39653fd4c874a2ecb128eccfa24c94266a00e349fd7fb13e22ad81f381",
+    "zh:6c81508044913f25083de132d0ff81d083732aba07c506cc2db05aa0cefcde2c",
+    "zh:7db5d18093047bfc4fe597f79610c0a281b21db0d61b0bacb3800585e976f814",
+    "zh:8269207b7422db99e7be80a5352d111966c3dfc7eb98511f11c8ff7b2e813456",
+    "zh:b1d7ababfb2374e72532308ff442cc906b79256b66b3fe7a98d42c68c4ddf9c5",
+    "zh:ca63e226cbdc964a5d63ef21189f059ce45c3fa4a5e972204d6916a9177d2b44",
+    "zh:d205a72d60e8cc362943d66f5bcdd6b6aaaa9aab2b89fd83bf6f1978ac0b1e4c",
+    "zh:db47dc579a0e68e5bfe3a61f2e950e6e2af82b1f388d1069de014a937962b56a",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/kubernetes" {
+  version = "2.12.1"
+  hashes = [
+    "h1:6ZgqegUao9WcfVzYg7taxCQOQldTmMVw0HqjG5S46OY=",
+    "zh:1ecb2adff52754fb4680c7cfe6143d1d8c264b00bb0c44f07f5583b1c7f978b8",
+    "zh:1fbd155088cd5818ad5874e4d59ccf1801e4e1961ac0711442b963315f1967ab",
+    "zh:29e927c7c8f112ee0e8ab70e71b498f2f2ae6f47df1a14e6fd0fdb6f14b57c00",
+    "zh:42c2f421da6b5b7c997e42aa04ca1457fceb13dd66099a057057a0812b680836",
+    "zh:522a7bccd5cd7acbb4ec3ef077d47f4888df7e59ff9f3d598b717ad3ee4fe9c9",
+    "zh:b45d8dc5dcbc5e30ae570d0c2e198505f47d09098dfd5f004871be8262e6ec1e",
+    "zh:c3ea0943f2050001c7d6a7115b9b990f148b082ebfc4ff3c2ff3463a8affcc4a",
+    "zh:f111833a64e06659d2e21864de39b7b7dec462615294d02f04c777956742a930",
+    "zh:f182dba5707b90b0952d5984c23f7a2da3baa62b4d71e78df7759f16cc88d957",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:f76655a68680887daceabd947b2f68e2103f5bbec49a2bc29530f82ab8e3bca3",
+    "zh:fadb77352caa570bd3259dfb59c31db614d55bc96df0ff15a3c0cd2e685678b9",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/local" {
+  version = "2.2.3"
+  hashes = [
+    "h1:aWp5iSUxBGgPv1UnV5yag9Pb0N+U1I0sZb38AXBFO8A=",
+    "zh:04f0978bb3e052707b8e82e46780c371ac1c66b689b4a23bbc2f58865ab7d5c0",
+    "zh:6484f1b3e9e3771eb7cc8e8bab8b35f939a55d550b3f4fb2ab141a24269ee6aa",
+    "zh:78a56d59a013cb0f7eb1c92815d6eb5cf07f8b5f0ae20b96d049e73db915b238",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:8aa9950f4c4db37239bcb62e19910c49e47043f6c8587e5b0396619923657797",
+    "zh:996beea85f9084a725ff0e6473a4594deb5266727c5f56e9c1c7c62ded6addbb",
+    "zh:9a7ef7a21f48fabfd145b2e2a4240ca57517ad155017e86a30860d7c0c109de3",
+    "zh:a63e70ac052aa25120113bcddd50c1f3cfe61f681a93a50cea5595a4b2cc3e1c",
+    "zh:a6e8d46f94108e049ad85dbed60354236dc0b9b5ec8eabe01c4580280a43d3b8",
+    "zh:bb112ce7efbfcfa0e65ed97fa245ef348e0fd5bfa5a7e4ab2091a9bd469f0a9e",
+    "zh:d7bec0da5c094c6955efed100f3fe22fca8866859f87c025be1760feb174d6d9",
+    "zh:fb9f271b72094d07cef8154cd3d50e9aa818a0ea39130bc193132ad7b23076fd",
+  ]
+}

--- a/install/infra/single-cluster/gcp/.terraform.lock.hcl
+++ b/install/infra/single-cluster/gcp/.terraform.lock.hcl
@@ -76,3 +76,22 @@ provider "registry.terraform.io/hashicorp/local" {
     "zh:fb9f271b72094d07cef8154cd3d50e9aa818a0ea39130bc193132ad7b23076fd",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.3.2"
+  hashes = [
+    "h1:H5V+7iXol/EHB2+BUMzGlpIiCOdV74H8YjzCxnSAWcg=",
+    "zh:038293aebfede983e45ee55c328e3fde82ae2e5719c9bd233c324cfacc437f9c",
+    "zh:07eaeab03a723d83ac1cc218f3a59fceb7bbf301b38e89a26807d1c93c81cef8",
+    "zh:427611a4ce9d856b1c73bea986d841a969e4c2799c8ac7c18798d0cc42b78d32",
+    "zh:49718d2da653c06a70ba81fd055e2b99dfd52dcb86820a6aeea620df22cd3b30",
+    "zh:5574828d90b19ab762604c6306337e6cd430e65868e13ef6ddb4e25ddb9ad4c0",
+    "zh:7222e16f7833199dabf1bc5401c56d708ec052b2a5870988bc89ff85b68a5388",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:b1b2d7d934784d2aee98b0f8f07a8ccfc0410de63493ae2bf2222c165becf938",
+    "zh:b8f85b6a20bd264fcd0814866f415f0a368d1123cd7879c8ebbf905d370babc8",
+    "zh:c3813133acc02bbebddf046d9942e8ba5c35fc99191e3eb057957dafc2929912",
+    "zh:e7a41dbc919d1de800689a81c240c27eec6b9395564630764ebb323ea82ac8a9",
+    "zh:ee6d23208449a8eaa6c4f203e33f5176fa795b4b9ecf32903dffe6e2574732c2",
+  ]
+}

--- a/install/infra/single-cluster/gcp/Makefile
+++ b/install/infra/single-cluster/gcp/Makefile
@@ -1,0 +1,67 @@
+##
+# Terraform AWS reference architecture
+#
+
+.PHONY: init
+init:
+	@terraform init
+
+.PHONY: plan
+plan: plan-cluster plan-cm-edns
+
+.PHONY: apply
+apply: apply-cluster apply-tools
+
+.PHONY: destroy
+destroy: destroy-tools destroy-cluster
+
+.PHONY: output
+output:
+	@terraform output -json
+
+.PHONY: plan-cluster
+plan-cluster:
+	@terraform plan -target=module.eks
+
+.PHONY: plan-tools
+plan-tools: plan-cm-edns plan-cluster-issuer
+
+.PHONY: plan-cm-edns
+plan-cm-edns:
+	@terraform plan -target=module.certmanager -target=module.externaldns
+
+.PHONY: plan-cluster-issuer
+plan-cluster-issuer:
+	@terraform plan -target=module.cluster-issuer
+
+.PHONY: apply-cluster
+apply-cluster:
+	@terraform apply -target=module.eks --auto-approve
+
+.PHONY: apply-tools
+apply-tools: install-cm-edns install-cluster-issuer
+
+.PHONY: install-cm-edns
+install-cm-edns:
+	@terraform apply -target=module.certmanager -target=module.externaldns --auto-approve
+
+.PHONY: install-cluster-issuer
+install-cluster-issuer:
+	@terraform apply -target=module.externaldns  --auto-approve
+
+.PHONY: destroy-cluster
+destroy-cluster:
+	@terraform destroy -target=module.gke --auto-approve
+
+.PHONY: destroy-tools
+destroy-tools: destroy-cluster-issuer destroy-cm-edns
+
+.PHONY: destroy-cm-edns
+destroy-cm-edns:
+	@terraform destroy -target=module.certmanager  -target=module.externaldns --auto-approve
+
+.PHONY: destroy-cluster-issuer
+destroy-cluster-issuer:
+	@terraform destroy -target=module.cluster-issuer  --auto-approve
+
+# end

--- a/install/infra/single-cluster/gcp/Makefile
+++ b/install/infra/single-cluster/gcp/Makefile
@@ -6,8 +6,14 @@
 init:
 	@terraform init
 
+touch-kubeconfig:
+	@touch kubeconfig
+
+cleanup-kubeconfig:
+	@rm kubeconfig
+
 .PHONY: plan
-plan: plan-cluster plan-cm-edns
+plan: touch-kubeconfig plan-cluster plan-cm-edns cleanup-kubeconfig
 
 .PHONY: apply
 apply: apply-cluster apply-tools
@@ -15,13 +21,61 @@ apply: apply-cluster apply-tools
 .PHONY: destroy
 destroy: destroy-tools destroy-cluster
 
+.PHONY: refresh
+refresh:
+	@echo "Refreshing terraform state"
+	@terraform refresh
+	@echo ""
+	@echo "Done!"
+
 .PHONY: output
-output:
-	@terraform output -json
+output: refresh output-done-msg output-url output-nameservers output-registry output-database output-storage output-issuer
+
+output-done-msg:
+	@echo ""
+	@echo ""
+	@echo "=========================="
+	@echo "🎉🥳🔥🧡🚀"
+	@echo "Your cloud infrastructure is ready to install Gitpod. Please visit"
+	@echo "https://www.gitpod.io/docs/self-hosted/latest/getting-started#step-4-install-gitpod"
+	@echo "for your next steps."
+	@echo "================="
+	@echo "Config Parameters"
+	@echo "================="
+
+output-url:
+	@echo "\nGitpod domain name:"
+	@echo "================="
+	@terraform output -json url | jq
+
+output-nameservers:
+	@echo "\nNameservers for the domain(to be added as NS records in your domain provider):"
+	@echo "================="
+	@terraform output -json nameservers | jq
+
+output-storage:
+	@echo "\nObject storage:"
+	@echo "=============="
+	@terraform output -json storage | jq
+
+output-registry:
+	@echo "\nGCR registry:"
+	@echo "=================="
+	@terraform output -json registry | jq
+
+output-database:
+	@echo "\nDatabase:"
+	@echo "========"
+	@terraform output -json database | jq
+
+output-issuer:
+	@echo "\nClusterIssuer name:"
+	@echo "================="
+	@terraform output -json cluster_issuer | jq
 
 .PHONY: plan-cluster
 plan-cluster:
-	@terraform plan -target=module.eks
+	@terraform plan -target=module.gke
 
 .PHONY: plan-tools
 plan-tools: plan-cm-edns plan-cluster-issuer
@@ -36,7 +90,7 @@ plan-cluster-issuer:
 
 .PHONY: apply-cluster
 apply-cluster:
-	@terraform apply -target=module.eks --auto-approve
+	@terraform apply -target=module.gke --auto-approve
 
 .PHONY: apply-tools
 apply-tools: install-cm-edns install-cluster-issuer
@@ -47,7 +101,7 @@ install-cm-edns:
 
 .PHONY: install-cluster-issuer
 install-cluster-issuer:
-	@terraform apply -target=module.externaldns  --auto-approve
+	@terraform apply -target=module.cluster-issuer  --auto-approve
 
 .PHONY: destroy-cluster
 destroy-cluster:

--- a/install/infra/single-cluster/gcp/README.md
+++ b/install/infra/single-cluster/gcp/README.md
@@ -1,0 +1,235 @@
+# Terraform setup for GCP Single-cluster Gitpod reference architecture
+
+This directory has terraform configuration necessary to achieve a infrastructure
+corresponding to the [Single-cluster reference architecture for Gitpod on GCP](https://www.gitpod.io/docs/self-hosted/latest/reference-architecture/single-cluster-ref-arch).
+
+This module will do the following steps:
+- Creates the infrastructure using our [`gke` terraform module](../../modules/gke/), which does:
+  - Setup an GKE managed cluster, along with external dependencies like database, storage and registry (if chosen)
+  - Sets up `CloudDNS` entries for the domain name (if provided)
+- Provisioning the cluster:
+  - Set up cert-manager using our [`cert-manager` module](../../modules/tools/cert-manager/)
+  - Set up external-dns using our [`external-dns` module](../../modules/tools/external-dns/)
+  - Creates a cluster-issuer using our [`issuer` module](../../modules/tools/issuer/)
+
+> 💡 If you would like to create the infrastructure orchestrating the terraform modules by yourself, you can find all the modules we support [here](../../modules/).
+
+
+Since the entire setup requires more than one terraform target to be run due to
+dependencies (eg: helm provider depends on kubernetes cluster config, which is
+not available until the `gke` module finishes), this directory has a `Makefile`
+with targets binding together targeted terraform calls. This document will
+explain the execution of the terraform module in terms of these `make` targets.
+
+## Requirements
+
+* `terraform` >= `v1.1.0`
+* `kubectl`   >= `v1.20.0`
+* [`jq`](https://stedolan.github.io/jq/download/)
+* [`gcloud`](https://cloud.google.com/sdk/docs/install)
+
+## Setup GCP authentication and GCS backend storage
+
+Before starting the installation process, you need:
+
+* A GCP account with administative access
+  * [Create one now by clicking here](https://console.cloud.google.com/freetrial)
+* Store the JSON credentials corresponding to the service account locally in a file
+* Create and configure GCS bucket for terraform backend
+  * Create a [GCS bucket](https://cloud.google.com/storage) to store the terraform backend state
+  * Replace the name of the bucket in [`main.tf`](./main.tf) - currently it is set as `gitpod-tf`
+
+## Update the `terraform.tfvars` file with appropriate values
+
+The file [`terraform.tfvars`](./terraform.tfvars) with values that will be used
+by terraform to create the cluster. While some of them are fairly
+straightforward like the name of the cluster(`cluster_name`), others need a bit
+more attention:
+
+### Credentials and project configuration
+
+To configure against a standing GCP account, we expect the the key corresponding
+to the service account stored as a JSON file. The path to the JSON file is
+expected to be provided as a value to the `credentials` field. Alongside, one is
+expected to provide the name of the project(`project` field) corresponding to
+this service account and region in with the cluster to be created(`region`
+field). If you want your cluster to be zonal(only existing in one zone), you can
+provide a zone corresponding to the project(`zone` field), else the cluster will
+be regional.
+
+### External database, storage and registry
+
+If you wish to create cloud specific database, storage and registry backend to be used
+with `Gitpod`, leave the following 3 booleans set:
+
+``` sh
+enable_external_database                     = true
+enable_external_storage                      = true
+enable_external_registry                     = true
+```
+
+The corresponding resources will be created by the terraform script which
+inclustes an `CloudSQL` mysql database, and access credentials to the GCS storage and GCR registry.
+
+The expectation is that you can use the credentials to these setups(provided later
+as terraform outputs) during the setup of Gitpod via UI later in the process.
+Alternatively, one can choose to use incluster dependencies or separately
+created resources of choice.
+
+### Kubernetes version
+
+Make sure you provide the corresponding kubernetes version as a value to the
+variable `cluster_version`. We officially support kubernetes versions >= `1.20`.
+
+### Domain name configuration
+
+If you are already sure of the domain name under which you want to setup Gitpod,
+we recommend highly to provide the value as `domain_name`. This will save a lot
+of hassle in setting up `Cloud DNS` records to point to the cluster and
+corresponding TLS certificate requests.
+
+## Initialize terraform backend and confirm the plan
+
+* Initialize the terraform backend with:
+
+  ``` sh
+  make init
+  ```
+
+* Get the plan of the execution to verify the resources that are going to get
+  created:
+
+  ```sh
+  make plan
+  ```
+
+## Apply terraform setup
+
+If the plan looks good, now you can go ahead and create the resources:
+
+``` sh
+make apply
+```
+
+The `apply` target calls the `terraform` apply on `eks` module, `cert-manager`
+module, `external-dns` module and `cluster-issuer` module in that exact order.
+The entire operation would take around *30 minutes* to complete.
+
+Upon completion, you will find a creation `kubeconfig` file in the local
+directory. You can try accessing the cluster using this file as follows:
+
+``` sh
+export KUBECONFIG=/path/to/kubeconfig
+kubectl get pods -A
+```
+
+You can list all the other outputs with the following command:
+
+``` sh
+make output
+```
+
+> 💡 Alternatively, you can get the simple JSON output with a `terraform output` command
+
+## Note the NS records from terraform output
+
+Once the apply process has exited successfully, we can go ahead and prepare to
+setup Gitpod. If you specified the `domain_name` in the `terraform.tfvars` file,
+the terraform module registers the module with `cloudDNS` to point to the
+cluster. Now you have to configure whichever provider you use to host your
+domain name to route traffic to the GCP name servers. You can find these name
+servers in the `make output` command from above. It would be of the format:
+
+```json
+Nameservers for the domain(to be added as NS records in your domain provider):
+=================
+[
+  "ns-cloud-c1.googledomains.com.",
+  "ns-cloud-c2.googledomains.com.",
+  "ns-cloud-c3.googledomains.com.",
+  "ns-cloud-c4.googledomains.com."
+]
+
+
+```
+
+Add the `ns` records similar to the above 4 URIs as NS records under your domain
+DNS management setup. Check with your domain hosting service for specific information.
+
+## Note the dependency credentials from terraform output
+
+If you enabled the creation of external database, storage and registry, the
+above `make output` command would list the credentials to connect to the
+corresponding resource. Make a note of this, so as to provide the same when
+setting up Gitpod via KOTS UI.
+
+## Install Gitpod
+
+You can install `KOTS` CLI to install Gitpod:
+
+``` sh
+curl https://kots.io/install | bash
+```
+
+Run the following to get started with Gitpod installation:
+
+``` sh
+export KUBECONFIG=kubeconfig
+kubectl kots install gitpod/stable # you can replace `stable` with `unstable` or `beta` as per the requirement
+```
+
+Upon completion, you can access `KOTS` UI in `localhost:8800`. Here you can
+proceed to configuring and intalling Gitpod. Please follow the [official
+documentaion](https://www.gitpod.io/docs/self-hosted/latest/getting-started#step-4-install-gitpod) to complete the Gitpod setup.
+
+## Troubleshooting
+
+### Some pods never start (Init state)
+
+```sh
+kubectl get pods -l component=proxy
+NAME                     READY   STATUS    RESTARTS   AGE
+proxy-5998488f4c-t8vkh   0/1     Init 0/1  0          5m
+```
+
+The most likely reason is that the DNS01 challenge has yet to resolve. To fix this, make sure you have added the NS records corresponding to the `cloudDNS` zone of the `domain_name` added to your domain provider.
+
+Once the DNS record has been updated, you will need to delete all Cert Manager pods to retrigger the certificate request
+
+```
+kubectl delete pods -n cert-manager --all
+```
+
+After a few minutes, you should see the https-certificate become ready.
+
+```
+kubectl get certificate
+NAME                        READY   SECRET                      AGE
+https-certificates          True    https-certificates          5m
+```
+
+### Cannot connect to the created cluster after a while
+
+There is a chance that your kubeconfig has gotten expired after a specific amount of time. You can reconnect to the cluster by using:
+
+``` sh
+gcloud container clusters get-credentials <cluster_name> --region <region> --zone <zone> --project <project>
+```
+
+## Cleanup
+
+Make sure you first delete the `gitpod` resources in the cluster so things like load balancer created by the k8s `service` gets deleted. Otherwise terraform will not be able to delete the VPC.
+
+```sh
+kubectl delete --now namespace gitpod
+```
+
+> It is okay to ignore any dangling workspaces that are not deleted
+
+Now run the terraform destroy step to cleanup all the cloud resources:
+
+```sh
+make destroy
+```
+
+The destroy should take around 20 minutes.

--- a/install/infra/single-cluster/gcp/README.md
+++ b/install/infra/single-cluster/gcp/README.md
@@ -69,7 +69,7 @@ enable_external_registry                     = true
 ```
 
 The corresponding resources will be created by the terraform script which
-inclustes an `CloudSQL` mysql database, and access credentials to the GCS storage and GCR registry.
+creates an `CloudSQL` mysql database, and access credentials to the GCS storage and GCR registry.
 
 The expectation is that you can use the credentials to these setups(provided later
 as terraform outputs) during the setup of Gitpod via UI later in the process.

--- a/install/infra/single-cluster/gcp/README.md
+++ b/install/infra/single-cluster/gcp/README.md
@@ -193,7 +193,7 @@ NAME                     READY   STATUS    RESTARTS   AGE
 proxy-5998488f4c-t8vkh   0/1     Init 0/1  0          5m
 ```
 
-The most likely reason is that the DNS01 challenge has yet to resolve. To fix this, make sure you have added the NS records corresponding to the `cloudDNS` zone of the `domain_name` added to your domain provider.
+The most likely reason is that the DNS01 challenge cannot be completed, typically because DNS zone delegation hasn't been set up from the parent domain to the subdomain that Gitpod is managing (specified by the `domain_name` variable). To fix this, make sure that NS records for `domain_name` in the parent zone are created and point to the nameservers of the Gitpod managed zone. See the [Google Cloud DNS documentation](https://cloud.google.com/dns/docs/dns-overview#delegated_subzone) for more information on zone delegation.
 
 Once the DNS record has been updated, you will need to delete all Cert Manager pods to retrigger the certificate request
 
@@ -214,6 +214,8 @@ https-certificates          True    https-certificates          5m
 There is a chance that your kubeconfig has gotten expired after a specific amount of time. You can reconnect to the cluster by using:
 
 ``` sh
+# make sure you are authenticated using the service account you used to create the cluster
+gcloud auth activate-service-account --key-file=/path/to/account/key.json
 gcloud container clusters get-credentials <cluster_name> --region <region> --zone <zone> --project <project>
 ```
 

--- a/install/infra/single-cluster/gcp/README.md
+++ b/install/infra/single-cluster/gcp/README.md
@@ -83,8 +83,9 @@ variable `cluster_version`. We officially support kubernetes versions >= `1.20`.
 
 ### Domain name configuration
 
-If you are already sure of the domain name under which you want to setup Gitpod,
-we recommend highly to provide the value as `domain_name`. This will save a lot
+If you do not yet have a DNS zone created for Gitpod or plan on using cert-manager
+to generate TLS certificates for gitpod, we strongly recommend setting `domain_name`
+to a domain for use with Gitpod. This will save a lot
 of hassle in setting up `Cloud DNS` records to point to the cluster and
 corresponding TLS certificate requests.
 

--- a/install/infra/single-cluster/gcp/cluster.tf
+++ b/install/infra/single-cluster/gcp/cluster.tf
@@ -1,0 +1,12 @@
+module "gke" {
+  source = "../../modules/gke"
+
+  name            = "gitpod-cluster"
+  kubeconfig      = "./kubeconfig"
+  cluster_version = "1.23"
+  project         = "sh-automated-tests"
+  region          = "europe-west1"
+  zone            = "europe-west1-d" # remove this to create a regional cluster
+
+  domain_name     = "tests-gcp-tf.gitpod-self-hosted.com"
+}

--- a/install/infra/single-cluster/gcp/cluster.tf
+++ b/install/infra/single-cluster/gcp/cluster.tf
@@ -1,12 +1,13 @@
 module "gke" {
   source = "../../modules/gke"
 
-  name            = "gitpod-cluster"
-  kubeconfig      = "./kubeconfig"
-  cluster_version = "1.23"
-  project         = "sh-automated-tests"
-  region          = "europe-west1"
-  zone            = "europe-west1-d" # remove this to create a regional cluster
+  credentials     = var.credentials
+  name            = var.cluster_name
+  kubeconfig      = var.kubeconfig
+  cluster_version = var.cluster_version
+  project         = var.project
+  region          = var.region
+  zone            = var.zone
 
-  domain_name     = "tests-gcp-tf.gitpod-self-hosted.com"
+  domain_name     = var.domain_name
 }

--- a/install/infra/single-cluster/gcp/cluster.tf
+++ b/install/infra/single-cluster/gcp/cluster.tf
@@ -2,12 +2,15 @@ module "gke" {
   source = "../../modules/gke"
 
   credentials     = var.credentials
-  name            = var.cluster_name
+  cluster_name    = var.cluster_name
   kubeconfig      = var.kubeconfig
   cluster_version = var.cluster_version
   project         = var.project
   region          = var.region
   zone            = var.zone
 
-  domain_name     = var.domain_name
+  domain_name = var.domain_name
+  enable_external_database = var.enable_external_database
+  enable_external_storage  = var.enable_external_storage
+  enable_external_registry = var.enable_external_registry
 }

--- a/install/infra/single-cluster/gcp/main.tf
+++ b/install/infra/single-cluster/gcp/main.tf
@@ -1,0 +1,20 @@
+terraform {
+  backend "gcs" {
+    bucket = "gitpod-tf"
+    prefix = "gcp/terraform.state"
+  }
+
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+
+    helm = {
+      source = "hashicorp/helm"
+    }
+  }
+}

--- a/install/infra/single-cluster/gcp/output.tf
+++ b/install/infra/single-cluster/gcp/output.tf
@@ -1,0 +1,4 @@
+output "nameservers" {
+  sensitive = false
+  value     = module.gke.name_servers
+}

--- a/install/infra/single-cluster/gcp/output.tf
+++ b/install/infra/single-cluster/gcp/output.tf
@@ -1,4 +1,36 @@
+output "url" {
+  value = var.domain_name
+}
+
+output "cluster_name" {
+  value = var.cluster_name
+}
+
+output "region" {
+  value = var.region
+}
+
 output "nameservers" {
   sensitive = false
   value     = module.gke.name_servers
+}
+
+output "database" {
+  sensitive = true
+  value     = module.gke.database
+}
+
+output "cluster_issuer" {
+  sensitive = false
+  value     = module.cluster-issuer.cluster_issuer
+}
+
+output "registry" {
+  sensitive = true
+  value     = module.gke.registry
+}
+
+output "storage" {
+  sensitive = true
+  value     = module.gke.storage
 }

--- a/install/infra/single-cluster/gcp/terraform.tfvars
+++ b/install/infra/single-cluster/gcp/terraform.tfvars
@@ -1,0 +1,16 @@
+# the cluster_name should be of length less than 16 characters
+cluster_name = "nan-cluster"
+
+# a cloudDNS zone and certificate request will be created for this domain
+domain_name = "nan-cluster.gitpod-self-hosted.com"
+
+region      = "europe-west1"
+zone        = "europe-west1-d"
+project     = "my-gcp-project"
+credentials = "/path/to/account/key.json"
+
+cluster_version = "1.22"
+
+enable_external_database = true
+enable_external_storage  = true
+enable_external_registry = true

--- a/install/infra/single-cluster/gcp/tools.tf
+++ b/install/infra/single-cluster/gcp/tools.tf
@@ -9,17 +9,17 @@ module "externaldns" {
   source      = "../../modules/tools/cloud-dns-external-dns"
   kubeconfig  = var.kubeconfig
   credentials = var.credentials
-  project     = "sh-automated-tests"
-  region      = "europe-west1"
-  zone        = "europe-west1-d"
+  project     = var.project
+  region      = var.region
+  zone        = var.zone
 }
 
 module "cluster-issuer" {
-  source      = "../../modules/tools/issuer"
-  kubeconfig  = var.kubeconfig
-  issuer_name = "cloudDNS"
+  source              = "../../modules/tools/issuer"
+  kubeconfig          = var.kubeconfig
+  issuer_name         = "cloudDNS"
   cert_manager_issuer = {
-    project = "sh-automated-tests"
+    project                 = var.project
     serviceAccountSecretRef = {
       name = "clouddns-dns01-solver"
       key  = "keys.json"

--- a/install/infra/single-cluster/gcp/tools.tf
+++ b/install/infra/single-cluster/gcp/tools.tf
@@ -1,0 +1,28 @@
+module "certmanager" {
+  source = "../../modules/tools/cert-manager"
+
+  kubeconfig  = var.kubeconfig
+  credentials = var.credentials
+}
+
+module "externaldns" {
+  source      = "../../modules/tools/cloud-dns-external-dns"
+  kubeconfig  = var.kubeconfig
+  credentials = var.credentials
+  project     = "sh-automated-tests"
+  region      = "europe-west1"
+  zone        = "europe-west1-d"
+}
+
+module "cluster-issuer" {
+  source      = "../../modules/tools/issuer"
+  kubeconfig  = var.kubeconfig
+  issuer_name = "cloudDNS"
+  cert_manager_issuer = {
+    project = "sh-automated-tests"
+    serviceAccountSecretRef = {
+      name = "clouddns-dns01-solver"
+      key  = "keys.json"
+    }
+  }
+}

--- a/install/infra/single-cluster/gcp/variables.tf
+++ b/install/infra/single-cluster/gcp/variables.tf
@@ -1,0 +1,7 @@
+variable "kubeconfig" {
+  default = "./kubeconfig"
+}
+
+variable "credentials" {
+  default = "/workspace/gcp.json"
+}

--- a/install/infra/single-cluster/gcp/variables.tf
+++ b/install/infra/single-cluster/gcp/variables.tf
@@ -37,3 +37,18 @@ variable "cluster_version" {
   description = "Kubernetes version to create the cluster with"
   default     = "1.22"
 }
+
+variable "enable_external_database" {
+  default     = true
+  description = "Set this to false to avoid creating an RDS database to use with Gitpod instead of inclsuter mysql"
+}
+
+variable "enable_external_storage" {
+  default     = true
+  description = "Set this to false to avoid creating an s3 storage to use with Gitpod instead of incluster minio"
+}
+
+variable "enable_external_registry" {
+  default     = true
+  description = "Set this to false to create an AWS ECR registry to use with Gitpod(Not officially supported)"
+}

--- a/install/infra/single-cluster/gcp/variables.tf
+++ b/install/infra/single-cluster/gcp/variables.tf
@@ -1,7 +1,39 @@
-variable "kubeconfig" {
-  default = "./kubeconfig"
+variable "credentials" {
+  description = "Path to JSON file authenticating to GCP service account"
 }
 
-variable "credentials" {
-  default = "/workspace/gcp.json"
+variable "project" {
+  description = "GCP project to create the resources in"
+}
+
+variable "cluster_name" {
+  type        = string
+  description = "GKE cluster name."
+}
+variable "kubeconfig" {
+  type        = string
+  description = "Path to the kubeconfig file to write the KUBECONFIG output in"
+  default     = "kubeconfig"
+}
+
+variable "region" {
+  type        = string
+  description = "Region to create the resources in"
+  default     = "europe-west1"
+}
+
+variable "zone" {
+  type        = string
+  description = "Zones under the provided region, if left empty a regional cluster will be created"
+  default     = "europe-west1-b"
+}
+
+variable "domain_name" {
+  description = "Domain name to associate with the Gitpod installation"
+}
+
+variable "cluster_version" {
+  type        = string
+  description = "Kubernetes version to create the cluster with"
+  default     = "1.22"
 }

--- a/install/infra/single-cluster/gcp/variables.tf
+++ b/install/infra/single-cluster/gcp/variables.tf
@@ -40,15 +40,15 @@ variable "cluster_version" {
 
 variable "enable_external_database" {
   default     = true
-  description = "Set this to false to avoid creating an RDS database to use with Gitpod instead of inclsuter mysql"
+  description = "Create an external Cloud DNS instance for Gitpod"
 }
 
 variable "enable_external_storage" {
   default     = true
-  description = "Set this to false to avoid creating an s3 storage to use with Gitpod instead of incluster minio"
+  description = "Create a GCS bucket for Gitpod object storage"
 }
 
 variable "enable_external_registry" {
   default     = true
-  description = "Set this to false to create an AWS ECR registry to use with Gitpod(Not officially supported)"
+  description = "Create a Google Container Registry for Gitpod workspace images"
 }

--- a/install/tests/Makefile
+++ b/install/tests/Makefile
@@ -46,7 +46,7 @@ k3s-kubeconfig: sync-kubeconfig
 gcp-kubeconfig:
 	gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS} --project=sh-automated-tests
 	export KUBECONFIG=${KUBECONFIG} && \
-	gcloud container clusters get-credentials gitpod-${TF_VAR_TEST_ID} --zone europe-west1-d --project sh-automated-tests || $(MAKE) sync-kubeconfig || echo "No cluster present"
+	gcloud container clusters get-credentials gp-${TF_VAR_TEST_ID} --zone europe-west1-d --project sh-automated-tests || $(MAKE) sync-kubeconfig || echo "No cluster present"
 
 ## azure-kubeconfig: Get the kubeconfig configuration for Azure AKS
 azure-kubeconfig:

--- a/install/tests/main.tf
+++ b/install/tests/main.tf
@@ -29,7 +29,7 @@ module "gke" {
   # source = "github.com/gitpod-io/gitpod//install/infra/terraform/gke?ref=main" # we can later use tags here
   source = "../infra/modules/gke" # we can later use tags here
 
-  name            = var.TEST_ID
+  cluster_name    = "gp-${var.TEST_ID}"
   project         = var.project
   credentials     = var.sa_creds
   kubeconfig      = var.kubeconfig


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PR adds a `single-cluster` gcp terraform module, corresponding to our reference architecture for the same cloud provider.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #11535

## How to test
<!-- Provide steps to test this PR -->
You can follow the README [added to this PR](https://github.com/gitpod-io/gitpod/tree/nvn/tf-doc-gcp/install/infra/single-cluster/gcp#readme) to test this terraform module.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
