### PR TITLE
[kots] Allow users to upload a `.docker/config.json` file

### DIFF
--- a/install/kots/manifests/gitpod-installer-job.yaml
+++ b/install/kots/manifests/gitpod-installer-job.yaml
@@ -78,6 +78,17 @@ spec:
                 fi
               fi
 
+              echo "Gitpod: Create a Helm template directory"
+              rm -Rf "${GITPOD_OBJECTS}"
+              mkdir -p "${GITPOD_OBJECTS}/templates"
+              cat <<EOF >> "${GITPOD_OBJECTS}/Chart.yaml"
+              apiVersion: v2
+              name: gitpod-kots
+              description: Always ready-to-code
+              version: "1.0.0"
+              appVersion: "$(/app/installer version | yq e '.version' -)"
+              EOF
+
               echo "Gitpod: Generate the base Installer config"
               /app/installer init > "${CONFIG_FILE}"
 
@@ -174,8 +185,7 @@ spec:
                 kubectl create secret docker-registry container-registry \
                   --namespace "{{repl Namespace }}" \
                   --from-file=.dockerconfigjson=/tmp/container-registry-secret \
-                  -o yaml --dry-run=client | \
-                  kubectl replace --namespace "{{repl Namespace }}" --force -f -
+                  -o yaml --dry-run=client >  "${GITPOD_OBJECTS}/templates/gitpod.yaml"
 
                 yq e -i ".containerRegistry.inCluster = false" "${CONFIG_FILE}"
                 yq e -i ".containerRegistry.external.url = \"{{repl ConfigOption "reg_url" }}\"" "${CONFIG_FILE}"
@@ -298,19 +308,8 @@ spec:
               config=$(cat "${CONFIG_FILE}")
               echo "Gitpod: ${CONFIG_FILE}=${config}"
 
-              echo "Gitpod: Create a Helm template directory"
-              rm -Rf "${GITPOD_OBJECTS}"
-              mkdir -p "${GITPOD_OBJECTS}/templates"
-              cat <<EOF >> "${GITPOD_OBJECTS}/Chart.yaml"
-              apiVersion: v2
-              name: gitpod-kots
-              description: Always ready-to-code
-              version: "1.0.0"
-              appVersion: "$(/app/installer version | yq e '.version' -)"
-              EOF
-
               echo "Gitpod: render Kubernetes manifests"
-              /app/installer render -c "${CONFIG_FILE}" --namespace {{repl Namespace }} --use-experimental-config > "${GITPOD_OBJECTS}/templates/gitpod.yaml"
+              /app/installer render -c "${CONFIG_FILE}" --namespace {{repl Namespace }} --use-experimental-config >> "${GITPOD_OBJECTS}/templates/gitpod.yaml"
 
               if [ '{{repl ConfigOptionEquals "reg_incluster" "1" }}' = "true" ];
               then
@@ -326,6 +325,33 @@ spec:
 
                 echo "Gitpod: update the in-cluster registry secret"
                 yq eval-all --inplace '(select(.kind == "Secret" and .metadata.name == "builtin-registry-auth") | .data.".dockerconfigjson") |= env(REGISTRY_SECRET)' \
+                  "${GITPOD_OBJECTS}/templates/gitpod.yaml"
+              fi
+
+              # figure out the secret to use
+              if [ '{{repl ConfigOptionEquals "reg_incluster" "0" }}' = "true" ];
+              then
+                export REGISTRY_SECRET_NAME="container-registry"
+              else
+                export REGISTRY_SECRET_NAME="builtin-registry-auth"
+              fi
+
+              if [ '{{repl ConfigOptionNotEquals "reg_docker_config" "" }}' = "true" ];
+              then
+                echo "Gitpod: Add given extra docker config json file to ${REGISTRY_SECRET_NAME}"
+
+                yq eval-all '(select(.kind == "Secret" and .metadata.name == env(REGISTRY_SECRET_NAME)) | .data.".dockerconfigjson")' \
+                  "${GITPOD_OBJECTS}/templates/gitpod.yaml" \
+                  | base64 -d \
+                  > /tmp/currentconfig.json
+
+                DOCKER_CONFIG='{{repl ConfigOptionData "reg_docker_config" | Base64Encode }}'
+                echo "${DOCKER_CONFIG}" | base64 -d  > /tmp/userconfig.json
+
+                export REGISTRY_SECRET=$(jq -s '.[0] * .[1]' /tmp/userconfig.json /tmp/currentconfig.json | base64 -w 0)
+
+                echo "Gitpod: update the in-cluster registry secret"
+                yq eval-all --inplace '(select(.kind == "Secret" and .metadata.name == env(REGISTRY_SECRET_NAME)) | .data.".dockerconfigjson") |= env(REGISTRY_SECRET)' \
                   "${GITPOD_OBJECTS}/templates/gitpod.yaml"
               fi
 

--- a/install/kots/manifests/kots-config.yaml
+++ b/install/kots/manifests/kots-config.yaml
@@ -23,7 +23,7 @@ spec:
 
     - name: container_registry
       title: Container registry
-      description: Gitpod requires a container registry to store container images. This can either be an in-cluster or external container registry.
+      description: Gitpod [requires a container registry](https://www.gitpod.io/docs/self-hosted/latest/reference-architecture/single-cluster-ref-arch#oci-image-registry) to push and store workspace images. This can either be an in-cluster or external container registry.
       items:
         - name: reg_incluster
           title: Use in-cluster container registry
@@ -107,6 +107,19 @@ spec:
           when: '{{repl ConfigOptionEquals "reg_incluster" "0" }}'
           required: true
           help_text: The password for your container registry.
+
+        - name: reg_docker_config_enable
+          title: Configure additional registry credentials for pulling workspace images
+          type: bool
+          default: "0"
+          help_text: This is useful when you have base workspace images in private registries other than the above configured ones.
+
+        - name: reg_docker_config
+          title: Registry credentials
+          when: '{{repl ConfigOptionEquals "reg_docker_config_enable" "1" }}'
+          type: file
+          required: true
+          help_text: Docker [config JSON file](https://docs.docker.com/engine/reference/commandline/cli/#sample-configuration-file) with auth credentials used to access private registries, for workspace images.
 
     - name: database
       title: Database


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This PR updates the `kots` UI to add a new config option to upload registry
credentials irrespective of the registry being used, which is then merged
into a single `config.json` file and passed as the registry secret which
is then used across the workspace image builder components.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/12136

## How to test
<!-- Provide steps to test this PR -->

Upload a `dockerconfigjson` file through the new option, 
![Screenshot from 2022-08-18 19-03-10](https://user-images.githubusercontent.com/7892868/185416793-f3106f93-3894-49c5-8ebd-4f3dcb022e8c.png)

and see those credentials in the secret by running
```
kubectl -n gitpod get secret builtin-registry-auth --output="jsonpath={.data.\.dockerconfigjson}" | base64 -d
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[kots] Allow users to upload a `.docker/config.json` file
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
