### PR TITLE
Update spending limit modal on workspace start

### DIFF
--- a/components/dashboard/src/start/CreateWorkspace.tsx
+++ b/components/dashboard/src/start/CreateWorkspace.tsx
@@ -29,6 +29,7 @@ import { isGitpodIo } from "../utils";
 import { BillingAccountSelector } from "../components/BillingAccountSelector";
 import { AttributionId } from "@gitpod/gitpod-protocol/lib/attribution";
 import { TeamsContext } from "../teams/teams-context";
+import Alert from "../components/Alert";
 
 export interface CreateWorkspaceProps {
     contextUrl: string;
@@ -382,23 +383,30 @@ function SpendingLimitReachedModal(p: { hints: any }) {
         }
     }, []);
 
+    const attributedTeamName = attributedTeam?.name;
     return (
         <Modal visible={true} closeable={false} onClose={() => {}}>
             <h3 className="flex">
-                <span className="flex-grow">Spending Limit Reached</span>
+                <span className="flex-grow">Usage Limit Reached</span>
             </h3>
-            <div className="border-t border-b border-gray-200 dark:border-gray-800 mt-4 -mx-6 px-6 py-2">
-                <p className="mt-1 mb-2 text-base dark:text-gray-400">Please increase the spending limit and retry.</p>
+            <div className="border-t border-b border-gray-200 dark:border-gray-800 mt-4 -mx-6 px-6 py-6">
+                <Alert type="error" className="app-container rounded-md">
+                    You have reached the <strong>spending limit</strong> of your billing account.
+                </Alert>
+                <p className="mt-3 text-base text-gray-600 dark:text-gray-300">
+                    {"Contact a team owner "}
+                    {attributedTeamName && (
+                        <>
+                            of <strong>{attributedTeamName} </strong>
+                        </>
+                    )}
+                    to increase the spending limit, or change your <a href="/billing">billing settings</a>.
+                </p>
             </div>
             <div className="flex justify-end mt-6 space-x-2">
-                <a href={gitpodHostUrl.with({ pathname: "billing" }).toString()}>
-                    <button>Billing Settings</button>
+                <a href={gitpodHostUrl.asDashboard().toString()}>
+                    <button className="secondary">Go to Dashboard</button>
                 </a>
-                {attributedTeam && (
-                    <a href={gitpodHostUrl.with({ pathname: `t/${attributedTeam?.slug}/billing` }).toString()}>
-                        <button>Team Billing</button>
-                    </a>
-                )}
             </div>
         </Modal>
     );


### PR DESCRIPTION
## Description
This will update the spending limit modal, following the updates in https://github.com/gitpod-io/gitpod/issues/11927#issuecomment-1210813607 and https://github.com/gitpod-io/gitpod/issues/11927#issuecomment-1211812281.

See also [relevant discussion](https://gitpod.slack.com/archives/C02EN94AEPL/p1660213626025459?thread_ts=1660138187.580269&cid=C02EN94AEPL) (internal).

## Related Issue(s)
Fixes https://github.com/gitpod-io/gitpod/issues/11927

## How to test
1. Enable billing or a team
2. Set a low spending limit
3. Open a workspace

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Update spending limit modal on workspace start
```

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [X] /werft with-preview
