### PR TITLE
[Gitpod CLI] Align `gp top` thresholds with JetBrains

### DIFF
--- a/components/gitpod-cli/cmd/top.go
+++ b/components/gitpod-cli/cmd/top.go
@@ -45,11 +45,12 @@ func outputTable(workspaceResources *supervisor.ResourcesStatusResponse) {
 	table.Render()
 }
 
+// TODO: retrieve thresholds from supervisor once we implement this: https://github.com/gitpod-io/gitpod/issues/12075
 func getColor(value int64) int {
 	switch {
-	case value >= 85:
+	case value >= 95:
 		return tablewriter.FgRedColor
-	case value >= 65:
+	case value >= 80:
 		return tablewriter.FgYellowColor
 	default:
 		return tablewriter.FgHiGreenColor


### PR DESCRIPTION
## Description
Small PR to align thresholds with JetBrains IDE https://github.com/gitpod-io/gitpod/pull/12053/files#diff-5490862e00fecdc038c16bc92b93a0acfd0add183d15e5fcd5a09898f3414978R27-R33

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
N/A

## How to test
N/A

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
