### PR TITLE
Capture errors in supervisor frontend

### DIFF
--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -7,7 +7,7 @@ defaultArgs:
   jbMarketplacePublishTrigger: "false"
   publishToJBMarketplace: true
   localAppVersion: unknown
-  codeCommit: 663d7021754843f9f3532c556963e31d04fa5231
+  codeCommit: 422fc166adbf15fcc61b361b6e4b2cfd44fc7ecb
   codeQuality: stable
   intellijDownloadUrl: "https://download.jetbrains.com/idea/ideaIU-2022.2.1.tar.gz"
   golandDownloadUrl: "https://download.jetbrains.com/go/goland-2022.2.2.tar.gz"

--- a/components/ide-metrics/pkg/server/server.go
+++ b/components/ide-metrics/pkg/server/server.go
@@ -236,8 +236,6 @@ func (s *IDEMetricsServer) Start() error {
 			return true
 		},
 		AllowedHeaders: []string{"*"},
-		// Enable Debugging for testing, consider disabling in production
-		Debug: true,
 	})
 
 	routes.Handle("/metrics-api/", http.StripPrefix("/metrics-api", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -247,7 +245,8 @@ func (s *IDEMetricsServer) Start() error {
 			websocket.IsWebSocketUpgrade(r) {
 			grpcWebServer.ServeHTTP(w, r)
 		} else {
-			restMux.ServeHTTP(w, r)
+			x := c.Handler(restMux)
+			x.ServeHTTP(w, r)
 		}
 	})))
 	go http.Serve(httpMux, routes)

