### PR TITLE
[ready-probe-labeler] Refactor timeout handling

### DIFF
--- a/dev/ready-probe-labeler/main.go
+++ b/dev/ready-probe-labeler/main.go
@@ -171,21 +171,21 @@ func waitForURLToBeReachable(probeURL string, timeout time.Duration) error {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
-	tick := 500 * time.Millisecond
-
-	ticker := time.NewTicker(tick)
+	ticker := time.NewTicker(1 * time.Second)
 	defer ticker.Stop()
-
-	client := &http.Client{
-		Timeout: tick,
-	}
 
 	for {
 		select {
 		case <-ctx.Done():
 			return xerrors.Errorf("URL %v never returned status code 200", probeURL)
 		case <-ticker.C:
-			resp, err := client.Get(probeURL)
+			req, err := http.NewRequestWithContext(ctx, "GET", probeURL, nil)
+			if err != nil {
+				continue
+			}
+
+			client := &http.Client{}
+			resp, err := client.Do(req)
 			if err != nil {
 				continue
 			}


### PR DESCRIPTION
## Description

Do not use tick value as timeout for the probe URL and instead set one with the one defined in `waitForURLToBeReachable` 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #12220

## How to test
- Open a workspace
- Check `node-labeler` container logs in `registry-facade` pod

```
{"level":"info","message":"Starting node labeler...","serviceContext":{"service":"ready-probe-labeler","version":""},"severity":"INFO","time":"2022-08-22T15:33:55Z"}
{"label":"gitpod.io/registry-facade_ready_ns_default","level":"info","message":"adding label to node","serviceContext":{"service":"ready-probe-labeler","version":""},"severity":"INFO","time":"2022-08-22T15:34:12Z"}
{"fields.time":16.043640853,"level":"info","message":"node label updated","node":"g1fa206bed499b8bdc9c662.workspace-preview.gitpod-io-dev.com","serviceContext":{"service":"ready-probe-labeler","version":""},"severity":"INFO","time":"2022-08-22T15:34:12Z"}
``` 

## Release Notes
```release-note
NONE
```

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
