### PR TITLE
Fix workspace integration test

### DIFF
--- a/test/pkg/integration/integration.go
+++ b/test/pkg/integration/integration.go
@@ -294,7 +294,7 @@ func buildAgent(name string) (loc string, err error) {
 	}
 	f.Close()
 
-	cmd := exec.Command("go", "build", "-trimpath", "-ldflags='-buildid= -w -s'", "-o", f.Name(), src)
+	cmd := exec.Command("go", "build", "-trimpath", "-ldflags", "-buildid= -w -s", "-o", f.Name(), src)
 	cmd.Env = append(os.Environ(),
 		"CGO_ENABLED=0",
 	)


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Fix the workspace integration test failed with `invalid value "'-buildid= -w -s'" for flag -ldflags: parameter may not start with quote character '`.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
`werft job run github -j .werft/workspace-run-integration-tests.yaml `

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
None

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
