### PR TITLE
Fix order of installer testdata ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,7 +3,6 @@
 # A single review from anyone who is allowed to review PRs is sufficent.
 #
 /.github/CODEOWNERS
-/install/installer/cmd/testdata
 
 /components/blobserve @gitpod-io/engineering-ide
 /components/common-go @gitpod-io/engineering-workspace @gitpod-io/engineering-webapp
@@ -29,6 +28,8 @@
 /components/installation-telemetry @gitpod-io/engineering-self-hosted
 /install @gitpod-io/engineering-self-hosted
 /install/installer @gitpod-io/engineering-self-hosted
+# For testdata a single review from anyone who is allowed to review PRs is sufficent.
+/install/installer/cmd/testdata
 /install/installer/pkg/components/agent-smith @gitpod-io/engineering-workspace
 /install/installer/pkg/components/blobserve @gitpod-io/engineering-ide
 /install/installer/pkg/components/components-webapp @gitpod-io/engineering-webapp


### PR DESCRIPTION
Otherwise it does not seem to have any effect.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```