### PR TITLE
[server] Reliably set log the value for volumeSnapshotId

### DIFF
--- a/components/gitpod-protocol/src/util/logging.spec.ts
+++ b/components/gitpod-protocol/src/util/logging.spec.ts
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { suite, test } from "mocha-typescript";
+import { log } from "./logging";
+
+@suite
+class TestLogging {
+    @test public async testLogInfo_output() {
+        const testObj = {
+            null: null,
+            undefined: undefined,
+            empty: "",
+            foo: "bar",
+            number: 0,
+        };
+        log.info("info logging test", testObj);
+    }
+}
+module.exports = new TestLogging();

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -1423,11 +1423,11 @@ export class WorkspaceStarter {
             }
         }
 
-        let volumeSnapshotId = lastValidWorkspaceInstanceId;
-        // if this is snapshot or prebuild context, then try to find volume snapshot id in it
-        if (SnapshotContext.is(workspace.context) || WithPrebuild.is(workspace.context)) {
-            volumeSnapshotId = workspace.context.snapshotBucketId;
-        }
+        const volumeSnapshotId =
+            SnapshotContext.is(workspace.context) || WithPrebuild.is(workspace.context)
+                ? workspace.context.snapshotBucketId
+                : lastValidWorkspaceInstanceId;
+
         let volumeSnapshotInfo = new VolumeSnapshotInfo();
         const volumeSnapshots = await this.workspaceDb.trace(traceCtx).findVolumeSnapshotById(volumeSnapshotId);
         if (volumeSnapshots !== undefined) {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Set the value for `volumeSnapshotId` one time.

Background: we're trying to log/capture the above field. Why? The problem is, sometimes a feature (PVC) is enabled for workspace start in production, and we do not know why. We added logging to learn more, but, it is missing this field `volSnapshotId: volumeSnapshotId,`. 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related to #11823

## How to test
<!-- Provide steps to test this PR -->
Start a workspace

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
