### PR TITLE
[supervisor] fix chown of /workspace when using PVC

### DIFF
--- a/components/supervisor/pkg/supervisor/supervisor.go
+++ b/components/supervisor/pkg/supervisor/supervisor.go
@@ -1340,6 +1340,8 @@ func startContentInit(ctx context.Context, cfg *Config, wg *sync.WaitGroup, cst 
 			return
 		}
 
+		log.Infof("%s does not exist, going to wait for %s", fn, fnReady)
+
 		// If there is no content descriptor the content must have come from somewhere (i.e. a layer or ws-daemon).
 		// Let's wait for that to happen.
 		// TODO: rewrite using fsnotify
@@ -1372,6 +1374,7 @@ func startContentInit(ctx context.Context, cfg *Config, wg *sync.WaitGroup, cst 
 
 	defer contentFile.Close()
 
+	log.Info("supervisor: running content service executor with content descriptor")
 	var src csapi.WorkspaceInitSource
 	src, err = executor.Execute(ctx, "/workspace", contentFile, true)
 	if err != nil {

--- a/components/supervisor/pkg/supervisor/supervisor.go
+++ b/components/supervisor/pkg/supervisor/supervisor.go
@@ -1325,9 +1325,11 @@ func startContentInit(ctx context.Context, cfg *Config, wg *sync.WaitGroup, cst 
 
 	fn := "/workspace/.gitpod/content.json"
 	fnReady := "/workspace/.gitpod/ready"
+	doChown := true
 	if _, err := os.Stat("/.workspace/.gitpod/content.json"); !os.IsNotExist(err) {
 		fn = "/.workspace/.gitpod/content.json"
 		fnReady = "/.workspace/.gitpod/ready"
+		doChown = false // cannot chown when using PVC as it is owned by 133332 user
 		log.Info("Detected content.json in /.workspace folder, assuming PVC feature enabled")
 	}
 
@@ -1376,7 +1378,7 @@ func startContentInit(ctx context.Context, cfg *Config, wg *sync.WaitGroup, cst 
 
 	log.Info("supervisor: running content service executor with content descriptor")
 	var src csapi.WorkspaceInitSource
-	src, err = executor.Execute(ctx, "/workspace", contentFile, true)
+	src, err = executor.Execute(ctx, "/workspace", contentFile, doChown)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Fixes content init when using PVC.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
none
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
