### PR TITLE
Generate and apply CRDs for observability CLI installation method

### DIFF
--- a/.werft/observability/monitoring-satellite.ts
+++ b/.werft/observability/monitoring-satellite.ts
@@ -63,7 +63,11 @@ export class MonitoringSatelliteInstaller {
         if (installationMethod == "observability-installer") {
             // As YAML is indentation sensitive we're using json instead so we don't have to worry about
             // getting the indentation right when formatting the code in TypeScript.
-            const observabilityInstallerRenderCmd = `cd observability && make generate && ./hack/deploy-crds.sh --kubeconfig ${this.options.kubeconfigPath} && cd installer && echo '
+            const observabilityInstallerRenderCmd = `cd observability && \
+            make generate && \
+            ./hack/deploy-crds.sh --kubeconfig ${this.options.kubeconfigPath} && \
+            kubectl create ns monitoring-satellite --kubeconfig ${this.options.kubeconfigPath} || true && \
+            cd installer && echo '
             {
                 "alerting": {
                     "config": {}
@@ -88,7 +92,7 @@ export class MonitoringSatelliteInstaller {
                     "enableFeatures": []
                 }
             }' | go run main.go render --config - | kubectl --kubeconfig ${this.options.kubeconfigPath} apply -f -`;
-            const renderingResult = exec(observabilityInstallerRenderCmd, { silent: true, dontCheckRc: true});
+            const renderingResult = exec(observabilityInstallerRenderCmd, { silent: false, dontCheckRc: true});
             if (renderingResult.code > 0) {
                 const err = new Error(`Failed rendering YAML with exit code ${renderingResult.code}`)
                 renderingResult.stderr.split('\n').forEach(stderrLine => werft.log(sliceName, stderrLine))

--- a/.werft/observability/monitoring-satellite.ts
+++ b/.werft/observability/monitoring-satellite.ts
@@ -63,7 +63,7 @@ export class MonitoringSatelliteInstaller {
         if (installationMethod == "observability-installer") {
             // As YAML is indentation sensitive we're using json instead so we don't have to worry about
             // getting the indentation right when formatting the code in TypeScript.
-            const observabilityInstallerRenderCmd = `cd observability/installer && echo '
+            const observabilityInstallerRenderCmd = `cd observability && make generate && ./hack/deploy-crds.sh --kubeconfig ${this.options.kubeconfigPath} && cd installer && echo '
             {
                 "alerting": {
                     "config": {}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PR does 2 things:
* Generate CRDs from Jsonnet, and apply them so we can use the CLI installer
* Updates the configuration to match the one used by jsonnet



## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #12036

## How to test
<!-- Provide steps to test this PR -->
To get a fresh installation, you can delete the previous previews as much as needed with
```
kubectl --context harvester delete ns preview-as-cli-installer-crd
```

To spin up a fresh new environment with the new CLI, run the command from inside the workspace:
```
werft run github -f -a with-preview=true -a observabilityInstallationMethod=observability-installer
```

The CLI is hardcoded to install the observability stack in the `monitoring-satellite` namespace, while jsonnet installs in the `default` namespace.

After running the werft job, you can install the preview kubecontext with `previewctl install-context`. If you noticed that the observability stack is installed in the `monitoring-satellite` namespace, it means that the job was successful 🙂 


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
