### PR TITLE
[installer] Use same domain for all tests

### DIFF
--- a/install/installer/cmd/testdata/render/customization/config.yaml
+++ b/install/installer/cmd/testdata/render/customization/config.yaml
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See License-MIT.txt in the project root for license information.
 
 apiVersion: v1
-domain: customization-test.gitpod.com
+domain: gitpod.example.com
 customization:
   - apiVersion: "*"
     kind: "*"

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -537,7 +537,7 @@ metadata:
   namespace: default
 spec:
   dnsNames:
-  - reg.customization-test.gitpod.com
+  - reg.gitpod.example.com
   duration: 2160h0m0s
   issuerRef:
     group: cert-manager.io
@@ -1296,7 +1296,7 @@ metadata:
 # v1/Secret builtin-registry-auth
 apiVersion: v1
 data:
-  .dockerconfigjson: eyJhdXRocyI6eyJyZWdpc3RyeS5jdXN0b21pemF0aW9uLXRlc3QuZ2l0cG9kLmNvbSI6eyJhdXRoIjoiZUZObFpFcHBSR2RLVVZGbk5FSnJWelY0UzNVNlExYzBRMUpDYW1rMlVqQmlSMGM0TVdkNVJYaz0ifX19
+  .dockerconfigjson: eyJhdXRocyI6eyJyZWdpc3RyeS5naXRwb2QuZXhhbXBsZS5jb20iOnsiYXV0aCI6ImVGTmxaRXBwUkdkS1VWRm5ORUpyVnpWNFMzVTZRMWMwUTFKQ2FtazJVakJpUjBjNE1XZDVSWGs9In19fQ==
   password: Q1c0Q1JCamk2UjBiR0c4MWd5RXk=
   user: eFNlZEppRGdKUVFnNEJrVzV4S3U=
 kind: Secret
@@ -1477,7 +1477,7 @@ data:
   config.json: |-
     {
       "gitpodAPI": {
-        "hostURL": "https://customization-test.gitpod.com",
+        "hostURL": "https://gitpod.example.com",
         "apiToken": ""
       },
       "enforcement": {},
@@ -1517,32 +1517,32 @@ data:
               {
                 "path": "/ide/out/vs/workbench/workbench.web.api.js",
                 "search": "vscode-cdn.net",
-                "replacement": "customization-test.gitpod.com"
+                "replacement": "gitpod.example.com"
               },
               {
                 "path": "/ide/out/vs/workbench/workbench.web.main.js",
                 "search": "vscode-cdn.net",
-                "replacement": "customization-test.gitpod.com"
+                "replacement": "gitpod.example.com"
               },
               {
                 "path": "/ide/out/vs/workbench/services/extensions/worker/extensionHostWorker.js",
                 "search": "vscode-cdn.net",
-                "replacement": "customization-test.gitpod.com"
+                "replacement": "gitpod.example.com"
               },
               {
                 "path": "/ide/out/vs/workbench/workbench.web.api.js",
                 "search": "open-vsx.org",
-                "replacement": "open-vsx.customization-test.gitpod.com"
+                "replacement": "open-vsx.gitpod.example.com"
               },
               {
                 "path": "/ide/out/vs/workbench/workbench.web.main.js",
                 "search": "open-vsx.org",
-                "replacement": "open-vsx.customization-test.gitpod.com"
+                "replacement": "open-vsx.gitpod.example.com"
               },
               {
                 "path": "/ide/out/vs/workbench/workbench.web.main.js",
                 "search": "ide.gitpod.io/code/markeplace.json",
-                "replacement": "ide.customization-test.gitpod.com/code/marketplace.json"
+                "replacement": "ide.gitpod.example.com/code/marketplace.json"
               }
             ],
             "inlineStatic": [
@@ -1734,7 +1734,7 @@ data:
     database:
       inCluster: true
     disableDefinitelyGp: true
-    domain: customization-test.gitpod.com
+    domain: gitpod.example.com
     kind: Full
     metadata:
       region: local
@@ -2800,7 +2800,7 @@ data:
     metadata:
       annotations:
         cloud.google.com/neg: '{"exposed_ports": {"80":{},"443": {}}}'
-        external-dns.alpha.kubernetes.io/hostname: customization-test.gitpod.com,*.customization-test.gitpod.com,*.ws.customization-test.gitpod.com
+        external-dns.alpha.kubernetes.io/hostname: gitpod.example.com,*.gitpod.example.com,*.ws.gitpod.example.com
         gitpod.io: hello
         hello: world
       creationTimestamp: null
@@ -3067,7 +3067,7 @@ data:
     metadata:
       annotations:
         gitpod.io: hello
-        gitpod.io/checksum_config: dd6972e67626d2cbc4b169d4e10cab9ab836b521ef2e6c1a5e5c22c99c2773bf
+        gitpod.io/checksum_config: 9b9fb6639d78350728d0748fdd5b109337da7648e8558f3fea4171e037ae3e20
         hello: world
       creationTimestamp: null
       labels:
@@ -4195,8 +4195,8 @@ data:
         },
         "pullSecret": "builtin-registry-auth",
         "pullSecretFile": "/config/pull-secret.json",
-        "baseImageRepository": "registry.customization-test.gitpod.com/base-images",
-        "workspaceImageRepository": "registry.customization-test.gitpod.com/workspace-images",
+        "baseImageRepository": "registry.gitpod.example.com/base-images",
+        "workspaceImageRepository": "registry.gitpod.example.com/workspace-images",
         "builderImage": "eu.gcr.io/gitpod-core-dev/build/image-builder-mk3/bob:test"
       },
       "refCache": {
@@ -4294,7 +4294,7 @@ data:
       "cache_duration_regular": "5m0s",
       "cache_duration_backup": "72h0m0s",
       "url_upstream": "https://open-vsx.org",
-      "url_local": "https://open-vsx.customization-test.gitpod.com",
+      "url_local": "https://open-vsx.gitpod.example.com",
       "max_idle_conns": 1000,
       "max_idle_conns_per_host": 1000,
       "redis_addr": "localhost:6379",
@@ -4319,7 +4319,7 @@ metadata:
 apiVersion: v1
 data:
   vhost.docker-registry: |-
-    https://registry.customization-test.gitpod.com {
+    https://registry.gitpod.example.com {
         import enable_log
         import remove_server_header
         import ssl_configuration
@@ -4337,7 +4337,7 @@ data:
     }
   vhost.empty: '# Placeholder to avoid errors loading files using a glob pattern'
   vhost.ide-proxy: |
-    https://ide.customization-test.gitpod.com {
+    https://ide.gitpod.example.com {
         import enable_log_debug
         import remove_server_header
         import ssl_configuration
@@ -4347,7 +4347,7 @@ data:
         }
     }
   vhost.minio: |-
-    https://minio.customization-test.gitpod.com {
+    https://minio.gitpod.example.com {
         import enable_log
         import remove_server_header
         import ssl_configuration
@@ -4357,7 +4357,7 @@ data:
         }
     }
   vhost.open-vsx: |-
-    https://open-vsx.customization-test.gitpod.com {
+    https://open-vsx.gitpod.example.com {
         import enable_log_debug
         import remove_server_header
         import ssl_configuration
@@ -4367,7 +4367,7 @@ data:
         }
     }
   vhost.payment-endpoint: |
-    https://payment.customization-test.gitpod.com {
+    https://payment.gitpod.example.com {
         import enable_log
         import remove_server_header
         import ssl_configuration
@@ -4504,7 +4504,7 @@ data:
   config.json: |-
     {
       "version": "pd-ide-metrics.23",
-      "hostUrl": "https://customization-test.gitpod.com",
+      "hostUrl": "https://gitpod.example.com",
       "installationShortname": "default",
       "devBranch": "",
       "insecureNoDomain": false,
@@ -4521,7 +4521,7 @@ data:
       "contentServiceAddr": "content-service:8080",
       "imageBuilderAddr": "image-builder-mk3:8080",
       "usageServiceAddr": "usage:9001",
-      "vsxRegistryUrl": "https://open-vsx.customization-test.gitpod.com",
+      "vsxRegistryUrl": "https://open-vsx.gitpod.example.com",
       "chargebeeProviderOptionsFile": "/chargebee/providerOptions",
       "stripeSecretsFile": "/stripe-secret/apikeys",
       "stripeConfigFile": "/stripe-config/config",
@@ -4644,7 +4644,7 @@ data:
             "orderKey": "00",
             "title": "VS Code",
             "type": "browser",
-            "logo": "https://ide.customization-test.gitpod.com/image/ide-logo/vscode.svg",
+            "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-034e1ea1e89e0b6a6be50de20bf67509111efa65",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
@@ -4653,7 +4653,7 @@ data:
             "orderKey": "02",
             "title": "VS Code",
             "type": "desktop",
-            "logo": "https://ide.customization-test.gitpod.com/image/ide-logo/vscode.svg",
+            "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code-desktop:test",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code-desktop-insiders:test"
           },
@@ -4661,7 +4661,7 @@ data:
             "orderKey": "05",
             "title": "GoLand",
             "type": "desktop",
-            "logo": "https://ide.customization-test.gitpod.com/image/ide-logo/golandLogo.svg",
+            "logo": "https://ide.gitpod.example.com/image/ide-logo/golandLogo.svg",
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/goland:test",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/goland:latest"
           },
@@ -4669,7 +4669,7 @@ data:
             "orderKey": "04",
             "title": "IntelliJ IDEA",
             "type": "desktop",
-            "logo": "https://ide.customization-test.gitpod.com/image/ide-logo/intellijIdeaLogo.svg",
+            "logo": "https://ide.gitpod.example.com/image/ide-logo/intellijIdeaLogo.svg",
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/intellij:test",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/intellij:latest"
           },
@@ -4677,7 +4677,7 @@ data:
             "orderKey": "07",
             "title": "PhpStorm",
             "type": "desktop",
-            "logo": "https://ide.customization-test.gitpod.com/image/ide-logo/phpstormLogo.svg",
+            "logo": "https://ide.gitpod.example.com/image/ide-logo/phpstormLogo.svg",
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/phpstorm:test",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/phpstorm:latest"
           },
@@ -4685,7 +4685,7 @@ data:
             "orderKey": "06",
             "title": "PyCharm",
             "type": "desktop",
-            "logo": "https://ide.customization-test.gitpod.com/image/ide-logo/pycharmLogo.svg",
+            "logo": "https://ide.gitpod.example.com/image/ide-logo/pycharmLogo.svg",
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/pycharm:test",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/pycharm:latest"
           }
@@ -4844,7 +4844,7 @@ data:
             "registryFacade": [
               {
                 "addr": "127.0.0.1",
-                "name": "reg.customization-test.gitpod.com"
+                "name": "reg.gitpod.example.com"
               }
             ]
           }
@@ -4906,11 +4906,11 @@ data:
         "initProbe": {
           "timeout": "1s"
         },
-        "urlTemplate": "https://{{ .Prefix }}.ws.customization-test.gitpod.com",
-        "portUrlTemplate": "https://{{ .WorkspacePort }}-{{ .Prefix }}.ws.customization-test.gitpod.com",
+        "urlTemplate": "https://{{ .Prefix }}.ws.gitpod.example.com",
+        "portUrlTemplate": "https://{{ .WorkspacePort }}-{{ .Prefix }}.ws.gitpod.example.com",
         "workspaceHostPath": "/var/gitpod/workspaces",
         "heartbeatInterval": "30s",
-        "hostURL": "https://customization-test.gitpod.com",
+        "hostURL": "https://gitpod.example.com",
         "reconnectionInterval": "30s",
         "wsdaemon": {
           "port": 8080,
@@ -4920,8 +4920,8 @@ data:
             "key": "/ws-daemon-tls-certs/tls.key"
           }
         },
