### PR TITLE
re-enable PVC support

### DIFF
--- a/components/ws-manager/pkg/manager/create.go
+++ b/components/ws-manager/pkg/manager/create.go
@@ -30,7 +30,6 @@ import (
 
 	"github.com/gitpod-io/gitpod/common-go/kubernetes"
 	wsk8s "github.com/gitpod-io/gitpod/common-go/kubernetes"
-	"github.com/gitpod-io/gitpod/common-go/log"
 	"github.com/gitpod-io/gitpod/common-go/tracing"
 	"github.com/gitpod-io/gitpod/common-go/util"
 	csapi "github.com/gitpod-io/gitpod/content-service/api"
@@ -558,11 +557,6 @@ func (m *Manager) createDefiniteWorkspacePod(startContext *startWorkspaceContext
 			continue
 		}
 		ffidx[feature] = struct{}{}
-
-		if feature == api.WorkspaceFeatureFlag_PERSISTENT_VOLUME_CLAIM {
-			log.WithField("request", startContext).Warn("Request with PVC enabled. Skipping feature.")
-			continue
-		}
 
 		switch feature {
 		case api.WorkspaceFeatureFlag_FULL_WORKSPACE_BACKUP:


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PR contains two fixes:
1. Re-enables PVC support in ws-manager
2. Fixes PVC not working when restoring from prebuild.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

Needs following merged and deployed into webapp prod prior to merging:
:heavy_check_mark: https://github.com/gitpod-io/gitpod/pull/12105
:heavy_check_mark: https://github.com/gitpod-io/gitpod/pull/12165
:heavy_check_mark: https://github.com/gitpod-io/gitpod/pull/12180

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
none
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