--- a/components/supervisor/frontend/package.json
+++ b/components/supervisor/frontend/package.json
@@ -5,8 +5,7 @@
   "version": "0.0.0",
   "dependencies": {
     "@gitpod/gitpod-protocol": "0.1.5",
-    "@gitpod/supervisor-api-grpc": "0.1.5",
-    "@gitpod/ide-metrics-api-grpcweb": "0.0.1"
+    "@gitpod/supervisor-api-grpc": "0.1.5"
   },
   "devDependencies": {
     "@babel/core": "^7.10.0",

--- a/components/supervisor/frontend/src/ide/ide-metrics-service-client.ts
+++ b/components/supervisor/frontend/src/ide/ide-metrics-service-client.ts
@@ -4,31 +4,40 @@
  * See License-AGPL.txt in the project root for license information.
  */
 
-import { MetricsServicePromiseClient } from '@gitpod/ide-metrics-api-grpcweb/lib/idemetrics_grpc_web_pb'
-import { AddCounterRequest, AddCounterResponse } from '@gitpod/ide-metrics-api-grpcweb/lib/idemetrics_pb'
 import { serverUrl } from '../shared/urls';
-
-const client = new MetricsServicePromiseClient(serverUrl.asIDEMetrics().toString())
 
 export enum MetricsName {
     SupervisorFrontendClientTotal = "gitpod_supervisor_frontend_client_total",
     SupervisorFrontendErrorTotal = "gitpod_supervisor_frontend_error_total"
 }
 
+const MetricsUrl = serverUrl.asIDEMetrics().toString();
+
+interface AddCounterParam {
+    value?: number;
+    labels?: Record<string, string>;
+}
+
 export class IDEMetricsServiceClient {
 
-    static async addCounter(metricsName: string, labels?: Map<string, string>, value?: number) : Promise<AddCounterResponse> {
-        const req = new AddCounterRequest()
-        req.setName(metricsName)
-        if (value) {
-            req.setValue(value)
-        }
-        if (labels) {
-            const m = req.getLabelsMap()
-            for (const [name, value] of labels) {
-                m.set(name, value)
+    static async addCounter(metricsName: MetricsName, labels?: Record<string, string>, value?: number) : Promise<boolean> {
+        const url = `${MetricsUrl}/metrics/counter/add/${metricsName}`
+        const params: AddCounterParam = { value, labels }
+        try {
+            const response = await fetch(url, {
+                method: "POST",
+                body: JSON.stringify(params),
+                credentials: "omit",
+            })
+            if (!response.ok) {
+                const data = await response.json() // { code: number; message: string; }
+                console.error(`Cannot report metrics with addCounter: ${response.status} ${response.statusText}`, data)
+                return false
             }
+            return true
+        } catch (err) {
+            console.error("Cannot report metrics with addCounter, error:", err)
+            return false
         }
-        return client.addCounter(req)
     }
 }

--- a/components/supervisor/frontend/src/index.ts
+++ b/components/supervisor/frontend/src/index.ts
@@ -10,9 +10,29 @@
  */
 import { IDEMetricsServiceClient, MetricsName } from "./ide/ide-metrics-service-client";
 IDEMetricsServiceClient.addCounter(MetricsName.SupervisorFrontendClientTotal).catch(() => {})
-window.addEventListener('error', () => {
-    IDEMetricsServiceClient.addCounter(MetricsName.SupervisorFrontendErrorTotal).catch(() => {})
-})
+
+//#region supervisor frontend error capture
+function isElement(obj: any): obj is Element {
+    return typeof obj.getAttribute === 'function'
+}
+
+window.addEventListener('error', (event) => {
+    const labels: Record<string, string> = {};
+    if (isElement(event.target)) {
+        // We take a look at what is the resource that was attempted to load;
+        const resourceSource = event.target.getAttribute('src') || event.target.getAttribute('href')
+        // If the event has a `target`, it means that it wasn't a script error
+        if (resourceSource) {
+            if (resourceSource.match(new RegExp(/\/build\/ide\/code:.+\/__files__\//g))) {
+                labels['resource'] = 'vscode-web-workbench';
+            }
+            labels['error'] = 'LoadError';
+        }
+    }
+    IDEMetricsServiceClient.addCounter(MetricsName.SupervisorFrontendErrorTotal, labels).catch(() => {});
+});
+//#endregion
+
 require('../src/shared/index.css');
 
 import { createGitpodService, WorkspaceInstancePhase } from "@gitpod/gitpod-protocol";

--- a/install/installer/cmd/testdata/render/aws-setup/output.golden
+++ b/install/installer/cmd/testdata/render/aws-setup/output.golden
@@ -3439,7 +3439,23 @@ data:
           {
             "name": "gitpod_supervisor_frontend_error_total",
             "help": "Total count of supervisor frontend client errors",
-            "labels": null
+            "labels": [
+              {
+                "name": "resource",
+                "allowValues": [
+                  "vscode-web-workbench"
+                ],
+                "defaultValue": "unknown"
+              },
+              {
+                "name": "error",
+                "allowValues": [
+                  "LoadError",
+                  "Unknown"
+                ],
+                "defaultValue": "Unknown"
+              }
+            ]
           },
           {
             "name": "gitpod_supervisor_frontend_client_total",
@@ -7211,7 +7227,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 429b9479c206dc66164883793af80586bca4017bb59e108fa7501a530d24ef57
+        gitpod.io/checksum_config: 3e35ede3647b985d307718989309d2794fdcb8691dd27fb35f538496fb209d79
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/azure-setup/output.golden
+++ b/install/installer/cmd/testdata/render/azure-setup/output.golden
@@ -3357,7 +3357,23 @@ data:
           {
             "name": "gitpod_supervisor_frontend_error_total",
             "help": "Total count of supervisor frontend client errors",
-            "labels": null
+            "labels": [
+              {
+                "name": "resource",
+                "allowValues": [
+                  "vscode-web-workbench"
+                ],
+                "defaultValue": "unknown"
+              },
+              {
+                "name": "error",
+                "allowValues": [
+                  "LoadError",
+                  "Unknown"
+                ],
+                "defaultValue": "Unknown"
+              }
+            ]
           },
           {
             "name": "gitpod_supervisor_frontend_client_total",
@@ -7045,7 +7061,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 429b9479c206dc66164883793af80586bca4017bb59e108fa7501a530d24ef57
+        gitpod.io/checksum_config: 3e35ede3647b985d307718989309d2794fdcb8691dd27fb35f538496fb209d79
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -4139,7 +4139,23 @@ data:
           {
             "name": "gitpod_supervisor_frontend_error_total",
             "help": "Total count of supervisor frontend client errors",
-            "labels": null
+            "labels": [
+              {
+                "name": "resource",
+                "allowValues": [
+                  "vscode-web-workbench"
+                ],
+                "defaultValue": "unknown"
+              },
+              {
+                "name": "error",
+                "allowValues": [
+                  "LoadError",
+                  "Unknown"
+                ],
+                "defaultValue": "Unknown"
+              }
+            ]
           },
           {
             "name": "gitpod_supervisor_frontend_client_total",
@@ -8438,7 +8454,7 @@ spec:
     metadata:
       annotations:
         gitpod.io: hello
-        gitpod.io/checksum_config: 0168f083c528ac1a13770cc46ed4b75a93ec76139c1f5fdfc7d4038b5d32985a
+        gitpod.io/checksum_config: 609010229ed54266e0b515dbb1a2bc6622f497c83d9b33a86e0f7f220818500a
         hello: world
       creationTimestamp: null
       labels:

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -3498,7 +3498,23 @@ data:
           {
             "name": "gitpod_supervisor_frontend_error_total",
             "help": "Total count of supervisor frontend client errors",
-            "labels": null
+            "labels": [
+              {
+                "name": "resource",
+                "allowValues": [
+                  "vscode-web-workbench"
+                ],
+                "defaultValue": "unknown"
+              },
+              {
+                "name": "error",
+                "allowValues": [
+                  "LoadError",
+                  "Unknown"
+                ],
+                "defaultValue": "Unknown"
+              }
+            ]
           },
           {
             "name": "gitpod_supervisor_frontend_client_total",
@@ -7486,7 +7502,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 429b9479c206dc66164883793af80586bca4017bb59e108fa7501a530d24ef57
+        gitpod.io/checksum_config: 3e35ede3647b985d307718989309d2794fdcb8691dd27fb35f538496fb209d79
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/gcp-setup/output.golden
+++ b/install/installer/cmd/testdata/render/gcp-setup/output.golden
@@ -3328,7 +3328,23 @@ data:
           {
             "name": "gitpod_supervisor_frontend_error_total",
             "help": "Total count of supervisor frontend client errors",
-            "labels": null
+            "labels": [
+              {
+                "name": "resource",
+                "allowValues": [
+                  "vscode-web-workbench"
+                ],
+                "defaultValue": "unknown"
+              },
+              {
+                "name": "error",
+                "allowValues": [
+                  "LoadError",
+                  "Unknown"
+                ],
+                "defaultValue": "Unknown"
+              }
+            ]
           },
           {
             "name": "gitpod_supervisor_frontend_client_total",
@@ -7100,7 +7116,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 429b9479c206dc66164883793af80586bca4017bb59e108fa7501a530d24ef57
+        gitpod.io/checksum_config: 3e35ede3647b985d307718989309d2794fdcb8691dd27fb35f538496fb209d79
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -3664,7 +3664,23 @@ data:
           {
             "name": "gitpod_supervisor_frontend_error_total",
             "help": "Total count of supervisor frontend client errors",
-            "labels": null
+            "labels": [
+              {
+                "name": "resource",
+                "allowValues": [
+                  "vscode-web-workbench"
+                ],
+                "defaultValue": "unknown"
+              },
+              {
+                "name": "error",
+                "allowValues": [
+                  "LoadError",
+                  "Unknown"
+                ],
+                "defaultValue": "Unknown"
+              }
+            ]
           },
           {
             "name": "gitpod_supervisor_frontend_client_total",
@@ -7766,7 +7782,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 429b9479c206dc66164883793af80586bca4017bb59e108fa7501a530d24ef57
+        gitpod.io/checksum_config: 3e35ede3647b985d307718989309d2794fdcb8691dd27fb35f538496fb209d79
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -3676,7 +3676,23 @@ data:
           {
             "name": "gitpod_supervisor_frontend_error_total",
             "help": "Total count of supervisor frontend client errors",
-            "labels": null
+            "labels": [
+              {
+                "name": "resource",
+                "allowValues": [
+                  "vscode-web-workbench"
+                ],
+                "defaultValue": "unknown"
+              },
+              {
+                "name": "error",
+                "allowValues": [
+                  "LoadError",
+                  "Unknown"
+                ],
+                "defaultValue": "Unknown"
+              }
+            ]
           },
           {
             "name": "gitpod_supervisor_frontend_client_total",
@@ -7778,7 +7794,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 429b9479c206dc66164883793af80586bca4017bb59e108fa7501a530d24ef57
+        gitpod.io/checksum_config: 3e35ede3647b985d307718989309d2794fdcb8691dd27fb35f538496fb209d79
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
+++ b/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
@@ -3667,7 +3667,23 @@ data:
           {
             "name": "gitpod_supervisor_frontend_error_total",
             "help": "Total count of supervisor frontend client errors",
-            "labels": null
+            "labels": [
+              {
+                "name": "resource",
+                "allowValues": [
+                  "vscode-web-workbench"
+                ],
+                "defaultValue": "unknown"
+              },
+              {
+                "name": "error",
+                "allowValues": [
+                  "LoadError",
+                  "Unknown"
+                ],
+                "defaultValue": "Unknown"
+              }
+            ]
           },
           {
             "name": "gitpod_supervisor_frontend_client_total",
@@ -7769,7 +7785,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 429b9479c206dc66164883793af80586bca4017bb59e108fa7501a530d24ef57
+        gitpod.io/checksum_config: 3e35ede3647b985d307718989309d2794fdcb8691dd27fb35f538496fb209d79
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/pkg/components/ide-metrics/configmap.go
+++ b/install/installer/pkg/components/ide-metrics/configmap.go
@@ -20,6 +20,23 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		{
 			Name: "gitpod_supervisor_frontend_error_total",
 			Help: "Total count of supervisor frontend client errors",
+			Labels: []config.LabelAllowList{
+				{
+					Name: "resource",
+					AllowValues: []string{
+						"vscode-web-workbench",
+					},
+					DefaultValue: "unknown",
+				},
+				{
+					Name: "error",
+					AllowValues: []string{
+						"LoadError", // js script style of errors
+						"Unknown",
+					},
+					DefaultValue: "Unknown",
+				},
+			},
 		},
 		{
 			Name: "gitpod_supervisor_frontend_client_total",


### PR DESCRIPTION
## Description

This PR adds error counting of failed VS Code Web resources to track down https://github.com/gitpod-io/gitpod/issues/12107. We investigated one such case at level of GCP Load Balancer and found out that resources are successfully returned by blobserve. [[1](https://gitpod.slack.com/archives/C01KGM9BH54/p1660889332074709?thread_ts=1660861342.562669&cid=C01KGM9BH54)] Something goes wrong in the browser.

https://github.com/gitpod-io/openvscode-server/pull/417 is a PR to instrument critical resources with error handler.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related to https://github.com/gitpod-io/gitpod/issues/12107

## How to test

- Open a preview environment workspace
- Cause a load error by for example blocking `workbench.web.main.css` as a source
- Check if error count increased (with label)
- Exec `throw new Error('1')` in browser devTool terminal
- Check if error count increased

### How to monitor Prometheus data

- Start a new workspace with this PR
- Run `./dev/preview/portforward-monitoring-satellite.sh -c harvester`
- Open in Browser

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
