### PR TITLE
Update jetbrains-update-plugin-platform-template.yml

### DIFF
--- a/.github/workflows/jetbrains-update-plugin-platform-template.yml
+++ b/.github/workflows/jetbrains-update-plugin-platform-template.yml
@@ -88,7 +88,7 @@ jobs:
 
                       _This PR was created automatically with GitHub Actions using [this](https://github.com/gitpod-io/gitpod/blob/main/.github/workflows/jetbrains-update-plugin-platform-template.yml) template._
                   commit-message: "Update Platform Version of ${{ inputs.pluginName }} to ${{ steps.latest-version.outputs.result }}"
-                  branch: "jetbrains/${{ inputs.pluginId }}-platform-${{ steps.latest-version.outputs.result }}"
+                  branch: "jetbrains/${{ inputs.pluginId }}-platform"
                   labels: "team: IDE"
                   team-reviewers: "engineering-ide"
             - name: Create Pull Request for Backend Plugin
@@ -102,7 +102,7 @@ jobs:
 
                       ## How to test
                       1. Open the preview environment generated for this branch
-                      2. Choose the stable version of IntelliJ IDEA as your preferred editor
+                      2. Choose the _Latest Release (Unstable)_ version of IntelliJ IDEA as your preferred editor
                       3. Start a workspace using this repository: https://github.com/gitpod-io/spring-petclinic
                       4. Verify that the workspace starts successfully
                       5. Verify that the IDE opens successfully
@@ -117,7 +117,7 @@ jobs:
 
                       _This PR was created automatically with GitHub Actions using [this](https://github.com/gitpod-io/gitpod/blob/main/.github/workflows/jetbrains-update-plugin-platform-template.yml) template._
                   commit-message: "Update Platform Version of ${{ inputs.pluginName }} to ${{ steps.latest-version.outputs.result }}"
-                  branch: "jetbrains/${{ inputs.pluginId }}-platform-${{ steps.latest-version.outputs.result }}"
+                  branch: "jetbrains/${{ inputs.pluginId }}-platform"
                   labels: "team: IDE"
                   team-reviewers: "engineering-ide"
             - name: Slack Notification


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Two changes:
- The update targets the Latest version of JetBrains IDEs, not the stable one.
- Remove the _version_ from the branch name because when GitHub Action is going to create a PR, it checks if there's already a PR with that branch name, and if there's it will re-utilize it. 
  - See, for example, #11837 that was closed due to #11919, which came out before it could be merged.

## How to test
<!-- Provide steps to test this PR -->
No need to test, as it's just a textual change.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```