### PR TITLE
optimize build of JB images

### DIFF
--- a/components/ide/jetbrains/backend-plugin/BUILD.yaml
+++ b/components/ide/jetbrains/backend-plugin/BUILD.yaml
@@ -18,6 +18,7 @@ packages:
       commands:
         - ["./gradlew", "-PsupervisorApiProjectPath=components-supervisor-api-java--lib/", "-PgitpodProtocolProjectPath=components-gitpod-protocol-java--lib/", "-PenvironmentName=stable", "runPluginVerifier"]
         - ["./gradlew", "-PsupervisorApiProjectPath=components-supervisor-api-java--lib/", "-PgitpodProtocolProjectPath=components-gitpod-protocol-java--lib/", "-PenvironmentName=stable", "buildPlugin"]
+        - ["unzip", "./build/distributions/gitpod-remote-0.0.1.zip", "-d", "./build"]
   - name: plugin-latest
     type: generic
     deps:
@@ -37,3 +38,4 @@ packages:
       commands:
         - ["./gradlew", "-PsupervisorApiProjectPath=components-supervisor-api-java--lib/", "-PgitpodProtocolProjectPath=components-gitpod-protocol-java--lib/", "-PenvironmentName=latest", "runPluginVerifier"]
         - ["./gradlew", "-PsupervisorApiProjectPath=components-supervisor-api-java--lib/", "-PgitpodProtocolProjectPath=components-gitpod-protocol-java--lib/", "-PenvironmentName=latest", "buildPlugin"]
+        - ["unzip", "./build/distributions/gitpod-remote-0.0.1.zip", "-d", "./build"]

--- a/components/ide/jetbrains/image/BUILD.yaml
+++ b/components/ide/jetbrains/image/BUILD.yaml
@@ -20,16 +20,16 @@ packages:
     deps:
       - components/ide/jetbrains/backend-plugin:plugin-stable
       - components/ide/jetbrains/image/status:app
+      - components/ide/jetbrains/image/download:intellij
       - components/ide/jetbrains/cli:app
     argdeps:
       - imageRepoBase
-      - intellijDownloadUrl
     config:
       dockerfile: leeway.Dockerfile
       metadata:
         helm-component: workspace.desktopIdeImages.intellij
       buildArgs:
-        JETBRAINS_BACKEND_URL: ${intellijDownloadUrl}
+        JETBRAINS_DOWNLOAD_QUALIFIER: intellij
         SUPERVISOR_IDE_CONFIG: supervisor-ide-config_intellij.json
         JETBRAINS_BACKEND_QUALIFIER: stable
       image:
@@ -42,6 +42,7 @@ packages:
     deps:
       - components/ide/jetbrains/backend-plugin:plugin-latest
       - components/ide/jetbrains/image/status:app
+      - components/ide/jetbrains/image/download:intellij-latest
       - components/ide/jetbrains/cli:app
     argdeps:
       - imageRepoBase
@@ -50,7 +51,7 @@ packages:
       metadata:
         helm-component: workspace.desktopIdeImages.intellijLatest
       buildArgs:
-        JETBRAINS_BACKEND_URL: "https://download.jetbrains.com/product?type=release,rc,eap&distribution=linux&code=IIU"
+        JETBRAINS_DOWNLOAD_QUALIFIER: intellij-latest
         SUPERVISOR_IDE_CONFIG: supervisor-ide-config_intellij.json
         JETBRAINS_BACKEND_QUALIFIER: latest
       image:
@@ -64,16 +65,16 @@ packages:
     deps:
       - components/ide/jetbrains/backend-plugin:plugin-stable
       - components/ide/jetbrains/image/status:app
+      - components/ide/jetbrains/image/download:goland
       - components/ide/jetbrains/cli:app
     argdeps:
       - imageRepoBase
-      - golandDownloadUrl
     config:
       dockerfile: leeway.Dockerfile
       metadata:
         helm-component: workspace.desktopIdeImages.goland
       buildArgs:
-        JETBRAINS_BACKEND_URL: ${golandDownloadUrl}
+        JETBRAINS_DOWNLOAD_QUALIFIER: goland
         SUPERVISOR_IDE_CONFIG: supervisor-ide-config_goland.json
         JETBRAINS_BACKEND_QUALIFIER: stable
       image:
@@ -86,6 +87,7 @@ packages:
     deps:
       - components/ide/jetbrains/backend-plugin:plugin-latest
       - components/ide/jetbrains/image/status:app
+      - components/ide/jetbrains/image/download:goland-latest
       - components/ide/jetbrains/cli:app
     argdeps:
       - imageRepoBase
@@ -94,7 +96,7 @@ packages:
       metadata:
         helm-component: workspace.desktopIdeImages.golandLatest
       buildArgs:
-        JETBRAINS_BACKEND_URL: "https://download.jetbrains.com/product?type=release,rc,eap&distribution=linux&code=GO"
+        JETBRAINS_DOWNLOAD_QUALIFIER: goland-latest
         SUPERVISOR_IDE_CONFIG: supervisor-ide-config_goland.json
         JETBRAINS_BACKEND_QUALIFIER: latest
       image:
