### PR TITLE
[dashboard] Show workspace class in admin view

### DIFF
--- a/components/dashboard/src/admin/WorkspaceDetail.tsx
+++ b/components/dashboard/src/admin/WorkspaceDetail.tsx
@@ -148,6 +148,9 @@ export default function WorkspaceDetail(props: { workspace: WorkspaceAndInstance
                         <Property name="Node">
                             <div className="overflow-scroll">{workspace.status.nodeName ?? "not assigned"}</div>
                         </Property>
+                        <Property name="Class">
+                            <div>{workspace.workspaceClass ?? "unknown"}</div>
+                        </Property>
                     </div>
                     <div className="flex w-full mt-6">{[0, 1, 2].map(adminLink)}</div>
                     <div className="flex w-full mt-6">{[3, 4, 5].map(adminLink)}</div>


### PR DESCRIPTION
## Description
Show workspace class in admin view

![AdminClassName2](https://user-images.githubusercontent.com/24721048/183938360-3bedb945-1cd0-4907-af3c-772432f239fc.png)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/12048

## How to test
- Open workspace and check admin view

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
