### PR TITLE
[terraform] Updating terraform GCP module

### DIFF
--- a/install/infra/modules/gke/main.tf
+++ b/install/infra/modules/gke/main.tf
@@ -112,7 +112,7 @@ resource "google_container_node_pool" "services" {
     preemptible  = false
     image_type   = "UBUNTU_CONTAINERD"
     disk_type    = "pd-ssd"
-    disk_size_gb = var.disk_size_gb
+    disk_size_gb = var.services_disk_size_gb
     machine_type = var.services_machine_type
     tags         = ["gke-node", "${var.project}-gke"]
     metadata = {
@@ -153,7 +153,7 @@ resource "google_container_node_pool" "workspaces" {
     preemptible  = false
     image_type   = "UBUNTU_CONTAINERD"
     disk_type    = "pd-ssd"
-    disk_size_gb = var.disk_size_gb
+    disk_size_gb = var.workspaces_disk_size_gb
     machine_type = var.workspaces_machine_type
     tags         = ["gke-node", "${var.project}-gke"]
     metadata = {

--- a/install/infra/modules/gke/variables.tf
+++ b/install/infra/modules/gke/variables.tf
@@ -65,7 +65,7 @@ variable "services_disk_size_gb" {
 variable "workspaces_disk_size_gb" {
   type        = number
   description = "Size of the workspace node's disk."
-  default     = 360
+  default     = 512
 }
 
 variable "credentials" {

--- a/install/infra/modules/gke/variables.tf
+++ b/install/infra/modules/gke/variables.tf
@@ -44,10 +44,16 @@ variable "services_machine_type" {
   default     = "n2d-standard-4"
 }
 
-variable "max_count" {
+variable "max_node_count_workspaces" {
   type        = number
-  description = "Maximum number of nodes in the NodePool. Must be >= 1."
+  description = "Maximum number of nodes in the workspaces NodePool. Must be >= 1."
   default     = 50
+}
+
+variable "max_node_count_services" {
+  type        = number
+  description = "Maximum number of nodes in the services NodePool. Must be >= 1."
+  default     = 4
 }
 
 variable "disk_size_gb" {

--- a/install/infra/modules/gke/variables.tf
+++ b/install/infra/modules/gke/variables.tf
@@ -56,10 +56,16 @@ variable "max_node_count_services" {
   default     = 4
 }
 
-variable "disk_size_gb" {
+variable "services_disk_size_gb" {
   type        = number
-  description = "Size of the node's disk."
+  description = "Size of the services node's disk."
   default     = 100
+}
+
+variable "workspaces_disk_size_gb" {
+  type        = number
+  description = "Size of the workspace node's disk."
+  default     = 360
 }
 
 variable "credentials" {

--- a/install/infra/single-cluster/gcp/Makefile
+++ b/install/infra/single-cluster/gcp/Makefile
@@ -72,6 +72,8 @@ output-database:
 	@echo "Database:"
 	@echo "========"
 	@terraform output -json database | jq
+	@echo ""
+	@echo "Tick the option 'Use Google Cloud SQL Proxy', if using this database"
 
 output-issuer:
 	@echo ""

--- a/install/infra/single-cluster/gcp/README.md
+++ b/install/infra/single-cluster/gcp/README.md
@@ -38,6 +38,10 @@ Before starting the installation process, you need:
 * Create and configure GCS bucket for terraform backend
   * Create a [GCS bucket](https://cloud.google.com/storage) to store the terraform backend state
   * Replace the name of the bucket in [`main.tf`](./main.tf) - currently it is set as `gitpod-tf`
+  * Provide [credentials to access the bucket](https://www.terraform.io/language/settings/backends/gcs#credentials) for terraform by running:
+    ```
+    export GOOGLE_BACKEND_CREDENTIALS=/path/to/the/account/key.json
+    ```
 
 ## Update the `terraform.tfvars` file with appropriate values
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PR makes some small changes to GKE terraform module, making it in sync with the reference architecture. The following are the changes:
- Delete the default node pool and create a separate one for `services` workload, since this is what is being done in the reference architrecture
- Set the node count for both services and workspaces workloads
- some minor changes to the terraform output 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
Please follow the [GCP README](https://github.com/gitpod-io/gitpod/tree/main/install/infra/single-cluster/gcp#readme) to test this.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