@@ -108,16 +110,16 @@ packages:
     deps:
       - components/ide/jetbrains/backend-plugin:plugin-stable
       - components/ide/jetbrains/image/status:app
+      - components/ide/jetbrains/image/download:pycharm
       - components/ide/jetbrains/cli:app
     argdeps:
       - imageRepoBase
-      - pycharmDownloadUrl
     config:
       dockerfile: leeway.Dockerfile
       metadata:
         helm-component: workspace.desktopIdeImages.pycharm
       buildArgs:
-        JETBRAINS_BACKEND_URL: ${pycharmDownloadUrl}
+        JETBRAINS_DOWNLOAD_QUALIFIER: pycharm
         SUPERVISOR_IDE_CONFIG: supervisor-ide-config_pycharm.json
         JETBRAINS_BACKEND_QUALIFIER: stable
       image:
@@ -130,6 +132,7 @@ packages:
     deps:
       - components/ide/jetbrains/backend-plugin:plugin-latest
       - components/ide/jetbrains/image/status:app
+      - components/ide/jetbrains/image/download:pycharm-latest
       - components/ide/jetbrains/cli:app
     argdeps:
       - imageRepoBase
@@ -138,7 +141,7 @@ packages:
       metadata:
         helm-component: workspace.desktopIdeImages.pycharmLatest
       buildArgs:
-        JETBRAINS_BACKEND_URL: "https://download.jetbrains.com/product?type=release,rc,eap&distribution=linux&code=PCP"
+        JETBRAINS_DOWNLOAD_QUALIFIER: pycharm-latest
         SUPERVISOR_IDE_CONFIG: supervisor-ide-config_pycharm.json
         JETBRAINS_BACKEND_QUALIFIER: latest
       image:
@@ -152,16 +155,16 @@ packages:
     deps:
       - components/ide/jetbrains/backend-plugin:plugin-stable
       - components/ide/jetbrains/image/status:app
+      - components/ide/jetbrains/image/download:phpstorm
       - components/ide/jetbrains/cli:app
     argdeps:
       - imageRepoBase
-      - phpstormDownloadUrl
     config:
       dockerfile: leeway.Dockerfile
       metadata:
         helm-component: workspace.desktopIdeImages.phpstorm
       buildArgs:
-        JETBRAINS_BACKEND_URL: ${phpstormDownloadUrl}
+        JETBRAINS_DOWNLOAD_QUALIFIER: phpstorm
         SUPERVISOR_IDE_CONFIG: supervisor-ide-config_phpstorm.json
         JETBRAINS_BACKEND_QUALIFIER: stable
       image:
@@ -174,6 +177,7 @@ packages:
     deps:
       - components/ide/jetbrains/backend-plugin:plugin-latest
       - components/ide/jetbrains/image/status:app
+      - components/ide/jetbrains/image/download:phpstorm-latest
       - components/ide/jetbrains/cli:app
     argdeps:
       - imageRepoBase
@@ -182,7 +186,7 @@ packages:
       metadata:
         helm-component: workspace.desktopIdeImages.phpstormLatest
       buildArgs:
-        JETBRAINS_BACKEND_URL: "https://download.jetbrains.com/product?type=release,rc,eap&distribution=linux&code=PS"
+        JETBRAINS_DOWNLOAD_QUALIFIER: phpstorm-latest
         SUPERVISOR_IDE_CONFIG: supervisor-ide-config_phpstorm.json
         JETBRAINS_BACKEND_QUALIFIER: latest
       image:

--- a/components/ide/jetbrains/image/download/BUILD.yaml
+++ b/components/ide/jetbrains/image/download/BUILD.yaml
@@ -1,0 +1,81 @@
+packages:
+  - name: intellij
+    type: generic
+    srcs:
+      - "download.sh"
+    argdeps:
+      - intellijDownloadUrl
+    env:
+      - JETBRAINS_BACKEND_URL=${intellijDownloadUrl}
+    config:
+      commands:
+        - ["./download.sh"]
+  - name: intellij-latest
+    type: generic
+    srcs:
+      - "download.sh"
+    env:
+      - JETBRAINS_BACKEND_URL=https://download.jetbrains.com/product?type=release,rc,eap&distribution=linux&code=IIU
+    config:
+      commands:
+        - ["./download.sh"]
+  - name: goland
+    type: generic
+    srcs:
+      - "download.sh"
+    argdeps:
+      - golandDownloadUrl
+    env:
+      - JETBRAINS_BACKEND_URL=${golandDownloadUrl}
+    config:
+      commands:
+        - ["./download.sh"]
+  - name: goland-latest
+    type: generic
+    srcs:
+      - "download.sh"
+    env:
+      - JETBRAINS_BACKEND_URL=https://download.jetbrains.com/product?type=release,rc,eap&distribution=linux&code=GO
+    config:
+      commands:
+        - ["./download.sh"]
+  - name: pycharm
+    type: generic
+    srcs:
+      - "download.sh"
+    argdeps:
+      - pycharmDownloadUrl
+    env:
+      - JETBRAINS_BACKEND_URL=${pycharmDownloadUrl}
+    config:
+      commands:
+        - ["./download.sh"]
+  - name: pycharm-latest
+    type: generic
+    srcs:
+      - "download.sh"
+    env:
+      - JETBRAINS_BACKEND_URL=https://download.jetbrains.com/product?type=release,rc,eap&distribution=linux&code=PCP
+    config:
+      commands:
+        - ["./download.sh"]
+  - name: phpstorm
+    type: generic
+    srcs:
+      - "download.sh"
+    argdeps:
+      - phpstormDownloadUrl
+    env:
+      - JETBRAINS_BACKEND_URL=${phpstormDownloadUrl}
+    config:
+      commands:
+        - ["./download.sh"]
+  - name: phpstorm-latest
+    type: generic
+    srcs:
+      - "download.sh"
+    env:
+      - JETBRAINS_BACKEND_URL=https://download.jetbrains.com/product?type=release,rc,eap&distribution=linux&code=PS
+    config:
+      commands:
+        - ["./download.sh"]

