### PR TITLE
[usage] Implement GetCostCenter RPC

### DIFF
--- a/components/usage/pkg/db/cost_center.go
+++ b/components/usage/pkg/db/cost_center.go
@@ -5,15 +5,20 @@
 package db
 
 import (
+	"context"
+	"errors"
+	"fmt"
 	"time"
 
-	"github.com/google/uuid"
+	"gorm.io/gorm"
 )
 
+var CostCenterNotFound = errors.New("CostCenter not found")
+
 type CostCenter struct {
-	ID            uuid.UUID `gorm:"primary_key;column:id;type:char;size:36;" json:"id"`
-	SpendingLimit int       `gorm:"column:spendingLimit;type:int;default:0;" json:"spendingLimit"`
-	LastModified  time.Time `gorm:"column:_lastModified;type:timestamp;default:CURRENT_TIMESTAMP(6);" json:"_lastModified"`
+	ID            AttributionID `gorm:"primary_key;column:id;type:char;size:36;" json:"id"`
+	SpendingLimit int32         `gorm:"column:spendingLimit;type:int;default:0;" json:"spendingLimit"`
+	LastModified  time.Time     `gorm:"->:column:_lastModified;type:timestamp;default:CURRENT_TIMESTAMP(6);" json:"_lastModified"`
 
 	// deleted is restricted for use by db-sync
 	_ bool `gorm:"column:deleted;type:tinyint;default:0;" json:"deleted"`
@@ -22,4 +27,20 @@ type CostCenter struct {
 // TableName sets the insert table name for this struct type
 func (d *CostCenter) TableName() string {
 	return "d_b_cost_center"
+}
+
+func GetCostCenter(ctx context.Context, conn *gorm.DB, attributionId AttributionID) (*CostCenter, error) {
+	db := conn.WithContext(ctx)
+	var costCenter CostCenter
+
+	result := db.First(&costCenter, attributionId)
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return nil, CostCenterNotFound
+		}
+		return nil, fmt.Errorf("failed to get cost center: %w", result.Error)
+
+	}
+
+	return &costCenter, nil
 }


### PR DESCRIPTION
## Description
Implements the GetCostCenter RPC.
The use of this RPC in UpdateInvoices() will be a separate PR.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Relates #12264

## How to test
Under `/components/usage/pkg/db` run `go test`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
