### PR TITLE
[server] ensure that user that has PVC enabled will not force prebuilds into PVC use

### DIFF
--- a/components/server/ee/src/prebuilds/prebuild-manager.ts
+++ b/components/server/ee/src/prebuilds/prebuild-manager.ts
@@ -238,7 +238,7 @@ export class PrebuildManager {
                 const usePVC = this.shouldUsePersistentVolumeClaim(project);
                 await this.workspaceStarter.startWorkspace({ span }, workspace, user, [], projectEnvVars, {
                     excludeFeatureFlags: ["full_workspace_backup"],
-                    forcePVC: usePVC,
+                    pvcEnabledForPrebuilds: usePVC,
                 });
             }
 

--- a/components/server/ee/src/workspace/workspace-starter.ts
+++ b/components/server/ee/src/workspace/workspace-starter.ts
@@ -24,7 +24,7 @@ export class WorkspaceStarterEE extends WorkspaceStarter {
         user: User,
         excludeFeatureFlags: NamedWorkspaceFeatureFlag[],
         ideConfig: IDEConfig,
-        forcePVC: boolean,
+        pvcEnabledForPrebuilds: boolean,
     ): Promise<WorkspaceInstance> {
         const instance = await super.newInstance(
             ctx,
@@ -33,7 +33,7 @@ export class WorkspaceStarterEE extends WorkspaceStarter {
             user,
             excludeFeatureFlags,
             ideConfig,
-            forcePVC,
+            pvcEnabledForPrebuilds,
         );
 
         return instance;

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -128,7 +128,7 @@ export interface StartWorkspaceOptions {
     rethrow?: boolean;
     forceDefaultImage?: boolean;
     excludeFeatureFlags?: NamedWorkspaceFeatureFlag[];
-    forcePVC?: boolean;
+    pvcEnabledForPrebuilds?: boolean;
 }
 
 const MAX_INSTANCE_START_RETRIES = 2;
@@ -352,7 +352,7 @@ export class WorkspaceStarter {
                         user,
                         options.excludeFeatureFlags || [],
                         ideConfig,
-                        options.forcePVC || false,
+                        options.pvcEnabledForPrebuilds || false,
                     ),
                 );
             span.log({ newInstance: instance.id });
@@ -743,7 +743,7 @@ export class WorkspaceStarter {
         user: User,
         excludeFeatureFlags: NamedWorkspaceFeatureFlag[],
         ideConfig: IDEConfig,
-        forcePVC: boolean,
+        pvcEnabledForPrebuilds: boolean,
     ): Promise<WorkspaceInstance> {
         const span = TraceContext.startSpan("buildWorkspaceImage", ctx);
         //#endregion IDE resolution TODO(ak) move to IDE service
@@ -828,8 +828,15 @@ export class WorkspaceStarter {
 
             featureFlags = featureFlags.filter((f) => !excludeFeatureFlags.includes(f));
 
-            if (forcePVC === true) {
-                featureFlags = featureFlags.concat(["persistent_volume_claim"]);
+            if (workspace.type === "prebuild") {
+                if (pvcEnabledForPrebuilds === true) {
+                    featureFlags = featureFlags.concat(["persistent_volume_claim"]);
+                } else {
+                    // If PVC is disabled for prebuilds, we need to remove the PVC feature flag.
+                    // This is necessary to ensure if user has PVC enabled on their account, that they
+                    // will not hijack prebuild with PVC and make everyone who use this prebuild to auto enroll into PVC feature.
+                    featureFlags = featureFlags.filter((f) => f !== "persistent_volume_claim");
+                }
             }
 
             let workspaceClass = "";
@@ -1428,7 +1435,8 @@ export class WorkspaceStarter {
         }
 
         const volumeSnapshotId =
-((SnapshotContext.is(workspace.context) || WithPrebuild.is(workspace.context)) && !!workspace.context.snapshotBucketId)
+            (SnapshotContext.is(workspace.context) || WithPrebuild.is(workspace.context)) &&
+            !!workspace.context.snapshotBucketId
                 ? workspace.context.snapshotBucketId
                 : lastValidWorkspaceInstanceId;
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
ensure that user that has PVC enabled will not force prebuilds to use them on projects that don't have PVC turned on

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #11769 

## How to test

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
none
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
