### PR TITLE
[kots]: remove help text documenting the limitation on custom labels

### DIFF
--- a/install/kots/manifests/kots-config.yaml
+++ b/install/kots/manifests/kots-config.yaml
@@ -389,11 +389,6 @@ spec:
             [advanced documentation](https://www.gitpod.io/docs/self-hosted/latest/advanced/customization) for
             more details and the format.
 
-            Labels are an immutable property in Kubernetes, so you may need to uninstall your Gitpod instance
-            before applying - run `helm uninstall -n {{repl Namespace }} gitpod`.
-
-            **WARNING** this should not be run if using in-cluster database and/or object storage.
-
         - name: config_patch
           title: Gitpod config patch (YAML file)
           type: file


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Now that #11954 has been merged and the [`help_text` fix](https://github.com/replicated-collab/replicated-gitpod/issues/29) has been merged by Replicated, I noticed that the old label limitation workaround is still documented in KOTS dashboard

## How to test
<!-- Provide steps to test this PR -->
View in KOTS

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[kots]: remove help text documenting the limitation on custom labels
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
