### PR TITLE
[server] trim rawEvents to avoid DB pollution

### DIFF
--- a/components/server/ee/src/prebuilds/github-app.ts
+++ b/components/server/ee/src/prebuilds/github-app.ts
@@ -240,6 +240,10 @@ export class GithubApp {
         const span = TraceContext.startSpan("GithubApp.handlePushEvent", {});
         span.setTag("request", ctx.id);
 
+        // trim commits to avoid DB pollution
+        // https://github.com/gitpod-io/gitpod/issues/11578
+        ctx.payload.head_commit = null;
+
         const event = await this.webhookEvents.createEvent({
             type: "push",
             status: "received",

--- a/components/server/ee/src/prebuilds/gitlab-app.ts
+++ b/components/server/ee/src/prebuilds/gitlab-app.ts
@@ -47,6 +47,10 @@ export class GitLabApp {
             const secretToken = req.header("X-Gitlab-Token");
             const context = req.body as GitLabPushHook;
 
+            // trim commits to avoid DB pollution
+            // https://github.com/gitpod-io/gitpod/issues/11578
+            context.commits = [];
+
             const event = await this.webhookEvents.createEvent({
                 type: "push",
                 status: "received",
@@ -274,6 +278,21 @@ interface GitLabPushHook {
     user_name: string;
     project: GitLabProject;
     repository: GitLabRepository;
+    commits: GitLabCommit[];
+}
+
+interface GitLabCommit {
+    id: string;
+    title: string;
+    message: string;
+    url: string;
+    author: {
+        name: string;
+        email: string;
+    };
+    // modified
+    // added
+    // removed
 }
 
 interface GitLabRepository {


### PR DESCRIPTION
## Description
This PR should fix handling of webhook events with large amount of changes attached as payload.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #11578

## How to test
* Setup a projects and push a change to the repo. Webhook events should be received as usual.
* Create an artificial change with a ton of files modified/added/removed. See that webhook events are captures without errors logged in server.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
