### PR TITLE
[server] Mark instances whose image build failed as "stopped"

### DIFF
--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -1226,8 +1226,12 @@ export class WorkspaceStarter {
                 message = err.message;
             }
 
+            // This instance's image build "failed" as well, so mark it as such.
+            const now = new Date().toISOString();
             instance = await this.workspaceDb.trace({ span }).updateInstancePartial(instance.id, {
-                status: { ...instance.status, phase: "building", conditions: { failed: message }, message },
+                status: { ...instance.status, phase: "stopped", conditions: { failed: message }, message },
+                stoppedTime: now,
+                stoppingTime: now,
             });
             await this.messageBus.notifyOnInstanceUpdate(workspace.ownerId, instance);
 


### PR DESCRIPTION
## Description
This is a leftover/oversight from long ago. It does not make sense to mark an instances as `failed` when not also setting it to `stopped`.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #12138

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Mark workspace's whose image builds failed as `stopped`
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
