### PR TITLE
[billing] Check if network connections should be limited

### DIFF
--- a/components/gitpod-protocol/src/plans.ts
+++ b/components/gitpod-protocol/src/plans.ts
@@ -482,6 +482,10 @@ export namespace Plans {
         );
     }
 
+    export function isFreeTier(chargebeeId: string | undefined): boolean {
+        return chargebeeId === Plans.FREE.chargebeeId || chargebeeId === Plans.FREE_50.chargebeeId;
+    }
+
     export function isFreeNonTransientPlan(chargebeeId: string | undefined): boolean {
         return chargebeeId === Plans.FREE_OPEN_SOURCE.chargebeeId;
     }

--- a/components/server/ee/src/billing/entitlement-service-chargebee.ts
+++ b/components/server/ee/src/billing/entitlement-service-chargebee.ts
@@ -189,4 +189,15 @@ export class EntitlementServiceChargebee implements EntitlementService {
 
         return true;
     }
+
+    /**
+     * Returns true if network connections should be limited
+     * @param user
+     */
+    async limitNetworkConnections(user: User, date: Date = new Date()): Promise<boolean> {
+        const subscriptions = await this.subscriptionService.getNotYetCancelledSubscriptions(user, date.toISOString());
+        const freePlans = [Plans.FREE, Plans.FREE_50].map((p) => p.chargebeeId);
+
+        return subscriptions.filter((s) => !freePlans.includes(s.planId!)).length > 0;
+    }
 }

--- a/components/server/ee/src/billing/entitlement-service-chargebee.ts
+++ b/components/server/ee/src/billing/entitlement-service-chargebee.ts
@@ -196,8 +196,7 @@ export class EntitlementServiceChargebee implements EntitlementService {
      */
     async limitNetworkConnections(user: User, date: Date = new Date()): Promise<boolean> {
         const subscriptions = await this.subscriptionService.getNotYetCancelledSubscriptions(user, date.toISOString());
-        const freePlans = [Plans.FREE, Plans.FREE_50].map((p) => p.chargebeeId);
-
-        return subscriptions.filter((s) => !freePlans.includes(s.planId!)).length > 0;
+        const hasPaidPlan = subscriptions.some((s) => !Plans.isFreeTier(s.planId));
+        return !hasPaidPlan;
     }
 }

--- a/components/server/ee/src/billing/entitlement-service-license.ts
+++ b/components/server/ee/src/billing/entitlement-service-license.ts
@@ -53,4 +53,12 @@ export class EntitlementServiceLicense implements EntitlementService {
         // TODO(gpl) Not sure this makes sense, but it's the way it was before
         return false;
     }
+
+    /**
+     * Returns true if network connections should be limited
+     * @param user
+     */
+    async limitNetworkConnections(user: User, date: Date): Promise<boolean> {
+        return false;
+    }
 }

--- a/components/server/ee/src/billing/entitlement-service-ubp.ts
+++ b/components/server/ee/src/billing/entitlement-service-ubp.ts
@@ -97,6 +97,14 @@ export class EntitlementServiceUBP implements EntitlementService {
         return this.hasPaidSubscription(user, date);
     }
 
+    /**
+     * Returns true if network connections should be limited
+     * @param user
+     */
+    async limitNetworkConnections(user: User, date: Date): Promise<boolean> {
+        return !this.hasPaidSubscription(user, date);
+    }
+
     protected async hasPaidSubscription(user: User, date: Date): Promise<boolean> {
         // TODO(gpl) UBP personal: implement!
         return true;

--- a/components/server/ee/src/billing/entitlement-service-ubp.ts
+++ b/components/server/ee/src/billing/entitlement-service-ubp.ts
@@ -102,7 +102,8 @@ export class EntitlementServiceUBP implements EntitlementService {
      * @param user
      */
     async limitNetworkConnections(user: User, date: Date): Promise<boolean> {
-        return !this.hasPaidSubscription(user, date);
+        const hasPaidPlan = await this.hasPaidSubscription(user, date);
+        return !hasPaidPlan;
     }
 
     protected async hasPaidSubscription(user: User, date: Date): Promise<boolean> {

--- a/components/server/ee/src/billing/entitlement-service.ts
+++ b/components/server/ee/src/billing/entitlement-service.ts
@@ -110,4 +110,25 @@ export class EntitlementServiceImpl implements EntitlementService {
             return true;
         }
     }
+
+    /**
+     * Returns true if network connections should be limited
+     * @param user
+     */
+    async limitNetworkConnections(user: User, date: Date): Promise<boolean> {
+        try {
+            const billingMode = await this.billingModes.getBillingModeForUser(user, date);
+            switch (billingMode.mode) {
+                case "none":
+                    return this.license.limitNetworkConnections(user, date);
+                case "chargebee":
+                    return this.chargebee.limitNetworkConnections(user, date);
+                case "usage-based":
+                    return this.ubp.limitNetworkConnections(user, date);
+            }
+        } catch (err) {
+            log.error({ userId: user.id }, "EntitlementService error: limitNetworkConnections", err);
+            return false;
+        }
+    }
 }

--- a/components/server/src/billing/entitlement-service.ts
+++ b/components/server/src/billing/entitlement-service.ts
@@ -63,6 +63,12 @@ export interface EntitlementService {
      * compared to the default case.
      */
     userGetsMoreResources(user: User): Promise<boolean>;
+
+    /**
+     * Returns true if network connections should be limited
+     * @param user
+     */
+    limitNetworkConnections(user: User, date: Date): Promise<boolean>;
 }
 
 /**
@@ -87,6 +93,10 @@ export class CommunityEntitlementService implements EntitlementService {
     }
 
     async userGetsMoreResources(user: User): Promise<boolean> {
+        return false;
+    }
+
+    async limitNetworkConnections(user: User): Promise<boolean> {
         return false;
     }
 }


### PR DESCRIPTION
## Description
If a user is on the free tier, we want to limit the network connections that they can create.

## Related Issue(s)
Fixes https://github.com/gitpod-io/gitpod/issues/12161)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
