### PR TITLE
redirect to desktop IDE on app domain

### DIFF
--- a/components/supervisor/frontend/src/ide/heart-beat.ts
+++ b/components/supervisor/frontend/src/ide/heart-beat.ts
@@ -19,7 +19,7 @@ export const track = (w: Window) => {
 }
 
 let pageCloseCompatibile: boolean = false
-
+// TODO(ak) remove
 isSaaSServerGreaterThan("main.4124").then((r) => {
     pageCloseCompatibile = r
 })

--- a/components/supervisor/frontend/src/index.ts
+++ b/components/supervisor/frontend/src/index.ts
@@ -158,16 +158,7 @@ const toStop = new DisposableCollection();
                         });
                         if (!desktopRedirected) {
                             desktopRedirected = true;
-                            try {
-                                const desktopLink = new URL(ideStatus.desktop.link)
-                                // redirect only if points to desktop application
-                                // don't navigate browser to another page
-                                if (desktopLink.protocol != 'http:' && desktopLink.protocol != 'https:') {
-                                    window.location.href = ideStatus.desktop.link;
-                                }
-                            } catch (e) {
-                                console.error('invalid desktop link:', e)
-                            }
+                            loading.openDesktopLink(ideStatus.desktop.link)
                         }
                         return loading.frame;
                     }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

An idea to redirect always on parent app domain, i.e. gitpod.io, via iframe to suppress popup on each new workspace start.

<img width="1318" alt="Screenshot 2022-08-12 at 09 09 44" src="https://user-images.githubusercontent.com/3082655/184303378-22bba6b4-3f0f-4b4e-b2be-de1a354ef5b3.png">

**Important** We need to consider a case if a user does not have yet app, but allowed pop-up always for some reason, i.e. for another IDE.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

- Select VS Code Desktop in settings.
- Start one workspace, click allow always in pop-up.
- Start another workspace, check that pop-up does not come anymore. VS Code Desktop is opened automatically.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Enable allowing redirect to Desktop IDEs for all workspaces.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
