### PR TITLE
[dashboard] Fix active state in usage-based billing account selector

### DIFF
--- a/components/dashboard/src/components/BillingAccountSelector.tsx
+++ b/components/dashboard/src/components/BillingAccountSelector.tsx
@@ -47,6 +47,14 @@ export function BillingAccountSelector(props: { onSelected?: () => void }) {
             props.onSelected();
         }
     };
+
+    let selectedAttributionId = user?.usageAttributionId;
+    if (!selectedAttributionId && teamsWithBillingEnabled?.length === 1) {
+        // When the user hasn't selected a billing account, but there is only one possible billing account,
+        // we auto-select that one.
+        selectedAttributionId = AttributionId.render({ kind: "team", teamId: teamsWithBillingEnabled[0].id });
+    }
+
     return (
         <>
             {teamsWithBillingEnabled === undefined && <Spinner className="m-2 h-5 w-5 animate-spin" />}
@@ -58,11 +66,8 @@ export function BillingAccountSelector(props: { onSelected?: () => void }) {
                             className="w-36 h-32"
                             title="(myself)"
                             selected={
-                                !teamsWithBillingEnabled.find(
-                                    (t) =>
-                                        AttributionId.render({ kind: "team", teamId: t.id }) ===
-                                        user?.usageAttributionId,
-                                )?.name
+                                !!user &&
+                                selectedAttributionId === AttributionId.render({ kind: "user", userId: user.id })
                             }
                             onClick={() => setUsageAttributionTeam(undefined)}
                         >
@@ -73,11 +78,7 @@ export function BillingAccountSelector(props: { onSelected?: () => void }) {
                                 className="w-36 h-32"
                                 title={t.name}
                                 selected={
-                                    !!teamsWithBillingEnabled.find(
-                                        (t) =>
-                                            AttributionId.render({ kind: "team", teamId: t.id }) ===
-                                            user?.usageAttributionId,
-                                    )?.name
+                                    selectedAttributionId === AttributionId.render({ kind: "team", teamId: t.id })
                                 }
                                 onClick={() => setUsageAttributionTeam(t)}
                             >

--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -2044,8 +2044,7 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
 
     async findStripeSubscriptionIdForTeam(ctx: TraceContext, teamId: string): Promise<string | undefined> {
         this.checkAndBlockUser("findStripeSubscriptionIdForTeam");
-        const team = await this.guardTeamOperation(teamId, "get");
-        await this.ensureStripeApiIsAllowed({ team });
+        await this.guardTeamOperation(teamId, "get");
         try {
             const customer = await this.stripeService.findCustomerByTeamId(teamId);
             if (!customer?.id) {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Fix active state in usage-based billing account selector:
- When a team is selected, only show one team as active, not all teams (🤦)
- Align with workspace-start auto-selection logic (i.e. no user choice + only one billing team --> auto-select that one)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/11962

## How to test
<!-- Provide steps to test this PR -->

1. Enable usage-based billing by creating a team called `Gitpod [Something]`
2. In `/billing`, no billing account should be selected
3. Upgrade team `Gitpod [Something]` to usage-based billing by adding a payment method (e.g. 4242 4242 4242 4242, 4/24, 424)
4. In `/billing`, that one team should now be auto-selected
5. Create and upgrade a second team called `Gitpod [Something Else]` to usage-based billing (you can add the same credit card as above)
6. In `/billing`, no billing account should be selected
7. If you manually select one team, it should show up as active (and all other options should remain inactive)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
- [x] /werft with-payment
