### PR TITLE
[server] Implement EntitlementServiceUBP.hasPaidSubscription

### DIFF
--- a/components/server/ee/src/billing/entitlement-service-ubp.ts
+++ b/components/server/ee/src/billing/entitlement-service-ubp.ts
@@ -95,8 +95,12 @@ export class EntitlementServiceUBP implements EntitlementService {
         }
     }
 
+    /**
+     * DEPRECATED: With usage-based billing, users can choose exactly how many resources they want to get.
+     * Thus, we no longer need to "force" extra resources via the `userGetsMoreResources` mechanism.
+     */
     async userGetsMoreResources(user: User, date: Date = new Date()): Promise<boolean> {
-        return this.hasPaidSubscription(user, date);
+        return false;
     }
 
     /**


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

- [x] Implement `hasPaidSubscription` logic in `EntitlementServiceUBP`.

Drive-by fix:
- [x] No longer "force" "more resources" in usage-based billing -- users can choose their resources, so we can deprecate `userGetsMoreResources` with usage-based billing (but it's still used by Chargebee customers)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/12169

## How to test
<!-- Provide steps to test this PR -->

1. Create a team called "Gitpod Something" to **enable the Usage-Based flag** for your user and team
2. Don't add a credit card just yet
3. ~~Try starting multiple workspaces in parallel -- at **4 parallel workspaces**, you should start seeing a paywall that prevents you from starting more (until the currently-running workspaces are stopped again)~~
4. ~~Once a workspace is running, you should **not be able to extend** the workspace timeout (i.e. no "clock" button in the IDE bottom bar)~~
5. Now, upgrade your team to paid by adding a credit card
6. Once upgraded, you should now be able to start up to **16 parallel workspaces** before seeing a paywall
7. You should also **be able to extend** the workspace timeout (using the "clock" button in the IDE bottom bar)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
- [x] /werft with-payment
