### PR TITLE
[usage] Use actual date for start time

### DIFF
--- a/components/dashboard/src/teams/TeamUsage.tsx
+++ b/components/dashboard/src/teams/TeamUsage.tsx
@@ -16,7 +16,6 @@ import {
 } from "@gitpod/gitpod-protocol/lib/usage";
 import { AttributionId } from "@gitpod/gitpod-protocol/lib/attribution";
 import { Item, ItemField, ItemsList } from "../components/ItemsList";
-import moment from "moment";
 import Pagination from "../Pagination/Pagination";
 import Header from "../components/Header";
 import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
@@ -139,6 +138,17 @@ function TeamUsage() {
         return rows;
     };
 
+    const displayTime = (time: string) => {
+        const options: Intl.DateTimeFormatOptions = {
+            day: "numeric",
+            month: "long",
+            year: "numeric",
+            hour: "numeric",
+            minute: "numeric",
+        };
+        return new Date(time).toLocaleDateString(undefined, options).replace("at ", "");
+    };
+
     const lastResultOnCurrentPage = currentPage * resultsPerPage;
     const firstResultOnCurrentPage = lastResultOnCurrentPage - resultsPerPage;
     const totalNumberOfPages = Math.ceil(billedUsage.length / resultsPerPage);
@@ -250,7 +260,7 @@ function TeamUsage() {
                                                 </div>
                                                 <div className="my-auto">
                                                     <span className="text-gray-400">
-                                                        {moment(new Date(usage.startTime).toDateString()).fromNow()}
+                                                        {displayTime(usage.startTime)}
                                                     </span>
                                                 </div>
                                             </div>


### PR DESCRIPTION
## Description
Shows the actual time instead of "... ago"

| Before | After |
| - | - |
| <img width="203" alt="Screenshot 2022-08-15 at 01 39 03" src="https://user-images.githubusercontent.com/8015191/184559129-f3b487ff-fbf4-46b0-85ec-4f8fc0ddc1f8.png"> | <img width="230" alt="Screenshot 2022-08-15 at 01 38 13" src="https://user-images.githubusercontent.com/8015191/184559098-8346e097-6fd0-4a24-b21b-1f8c50e90cf6.png"> |

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Relates #12090 and #11640

## How to test
1. Join the [team](https://lau-show-actual-time.preview.gitpod-dev.com/teams/join?inviteId=a8a0d60c-3bc2-4724-9599-bd7910f7bf6e)
2. Go to https://lau-show-actual-time.preview.gitpod-dev.com/t/gitpod/usage
3. See the actual date and time.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
- [x] /werft with-payment