### PR TITLE
ws-daemon: ignore error when workspace persistent state location not exist

### DIFF
--- a/components/ws-daemon/pkg/internal/session/workspace.go
+++ b/components/ws-daemon/pkg/internal/session/workspace.go
@@ -204,7 +204,12 @@ func (s *Workspace) Dispose(ctx context.Context) (err error) {
 	// old workspace content we can garbage collect that content later.
 	err = os.Remove(s.persistentStateLocation())
 	if err != nil {
-		return xerrors.Errorf("cannot remove workspace persistent state location: %w", err)
+		if os.IsNotExist(err) {
+			log.WithError(err).Warn("workspace persistent state location not exist")
+			err = nil
+		} else {
+			return xerrors.Errorf("cannot remove workspace persistent state location: %w", err)
+		}
 	}
 
 	s.stateLock.Lock()


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
The initial workspace failed at the beginning, so the workspace's persistent state location never exist.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #11715

## How to test
<!-- Provide steps to test this PR -->
Not sure, but we did see some nodes path `/var/gitpod/workspaces` with the folders
- `<instance-id>`
- `<instance-id>-daemon`

but without the corresponding `<instance-id>.workspace.json`.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
None

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