-        "registryFacadeHost": "reg.customization-test.gitpod.com:20000",
-        "workspaceClusterHost": "ws.customization-test.gitpod.com",
+        "registryFacadeHost": "reg.gitpod.example.com:20000",
+        "workspaceClusterHost": "ws.gitpod.example.com",
         "workspaceClass": {
           "default": {
             "name": "default",
@@ -5077,14 +5077,14 @@ data:
         },
         "blobServer": {
           "scheme": "https",
-          "host": "ide.customization-test.gitpod.com",
+          "host": "ide.gitpod.example.com",
           "pathPrefix": "/blobserve"
         },
         "gitpodInstallation": {
           "scheme": "https",
-          "hostName": "customization-test.gitpod.com",
-          "workspaceHostSuffix": ".ws.customization-test.gitpod.com",
-          "workspaceHostSuffixRegex": "\\.ws[^\\.]*\\.customization-test.gitpod.com"
+          "hostName": "gitpod.example.com",
+          "workspaceHostSuffix": ".ws.gitpod.example.com",
+          "workspaceHostSuffixRegex": "\\.ws[^\\.]*\\.gitpod.example.com"
         },
         "workspacePodConfig": {
           "theiaPort": 23000,
@@ -6690,7 +6690,7 @@ kind: Service
 metadata:
   annotations:
     cloud.google.com/neg: '{"exposed_ports": {"80":{},"443": {}}}'
-    external-dns.alpha.kubernetes.io/hostname: customization-test.gitpod.com,*.customization-test.gitpod.com,*.ws.customization-test.gitpod.com
+    external-dns.alpha.kubernetes.io/hostname: gitpod.example.com,*.gitpod.example.com,*.ws.gitpod.example.com
     gitpod.io: hello
     hello: world
   creationTimestamp: null
@@ -6924,7 +6924,7 @@ kind: DaemonSet
 metadata:
   annotations:
     gitpod.io: hello
-    gitpod.io/checksum_config: dd6972e67626d2cbc4b169d4e10cab9ab836b521ef2e6c1a5e5c22c99c2773bf
+    gitpod.io/checksum_config: 9b9fb6639d78350728d0748fdd5b109337da7648e8558f3fea4171e037ae3e20
     hello: world
   creationTimestamp: null
   labels:
@@ -6969,13 +6969,13 @@ spec:
         - /config/config.json
         env:
         - name: GITPOD_DOMAIN
-          value: customization-test.gitpod.com
+          value: gitpod.example.com
         - name: GITPOD_INSTALLATION_SHORTNAME
           value: default
         - name: GITPOD_REGION
           value: local
         - name: HOST_URL
-          value: https://customization-test.gitpod.com
+          value: https://gitpod.example.com
         - name: KUBE_NAMESPACE
           valueFrom:
             fieldRef:
@@ -7093,13 +7093,13 @@ spec:
         - /mnt/config/config.json
         env:
         - name: GITPOD_DOMAIN
-          value: customization-test.gitpod.com
+          value: gitpod.example.com
         - name: GITPOD_INSTALLATION_SHORTNAME
           value: default
         - name: GITPOD_REGION
           value: local
         - name: HOST_URL
-          value: https://customization-test.gitpod.com
+          value: https://gitpod.example.com
         - name: KUBE_NAMESPACE
           valueFrom:
             fieldRef:
@@ -7280,7 +7280,7 @@ spec:
     metadata:
       annotations:
         gitpod.io: hello
-        gitpod.io/checksum_config: 8e974feb4ff67ee84a2ff69e9b828a8ae10db143da8177357e99165985bfc3bd
+        gitpod.io/checksum_config: a112f51a51ede1e9f2d6202871301fac2ea3622de94b33038c10a11c62fcf049
         hello: world
         seccomp.security.alpha.kubernetes.io/shiftfs-module-loader: unconfined
       creationTimestamp: null
@@ -7307,13 +7307,13 @@ spec:
         - /config/config.json
         env:
         - name: GITPOD_DOMAIN
-          value: customization-test.gitpod.com
+          value: gitpod.example.com
         - name: GITPOD_INSTALLATION_SHORTNAME
           value: default
         - name: GITPOD_REGION
           value: local
         - name: HOST_URL
-          value: https://customization-test.gitpod.com
+          value: https://gitpod.example.com
         - name: KUBE_NAMESPACE
           valueFrom:
             fieldRef:
@@ -7924,7 +7924,7 @@ spec:
     metadata:
       annotations:
         gitpod.io: hello
-        gitpod.io/checksum_config: 556aa4db327140511ae3e20db95a175a8da5347b4cb8ac005d5524e8754e44d1
+        gitpod.io/checksum_config: f8f0312e31202b20aca17accffa9ba2cc361ecd01ef6c1a21252ce9b85e22b7f
         hello: world
       creationTimestamp: null
       labels:
@@ -7947,13 +7947,13 @@ spec:
             - /config/config.json
           env:
             - name: GITPOD_DOMAIN
-              value: customization-test.gitpod.com
+              value: gitpod.example.com
             - name: GITPOD_INSTALLATION_SHORTNAME
               value: default
             - name: GITPOD_REGION
               value: local
             - name: HOST_URL
-              value: https://customization-test.gitpod.com
+              value: https://gitpod.example.com
             - name: KUBE_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -8080,7 +8080,7 @@ spec:
     metadata:
       annotations:
         gitpod.io: hello
-        gitpod.io/checksum_config: b2d022d33dc03e51cf59553f4660dbdd8ce589ab6899a0bc2baf7cc0eb6c9c4d
+        gitpod.io/checksum_config: 8c04c7c1329d7427dcba1dc471c9a3323aa4d5de5578c302bbbc34fd013ca3d4
         hello: world
       creationTimestamp: null
       labels:
@@ -8104,13 +8104,13 @@ spec:
         - /mnt/config/config.json
         env:
         - name: GITPOD_DOMAIN
-          value: customization-test.gitpod.com
+          value: gitpod.example.com
         - name: GITPOD_INSTALLATION_SHORTNAME
           value: default
         - name: GITPOD_REGION
           value: local
         - name: HOST_URL
-          value: https://customization-test.gitpod.com
+          value: https://gitpod.example.com
         - name: KUBE_NAMESPACE
           valueFrom:
             fieldRef:
@@ -8252,13 +8252,13 @@ spec:
         - /config/config.json
         env:
         - name: GITPOD_DOMAIN
-          value: customization-test.gitpod.com
+          value: gitpod.example.com
         - name: GITPOD_INSTALLATION_SHORTNAME
           value: default
         - name: GITPOD_REGION
           value: local
         - name: HOST_URL
-          value: https://customization-test.gitpod.com
+          value: https://gitpod.example.com
         - name: KUBE_NAMESPACE
           valueFrom:
             fieldRef:
@@ -8374,13 +8374,13 @@ spec:
       containers:
       - env:
         - name: GITPOD_DOMAIN
-          value: customization-test.gitpod.com
+          value: gitpod.example.com
         - name: GITPOD_INSTALLATION_SHORTNAME
           value: default
         - name: GITPOD_REGION
           value: local
         - name: HOST_URL
-          value: https://customization-test.gitpod.com
+          value: https://gitpod.example.com
         - name: KUBE_NAMESPACE
           valueFrom:
             fieldRef:
@@ -8470,13 +8470,13 @@ spec:
         - /config/config.json
         env:
         - name: GITPOD_DOMAIN
-          value: customization-test.gitpod.com
+          value: gitpod.example.com
         - name: GITPOD_INSTALLATION_SHORTNAME
           value: default
         - name: GITPOD_REGION
           value: local
         - name: HOST_URL
-          value: https://customization-test.gitpod.com
+          value: https://gitpod.example.com
         - name: KUBE_NAMESPACE
           valueFrom:
             fieldRef:
@@ -8591,13 +8591,13 @@ spec:
       containers:
       - env:
         - name: GITPOD_DOMAIN
-          value: customization-test.gitpod.com
+          value: gitpod.example.com
         - name: GITPOD_INSTALLATION_SHORTNAME
           value: default
         - name: GITPOD_REGION
           value: local
         - name: HOST_URL
-          value: https://customization-test.gitpod.com
+          value: https://gitpod.example.com
         - name: KUBE_NAMESPACE
           valueFrom:
             fieldRef:
@@ -8663,7 +8663,7 @@ spec:
     metadata:
       annotations:
         gitpod.io: hello
-        gitpod.io/checksum_config: 7effbcf107b4284241fab0cb7e704b0d850b1dbb41628cb602028d4f032f2f76
+        gitpod.io/checksum_config: ecd350f0d685aba1d7fb6e36ab8eed6fc4fa34f2729563a482c5685f4abce748
         hello: world
       creationTimestamp: null
       labels:
@@ -8688,13 +8688,13 @@ spec:
         - /config/image-builder.json
         env:
         - name: GITPOD_DOMAIN
-          value: customization-test.gitpod.com
+          value: gitpod.example.com
         - name: GITPOD_INSTALLATION_SHORTNAME
           value: default
         - name: GITPOD_REGION
           value: local
         - name: HOST_URL
-          value: https://customization-test.gitpod.com
+          value: https://gitpod.example.com
         - name: KUBE_NAMESPACE
           valueFrom:
             fieldRef:
@@ -8929,7 +8929,7 @@ spec:
     metadata:
       annotations:
         gitpod.io: hello
-        gitpod.io/checksum_config: 801a2876902552f99dd12a9a954562935cb4cb1239b3d6d8fa05891cc65e3995
+        gitpod.io/checksum_config: 0f81d4cad6198e5d0222f29f92143d4db7e502feae211f06ed3a71978d5be7e6
         hello: world
       creationTimestamp: null
       labels:
@@ -8975,13 +8975,13 @@ spec:
           runAsUser: 65532
       - env:
         - name: GITPOD_DOMAIN
-          value: customization-test.gitpod.com
+          value: gitpod.example.com
         - name: GITPOD_INSTALLATION_SHORTNAME
           value: default
         - name: GITPOD_REGION
           value: local
         - name: HOST_URL
-          value: https://customization-test.gitpod.com
+          value: https://gitpod.example.com
         - name: KUBE_NAMESPACE
           valueFrom:
             fieldRef:
@@ -8991,7 +8991,7 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: PROXY_DOMAIN
-          value: customization-test.gitpod.com
+          value: gitpod.example.com
         image: eu.gcr.io/gitpod-core-dev/build/proxy:test
         imagePullPolicy: IfNotPresent
         name: proxy
@@ -9183,7 +9183,7 @@ spec:
     metadata:
       annotations:
         gitpod.io: hello
-        gitpod.io/checksum_config: c4726c9bb3cc30ff75e907efa81f54922b7f7a689ccba523442fcdd7c3bb5ded
+        gitpod.io/checksum_config: abcabbe0f0755c297b38713fd5dcbdf5613cca1ecc2f5180b4c66ae59b189df5
         hello: world
       creationTimestamp: null
       labels:
@@ -9204,13 +9204,13 @@ spec:
       containers:
       - env:
         - name: GITPOD_DOMAIN
-          value: customization-test.gitpod.com
+          value: gitpod.example.com
         - name: GITPOD_INSTALLATION_SHORTNAME
           value: default
         - name: GITPOD_REGION
           value: local
         - name: HOST_URL
-          value: https://customization-test.gitpod.com
+          value: https://gitpod.example.com
         - name: KUBE_NAMESPACE
           valueFrom:
             fieldRef:
@@ -9453,7 +9453,7 @@ spec:
     metadata:
       annotations:
         gitpod.io: hello
-        gitpod.io/checksum_config: 0eb43682b01551c8f0754c04ce1f393177d178a05a4a7758e5c3a5bff96eb446
+        gitpod.io/checksum_config: 482447a616ea373c4ed547cc8cc8ab2b2c90ec1b51610d304792ec8c9f180c70
         hello: world
       creationTimestamp: null
       labels:
@@ -9478,13 +9478,13 @@ spec:
         - /config/config.json
         env:
         - name: GITPOD_DOMAIN
-          value: customization-test.gitpod.com
+          value: gitpod.example.com
         - name: GITPOD_INSTALLATION_SHORTNAME
           value: default
         - name: GITPOD_REGION
           value: local
         - name: HOST_URL
-          value: https://customization-test.gitpod.com
+          value: https://gitpod.example.com
         - name: KUBE_NAMESPACE
           valueFrom:
             fieldRef:
@@ -9616,13 +9616,13 @@ spec:
       containers:
       - env:
         - name: GITPOD_DOMAIN
-          value: customization-test.gitpod.com
+          value: gitpod.example.com
         - name: GITPOD_INSTALLATION_SHORTNAME
           value: default
         - name: GITPOD_REGION
           value: local
         - name: HOST_URL
-          value: https://customization-test.gitpod.com
+          value: https://gitpod.example.com
         - name: KUBE_NAMESPACE
           valueFrom:
             fieldRef:
@@ -9844,7 +9844,7 @@ spec:
     metadata:
       annotations:
         gitpod.io: hello
-        gitpod.io/checksum_config: 555e939b7c9f3124688018750fc1fbc87e1755665f98997def6f96ddc0bf4628
+        gitpod.io/checksum_config: a215d15f9dc39f54db7c2553b752027cd4c905b7f30c07c0fbe0193cbf1c1df1
         hello: world
       creationTimestamp: null
       labels:
@@ -9868,13 +9868,13 @@ spec:
         - /config/config.json
         env:
         - name: GITPOD_DOMAIN
-          value: customization-test.gitpod.com
+          value: gitpod.example.com
         - name: GITPOD_INSTALLATION_SHORTNAME
           value: default
         - name: GITPOD_REGION
           value: local
         - name: HOST_URL
-          value: https://customization-test.gitpod.com
+          value: https://gitpod.example.com
         - name: KUBE_NAMESPACE
           valueFrom:
             fieldRef:

--- a/install/installer/cmd/testdata/render/external-registry/config.yaml
+++ b/install/installer/cmd/testdata/render/external-registry/config.yaml
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See License-MIT.txt in the project root for license information.
 
 apiVersion: v1
-domain: minimal-test.gitpod.com
+domain: gitpod.example.com
 containerRegistry:
   inCluster: false
   external:

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -512,7 +512,7 @@ metadata:
   namespace: default
 spec:
   dnsNames:
-  - reg.minimal-test.gitpod.com
+  - reg.gitpod.example.com
   duration: 2160h0m0s
   issuerRef:
     group: cert-manager.io
@@ -1301,7 +1301,7 @@ data:
   config.json: |-
     {
       "gitpodAPI": {
-        "hostURL": "https://minimal-test.gitpod.com",
+        "hostURL": "https://gitpod.example.com",
         "apiToken": ""
       },
       "enforcement": {},
@@ -1336,32 +1336,32 @@ data:
               {
                 "path": "/ide/out/vs/workbench/workbench.web.api.js",
                 "search": "vscode-cdn.net",
-                "replacement": "minimal-test.gitpod.com"
+                "replacement": "gitpod.example.com"
               },
               {
                 "path": "/ide/out/vs/workbench/workbench.web.main.js",
                 "search": "vscode-cdn.net",
-                "replacement": "minimal-test.gitpod.com"
+                "replacement": "gitpod.example.com"
               },
               {
                 "path": "/ide/out/vs/workbench/services/extensions/worker/extensionHostWorker.js",
                 "search": "vscode-cdn.net",
-                "replacement": "minimal-test.gitpod.com"
+                "replacement": "gitpod.example.com"
               },
               {
                 "path": "/ide/out/vs/workbench/workbench.web.api.js",
                 "search": "open-vsx.org",
-                "replacement": "open-vsx.minimal-test.gitpod.com"
+                "replacement": "open-vsx.gitpod.example.com"
               },
               {
                 "path": "/ide/out/vs/workbench/workbench.web.main.js",
                 "search": "open-vsx.org",
-                "replacement": "open-vsx.minimal-test.gitpod.com"
+                "replacement": "open-vsx.gitpod.example.com"
               },
               {
                 "path": "/ide/out/vs/workbench/workbench.web.main.js",
                 "search": "ide.gitpod.io/code/markeplace.json",
-                "replacement": "ide.minimal-test.gitpod.com/code/marketplace.json"
+                "replacement": "ide.gitpod.example.com/code/marketplace.json"
               }
             ],
             "inlineStatic": [
@@ -1529,7 +1529,7 @@ data:
     database:
       inCluster: true
     disableDefinitelyGp: true
-    domain: minimal-test.gitpod.com
+    domain: gitpod.example.com
     kind: Full
     metadata:
       region: local
@@ -2400,7 +2400,7 @@ data:
     metadata:
       annotations:
         cloud.google.com/neg: '{"exposed_ports": {"80":{},"443": {}}}'
-        external-dns.alpha.kubernetes.io/hostname: minimal-test.gitpod.com,*.minimal-test.gitpod.com,*.ws.minimal-test.gitpod.com
+        external-dns.alpha.kubernetes.io/hostname: gitpod.example.com,*.gitpod.example.com,*.ws.gitpod.example.com
       creationTimestamp: null
       labels:
         app: gitpod
@@ -2612,7 +2612,7 @@ data:
     kind: DaemonSet
     metadata:
       annotations:
-        gitpod.io/checksum_config: 6953509cf3cc9e054d55384d788fb0de0bd798b969d752d7e1c40b75de4b4a62
+        gitpod.io/checksum_config: e5f1dd2a1327394b4bef4172c43487842026ef965fe8cec2475f00b1588de01f
       creationTimestamp: null
       labels:
         app: gitpod
@@ -3643,7 +3643,7 @@ data:
       "cache_duration_regular": "5m0s",
       "cache_duration_backup": "72h0m0s",
       "url_upstream": "https://open-vsx.org",
-      "url_local": "https://open-vsx.minimal-test.gitpod.com",
+      "url_local": "https://open-vsx.gitpod.example.com",
       "max_idle_conns": 1000,
       "max_idle_conns_per_host": 1000,
       "redis_addr": "localhost:6379",
@@ -3664,7 +3664,7 @@ apiVersion: v1
 data:
   vhost.empty: '# Placeholder to avoid errors loading files using a glob pattern'
   vhost.ide-proxy: |
-    https://ide.minimal-test.gitpod.com {
+    https://ide.gitpod.example.com {
         import enable_log_debug
         import remove_server_header
         import ssl_configuration
@@ -3674,7 +3674,7 @@ data:
         }
     }
   vhost.minio: |-
-    https://minio.minimal-test.gitpod.com {
+    https://minio.gitpod.example.com {
         import enable_log
         import remove_server_header
         import ssl_configuration
@@ -3684,7 +3684,7 @@ data:
         }
     }
   vhost.open-vsx: |-
