### PR TITLE
[dashboard] Clarify that spending limit is in credits

### DIFF
--- a/components/dashboard/src/teams/TeamUsageBasedBilling.tsx
+++ b/components/dashboard/src/teams/TeamUsageBasedBilling.tsx
@@ -201,7 +201,9 @@ export default function TeamUsageBasedBilling() {
                             </a>
                         </div>
                         <div className="flex flex-col w-72 mt-4 h-32 p-4 rounded-xl bg-gray-100 dark:bg-gray-800">
-                            <div className="uppercase text-sm text-gray-400 dark:text-gray-500">Spending Limit</div>
+                            <div className="uppercase text-sm text-gray-400 dark:text-gray-500">
+                                Spending Limit (Credits)
+                            </div>
                             <div className="text-xl font-semibold flex-grow text-gray-600 dark:text-gray-400">
                                 {spendingLimit || "–"}
                             </div>
@@ -241,23 +243,22 @@ function UpdateLimitModal(props: {
 
     return (
         <Modal visible={true} onClose={props.onClose}>
-            <h3 className="flex">Update Limit</h3>
+            <h3 className="flex">Update Spending Limit</h3>
             <div className="border-t border-b border-gray-200 dark:border-gray-800 -mx-6 px-6 py-4 flex flex-col">
                 <p className="pb-4 text-gray-500 text-base">Set up a spending limit on a monthly basis.</p>
 
-                <label htmlFor="newLimit" className="font-medium">
-                    Limit
+                <label className="font-medium">
+                    Credits
+                    <div className="w-full">
+                        <input
+                            type="number"
+                            min={0}
+                            value={newLimit}
+                            className="rounded-md w-full truncate overflow-x-scroll pr-8"
+                            onChange={(e) => setNewLimit(e.target.value)}
+                        />
+                    </div>
                 </label>
-                <div className="w-full">
-                    <input
-                        name="newLimit"
-                        type="number"
-                        min={0}
-                        value={newLimit}
-                        className="rounded-md w-full truncate overflow-x-scroll pr-8"
-                        onChange={(e) => setNewLimit(e.target.value)}
-                    />
-                </div>
             </div>
             <div className="flex justify-end mt-6 space-x-2">
                 <button


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Clarify that spending limit is in credits

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/12115

## How to test
<!-- Provide steps to test this PR -->

1. Upgrade a team to Usage-Based Billing
2. Try updating the Spending Limit

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
- [x] /werft with-payment
