### PR TITLE
Fix IntelliJ IDEA detection of Gradle projects from Gitpod repository

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -3,3 +3,4 @@
 # Except these files
 !.gitignore
 !gradle.xml
+!misc.xml

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -4,9 +4,10 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
+        <option name="delegatedBuild" value="true" />
+        <option name="testRunner" value="GRADLE" />
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$/components/ide/jetbrains/backend-plugin" />
-        <option name="gradleJvm" value="11" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$/components/gitpod-protocol/java" />
@@ -16,9 +17,10 @@
         </option>
       </GradleProjectSettings>
       <GradleProjectSettings>
+        <option name="delegatedBuild" value="true" />
+        <option name="testRunner" value="GRADLE" />
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$/components/ide/jetbrains/gateway-plugin" />
-        <option name="gradleJvm" value="11" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$/components/gitpod-protocol/java" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_18" project-jdk-name="17" project-jdk-type="JavaSDK" />
+</project>

--- a/components/gitpod-protocol/java/.classpath
+++ b/components/gitpod-protocol/java/.classpath
@@ -6,7 +6,7 @@
 			<attribute name="gradle_used_by_scope" value="main,test"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11/"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17/"/>
 	<classpathentry kind="con" path="org.eclipse.buildship.core.gradleclasspathcontainer"/>
 	<classpathentry kind="output" path="bin/default"/>
 </classpath>

--- a/components/ide/jetbrains/backend-plugin/.classpath
+++ b/components/ide/jetbrains/backend-plugin/.classpath
@@ -12,7 +12,20 @@
 			<attribute name="gradle_used_by_scope" value="main,test"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11/"/>
+	<classpathentry kind="src" output="bin/main" path="src/main/resources-latest">
+		<attributes>
+			<attribute name="gradle_scope" value="main"/>
+			<attribute name="gradle_used_by_scope" value="main,test"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="bin/test" path="src/test/kotlin">
+		<attributes>
+			<attribute name="gradle_scope" value="test"/>
+			<attribute name="gradle_used_by_scope" value="test"/>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17/"/>
 	<classpathentry kind="con" path="org.eclipse.buildship.core.gradleclasspathcontainer"/>
 	<classpathentry kind="output" path="bin/default"/>
 </classpath>

--- a/components/supervisor-api/java/.classpath
+++ b/components/supervisor-api/java/.classpath
@@ -6,7 +6,7 @@
 			<attribute name="gradle_used_by_scope" value="main,test"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11/"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17/"/>
 	<classpathentry kind="con" path="org.eclipse.buildship.core.gradleclasspathcontainer"/>
 	<classpathentry kind="output" path="bin/default"/>
 </classpath>


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Currently, when opening Gitpod repo main branch(independently of using Stable or Latest IDEA version), it's only displaying displaying one of the two Gradle Projects we have (along with some warnings about Gradle not being properly configured):

|       |        |
| --- | --- |
| <img width="834" alt="image" src="https://user-images.githubusercontent.com/418083/183907537-2a489143-79d7-4f32-9220-fe3d9ef164d6.png"> | <img width="339" alt="image" src="https://user-images.githubusercontent.com/418083/183908280-4fc87fd1-6b4e-4128-a0e0-ee607ec22e79.png"> |

With these changes, when we open the Gitpod repo on IntelliJ IDEA it should display the two Gradle Projects correctly configured without any warning notifications.

| Stable IDEA | Latest IDEA|
| --- | --- |
| <img width="833" alt="image" src="https://user-images.githubusercontent.com/418083/183906166-363e7f27-77cb-4314-8839-b3f34cec92d6.png"> | <img width="834" alt="image" src="https://user-images.githubusercontent.com/418083/183906388-ef57b035-374c-4f48-a78d-3d4838439d96.png"> |

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
The three _.classpath_ files are a follow-up from https://github.com/gitpod-io/gitpod/pull/11991, which were only updated by the IDE the second time we opened it.

## How to test
<!-- Provide steps to test this PR -->
1. Open the [preview environment generated for this branch](https://gitpod.io/preferences) and select the _Latest (Unstable)_ version of IntelliJ IDEA as your preferred editor.
    - Note: It also works with _Stable_ version of IntelliJ IDEA. But for developing Gitpod we use the unstable version, so you don't need to test the stable.
3. Open the branch of this PR in gitpod.io: https://gitpod.io/#https://github.com/gitpod-io/gitpod/pull/12032
4. Verify that the workspace starts successfully
5. Verify that the IDE opens successfully
6. Verify that both _jetbrains-backend-plugin_ and _jetbrains-gateway-plugin_ are correctly identified as Gradle Projects.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