-    https://open-vsx.minimal-test.gitpod.com {
+    https://open-vsx.gitpod.example.com {
         import enable_log_debug
         import remove_server_header
         import ssl_configuration
@@ -3694,7 +3694,7 @@ data:
         }
     }
   vhost.payment-endpoint: |
-    https://payment.minimal-test.gitpod.com {
+    https://payment.gitpod.example.com {
         import enable_log
         import remove_server_header
         import ssl_configuration
@@ -3784,7 +3784,7 @@ data:
   config.json: |-
     {
       "version": "pd-ide-metrics.23",
-      "hostUrl": "https://minimal-test.gitpod.com",
+      "hostUrl": "https://gitpod.example.com",
       "installationShortname": "default",
       "devBranch": "",
       "insecureNoDomain": false,
@@ -3801,7 +3801,7 @@ data:
       "contentServiceAddr": "content-service:8080",
       "imageBuilderAddr": "image-builder-mk3:8080",
       "usageServiceAddr": "usage:9001",
-      "vsxRegistryUrl": "https://open-vsx.minimal-test.gitpod.com",
+      "vsxRegistryUrl": "https://open-vsx.gitpod.example.com",
       "chargebeeProviderOptionsFile": "/chargebee/providerOptions",
       "stripeSecretsFile": "/stripe-secret/apikeys",
       "stripeConfigFile": "/stripe-config/config",
@@ -3919,7 +3919,7 @@ data:
             "orderKey": "00",
             "title": "VS Code",
             "type": "browser",
-            "logo": "https://ide.minimal-test.gitpod.com/image/ide-logo/vscode.svg",
+            "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-034e1ea1e89e0b6a6be50de20bf67509111efa65",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
@@ -3928,7 +3928,7 @@ data:
             "orderKey": "02",
             "title": "VS Code",
             "type": "desktop",
-            "logo": "https://ide.minimal-test.gitpod.com/image/ide-logo/vscode.svg",
+            "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code-desktop:test",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code-desktop-insiders:test"
           },
@@ -3936,7 +3936,7 @@ data:
             "orderKey": "05",
             "title": "GoLand",
             "type": "desktop",
-            "logo": "https://ide.minimal-test.gitpod.com/image/ide-logo/golandLogo.svg",
+            "logo": "https://ide.gitpod.example.com/image/ide-logo/golandLogo.svg",
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/goland:test",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/goland:latest"
           },
@@ -3944,7 +3944,7 @@ data:
             "orderKey": "04",
             "title": "IntelliJ IDEA",
             "type": "desktop",
-            "logo": "https://ide.minimal-test.gitpod.com/image/ide-logo/intellijIdeaLogo.svg",
+            "logo": "https://ide.gitpod.example.com/image/ide-logo/intellijIdeaLogo.svg",
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/intellij:test",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/intellij:latest"
           },
@@ -3952,7 +3952,7 @@ data:
             "orderKey": "07",
             "title": "PhpStorm",
             "type": "desktop",
-            "logo": "https://ide.minimal-test.gitpod.com/image/ide-logo/phpstormLogo.svg",
+            "logo": "https://ide.gitpod.example.com/image/ide-logo/phpstormLogo.svg",
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/phpstorm:test",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/phpstorm:latest"
           },
@@ -3960,7 +3960,7 @@ data:
             "orderKey": "06",
             "title": "PyCharm",
             "type": "desktop",
-            "logo": "https://ide.minimal-test.gitpod.com/image/ide-logo/pycharmLogo.svg",
+            "logo": "https://ide.gitpod.example.com/image/ide-logo/pycharmLogo.svg",
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/pycharm:test",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/pycharm:latest"
           }
@@ -4114,7 +4114,7 @@ data:
             "registryFacade": [
               {
                 "addr": "127.0.0.1",
-                "name": "reg.minimal-test.gitpod.com"
+                "name": "reg.gitpod.example.com"
               }
             ]
           }
@@ -4171,11 +4171,11 @@ data:
         "initProbe": {
           "timeout": "1s"
         },
-        "urlTemplate": "https://{{ .Prefix }}.ws.minimal-test.gitpod.com",
-        "portUrlTemplate": "https://{{ .WorkspacePort }}-{{ .Prefix }}.ws.minimal-test.gitpod.com",
+        "urlTemplate": "https://{{ .Prefix }}.ws.gitpod.example.com",
+        "portUrlTemplate": "https://{{ .WorkspacePort }}-{{ .Prefix }}.ws.gitpod.example.com",
         "workspaceHostPath": "/var/gitpod/workspaces",
         "heartbeatInterval": "30s",
-        "hostURL": "https://minimal-test.gitpod.com",
+        "hostURL": "https://gitpod.example.com",
         "reconnectionInterval": "30s",
         "wsdaemon": {
           "port": 8080,
@@ -4185,8 +4185,8 @@ data:
             "key": "/ws-daemon-tls-certs/tls.key"
           }
         },
