### PR TITLE
[supervisor] Make resource status request more resilient

### DIFF
--- a/components/supervisor/pkg/supervisor/services.go
+++ b/components/supervisor/pkg/supervisor/services.go
@@ -97,6 +97,7 @@ type statusService struct {
 	Tasks           *tasksManager
 	ideReady        *ideReadyState
 	desktopIdeReady *ideReadyState
+	topService      *TopService
 
 	api.UnimplementedStatusServiceServer
 }
@@ -933,5 +934,5 @@ func (s *portService) RetryAutoExpose(ctx context.Context, req *api.RetryAutoExp
 
 // ResourcesStatus provides workspace resources status information.
 func (s *statusService) ResourcesStatus(ctx context.Context, in *api.ResourcesStatuRequest) (*api.ResourcesStatusResponse, error) {
-	return Top(ctx)
+	return s.topService.data, nil
 }

--- a/components/supervisor/pkg/supervisor/supervisor.go
+++ b/components/supervisor/pkg/supervisor/supervisor.go
@@ -257,6 +257,9 @@ func Run(options ...RunOption) {
 		go analyseConfigChanges(ctx, cfg, analytics, gitpodConfigService, gitpodService)
 	}
 
+	topService := NewTopService()
+	topService.Observe(ctx)
+
 	termMux := terminal.NewMux()
 	termMuxSrv := terminal.NewMuxTerminalService(termMux)
 	termMuxSrv.DefaultWorkdir = cfg.RepoRoot
@@ -287,6 +290,7 @@ func Run(options ...RunOption) {
 			Tasks:           taskManager,
 			ideReady:        ideReady,
 			desktopIdeReady: desktopIdeReady,
+			topService:      topService,
 		},
 		termMuxSrv,
 		RegistrableTokenService{Service: tokenService},

--- a/components/supervisor/pkg/supervisor/top_test.go
+++ b/components/supervisor/pkg/supervisor/top_test.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package supervisor
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/gitpod-io/gitpod/supervisor/api"
+	"golang.org/x/xerrors"
+)
+
+func TestTopServiceHappyPath(t *testing.T) {
+	ctx := context.Background()
+
+	topService := NewTopService()
+	topService.Observe(ctx)
+
+	<-topService.ready
+
+	if topService.data == nil {
+		t.Errorf("topService data should not be nil")
+	}
+	if topService.data.Memory.Used == 0 {
+		t.Errorf("Used Memory should not be zero")
+	}
+	if topService.data.Memory.Limit == 0 {
+		t.Errorf("Total Memory should not be zero")
+	}
+	if topService.data.Cpu.Used == 0 {
+		t.Errorf("Used CPU should not be zero")
+	}
+	if topService.data.Cpu.Limit == 0 {
+		t.Errorf("Total CPU should not be zero")
+	}
+}
+
+func TestTopServiceWithUpstreamFailure(t *testing.T) {
+	ctx := context.Background()
+
+	var isFirstRun = true
+
+	topService := NewTopService()
+	topService.top = func(ctx context.Context) (*api.ResourcesStatusResponse, error) {
+		if isFirstRun {
+			isFirstRun = false
+			return &api.ResourcesStatusResponse{
+				Memory: &api.ResourceStatus{
+					Used:  1,
+					Limit: 10,
+				},
+				Cpu: &api.ResourceStatus{
+					Used:  2,
+					Limit: 5,
+				},
+			}, nil
+		} else {
+			return nil, xerrors.Errorf("some error occurred with the sock file")
+		}
+	}
+	topService.Observe(ctx)
+	<-topService.ready
+
+	if topService.data.Memory.Used != 1 {
+		t.Errorf("Used Memory should be 1")
+	}
+	if topService.data.Memory.Limit != 10 {
+		t.Errorf("Total Memory should be 10")
+	}
+	if topService.data.Cpu.Used != 2 {
+		t.Errorf("Used Cpu should be 2")
+	}
+	if topService.data.Cpu.Limit != 5 {
+		t.Errorf("Total Cpu should be 5")
+	}
+
+	time.Sleep(2 * time.Second)
+
+	if topService.data.Memory.Used != 1 {
+		t.Errorf("Used Memory should be 1")
+	}
+	if topService.data.Memory.Limit != 10 {
+		t.Errorf("Total Memory should be 10")
+	}
+	if topService.data.Cpu.Used != 2 {
+		t.Errorf("Used Cpu should be 2")
+	}
+	if topService.data.Cpu.Limit != 5 {
+		t.Errorf("Total Cpu should be 5")
+	}
+}


### PR DESCRIPTION
## Description
Makes the resource status request more resilient by avoiding calling syncronously upstream to fetch resource status at every requests. With more clients adding functionalities such as `gp top` or workspace cpu/memory in jetbrains ide control center, the risk of getting rate-limited is guaranteed. 

With the approached used in this PR, we retrieve data from upstream at every second and when clients request it, we return the latest available data. Additional, an exponential backoff strategy is in place to be more resilient.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #12083

## How to test
Compare how [this prev](https://afalz-1208328e4f3122.preview.gitpod-dev.com) env behaves in comparison with gitpod.io by running a workspace and run `watch -n 0.1 gp top`. In gitpod.io (prod) it will almost immediately fail by returning gRPC errors because ResourceStatus endpoint is pulled too frequently and we hit the rate-limit.

In the prev env, you should be able to run multiple `watch -n 0.1 gp top` without any errors.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
