### PR TITLE
[bridge] Return instances preventing deregistration

### DIFF
--- a/components/ws-manager-bridge/src/cluster-service-server.ts
+++ b/components/ws-manager-bridge/src/cluster-service-server.ts
@@ -265,7 +265,9 @@ export class ClusterService implements IClusterServiceServer {
                     });
                     throw new GRPCError(
                         grpc.status.FAILED_PRECONDITION,
-                        `cluster is not empty (${relevantInstances.length} instances remaining)`,
+                        `cluster is not empty (${relevantInstances.length} instances remaining)[${relevantInstances
+                            .map((i) => i.id)
+                            .join(",")}]`,
                     );
                 }
 


### PR DESCRIPTION
## Description
Return the instance ids that are preventing deregistration of the cluster

`FATA[0000] rpc error: code = Unknown desc = cluster is not empty (2 instances remaining)[21d014d2-f2a4-4085-bd7c-2835f2e58b79,8c66ad5d-13d0-4cd7-9894-5a7e01d46fa1] `

## Related Issue(s)
n.a.

## How to test
- Register workspace cluster for preview environment with `gpctl clusters register --name ws-cluster 1 --hint-cordoned --hint-govern --tls-path ./wsman-tls/ --url [workspaceClusterIP]:8081`
- Create workspaces and set their region to the workspace-cluster
- Try to deregister workspace cluster with `gpctl clusters deregister --name ws-cluster`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
