### PR TITLE
[kots]: give installer same node affinity as ws-daemon

### DIFF
--- a/install/kots/manifests/gitpod-installer-job.yaml
+++ b/install/kots/manifests/gitpod-installer-job.yaml
@@ -23,6 +23,17 @@ spec:
         component: gitpod-installer
         cursor: "{{repl Cursor }}"
     spec:
+      affinity:
+        nodeAffinity:
+          # Same affinity as ws-daemon as detecting the containerd location
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                - key: gitpod.io/workload_workspace_regular
+                  operator: Exists
+              - matchExpressions:
+                - key: gitpod.io/workload_workspace_headless
+                  operator: Exists
       serviceAccountName: installer
       restartPolicy: OnFailure
       containers:


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
As we're auto-detecting the containerd location in the installer job, we should be on a "workspace" node so this ensures that the installer job is run on the correct node.

This is an edge case and not one we've yet been caught by, but it's possible that the nodes are configured differently (as with SaaS) so it's something I think we should do.

## How to test
<!-- Provide steps to test this PR -->
Install via KOTS.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[kots]: give installer same node affinity as ws-daemon
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
