### PR TITLE
[usage] Test for and fix negative credits in GenerateUsageReport

### DIFF
--- a/components/usage/pkg/apiv1/usage-report.go
+++ b/components/usage/pkg/apiv1/usage-report.go
@@ -52,7 +52,7 @@ func (g *ReportGenerator) GenerateUsageReport(ctx context.Context, from, to time
 
 	// Sanity check: from <= now
 	if now.Before(from) {
-		return nil, status.Errorf(codes.InvalidArgument, "Now must be before from")
+		return nil, status.Errorf(codes.InvalidArgument, "Now must be after (or be equal to) from")
 	}
 
 	// Enforce: to <= now

--- a/components/usage/pkg/apiv1/usage_test.go
+++ b/components/usage/pkg/apiv1/usage_test.go
@@ -347,6 +347,7 @@ func TestReportGenerator_GenerateUsageReportTable(t *testing.T) {
 				}),
 			},
 			expectation: Expectation{
+				usageRecords: nil,
 				// usageRecords: []db.WorkspaceInstanceUsage{
 				// 	{
 				// 		InstanceID: instanceID,


### PR DESCRIPTION
## Description
There was a disconnect between when we determined `now`, and when we used it in combination with start-/stopTimes that - based on runtime behavior - _could_ lead to negative usage being calculated.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #12064 

## How to test

### Run unit tests
 - [open a workspace](https://gitpod.io/#https://github.com/gitpod-io/gitpod/pull/12178)
 - `leeway build components/usage:init-testdb && (cd components/usage && go test -v ./...)`

### Manual test
I did not manage to provoke this situation in preview envs, mainly due to data volume I guess.
It's still worth testing that usage still works as expected: 
 - signup
 - create a team starting with `Gitpod-...`
 - import a project
 - start a workspace on that project
 - go to the usage view and notice the correct usage being displayed

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
- [x] /werft with-payment
