### PR TITLE
Add clusterrolebinding to allow kube-rbac-proxy verify tokens

### DIFF
--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -2215,6 +2215,15 @@ data:
       name: content-service
       namespace: default
     ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: content-service
+      name: default-content-service-rb-kube-rbac-proxy
+    ---
     apiVersion: v1
     kind: Service
     metadata:
@@ -5170,6 +5179,24 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: blobserve
+  namespace: default
+---
+# rbac.authorization.k8s.io/v1/ClusterRoleBinding default-content-service-rb-kube-rbac-proxy
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: content-service
+  name: default-content-service-rb-kube-rbac-proxy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-kube-rbac-proxy
+subjects:
+- kind: ServiceAccount
+  name: content-service
   namespace: default
 ---
 # rbac.authorization.k8s.io/v1/ClusterRoleBinding default-ide-metrics-kube-rbac-proxy

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -1995,6 +1995,15 @@ data:
       name: content-service
       namespace: default
     ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: content-service
+      name: default-content-service-rb-kube-rbac-proxy
+    ---
     apiVersion: v1
     kind: Service
     metadata:
@@ -4610,6 +4619,24 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: blobserve
+  namespace: default
+---
+# rbac.authorization.k8s.io/v1/ClusterRoleBinding default-content-service-rb-kube-rbac-proxy
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: content-service
+  name: default-content-service-rb-kube-rbac-proxy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-kube-rbac-proxy
+subjects:
+- kind: ServiceAccount
+  name: content-service
   namespace: default
 ---
 # rbac.authorization.k8s.io/v1/ClusterRoleBinding default-ide-metrics-kube-rbac-proxy

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -2101,6 +2101,15 @@ data:
       name: content-service
       namespace: default
     ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: content-service
+      name: default-content-service-rb-kube-rbac-proxy
+    ---
     apiVersion: v1
     kind: Service
     metadata:
@@ -4849,6 +4858,24 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: blobserve
+  namespace: default
+---
+# rbac.authorization.k8s.io/v1/ClusterRoleBinding default-content-service-rb-kube-rbac-proxy
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: content-service
+  name: default-content-service-rb-kube-rbac-proxy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-kube-rbac-proxy
+subjects:
+- kind: ServiceAccount
+  name: content-service
   namespace: default
 ---
 # rbac.authorization.k8s.io/v1/ClusterRoleBinding default-ide-metrics-kube-rbac-proxy

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -2113,6 +2113,15 @@ data:
       name: content-service
       namespace: default
     ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: content-service
+      name: default-content-service-rb-kube-rbac-proxy
+    ---
     apiVersion: v1
     kind: Service
     metadata:
@@ -4861,6 +4870,24 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: blobserve
+  namespace: default
+---
+# rbac.authorization.k8s.io/v1/ClusterRoleBinding default-content-service-rb-kube-rbac-proxy
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: content-service
+  name: default-content-service-rb-kube-rbac-proxy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-kube-rbac-proxy
+subjects:
+- kind: ServiceAccount
+  name: content-service
   namespace: default
 ---
 # rbac.authorization.k8s.io/v1/ClusterRoleBinding default-ide-metrics-kube-rbac-proxy

--- a/install/installer/pkg/components/content-service/rolebinding.go
+++ b/install/installer/pkg/components/content-service/rolebinding.go
@@ -31,5 +31,24 @@ func rolebinding(ctx *common.RenderContext) ([]runtime.Object, error) {
 			Kind: "ServiceAccount",
 			Name: Component,
 		}},
-	}}, nil
+	}, &rbacv1.ClusterRoleBinding{
+		TypeMeta: common.TypeMetaClusterRoleBinding,
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   fmt.Sprintf("%s-%s-rb-kube-rbac-proxy", ctx.Namespace, Component),
+			Labels: common.DefaultLabels(Component),
+		},
+		RoleRef: rbacv1.RoleRef{
+			Kind:     "ClusterRole",
+			Name:     fmt.Sprintf("%s-kube-rbac-proxy", ctx.Namespace),
+			APIGroup: "rbac.authorization.k8s.io",
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      Component,
+				Namespace: ctx.Namespace,
+			},
+		},
+	},
+	}, nil
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
In https://github.com/gitpod-io/gitpod/pull/11782 I've added kube-rbac-proxy to content-service because Prometheus was not able to reach the metrics endpoint of content-service.

After this change got deployed, the error only changed to another one. We're now getting `401 Unathorized` errors. 

Looks like I forgot to add the role binding that authorizes kube-rbac-proxy to actually verify valid tokens.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Solves alerts like [this one](https://gitpod.slack.com/archives/C03MWBB5MP1/p1660118826886249).

## How to test
<!-- Provide steps to test this PR -->
You can connect to the preview of this PR, port-forward prometheus and verify that content-service is being scraped successfully at the page `/targets`


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```


## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
