### PR TITLE
Add support for the new observability installer in preview environments

### DIFF
--- a/.werft/jobs/build/deploy-to-preview-environment.ts
+++ b/.werft/jobs/build/deploy-to-preview-environment.ts
@@ -216,6 +216,7 @@ export async function deployToPreviewEnvironment(werft: Werft, jobConfig: JobCon
         previewName: previewNameFromBranchName(jobConfig.repository.branch),
         stackdriverServiceAccount: STACKDRIVER_SERVICEACCOUNT,
         werft: werft,
+        installationMethod: jobConfig.observability.installationMethod,
     });
     const sliceID = "observability";
     monitoringSatelliteInstaller
@@ -235,13 +236,7 @@ export async function deployToPreviewEnvironment(werft: Werft, jobConfig: JobCon
         .finally(() => werft.done(sliceID));
 
     werft.phase(phases.DEPLOY, "deploying to dev with Installer");
-    await deployToDevWithInstaller(
-        werft,
-        jobConfig,
-        deploymentConfig,
-        workspaceFeatureFlags,
-        storage
-    );
+    await deployToDevWithInstaller(werft, jobConfig, deploymentConfig, workspaceFeatureFlags, storage);
 }
 
 /*
@@ -514,7 +509,7 @@ export async function issueMetaCerts(
     metaClusterCertParams.gcpSaPath = GCLOUD_SERVICE_ACCOUNT_PATH;
     metaClusterCertParams.certName = certName;
     metaClusterCertParams.certNamespace = certsNamespace;
-    metaClusterCertParams.previewName = previewNameFromBranchName(branch)
+    metaClusterCertParams.previewName = previewNameFromBranchName(branch);
     metaClusterCertParams.dnsZoneDomain = "gitpod-dev.com";
     metaClusterCertParams.domain = domain;
     metaClusterCertParams.ip = getCoreDevIngressIP();

--- a/.werft/jobs/build/job-config.ts
+++ b/.werft/jobs/build/job-config.ts
@@ -45,9 +45,13 @@ export interface Repository {
     branch: string;
 }
 
+export type ObservabilityInstallationMethod = "jsonnet" | "observability-installer";
+
 export interface Observability {
     // The branch of gitpod-io/observability to use
     branch: string;
+    // What tool to use to install monitoring-satellite from gitpod-io/observability
+    installationMethod: ObservabilityInstallationMethod;
 }
 
 export function jobConfig(werft: Werft, context: any): JobConfig {
@@ -111,6 +115,7 @@ export function jobConfig(werft: Werft, context: any): JobConfig {
 
     const observability: Observability = {
         branch: context.Annotations.withObservabilityBranch || "main",
+        installationMethod: context.Annotations.observabilityInstallationMethod || "jsonnet",
     };
 
     const jobConfig = {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This adds a new Werft annotation `observabilityInstallationMethod` which can be used to switch the installation method used for gitpod-io/observability. The two valid options are `jsonnet` and `observability-installer` - it defaults to `jsonnet`.

When using `observability-installer` the installation is currently not successful - I consider getting it to a point where the installation is happy out of scope of this PR. Logs from [this job](https://werft.gitpod-dev.com/job/gitpod-build-mads-add-support-for-observability-installer.24/logs) below:

```
[resource mapping not found for name: "alertmanager-main" namespace: "monitoring-satellite" from "STDIN": no matches for kind "ServiceMonitor" in version "monitoring.coreos.com/v1"
ensure CRDs are installed first, resource mapping not found for name: "gitpod-monitoring" namespace: "monitoring-satellite" from "STDIN": no matches for kind "PrometheusRule" in version "monitoring.coreos.com/v1"
ensure CRDs are installed first, resource mapping not found for name: "k8s" namespace: "monitoring-satellite" from "STDIN": no matches for kind "Prometheus" in version "monitoring.coreos.com/v1"
ensure CRDs are installed first, resource mapping not found for name: "kube-state-metrics" namespace: "monitoring-satellite" from "STDIN": no matches for kind "PrometheusRule" in version "monitoring.coreos.com/v1"
ensure CRDs are installed first, resource mapping not found for name: "kube-state-metrics" namespace: "monitoring-satellite" from "STDIN": no matches for kind "ServiceMonitor" in version "monitoring.coreos.com/v1"
ensure CRDs are installed first, resource mapping not found for name: "main" namespace: "monitoring-satellite" from "STDIN": no matches for kind "Alertmanager" in version "monitoring.coreos.com/v1"
ensure CRDs are installed first, resource mapping not found for name: "node-exporter" namespace: "monitoring-satellite" from "STDIN": no matches for kind "ServiceMonitor" in version "monitoring.coreos.com/v1"
ensure CRDs are installed first, resource mapping not found for name: "prometheus-k8s" namespace: "monitoring-satellite" from "STDIN": no matches for kind "ServiceMonitor" in version "monitoring.coreos.com/v1"
ensure CRDs are installed first, resource mapping not found for name: "prometheus-operator" namespace: "monitoring-satellite" from "STDIN": no matches for kind "ServiceMonitor" in version "monitoring.coreos.com/v1"
ensure CRDs are installed first]
Error from server (NotFound): error when creating "STDIN": namespaces "monitoring-satellite" not found
Error from server (NotFound): error when creating "STDIN": namespaces "monitoring-satellite" not found
Error from server (NotFound): error when creating "STDIN": namespaces "monitoring-satellite" not found
Error from server (NotFound): error when creating "STDIN": namespaces "monitoring-satellite" not found
Error from server (NotFound): error when creating "STDIN": namespaces "monitoring-satellite" not found
Error from server (NotFound): error when creating "STDIN": namespaces "monitoring-satellite" not found
Error from server (NotFound): error when creating "STDIN": namespaces "monitoring-satellite" not found
Error from server (NotFound): error when creating "STDIN": namespaces "monitoring-satellite" not found
Error from server (NotFound): error when creating "STDIN": namespaces "monitoring-satellite" not found
Error from server (NotFound): error when creating "STDIN": namespaces "monitoring-satellite" not found
Error from server (NotFound): error when creating "STDIN": namespaces "monitoring-satellite" not found
Error from server (NotFound): error when creating "STDIN": namespaces "monitoring-satellite" not found
Error from server (NotFound): error when creating "STDIN": namespaces "monitoring-satellite" not found
Error from server (NotFound): error when creating "STDIN": namespaces "monitoring-satellite" not found
Error from server (NotFound): error when creating "STDIN": namespaces "monitoring-satellite" not found
Error from server (NotFound): error when creating "STDIN": namespaces "monitoring-satellite" not found
Error from server (NotFound): error when creating "STDIN": namespaces "monitoring-satellite" not found
Error from server (NotFound): error when creating "STDIN": namespaces "monitoring-satellite" not found
Error from server (NotFound): error when creating "STDIN": namespaces "monitoring-satellite" not found
Error from server (NotFound): error when creating "STDIN": namespaces "monitoring-satellite" not found
Error from server (NotFound): error when creating "STDIN": namespaces "monitoring-satellite" not found
```

There is also a bit of functionality I'm not including if you use observability-installer

```
this.postProcessManifests();
this.ensureCorrectInstallationOrder();
this.deployGitpodServiceMonitors();
await this.waitForReadiness(werft);
```

I'm hoping that some of these won't be needed with the observability-installer so left them out for now.

### Implementation notes

This PR also contains a few auto-formatter changes.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

https://github.com/gitpod-io/gitpod/issues/12036

## How to test
<!-- Provide steps to test this PR -->

- That I didn't break the default behaviour of using jsonnet: `werft job run github -a with-preview=1` ([job](https://werft.gitpod-dev.com/job/gitpod-build-mads-add-support-for-observability-installer.26))
- That it invokes the new installer when asking it to: `werft job run github -a observabilityInstallationMethod=observability-installer -a with-preview=true -a with-clean-slate-deployment=true` ([job](https://werft.gitpod-dev.com/job/gitpod-build-mads-add-support-for-observability-installer.24/logs))

For the installation method I did a quick check to see that Grafana still works:

```sh
./dev/preview/portforward-monitoring-satellite.sh -c harvester
```

Example of the job failing due to missing config can be found here: [job](https://werft.gitpod-dev.com/job/gitpod-build-mads-add-support-for-observability-installer.18/logs)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

N/A

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
