### PR TITLE
[kots]: add useful links to the KOTS dashboard

### DIFF
--- a/install/kots/manifests/kots-links.yaml
+++ b/install/kots/manifests/kots-links.yaml
@@ -1,0 +1,24 @@
+# Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+# Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  name: gitpod
+  labels:
+    app.kubernetes.io/name: gitpod
+    app.kubernetes.io/version: "1.0.0"
+spec:
+  selector:
+    matchLabels:
+     app.kubernetes.io/name: gitpod
+  descriptor:
+    links:
+      - description: Open {{repl ConfigOption "domain" }}
+        url: https://{{repl ConfigOption "domain" }}
+      - description: Gitpod Docs
+        url: https://www.gitpod.io/docs
+      - description: Gitpod Source Code
+        url: https://www.github.com/gitpod-io/gitpod
+      - description: Gitpod Website
+        url: https://www.gitpod.io


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Whilst scouring the KOTS documentation, I discovered we have the ability to add [custom links](https://docs.replicated.com/vendor/admin-console-adding-buttons-links#add-a-button-to-the-dashboard) to the KOTS dashboard. I've added a couple as these could be quite useful for users.

![image](https://user-images.githubusercontent.com/275848/183916601-60e06cd7-2228-4367-a7c0-9d7fd69c7387.png)

This is what occurred to me, but the content/ordering is entirely configurable. Probably best for @lucasvaltl to decide on what (if anything) goes here.

## How to test
<!-- Provide steps to test this PR -->
Create a KOTS instance and this is on the homepage once installed

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[kots]: add useful links to the KOTS dashboard
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
