### PR TITLE
Update dev workspace image with awscliv2

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
-image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-bump-leeway.36
+image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:alt-aws-update-awscliv2.3
 workspaceLocation: gitpod/gitpod-ws.code-workspace
 checkoutLocation: gitpod
 ports:

--- a/.werft/aks-installer-tests.yaml
+++ b/.werft/aks-installer-tests.yaml
@@ -61,7 +61,7 @@ pod:
       secretName: sh-playground-dns-perm
   containers:
   - name: nightly-test
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-bump-leeway.36
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:alt-aws-update-awscliv2.3
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/build.yaml
+++ b/.werft/build.yaml
@@ -75,7 +75,7 @@ pod:
     - name: MYSQL_TCP_PORT
       value: 23306
   - name: build
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-bump-leeway.36
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:alt-aws-update-awscliv2.3
     workingDir: /workspace
     imagePullPolicy: IfNotPresent
     resources:

--- a/.werft/cleanup-installer-tests.yaml
+++ b/.werft/cleanup-installer-tests.yaml
@@ -24,7 +24,7 @@ pod:
       secretName: aks-credentials
   containers:
   - name: nightly-test
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-bump-leeway.36
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:alt-aws-update-awscliv2.3
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/debug.yaml
+++ b/.werft/debug.yaml
@@ -53,7 +53,7 @@ pod:
     - name: MYSQL_TCP_PORT
       value: 23306
   - name: build
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-bump-leeway.36
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:alt-aws-update-awscliv2.3
     workingDir: /workspace
     imagePullPolicy: IfNotPresent
     volumeMounts:

--- a/.werft/eks-installer-tests.yaml
+++ b/.werft/eks-installer-tests.yaml
@@ -61,7 +61,7 @@ pod:
       secretName: sh-playground-dns-perm
   containers:
   - name: nightly-test
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-bump-leeway.36
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:alt-aws-update-awscliv2.3
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/gke-installer-tests.yaml
+++ b/.werft/gke-installer-tests.yaml
@@ -61,7 +61,7 @@ pod:
         secretName: sh-playground-dns-perm
   containers:
     - name: nightly-test
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-bump-leeway.36
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:alt-aws-update-awscliv2.3
       workingDir: /workspace
       imagePullPolicy: Always
       volumeMounts:

--- a/.werft/ide-integration-tests-startup.yaml
+++ b/.werft/ide-integration-tests-startup.yaml
@@ -16,7 +16,7 @@ pod:
         secretName: github-token-gitpod-bot
   containers:
     - name: gcloud
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-bump-leeway.36
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:alt-aws-update-awscliv2.3
       workingDir: /workspace
       imagePullPolicy: IfNotPresent
       env:

--- a/.werft/k3s-installer-tests.yaml
+++ b/.werft/k3s-installer-tests.yaml
@@ -64,7 +64,7 @@ pod:
       secretName: self-hosted-github-oauth
   containers:
   - name: nightly-test
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-bump-leeway.36
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:alt-aws-update-awscliv2.3
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/platform-delete-preview-environment.yaml
+++ b/.werft/platform-delete-preview-environment.yaml
@@ -24,7 +24,7 @@ pod:
         secretName: harvester-vm-ssh-keys
   containers:
     - name: build
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-bump-leeway.36
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:alt-aws-update-awscliv2.3
       workingDir: /workspace
       imagePullPolicy: IfNotPresent
       volumeMounts:

--- a/.werft/platform-delete-preview-environments-cron.yaml
+++ b/.werft/platform-delete-preview-environments-cron.yaml
@@ -28,7 +28,7 @@ pod:
         secretName: github-token-gitpod-bot
   containers:
     - name: build
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-bump-leeway.36
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:alt-aws-update-awscliv2.3
       workingDir: /workspace
       imagePullPolicy: IfNotPresent
       volumeMounts:

--- a/.werft/platform-trigger-werft-cleanup.yaml
+++ b/.werft/platform-trigger-werft-cleanup.yaml
@@ -21,7 +21,7 @@ pod:
         secretName: gcp-sa-gitpod-dev-deployer
   containers:
     - name: build
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-bump-leeway.36
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:alt-aws-update-awscliv2.3
       workingDir: /workspace
       imagePullPolicy: IfNotPresent
       volumeMounts:

--- a/.werft/workspace-run-integration-tests.yaml
+++ b/.werft/workspace-run-integration-tests.yaml
@@ -21,7 +21,7 @@ pod:
         secretName: github-token-gitpod-bot
   containers:
     - name: gcloud
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-bump-leeway.36
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:alt-aws-update-awscliv2.3
       workingDir: /workspace
       imagePullPolicy: IfNotPresent
       env:

--- a/dev/image/Dockerfile
+++ b/dev/image/Dockerfile
@@ -180,15 +180,13 @@ ENV DB_HOST=localhost
 ENV LEEWAY_WORKSPACE_ROOT=/workspace/gitpod
 ENV LEEWAY_REMOTE_CACHE_BUCKET=gitpod-core-leeway-cache-branch
 
-### AWS Cli ###
-RUN sudo python3 -m pip install --no-cache-dir awscli
-
-# Install aws-iam-authenticator
-RUN sudo curl -fsSL -o aws-iam-authenticator "https://amazon-eks.s3.us-west-2.amazonaws.com/1.21.2/2021-07-05/bin/linux/amd64/aws-iam-authenticator" \
-    && sudo chmod +x ./aws-iam-authenticator \
-    && sudo mkdir -p $HOME/.aws-iam \
-    && sudo mv ./aws-iam-authenticator $HOME/.aws-iam/aws-iam-authenticator \
-    && sudo chown -R gitpod:gitpod $HOME/.aws-iam
+# awscliv2
+# See also: https://docs.aws.amazon.com/cli/latest/userguide/getting-started-version.html
+# See also: https://github.com/aws/aws-cli/blob/v2/CHANGELOG.rst
+RUN curl -L "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.7.25.zip" -o "awscliv2.zip" \
+    && unzip awscliv2.zip \
+    && sudo ./aws/install \
+    && rm -f awscliv2.zip
 
 # Install Terraform
 ARG RELEASE_URL="https://releases.hashicorp.com/terraform/1.1.7/terraform_1.1.7_linux_amd64.zip"


### PR DESCRIPTION
## Description

This pull request updates the awscli package to version 2. awscliv2 has been generally available since [February 10, 2020](https://github.com/aws/aws-cli/releases/tag/2.0.0) and commonly available AWS documentation references commands that are not available in awscliv1 (such as `aws sts get-caller-identity`).

## Related Issue(s)


## How to test

Using the [aws access tl;dr](https://www.notion.so/gitpod/AWS-access-tl-dr-a2b322f4d67b47aba1c1ec0569224327) setup steps, confirm the following commands work and provide outputs matching the following:

```bash
aws --version
# => aws-cli/2.7.25 Python/3.9.11 Linux/5.15.0-46-generic exe/x86_64.ubuntu.20 prompt/off
```

```bash
# Check for the presence of `aws sts get-caller-identity
aws sts get-caller-identity | jq 'with_entries(.value = "redacted")'
# {
#  "UserId": "redacted",
#  "Account": "redacted",
#  "Arn": "redacted"
# }
```

## Release Notes

```release-note
Update Gitpod workspace image to with awscliv2
```

## Documentation

N/A

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
