### PR TITLE
[server] Never block getStripePublishableKey/getStripeSetupIntentClie…

### DIFF
--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -2007,8 +2007,7 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
     }
 
     async getStripePublishableKey(ctx: TraceContext): Promise<string> {
-        const user = this.checkAndBlockUser("getStripePublishableKey");
-        await this.ensureStripeApiIsAllowed({ user });
+        this.checkAndBlockUser("getStripePublishableKey");
         const publishableKey = this.config.stripeSecrets?.publishableKey;
         if (!publishableKey) {
             throw new ResponseError(
@@ -2020,8 +2019,7 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
     }
 
     async getStripeSetupIntentClientSecret(ctx: TraceContext): Promise<string> {
-        const user = this.checkAndBlockUser("getStripeSetupIntentClientSecret");
-        await this.ensureStripeApiIsAllowed({ user });
+        this.checkAndBlockUser("getStripeSetupIntentClientSecret");
         try {
             const setupIntent = await this.stripeService.createSetupIntent();
             if (!setupIntent.client_secret) {


### PR DESCRIPTION
…ntSecret based on BillingMode

## Description
Fixes a bug we detected while reviewing https://github.com/gitpod-io/gitpod/pull/12178

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
