### PR TITLE
[dashboard] Don't forcefully set spending limit to '1' when the input is empty

### DIFF
--- a/components/dashboard/src/index.css
+++ b/components/dashboard/src/index.css
@@ -79,6 +79,7 @@
 
     textarea,
     input[type="text"],
+    input[type="number"],
     input[type="search"],
     input[type="password"],
     select {
@@ -86,11 +87,14 @@
     }
     textarea::placeholder,
     input[type="text"]::placeholder,
+    input[type="number"]::placeholder,
     input[type="search"]::placeholder,
     input[type="password"]::placeholder {
         @apply text-gray-400 dark:text-gray-500;
     }
     input[type="text"].error,
+    input[type="number"].error,
+    input[type="search"].error,
     input[type="password"].error,
     select.error {
         @apply border-gitpod-red dark:border-gitpod-red focus:border-gitpod-red dark:focus:border-gitpod-red;

--- a/components/dashboard/src/teams/TeamUsageBasedBilling.tsx
+++ b/components/dashboard/src/teams/TeamUsageBasedBilling.tsx
@@ -235,7 +235,9 @@ function UpdateLimitModal(props: {
     onClose: () => void;
     onUpdate: (newLimit: number) => {};
 }) {
-    const [newLimit, setNewLimit] = useState<number | undefined>(props.currentValue);
+    const [newLimit, setNewLimit] = useState<string | undefined>(
+        props.currentValue ? String(props.currentValue) : undefined,
+    );
 
     return (
         <Modal visible={true} onClose={props.onClose}>
@@ -253,7 +255,7 @@ function UpdateLimitModal(props: {
                         min={0}
                         value={newLimit}
                         className="rounded-md w-full truncate overflow-x-scroll pr-8"
-                        onChange={(e) => setNewLimit(parseInt(e.target.value || "1", 10))}
+                        onChange={(e) => setNewLimit(e.target.value)}
                     />
                 </div>
             </div>
@@ -261,9 +263,14 @@ function UpdateLimitModal(props: {
                 <button
                     className="secondary"
                     onClick={() => {
-                        if (typeof newLimit === "number") {
-                            props.onUpdate(newLimit);
+                        if (!newLimit) {
+                            return;
                         }
+                        const n = parseInt(newLimit, 10);
+                        if (typeof n !== "number") {
+                            return;
+                        }
+                        props.onUpdate(n);
                     }}
                 >
                     Update


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Don't forcefully set spending limit to '1' when the input is empty.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/12091

## How to test
<!-- Provide steps to test this PR -->

1. Upgrade a team to usage-based billing
2. Update the spending limit
3. Delete everything in the input (in preparation for entering a new value)
4. The input should not forcefully reset to the value `1` when empty

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
- [x] /werft with-payment
