### PR TITLE
[registry-facade] Improve IPFS logging

### DIFF
--- a/components/registry-facade/pkg/registry/blob.go
+++ b/components/registry-facade/pkg/registry/blob.go
@@ -123,8 +123,9 @@ func (bh *blobHandler) getBlob(w http.ResponseWriter, r *http.Request) {
 
 		var srcs []BlobSource
 
+		ipfsSrc := ipfsBlobSource{source: bh.IPFS}
 		if bh.IPFS != nil {
-			srcs = append(srcs, ipfsBlobSource{source: bh.IPFS})
+			srcs = append(srcs, ipfsSrc)
 		}
 
 		srcs = append(srcs, storeBlobSource{Store: bh.Store})
@@ -173,6 +174,11 @@ func (bh *blobHandler) getBlob(w http.ResponseWriter, r *http.Request) {
 		bh.Metrics.BlobDownloadSpeedHist.Observe(float64(n) / time.Since(t0).Seconds())
 
 		if dontCache {
+			return nil
+		}
+
+		// do not duplicate content in IPFS
+		if src == ipfsSrc {
 			return nil
 		}
 


### PR DESCRIPTION
## Description

IPFS client should respect log levels.

## How to test
- Enable IPFS
- Open a workspace
- Check registry-facade logs and confirm there are no entries similar to

`{"level":"info","message":"[DEBUG] POST http://ipfs.storage:9095/api/v0/cat?arg=%2Fipfs%2Fbafkreigmgbjgwxkqco552ec4h2rx7cjdytiyhnca77uha7msl6g7rjctfq","serviceContext":{"service":"registry-facade","version":"commit-4e941c628adc62d67b67d39df1765152f34ba703"},"severity":"INFO","time":"2022-08-12T14:47:51Z"}
`
 
## Release Notes
```release-note
NONE
```

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