-        "registryFacadeHost": "reg.minimal-test.gitpod.com:20000",
-        "workspaceClusterHost": "ws.minimal-test.gitpod.com",
+        "registryFacadeHost": "reg.gitpod.example.com:20000",
+        "workspaceClusterHost": "ws.gitpod.example.com",
         "workspaceClass": {
           "default": {
             "name": "default",
@@ -4332,14 +4332,14 @@ data:
         },
         "blobServer": {
           "scheme": "https",
-          "host": "ide.minimal-test.gitpod.com",
+          "host": "ide.gitpod.example.com",
           "pathPrefix": "/blobserve"
         },
         "gitpodInstallation": {
           "scheme": "https",
-          "hostName": "minimal-test.gitpod.com",
-          "workspaceHostSuffix": ".ws.minimal-test.gitpod.com",
-          "workspaceHostSuffixRegex": "\\.ws[^\\.]*\\.minimal-test.gitpod.com"
+          "hostName": "gitpod.example.com",
+          "workspaceHostSuffix": ".ws.gitpod.example.com",
+          "workspaceHostSuffixRegex": "\\.ws[^\\.]*\\.gitpod.example.com"
         },
         "workspacePodConfig": {
           "theiaPort": 23000,
@@ -5863,7 +5863,7 @@ kind: Service
 metadata:
   annotations:
     cloud.google.com/neg: '{"exposed_ports": {"80":{},"443": {}}}'
-    external-dns.alpha.kubernetes.io/hostname: minimal-test.gitpod.com,*.minimal-test.gitpod.com,*.ws.minimal-test.gitpod.com
+    external-dns.alpha.kubernetes.io/hostname: gitpod.example.com,*.gitpod.example.com,*.ws.gitpod.example.com
   creationTimestamp: null
   labels:
     app: gitpod
@@ -6041,7 +6041,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   annotations:
-    gitpod.io/checksum_config: 6953509cf3cc9e054d55384d788fb0de0bd798b969d752d7e1c40b75de4b4a62
+    gitpod.io/checksum_config: e5f1dd2a1327394b4bef4172c43487842026ef965fe8cec2475f00b1588de01f
   creationTimestamp: null
   labels:
     app: gitpod
@@ -6078,13 +6078,13 @@ spec:
         - /config/config.json
         env:
         - name: GITPOD_DOMAIN
-          value: minimal-test.gitpod.com
+          value: gitpod.example.com
         - name: GITPOD_INSTALLATION_SHORTNAME
           value: default
         - name: GITPOD_REGION
           value: local
         - name: HOST_URL
-          value: https://minimal-test.gitpod.com
+          value: https://gitpod.example.com
         - name: KUBE_NAMESPACE
           valueFrom:
             fieldRef:
@@ -6193,13 +6193,13 @@ spec:
         - /mnt/config/config.json
         env:
         - name: GITPOD_DOMAIN
-          value: minimal-test.gitpod.com
+          value: gitpod.example.com
         - name: GITPOD_INSTALLATION_SHORTNAME
           value: default
         - name: GITPOD_REGION
           value: local
         - name: HOST_URL
-          value: https://minimal-test.gitpod.com
+          value: https://gitpod.example.com
         - name: KUBE_NAMESPACE
           valueFrom:
             fieldRef:
@@ -6374,7 +6374,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 7b3c26f99bf554df16b50f731d661892d434d46344675d315726d6782b518ec6
+        gitpod.io/checksum_config: f23d3442050785945a5c6109bc25a11f48414e6b0ba3734f499e40def0ce8a6d
         seccomp.security.alpha.kubernetes.io/shiftfs-module-loader: unconfined
       creationTimestamp: null
       labels:
@@ -6398,13 +6398,13 @@ spec:
         - /config/config.json
         env:
         - name: GITPOD_DOMAIN
-          value: minimal-test.gitpod.com
+          value: gitpod.example.com
         - name: GITPOD_INSTALLATION_SHORTNAME
           value: default
         - name: GITPOD_REGION
           value: local
         - name: HOST_URL
-          value: https://minimal-test.gitpod.com
+          value: https://gitpod.example.com
         - name: KUBE_NAMESPACE
           valueFrom:
             fieldRef:
@@ -7009,7 +7009,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 241a200000160fb1de7b54c3b4b8f84deda8a1aeec7b002a62e713da8e141a33
+        gitpod.io/checksum_config: 7c868f444d805d107d758063ca5d27eb27acce6de2e5a5d917d0a5bb46cc13b6
       creationTimestamp: null
       labels:
         app: gitpod
@@ -7029,13 +7029,13 @@ spec:
             - /config/config.json
           env:
             - name: GITPOD_DOMAIN
-              value: minimal-test.gitpod.com
+              value: gitpod.example.com
             - name: GITPOD_INSTALLATION_SHORTNAME
               value: default
             - name: GITPOD_REGION
               value: local
             - name: HOST_URL
-              value: https://minimal-test.gitpod.com
+              value: https://gitpod.example.com
             - name: KUBE_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -7156,7 +7156,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 262835c16ef5b84c2a90ab17cc4232ca5dbd48408c36a3452d3a74e23f1aec84
+        gitpod.io/checksum_config: 852534778d4ef3fe1d87dd19fa8290cf02561d3b98c11493053ee39ea8a627b4
       creationTimestamp: null
       labels:
         app: gitpod
@@ -7177,13 +7177,13 @@ spec:
         - /mnt/config/config.json
         env:
         - name: GITPOD_DOMAIN
-          value: minimal-test.gitpod.com
+          value: gitpod.example.com
         - name: GITPOD_INSTALLATION_SHORTNAME
           value: default
         - name: GITPOD_REGION
           value: local
         - name: HOST_URL
-          value: https://minimal-test.gitpod.com
+          value: https://gitpod.example.com
         - name: KUBE_NAMESPACE
           valueFrom:
             fieldRef:
@@ -7316,13 +7316,13 @@ spec:
         - /config/config.json
         env:
         - name: GITPOD_DOMAIN
-          value: minimal-test.gitpod.com
+          value: gitpod.example.com
         - name: GITPOD_INSTALLATION_SHORTNAME
           value: default
         - name: GITPOD_REGION
           value: local
         - name: HOST_URL
-          value: https://minimal-test.gitpod.com
+          value: https://gitpod.example.com
         - name: KUBE_NAMESPACE
           valueFrom:
             fieldRef:
@@ -7428,13 +7428,13 @@ spec:
       containers:
       - env:
         - name: GITPOD_DOMAIN
-          value: minimal-test.gitpod.com
+          value: gitpod.example.com
         - name: GITPOD_INSTALLATION_SHORTNAME
           value: default
         - name: GITPOD_REGION
           value: local
         - name: HOST_URL
-          value: https://minimal-test.gitpod.com
+          value: https://gitpod.example.com
         - name: KUBE_NAMESPACE
           valueFrom:
             fieldRef:
@@ -7514,13 +7514,13 @@ spec:
         - /config/config.json
         env:
         - name: GITPOD_DOMAIN
-          value: minimal-test.gitpod.com
+          value: gitpod.example.com
         - name: GITPOD_INSTALLATION_SHORTNAME
           value: default
         - name: GITPOD_REGION
           value: local
         - name: HOST_URL
-          value: https://minimal-test.gitpod.com
+          value: https://gitpod.example.com
         - name: KUBE_NAMESPACE
           valueFrom:
             fieldRef:
@@ -7625,13 +7625,13 @@ spec:
       containers:
       - env:
         - name: GITPOD_DOMAIN
-          value: minimal-test.gitpod.com
+          value: gitpod.example.com
         - name: GITPOD_INSTALLATION_SHORTNAME
           value: default
         - name: GITPOD_REGION
           value: local
         - name: HOST_URL
-          value: https://minimal-test.gitpod.com
+          value: https://gitpod.example.com
         - name: KUBE_NAMESPACE
           valueFrom:
             fieldRef:
@@ -7713,13 +7713,13 @@ spec:
         - /config/image-builder.json
         env:
         - name: GITPOD_DOMAIN
-          value: minimal-test.gitpod.com
+          value: gitpod.example.com
         - name: GITPOD_INSTALLATION_SHORTNAME
           value: default
         - name: GITPOD_REGION
           value: local
         - name: HOST_URL
-          value: https://minimal-test.gitpod.com
+          value: https://gitpod.example.com
         - name: KUBE_NAMESPACE
           valueFrom:
             fieldRef:
@@ -7948,7 +7948,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 58f3f5c52d162ce5a98c0323a1b089b258f70721e9b3bb3b1d152af6896ab619
+        gitpod.io/checksum_config: e6eea49478778c68ec71eee2aa5d2be8b67ebcfda86107a44d2cc80b88c1ecfe
       creationTimestamp: null
       labels:
         app: gitpod
@@ -7991,13 +7991,13 @@ spec:
           runAsUser: 65532
       - env:
         - name: GITPOD_DOMAIN
-          value: minimal-test.gitpod.com
+          value: gitpod.example.com
         - name: GITPOD_INSTALLATION_SHORTNAME
           value: default
         - name: GITPOD_REGION
           value: local
         - name: HOST_URL
-          value: https://minimal-test.gitpod.com
+          value: https://gitpod.example.com
         - name: KUBE_NAMESPACE
           valueFrom:
             fieldRef:
@@ -8007,7 +8007,7 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: PROXY_DOMAIN
-          value: minimal-test.gitpod.com
+          value: gitpod.example.com
         image: eu.gcr.io/gitpod-core-dev/build/proxy:test
         imagePullPolicy: IfNotPresent
         name: proxy
@@ -8094,7 +8094,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 03ddfd9ca77e5d762d5752ef22be533b7cbe0ccaf9013470f435b3959224727b
+        gitpod.io/checksum_config: 0bc76c867af13d6037264732e25991af8de7c19a2f2e91d1fb1e64df1a9833db
       creationTimestamp: null
       labels:
         app: gitpod
@@ -8112,13 +8112,13 @@ spec:
       containers:
       - env:
         - name: GITPOD_DOMAIN
-          value: minimal-test.gitpod.com
+          value: gitpod.example.com
         - name: GITPOD_INSTALLATION_SHORTNAME
           value: default
         - name: GITPOD_REGION
           value: local
         - name: HOST_URL
-          value: https://minimal-test.gitpod.com
+          value: https://gitpod.example.com
         - name: KUBE_NAMESPACE
           valueFrom:
             fieldRef:
@@ -8355,7 +8355,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 91334333afc36abcdd564e6271c0d52cc9aa33f735cb966f3eec38e64b625673
+        gitpod.io/checksum_config: 4ac62854eccd472efc91ccb1041633960da4448fe1534555abb4ac94fe22861d
       creationTimestamp: null
       labels:
         app: gitpod
@@ -8377,13 +8377,13 @@ spec:
         - /config/config.json
         env:
         - name: GITPOD_DOMAIN
-          value: minimal-test.gitpod.com
+          value: gitpod.example.com
         - name: GITPOD_INSTALLATION_SHORTNAME
           value: default
         - name: GITPOD_REGION
           value: local
         - name: HOST_URL
-          value: https://minimal-test.gitpod.com
+          value: https://gitpod.example.com
         - name: KUBE_NAMESPACE
           valueFrom:
             fieldRef:
@@ -8506,13 +8506,13 @@ spec:
       containers:
       - env:
         - name: GITPOD_DOMAIN
-          value: minimal-test.gitpod.com
+          value: gitpod.example.com
         - name: GITPOD_INSTALLATION_SHORTNAME
           value: default
         - name: GITPOD_REGION
           value: local
         - name: HOST_URL
-          value: https://minimal-test.gitpod.com
+          value: https://gitpod.example.com
         - name: KUBE_NAMESPACE
           valueFrom:
             fieldRef:
@@ -8728,7 +8728,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 877efb2e41ba2a82e0d19c011804fa2bff310f5a5a9cbba236a49bb4cf9ff176
+        gitpod.io/checksum_config: dcbc53af67e4007a4affc029e880c338b93e4484010727f4bf0a08ad7c93a112
       creationTimestamp: null
       labels:
         app: gitpod
@@ -8749,13 +8749,13 @@ spec:
         - /config/config.json
         env:
         - name: GITPOD_DOMAIN
-          value: minimal-test.gitpod.com
+          value: gitpod.example.com
         - name: GITPOD_INSTALLATION_SHORTNAME
           value: default
         - name: GITPOD_REGION
           value: local
         - name: HOST_URL
-          value: https://minimal-test.gitpod.com
+          value: https://gitpod.example.com
         - name: KUBE_NAMESPACE
           valueFrom:
             fieldRef:

--- a/install/installer/cmd/testdata/render/minimal/config.yaml
+++ b/install/installer/cmd/testdata/render/minimal/config.yaml
@@ -2,4 +2,4 @@
 # Licensed under the MIT License. See License-MIT.txt in the project root for license information.
 
 apiVersion: v1
-domain: minimal-test.gitpod.com
+domain: gitpod.example.com

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -537,7 +537,7 @@ metadata:
   namespace: default
 spec:
   dnsNames:
-  - reg.minimal-test.gitpod.com
+  - reg.gitpod.example.com
   duration: 2160h0m0s
   issuerRef:
     group: cert-manager.io
@@ -1191,7 +1191,7 @@ metadata:
 # v1/Secret builtin-registry-auth
 apiVersion: v1
 data:
-  .dockerconfigjson: eyJhdXRocyI6eyJyZWdpc3RyeS5taW5pbWFsLXRlc3QuZ2l0cG9kLmNvbSI6eyJhdXRoIjoiZUZObFpFcHBSR2RLVVZGbk5FSnJWelY0UzNVNlExYzBRMUpDYW1rMlVqQmlSMGM0TVdkNVJYaz0ifX19
+  .dockerconfigjson: eyJhdXRocyI6eyJyZWdpc3RyeS5naXRwb2QuZXhhbXBsZS5jb20iOnsiYXV0aCI6ImVGTmxaRXBwUkdkS1VWRm5ORUpyVnpWNFMzVTZRMWMwUTFKQ2FtazJVakJpUjBjNE1XZDVSWGs9In19fQ==
   password: Q1c0Q1JCamk2UjBiR0c4MWd5RXk=
   user: eFNlZEppRGdKUVFnNEJrVzV4S3U=
 kind: Secret
@@ -1372,7 +1372,7 @@ data:
   config.json: |-
     {
       "gitpodAPI": {
-        "hostURL": "https://minimal-test.gitpod.com",
+        "hostURL": "https://gitpod.example.com",
         "apiToken": ""
       },
       "enforcement": {},
@@ -1407,32 +1407,32 @@ data:
               {
                 "path": "/ide/out/vs/workbench/workbench.web.api.js",
                 "search": "vscode-cdn.net",
-                "replacement": "minimal-test.gitpod.com"
+                "replacement": "gitpod.example.com"
               },
               {
                 "path": "/ide/out/vs/workbench/workbench.web.main.js",
                 "search": "vscode-cdn.net",
-                "replacement": "minimal-test.gitpod.com"
+                "replacement": "gitpod.example.com"
               },
               {
                 "path": "/ide/out/vs/workbench/services/extensions/worker/extensionHostWorker.js",
                 "search": "vscode-cdn.net",
-                "replacement": "minimal-test.gitpod.com"
+                "replacement": "gitpod.example.com"
               },
               {
                 "path": "/ide/out/vs/workbench/workbench.web.api.js",
                 "search": "open-vsx.org",
-                "replacement": "open-vsx.minimal-test.gitpod.com"
+                "replacement": "open-vsx.gitpod.example.com"
               },
               {
                 "path": "/ide/out/vs/workbench/workbench.web.main.js",
                 "search": "open-vsx.org",
-                "replacement": "open-vsx.minimal-test.gitpod.com"
+                "replacement": "open-vsx.gitpod.example.com"
               },
               {
                 "path": "/ide/out/vs/workbench/workbench.web.main.js",
                 "search": "ide.gitpod.io/code/markeplace.json",
-                "replacement": "ide.minimal-test.gitpod.com/code/marketplace.json"
+                "replacement": "ide.gitpod.example.com/code/marketplace.json"
               }
             ],
             "inlineStatic": [
@@ -1595,7 +1595,7 @@ data:
     database:
       inCluster: true
     disableDefinitelyGp: true
-    domain: minimal-test.gitpod.com
+    domain: gitpod.example.com
     kind: Full
     metadata:
       region: local
@@ -2506,7 +2506,7 @@ data:
     metadata:
       annotations:
         cloud.google.com/neg: '{"exposed_ports": {"80":{},"443": {}}}'
-        external-dns.alpha.kubernetes.io/hostname: minimal-test.gitpod.com,*.minimal-test.gitpod.com,*.ws.minimal-test.gitpod.com
+        external-dns.alpha.kubernetes.io/hostname: gitpod.example.com,*.gitpod.example.com,*.ws.gitpod.example.com
       creationTimestamp: null
       labels:
         app: gitpod
@@ -2718,7 +2718,7 @@ data:
     kind: DaemonSet
     metadata:
       annotations:
-        gitpod.io/checksum_config: 6953509cf3cc9e054d55384d788fb0de0bd798b969d752d7e1c40b75de4b4a62
+        gitpod.io/checksum_config: e5f1dd2a1327394b4bef4172c43487842026ef965fe8cec2475f00b1588de01f
       creationTimestamp: null
       labels:
         app: gitpod
@@ -3715,8 +3715,8 @@ data:
         },
         "pullSecret": "builtin-registry-auth",
         "pullSecretFile": "/config/pull-secret.json",
-        "baseImageRepository": "registry.minimal-test.gitpod.com/base-images",
-        "workspaceImageRepository": "registry.minimal-test.gitpod.com/workspace-images",
+        "baseImageRepository": "registry.gitpod.example.com/base-images",
+        "workspaceImageRepository": "registry.gitpod.example.com/workspace-images",
         "builderImage": "eu.gcr.io/gitpod-core-dev/build/image-builder-mk3/bob:test"
       },
       "refCache": {
@@ -3809,7 +3809,7 @@ data:
       "cache_duration_regular": "5m0s",
       "cache_duration_backup": "72h0m0s",
       "url_upstream": "https://open-vsx.org",
-      "url_local": "https://open-vsx.minimal-test.gitpod.com",
+      "url_local": "https://open-vsx.gitpod.example.com",
       "max_idle_conns": 1000,
       "max_idle_conns_per_host": 1000,
       "redis_addr": "localhost:6379",
@@ -3829,7 +3829,7 @@ metadata:
 apiVersion: v1
 data:
   vhost.docker-registry: |-
-    https://registry.minimal-test.gitpod.com {
+    https://registry.gitpod.example.com {
         import enable_log
         import remove_server_header
         import ssl_configuration
@@ -3847,7 +3847,7 @@ data:
     }
   vhost.empty: '# Placeholder to avoid errors loading files using a glob pattern'
   vhost.ide-proxy: |
-    https://ide.minimal-test.gitpod.com {
+    https://ide.gitpod.example.com {
         import enable_log_debug
         import remove_server_header
         import ssl_configuration
@@ -3857,7 +3857,7 @@ data:
         }
     }
   vhost.minio: |-
