### PR TITLE
[JetBrains] Show Workspace CPU/Memory resources in control center

### DIFF
--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/latest/GitpodMetricControlProvider.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/latest/GitpodMetricControlProvider.kt
@@ -1,0 +1,71 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package io.gitpod.jetbrains.remote.latest
+
+import com.jetbrains.ide.model.uiautomation.BeControl
+import com.jetbrains.rd.ui.bedsl.dsl.VerticalGridBuilder
+import com.jetbrains.rd.ui.bedsl.dsl.verticalGrid
+import com.jetbrains.rd.util.lifetime.Lifetime
+import com.jetbrains.rd.util.reactive.Property
+import com.jetbrains.rdserver.diagnostics.BackendDiagnosticsService
+import com.jetbrains.rdserver.unattendedHost.customization.controlCenter.performance.MetricControlProvider
+import com.jetbrains.rdserver.unattendedHost.customization.controlCenter.performance.createProgressBar
+import com.jetbrains.rdserver.unattendedHost.customization.controlCenter.performance.createProgressRow
+
+class GitpodMetricControlProvider : MetricControlProvider {
+    override val id: String = "gitpodMetricsControl"
+    override fun getControl(lifetime: Lifetime): BeControl {
+        return verticalGrid {
+            val backendDiagnosticsService = BackendDiagnosticsService.Companion.getInstance()
+            createCpuControl(this, backendDiagnosticsService, lifetime)
+            createMemoryControl(this, backendDiagnosticsService, lifetime)
+        }
+    }
+
+    private fun createCpuControl(ctx: VerticalGridBuilder, backendDiagnosticsService: BackendDiagnosticsService, lifetime: Lifetime) {
+        val cpuUsed = backendDiagnosticsService.getMetric("gitpod_workspace_cpu_used")
+        val cpuTotal = backendDiagnosticsService.getMetric("gitpod_workspace_cpu_total")
+        val cpuPercentage = backendDiagnosticsService.getMetric("gitpod_workspace_cpu_percentage")
+        val cpuPercentageProperty = Property("$cpuPercentage %")
+        val label = "Workspace CPU"
+        val progressBar = createProgressBar(lifetime, cpuPercentage.valueProperty, cpuPercentageProperty)
+        val labelProperty = Property("")
+
+        fun updateLabel() {
+            labelProperty.set("${cpuUsed}m / ${cpuTotal}m")
+        }
+        updateLabel()
+        cpuUsed.valueProperty.change.advise(lifetime) {
+            updateLabel()
+        }
+        cpuTotal.valueProperty.change.advise(lifetime) {
+            updateLabel()
+        }
+        createProgressRow(ctx, lifetime, label, cpuPercentage.statusProperty, labelProperty, cpuPercentageProperty, progressBar)
+    }
+
+    private fun createMemoryControl(ctx: VerticalGridBuilder, backendDiagnosticsService: BackendDiagnosticsService, lifetime: Lifetime) {
+        val memoryUsed = backendDiagnosticsService.getMetric("gitpod_workspace_memory_used")
+        val memoryTotal = backendDiagnosticsService.getMetric("gitpod_workspace_memory_total")
+        val memoryPercentage = backendDiagnosticsService.getMetric("gitpod_workspace_memory_percentage")
+        val memoryPercentageProperty = Property("$memoryPercentage %")
+        val label = "Workspace Memory"
+        val progressBar = createProgressBar(lifetime, memoryPercentage.valueProperty, memoryPercentageProperty)
+        val labelProperty = Property("")
+
+        fun updateLabel() {
+            labelProperty.set("${memoryUsed}GB / ${memoryTotal}GB")
+        }
+        updateLabel()
+        memoryUsed.valueProperty.change.advise(lifetime) {
+            updateLabel()
+        }
+        memoryTotal.valueProperty.change.advise(lifetime) {
+            updateLabel()
+        }
+
+        createProgressRow(ctx, lifetime, label, memoryPercentage.statusProperty, labelProperty, memoryPercentageProperty, progressBar)
+    }
+}

