### PR TITLE
[stripe] Inject Webhook Signing Secret into public-api

### DIFF
--- a/.werft/jobs/build/installer/installer.ts
+++ b/.werft/jobs/build/installer/installer.ts
@@ -235,9 +235,7 @@ EOF`);
     }
 
     private configurePublicAPIServer(slice: string) {
-        exec(`yq w -i ${this.options.installerConfigPath} experimental.webapp.publicApi.enabled true`, {
-            slice: slice,
-        });
+        exec(`yq w -i ${this.options.installerConfigPath} experimental.webapp.publicApi.enabled true`, { slice: slice });
     }
 
     private configureUsage(slice: string) {

--- a/components/public-api/go/config/config.go
+++ b/components/public-api/go/config/config.go
@@ -11,5 +11,12 @@ type Configuration struct {
 
 	BillingServiceAddress string `json:"billingServiceAddress,omitempty"`
 
+	// StripeWebhookSigningSecretPath is a filepath to a secret used to validate incoming webhooks from Stripe
+	StripeWebhookSigningSecretPath string `json:"stripeWebhookSigningSecretPath"`
+
 	Server *baseserver.Configuration `json:"server,omitempty"`
+}
+
+type StripeSecret struct {
+	WebhookSigningKey string `json:"signingKey"`
 }

--- a/install/installer/pkg/components/public-api-server/configmap_test.go
+++ b/install/installer/pkg/components/public-api-server/configmap_test.go
@@ -5,6 +5,7 @@ package public_api_server
 
 import (
 	"fmt"
+	"github.com/gitpod-io/gitpod/installer/pkg/config/v1/experimental"
 	"testing"
 
 	"github.com/gitpod-io/gitpod/common-go/baseserver"
@@ -22,9 +23,16 @@ func TestConfigMap(t *testing.T) {
 
 	require.Len(t, objs, 1, "must only render one configmap")
 
+	var stripeSecretPath string
+	_ = ctx.WithExperimental(func(ucfg *experimental.Config) error {
+		_, _, stripeSecretPath, _ = getStripeConfig(ucfg)
+		return nil
+	})
+
 	expectedConfiguration := config.Configuration{
-		GitpodServiceURL:      "wss://test.domain.everything.awesome.is/api/v1",
-		BillingServiceAddress: "usage:9001",
+		GitpodServiceURL:               "wss://test.domain.everything.awesome.is/api/v1",
+		BillingServiceAddress:          "usage:9001",
+		StripeWebhookSigningSecretPath: stripeSecretPath,
 		Server: &baseserver.Configuration{
 			Services: baseserver.ServicesConfiguration{
 				GRPC: &baseserver.ServerConfiguration{

--- a/install/installer/pkg/components/public-api-server/constants.go
+++ b/install/installer/pkg/components/public-api-server/constants.go
@@ -13,4 +13,7 @@ const (
 	HTTPContainerPort = 9002
 	HTTPServicePort   = 9002
 	HTTPPortName      = "http"
+
+	secretsDirectory      = "secrets"
+	stripeSecretMountPath = "stripe-secret"
 )

--- a/install/installer/pkg/components/public-api-server/deployment_test.go
+++ b/install/installer/pkg/components/public-api-server/deployment_test.go
@@ -5,6 +5,7 @@ package public_api_server
 
 import (
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/pointer"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -42,14 +43,25 @@ func TestDeployment_ServerArguments(t *testing.T) {
 		`--json-log=true`,
 	}, apiContainer.Args)
 
-	require.Equal(t, []corev1.Volume{{
-		Name: configmapVolume,
-		VolumeSource: corev1.VolumeSource{
-			ConfigMap: &corev1.ConfigMapVolumeSource{
-				LocalObjectReference: corev1.LocalObjectReference{
-					Name: Component,
+	require.Equal(t, []corev1.Volume{
+		{
+			Name: configmapVolume,
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: Component,
+					},
 				},
 			},
 		},
-	}}, dpl.Spec.Template.Spec.Volumes, "must bind config as a volume")
+		{
+			Name: "stripe-secret",
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: "stripe-webhook-secret",
+					Optional:   pointer.Bool(true),
+				},
+			},
+		},
+	}, dpl.Spec.Template.Spec.Volumes, "must bind config as a volume")
 }

--- a/install/installer/pkg/components/public-api-server/objects_test.go
+++ b/install/installer/pkg/components/public-api-server/objects_test.go
@@ -36,7 +36,10 @@ func renderContextWithPublicAPIEnabled(t *testing.T) *common.RenderContext {
 		Domain: "test.domain.everything.awesome.is",
 		Experimental: &experimental.Config{
 			WebApp: &experimental.WebAppConfig{
-				PublicAPI: &experimental.PublicAPIConfig{Enabled: true},
+				PublicAPI: &experimental.PublicAPIConfig{
+					Enabled:          true,
+					StripeSecretName: "stripe-webhook-secret",
+				},
 			},
 		},
 	}, versions.Manifest{

--- a/install/installer/pkg/config/v1/experimental/experimental.go
+++ b/install/installer/pkg/config/v1/experimental/experimental.go
@@ -224,6 +224,8 @@ type ProxyConfig struct {
 
 type PublicAPIConfig struct {
 	Enabled bool `json:"enabled"`
+	// Name of the kubernetes secret to use for Stripe secrets
+	StripeSecretName string `json:"stripeSecretName"`
 }
 
 type UsageConfig struct {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Adds config to installer to specify the name of a kubernetes secret to load stripe webhook signing secret from.

Actual usage of the secret will happen in another PR.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
Unit tests

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
- [x] /werft with-payment
