### PR TITLE
Fix redirect on team usage page

### DIFF
--- a/components/dashboard/src/teams/TeamUsage.tsx
+++ b/components/dashboard/src/teams/TeamUsage.tsx
@@ -50,6 +50,12 @@ function TeamUsage() {
             const teamBillingMode = await getGitpodService().server.getBillingModeForTeam(team.id);
             setTeamBillingMode(teamBillingMode);
         })();
+    }, [team]);
+
+    useEffect(() => {
+        if (!team) {
+            return;
+        }
         (async () => {
             const attributionId = AttributionId.render({ kind: "team", teamId: team.id });
             const request: BillableSessionRequest = {

--- a/components/dashboard/src/teams/TeamUsage.tsx
+++ b/components/dashboard/src/teams/TeamUsage.tsx
@@ -5,7 +5,7 @@
  */
 
 import { useContext, useEffect, useState } from "react";
-import { Redirect, useLocation } from "react-router";
+import { useLocation } from "react-router";
 import { getCurrentTeam, TeamsContext } from "./teams-context";
 import { getGitpodService, gitpodHostUrl } from "../service/service";
 import {
@@ -71,9 +71,14 @@ function TeamUsage() {
         })();
     }, [team, startDateOfBillMonth, endDateOfBillMonth, isStartedTimeDescending]);
 
-    if (!BillingMode.showUsageBasedBilling(teamBillingMode)) {
-        return <Redirect to="/" />;
-    }
+    useEffect(() => {
+        if (!teamBillingMode) {
+            return;
+        }
+        if (!BillingMode.showUsageBasedBilling(teamBillingMode)) {
+            window.location.href = gitpodHostUrl.asDashboard().toString();
+        }
+    }, [teamBillingMode]);
 
     const getType = (type: BillableWorkspaceType) => {
         if (type === "regular") {


### PR DESCRIPTION
## Description


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Aftermath of #11814

## How to test
1. Usage page should be shown if UB is enabled
2. If UB is not enabled, redirect to dashboard's root should happen

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
- [x] /werft with-payment
