### PR TITLE
Match google-protobuf version across components

### DIFF
--- a/components/gitpod-protocol/package.json
+++ b/components/gitpod-protocol/package.json
@@ -64,6 +64,6 @@
         "vscode-uri": "^3.0.3",
         "vscode-ws-jsonrpc": "^0.2.0",
         "ws": "^7.4.6",
-        "google-protobuf": "^3.18.0-rc.2"
+        "google-protobuf": "^3.19.1"
     }
 }

--- a/components/image-builder-api/typescript/package.json
+++ b/components/image-builder-api/typescript/package.json
@@ -14,7 +14,7 @@
     "@gitpod/content-service": "0.1.5",
     "@gitpod/gitpod-protocol": "0.1.5",
     "@grpc/grpc-js": "^1.3.7",
-    "google-protobuf": "^3.18.0-rc.2",
+    "google-protobuf": "^3.19.1",
     "inversify": "^5.0.1",
     "opentracing": "^0.14.4"
   },

--- a/components/server/package.json
+++ b/components/server/package.json
@@ -59,7 +59,7 @@
     "express-mysql-session": "^2.1.0",
     "express-session": "^1.15.6",
     "fs-extra": "^10.0.0",
-    "google-protobuf": "^3.18.0-rc.2",
+    "google-protobuf": "^3.19.1",
     "heapdump": "^0.3.15",
     "inversify": "^5.0.1",
     "is-reachable": "^5.2.1",

--- a/components/ws-manager-bridge/package.json
+++ b/components/ws-manager-bridge/package.json
@@ -39,7 +39,7 @@
     "@types/amqplib": "^0.8.2",
     "@types/chai": "^4.2.21",
     "@types/express": "^4.17.13",
-    "@types/google-protobuf": "^3.7.4",
+    "@types/google-protobuf": "^3.15.5",
     "@types/mocha": "^2.2.45",
     "chai": "^4.3.4",
     "expect": "^1.20.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2781,7 +2781,7 @@
     "@types/minimatch" "*"
     "@types/node" "*"
 
-"@types/google-protobuf@^3.15.5", "@types/google-protobuf@^3.7.4":
+"@types/google-protobuf@^3.15.5":
   version "3.15.5"
   resolved "https://registry.npmjs.org/@types/google-protobuf/-/google-protobuf-3.15.5.tgz"
   integrity sha512-6bgv24B+A2bo9AfzReeg5StdiijKzwwnRflA8RLd1V4Yv995LeTmo0z69/MPbBDFSiZWdZHQygLo/ccXhMEDgw==
@@ -8853,7 +8853,7 @@ google-protobuf@3.15.8:
   resolved "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.15.8.tgz"
   integrity sha512-2jtfdqTaSxk0cuBJBtTTWsot4WtR9RVr2rXg7x7OoqiuOKopPrwXpM1G4dXIkLcUNRh3RKzz76C8IOkksZSeOw==
 
-google-protobuf@^3.18.0-rc.2, google-protobuf@^3.19.1, google-protobuf@^3.6.1:
+google-protobuf@^3.19.1, google-protobuf@^3.6.1:
   version "3.19.1"
   resolved "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.19.1.tgz"
   integrity sha512-Isv1RlNC+IzZzilcxnlVSf+JvuhxmY7DaxYCBy+zPS9XVuJRtlTTIXR9hnZ1YL1MMusJn/7eSy2swCzZIomQSg==


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Most gitpod components where using `google-protobuf` with version `3.19.1`, so I just updated the remaining components 


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
