### PR TITLE
[dashboard] Improve explicit usage-based billing attribution UX

### DIFF
--- a/components/dashboard/src/components/BillingAccountSelector.tsx
+++ b/components/dashboard/src/components/BillingAccountSelector.tsx
@@ -62,7 +62,7 @@ export function BillingAccountSelector(props: { onSelected?: () => void }) {
                 <div>
                     <p>Bill all my usage to:</p>
                     <div className="mt-4 flex space-x-3">
-                        <SelectableCardSolid
+                        {/* <SelectableCardSolid
                             className="w-36 h-32"
                             title="(myself)"
                             selected={
@@ -72,7 +72,13 @@ export function BillingAccountSelector(props: { onSelected?: () => void }) {
                             onClick={() => setUsageAttributionTeam(undefined)}
                         >
                             <div className="flex-grow flex items-end p-1"></div>
-                        </SelectableCardSolid>
+                        </SelectableCardSolid> */}
+                        {teamsWithBillingEnabled.length === 0 && (
+                            <span>
+                                Please enable billing for one of your teams, or create a new team and enable billing for
+                                it.
+                            </span>
+                        )}
                         {teamsWithBillingEnabled.map((t) => (
                             <SelectableCardSolid
                                 className="w-36 h-32"

--- a/components/dashboard/src/settings/Billing.tsx
+++ b/components/dashboard/src/settings/Billing.tsx
@@ -10,9 +10,7 @@ import { BillingAccountSelector } from "../components/BillingAccountSelector";
 export default function Billing() {
     return (
         <PageWithSettingsSubMenu title="Billing" subtitle="Usage-Based Billing.">
-            <h3>Usage-Based Billing</h3>
-            <h2 className="text-gray-500">Manage usage-based billing, spending limit, and payment method.</h2>
-            <div className="mt-8">
+            <div>
                 <h3>Billing Account</h3>
                 <BillingAccountSelector />
             </div>


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

- Temporarily disable selecting personal account for usage-based billing attribution
- Improve usage-based billing account selection UX

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/12097
Fixes https://github.com/gitpod-io/gitpod/issues/11498

## How to test
<!-- Provide steps to test this PR -->

1. Enable usage-based billing for your personal account
2. Go to `/billing`
3. You should not be able to select yourself (i.e. your individual user account) as a billing account

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
- [x] /werft with-payment
