### PR TITLE
observability: add #workspace > 20 in alert GitpodWorkspaceTooManyRegularNotActive

### DIFF
--- a/operations/observability/mixins/workspace/rules/components/workspaces/alerts.libsonnet
+++ b/operations/observability/mixins/workspace/rules/components/workspaces/alerts.libsonnet
@@ -86,6 +86,8 @@
             },
             expr: |||
               gitpod_workspace_regular_not_active_percentage > 0.10
+              AND
+              sum(gitpod_ws_manager_workspace_activity_total) > 20
             |||,
           },
           {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
To prevent the alert from being triggered once we start traffic shifting.
The number of workspaces might be low, this cause the
gitpod_workspace_regular_not_active_percentage is easily to hit because
the gitpod_ws_manager_workspace_activity_total is low number.

Therefore, we add #workspace > 20 as another criterion for the alert.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #
https://gitpod.slack.com/archives/C01TNS8EVQT/p1660179022948519?thread_ts=1660178901.055319&cid=C01TNS8EVQT

## How to test
<!-- Provide steps to test this PR -->
Was:
![image](https://user-images.githubusercontent.com/49380831/184059656-8deda869-2837-44fa-8fc2-d8bdfba29e6d.png)

Is:
![image](https://user-images.githubusercontent.com/49380831/184059695-6f327989-3883-404e-9a92-aa99f7e0cb89.png)

Note: if we set the #workspace > 5
![image](https://user-images.githubusercontent.com/49380831/184059731-9b10b72c-d793-4095-b7eb-c63df6986980.png)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
None

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