-    https://minio.minimal-test.gitpod.com {
+    https://minio.gitpod.example.com {
         import enable_log
         import remove_server_header
         import ssl_configuration
@@ -3867,7 +3867,7 @@ data:
         }
     }
   vhost.open-vsx: |-
-    https://open-vsx.minimal-test.gitpod.com {
+    https://open-vsx.gitpod.example.com {
         import enable_log_debug
         import remove_server_header
         import ssl_configuration
@@ -3877,7 +3877,7 @@ data:
         }
     }
   vhost.payment-endpoint: |
-    https://payment.minimal-test.gitpod.com {
+    https://payment.gitpod.example.com {
         import enable_log
         import remove_server_header
         import ssl_configuration
@@ -4004,7 +4004,7 @@ data:
   config.json: |-
     {
       "version": "pd-ide-metrics.23",
-      "hostUrl": "https://minimal-test.gitpod.com",
+      "hostUrl": "https://gitpod.example.com",
       "installationShortname": "default",
       "devBranch": "",
       "insecureNoDomain": false,
@@ -4021,7 +4021,7 @@ data:
       "contentServiceAddr": "content-service:8080",
       "imageBuilderAddr": "image-builder-mk3:8080",
       "usageServiceAddr": "usage:9001",
-      "vsxRegistryUrl": "https://open-vsx.minimal-test.gitpod.com",
+      "vsxRegistryUrl": "https://open-vsx.gitpod.example.com",
       "chargebeeProviderOptionsFile": "/chargebee/providerOptions",
       "stripeSecretsFile": "/stripe-secret/apikeys",
       "stripeConfigFile": "/stripe-config/config",
@@ -4139,7 +4139,7 @@ data:
             "orderKey": "00",
             "title": "VS Code",
             "type": "browser",
-            "logo": "https://ide.minimal-test.gitpod.com/image/ide-logo/vscode.svg",
+            "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-034e1ea1e89e0b6a6be50de20bf67509111efa65",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
@@ -4148,7 +4148,7 @@ data:
             "orderKey": "02",
             "title": "VS Code",
             "type": "desktop",
-            "logo": "https://ide.minimal-test.gitpod.com/image/ide-logo/vscode.svg",
+            "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code-desktop:test",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code-desktop-insiders:test"
           },
@@ -4156,7 +4156,7 @@ data:
             "orderKey": "05",
             "title": "GoLand",
             "type": "desktop",
-            "logo": "https://ide.minimal-test.gitpod.com/image/ide-logo/golandLogo.svg",
+            "logo": "https://ide.gitpod.example.com/image/ide-logo/golandLogo.svg",
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/goland:test",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/goland:latest"
           },
@@ -4164,7 +4164,7 @@ data:
             "orderKey": "04",
             "title": "IntelliJ IDEA",
             "type": "desktop",
-            "logo": "https://ide.minimal-test.gitpod.com/image/ide-logo/intellijIdeaLogo.svg",
+            "logo": "https://ide.gitpod.example.com/image/ide-logo/intellijIdeaLogo.svg",
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/intellij:test",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/intellij:latest"
           },
@@ -4172,7 +4172,7 @@ data:
             "orderKey": "07",
             "title": "PhpStorm",
             "type": "desktop",
-            "logo": "https://ide.minimal-test.gitpod.com/image/ide-logo/phpstormLogo.svg",
+            "logo": "https://ide.gitpod.example.com/image/ide-logo/phpstormLogo.svg",
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/phpstorm:test",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/phpstorm:latest"
           },
@@ -4180,7 +4180,7 @@ data:
             "orderKey": "06",
             "title": "PyCharm",
             "type": "desktop",
-            "logo": "https://ide.minimal-test.gitpod.com/image/ide-logo/pycharmLogo.svg",
+            "logo": "https://ide.gitpod.example.com/image/ide-logo/pycharmLogo.svg",
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/pycharm:test",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/pycharm:latest"
           }
@@ -4334,7 +4334,7 @@ data:
             "registryFacade": [
               {
                 "addr": "127.0.0.1",
-                "name": "reg.minimal-test.gitpod.com"
+                "name": "reg.gitpod.example.com"
               }
             ]
           }
@@ -4391,11 +4391,11 @@ data:
         "initProbe": {
           "timeout": "1s"
         },
-        "urlTemplate": "https://{{ .Prefix }}.ws.minimal-test.gitpod.com",
-        "portUrlTemplate": "https://{{ .WorkspacePort }}-{{ .Prefix }}.ws.minimal-test.gitpod.com",
+        "urlTemplate": "https://{{ .Prefix }}.ws.gitpod.example.com",
+        "portUrlTemplate": "https://{{ .WorkspacePort }}-{{ .Prefix }}.ws.gitpod.example.com",
         "workspaceHostPath": "/var/gitpod/workspaces",
         "heartbeatInterval": "30s",
-        "hostURL": "https://minimal-test.gitpod.com",
+        "hostURL": "https://gitpod.example.com",
         "reconnectionInterval": "30s",
         "wsdaemon": {
           "port": 8080,
@@ -4405,8 +4405,8 @@ data:
             "key": "/ws-daemon-tls-certs/tls.key"
           }
         },
