### PR TITLE
[bug][usage] Fixes return of SetBilledSession

### DIFF
--- a/components/usage/pkg/apiv1/billing.go
+++ b/components/usage/pkg/apiv1/billing.go
@@ -105,5 +105,5 @@ func (s *BillingService) SetBilledSession(ctx context.Context, in *v1.SetBilledS
 		return nil, status.Errorf(codes.Internal, "failed to set session: %s", err)
 	}
 
-	return nil, nil
+	return &v1.SetBilledSessionResponse{}, nil
 }


### PR DESCRIPTION
## Description
This fixes the marshalling error where the SetBilledSession call returns nil.

## Related Issue(s)
Caused #12067

## How to test
<!-- Provide steps to test this PR -->
1. Tail the server logs
2. Check `d_b_billed_session`
3. Run a workspace without usage mode (don't have a Gitpod team). The workspace should run without setBilledSession-related errors and the DB entry should be created.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
- [x] /werft with-payment