### PR TITLE
Decrease spacing between the timestamp table header and the sorting icon

### DIFF
--- a/components/dashboard/src/teams/TeamUsage.tsx
+++ b/components/dashboard/src/teams/TeamUsage.tsx
@@ -239,7 +239,7 @@ function TeamUsage() {
                                             >
                                                 Timestamp
                                                 <SortArrow
-                                                    className={`ml-2 h-4 w-4 my-auto ${
+                                                    className={`ml-1 h-4 w-4 my-auto ${
                                                         isStartedTimeDescending ? "" : " transform rotate-180"
                                                     }`}
                                                 />


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
re-opening - #12244
## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #12221

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Decrease spacing between the timestamp table header and the sorting icon
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
