### PR TITLE
Remove code cli from path

### DIFF
--- a/components/ide/code/leeway.Dockerfile
+++ b/components/ide/code/leeway.Dockerfile
@@ -87,8 +87,6 @@ COPY --from=code_builder --chown=33333:33333 /vscode-web/ /ide/
 COPY --from=code_builder --chown=33333:33333 /vscode-reh-linux-x64/ /ide/
 COPY --chown=33333:33333 startup.sh supervisor-ide-config.json components-ide-code-codehelper--app/codehelper /ide/
 
-ENV GITPOD_ENV_APPEND_PATH=/ide/bin/remote-cli:
-
 # editor config
 ENV GITPOD_ENV_SET_EDITOR=/ide/bin/remote-cli/gitpod-code
 ENV GITPOD_ENV_SET_VISUAL="$GITPOD_ENV_SET_EDITOR"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Do not add code cli to path, vscode adds it to the terminals env internally

## How to test
<!-- Provide steps to test this PR -->
1. Print `env` and check `/ide/bin/remote-cli` is not in the path

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
