### PR TITLE
Avoid displaying prebuild-related workspaces in the workspaces list from JetBrains Gateway

### DIFF
--- a/components/gitpod-protocol/java/src/main/java/io/gitpod/gitpodprotocol/api/entities/Workspace.java
+++ b/components/gitpod-protocol/java/src/main/java/io/gitpod/gitpodprotocol/api/entities/Workspace.java
@@ -14,6 +14,8 @@ public class Workspace {
 
     private String creationTime;
 
+    private String type;
+
     public String getId() {
         return id;
     }
@@ -44,5 +46,13 @@ public class Workspace {
 
     public void setCreationTime(String creationTime) {
         this.creationTime = creationTime;
+    }
+
+    public WorkspaceType getType() {
+        return WorkspaceType.valueOf(type);
+    }
+
+    public void setType(WorkspaceType type) {
+        this.type = type.toString();
     }
 }

--- a/components/gitpod-protocol/java/src/main/java/io/gitpod/gitpodprotocol/api/entities/WorkspaceType.java
+++ b/components/gitpod-protocol/java/src/main/java/io/gitpod/gitpodprotocol/api/entities/WorkspaceType.java
@@ -1,0 +1,10 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package io.gitpod.gitpodprotocol.api.entities;
+
+public enum WorkspaceType {
+    regular,
+    prebuild
+}

--- a/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodWorkspacesView.kt
+++ b/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodWorkspacesView.kt
@@ -28,6 +28,7 @@ import com.jetbrains.rd.util.lifetime.isAlive
 import com.jetbrains.rd.util.lifetime.isNotAlive
 import io.gitpod.gitpodprotocol.api.entities.GetWorkspacesOptions
 import io.gitpod.gitpodprotocol.api.entities.WorkspaceInstance
+import io.gitpod.gitpodprotocol.api.entities.WorkspaceType
 import io.gitpod.jetbrains.auth.GitpodAuthService
 import io.gitpod.jetbrains.icons.GitpodIcons
 import kotlinx.coroutines.GlobalScope
@@ -247,7 +248,7 @@ class GitpodWorkspacesView(
                             }
                         }
                     for (info in sortedInfos) {
-                        if (info.latestInstance == null) {
+                        if (info.latestInstance == null || info.workspace.type != WorkspaceType.regular) {
                             continue
                         }
                         indent {
@@ -341,7 +342,9 @@ class GitpodWorkspacesView(
                         thisLogger().error("$gitpodHost: ${update.workspaceId}: failed to sync", t)
                         continue
                     }
-                    workspacesMap[update.workspaceId] = info
+                    if (info.workspace.type == WorkspaceType.regular) {
+                        workspacesMap[update.workspaceId] = info
+                    }
                 } else if (WorkspaceInstance.isUpToDate(info.latestInstance, update)) {
                     continue
                 } else {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
These changes ensure that only regular workspaces are added to the workspaces list from JetBrains Gateway.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #11450

## How to test
<!-- Provide steps to test this PR -->
1. Ensure you have the [latest JetBrains Gateway](https://www.jetbrains.com/remote-development/gateway/) installed.
2. Download the plugin build related to this branch in [Dev Versions](https://plugins.jetbrains.com/plugin/18438-gitpod-gateway/versions/dev), and [install it on the Gateway](https://www.jetbrains.com/help/idea/managing-plugins.html#install_plugin_from_disk).
3. Start a [manual prebuild](https://www.gitpod.io/docs/prebuilds#manual-prebuilds) of one of your workspaces.
4. Confirm the Prebuild instance doesn't appear on the workspaces list from JetBrains Gateway.
    - Note: After the prebuild finishes, it will open the workspace. At this moment, it's fine the workspace appears in the list, as now it's a regular workspace that is starting.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```