### PR TITLE
Update Platform Version from stable JetBrains Backend Plugin

### DIFF
--- a/components/ide/jetbrains/backend-plugin/gradle-stable.properties
+++ b/components/ide/jetbrains/backend-plugin/gradle-stable.properties
@@ -1,9 +1,9 @@
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
-pluginSinceBuild=221
-pluginUntilBuild=221.*
+pluginSinceBuild=222
+pluginUntilBuild=222.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions.
-pluginVerifierIdeVersions=2022.1
+pluginVerifierIdeVersions=2022.2
 # Version from "com.jetbrains.intellij.idea" which can be found at https://www.jetbrains.com/intellij-repository/snapshots
-platformVersion=221-EAP-SNAPSHOT
+platformVersion=222.3345-EAP-CANDIDATE-SNAPSHOT


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Update Platform Version from stable JetBrains Backend Plugin, as we're now [using v222.3345 for all stable JetBrains IDEs](https://github.com/gitpod-io/gitpod/blob/611800ccb662fc2ccda6cab0e387ac1285c5472e/WORKSPACE.yaml#L12-L15).

## How to test
<!-- Provide steps to test this PR -->
1. Open the preview environment generated for this branch
2. Choose the _Stable_ version of IntelliJ IDEA as your preferred editor
3. Start a workspace using this repository: https://github.com/gitpod-io/spring-petclinic
4. Verify that the workspace starts successfully
5. Verify that the IDE opens successfully

Note: To know what's the version of the IDE (instead of the JetBrains Client version), you need to click the Control widget and "Show Main Window". Then from backend IDE you click "Top Menu >> About", to see something like:

<img width="410" alt="image" src="https://user-images.githubusercontent.com/418083/183650144-f631d59b-d1ab-4c35-80ab-3d6322b63e70.png">


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
