### PR TITLE
[usage] Add Go definition for d_b_cost_center

### DIFF
--- a/components/usage/pkg/db/cost_center.go
+++ b/components/usage/pkg/db/cost_center.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package db
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type CostCenter struct {
+	ID            uuid.UUID `gorm:"primary_key;column:id;type:char;size:36;" json:"id"`
+	SpendingLimit int       `gorm:"column:spendingLimit;type:int;default:0;" json:"spendingLimit"`
+	LastModified  time.Time `gorm:"column:_lastModified;type:timestamp;default:CURRENT_TIMESTAMP(6);" json:"_lastModified"`
+
+	// deleted is restricted for use by db-sync
+	_ bool `gorm:"column:deleted;type:tinyint;default:0;" json:"deleted"`
+}
+
+// TableName sets the insert table name for this struct type
+func (d *CostCenter) TableName() string {
+	return "d_b_cost_center"
+}

--- a/components/usage/pkg/db/cost_center_test.go
+++ b/components/usage/pkg/db/cost_center_test.go
@@ -1,0 +1,32 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package db_test
+
+import (
+	"testing"
+
+	"github.com/gitpod-io/gitpod/usage/pkg/db"
+	"github.com/gitpod-io/gitpod/usage/pkg/db/dbtest"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCostCenter_WriteRead(t *testing.T) {
+	conn := dbtest.ConnectForTests(t)
+
+	costCenter := &db.CostCenter{
+		ID:            uuid.New(),
+		SpendingLimit: 100,
+	}
+
+	tx := conn.Create(costCenter)
+	require.NoError(t, tx.Error)
+
+	read := &db.CostCenter{ID: costCenter.ID}
+	tx = conn.First(read)
+	require.NoError(t, tx.Error)
+	require.Equal(t, costCenter.ID, read.ID)
+	require.Equal(t, costCenter.SpendingLimit, read.SpendingLimit)
+}


### PR DESCRIPTION
## Description
Adds the model for d_b_cost_center in the Usage component.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Relates #12264

## How to test
Under `/components/usage/pkg/db` run `go test`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