-        "registryFacadeHost": "reg.minimal-test.gitpod.com:20000",
-        "workspaceClusterHost": "ws.minimal-test.gitpod.com",
+        "registryFacadeHost": "reg.gitpod.example.com:20000",
+        "workspaceClusterHost": "ws.gitpod.example.com",
         "workspaceClass": {
           "default": {
             "name": "default",
@@ -4552,14 +4552,14 @@ data:
         },
         "blobServer": {
           "scheme": "https",
-          "host": "ide.minimal-test.gitpod.com",
+          "host": "ide.gitpod.example.com",
           "pathPrefix": "/blobserve"
         },
         "gitpodInstallation": {
           "scheme": "https",
-          "hostName": "minimal-test.gitpod.com",
-          "workspaceHostSuffix": ".ws.minimal-test.gitpod.com",
-          "workspaceHostSuffixRegex": "\\.ws[^\\.]*\\.minimal-test.gitpod.com"
+          "hostName": "gitpod.example.com",
+          "workspaceHostSuffix": ".ws.gitpod.example.com",
+          "workspaceHostSuffixRegex": "\\.ws[^\\.]*\\.gitpod.example.com"
         },
         "workspacePodConfig": {
           "theiaPort": 23000,
@@ -6120,7 +6120,7 @@ kind: Service
 metadata:
   annotations:
     cloud.google.com/neg: '{"exposed_ports": {"80":{},"443": {}}}'
-    external-dns.alpha.kubernetes.io/hostname: minimal-test.gitpod.com,*.minimal-test.gitpod.com,*.ws.minimal-test.gitpod.com
+    external-dns.alpha.kubernetes.io/hostname: gitpod.example.com,*.gitpod.example.com,*.ws.gitpod.example.com
   creationTimestamp: null
   labels:
     app: gitpod
@@ -6321,7 +6321,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   annotations:
-    gitpod.io/checksum_config: 6953509cf3cc9e054d55384d788fb0de0bd798b969d752d7e1c40b75de4b4a62
+    gitpod.io/checksum_config: e5f1dd2a1327394b4bef4172c43487842026ef965fe8cec2475f00b1588de01f
   creationTimestamp: null
   labels:
     app: gitpod
@@ -6358,13 +6358,13 @@ spec:
         - /config/config.json
         env:
         - name: GITPOD_DOMAIN
-          value: minimal-test.gitpod.com
+          value: gitpod.example.com
         - name: GITPOD_INSTALLATION_SHORTNAME
           value: default
         - name: GITPOD_REGION
           value: local
         - name: HOST_URL
-          value: https://minimal-test.gitpod.com
+          value: https://gitpod.example.com
         - name: KUBE_NAMESPACE
           valueFrom:
             fieldRef:
@@ -6473,13 +6473,13 @@ spec:
         - /mnt/config/config.json
         env:
         - name: GITPOD_DOMAIN
-          value: minimal-test.gitpod.com
+          value: gitpod.example.com
         - name: GITPOD_INSTALLATION_SHORTNAME
           value: default
         - name: GITPOD_REGION
           value: local
         - name: HOST_URL
-          value: https://minimal-test.gitpod.com
+          value: https://gitpod.example.com
         - name: KUBE_NAMESPACE
           valueFrom:
             fieldRef:
@@ -6654,7 +6654,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 7b3c26f99bf554df16b50f731d661892d434d46344675d315726d6782b518ec6
+        gitpod.io/checksum_config: f23d3442050785945a5c6109bc25a11f48414e6b0ba3734f499e40def0ce8a6d
         seccomp.security.alpha.kubernetes.io/shiftfs-module-loader: unconfined
       creationTimestamp: null
       labels:
@@ -6678,13 +6678,13 @@ spec:
         - /config/config.json
         env:
         - name: GITPOD_DOMAIN
-          value: minimal-test.gitpod.com
+          value: gitpod.example.com
         - name: GITPOD_INSTALLATION_SHORTNAME
           value: default
         - name: GITPOD_REGION
           value: local
         - name: HOST_URL
-          value: https://minimal-test.gitpod.com
+          value: https://gitpod.example.com
         - name: KUBE_NAMESPACE
           valueFrom:
             fieldRef:
@@ -7289,7 +7289,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 241a200000160fb1de7b54c3b4b8f84deda8a1aeec7b002a62e713da8e141a33
+        gitpod.io/checksum_config: 7c868f444d805d107d758063ca5d27eb27acce6de2e5a5d917d0a5bb46cc13b6
       creationTimestamp: null
       labels:
         app: gitpod
@@ -7309,13 +7309,13 @@ spec:
             - /config/config.json
           env:
             - name: GITPOD_DOMAIN
-              value: minimal-test.gitpod.com
+              value: gitpod.example.com
             - name: GITPOD_INSTALLATION_SHORTNAME
               value: default
             - name: GITPOD_REGION
               value: local
             - name: HOST_URL
-              value: https://minimal-test.gitpod.com
+              value: https://gitpod.example.com
             - name: KUBE_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -7436,7 +7436,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: d2c36ebee01aaa9b448075b9c868cbf6abc18874d7cbc537c500683f1b6109ef
+        gitpod.io/checksum_config: 9a515b004a89b33642ea51cf15082f48f0912d8ca3d54c20bfc2f032e550931c
       creationTimestamp: null
       labels:
         app: gitpod
@@ -7457,13 +7457,13 @@ spec:
         - /mnt/config/config.json
         env:
         - name: GITPOD_DOMAIN
-          value: minimal-test.gitpod.com
+          value: gitpod.example.com
         - name: GITPOD_INSTALLATION_SHORTNAME
           value: default
         - name: GITPOD_REGION
           value: local
         - name: HOST_URL
-          value: https://minimal-test.gitpod.com
+          value: https://gitpod.example.com
         - name: KUBE_NAMESPACE
           valueFrom:
             fieldRef:
@@ -7596,13 +7596,13 @@ spec:
         - /config/config.json
         env:
         - name: GITPOD_DOMAIN
-          value: minimal-test.gitpod.com
+          value: gitpod.example.com
         - name: GITPOD_INSTALLATION_SHORTNAME
           value: default
         - name: GITPOD_REGION
           value: local
         - name: HOST_URL
-          value: https://minimal-test.gitpod.com
+          value: https://gitpod.example.com
         - name: KUBE_NAMESPACE
           valueFrom:
             fieldRef:
@@ -7708,13 +7708,13 @@ spec:
       containers:
       - env:
         - name: GITPOD_DOMAIN
-          value: minimal-test.gitpod.com
+          value: gitpod.example.com
         - name: GITPOD_INSTALLATION_SHORTNAME
           value: default
         - name: GITPOD_REGION
           value: local
         - name: HOST_URL
-          value: https://minimal-test.gitpod.com
+          value: https://gitpod.example.com
         - name: KUBE_NAMESPACE
           valueFrom:
             fieldRef:
@@ -7794,13 +7794,13 @@ spec:
         - /config/config.json
         env:
         - name: GITPOD_DOMAIN
-          value: minimal-test.gitpod.com
+          value: gitpod.example.com
         - name: GITPOD_INSTALLATION_SHORTNAME
           value: default
         - name: GITPOD_REGION
           value: local
         - name: HOST_URL
-          value: https://minimal-test.gitpod.com
+          value: https://gitpod.example.com
         - name: KUBE_NAMESPACE
           valueFrom:
             fieldRef:
@@ -7905,13 +7905,13 @@ spec:
       containers:
       - env:
         - name: GITPOD_DOMAIN
-          value: minimal-test.gitpod.com
+          value: gitpod.example.com
         - name: GITPOD_INSTALLATION_SHORTNAME
           value: default
         - name: GITPOD_REGION
           value: local
         - name: HOST_URL
-          value: https://minimal-test.gitpod.com
+          value: https://gitpod.example.com
         - name: KUBE_NAMESPACE
           valueFrom:
             fieldRef:
@@ -7971,7 +7971,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 02d7698e64b8dddb6eeca7a683b69c5cc8895cebdcfe2c94d80f56526c5cec0a
+        gitpod.io/checksum_config: 5a02760487dc021fb50bdfc0d92a3a453348b226fb74729cd57a33927d5b6e08
       creationTimestamp: null
       labels:
         app: gitpod
@@ -7993,13 +7993,13 @@ spec:
         - /config/image-builder.json
         env:
         - name: GITPOD_DOMAIN
-          value: minimal-test.gitpod.com
+          value: gitpod.example.com
         - name: GITPOD_INSTALLATION_SHORTNAME
           value: default
         - name: GITPOD_REGION
           value: local
         - name: HOST_URL
-          value: https://minimal-test.gitpod.com
+          value: https://gitpod.example.com
         - name: KUBE_NAMESPACE
           valueFrom:
             fieldRef:
@@ -8228,7 +8228,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: e7bd0fbf14bea22bc368a35dacba85c5ed8b12f98149b351f0038af13985dddf
+        gitpod.io/checksum_config: c52c73e63eaa95613a8f4fe77167c754cd48eaf757dd69c2048400311a5ae0a6
       creationTimestamp: null
       labels:
         app: gitpod
@@ -8271,13 +8271,13 @@ spec:
           runAsUser: 65532
       - env:
         - name: GITPOD_DOMAIN
-          value: minimal-test.gitpod.com
+          value: gitpod.example.com
         - name: GITPOD_INSTALLATION_SHORTNAME
           value: default
         - name: GITPOD_REGION
           value: local
         - name: HOST_URL
-          value: https://minimal-test.gitpod.com
+          value: https://gitpod.example.com
         - name: KUBE_NAMESPACE
           valueFrom:
             fieldRef:
@@ -8287,7 +8287,7 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: PROXY_DOMAIN
-          value: minimal-test.gitpod.com
+          value: gitpod.example.com
         image: eu.gcr.io/gitpod-core-dev/build/proxy:test
         imagePullPolicy: IfNotPresent
         name: proxy
@@ -8469,7 +8469,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 03ddfd9ca77e5d762d5752ef22be533b7cbe0ccaf9013470f435b3959224727b
+        gitpod.io/checksum_config: 0bc76c867af13d6037264732e25991af8de7c19a2f2e91d1fb1e64df1a9833db
       creationTimestamp: null
       labels:
         app: gitpod
@@ -8487,13 +8487,13 @@ spec:
       containers:
       - env:
         - name: GITPOD_DOMAIN
-          value: minimal-test.gitpod.com
+          value: gitpod.example.com
         - name: GITPOD_INSTALLATION_SHORTNAME
           value: default
         - name: GITPOD_REGION
           value: local
         - name: HOST_URL
-          value: https://minimal-test.gitpod.com
+          value: https://gitpod.example.com
         - name: KUBE_NAMESPACE
           valueFrom:
             fieldRef:
@@ -8730,7 +8730,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 91334333afc36abcdd564e6271c0d52cc9aa33f735cb966f3eec38e64b625673
+        gitpod.io/checksum_config: 4ac62854eccd472efc91ccb1041633960da4448fe1534555abb4ac94fe22861d
       creationTimestamp: null
       labels:
         app: gitpod
@@ -8752,13 +8752,13 @@ spec:
         - /config/config.json
         env:
         - name: GITPOD_DOMAIN
-          value: minimal-test.gitpod.com
+          value: gitpod.example.com
         - name: GITPOD_INSTALLATION_SHORTNAME
           value: default
         - name: GITPOD_REGION
           value: local
         - name: HOST_URL
-          value: https://minimal-test.gitpod.com
+          value: https://gitpod.example.com
         - name: KUBE_NAMESPACE
           valueFrom:
             fieldRef:
@@ -8881,13 +8881,13 @@ spec:
       containers:
       - env:
         - name: GITPOD_DOMAIN
-          value: minimal-test.gitpod.com
+          value: gitpod.example.com
         - name: GITPOD_INSTALLATION_SHORTNAME
           value: default
         - name: GITPOD_REGION
           value: local
         - name: HOST_URL
-          value: https://minimal-test.gitpod.com
+          value: https://gitpod.example.com
         - name: KUBE_NAMESPACE
           valueFrom:
             fieldRef:
@@ -9103,7 +9103,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 877efb2e41ba2a82e0d19c011804fa2bff310f5a5a9cbba236a49bb4cf9ff176
+        gitpod.io/checksum_config: dcbc53af67e4007a4affc029e880c338b93e4484010727f4bf0a08ad7c93a112
       creationTimestamp: null
       labels:
         app: gitpod
@@ -9124,13 +9124,13 @@ spec:
         - /config/config.json
         env:
         - name: GITPOD_DOMAIN
-          value: minimal-test.gitpod.com
+          value: gitpod.example.com
         - name: GITPOD_INSTALLATION_SHORTNAME
           value: default
         - name: GITPOD_REGION
           value: local
         - name: HOST_URL
-          value: https://minimal-test.gitpod.com
+          value: https://gitpod.example.com
         - name: KUBE_NAMESPACE
           valueFrom:
             fieldRef:

--- a/install/installer/cmd/testdata/render/statefulset-customization/config.yaml
+++ b/install/installer/cmd/testdata/render/statefulset-customization/config.yaml
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See License-MIT.txt in the project root for license information.
 
 apiVersion: v1
-domain: statefulset-customization-test.gitpod.com
+domain: gitpod.example.com
 customization:
   - apiVersion: apps/v1
     kind: StatefulSet

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -537,7 +537,7 @@ metadata:
   namespace: default
 spec:
   dnsNames:
-  - reg.statefulset-customization-test.gitpod.com
+  - reg.gitpod.example.com
   duration: 2160h0m0s
   issuerRef:
     group: cert-manager.io
@@ -1191,7 +1191,7 @@ metadata:
 # v1/Secret builtin-registry-auth
 apiVersion: v1
 data:
-  .dockerconfigjson: eyJhdXRocyI6eyJyZWdpc3RyeS5zdGF0ZWZ1bHNldC1jdXN0b21pemF0aW9uLXRlc3QuZ2l0cG9kLmNvbSI6eyJhdXRoIjoiZUZObFpFcHBSR2RLVVZGbk5FSnJWelY0UzNVNlExYzBRMUpDYW1rMlVqQmlSMGM0TVdkNVJYaz0ifX19
+  .dockerconfigjson: eyJhdXRocyI6eyJyZWdpc3RyeS5naXRwb2QuZXhhbXBsZS5jb20iOnsiYXV0aCI6ImVGTmxaRXBwUkdkS1VWRm5ORUpyVnpWNFMzVTZRMWMwUTFKQ2FtazJVakJpUjBjNE1XZDVSWGs9In19fQ==
   password: Q1c0Q1JCamk2UjBiR0c4MWd5RXk=
   user: eFNlZEppRGdKUVFnNEJrVzV4S3U=
 kind: Secret
@@ -1372,7 +1372,7 @@ data:
   config.json: |-
     {
       "gitpodAPI": {
-        "hostURL": "https://statefulset-customization-test.gitpod.com",
+        "hostURL": "https://gitpod.example.com",
         "apiToken": ""
       },
       "enforcement": {},
@@ -1407,32 +1407,32 @@ data:
               {
                 "path": "/ide/out/vs/workbench/workbench.web.api.js",
                 "search": "vscode-cdn.net",
-                "replacement": "statefulset-customization-test.gitpod.com"
+                "replacement": "gitpod.example.com"
               },
               {
                 "path": "/ide/out/vs/workbench/workbench.web.main.js",
                 "search": "vscode-cdn.net",
-                "replacement": "statefulset-customization-test.gitpod.com"
+                "replacement": "gitpod.example.com"
               },
               {
                 "path": "/ide/out/vs/workbench/services/extensions/worker/extensionHostWorker.js",
                 "search": "vscode-cdn.net",
-                "replacement": "statefulset-customization-test.gitpod.com"
+                "replacement": "gitpod.example.com"
               },
               {
                 "path": "/ide/out/vs/workbench/workbench.web.api.js",
                 "search": "open-vsx.org",
-                "replacement": "open-vsx.statefulset-customization-test.gitpod.com"
+                "replacement": "open-vsx.gitpod.example.com"
               },
               {
                 "path": "/ide/out/vs/workbench/workbench.web.main.js",
                 "search": "open-vsx.org",
-                "replacement": "open-vsx.statefulset-customization-test.gitpod.com"
+                "replacement": "open-vsx.gitpod.example.com"
               },
               {
                 "path": "/ide/out/vs/workbench/workbench.web.main.js",
                 "search": "ide.gitpod.io/code/markeplace.json",
-                "replacement": "ide.statefulset-customization-test.gitpod.com/code/marketplace.json"
+                "replacement": "ide.gitpod.example.com/code/marketplace.json"
               }
             ],
             "inlineStatic": [
@@ -1607,7 +1607,7 @@ data:
     database:
       inCluster: true
     disableDefinitelyGp: true
-    domain: statefulset-customization-test.gitpod.com
+    domain: gitpod.example.com
     kind: Full
     metadata:
       region: local
@@ -2518,7 +2518,7 @@ data:
     metadata:
       annotations:
         cloud.google.com/neg: '{"exposed_ports": {"80":{},"443": {}}}'
-        external-dns.alpha.kubernetes.io/hostname: statefulset-customization-test.gitpod.com,*.statefulset-customization-test.gitpod.com,*.ws.statefulset-customization-test.gitpod.com
+        external-dns.alpha.kubernetes.io/hostname: gitpod.example.com,*.gitpod.example.com,*.ws.gitpod.example.com
       creationTimestamp: null
       labels:
         app: gitpod
@@ -2730,7 +2730,7 @@ data:
     kind: DaemonSet
     metadata:
       annotations:
-        gitpod.io/checksum_config: a27161ee959600e8bdd84a2485842ba8490e222457c3ecf42700be99ab0617f0
+        gitpod.io/checksum_config: e5f1dd2a1327394b4bef4172c43487842026ef965fe8cec2475f00b1588de01f
       creationTimestamp: null
       labels:
         app: gitpod
@@ -3727,8 +3727,8 @@ data:
         },
         "pullSecret": "builtin-registry-auth",
         "pullSecretFile": "/config/pull-secret.json",
-        "baseImageRepository": "registry.statefulset-customization-test.gitpod.com/base-images",
-        "workspaceImageRepository": "registry.statefulset-customization-test.gitpod.com/workspace-images",
+        "baseImageRepository": "registry.gitpod.example.com/base-images",
+        "workspaceImageRepository": "registry.gitpod.example.com/workspace-images",
         "builderImage": "eu.gcr.io/gitpod-core-dev/build/image-builder-mk3/bob:test"
       },
       "refCache": {
@@ -3821,7 +3821,7 @@ data:
       "cache_duration_regular": "5m0s",
       "cache_duration_backup": "72h0m0s",
       "url_upstream": "https://open-vsx.org",
-      "url_local": "https://open-vsx.statefulset-customization-test.gitpod.com",
+      "url_local": "https://open-vsx.gitpod.example.com",
       "max_idle_conns": 1000,
       "max_idle_conns_per_host": 1000,
       "redis_addr": "localhost:6379",
@@ -3841,7 +3841,7 @@ metadata:
 apiVersion: v1
 data:
   vhost.docker-registry: |-
-    https://registry.statefulset-customization-test.gitpod.com {
+    https://registry.gitpod.example.com {
         import enable_log
         import remove_server_header
         import ssl_configuration
@@ -3859,7 +3859,7 @@ data:
     }
   vhost.empty: '# Placeholder to avoid errors loading files using a glob pattern'
   vhost.ide-proxy: |
-    https://ide.statefulset-customization-test.gitpod.com {
+    https://ide.gitpod.example.com {
         import enable_log_debug
         import remove_server_header
         import ssl_configuration
@@ -3869,7 +3869,7 @@ data:
         }
     }
   vhost.minio: |-
