### PR TITLE
[jb] Use the default Java SDK version when there's no explicit configuration for it yet

### DIFF
--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/GitpodProjectManager.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/GitpodProjectManager.kt
@@ -12,15 +12,19 @@ import com.intellij.openapi.project.ModuleListener
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.projectRoots.ProjectJdkTable
 import com.intellij.openapi.projectRoots.Sdk
+import com.intellij.openapi.projectRoots.SdkType
+import com.intellij.openapi.projectRoots.impl.JavaHomeFinder
+import com.intellij.openapi.projectRoots.impl.SdkConfigurationUtil
 import com.intellij.openapi.roots.ModuleRootModificationUtil
 import com.intellij.openapi.roots.ProjectRootManager
+import com.intellij.openapi.util.registry.Registry
 import com.intellij.util.application
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.future.await
 import kotlinx.coroutines.launch
 import java.util.concurrent.CompletableFuture
 
-
+@Suppress("UnstableApiUsage", "OPT_IN_USAGE")
 class GitpodProjectManager(
         private val project: Project
 ) {
@@ -33,15 +37,30 @@ class GitpodProjectManager(
      * It is a workaround for https://youtrack.jetbrains.com/issue/GTW-88
      */
     private fun configureSdks() {
-        if (application.isHeadlessEnvironment) {
+        if (application.isHeadlessEnvironment || Registry.get("gitpod.autoJdk.disabled").asBoolean()) {
             return
         }
         val pendingSdk = CompletableFuture<Sdk>()
         application.invokeLaterOnWriteThread {
             application.runWriteAction {
                 try {
-                    ProjectJdkTable.getInstance().preconfigure()
-                    pendingSdk.complete(ProjectJdkTable.getInstance().allJdks.firstOrNull())
+                    val jdkTable = ProjectJdkTable.getInstance()
+                    jdkTable.preconfigure()
+                    val preconfiguredJdk = ProjectRootManager.getInstance(project).projectSdk
+                    val preferredJdkHomePath = JavaHomeFinder.getFinder().findExistingJdks().firstOrNull()
+                    pendingSdk.complete(
+                            when {
+                                preconfiguredJdk != null -> preconfiguredJdk
+                                preferredJdkHomePath != null ->
+                                    jdkTable.allJdks.find { sdk -> sdk.homePath == preferredJdkHomePath }
+                                            ?: SdkConfigurationUtil.createAndAddSDK(
+                                                    preferredJdkHomePath,
+                                                    SdkType.findByName(jdkTable.defaultSdkType.name)!!
+                                            )
+
+                                else -> jdkTable.allJdks.firstOrNull()
+                            }
+                    )
                 } catch (t: Throwable) {
                     pendingSdk.completeExceptionally(t)
                 }

--- a/components/ide/jetbrains/backend-plugin/src/main/resources/META-INF/plugin.xml
+++ b/components/ide/jetbrains/backend-plugin/src/main/resources/META-INF/plugin.xml
@@ -33,6 +33,7 @@
         <gateway.customization.name implementation="io.gitpod.jetbrains.remote.GitpodGatewayClientCustomizationProvider"/>
         <gateway.customization.performance id="gitpodMetricsControl" order="before cpuControl" implementation="io.gitpod.jetbrains.remote.GitpodMetricControlProvider"/>
         <gateway.customization.metrics id="gitpodMetricsProvider" implementation="io.gitpod.jetbrains.remote.GitpodMetricProvider" />
+        <registryKey key="gitpod.autoJdk.disabled" defaultValue="false" description="Disable auto-detection of JDK for the project and its modules" restartRequired="true"/>
     </extensions>
 
 </idea-plugin>


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Currently, when we open a Java Workspace, it selects Java 17 as SDK by default:
<img width="808" alt="image" src="https://user-images.githubusercontent.com/418083/185409355-6777c6c8-6640-444f-81e0-9864ecff455a.png">

This PR changes it to use the JDK preferred by the user (the ones defined in JAVA_HOME or PATH environment variables), in case it's not defined in a configuration file yet (e.g. `.idea/misc.xml`):
<img width="847" alt="image" src="https://user-images.githubusercontent.com/418083/185913994-3396fc20-ad01-4926-a441-ccc21f7baf87.png">

## How does it work

`jdkTable.preconfigure()` will set the `ProjectRootManager.getInstance(project).projectSdk` to a specific version if there’s an `.idea/misc.xml` file defining the JDK for the project.
And if there’s no configuration file, it will add a JDK to the list of available SDKs but won't set up the project SDK. That's where we set them up with the default JDK version found by `JavaHomeFinder.`

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #12030

## How to test
<!-- Provide steps to test this PR -->
1. Open the preview environment generated for this branch
2. Choose the _Stable_ version of IntelliJ IDEA as your preferred editor
3. Test a repository that contains the JDK specified in `.idea/misc.xml`:
    a. Start a workspace using this repository: https://github.com/gitpod-io/spring-petclinic
    b. Verify that the workspace starts successfully
    c. Verify that the IDE opens successfully
    d. In JetBrains Client, open the menu "File" >> "Project Structure" and check if it's using the same JDK version as the one defined in `.idea/misc.xml`.
    <img width="803" alt="image" src="https://user-images.githubusercontent.com/418083/185628420-90296a5d-2817-4520-8d22-149827c44bee.png">
    e. Stop the workspace and restart it. Now confirm there are no duplicated SDKs listed in `File >> Project Structure >> Platform Settings >> SDKs`.
4. Test a repository that doesn't contain the JDK specified in `.idea/misc.xml` or doesn't contain that file at all:
    a. Start a workspace using this repository: https://github.com/gitpod-io/template-java-spring-boot
    b. Verify that the workspace starts successfully
    c. Verify that the IDE opens successfully
    d. In JetBrains Client, open the menu "File" >> "Project Structure" and check if it's using the same JDK version as the one you see when you run `echo $JAVA_HOME` on the terminal. (Notice there are also other auto-detected JDKs listed, allowing users to change it if they want.)
    <img width="847" alt="image" src="https://user-images.githubusercontent.com/418083/185913994-3396fc20-ad01-4926-a441-ccc21f7baf87.png">
    e. Stop the workspace and restart it. Now confirm there are no duplicated SDKs listed in `File >> Project Structure >> Platform Settings >> SDKs`.
    <img width="266" alt="image" src="https://user-images.githubusercontent.com/418083/185914963-4f7fb55f-c601-43ad-bfb6-74fa6b2f9a18.png">

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user-facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
JetBrains IDEs will use the default Java SDK version when there's no explicit configuration for it yet.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, there is nothing to do here.
-->
None.

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
