### PR TITLE
[kots] show `registry_s3` options only when `incluster` is enabled

### DIFF
--- a/install/kots/manifests/kots-config.yaml
+++ b/install/kots/manifests/kots-config.yaml
@@ -49,7 +49,7 @@ spec:
           title: Storage region
           type: text
           required: true
-          when: '{{repl (ConfigOptionEquals "reg_incluster_storage" "s3") }}'
+          when: '{{repl and (ConfigOptionEquals "reg_incluster" "1") (ConfigOptionEquals "reg_incluster_storage" "s3") }}'
           help_text: ID of the region where your storage exists, such as `eu-west-2`.
 
         - name: reg_incluster_storage_s3_endpoint
@@ -57,27 +57,27 @@ spec:
           type: text
           required: true
           value: s3.amazonaws.com
-          when: '{{repl (ConfigOptionEquals "reg_incluster_storage" "s3") }}'
+          when: '{{repl and (ConfigOptionEquals "reg_incluster" "1") (ConfigOptionEquals "reg_incluster_storage" "s3") }}'
           help_text: The endpoint used to connect to the S3 storage.
 
         - name: reg_incluster_storage_s3_bucketname
           title: S3 bucket name
           type: text
           required: true
-          when: '{{repl (ConfigOptionEquals "reg_incluster_storage" "s3") }}'
+          when: '{{repl and (ConfigOptionEquals "reg_incluster" "1") (ConfigOptionEquals "reg_incluster_storage" "s3") }}'
           help_text: The name of the bucket to act as your S3 storage backend.
 
         - name: reg_incluster_storage_s3_accesskey
           title: S3 access key
           type: text
           required: true
-          when: '{{repl (ConfigOptionEquals "reg_incluster_storage" "s3") }}'
+          when: '{{repl and (ConfigOptionEquals "reg_incluster" "1") (ConfigOptionEquals "reg_incluster_storage" "s3") }}'
           help_text: The access key to use for authentication of your S3 storage backend.
 
         - name: reg_incluster_storage_s3_secretkey
           title: S3 secret key
           type: password
-          when: '{{repl (ConfigOptionEquals "reg_incluster_storage" "s3") }}'
+          when: '{{repl and (ConfigOptionEquals "reg_incluster" "1") (ConfigOptionEquals "reg_incluster_storage" "s3") }}'
           required: true
           help_text: The secret key to use for authentication of your S3 storage backend.
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This PR updates the `reg_incluster_storage_s3*` options to
only be enabled both when `incluster` is enabled, and `s3` is
selected, instead of only the latter being used currently.

https://www.loom.com/share/2278f177783d4b9986fe3a2f2b316537

Signed-off-by: Tarun Pothulapati <tarun@gitpod.io>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/10257

## How to test
<!-- Provide steps to test this PR -->

Follow steps in https://www.loom.com/share/1cbe5fb5122b499797b41aeefbba8290, and
see that it does not happen

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[kots] show `registry_s3` options only when `incluster` is enabled
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