-    https://minio.statefulset-customization-test.gitpod.com {
+    https://minio.gitpod.example.com {
         import enable_log
         import remove_server_header
         import ssl_configuration
@@ -3879,7 +3879,7 @@ data:
         }
     }
   vhost.open-vsx: |-
-    https://open-vsx.statefulset-customization-test.gitpod.com {
+    https://open-vsx.gitpod.example.com {
         import enable_log_debug
         import remove_server_header
         import ssl_configuration
@@ -3889,7 +3889,7 @@ data:
         }
     }
   vhost.payment-endpoint: |
-    https://payment.statefulset-customization-test.gitpod.com {
+    https://payment.gitpod.example.com {
         import enable_log
         import remove_server_header
         import ssl_configuration
@@ -4016,7 +4016,7 @@ data:
   config.json: |-
     {
       "version": "pd-ide-metrics.23",
-      "hostUrl": "https://statefulset-customization-test.gitpod.com",
+      "hostUrl": "https://gitpod.example.com",
       "installationShortname": "default",
       "devBranch": "",
       "insecureNoDomain": false,
@@ -4033,7 +4033,7 @@ data:
       "contentServiceAddr": "content-service:8080",
       "imageBuilderAddr": "image-builder-mk3:8080",
       "usageServiceAddr": "usage:9001",
-      "vsxRegistryUrl": "https://open-vsx.statefulset-customization-test.gitpod.com",
+      "vsxRegistryUrl": "https://open-vsx.gitpod.example.com",
       "chargebeeProviderOptionsFile": "/chargebee/providerOptions",
       "stripeSecretsFile": "/stripe-secret/apikeys",
       "stripeConfigFile": "/stripe-config/config",
@@ -4151,7 +4151,7 @@ data:
             "orderKey": "00",
             "title": "VS Code",
             "type": "browser",
-            "logo": "https://ide.statefulset-customization-test.gitpod.com/image/ide-logo/vscode.svg",
+            "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-034e1ea1e89e0b6a6be50de20bf67509111efa65",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
@@ -4160,7 +4160,7 @@ data:
             "orderKey": "02",
             "title": "VS Code",
             "type": "desktop",
-            "logo": "https://ide.statefulset-customization-test.gitpod.com/image/ide-logo/vscode.svg",
+            "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code-desktop:test",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code-desktop-insiders:test"
           },
@@ -4168,7 +4168,7 @@ data:
             "orderKey": "05",
             "title": "GoLand",
             "type": "desktop",
-            "logo": "https://ide.statefulset-customization-test.gitpod.com/image/ide-logo/golandLogo.svg",
+            "logo": "https://ide.gitpod.example.com/image/ide-logo/golandLogo.svg",
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/goland:test",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/goland:latest"
           },
@@ -4176,7 +4176,7 @@ data:
             "orderKey": "04",
             "title": "IntelliJ IDEA",
             "type": "desktop",
-            "logo": "https://ide.statefulset-customization-test.gitpod.com/image/ide-logo/intellijIdeaLogo.svg",
+            "logo": "https://ide.gitpod.example.com/image/ide-logo/intellijIdeaLogo.svg",
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/intellij:test",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/intellij:latest"
           },
@@ -4184,7 +4184,7 @@ data:
             "orderKey": "07",
             "title": "PhpStorm",
             "type": "desktop",
-            "logo": "https://ide.statefulset-customization-test.gitpod.com/image/ide-logo/phpstormLogo.svg",
+            "logo": "https://ide.gitpod.example.com/image/ide-logo/phpstormLogo.svg",
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/phpstorm:test",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/phpstorm:latest"
           },
@@ -4192,7 +4192,7 @@ data:
             "orderKey": "06",
             "title": "PyCharm",
             "type": "desktop",
-            "logo": "https://ide.statefulset-customization-test.gitpod.com/image/ide-logo/pycharmLogo.svg",
+            "logo": "https://ide.gitpod.example.com/image/ide-logo/pycharmLogo.svg",
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/pycharm:test",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/pycharm:latest"
           }
@@ -4346,7 +4346,7 @@ data:
             "registryFacade": [
               {
                 "addr": "127.0.0.1",
-                "name": "reg.statefulset-customization-test.gitpod.com"
+                "name": "reg.gitpod.example.com"
               }
             ]
           }
@@ -4403,11 +4403,11 @@ data:
         "initProbe": {
           "timeout": "1s"
         },
-        "urlTemplate": "https://{{ .Prefix }}.ws.statefulset-customization-test.gitpod.com",
-        "portUrlTemplate": "https://{{ .WorkspacePort }}-{{ .Prefix }}.ws.statefulset-customization-test.gitpod.com",
+        "urlTemplate": "https://{{ .Prefix }}.ws.gitpod.example.com",
+        "portUrlTemplate": "https://{{ .WorkspacePort }}-{{ .Prefix }}.ws.gitpod.example.com",
         "workspaceHostPath": "/var/gitpod/workspaces",
         "heartbeatInterval": "30s",
-        "hostURL": "https://statefulset-customization-test.gitpod.com",
+        "hostURL": "https://gitpod.example.com",
         "reconnectionInterval": "30s",
         "wsdaemon": {
           "port": 8080,
@@ -4417,8 +4417,8 @@ data:
             "key": "/ws-daemon-tls-certs/tls.key"
           }
         },
