### PR TITLE
Polish handling of BillingMode

### DIFF
--- a/components/dashboard/src/Menu.tsx
+++ b/components/dashboard/src/Menu.tsx
@@ -152,9 +152,6 @@ export default function Menu() {
             server.isStudent().then((v) => () => setIsStudent(v)),
             server.isChargebeeCustomer().then((v) => () => setIsChargebeeCustomer(v)),
         ]).then((setters) => setters.forEach((s) => s()));
-
-        // Refresh billing mode
-        refreshUserBillingMode();
     }, []);
 
     useEffect(() => {
@@ -162,6 +159,11 @@ export default function Menu() {
             getGitpodService().server.getBillingModeForTeam(team.id).then(setTeamBillingMode);
         }
     }, [team]);
+
+    useEffect(() => {
+        // Refresh billing mode
+        refreshUserBillingMode();
+    }, [teams]);
 
     const teamOrUserSlug = !!team ? "/t/" + team.slug : "/projects";
     const leftMenu: Entry[] = (() => {

--- a/components/dashboard/src/settings/Preferences.tsx
+++ b/components/dashboard/src/settings/Preferences.tsx
@@ -14,11 +14,12 @@ import SelectIDE from "./SelectIDE";
 import SelectWorkspaceClass from "./selectClass";
 import { PageWithSettingsSubMenu } from "./PageWithSettingsSubMenu";
 import { FeatureFlagContext } from "../contexts/FeatureFlagContext";
+import { BillingMode } from "@gitpod/gitpod-protocol/lib/billing-mode";
 
 type Theme = "light" | "dark" | "system";
 
 export default function Preferences() {
-    const { user } = useContext(UserContext);
+    const { user, userBillingMode } = useContext(UserContext);
     const { setIsDark } = useContext(ThemeContext);
     const { showWorkspaceClassesUI } = useContext(FeatureFlagContext);
 
@@ -56,7 +57,9 @@ export default function Preferences() {
                 <h3>Editor</h3>
                 <p className="text-base text-gray-500 dark:text-gray-400">Choose the editor for opening workspaces.</p>
                 <SelectIDE location="preferences" />
-                <SelectWorkspaceClass enabled={showWorkspaceClassesUI} />
+                <SelectWorkspaceClass
+                    enabled={showWorkspaceClassesUI || BillingMode.canSetWorkspaceClass(userBillingMode)}
+                />
                 <h3 className="mt-12">Theme</h3>
                 <p className="text-base text-gray-500 dark:text-gray-400">Early bird or night owl? Choose your side.</p>
                 <div className="mt-4 space-x-3 flex">

--- a/components/dashboard/src/teams/TeamBilling.tsx
+++ b/components/dashboard/src/teams/TeamBilling.tsx
@@ -28,7 +28,7 @@ import { UserContext } from "../user-context";
 type PendingPlan = Plan & { pendingSince: number };
 
 export default function TeamBilling() {
-    const { user, userBillingMode } = useContext(UserContext);
+    const { user } = useContext(UserContext);
     const { teams } = useContext(TeamsContext);
     const location = useLocation();
     const team = getCurrentTeam(location, teams);
@@ -308,15 +308,23 @@ export default function TeamBilling() {
         );
     }
 
-    const showUBP = BillingMode.showUsageBasedBilling(userBillingMode);
+    const showUBP = BillingMode.showUsageBasedBilling(teamBillingMode);
     return (
         <PageWithSubMenu
             subMenu={getTeamSettingsMenu({ team, billingMode: teamBillingMode })}
             title="Billing"
             subtitle="Manage team billing and plans."
         >
-            {showUBP && <TeamUsageBasedBilling />}
-            {!showUBP && renderTeamBilling()}
+            {teamBillingMode === undefined ? (
+                <div className="p-20">
+                    <Spinner className="h-5 w-5 animate-spin" />
+                </div>
+            ) : (
+                <>
+                    {showUBP && <TeamUsageBasedBilling />}
+                    {!showUBP && renderTeamBilling()}
+                </>
+            )}
         </PageWithSubMenu>
     );
 }

--- a/components/gitpod-protocol/src/billing-mode.ts
+++ b/components/gitpod-protocol/src/billing-mode.ts
@@ -26,7 +26,11 @@ export namespace BillingMode {
         );
     }
 
-    export function canSetWorkspaceClass(billingMode: BillingMode): boolean {
+    export function canSetWorkspaceClass(billingMode?: BillingMode): boolean {
+        if (!billingMode) {
+            return false;
+        }
+
         // if has any Stripe subscription, either directly or per team
         return billingMode.mode === "usage-based";
     }

--- a/components/gitpod-protocol/src/billing-mode.ts
+++ b/components/gitpod-protocol/src/billing-mode.ts
@@ -56,6 +56,9 @@ interface Chargebee {
 interface UsageBased {
     mode: "usage-based";
 
+    /** True iff this is a team, and is based on a paid plan. Currently only set for teams! */
+    paid?: boolean;
+
     /** User is already converted, but is member with at least one Chargebee-based "Team Plan" */
     hasChargebeeTeamPlan?: boolean;
 

--- a/components/server/ee/src/billing/billing-mode.spec.db.ts
+++ b/components/server/ee/src/billing/billing-mode.spec.db.ts
@@ -202,7 +202,7 @@ class BillingModeSpec {
             },
             // user: chargebee
             {
-                name: "user: chargbee paid personal",
+                name: "user: chargebee paid personal",
                 subject: user(),
                 config: {
                     enablePayment: true,
@@ -214,7 +214,7 @@ class BillingModeSpec {
                 },
             },
             {
-                name: "user: chargbee paid team seat",
+                name: "user: chargebee paid team seat",
                 subject: user(),
                 config: {
                     enablePayment: true,
@@ -226,7 +226,7 @@ class BillingModeSpec {
                 },
             },
             {
-                name: "user: chargbee paid personal + team seat",
+                name: "user: chargebee paid personal + team seat",
                 subject: user(),
                 config: {
                     enablePayment: true,
@@ -239,7 +239,7 @@ class BillingModeSpec {
             },
             // user: transition chargebee -> UBB
             {
-                name: "user: chargbee paid personal (cancelled) + team seat",
+                name: "user: chargebee paid personal (cancelled) + team seat",
                 subject: user(),
                 config: {
                     enablePayment: true,
@@ -255,7 +255,7 @@ class BillingModeSpec {
                 },
             },
             {
-                name: "user: chargbee paid personal (cancelled) + team seat (cancelled)",
+                name: "user: chargebee paid personal (cancelled) + team seat (cancelled)",
                 subject: user(),
                 config: {
                     enablePayment: true,
@@ -271,7 +271,7 @@ class BillingModeSpec {
                 },
             },
             {
-                name: "user: chargbee paid personal (cancelled) + team seat (active) + stripe",
+                name: "user: chargebee paid personal (cancelled) + team seat (active) + stripe",
                 subject: user(),
                 config: {
                     enablePayment: true,
@@ -289,7 +289,7 @@ class BillingModeSpec {
             },
             // user: usage-based
             {
-                name: "user: stripe free, chargbee paid personal (inactive) + team seat (inactive)",
+                name: "user: stripe free, chargebee paid personal (inactive) + team seat (inactive)",
                 subject: user(),
                 config: {
                     enablePayment: true,
@@ -304,7 +304,7 @@ class BillingModeSpec {
                 },
             },
             {
-                name: "user: stripe paid, chargbee paid personal (inactive) + team seat (inactive)",
+                name: "user: stripe paid, chargebee paid personal (inactive) + team seat (inactive)",
                 subject: user(),
                 config: {
                     enablePayment: true,
@@ -378,7 +378,7 @@ class BillingModeSpec {
             },
             // team: chargebee
             {
-                name: "team: chargbee paid",
+                name: "team: chargebee paid",
                 subject: team(),
                 config: {
                     enablePayment: true,
@@ -390,7 +390,7 @@ class BillingModeSpec {
                 },
             },
             {
-                name: "team: chargbee paid (UBB)",
+                name: "team: chargebee paid (UBB)",
                 subject: team(),
                 config: {
                     enablePayment: true,
@@ -403,7 +403,7 @@ class BillingModeSpec {
             },
             // team: transition chargebee -> UBB
             {
-                name: "team: chargbee paid (TeamSubscription2, cancelled)",
+                name: "team: chargebee paid (TeamSubscription2, cancelled)",
                 subject: team(),
                 config: {
                     enablePayment: true,
@@ -416,7 +416,7 @@ class BillingModeSpec {
                 },
             },
             {
-                name: "team: chargbee paid (old TeamSubscription, cancelled)",
+                name: "team: chargebee paid (old TeamSubscription, cancelled)",
                 subject: team(),
                 config: {
                     enablePayment: true,
@@ -440,7 +440,7 @@ class BillingModeSpec {
                 },
             },
             {
-                name: "team: stripe free, chargbee (inactive)",
+                name: "team: stripe free, chargebee (inactive)",
                 subject: team(),
                 config: {
                     enablePayment: true,
@@ -452,7 +452,7 @@ class BillingModeSpec {
                 },
             },
             {
-                name: "team: stripe paid, chargbee (inactive)",
+                name: "team: stripe paid, chargebee (inactive)",
                 subject: team(),
                 config: {
                     enablePayment: true,
@@ -462,6 +462,7 @@ class BillingModeSpec {
                 },
                 expectation: {
                     mode: "usage-based",
+                    paid: true,
                 },
             },
             {
@@ -474,6 +475,7 @@ class BillingModeSpec {
                 },
                 expectation: {
                     mode: "usage-based",
+                    paid: true,
                 },
             },
         ];

--- a/components/server/ee/src/billing/billing-mode.spec.db.ts
+++ b/components/server/ee/src/billing/billing-mode.spec.db.ts
@@ -415,6 +415,18 @@ class BillingModeSpec {
                     canUpgradeToUBB: true,
                 },
             },
+            {
+                name: "team: chargbee paid (old TeamSubscription, cancelled)",
+                subject: team(),
+                config: {
+                    enablePayment: true,
+                    usageBasedPricingEnabled: true,
+                    subscriptions: [teamSubscription(Plans.TEAM_PROFESSIONAL_EUR, cancellationDate, endDate)],
+                },
+                expectation: {
+                    mode: "usage-based",
+                },
+            },
             // team: usage-based
             {
                 name: "team: usage-based free",

--- a/components/server/ee/src/billing/billing-mode.ts
+++ b/components/server/ee/src/billing/billing-mode.ts
@@ -135,12 +135,12 @@ export class BillingModesImpl implements BillingModes {
         // 3. Check team memberships/plans
         // UBB overrides wins if there is _any_. But if there is none, use the existing Chargebee subscription.
         const teamsModes = await Promise.all(teams.map((t) => this.getBillingModeForTeam(t, now)));
-        const hasUbbTeam = teamsModes.some((tm) => tm.mode === "usage-based");
+        const hasUbbPaidTeamSeat = teamsModes.some((tm) => tm.mode === "usage-based" && !!tm.paid);
         const hasCbTeam = teamsModes.some((tm) => tm.mode === "chargebee");
         const hasCbTeamSeat = cbTeamSubscriptions.length > 0;
 
-        if (hasUbbTeam || hasUbbPersonal) {
-            // UBB is gready: once a user has at least a team seat, they should benefit from it!
+        if (hasUbbPaidTeamSeat || hasUbbPersonal) {
+            // UBB is greedy: once a user has at least a team seat, they should benefit from it!
             const result: BillingMode = { mode: "usage-based" };
             if (hasCbTeam) {
                 result.hasChargebeeTeamPlan = true;
@@ -196,7 +196,15 @@ export class BillingModesImpl implements BillingModes {
             return { mode: "chargebee" };
         }
 
-        // 3. If not: we don't even have to check for a team subscription
-        return { mode: "usage-based" };
+        // 3. Now we're usage-based. We only have to figure out whether we have a plan yet or not.
+        const result: BillingMode = { mode: "usage-based" };
+        const customer = await this.stripeSvc.findCustomerByUserId(team.id);
+        if (customer) {
+            const subscription = await this.stripeSvc.findUncancelledSubscriptionByCustomer(customer.id);
+            if (subscription) {
+                result.paid = true;
+            }
+        }
+        return result;
     }
 }

--- a/components/server/ee/src/billing/billing-mode.ts
+++ b/components/server/ee/src/billing/billing-mode.ts
@@ -135,12 +135,12 @@ export class BillingModesImpl implements BillingModes {
         // 3. Check team memberships/plans
         // UBB overrides wins if there is _any_. But if there is none, use the existing Chargebee subscription.
         const teamsModes = await Promise.all(teams.map((t) => this.getBillingModeForTeam(t, now)));
-        const hasUbbPaidTeamSeat = teamsModes.some((tm) => tm.mode === "usage-based" && !!tm.paid);
+        const hasUbbPaidTeam = teamsModes.some((tm) => tm.mode === "usage-based" && !!tm.paid);
         const hasCbTeam = teamsModes.some((tm) => tm.mode === "chargebee");
         const hasCbTeamSeat = cbTeamSubscriptions.length > 0;
 
-        if (hasUbbPaidTeamSeat || hasUbbPersonal) {
-            // UBB is greedy: once a user has at least a team seat, they should benefit from it!
+        if (hasUbbPaidTeam || hasUbbPersonal) {
+            // UBB is greedy: once a user has at least a paid team membership, they should benefit from it!
             const result: BillingMode = { mode: "usage-based" };
             if (hasCbTeam) {
                 result.hasChargebeeTeamPlan = true;
@@ -198,7 +198,7 @@ export class BillingModesImpl implements BillingModes {
 
         // 3. Now we're usage-based. We only have to figure out whether we have a plan yet or not.
         const result: BillingMode = { mode: "usage-based" };
-        const customer = await this.stripeSvc.findCustomerByUserId(team.id);
+        const customer = await this.stripeSvc.findCustomerByTeamId(team.id);
         if (customer) {
             const subscription = await this.stripeSvc.findUncancelledSubscriptionByCustomer(customer.id);
             if (subscription) {

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -123,6 +123,7 @@ import { BillingModes } from "../../ee/src/billing/billing-mode";
 import { AttributionId } from "@gitpod/gitpod-protocol/lib/attribution";
 import { CachingBillingServiceClientProvider } from "@gitpod/usage-api/lib/usage/v1/sugar";
 import { Timestamp } from "google-protobuf/google/protobuf/timestamp_pb";
+import { BillingMode } from "@gitpod/gitpod-protocol/lib/billing-mode";
 
 export interface StartWorkspaceOptions {
     rethrow?: boolean;
@@ -838,8 +839,10 @@ export class WorkspaceStarter {
                 user: user,
                 teams: userTeams,
             });
+            const usageAttributionId = await this.userService.getWorkspaceUsageAttributionId(user, workspace.projectId);
+            const billingMode = await this.billingModes.getBillingMode(usageAttributionId, new Date());
 
-            if (classesEnabled) {
+            if (classesEnabled || BillingMode.canSetWorkspaceClass(billingMode)) {
                 // this is either the first time we start the workspace or the workspace was started
                 // before workspace classes and does not have a class yet
                 workspaceClass = await getWorkspaceClassForInstance(
@@ -871,8 +874,6 @@ export class WorkspaceStarter {
                 // few bytes of JSON in the database for no good reason.
                 configuration.featureFlags = featureFlags;
             }
-
-            const usageAttributionId = await this.userService.getWorkspaceUsageAttributionId(user, workspace.projectId);
 
             const now = new Date().toISOString();
             const instance: WorkspaceInstance = {
@@ -1424,7 +1425,8 @@ export class WorkspaceStarter {
         }
 
         const volumeSnapshotId =
-((SnapshotContext.is(workspace.context) || WithPrebuild.is(workspace.context)) && !!workspace.context.snapshotBucketId)
+            (SnapshotContext.is(workspace.context) || WithPrebuild.is(workspace.context)) &&
+            !!workspace.context.snapshotBucketId
                 ? workspace.context.snapshotBucketId
                 : lastValidWorkspaceInstanceId;
 


### PR DESCRIPTION
## Description
This PR includes a couple of alignments around BillingMode. It's reviewable by commit. As all changes share the same context I think it does not make sense to further split this up. :lotus_position: 

 1. Improved tests + additional tests (no change in behavior)
 2. Make "workspace classes" usable if either of these are true:
    1. You have the "workspace_classes" FF enabled
    2. The method `BillingMode.canSetWorkspaceClass` returns `true` for your BillingMode
 3. Small fix to BillingModes: Only have _paid_ UBP team memberships override existing Chargebee memberships
 4. Handle bad "CostCenter" error, in case you have not yet set a team spending limit for whatever reason
 5. ~Make `moment` time offset work on Usage List View~ removed
 6. Fix wrong usage of `findCustomerByUserId` and replace with `findCustomerByTeamId`

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #12098
Fixes https://github.com/gitpod-io/gitpod/issues/12090
Fixes https://github.com/gitpod-io/gitpod/issues/12149

## How to test
 - [signup](https://gpl-ubp.preview.gitpod-dev.com/workspaces)
 - create a Team called `Gitpod-heroes` or so
 - check:
   - user preferences: no workspace classes selector, yet :heavy_check_mark: 
   - user billing: no Usage-based stuff, yet :heavy_check_mark: 
   - user settings menu: still has entries for Plans/Team Subscriptions :heavy_check_mark: 
 - try to start a workspace: shows the "set spending limit" UI :heavy_check_mark: 
 - signup for a Usage-Based team plan
   - user preferences: see workspace classes selector, yet :heavy_check_mark: 
   - user billing: see the UBP attribution selector :heavy_check_mark: 
   - user settings menu: no entries for Plans/Team Subscriptions :heavy_check_mark: 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
- [x] /werft with-payment
