### PR TITLE
[installer-tests] Adding test support for s3 registry backend

### DIFF
--- a/.werft/installer-tests.ts
+++ b/.werft/installer-tests.ts
@@ -418,7 +418,7 @@ function randK8sVersion(config: string): string {
             break;
         }
         case "STANDARD_EKS_TEST": {
-            options = ["1.21", "1.22", "1.23"]
+            options = ["1.21", "1.22"] // we will start 1.23 when official Ubuntu image is out
             break;
         }
         case "STANDARD_K3S_TEST": {

--- a/install/tests/Makefile
+++ b/install/tests/Makefile
@@ -68,17 +68,12 @@ gke-standard-cluster: check-env-cluster-version
 	terraform apply -target=module.gke -var kubeconfig=${KUBECONFIG} --auto-approve
 	@echo "Done creating GKE cluster"
 
-ami_id_120 := "ami-0ecb917eb4fbf4387"
 
 ami_id_121 := "ami-0d57fb01036fac543"
 
 ami_id_122 := "ami-0b306cb7e98db98e4"
 
-ami_id_120 := "ami-0ecb917eb4fbf4387"
-
-ami_id_121 := "ami-0d57fb01036fac543"
-
-ami_id_122 := "ami-0b306cb7e98db98e4"
+ami_id_123 := "ami-0eba9c07a41b01c3b" # since there is no official ubuntu image, we do not support this
 
 .PHONY:
 ## eks-standard-cluster: Creates an EKS cluster
@@ -226,6 +221,15 @@ storage-config-aws:
 	envsubst < ./manifests/kots-config-aws-storage.yaml > tmp_2_config.yml
 	yq m -i tmp_config.yml tmp_2_config.yml
 
+s3-registry-backend-config-aws: # this registry config involves using s3 backend for incluster registry
+	export REGION=$$(terraform output -json aws_s3_registry_backend | yq r - 'region') && \
+	export ENDPOINT=$$(terraform output -json aws_s3_registry_backend | yq r - 'endpoint') && \
+	export BUCKET=$$(terraform output -json aws_s3_registry_backend | yq r - 'bucket_name') && \
+	export S3_ACCESS_KEY_ID=$$(terraform output -json aws_s3_registry_backend | yq r - 'access_key_id') && \
+	export S3_SECRET_ACCESS_KEY=$$(terraform output -json aws_s3_registry_backend | yq r - 'secret_access_key') && \
+	envsubst < ./manifests/kots-config-aws-s3-backend.yaml > tmp_2_config.yml
+	yq m -i tmp_config.yml tmp_2_config.yml
+
 registry-config-aws:
 	export SERVER=$$(terraform output -json aws_registry | yq r - 'server' | cut -d / -f 1) && \
 	export PASSWORD=$$(terraform output -json aws_registry | yq r - 'password') && \
@@ -240,9 +244,13 @@ db-config-incluster:
 	@echo "Nothing to do"
 
 registry-config-incluster:
+ifeq ($(cloud), aws)
+	$(MAKE) s3-registry-backend-config-aws
+else
 	@echo "Nothing to do"
+endif
 
-torage ?= incluster
+storage ?= incluster
 registry ?= incluster
 db ?= incluster
 .PHONY:

--- a/install/tests/main.tf
+++ b/install/tests/main.tf
@@ -95,6 +95,8 @@ module "eks" {
   create_external_registry = true
   create_external_database = true
   create_external_storage  = true
+  # we test against a separate bucket for registry backend
+  create_external_storage_for_registry_backend = true
 }
 
 module "certmanager" {

--- a/install/tests/manifests/kots-config-aws-s3-backend.yaml
+++ b/install/tests/manifests/kots-config-aws-s3-backend.yaml
@@ -1,0 +1,25 @@
+apiVersion: kots.io/v1beta1
+kind: ConfigValues
+spec:
+  values:
+      reg_incluster:
+        value: "1"
+        data: "reg_incluster"
+      reg_incluster_storage:
+        value: "s3"
+        data: "reg_incluster_storage"
+      reg_incluster_storage_s3_region:
+        value: ${REGION}
+        data: "reg_incluster_storage_s3_region"
+      reg_incluster_storage_s3_endpoint:
+        value: "${ENDPOINT}"
+        data: "reg_incluster_storage_s3_endpoint"
+      reg_incluster_storage_s3_bucketname:
+        value: "${BUCKET}"
+        data: "reg_incluster_storage_s3_bucketname"
+      reg_incluster_storage_s3_accesskey:
+        value: "${S3_ACCESS_KEY_ID}"
+        data: "reg_incluster_storage_s3_accesskey"
+      reg_incluster_storage_s3_secretkey:
+        value: "${S3_SECRET_ACCESS_KEY}"
+        data: "reg_incluster_storage_s3_secretkey"

--- a/install/tests/output.tf
+++ b/install/tests/output.tf
@@ -13,6 +13,11 @@ output "aws_database" {
     value = try(module.eks.database, null)
 }
 
+output "aws_s3_registry_backend" {
+    sensitive = true
+    value = try(module.eks.registry_backend, null)
+}
+
 output "azure_database" {
     sensitive = true
     value = try(module.aks.database, null)


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PR adds the automated test for `s3` used as registry backend in `EKS` cluster setup for Gitpod. As of the current test setup, when `incluster` registry is used, automatically `s3` registry backend config will be chosen for testing. 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #11269

## How to test
<!-- Provide steps to test this PR -->
You can the following command, opening this PR in a gitpod workspace to trigger this test:
```
   werft run github -j .werft/eks-installer-tests.yaml -a deps=incluster
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
