### PR TITLE
Use `toLocaleString` with usage of credits

### DIFF
--- a/components/dashboard/src/teams/TeamUsage.tsx
+++ b/components/dashboard/src/teams/TeamUsage.tsx
@@ -114,7 +114,7 @@ function TeamUsage() {
     const calculateTotalUsage = () => {
         let totalCredits = 0;
         billedUsage.forEach((session) => (totalCredits += session.credits));
-        return totalCredits.toLocaleString(undefined, { maximumFractionDigits: 2 });
+        return totalCredits.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
     };
 
     const handleMonthClick = (start: any, end: any) => {

--- a/components/dashboard/src/teams/TeamUsage.tsx
+++ b/components/dashboard/src/teams/TeamUsage.tsx
@@ -114,7 +114,7 @@ function TeamUsage() {
     const calculateTotalUsage = () => {
         let totalCredits = 0;
         billedUsage.forEach((session) => (totalCredits += session.credits));
-        return totalCredits.toFixed(2);
+        return totalCredits.toLocaleString(undefined, { maximumFractionDigits: 2 });
     };
 
     const handleMonthClick = (start: any, end: any) => {


### PR DESCRIPTION
## Description
Make bigger amounts of used credits more easily readable by using the browsers locale to format the number. This also solved an issue where trailing zeros would appear if the number was for example exactly `.2`. This may be intentional though and if so, it is easy to fix.

This change does not change how values are rounded, both this method and the previous one do it in the same way.

## Related Issue(s)
None I am aware of.

## How to test

TBD. Easier to test in prod 😆 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
