### PR TITLE
[UBP/baseserver] Allow gRPC server to receive much larger messages

### DIFF
--- a/components/common-go/baseserver/server.go
+++ b/components/common-go/baseserver/server.go
@@ -298,6 +298,7 @@ func (s *Server) initializeGRPC() error {
 		opts = append(opts, grpc.Creds(credentials.NewTLS(tlsConfig)))
 	}
 
+	opts = append(opts, grpc.MaxRecvMsgSize(100*1024*1024))
 	s.grpc = grpc.NewServer(opts...)
 
 	reflection.Register(s.grpc)

--- a/components/usage/pkg/apiv1/size_test.go
+++ b/components/usage/pkg/apiv1/size_test.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package apiv1
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/gitpod-io/gitpod/common-go/baseserver"
+	v1 "github.com/gitpod-io/gitpod/usage-api/v1"
+	"github.com/gitpod-io/gitpod/usage/pkg/stripe"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TestServerCanReceiveLargeMessages(t *testing.T) {
+	srv := baseserver.NewForTests(t,
+		baseserver.WithGRPC(baseserver.MustUseRandomLocalAddress(t)),
+	)
+
+	v1.RegisterBillingServiceServer(srv.GRPC(), NewBillingService(&stripe.Client{}, time.Time{}))
+	baseserver.StartServerForTests(t, srv)
+
+	conn, err := grpc.Dial(srv.GRPCAddress(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+
+	client := v1.NewBillingServiceClient(conn)
+
+	_, err = client.UpdateInvoices(context.Background(), &v1.UpdateInvoicesRequest{
+		Sessions: getBilledSessions(),
+	})
+
+	require.NoError(t, err)
+}
+
+func getBilledSessions() (sessions []*v1.BilledSession) {
+	for i := 0; i < 900000; i++ {
+		sessions = append(sessions, &v1.BilledSession{
+			AttributionId:     "user:1234",
+			UserId:            "1234",
+			TeamId:            "",
+			WorkspaceId:       "",
+			WorkspaceType:     "",
+			ProjectId:         "",
+			InstanceId:        "",
+			WorkspaceClass:    "",
+			StartTime:         &timestamppb.Timestamp{},
+			EndTime:           &timestamppb.Timestamp{},
+			CreditsDeprecated: 0,
+			Credits:           0,
+		})
+	}
+	return
+}

--- a/components/usage/pkg/server/server.go
+++ b/components/usage/pkg/server/server.go
@@ -76,8 +76,8 @@ func Start(cfg Config) error {
 		grpc.WithUnaryInterceptor(grpcClientMetrics.UnaryClientInterceptor()),
 		grpc.WithStreamInterceptor(grpcClientMetrics.StreamClientInterceptor()),
 		grpc.WithDefaultCallOptions(
-			grpc.MaxCallRecvMsgSize(50*1024*1024),
-			grpc.MaxCallSendMsgSize(50*1024*1024),
+			grpc.MaxCallRecvMsgSize(100*1024*1024),
+			grpc.MaxCallSendMsgSize(100*1024*1024),
 		))
 	if err != nil {
 		return fmt.Errorf("failed to create self-connection to grpc server: %w", err)


### PR DESCRIPTION
## Description

Increase baseserver's gRPC maximum receivable message size to 100MB. Change the `usage` client's maximum send and receive values to the same size.

The usage component is currently failing with this error:

```
{"@type":"type.googleapis.com/google.devtools.clouderrorreporting.v1beta1.ReportedErrorEvent","error":"failed to update invoices: rpc error: code = ResourceExhausted desc = grpc: received message larger than max (33395302 vs. 16777216)","level":"error","message":"Reconciliation run failed.","serviceContext":{"service":"usage","version":"commit-8e227e13ef2caae8f56c26387a78546b9fa93b30"},"severity":"ERROR","time":"2022-08-09T11:33:09Z"}
```

This change should allow the `UpdateInvoices` RPC (and all other gRPC services registered with `baseserver`) to accept larger message sizes.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/11997

## How to test

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
