### PR TITLE
ws-manager: Replace initializerMapLock with sync.Map

### DIFF
--- a/components/ws-manager/pkg/manager/monitor.go
+++ b/components/ws-manager/pkg/manager/monitor.go
@@ -818,7 +818,13 @@ func (m *Monitor) initializeWorkspaceContent(ctx context.Context, pod *corev1.Po
 	// The function below deliniates the initializer lock. It's just there so that we can
 	// defer the unlock call, thus making sure we actually call it.
 	err = func() error {
-		_, alreadyInitializing := m.initializerMap.Load(pod.Name)
+		_, alreadyInitializing := m.initializerMap.LoadOrStore(pod.Name, struct{}{})
+		defer func() {
+			if err != nil {
+				m.initializerMap.Delete(pod.Name)
+			}
+		}()
+
 		if alreadyInitializing {
 			return nil
 		}
@@ -872,9 +878,6 @@ func (m *Monitor) initializeWorkspaceContent(ctx context.Context, pod *corev1.Po
 		if err != nil {
 			return err
 		}
-
-		// mark that we're already initialising this workspace
-		m.initializerMap.Store(pod.Name, struct{}{})
 
 		return nil
 	}()

--- a/components/ws-manager/pkg/manager/monitor.go
+++ b/components/ws-manager/pkg/manager/monitor.go
@@ -77,10 +77,8 @@ type Monitor struct {
 	probeMap     map[string]context.CancelFunc
 	probeMapLock sync.Mutex
 
-	initializerMap     map[string]struct{}
-	initializerMapLock sync.Mutex
-
-	finalizerMap sync.Map
+	initializerMap sync.Map
+	finalizerMap   sync.Map
 
 	act actingManager
 
@@ -101,10 +99,9 @@ func (m *Manager) CreateMonitor() (*Monitor, error) {
 
 	log.WithField("interval", monitorInterval).Info("starting workspace monitor")
 	res := Monitor{
-		manager:        m,
-		ticker:         time.NewTicker(monitorInterval),
-		probeMap:       make(map[string]context.CancelFunc),
-		initializerMap: make(map[string]struct{}),
+		manager:  m,
+		ticker:   time.NewTicker(monitorInterval),
+		probeMap: make(map[string]context.CancelFunc),
 
 		OnError: func(err error) {
 			log.WithError(err).Error("workspace monitor error")
@@ -546,9 +543,7 @@ type actingManager interface {
 }
 
 func (m *Monitor) clearInitializerFromMap(podName string) {
-	m.initializerMapLock.Lock()
-	delete(m.initializerMap, podName)
-	m.initializerMapLock.Unlock()
+	m.initializerMap.Delete(podName)
 }
 
 // doHouskeeping is called regularly by the monitor and removes timed out or dangling workspaces/services
@@ -695,13 +690,11 @@ func (m *Monitor) waitForWorkspaceReady(ctx context.Context, pod *corev1.Pod) (e
 				// Looks like we have missed the CREATING phase in which we'd otherwise start the workspace content initialization.
 				// Let's see if we're initializing already. If so, there's something very wrong because ws-daemon does not know about
 				// this workspace yet. In that case we'll run another desperate attempt to initialize the workspace.
-				m.initializerMapLock.Lock()
-				if _, alreadyInitializing := m.initializerMap[pod.Name]; alreadyInitializing {
+				if _, alreadyInitializing := m.initializerMap.Load(pod.Name); alreadyInitializing {
 					// we're already initializing but wsdaemon does not know about this workspace. That's very bad.
 					log.WithFields(wsk8s.GetOWIFromObject(&pod.ObjectMeta)).Error("we were already initializing but wsdaemon does not know about this workspace (bug in ws-daemon?). Trying again!")
-					delete(m.initializerMap, pod.Name)
+					m.initializerMap.Delete(pod.Name)
 				}
-				m.initializerMapLock.Unlock()
 
 				// It's ok - maybe we were restarting in that time. Instead of waiting for things to finish, we'll just start the
 				// initialization now.
@@ -716,9 +709,7 @@ func (m *Monitor) waitForWorkspaceReady(ctx context.Context, pod *corev1.Pod) (e
 	if err != nil {
 		return xerrors.Errorf("cannot wait for workspace to initialize: %w", err)
 	}
-	m.initializerMapLock.Lock()
-	delete(m.initializerMap, pod.Name)
-	m.initializerMapLock.Unlock()
+	m.clearInitializerFromMap(pod.Name)
 	span.LogKV("event", "contentInitDone")
 
 	// workspace is ready - mark it as such
@@ -827,10 +818,7 @@ func (m *Monitor) initializeWorkspaceContent(ctx context.Context, pod *corev1.Po
 	// The function below deliniates the initializer lock. It's just there so that we can
 	// defer the unlock call, thus making sure we actually call it.
 	err = func() error {
-		m.initializerMapLock.Lock()
-		defer m.initializerMapLock.Unlock()
-
-		_, alreadyInitializing := m.initializerMap[pod.Name]
+		_, alreadyInitializing := m.initializerMap.Load(pod.Name)
 		if alreadyInitializing {
 			return nil
 		}
@@ -886,7 +874,7 @@ func (m *Monitor) initializeWorkspaceContent(ctx context.Context, pod *corev1.Po
 		}
 
 		// mark that we're already initialising this workspace
-		m.initializerMap[pod.Name] = struct{}{}
+		m.initializerMap.Store(pod.Name, struct{}{})
 
 		return nil
 	}()


### PR DESCRIPTION
## Description

There were several workspaces content-initializer was taking a very long time to start. [^log1]
As a result, it seemed that stop requests sometimes came before the content-initializer.[^log2]
If content-initializer runs on ws-daemon after the workspace pod has disappeared, it should not work well because there should be no workspace directory. The lock on the initializerMap was common in ws-manager. This could cause longer locks and slower content-initializer startup. This has been improved.

[^log1]: [internal log1](https://console.cloud.google.com/logs/query;query=jsonPayload.instanceId%3D%225663503e-a764-4d88-8657-0c7659594ee9%22;timeRange=2022-08-17T22:11:00.000Z%2F2022-08-18T03:49:00.000Z;summaryFields=jsonPayload%252Flocation:false:32:beginning;cursorTimestamp=2022-08-18T03:27:45Z?project=workspace-clusters)
[^log2]: [internal log2](https://console.cloud.google.com/logs/query;query=jsonPayload.instanceId%3D%2273b2749f-cf2d-4fca-a0b8-433ec126b273%22;timeRange=2022-08-18T03:04:00.000Z%2F2022-08-18T04:11:00.000Z;summaryFields=jsonPayload%252Flocation:false:32:beginning;cursorTimestamp=2022-08-18T03:58:13Z?project=workspace-clusters)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/11852

## How to test
<!-- Provide steps to test this PR -->

Do you know good way?

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