--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/latest/GitpodMetricProvider.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/latest/GitpodMetricProvider.kt
@@ -1,0 +1,65 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package io.gitpod.jetbrains.remote.latest
+
+import com.intellij.openapi.components.service
+import com.jetbrains.rd.platform.codeWithMe.unattendedHost.metrics.Metric
+import com.jetbrains.rd.platform.codeWithMe.unattendedHost.metrics.MetricType
+import com.jetbrains.rd.platform.codeWithMe.unattendedHost.metrics.MetricsStatus
+import com.jetbrains.rd.platform.codeWithMe.unattendedHost.metrics.providers.MetricProvider
+import io.gitpod.jetbrains.remote.GitpodManager
+import kotlin.math.roundToInt
+
+class GitpodMetricProvider: MetricProvider {
+    private val manager = service<GitpodManager>()
+
+    override val id: String = "gitpodMetricsProvider"
+    override fun getMetrics(): Map<String, Metric> {
+        val resourceStatus = manager.resourceStatus
+
+        val cpuUsed = resourceStatus?.cpu?.used?.toDouble() ?: 0.0
+        val cpuTotal = resourceStatus?.cpu?.limit?.toDouble() ?: 0.0
+        val cpuPercentage = (cpuUsed / cpuTotal) * 100
+
+        // TODO: retrieve thresholds from supervisor once we implement this: https://github.com/gitpod-io/gitpod/issues/12075
+        val cpuStatus = if (cpuPercentage >= 95) {
+            MetricsStatus.DANGER
+        } else if (cpuPercentage >= 80) {
+            MetricsStatus.WARNING
+        } else {
+            MetricsStatus.NORMAL
+        }
+
+        val memoryUsed = convertBytesToGB(resourceStatus?.memory?.used ?: 0)
+        val memoryTotal = convertBytesToGB(resourceStatus?.memory?.limit ?: 0)
+        val memoryPercentage = (memoryUsed / memoryTotal) * 100
+
+        // TODO: retrieve thresholds from supervisor once we implement this: https://github.com/gitpod-io/gitpod/issues/12075
+        val memoryStatus = if (memoryPercentage >= 95) {
+            MetricsStatus.DANGER
+        } else if (memoryPercentage >= 80) {
+            MetricsStatus.WARNING
+        } else {
+            MetricsStatus.NORMAL
+        }
+
+        return mapOf(
+                "gitpod_workspace_cpu_used" to Metric(MetricType.PERFORMANCE, MetricsStatus.NORMAL, roundTo(cpuUsed, 0)),
+                "gitpod_workspace_cpu_total" to Metric(MetricType.PERFORMANCE, MetricsStatus.NORMAL, roundTo(cpuTotal, 0)),
+                "gitpod_workspace_cpu_percentage" to Metric(MetricType.PERFORMANCE, cpuStatus, (cpuPercentage * 1000.0).roundToInt() / 1000.0),
+                "gitpod_workspace_memory_used" to Metric(MetricType.PERFORMANCE, MetricsStatus.NORMAL, roundTo(memoryUsed, 2)),
+                "gitpod_workspace_memory_total" to Metric(MetricType.PERFORMANCE, MetricsStatus.NORMAL, roundTo(memoryTotal, 2)),
+                "gitpod_workspace_memory_percentage" to Metric(MetricType.PERFORMANCE, memoryStatus, (memoryPercentage * 1000.0).roundToInt() / 1000.0)
+        )
+    }
+
+    private fun convertBytesToGB(bytes: Long) : Double {
+        return bytes.div(1073741824.0)
+    }
+
+    private fun roundTo(number: Double, decimals: Int) : String {
+        return String.format("%.${decimals}f", number)
+    }
+}

--- a/components/ide/jetbrains/backend-plugin/src/main/resources-latest/META-INF/extensions.xml
+++ b/components/ide/jetbrains/backend-plugin/src/main/resources-latest/META-INF/extensions.xml
@@ -7,5 +7,7 @@
     <extensions defaultExtensionNs="com.intellij">
         <projectService serviceImplementation="io.gitpod.jetbrains.remote.latest.GitpodTerminalService" client="guest" preload="true"/>
         <projectService serviceImplementation="io.gitpod.jetbrains.remote.latest.GitpodPortForwardingService" preload="true"/>
+        <gateway.customization.performance id="gitpodMetricsControl" order="before cpuControl" implementation="io.gitpod.jetbrains.remote.latest.GitpodMetricControlProvider"/>
+        <gateway.customization.metrics id="gitpodMetricsProvider" implementation="io.gitpod.jetbrains.remote.latest.GitpodMetricProvider" />
     </extensions>
 </idea-plugin>


### PR DESCRIPTION
## Context
Currently, in JetBrains IDE the CPU/Memory usage displayed applies to the whole node, instead of displaying the workspace's specific resources. 

## Description
With this PR we introduce two additional progress bars at the top displaying:

- `Workspace CPU`
- `Workspace Memory`

**Please note**: The Unit used for Memory resource is on purpose "GB" instead of "Mi" like in `gitpod-cli`, my reasons:
1. personally I find it shorter and easier to read `0.38GB / 1.55GB` instead of `2944Mi/11870Mi`
2. when talking about memory (in general) it's more common to refer to GB
3. in gitpod.io our memory (especially for XL) can be a large number to read if it's in `Mi`

I would actually like to propose a separate issue to change it also in `gp top` but I would like to know if there are any reasons or string objections in favor of the smaller unit. cc @akosyakov @felladrin 

## Related Issue(s)
Fixes #10580

## How to test
1. Signup to [this prev env](https://afalz-10581fa3bcc8cc.preview.gitpod-dev.com/workspaces)
5. Select `IntelliJ` + `Latest Release (Unstable)` as your preferred IDE
6. Start a workspace for https://github.com/gitpod-io/spring-petclinic
7. Click on the control center and see available resources, notice the additional rows at the top (Workspace CPU/Memory) before the default CPU/Memory

_OPTIONAL:_

9. To stress the CPU, run: `yes > /dev/null &` multiple times, observe the progress bar growing and moving to Warning and Danger.
10. To get the CPU back to a lower value, run: `killall yes`
11. To stress the Memory, run `cat /dev/zero | head -c 5G | tail` once or twice, and observe the memory progress bar behaving as expected

<img width="584" alt="Screenshot 2022-08-11 at 21 42 39" src="https://user-images.githubusercontent.com/2318450/184226677-d8a2c627-f801-4fdd-a74e-fd323a2eb34b.png">

<img width="590" alt="Screenshot 2022-08-11 at 21 51 25" src="https://user-images.githubusercontent.com/2318450/184227715-cab58ee8-fb2d-4df0-825a-e61c94cabe88.png">


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
JetBrains: Display Workspace CPU/Memory usage in Backend Control Center
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