-        "registryFacadeHost": "reg.statefulset-customization-test.gitpod.com:20000",
-        "workspaceClusterHost": "ws.statefulset-customization-test.gitpod.com",
+        "registryFacadeHost": "reg.gitpod.example.com:20000",
+        "workspaceClusterHost": "ws.gitpod.example.com",
         "workspaceClass": {
           "default": {
             "name": "default",
@@ -4564,14 +4564,14 @@ data:
         },
         "blobServer": {
           "scheme": "https",
-          "host": "ide.statefulset-customization-test.gitpod.com",
+          "host": "ide.gitpod.example.com",
           "pathPrefix": "/blobserve"
         },
         "gitpodInstallation": {
           "scheme": "https",
-          "hostName": "statefulset-customization-test.gitpod.com",
-          "workspaceHostSuffix": ".ws.statefulset-customization-test.gitpod.com",
-          "workspaceHostSuffixRegex": "\\.ws[^\\.]*\\.statefulset-customization-test.gitpod.com"
+          "hostName": "gitpod.example.com",
+          "workspaceHostSuffix": ".ws.gitpod.example.com",
+          "workspaceHostSuffixRegex": "\\.ws[^\\.]*\\.gitpod.example.com"
         },
         "workspacePodConfig": {
           "theiaPort": 23000,
@@ -6132,7 +6132,7 @@ kind: Service
 metadata:
   annotations:
     cloud.google.com/neg: '{"exposed_ports": {"80":{},"443": {}}}'
-    external-dns.alpha.kubernetes.io/hostname: statefulset-customization-test.gitpod.com,*.statefulset-customization-test.gitpod.com,*.ws.statefulset-customization-test.gitpod.com
+    external-dns.alpha.kubernetes.io/hostname: gitpod.example.com,*.gitpod.example.com,*.ws.gitpod.example.com
   creationTimestamp: null
   labels:
     app: gitpod
@@ -6333,7 +6333,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   annotations:
-    gitpod.io/checksum_config: a27161ee959600e8bdd84a2485842ba8490e222457c3ecf42700be99ab0617f0
+    gitpod.io/checksum_config: e5f1dd2a1327394b4bef4172c43487842026ef965fe8cec2475f00b1588de01f
   creationTimestamp: null
   labels:
     app: gitpod
@@ -6370,13 +6370,13 @@ spec:
         - /config/config.json
         env:
         - name: GITPOD_DOMAIN
-          value: statefulset-customization-test.gitpod.com
+          value: gitpod.example.com
         - name: GITPOD_INSTALLATION_SHORTNAME
           value: default
         - name: GITPOD_REGION
           value: local
         - name: HOST_URL
-          value: https://statefulset-customization-test.gitpod.com
+          value: https://gitpod.example.com
         - name: KUBE_NAMESPACE
           valueFrom:
             fieldRef:
@@ -6485,13 +6485,13 @@ spec:
         - /mnt/config/config.json
         env:
         - name: GITPOD_DOMAIN
-          value: statefulset-customization-test.gitpod.com
+          value: gitpod.example.com
         - name: GITPOD_INSTALLATION_SHORTNAME
           value: default
         - name: GITPOD_REGION
           value: local
         - name: HOST_URL
-          value: https://statefulset-customization-test.gitpod.com
+          value: https://gitpod.example.com
         - name: KUBE_NAMESPACE
           valueFrom:
             fieldRef:
@@ -6666,7 +6666,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 8f68ad77b5ec911b348da795ea435d45f5cf2ab73d44207b99a56bc8dd80fd31
+        gitpod.io/checksum_config: f23d3442050785945a5c6109bc25a11f48414e6b0ba3734f499e40def0ce8a6d
         seccomp.security.alpha.kubernetes.io/shiftfs-module-loader: unconfined
       creationTimestamp: null
       labels:
@@ -6690,13 +6690,13 @@ spec:
         - /config/config.json
         env:
         - name: GITPOD_DOMAIN
-          value: statefulset-customization-test.gitpod.com
+          value: gitpod.example.com
         - name: GITPOD_INSTALLATION_SHORTNAME
           value: default
         - name: GITPOD_REGION
           value: local
         - name: HOST_URL
-          value: https://statefulset-customization-test.gitpod.com
+          value: https://gitpod.example.com
         - name: KUBE_NAMESPACE
           valueFrom:
             fieldRef:
@@ -7301,7 +7301,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 0ae3f24e57cd38cdd6ab3c567d29e9959b2c553c6415b9ad9c2c43f385561970
+        gitpod.io/checksum_config: 7c868f444d805d107d758063ca5d27eb27acce6de2e5a5d917d0a5bb46cc13b6
       creationTimestamp: null
       labels:
         app: gitpod
@@ -7321,13 +7321,13 @@ spec:
             - /config/config.json
           env:
             - name: GITPOD_DOMAIN
-              value: statefulset-customization-test.gitpod.com
+              value: gitpod.example.com
             - name: GITPOD_INSTALLATION_SHORTNAME
               value: default
             - name: GITPOD_REGION
               value: local
             - name: HOST_URL
-              value: https://statefulset-customization-test.gitpod.com
+              value: https://gitpod.example.com
             - name: KUBE_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -7448,7 +7448,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 7c88dccc712ea64ecd86afda2086d1d8e881aac6e16c8781d4cff3d4c0afb470
+        gitpod.io/checksum_config: 9a515b004a89b33642ea51cf15082f48f0912d8ca3d54c20bfc2f032e550931c
       creationTimestamp: null
       labels:
         app: gitpod
@@ -7469,13 +7469,13 @@ spec:
         - /mnt/config/config.json
         env:
         - name: GITPOD_DOMAIN
-          value: statefulset-customization-test.gitpod.com
+          value: gitpod.example.com
         - name: GITPOD_INSTALLATION_SHORTNAME
           value: default
         - name: GITPOD_REGION
           value: local
         - name: HOST_URL
-          value: https://statefulset-customization-test.gitpod.com
+          value: https://gitpod.example.com
         - name: KUBE_NAMESPACE
           valueFrom:
             fieldRef:
@@ -7608,13 +7608,13 @@ spec:
         - /config/config.json
         env:
         - name: GITPOD_DOMAIN
-          value: statefulset-customization-test.gitpod.com
+          value: gitpod.example.com
         - name: GITPOD_INSTALLATION_SHORTNAME
           value: default
         - name: GITPOD_REGION
           value: local
         - name: HOST_URL
-          value: https://statefulset-customization-test.gitpod.com
+          value: https://gitpod.example.com
         - name: KUBE_NAMESPACE
           valueFrom:
             fieldRef:
@@ -7720,13 +7720,13 @@ spec:
       containers:
       - env:
         - name: GITPOD_DOMAIN
-          value: statefulset-customization-test.gitpod.com
+          value: gitpod.example.com
         - name: GITPOD_INSTALLATION_SHORTNAME
           value: default
         - name: GITPOD_REGION
           value: local
         - name: HOST_URL
-          value: https://statefulset-customization-test.gitpod.com
+          value: https://gitpod.example.com
         - name: KUBE_NAMESPACE
           valueFrom:
             fieldRef:
@@ -7806,13 +7806,13 @@ spec:
         - /config/config.json
         env:
         - name: GITPOD_DOMAIN
-          value: statefulset-customization-test.gitpod.com
+          value: gitpod.example.com
         - name: GITPOD_INSTALLATION_SHORTNAME
           value: default
         - name: GITPOD_REGION
           value: local
         - name: HOST_URL
-          value: https://statefulset-customization-test.gitpod.com
+          value: https://gitpod.example.com
         - name: KUBE_NAMESPACE
           valueFrom:
             fieldRef:
@@ -7917,13 +7917,13 @@ spec:
       containers:
       - env:
         - name: GITPOD_DOMAIN
-          value: statefulset-customization-test.gitpod.com
+          value: gitpod.example.com
         - name: GITPOD_INSTALLATION_SHORTNAME
           value: default
         - name: GITPOD_REGION
           value: local
         - name: HOST_URL
-          value: https://statefulset-customization-test.gitpod.com
+          value: https://gitpod.example.com
         - name: KUBE_NAMESPACE
           valueFrom:
             fieldRef:
@@ -7983,7 +7983,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: a35a205f32ddf7311799d0c9a51db000798ae663397820876d7343321a8e3442
+        gitpod.io/checksum_config: 5a02760487dc021fb50bdfc0d92a3a453348b226fb74729cd57a33927d5b6e08
       creationTimestamp: null
       labels:
         app: gitpod
@@ -8005,13 +8005,13 @@ spec:
         - /config/image-builder.json
         env:
         - name: GITPOD_DOMAIN
-          value: statefulset-customization-test.gitpod.com
+          value: gitpod.example.com
         - name: GITPOD_INSTALLATION_SHORTNAME
           value: default
         - name: GITPOD_REGION
           value: local
         - name: HOST_URL
-          value: https://statefulset-customization-test.gitpod.com
+          value: https://gitpod.example.com
         - name: KUBE_NAMESPACE
           valueFrom:
             fieldRef:
@@ -8240,7 +8240,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: b7e888c35d547f42f86672fe89a0d648b3ccec2d7076944716d4d714842fb67c
+        gitpod.io/checksum_config: c52c73e63eaa95613a8f4fe77167c754cd48eaf757dd69c2048400311a5ae0a6
       creationTimestamp: null
       labels:
         app: gitpod
@@ -8283,13 +8283,13 @@ spec:
           runAsUser: 65532
       - env:
         - name: GITPOD_DOMAIN
-          value: statefulset-customization-test.gitpod.com
+          value: gitpod.example.com
         - name: GITPOD_INSTALLATION_SHORTNAME
           value: default
         - name: GITPOD_REGION
           value: local
         - name: HOST_URL
-          value: https://statefulset-customization-test.gitpod.com
+          value: https://gitpod.example.com
         - name: KUBE_NAMESPACE
           valueFrom:
             fieldRef:
@@ -8299,7 +8299,7 @@ spec:
         - name: LOG_LEVEL
           value: info
         - name: PROXY_DOMAIN
-          value: statefulset-customization-test.gitpod.com
+          value: gitpod.example.com
         image: eu.gcr.io/gitpod-core-dev/build/proxy:test
         imagePullPolicy: IfNotPresent
         name: proxy
@@ -8481,7 +8481,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: d484f4f7e5a3d33ef26ff8a591a894c39bde9ee0485d7251debb79fc47e91ece
+        gitpod.io/checksum_config: 0bc76c867af13d6037264732e25991af8de7c19a2f2e91d1fb1e64df1a9833db
       creationTimestamp: null
       labels:
         app: gitpod
@@ -8499,13 +8499,13 @@ spec:
       containers:
       - env:
         - name: GITPOD_DOMAIN
-          value: statefulset-customization-test.gitpod.com
+          value: gitpod.example.com
         - name: GITPOD_INSTALLATION_SHORTNAME
           value: default
         - name: GITPOD_REGION
           value: local
         - name: HOST_URL
-          value: https://statefulset-customization-test.gitpod.com
+          value: https://gitpod.example.com
         - name: KUBE_NAMESPACE
           valueFrom:
             fieldRef:
@@ -8742,7 +8742,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 7f7ce7b51d259a9d6921f1133e866ef6c544dd154415eff9b729b90881e96536
+        gitpod.io/checksum_config: 4ac62854eccd472efc91ccb1041633960da4448fe1534555abb4ac94fe22861d
       creationTimestamp: null
       labels:
         app: gitpod
@@ -8764,13 +8764,13 @@ spec:
         - /config/config.json
         env:
         - name: GITPOD_DOMAIN
-          value: statefulset-customization-test.gitpod.com
+          value: gitpod.example.com
         - name: GITPOD_INSTALLATION_SHORTNAME
           value: default
         - name: GITPOD_REGION
           value: local
         - name: HOST_URL
-          value: https://statefulset-customization-test.gitpod.com
+          value: https://gitpod.example.com
         - name: KUBE_NAMESPACE
           valueFrom:
             fieldRef:
@@ -8893,13 +8893,13 @@ spec:
       containers:
       - env:
         - name: GITPOD_DOMAIN
-          value: statefulset-customization-test.gitpod.com
+          value: gitpod.example.com
         - name: GITPOD_INSTALLATION_SHORTNAME
           value: default
         - name: GITPOD_REGION
           value: local
         - name: HOST_URL
-          value: https://statefulset-customization-test.gitpod.com
+          value: https://gitpod.example.com
         - name: KUBE_NAMESPACE
           valueFrom:
             fieldRef:
@@ -9115,7 +9115,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 8ce647a78a11ce383b4639b6bf329bef936e5a6af2b3ac5758ddf1ea3cf52897
+        gitpod.io/checksum_config: dcbc53af67e4007a4affc029e880c338b93e4484010727f4bf0a08ad7c93a112
       creationTimestamp: null
       labels:
         app: gitpod
@@ -9136,13 +9136,13 @@ spec:
         - /config/config.json
         env:
         - name: GITPOD_DOMAIN
-          value: statefulset-customization-test.gitpod.com
+          value: gitpod.example.com
         - name: GITPOD_INSTALLATION_SHORTNAME
           value: default
         - name: GITPOD_REGION
           value: local
         - name: HOST_URL
-          value: https://statefulset-customization-test.gitpod.com
+          value: https://gitpod.example.com
         - name: KUBE_NAMESPACE
           valueFrom:
             fieldRef:


### PR DESCRIPTION
## Description

That allows to compare the output.golden files of different tests to see the differences the input produces. Different domains lead to too much noise.


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```