### PR TITLE
[server] Don't redirect to sorry on unrecognized login errors

### DIFF
--- a/components/server/src/auth/generic-auth-provider.ts
+++ b/components/server/src/auth/generic-auth-provider.ts
@@ -438,8 +438,7 @@ export class GenericAuthProvider implements AuthProvider {
                 ...defaultLogPayload,
                 err,
             });
-            response.redirect(this.getSorryUrl(message));
-            return;
+            return this.sendCompletionRedirectWithError(response, { error: `${message} ${err.message}` });
         }
 
         if (flowContext) {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Don't redirect to sorry on unrecognized login errors, but instead actually display the error message.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #12112

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
