### PR TITLE
ws-daemon: Proper use of `content.json`

### DIFF
--- a/components/ws-daemon/pkg/content/initializer.go
+++ b/components/ws-daemon/pkg/content/initializer.go
@@ -329,12 +329,13 @@ func RunInitializerChild() (err error) {
 
 	rs := &remoteContentStorage{RemoteContent: initmsg.RemoteContent}
 
-	initializer, err := wsinit.NewFromRequest(ctx, "/dst", rs, &req, wsinit.NewFromRequestOpts{ForceGitpodUserForGit: false})
+	dst := initmsg.Destination
+	initializer, err := wsinit.NewFromRequest(ctx, dst, rs, &req, wsinit.NewFromRequestOpts{ForceGitpodUserForGit: false})
 	if err != nil {
 		return err
 	}
 
-	initSource, err := wsinit.InitializeWorkspace(ctx, "/dst", rs,
+	initSource, err := wsinit.InitializeWorkspace(ctx, dst, rs,
 		wsinit.WithInitializer(initializer),
 		wsinit.WithMappings(initmsg.IDMappings),
 		wsinit.WithChown(initmsg.UID, initmsg.GID),
@@ -346,13 +347,13 @@ func RunInitializerChild() (err error) {
 
 	// some workspace content may have a `/dst/.gitpod` file or directory. That would break
 	// the workspace ready file placement (see https://github.com/gitpod-io/gitpod/issues/7694).
-	err = wsinit.EnsureCleanDotGitpodDirectory(ctx, "/dst")
+	err = wsinit.EnsureCleanDotGitpodDirectory(ctx, dst)
 	if err != nil {
 		return err
 	}
 
 	// Place the ready file to make Theia "open its gates"
-	err = wsinit.PlaceWorkspaceReadyFile(ctx, "/dst", initSource, initmsg.UID, initmsg.GID)
+	err = wsinit.PlaceWorkspaceReadyFile(ctx, dst, initSource, initmsg.UID, initmsg.GID)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description

Destination in content.json was ignored.
https://github.com/gitpod-io/gitpod/blob/3102716172335ed1215627bef1abcba836bfc7e8/components/ws-daemon/pkg/content/initializer.go#L162

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

Can open a workspace

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
