### PR TITLE
[ssh-gateway] support rsa sha256/sha512 algorithm

### DIFF
--- a/components/ws-proxy/go.mod
+++ b/components/ws-proxy/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/gitpod-io/gitpod/registry-facade/api v0.0.0-00010101000000-000000000000
 	github.com/gitpod-io/gitpod/supervisor/api v0.0.0-00010101000000-000000000000
 	github.com/gitpod-io/gitpod/ws-manager/api v0.0.0-00010101000000-000000000000
-	github.com/gitpod-io/golang-crypto v0.0.0-20220616163018-a0e3d8407552
+	github.com/gitpod-io/golang-crypto v0.0.0-20220823040820-b59f56dfbab3
 	github.com/go-ozzo/ozzo-validation v3.6.0+incompatible
 	github.com/google/go-cmp v0.5.7
 	github.com/gorilla/handlers v1.5.1

--- a/components/ws-proxy/go.sum
+++ b/components/ws-proxy/go.sum
@@ -147,6 +147,8 @@ github.com/getsentry/raven-go v0.2.0/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49P
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gitpod-io/golang-crypto v0.0.0-20220616163018-a0e3d8407552 h1:11beloYl4JFQZAj6VfJwZcPtrBqulK5Wzrs624m8qHI=
 github.com/gitpod-io/golang-crypto v0.0.0-20220616163018-a0e3d8407552/go.mod h1:tJgr4p01k+N5SV9KHeHLPsEYMCEpc0dTSNGPif2ZWac=
+github.com/gitpod-io/golang-crypto v0.0.0-20220823040820-b59f56dfbab3 h1:/tzCOhhOZCWxTdJ1rZqYubx+LIEVy+QYbJkTMGegcoo=
+github.com/gitpod-io/golang-crypto v0.0.0-20220823040820-b59f56dfbab3/go.mod h1:tJgr4p01k+N5SV9KHeHLPsEYMCEpc0dTSNGPif2ZWac=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=

--- a/install/installer/go.mod
+++ b/install/installer/go.mod
@@ -107,7 +107,7 @@ require (
 	github.com/gitpod-io/gitpod/content-service v0.0.0-00010101000000-000000000000 // indirect
 	github.com/gitpod-io/gitpod/registry-facade v0.0.0-00010101000000-000000000000 // indirect
 	github.com/gitpod-io/gitpod/usage-api v0.0.0-00010101000000-000000000000 // indirect
-	github.com/gitpod-io/golang-crypto v0.0.0-20220616163018-a0e3d8407552 // indirect
+	github.com/gitpod-io/golang-crypto v0.0.0-20220823040820-b59f56dfbab3 // indirect
 	github.com/go-errors/errors v1.0.1 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect

--- a/install/installer/go.sum
+++ b/install/installer/go.sum
@@ -586,8 +586,8 @@ github.com/garyburd/redigo v1.6.0 h1:0VruCpn7yAIIu7pWVClQC8wxCJEcG3nyzpMSHKi1PQc
 github.com/getkin/kin-openapi v0.76.0/go.mod h1:660oXbgy5JFMKreazJaQTw7o+X00qeSyhcnluiMv+Xg=
 github.com/getsentry/raven-go v0.2.0/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49PX4NzFV5kcQ=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
-github.com/gitpod-io/golang-crypto v0.0.0-20220616163018-a0e3d8407552 h1:11beloYl4JFQZAj6VfJwZcPtrBqulK5Wzrs624m8qHI=
-github.com/gitpod-io/golang-crypto v0.0.0-20220616163018-a0e3d8407552/go.mod h1:tJgr4p01k+N5SV9KHeHLPsEYMCEpc0dTSNGPif2ZWac=
+github.com/gitpod-io/golang-crypto v0.0.0-20220823040820-b59f56dfbab3 h1:/tzCOhhOZCWxTdJ1rZqYubx+LIEVy+QYbJkTMGegcoo=
+github.com/gitpod-io/golang-crypto v0.0.0-20220823040820-b59f56dfbab3/go.mod h1:tJgr4p01k+N5SV9KHeHLPsEYMCEpc0dTSNGPif2ZWac=
 github.com/gliderlabs/ssh v0.1.1/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
 github.com/go-asn1-ber/asn1-ber v1.3.1/go.mod h1:hEBeB/ic+5LoWskz+yKT7vGhhPYkProFKoKdwZRWMe0=
 github.com/go-check/check v0.0.0-20180628173108-788fd7840127/go.mod h1:9ES+weclKsC9YodN5RgxqK/VD9HM9JsCSh7rNhMZE98=


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
[ssh-gateway] support rsa sha256/sha512 algorithm

This PR include https://github.com/gitpod-io/golang-crypto/pull/3

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #12287 

## How to test
<!-- Provide steps to test this PR -->
1. use ssh-keygen to generate rsa key pair
2. upload public key to Gitpod
3. install openssh 9.0 client in your local machine or workspace
4. start a new workspace in preview environment
5. using this private key to connect new workspace via ssh gateway, you can use `-vvvv` flag to see verbose log, you will see it using `rsa-sha2-512`
<img width="897" alt="image" src="https://user-images.githubusercontent.com/8299500/186084677-da60ca2b-7f45-4952-846b-e92218470541.png">

<img width="848" alt="image" src="https://user-images.githubusercontent.com/8299500/186084727-b006ebf4-085f-4be3-aac3-5d2c7b63d66c.png">


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[ssh-gateway] support rsa sha256/sha512 algorithm
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
