### PR TITLE
ws-daemon: add span when NewWorkspace

### DIFF
--- a/components/ws-daemon/pkg/internal/session/store.go
+++ b/components/ws-daemon/pkg/internal/session/store.go
@@ -99,6 +99,10 @@ type WorkspaceFactory func(ctx context.Context, location string) (*Workspace, er
 // NewWorkspace creates a new workspace in this store.
 // CheckoutLocation is relative to location.
 func (s *Store) NewWorkspace(ctx context.Context, instanceID, location string, create WorkspaceFactory) (res *Workspace, err error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "Store.NewWorkspace")
+	tracing.ApplyOWI(span, log.OWI("", "", instanceID))
+	defer tracing.FinishSpan(span, &err)
+
 	s.workspacesLock.Lock()
 	defer s.workspacesLock.Unlock()
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Add span when NewWorkspace, it helps us to trace when call NewWorkspace error.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
None

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
None

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