--- a/components/ide/jetbrains/image/download/download.sh
+++ b/components/ide/jetbrains/image/download/download.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+# Licensed under the GNU Affero General Public License (AGPL).
+# See License-AGPL.txt in the project root for license information.
+
+mkdir backend && cd backend || exit
+curl -sSLo backend.tar.gz "$JETBRAINS_BACKEND_URL" && tar -xf backend.tar.gz --strip-components=1 && rm backend.tar.gz
+# enable shared indexes by default
+printf '\nshared.indexes.download.auto.consent=true' >> "bin/idea.properties"

--- a/components/ide/jetbrains/image/leeway.Dockerfile
+++ b/components/ide/jetbrains/image/leeway.Dockerfile
@@ -2,22 +2,16 @@
 # Licensed under the GNU Affero General Public License (AGPL).
 # See License-AGPL.txt in the project root for license information.
 
-FROM alpine:3.16 as download
-ARG JETBRAINS_BACKEND_URL
-ARG JETBRAINS_BACKEND_QUALIFIER
-WORKDIR /workdir
-RUN apk add --no-cache --upgrade curl gzip tar unzip
-RUN curl -sSLo backend.tar.gz "$JETBRAINS_BACKEND_URL" && tar -xf backend.tar.gz --strip-components=1 && rm backend.tar.gz
-COPY --chown=33333:33333 components-ide-jetbrains-backend-plugin--plugin-${JETBRAINS_BACKEND_QUALIFIER}/build/distributions/gitpod-remote-0.0.1.zip /workdir
-RUN unzip gitpod-remote-0.0.1.zip -d plugins/ && rm gitpod-remote-0.0.1.zip
-# enable shared indexes by default
-RUN printf '\nshared.indexes.download.auto.consent=true' >> "/workdir/bin/idea.properties"
-
+# for debugging
+# FROM alpine:3.16
 FROM scratch
+ARG JETBRAINS_DOWNLOAD_QUALIFIER
+ARG JETBRAINS_BACKEND_QUALIFIER
 ARG SUPERVISOR_IDE_CONFIG
 COPY --chown=33333:33333 ${SUPERVISOR_IDE_CONFIG} /ide-desktop/supervisor-ide-config.json
 COPY --chown=33333:33333 startup.sh /ide-desktop/
-COPY --chown=33333:33333 --from=download /workdir/ /ide-desktop/backend/
+COPY --chown=33333:33333 components-ide-jetbrains-image-download--${JETBRAINS_DOWNLOAD_QUALIFIER}/backend /ide-desktop/backend
+COPY --chown=33333:33333 components-ide-jetbrains-backend-plugin--plugin-${JETBRAINS_BACKEND_QUALIFIER}/build/gitpod-remote /ide-desktop/backend/plugins/gitpod-remote
 COPY --chown=33333:33333 components-ide-jetbrains-image-status--app/status /ide-desktop
 
 ARG JETBRAINS_BACKEND_QUALIFIER


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This PR separates download of JB backend from building JB images. It reduces the rebuild time to 15 mins instead of 25mins for the change of JB backend plugin.

Unfortunately copy step during image build gets invalidated for some reasons, so even we just change the backend plugin, copying of backend itself happens for all 8 images and it adds like 10 mins unnecessary. I will think later how to optimize father by probably decoupling deliver of plugins.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related to https://github.com/gitpod-io/gitpod/issues/12268

## How to test
<!-- Provide steps to test this PR -->

- See this job https://werft.gitpod-dev.com/job/gitpod-build-ak-jb-backend-via-proxy.8 after test change.
- Test JB images whether they are working and functionality in place.

/hold
to remove test commit

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
- [ ] /werft no-test
