### PR TITLE
[code] don't report empty vscode extensions as error

### DIFF
--- a/components/ide/code/codehelper/main.go
+++ b/components/ide/code/codehelper/main.go
@@ -166,7 +166,6 @@ func getExtensions(repoRoot string) (extensions []Extension, err error) {
 		return
 	}
 	if config == nil || config.Vscode == nil {
-		err = errors.New("config.vscode field not exists")
 		return
 	}
 	var wg sync.WaitGroup


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

We have many false positive errors for repos without VS Code extensions in .gitpod.yml [[1](https://console.cloud.google.com/errors/detail/CNzsobWPtZqyzgE?project=workspace-clusters)] This PR does not treat them as error.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

- Switch to latest VS Code: https://ak-code-em8be1e68403.preview.gitpod-dev.com/preferences
- Start a workspace without VS Code extensions: https://ak-code-em8be1e68403.preview.gitpod-dev.com/#https://github.com/akosyakov/parcel-demo
  - It should start without any issues. Check workspace lgos that there is no `config.vscode field not exists` error anymore.
- Start a workspace with VS Code extensions: https://ak-code-em8be1e68403.preview.gitpod-dev.com/#https://github.com/gitpod-io/spring-petclinic
  - It should start without any issues, Java extensions should be installed automatically.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
