### PR TITLE
[ide-metrics] allow dynamic labels for metrics

### DIFF
--- a/components/ide-metrics-api/go/config/config.go
+++ b/components/ide-metrics-api/go/config/config.go
@@ -14,8 +14,9 @@ import (
 )
 
 type LabelAllowList struct {
-	Name        string   `json:"name"`
-	AllowValues []string `json:"allowValues"`
+	Name         string   `json:"name"`
+	AllowValues  []string `json:"allowValues"`
+	DefaultValue string   `json:"defaultValue"`
 }
 
 type MetricsServerConfiguration struct {

--- a/components/ide-metrics/cmd/run.go
+++ b/components/ide-metrics/cmd/run.go
@@ -5,11 +5,9 @@
 package cmd
 
 import (
-	"context"
 	"net/http"
 
 	"github.com/gitpod-io/gitpod/common-go/log"
-	"github.com/gitpod-io/gitpod/common-go/watch"
 	"github.com/gitpod-io/gitpod/ide-metrics-api/config"
 	"github.com/gitpod-io/gitpod/ide-metrics/pkg/server"
 	"github.com/prometheus/client_golang/prometheus"
@@ -44,20 +42,6 @@ var runCommand = &cobra.Command{
 		}()
 		log.WithField("addr", cfg.Prometheus.Addr).Info("started prometheus metrics server")
 
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-
-		err = watch.File(ctx, rootOpts.CfgFile, func() {
-			cfg, err := config.Read(rootOpts.CfgFile)
-			if err != nil {
-				log.WithError(err).Warn("cannot read configuration")
-				return
-			}
-			s.ReloadConfig(cfg)
-		})
-		if err != nil {
-			log.WithError(err).Fatal("cannot start watch of configuration file")
-		}
 		if err := s.Start(); err != nil {
 			log.WithError(err).Fatal("cannot start server")
 		}

--- a/components/ide-metrics/config-example.json
+++ b/components/ide-metrics/config-example.json
@@ -8,7 +8,8 @@
         "labels": [
           {
             "name": "ide",
-            "allowValues": ["vscode", "idea", "goland", "pycharm"]
+            "allowValues": ["vscode", "idea", "goland", "pycharm"],
+            "defaultValue": "intellij"
           }
         ]
       }

--- a/components/ide-metrics/pkg/server/server_test.go
+++ b/components/ide-metrics/pkg/server/server_test.go
@@ -1,0 +1,126 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package server
+
+import (
+	"reflect"
+	"testing"
+)
+
+func Test_allowListCollector_Reconcile(t *testing.T) {
+	type args struct {
+		labels map[string]string
+	}
+	c := &allowListCollector{
+		Collector: nil,
+		Labels:    []string{"hello", "world"},
+		AllowLabelValues: map[string][]string{
+			"hello": {"awesome", "gitpod"},
+			"world": {"io"},
+		},
+		AllowLabelDefaultValues: map[string]string{
+			"hello": "defaultValue",
+		},
+	}
+	tests := []struct {
+		name string
+		args args
+		want map[string]string
+	}{
+		{
+			name: "HappyPath",
+			args: args{
+				labels: map[string]string{
+					"hello": "gitpod",
+					"world": "io",
+				},
+			},
+			want: map[string]string{
+				"hello": "gitpod",
+				"world": "io",
+			},
+		},
+		{
+			name: "MissedKeyFallbackToDefault",
+			args: args{
+				labels: map[string]string{
+					"world": "io",
+				},
+			},
+			want: map[string]string{
+				"hello": "defaultValue",
+				"world": "io",
+			},
+		},
+		{
+			name: "MissedDefaultFallbackToDefaultDefault",
+			args: args{
+				labels: map[string]string{},
+			},
+			want: map[string]string{
+				"hello": "defaultValue",
+				"world": UnknownValue,
+			},
+		},
+		{
+			name: "UnknownFiledDeleted",
+			args: args{
+				labels: map[string]string{
+					"foo": "bar",
+				},
+			},
+			want: map[string]string{
+				"hello": "defaultValue",
+				"world": UnknownValue,
+			},
+		},
+		{
+			name: "OutOfRangeValueUseDeafult",
+			args: args{
+				labels: map[string]string{
+					"hello": "wrongValue",
+				},
+			},
+			want: map[string]string{
+				"hello": "defaultValue",
+				"world": UnknownValue,
+			},
+		},
+		{
+			name: "OutOfRangeValueUseDeafult2",
+			args: args{
+				labels: map[string]string{
+					"hello": "wrongValue",
+					"world": "aa",
+				},
+			},
+			want: map[string]string{
+				"hello": "defaultValue",
+				"world": UnknownValue,
+			},
+		},
+		{
+			name: "FreeStyle",
+			args: args{
+				labels: map[string]string{
+					"hello": "gitpod",
+					"world": "aa",
+					"foo":   "bar",
+				},
+			},
+			want: map[string]string{
+				"hello": "gitpod",
+				"world": UnknownValue,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := c.Reconcile(tt.args.labels); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("allowListCollector.Reconcile() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/install/installer/cmd/testdata/render/aws-setup/output.golden
+++ b/install/installer/cmd/testdata/render/aws-setup/output.golden
@@ -6766,6 +6766,8 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      annotations:
+        gitpod.io/checksum_config: 429b9479c206dc66164883793af80586bca4017bb59e108fa7501a530d24ef57
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/azure-setup/output.golden
+++ b/install/installer/cmd/testdata/render/azure-setup/output.golden
@@ -6600,6 +6600,8 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      annotations:
+        gitpod.io/checksum_config: 429b9479c206dc66164883793af80586bca4017bb59e108fa7501a530d24ef57
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -7994,6 +7994,7 @@ spec:
     metadata:
       annotations:
         gitpod.io: hello
+        gitpod.io/checksum_config: 0168f083c528ac1a13770cc46ed4b75a93ec76139c1f5fdfc7d4038b5d32985a
         hello: world
       creationTimestamp: null
       labels:

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -7041,6 +7041,8 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      annotations:
+        gitpod.io/checksum_config: 429b9479c206dc66164883793af80586bca4017bb59e108fa7501a530d24ef57
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/gcp-setup/output.golden
+++ b/install/installer/cmd/testdata/render/gcp-setup/output.golden
@@ -6655,6 +6655,8 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      annotations:
+        gitpod.io/checksum_config: 429b9479c206dc66164883793af80586bca4017bb59e108fa7501a530d24ef57
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -7321,6 +7321,8 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      annotations:
+        gitpod.io/checksum_config: 429b9479c206dc66164883793af80586bca4017bb59e108fa7501a530d24ef57
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -7333,6 +7333,8 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      annotations:
+        gitpod.io/checksum_config: 429b9479c206dc66164883793af80586bca4017bb59e108fa7501a530d24ef57
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
+++ b/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
@@ -7324,6 +7324,8 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      annotations:
+        gitpod.io/checksum_config: 429b9479c206dc66164883793af80586bca4017bb59e108fa7501a530d24ef57
       creationTimestamp: null
       labels:
         app: gitpod


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Prometheus metrics' lables are defined when metric init and will return error when num of labels not fit. So if we change configmap to add labels, previous clients' requests will failed.

This PR make it supports with dynamic labels

Context see also https://github.com/gitpod-io/gitpod/pull/12222#issuecomment-1223695779

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

Open this PR/branch with Gitpod

### Check if configmap in k3s changed, ide-metrics will restart

Same as title

### Check if dynamic labels works

```
cd components/ide-metrics

# start a test server
go run main.go --config config-example.json run

# send requests to check if it works
curl -X "POST" "http://localhost:3000/metrics-api/metrics/counter/add/gitpod_test_counter" \
     -H 'Content-Type: application/json; charset=utf-8' \
     -d $'{
  "value": 12,
  "labels": {}
}'

# monitor Prometheus' data
curl http://localhost:9500/metrics
```

### Check if old behavior works well

See https://github.com/gitpod-io/gitpod/pull/12271#issue-1346547021


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
