### PR TITLE
[server] Introduce CachedBillingModes

### DIFF
--- a/components/gitpod-protocol/src/util/garbage-collected-cache.ts
+++ b/components/gitpod-protocol/src/util/garbage-collected-cache.ts
@@ -32,9 +32,14 @@ export class GarbageCollectedCache<T> {
         });
     }
 
-    public get(key: string): T | undefined {
+    public get(key: string, now: Date = new Date()): T | undefined {
         const entry = this.store.get(key);
         if (!entry) {
+            return undefined;
+        }
+        // Still valid?
+        if (entry.expiryDate < now.getTime()) {
+            this.store.delete(entry.key);
             return undefined;
         }
         return entry.value;

--- a/components/server/ee/src/billing/billing-modes-cache.ts
+++ b/components/server/ee/src/billing/billing-modes-cache.ts
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { Team, User } from "@gitpod/gitpod-protocol";
+import { AttributionId } from "@gitpod/gitpod-protocol/lib/attribution";
+import { BillingMode } from "@gitpod/gitpod-protocol/lib/billing-mode";
+import { GarbageCollectedCache } from "@gitpod/gitpod-protocol/lib/util/garbage-collected-cache";
+import { BillingModes } from "./billing-mode";
+
+/**
+ * Calculating BillingMode over and over again can be expensive. On the other hand, we want to be able to update it fast enough, because if it flips, the user is waiting for it.
+ * Adding this cache - with this configuration - is an attempt to find a sweet spot in between.
+ */
+export class CachedBillingModes implements BillingModes {
+    protected readonly cache = new GarbageCollectedCache<BillingMode>(10, 5 * 60);
+
+    constructor(protected readonly impl: BillingModes) {}
+
+    async getBillingMode(attributionId: AttributionId, now: Date): Promise<BillingMode> {
+        const cached = this.cache.get(AttributionId.render(attributionId));
+        if (cached) {
+            return cached;
+        }
+        return this.impl.getBillingMode(attributionId, now);
+    }
+
+    async getBillingModeForUser(user: User, now: Date): Promise<BillingMode> {
+        const cached = this.cache.get(AttributionId.render({ kind: "user", userId: user.id }));
+        if (cached) {
+            return cached;
+        }
+        return this.impl.getBillingModeForUser(user, now);
+    }
+
+    async getBillingModeForTeam(team: Team, now: Date): Promise<BillingMode> {
+        const cached = this.cache.get(AttributionId.render({ kind: "team", teamId: team.id }));
+        if (cached) {
+            return cached;
+        }
+        return this.impl.getBillingModeForTeam(team, now);
+    }
+}

--- a/components/server/ee/src/container-module.ts
+++ b/components/server/ee/src/container-module.ts
@@ -66,6 +66,7 @@ import { EntitlementServiceLicense } from "./billing/entitlement-service-license
 import { EntitlementServiceImpl } from "./billing/entitlement-service";
 import { EntitlementServiceUBP } from "./billing/entitlement-service-ubp";
 import { BillingService } from "./billing/billing-service";
+import { CachedBillingModes } from "./billing/billing-modes-cache";
 
 export const productionEEContainerModule = new ContainerModule((bind, unbind, isBound, rebind) => {
     rebind(Server).to(ServerEE).inSingletonScope();
@@ -132,7 +133,13 @@ export const productionEEContainerModule = new ContainerModule((bind, unbind, is
     bind(EntitlementServiceUBP).toSelf().inSingletonScope();
     bind(EntitlementServiceImpl).toSelf().inSingletonScope();
     rebind(EntitlementService).to(EntitlementServiceImpl).inSingletonScope();
-    bind(BillingModes).to(BillingModesImpl).inSingletonScope();
+    bind(BillingModesImpl).toSelf().inSingletonScope();
+    bind(BillingModes)
+        .toDynamicValue((ctx) => {
+            const impl = ctx.container.get<BillingModesImpl>(BillingModesImpl);
+            return new CachedBillingModes(impl);
+        })
+        .inSingletonScope();
 
     bind(BillingService).toSelf().inSingletonScope();
 });


### PR DESCRIPTION
## Description
This introduces a cache-layer on the `BillingModes` interface which caches BM calculations for 10s max. to prevent excessive impacts during the usage-based rollout.

Note: 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
 - signup
 - create a team starting with `Gitpod-...`
 - noticed that you can see the UBP billing, but _not_ the regular Team Subscription view (BM works)
 - upgrade to paid
 - noticed how your personal menu no longer shows

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
- [x] /werft with-payment
