### PR TITLE
Restrict codeowners of 'supervisor-api' only to '.proto' files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -64,7 +64,7 @@
 /components/registry-facade @gitpod-io/engineering-workspace
 /components/server @gitpod-io/engineering-webapp
 /components/service-waiter @gitpod-io/engineering-webapp
-/components/supervisor-api @csweichel @akosyakov
+/components/supervisor-api/*.proto @csweichel @akosyakov
 /components/supervisor @gitpod-io/engineering-ide
 /components/usage @gitpod-io/engineering-webapp
 /components/usage-api @gitpod-io/engineering-webapp


### PR DESCRIPTION
## Description
On the following PR there was no need for them to be reviewers:

- https://github.com/gitpod-io/gitpod/pull/12032

Anyone from IDE team could review it.

With the changes from this PR, those will be the files owned:

<img width="398" alt="image" src="https://user-images.githubusercontent.com/418083/183929488-171fc961-bab9-40a5-bddf-7b2ce1b01bbd.png">

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
