### PR TITLE
[usage] Change instance runtime calculation: creationTime → startedTime, stoppedTime → stoppingTime

### DIFF
--- a/components/usage/pkg/apiv1/usage-report.go
+++ b/components/usage/pkg/apiv1/usage-report.go
@@ -104,8 +104,8 @@ func validateInstances(instances []db.WorkspaceInstanceForUsage) (valid []db.Wor
 		start := instance.CreationTime.Time()
 
 		// Currently running instances do not have a stopped time set, so we ignore these.
-		if instance.StoppedTime.IsSet() {
-			stop := instance.StoppedTime.Time()
+		if instance.StoppingTime.IsSet() {
+			stop := instance.StoppingTime.Time()
 			if stop.Before(start) {
 				invalid = append(invalid, InvalidSession{
 					Reason:  "stop time is before start time",
@@ -125,12 +125,12 @@ func trimStartStopTime(instances []db.WorkspaceInstanceForUsage, maximumStart, m
 	var updated []db.WorkspaceInstanceForUsage
 
 	for _, instance := range instances {
-		if instance.CreationTime.Time().Before(maximumStart) {
-			instance.CreationTime = db.NewVarcharTime(maximumStart)
+		if instance.StartedTime.Time().Before(maximumStart) {
+			instance.StartedTime = db.NewVarcharTime(maximumStart)
 		}
 
-		if instance.StoppedTime.Time().After(minimumStop) {
-			instance.StoppedTime = db.NewVarcharTime(minimumStop)
+		if instance.StoppingTime.Time().After(minimumStop) {
+			instance.StoppingTime = db.NewVarcharTime(minimumStop)
 		}
 
 		updated = append(updated, instance)

--- a/components/usage/pkg/apiv1/usage.go
+++ b/components/usage/pkg/apiv1/usage.go
@@ -8,9 +8,10 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"time"
+
 	"github.com/gitpod-io/gitpod/common-go/log"
 	"github.com/gitpod-io/gitpod/usage/pkg/contentservice"
-	"time"
 
 	v1 "github.com/gitpod-io/gitpod/usage-api/v1"
 	"github.com/gitpod-io/gitpod/usage/pkg/db"
@@ -167,8 +168,8 @@ func instancesToUsageRecords(instances []db.WorkspaceInstanceForUsage, pricer *W
 
 	for _, instance := range instances {
 		var stoppedAt sql.NullTime
-		if instance.StoppedTime.IsSet() {
-			stoppedAt = sql.NullTime{Time: instance.StoppedTime.Time(), Valid: true}
+		if instance.StoppingTime.IsSet() {
+			stoppedAt = sql.NullTime{Time: instance.StoppingTime.Time(), Valid: true}
 		}
 
 		projectID := ""
@@ -184,7 +185,7 @@ func instancesToUsageRecords(instances []db.WorkspaceInstanceForUsage, pricer *W
 			UserID:         instance.OwnerID,
 			WorkspaceType:  instance.Type,
 			WorkspaceClass: instance.WorkspaceClass,
-			StartedAt:      instance.CreationTime.Time(),
+			StartedAt:      instance.StartedTime.Time(),
 			StoppedAt:      stoppedAt,
 			CreditsUsed:    pricer.CreditsUsedByInstance(&instance, now),
 			GenerationID:   0,

--- a/components/usage/pkg/apiv1/usage_test.go
+++ b/components/usage/pkg/apiv1/usage_test.go
@@ -177,9 +177,9 @@ func TestInstanceToUsageRecords(t *testing.T) {
 	teamAttributionID := db.NewTeamAttributionID(teamID)
 	instanceId := uuid.New()
 	creationTime := db.NewVarcharTime(time.Date(2022, 05, 30, 00, 00, 00, 00, time.UTC))
-	startedTime := db.NewVarcharTime(time.Date(2022, 05, 30, 00, 00, 00, 00, time.UTC))
+	startedTime := db.NewVarcharTime(time.Date(2022, 05, 30, 00, 01, 00, 00, time.UTC))
 	stoppingTime := db.NewVarcharTime(time.Date(2022, 06, 1, 1, 0, 0, 0, time.UTC))
-	stoppedTime := db.NewVarcharTime(time.Date(2022, 06, 1, 1, 0, 0, 0, time.UTC))
+	stoppedTime := db.NewVarcharTime(time.Date(2022, 06, 1, 1, 1, 0, 0, time.UTC))
 
 	scenarios := []struct {
 		Name     string
@@ -211,7 +211,7 @@ func TestInstanceToUsageRecords(t *testing.T) {
 				ProjectID:      "",
 				WorkspaceType:  db.WorkspaceType_Prebuild,
 				WorkspaceClass: defaultWorkspaceClass,
-				CreditsUsed:    470,
+				CreditsUsed:    469.8333333333333,
 				StartedAt:      startedTime.Time(),
 				StoppedAt:      sql.NullTime{Time: stoppingTime.Time(), Valid: true},
 				GenerationID:   0,
@@ -242,10 +242,10 @@ func TestInstanceToUsageRecords(t *testing.T) {
 				ProjectID:      projectID.String(),
 				WorkspaceID:    workspaceID,
 				WorkspaceType:  db.WorkspaceType_Regular,
-				StartedAt:      creationTime.Time(),
+				StartedAt:      startedTime.Time(),
 				StoppedAt:      sql.NullTime{},
 				WorkspaceClass: defaultWorkspaceClass,
-				CreditsUsed:    470,
+				CreditsUsed:    469.8333333333333,
 			}},
 		},
 	}
@@ -271,24 +271,24 @@ func TestReportGenerator_GenerateUsageReport(t *testing.T) {
 			ID:                 uuid.New(),
 			UsageAttributionID: db.NewTeamAttributionID(teamID.String()),
 			CreationTime:       db.NewVarcharTime(time.Date(2022, 05, 1, 00, 00, 00, 00, time.UTC)),
-			StartedTime:        db.NewVarcharTime(time.Date(2022, 05, 1, 00, 00, 00, 00, time.UTC)),
+			StartedTime:        db.NewVarcharTime(time.Date(2022, 05, 1, 00, 01, 00, 00, time.UTC)),
 			StoppingTime:       db.NewVarcharTime(time.Date(2022, 06, 1, 1, 0, 0, 0, time.UTC)),
-			StoppedTime:        db.NewVarcharTime(time.Date(2022, 06, 1, 1, 0, 0, 0, time.UTC)),
+			StoppedTime:        db.NewVarcharTime(time.Date(2022, 06, 1, 1, 1, 0, 0, time.UTC)),
 		}),
 		// Still running
 		dbtest.NewWorkspaceInstance(t, db.WorkspaceInstance{
 			ID:                 uuid.New(),
 			UsageAttributionID: db.NewTeamAttributionID(teamID.String()),
 			CreationTime:       db.NewVarcharTime(time.Date(2022, 05, 30, 00, 00, 00, 00, time.UTC)),
-			StartedTime:        db.NewVarcharTime(time.Date(2022, 05, 30, 00, 00, 00, 00, time.UTC)),
+			StartedTime:        db.NewVarcharTime(time.Date(2022, 05, 30, 00, 01, 00, 00, time.UTC)),
 		}),
 		// No creation time, invalid record
 		dbtest.NewWorkspaceInstance(t, db.WorkspaceInstance{
 			ID:                 uuid.New(),
 			UsageAttributionID: db.NewTeamAttributionID(teamID.String()),
-			StartedTime:        db.NewVarcharTime(time.Date(2022, 06, 1, 1, 0, 0, 0, time.UTC)),
+			StartedTime:        db.NewVarcharTime(time.Date(2022, 06, 1, 1, 1, 0, 0, time.UTC)),
 			StoppingTime:       db.NewVarcharTime(time.Date(2022, 06, 1, 1, 0, 0, 0, time.UTC)),
-			StoppedTime:        db.NewVarcharTime(time.Date(2022, 06, 1, 1, 0, 0, 0, time.UTC)),
+			StoppedTime:        db.NewVarcharTime(time.Date(2022, 06, 1, 1, 1, 0, 0, time.UTC)),
 		}),
 	}
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Change instance runtime calculation:
- Start: use startedTime instead of creationTime
  - don't count startup time at all, e.g. scale up, image build/pull, ...
  - don't double-count when waiting for a prebuild to finish
- Stop: use stoppingTime instead of stoppedTime
  - don't count stopping time at all, e.g. backup time

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/12177

## How to test
<!-- Provide steps to test this PR -->

1. Unit tests

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
- [x] /werft with-payment
