### PR TITLE
Revert "[installer]: remove all podsecuritypolicies"

### DIFF
--- a/install/installer/cmd/testdata/render/aws-setup/output.golden
+++ b/install/installer/cmd/testdata/render/aws-setup/output.golden
@@ -663,6 +663,228 @@ spec:
       component: ws-manager
 status: {}
 ---
+# policy/v1beta1/PodSecurityPolicy default-ns-privileged
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  annotations:
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
+    apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+  creationTimestamp: null
+  name: default-ns-privileged
+  namespace: default
+spec:
+  allowPrivilegeEscalation: true
+  allowedCapabilities:
+  - '*'
+  fsGroup:
+    rule: RunAsAny
+  hostIPC: true
+  hostNetwork: true
+  hostPID: true
+  hostPorts:
+  - max: 65535
+    min: 0
+  privileged: true
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - '*'
+---
+# policy/v1beta1/PodSecurityPolicy default-ns-privileged-unconfined
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  annotations:
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: unconfined
+    apparmor.security.beta.kubernetes.io/defaultProfileName: unconfined
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default,unconfined
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+  creationTimestamp: null
+  name: default-ns-privileged-unconfined
+  namespace: default
+spec:
+  allowPrivilegeEscalation: true
+  allowedCapabilities:
+  - '*'
+  fsGroup:
+    rule: RunAsAny
+  hostPID: true
+  hostPorts:
+  - max: 65535
+    min: 0
+  privileged: true
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - '*'
+---
+# policy/v1beta1/PodSecurityPolicy default-ns-registry-facade
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  annotations:
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
+    apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: registry-facade
+  name: default-ns-registry-facade
+spec:
+  fsGroup:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  hostNetwork: true
+  hostPorts:
+  - max: 20000
+    min: 20000
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  volumes:
+  - configMap
+  - secret
+  - emptyDir
+  - hostPath
+---
+# policy/v1beta1/PodSecurityPolicy default-ns-restricted-root-user
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  annotations:
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
+    apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+  creationTimestamp: null
+  name: default-ns-restricted-root-user
+  namespace: default
+spec:
+  fsGroup:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  hostNetwork: true
+  hostPorts:
+  - max: 33000
+    min: 30000
+  privileged: true
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  volumes:
+  - configMap
+  - projected
+  - secret
+  - emptyDir
+  - persistentVolumeClaim
+  - hostPath
+---
+# policy/v1beta1/PodSecurityPolicy default-ns-unprivileged
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  annotations:
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
+    apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+  creationTimestamp: null
+  name: default-ns-unprivileged
+  namespace: default
+spec:
+  allowPrivilegeEscalation: false
+  fsGroup:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  requiredDropCapabilities:
+  - ALL
+  runAsUser:
+    rule: MustRunAsNonRoot
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  volumes:
+  - configMap
+  - emptyDir
+  - projected
+  - secret
+  - persistentVolumeClaim
+---
+# policy/v1beta1/PodSecurityPolicy default-ns-workspace
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  annotations:
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default,unconfined
+    apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+  creationTimestamp: null
+  name: default-ns-workspace
+  namespace: default
+spec:
+  allowPrivilegeEscalation: true
+  allowedCapabilities:
+  - AUDIT_WRITE
+  - FSETID
+  - KILL
+  - NET_BIND_SERVICE
+  - SYS_PTRACE
+  fsGroup:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  volumes:
+  - configMap
+  - projected
+  - secret
+  - hostPath
+---
 # policy/v1/PodDisruptionBudget messagebus
 # Source: rabbitmq/charts/rabbitmq/templates/pdb.yaml
 apiVersion: policy/v1
@@ -1560,6 +1782,72 @@ data:
       creationTimestamp: null
       name: default-kube-rbac-proxy
     ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      creationTimestamp: null
+      name: default-ns-psp:privileged
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      creationTimestamp: null
+      name: default-ns-psp:restricted-root-user
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      creationTimestamp: null
+      name: default-ns-psp:unprivileged
+    ---
+    apiVersion: policy/v1beta1
+    kind: PodSecurityPolicy
+    metadata:
+      annotations:
+        apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
+        apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+        seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
+        seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+      creationTimestamp: null
+      name: default-ns-privileged
+      namespace: default
+    ---
+    apiVersion: policy/v1beta1
+    kind: PodSecurityPolicy
+    metadata:
+      annotations:
+        apparmor.security.beta.kubernetes.io/allowedProfileNames: unconfined
+        apparmor.security.beta.kubernetes.io/defaultProfileName: unconfined
+        seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default,unconfined
+        seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+      creationTimestamp: null
+      name: default-ns-privileged-unconfined
+      namespace: default
+    ---
+    apiVersion: policy/v1beta1
+    kind: PodSecurityPolicy
+    metadata:
+      annotations:
+        apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
+        apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+        seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
+        seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+      creationTimestamp: null
+      name: default-ns-restricted-root-user
+      namespace: default
+    ---
+    apiVersion: policy/v1beta1
+    kind: PodSecurityPolicy
+    metadata:
+      annotations:
+        apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
+        apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+        seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
+        seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+      creationTimestamp: null
+      name: default-ns-unprivileged
+      namespace: default
+    ---
     apiVersion: v1
     kind: ResourceQuota
     metadata:
@@ -2417,6 +2705,20 @@ data:
       name: registry-facade
       namespace: default
     ---
+    apiVersion: policy/v1beta1
+    kind: PodSecurityPolicy
+    metadata:
+      annotations:
+        apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
+        apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+        seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
+        seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: registry-facade
+      name: default-ns-registry-facade
+    ---
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
@@ -2474,6 +2776,28 @@ data:
         app: gitpod
         component: workspace
       name: workspace-default
+      namespace: default
+    ---
+    apiVersion: policy/v1beta1
+    kind: PodSecurityPolicy
+    metadata:
+      annotations:
+        apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default,unconfined
+        apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+        seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+        seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+      creationTimestamp: null
+      name: default-ns-workspace
+      namespace: default
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: workspace
+      name: workspace
       namespace: default
     ---
     apiVersion: rbac.authorization.k8s.io/v1
@@ -2812,6 +3136,15 @@ data:
         component: ws-proxy
       name: ws-proxy
       namespace: default
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: image-builder-mk3
+      name: default-ns-image-builder-mk3
     ---
     apiVersion: v1
     kind: ConfigMap
@@ -4004,6 +4337,73 @@ rules:
   verbs:
   - create
 ---
+# rbac.authorization.k8s.io/v1/ClusterRole default-ns-image-builder-mk3
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: image-builder-mk3
+  name: default-ns-image-builder-mk3
+rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - default-ns-privileged-unconfined
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+---
+# rbac.authorization.k8s.io/v1/ClusterRole default-ns-psp:privileged
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: default-ns-psp:privileged
+rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - default-ns-privileged
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+---
+# rbac.authorization.k8s.io/v1/ClusterRole default-ns-psp:restricted-root-user
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: default-ns-psp:restricted-root-user
+rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - default-ns-restricted-root-user
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+---
+# rbac.authorization.k8s.io/v1/ClusterRole default-ns-psp:unprivileged
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: default-ns-psp:unprivileged
+rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - default-ns-unprivileged
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+---
 # rbac.authorization.k8s.io/v1/ClusterRole default-ns-registry-facade
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -4014,6 +4414,14 @@ metadata:
     component: registry-facade
   name: default-ns-registry-facade
 rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - default-ns-registry-facade
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
 - apiGroups:
   - ""
   resources:
@@ -4034,6 +4442,14 @@ metadata:
     component: ws-daemon
   name: default-ns-ws-daemon
 rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - default-ns-privileged-unconfined
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
 - apiGroups:
   - ""
   resources:
@@ -4413,6 +4829,14 @@ metadata:
   namespace: default
 rules:
 - apiGroups:
+  - policy
+  resourceNames:
+  - default-ns-privileged-unconfined
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+- apiGroups:
   - ""
   resources:
   - pods
@@ -4474,6 +4898,26 @@ rules:
   - update
   - patch
   - watch
+---
+# rbac.authorization.k8s.io/v1/Role workspace
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: workspace
+  name: workspace
+  namespace: default
+rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - default-ns-workspace
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
 ---
 # rbac.authorization.k8s.io/v1/Role ws-manager
 apiVersion: rbac.authorization.k8s.io/v1

--- a/install/installer/cmd/testdata/render/azure-setup/output.golden
+++ b/install/installer/cmd/testdata/render/azure-setup/output.golden
@@ -638,6 +638,228 @@ spec:
       component: ws-manager
 status: {}
 ---
+# policy/v1beta1/PodSecurityPolicy default-ns-privileged
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  annotations:
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
+    apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+  creationTimestamp: null
+  name: default-ns-privileged
+  namespace: default
+spec:
+  allowPrivilegeEscalation: true
+  allowedCapabilities:
+  - '*'
+  fsGroup:
+    rule: RunAsAny
+  hostIPC: true
+  hostNetwork: true
+  hostPID: true
+  hostPorts:
+  - max: 65535
+    min: 0
+  privileged: true
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - '*'
+---
+# policy/v1beta1/PodSecurityPolicy default-ns-privileged-unconfined
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  annotations:
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: unconfined
+    apparmor.security.beta.kubernetes.io/defaultProfileName: unconfined
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default,unconfined
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+  creationTimestamp: null
+  name: default-ns-privileged-unconfined
+  namespace: default
+spec:
+  allowPrivilegeEscalation: true
+  allowedCapabilities:
+  - '*'
+  fsGroup:
+    rule: RunAsAny
+  hostPID: true
+  hostPorts:
+  - max: 65535
+    min: 0
+  privileged: true
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - '*'
+---
+# policy/v1beta1/PodSecurityPolicy default-ns-registry-facade
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  annotations:
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
+    apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: registry-facade
+  name: default-ns-registry-facade
+spec:
+  fsGroup:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  hostNetwork: true
+  hostPorts:
+  - max: 20000
+    min: 20000
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  volumes:
+  - configMap
+  - secret
+  - emptyDir
+  - hostPath
+---
+# policy/v1beta1/PodSecurityPolicy default-ns-restricted-root-user
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  annotations:
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
+    apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+  creationTimestamp: null
+  name: default-ns-restricted-root-user
+  namespace: default
+spec:
+  fsGroup:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  hostNetwork: true
+  hostPorts:
+  - max: 33000
+    min: 30000
+  privileged: true
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  volumes:
+  - configMap
+  - projected
+  - secret
+  - emptyDir
+  - persistentVolumeClaim
+  - hostPath
+---
+# policy/v1beta1/PodSecurityPolicy default-ns-unprivileged
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  annotations:
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
+    apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+  creationTimestamp: null
+  name: default-ns-unprivileged
+  namespace: default
+spec:
+  allowPrivilegeEscalation: false
+  fsGroup:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  requiredDropCapabilities:
+  - ALL
+  runAsUser:
+    rule: MustRunAsNonRoot
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  volumes:
+  - configMap
+  - emptyDir
+  - projected
+  - secret
+  - persistentVolumeClaim
+---
+# policy/v1beta1/PodSecurityPolicy default-ns-workspace
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  annotations:
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default,unconfined
+    apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+  creationTimestamp: null
+  name: default-ns-workspace
+  namespace: default
+spec:
+  allowPrivilegeEscalation: true
+  allowedCapabilities:
+  - AUDIT_WRITE
+  - FSETID
+  - KILL
+  - NET_BIND_SERVICE
+  - SYS_PTRACE
+  fsGroup:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  volumes:
+  - configMap
+  - projected
+  - secret
+  - hostPath
+---
 # policy/v1/PodDisruptionBudget messagebus
 # Source: rabbitmq/charts/rabbitmq/templates/pdb.yaml
 apiVersion: policy/v1
@@ -1477,6 +1699,72 @@ data:
     metadata:
       creationTimestamp: null
       name: default-kube-rbac-proxy
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      creationTimestamp: null
+      name: default-ns-psp:privileged
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      creationTimestamp: null
+      name: default-ns-psp:restricted-root-user
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      creationTimestamp: null
+      name: default-ns-psp:unprivileged
+    ---
+    apiVersion: policy/v1beta1
+    kind: PodSecurityPolicy
+    metadata:
+      annotations:
+        apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
+        apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+        seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
+        seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+      creationTimestamp: null
+      name: default-ns-privileged
+      namespace: default
+    ---
+    apiVersion: policy/v1beta1
+    kind: PodSecurityPolicy
+    metadata:
+      annotations:
+        apparmor.security.beta.kubernetes.io/allowedProfileNames: unconfined
+        apparmor.security.beta.kubernetes.io/defaultProfileName: unconfined
+        seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default,unconfined
+        seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+      creationTimestamp: null
+      name: default-ns-privileged-unconfined
+      namespace: default
+    ---
+    apiVersion: policy/v1beta1
+    kind: PodSecurityPolicy
+    metadata:
+      annotations:
+        apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
+        apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+        seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
+        seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+      creationTimestamp: null
+      name: default-ns-restricted-root-user
+      namespace: default
+    ---
+    apiVersion: policy/v1beta1
+    kind: PodSecurityPolicy
+    metadata:
+      annotations:
+        apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
+        apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+        seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
+        seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+      creationTimestamp: null
+      name: default-ns-unprivileged
+      namespace: default
     ---
     apiVersion: v1
     kind: ResourceQuota
@@ -2335,6 +2623,20 @@ data:
       name: registry-facade
       namespace: default
     ---
+    apiVersion: policy/v1beta1
+    kind: PodSecurityPolicy
+    metadata:
+      annotations:
+        apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
+        apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+        seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
+        seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: registry-facade
+      name: default-ns-registry-facade
+    ---
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
@@ -2392,6 +2694,28 @@ data:
         app: gitpod
         component: workspace
       name: workspace-default
+      namespace: default
+    ---
+    apiVersion: policy/v1beta1
+    kind: PodSecurityPolicy
+    metadata:
+      annotations:
+        apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default,unconfined
+        apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+        seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+        seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+      creationTimestamp: null
+      name: default-ns-workspace
+      namespace: default
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: workspace
+      name: workspace
       namespace: default
     ---
     apiVersion: rbac.authorization.k8s.io/v1
@@ -2730,6 +3054,15 @@ data:
         component: ws-proxy
       name: ws-proxy
       namespace: default
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: image-builder-mk3
+      name: default-ns-image-builder-mk3
     ---
     apiVersion: v1
     kind: ConfigMap
@@ -3864,6 +4197,73 @@ rules:
   verbs:
   - create
 ---
+# rbac.authorization.k8s.io/v1/ClusterRole default-ns-image-builder-mk3
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: image-builder-mk3
+  name: default-ns-image-builder-mk3
+rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - default-ns-privileged-unconfined
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+---
+# rbac.authorization.k8s.io/v1/ClusterRole default-ns-psp:privileged
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: default-ns-psp:privileged
+rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - default-ns-privileged
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+---
+# rbac.authorization.k8s.io/v1/ClusterRole default-ns-psp:restricted-root-user
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: default-ns-psp:restricted-root-user
+rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - default-ns-restricted-root-user
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+---
+# rbac.authorization.k8s.io/v1/ClusterRole default-ns-psp:unprivileged
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: default-ns-psp:unprivileged
+rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - default-ns-unprivileged
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+---
 # rbac.authorization.k8s.io/v1/ClusterRole default-ns-registry-facade
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -3874,6 +4274,14 @@ metadata:
     component: registry-facade
   name: default-ns-registry-facade
 rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - default-ns-registry-facade
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
 - apiGroups:
   - ""
   resources:
@@ -3894,6 +4302,14 @@ metadata:
     component: ws-daemon
   name: default-ns-ws-daemon
 rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - default-ns-privileged-unconfined
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
 - apiGroups:
   - ""
   resources:
@@ -4273,6 +4689,14 @@ metadata:
   namespace: default
 rules:
 - apiGroups:
+  - policy
+  resourceNames:
+  - default-ns-privileged-unconfined
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+- apiGroups:
   - ""
   resources:
   - pods
@@ -4334,6 +4758,26 @@ rules:
   - update
   - patch
   - watch
+---
+# rbac.authorization.k8s.io/v1/Role workspace
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: workspace
+  name: workspace
+  namespace: default
+rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - default-ns-workspace
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
 ---
 # rbac.authorization.k8s.io/v1/Role ws-manager
 apiVersion: rbac.authorization.k8s.io/v1

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -663,6 +663,228 @@ spec:
       component: ws-manager
 status: {}
 ---
+# policy/v1beta1/PodSecurityPolicy default-ns-privileged
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  annotations:
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
+    apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+  creationTimestamp: null
+  name: default-ns-privileged
+  namespace: default
+spec:
+  allowPrivilegeEscalation: true
+  allowedCapabilities:
+  - '*'
+  fsGroup:
+    rule: RunAsAny
+  hostIPC: true
+  hostNetwork: true
+  hostPID: true
+  hostPorts:
+  - max: 65535
+    min: 0
+  privileged: true
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - '*'
+---
+# policy/v1beta1/PodSecurityPolicy default-ns-privileged-unconfined
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  annotations:
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: unconfined
+    apparmor.security.beta.kubernetes.io/defaultProfileName: unconfined
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default,unconfined
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+  creationTimestamp: null
+  name: default-ns-privileged-unconfined
+  namespace: default
+spec:
+  allowPrivilegeEscalation: true
+  allowedCapabilities:
+  - '*'
+  fsGroup:
+    rule: RunAsAny
+  hostPID: true
+  hostPorts:
+  - max: 65535
+    min: 0
+  privileged: true
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - '*'
+---
+# policy/v1beta1/PodSecurityPolicy default-ns-registry-facade
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  annotations:
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
+    apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: registry-facade
+  name: default-ns-registry-facade
+spec:
+  fsGroup:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  hostNetwork: true
+  hostPorts:
+  - max: 20000
+    min: 20000
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  volumes:
+  - configMap
+  - secret
+  - emptyDir
+  - hostPath
+---
+# policy/v1beta1/PodSecurityPolicy default-ns-restricted-root-user
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  annotations:
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
+    apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+  creationTimestamp: null
+  name: default-ns-restricted-root-user
+  namespace: default
+spec:
+  fsGroup:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  hostNetwork: true
+  hostPorts:
+  - max: 33000
+    min: 30000
+  privileged: true
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  volumes:
+  - configMap
+  - projected
+  - secret
+  - emptyDir
+  - persistentVolumeClaim
+  - hostPath
+---
+# policy/v1beta1/PodSecurityPolicy default-ns-unprivileged
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  annotations:
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
+    apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+  creationTimestamp: null
+  name: default-ns-unprivileged
+  namespace: default
+spec:
+  allowPrivilegeEscalation: false
+  fsGroup:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  requiredDropCapabilities:
+  - ALL
+  runAsUser:
+    rule: MustRunAsNonRoot
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  volumes:
+  - configMap
+  - emptyDir
+  - projected
+  - secret
+  - persistentVolumeClaim
+---
+# policy/v1beta1/PodSecurityPolicy default-ns-workspace
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  annotations:
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default,unconfined
+    apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+  creationTimestamp: null
+  name: default-ns-workspace
+  namespace: default
+spec:
+  allowPrivilegeEscalation: true
+  allowedCapabilities:
+  - AUDIT_WRITE
+  - FSETID
+  - KILL
+  - NET_BIND_SERVICE
+  - SYS_PTRACE
+  fsGroup:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  volumes:
+  - configMap
+  - projected
+  - secret
+  - hostPath
+---
 # policy/v1/PodDisruptionBudget messagebus
 # Source: rabbitmq/charts/rabbitmq/templates/pdb.yaml
 apiVersion: policy/v1
@@ -1793,6 +2015,54 @@ data:
       creationTimestamp: null
       name: default-ns-psp:unprivileged
     ---
+    apiVersion: policy/v1beta1
+    kind: PodSecurityPolicy
+    metadata:
+      annotations:
+        apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
+        apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+        seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
+        seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+      creationTimestamp: null
+      name: default-ns-privileged
+      namespace: default
+    ---
+    apiVersion: policy/v1beta1
+    kind: PodSecurityPolicy
+    metadata:
+      annotations:
+        apparmor.security.beta.kubernetes.io/allowedProfileNames: unconfined
+        apparmor.security.beta.kubernetes.io/defaultProfileName: unconfined
+        seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default,unconfined
+        seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+      creationTimestamp: null
+      name: default-ns-privileged-unconfined
+      namespace: default
+    ---
+    apiVersion: policy/v1beta1
+    kind: PodSecurityPolicy
+    metadata:
+      annotations:
+        apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
+        apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+        seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
+        seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+      creationTimestamp: null
+      name: default-ns-restricted-root-user
+      namespace: default
+    ---
+    apiVersion: policy/v1beta1
+    kind: PodSecurityPolicy
+    metadata:
+      annotations:
+        apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
+        apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+        seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
+        seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+      creationTimestamp: null
+      name: default-ns-unprivileged
+      namespace: default
+    ---
     apiVersion: v1
     kind: ResourceQuota
     metadata:
@@ -2903,6 +3173,20 @@ data:
       name: registry-facade
       namespace: default
     ---
+    apiVersion: policy/v1beta1
+    kind: PodSecurityPolicy
+    metadata:
+      annotations:
+        apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
+        apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+        seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
+        seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: registry-facade
+      name: default-ns-registry-facade
+    ---
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
@@ -2970,6 +3254,18 @@ data:
         app: gitpod
         component: workspace
       name: workspace-default
+      namespace: default
+    ---
+    apiVersion: policy/v1beta1
+    kind: PodSecurityPolicy
+    metadata:
+      annotations:
+        apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default,unconfined
+        apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+        seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+        seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+      creationTimestamp: null
+      name: default-ns-workspace
       namespace: default
     ---
     apiVersion: rbac.authorization.k8s.io/v1

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -1775,6 +1775,24 @@ data:
       creationTimestamp: null
       name: default-kube-rbac-proxy
     ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      creationTimestamp: null
+      name: default-ns-psp:privileged
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      creationTimestamp: null
+      name: default-ns-psp:restricted-root-user
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      creationTimestamp: null
+      name: default-ns-psp:unprivileged
+    ---
     apiVersion: v1
     kind: ResourceQuota
     metadata:
@@ -2955,6 +2973,16 @@ data:
       namespace: default
     ---
     apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: workspace
+      name: workspace
+      namespace: default
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
     metadata:
       creationTimestamp: null
@@ -3355,6 +3383,15 @@ data:
         hello: world
       name: ws-proxy
       namespace: default
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: image-builder-mk3
+      name: default-ns-image-builder-mk3
     ---
     apiVersion: v1
     kind: ConfigMap
@@ -4839,6 +4876,73 @@ rules:
   verbs:
   - create
 ---
+# rbac.authorization.k8s.io/v1/ClusterRole default-ns-image-builder-mk3
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: image-builder-mk3
+  name: default-ns-image-builder-mk3
+rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - default-ns-privileged-unconfined
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+---
+# rbac.authorization.k8s.io/v1/ClusterRole default-ns-psp:privileged
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: default-ns-psp:privileged
+rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - default-ns-privileged
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+---
+# rbac.authorization.k8s.io/v1/ClusterRole default-ns-psp:restricted-root-user
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: default-ns-psp:restricted-root-user
+rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - default-ns-restricted-root-user
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+---
+# rbac.authorization.k8s.io/v1/ClusterRole default-ns-psp:unprivileged
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: default-ns-psp:unprivileged
+rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - default-ns-unprivileged
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+---
 # rbac.authorization.k8s.io/v1/ClusterRole default-ns-registry-facade
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -4849,6 +4953,14 @@ metadata:
     component: registry-facade
   name: default-ns-registry-facade
 rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - default-ns-registry-facade
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
 - apiGroups:
   - ""
   resources:
@@ -4869,6 +4981,14 @@ metadata:
     component: ws-daemon
   name: default-ns-ws-daemon
 rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - default-ns-privileged-unconfined
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
 - apiGroups:
   - ""
   resources:
@@ -5248,6 +5368,14 @@ metadata:
   namespace: default
 rules:
 - apiGroups:
+  - policy
+  resourceNames:
+  - default-ns-privileged-unconfined
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+- apiGroups:
   - ""
   resources:
   - pods
@@ -5309,6 +5437,26 @@ rules:
   - update
   - patch
   - watch
+---
+# rbac.authorization.k8s.io/v1/Role workspace
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: workspace
+  name: workspace
+  namespace: default
+rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - default-ns-workspace
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
 ---
 # rbac.authorization.k8s.io/v1/Role ws-manager
 apiVersion: rbac.authorization.k8s.io/v1

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -1525,6 +1525,24 @@ data:
       creationTimestamp: null
       name: default-kube-rbac-proxy
     ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      creationTimestamp: null
+      name: default-ns-psp:privileged
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      creationTimestamp: null
+      name: default-ns-psp:restricted-root-user
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      creationTimestamp: null
+      name: default-ns-psp:unprivileged
+    ---
     apiVersion: v1
     kind: ResourceQuota
     metadata:
@@ -2472,6 +2490,16 @@ data:
       namespace: default
     ---
     apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: workspace
+      name: workspace
+      namespace: default
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
     metadata:
       creationTimestamp: null
@@ -2807,6 +2835,15 @@ data:
         component: ws-proxy
       name: ws-proxy
       namespace: default
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: image-builder-mk3
+      name: default-ns-image-builder-mk3
     ---
     apiVersion: v1
     kind: ConfigMap
@@ -4070,6 +4107,73 @@ rules:
   verbs:
   - create
 ---
+# rbac.authorization.k8s.io/v1/ClusterRole default-ns-image-builder-mk3
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: image-builder-mk3
+  name: default-ns-image-builder-mk3
+rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - default-ns-privileged-unconfined
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+---
+# rbac.authorization.k8s.io/v1/ClusterRole default-ns-psp:privileged
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: default-ns-psp:privileged
+rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - default-ns-privileged
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+---
+# rbac.authorization.k8s.io/v1/ClusterRole default-ns-psp:restricted-root-user
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: default-ns-psp:restricted-root-user
+rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - default-ns-restricted-root-user
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+---
+# rbac.authorization.k8s.io/v1/ClusterRole default-ns-psp:unprivileged
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: default-ns-psp:unprivileged
+rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - default-ns-unprivileged
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+---
 # rbac.authorization.k8s.io/v1/ClusterRole default-ns-registry-facade
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -4080,6 +4184,14 @@ metadata:
     component: registry-facade
   name: default-ns-registry-facade
 rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - default-ns-registry-facade
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
 - apiGroups:
   - ""
   resources:
@@ -4100,6 +4212,14 @@ metadata:
     component: ws-daemon
   name: default-ns-ws-daemon
 rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - default-ns-privileged-unconfined
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
 - apiGroups:
   - ""
   resources:
@@ -4479,6 +4599,14 @@ metadata:
   namespace: default
 rules:
 - apiGroups:
+  - policy
+  resourceNames:
+  - default-ns-privileged-unconfined
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+- apiGroups:
   - ""
   resources:
   - pods
@@ -4540,6 +4668,26 @@ rules:
   - update
   - patch
   - watch
+---
+# rbac.authorization.k8s.io/v1/Role workspace
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: workspace
+  name: workspace
+  namespace: default
+rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - default-ns-workspace
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
 ---
 # rbac.authorization.k8s.io/v1/Role ws-manager
 apiVersion: rbac.authorization.k8s.io/v1

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -638,6 +638,228 @@ spec:
       component: ws-manager
 status: {}
 ---
+# policy/v1beta1/PodSecurityPolicy default-ns-privileged
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  annotations:
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
+    apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+  creationTimestamp: null
+  name: default-ns-privileged
+  namespace: default
+spec:
+  allowPrivilegeEscalation: true
+  allowedCapabilities:
+  - '*'
+  fsGroup:
+    rule: RunAsAny
+  hostIPC: true
+  hostNetwork: true
+  hostPID: true
+  hostPorts:
+  - max: 65535
+    min: 0
+  privileged: true
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - '*'
+---
+# policy/v1beta1/PodSecurityPolicy default-ns-privileged-unconfined
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  annotations:
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: unconfined
+    apparmor.security.beta.kubernetes.io/defaultProfileName: unconfined
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default,unconfined
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+  creationTimestamp: null
+  name: default-ns-privileged-unconfined
+  namespace: default
+spec:
+  allowPrivilegeEscalation: true
+  allowedCapabilities:
+  - '*'
+  fsGroup:
+    rule: RunAsAny
+  hostPID: true
+  hostPorts:
+  - max: 65535
+    min: 0
+  privileged: true
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - '*'
+---
+# policy/v1beta1/PodSecurityPolicy default-ns-registry-facade
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  annotations:
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
+    apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: registry-facade
+  name: default-ns-registry-facade
+spec:
+  fsGroup:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  hostNetwork: true
+  hostPorts:
+  - max: 20000
+    min: 20000
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  volumes:
+  - configMap
+  - secret
+  - emptyDir
+  - hostPath
+---
+# policy/v1beta1/PodSecurityPolicy default-ns-restricted-root-user
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  annotations:
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
+    apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+  creationTimestamp: null
+  name: default-ns-restricted-root-user
+  namespace: default
+spec:
+  fsGroup:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  hostNetwork: true
+  hostPorts:
+  - max: 33000
+    min: 30000
+  privileged: true
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  volumes:
+  - configMap
+  - projected
+  - secret
+  - emptyDir
+  - persistentVolumeClaim
+  - hostPath
+---
+# policy/v1beta1/PodSecurityPolicy default-ns-unprivileged
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  annotations:
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
+    apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+  creationTimestamp: null
+  name: default-ns-unprivileged
+  namespace: default
+spec:
+  allowPrivilegeEscalation: false
+  fsGroup:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  requiredDropCapabilities:
+  - ALL
+  runAsUser:
+    rule: MustRunAsNonRoot
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  volumes:
+  - configMap
+  - emptyDir
+  - projected
+  - secret
+  - persistentVolumeClaim
+---
+# policy/v1beta1/PodSecurityPolicy default-ns-workspace
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  annotations:
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default,unconfined
+    apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+  creationTimestamp: null
+  name: default-ns-workspace
+  namespace: default
+spec:
+  allowPrivilegeEscalation: true
+  allowedCapabilities:
+  - AUDIT_WRITE
+  - FSETID
+  - KILL
+  - NET_BIND_SERVICE
+  - SYS_PTRACE
+  fsGroup:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  volumes:
+  - configMap
+  - projected
+  - secret
+  - hostPath
+---
 # policy/v1/PodDisruptionBudget messagebus
 # Source: rabbitmq/charts/rabbitmq/templates/pdb.yaml
 apiVersion: policy/v1
@@ -1543,6 +1765,54 @@ data:
       creationTimestamp: null
       name: default-ns-psp:unprivileged
     ---
+    apiVersion: policy/v1beta1
+    kind: PodSecurityPolicy
+    metadata:
+      annotations:
+        apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
+        apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+        seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
+        seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+      creationTimestamp: null
+      name: default-ns-privileged
+      namespace: default
+    ---
+    apiVersion: policy/v1beta1
+    kind: PodSecurityPolicy
+    metadata:
+      annotations:
+        apparmor.security.beta.kubernetes.io/allowedProfileNames: unconfined
+        apparmor.security.beta.kubernetes.io/defaultProfileName: unconfined
+        seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default,unconfined
+        seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+      creationTimestamp: null
+      name: default-ns-privileged-unconfined
+      namespace: default
+    ---
+    apiVersion: policy/v1beta1
+    kind: PodSecurityPolicy
+    metadata:
+      annotations:
+        apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
+        apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+        seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
+        seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+      creationTimestamp: null
+      name: default-ns-restricted-root-user
+      namespace: default
+    ---
+    apiVersion: policy/v1beta1
+    kind: PodSecurityPolicy
+    metadata:
+      annotations:
+        apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
+        apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+        seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
+        seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+      creationTimestamp: null
+      name: default-ns-unprivileged
+      namespace: default
+    ---
     apiVersion: v1
     kind: ResourceQuota
     metadata:
@@ -2430,6 +2700,20 @@ data:
       name: registry-facade
       namespace: default
     ---
+    apiVersion: policy/v1beta1
+    kind: PodSecurityPolicy
+    metadata:
+      annotations:
+        apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
+        apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+        seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
+        seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: registry-facade
+      name: default-ns-registry-facade
+    ---
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
@@ -2487,6 +2771,18 @@ data:
         app: gitpod
         component: workspace
       name: workspace-default
+      namespace: default
+    ---
+    apiVersion: policy/v1beta1
+    kind: PodSecurityPolicy
+    metadata:
+      annotations:
+        apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default,unconfined
+        apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+        seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+        seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+      creationTimestamp: null
+      name: default-ns-workspace
       namespace: default
     ---
     apiVersion: rbac.authorization.k8s.io/v1

--- a/install/installer/cmd/testdata/render/gcp-setup/output.golden
+++ b/install/installer/cmd/testdata/render/gcp-setup/output.golden
@@ -638,6 +638,228 @@ spec:
       component: ws-manager
 status: {}
 ---
+# policy/v1beta1/PodSecurityPolicy default-ns-privileged
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  annotations:
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
+    apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+  creationTimestamp: null
+  name: default-ns-privileged
+  namespace: default
+spec:
+  allowPrivilegeEscalation: true
+  allowedCapabilities:
+  - '*'
+  fsGroup:
+    rule: RunAsAny
+  hostIPC: true
+  hostNetwork: true
+  hostPID: true
+  hostPorts:
+  - max: 65535
+    min: 0
+  privileged: true
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - '*'
+---
+# policy/v1beta1/PodSecurityPolicy default-ns-privileged-unconfined
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  annotations:
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: unconfined
+    apparmor.security.beta.kubernetes.io/defaultProfileName: unconfined
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default,unconfined
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+  creationTimestamp: null
+  name: default-ns-privileged-unconfined
+  namespace: default
+spec:
+  allowPrivilegeEscalation: true
+  allowedCapabilities:
+  - '*'
+  fsGroup:
+    rule: RunAsAny
+  hostPID: true
+  hostPorts:
+  - max: 65535
+    min: 0
+  privileged: true
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - '*'
+---
+# policy/v1beta1/PodSecurityPolicy default-ns-registry-facade
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  annotations:
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
+    apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: registry-facade
+  name: default-ns-registry-facade
+spec:
+  fsGroup:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  hostNetwork: true
+  hostPorts:
+  - max: 20000
+    min: 20000
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  volumes:
+  - configMap
+  - secret
+  - emptyDir
+  - hostPath
+---
+# policy/v1beta1/PodSecurityPolicy default-ns-restricted-root-user
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  annotations:
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
+    apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+  creationTimestamp: null
+  name: default-ns-restricted-root-user
+  namespace: default
+spec:
+  fsGroup:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  hostNetwork: true
+  hostPorts:
+  - max: 33000
+    min: 30000
+  privileged: true
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  volumes:
+  - configMap
+  - projected
+  - secret
+  - emptyDir
+  - persistentVolumeClaim
+  - hostPath
+---
+# policy/v1beta1/PodSecurityPolicy default-ns-unprivileged
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  annotations:
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
+    apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+  creationTimestamp: null
+  name: default-ns-unprivileged
+  namespace: default
+spec:
+  allowPrivilegeEscalation: false
+  fsGroup:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  requiredDropCapabilities:
+  - ALL
+  runAsUser:
+    rule: MustRunAsNonRoot
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  volumes:
+  - configMap
+  - emptyDir
+  - projected
+  - secret
+  - persistentVolumeClaim
+---
+# policy/v1beta1/PodSecurityPolicy default-ns-workspace
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  annotations:
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default,unconfined
+    apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+  creationTimestamp: null
+  name: default-ns-workspace
+  namespace: default
+spec:
+  allowPrivilegeEscalation: true
+  allowedCapabilities:
+  - AUDIT_WRITE
+  - FSETID
+  - KILL
+  - NET_BIND_SERVICE
+  - SYS_PTRACE
+  fsGroup:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  volumes:
+  - configMap
+  - projected
+  - secret
+  - hostPath
+---
 # policy/v1/PodDisruptionBudget messagebus
 # Source: rabbitmq/charts/rabbitmq/templates/pdb.yaml
 apiVersion: policy/v1
@@ -1455,6 +1677,72 @@ data:
     metadata:
       creationTimestamp: null
       name: default-kube-rbac-proxy
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      creationTimestamp: null
+      name: default-ns-psp:privileged
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      creationTimestamp: null
+      name: default-ns-psp:restricted-root-user
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      creationTimestamp: null
+      name: default-ns-psp:unprivileged
+    ---
+    apiVersion: policy/v1beta1
+    kind: PodSecurityPolicy
+    metadata:
+      annotations:
+        apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
+        apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+        seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
+        seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+      creationTimestamp: null
+      name: default-ns-privileged
+      namespace: default
+    ---
+    apiVersion: policy/v1beta1
+    kind: PodSecurityPolicy
+    metadata:
+      annotations:
+        apparmor.security.beta.kubernetes.io/allowedProfileNames: unconfined
+        apparmor.security.beta.kubernetes.io/defaultProfileName: unconfined
+        seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default,unconfined
+        seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+      creationTimestamp: null
+      name: default-ns-privileged-unconfined
+      namespace: default
+    ---
+    apiVersion: policy/v1beta1
+    kind: PodSecurityPolicy
+    metadata:
+      annotations:
+        apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
+        apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+        seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
+        seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+      creationTimestamp: null
+      name: default-ns-restricted-root-user
+      namespace: default
+    ---
+    apiVersion: policy/v1beta1
+    kind: PodSecurityPolicy
+    metadata:
+      annotations:
+        apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
+        apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+        seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
+        seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+      creationTimestamp: null
+      name: default-ns-unprivileged
+      namespace: default
     ---
     apiVersion: v1
     kind: ResourceQuota
@@ -2354,6 +2642,20 @@ data:
       name: registry-facade
       namespace: default
     ---
+    apiVersion: policy/v1beta1
+    kind: PodSecurityPolicy
+    metadata:
+      annotations:
+        apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
+        apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+        seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
+        seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: registry-facade
+      name: default-ns-registry-facade
+    ---
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
@@ -2411,6 +2713,28 @@ data:
         app: gitpod
         component: workspace
       name: workspace-default
+      namespace: default
+    ---
+    apiVersion: policy/v1beta1
+    kind: PodSecurityPolicy
+    metadata:
+      annotations:
+        apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default,unconfined
+        apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+        seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+        seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+      creationTimestamp: null
+      name: default-ns-workspace
+      namespace: default
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: workspace
+      name: workspace
       namespace: default
     ---
     apiVersion: rbac.authorization.k8s.io/v1
@@ -2749,6 +3073,15 @@ data:
         component: ws-proxy
       name: ws-proxy
       namespace: default
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: image-builder-mk3
+      name: default-ns-image-builder-mk3
     ---
     apiVersion: v1
     kind: ConfigMap
@@ -3823,6 +4156,73 @@ rules:
   verbs:
   - create
 ---
+# rbac.authorization.k8s.io/v1/ClusterRole default-ns-image-builder-mk3
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: image-builder-mk3
+  name: default-ns-image-builder-mk3
+rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - default-ns-privileged-unconfined
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+---
+# rbac.authorization.k8s.io/v1/ClusterRole default-ns-psp:privileged
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: default-ns-psp:privileged
+rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - default-ns-privileged
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+---
+# rbac.authorization.k8s.io/v1/ClusterRole default-ns-psp:restricted-root-user
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: default-ns-psp:restricted-root-user
+rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - default-ns-restricted-root-user
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+---
+# rbac.authorization.k8s.io/v1/ClusterRole default-ns-psp:unprivileged
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: default-ns-psp:unprivileged
+rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - default-ns-unprivileged
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+---
 # rbac.authorization.k8s.io/v1/ClusterRole default-ns-registry-facade
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -3833,6 +4233,14 @@ metadata:
     component: registry-facade
   name: default-ns-registry-facade
 rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - default-ns-registry-facade
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
 - apiGroups:
   - ""
   resources:
@@ -3853,6 +4261,14 @@ metadata:
     component: ws-daemon
   name: default-ns-ws-daemon
 rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - default-ns-privileged-unconfined
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
 - apiGroups:
   - ""
   resources:
@@ -4232,6 +4648,14 @@ metadata:
   namespace: default
 rules:
 - apiGroups:
+  - policy
+  resourceNames:
+  - default-ns-privileged-unconfined
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+- apiGroups:
   - ""
   resources:
   - pods
@@ -4293,6 +4717,26 @@ rules:
   - update
   - patch
   - watch
+---
+# rbac.authorization.k8s.io/v1/Role workspace
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: workspace
+  name: workspace
+  namespace: default
+rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - default-ns-workspace
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
 ---
 # rbac.authorization.k8s.io/v1/Role ws-manager
 apiVersion: rbac.authorization.k8s.io/v1

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -1631,6 +1631,24 @@ data:
       creationTimestamp: null
       name: default-kube-rbac-proxy
     ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      creationTimestamp: null
+      name: default-ns-psp:privileged
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      creationTimestamp: null
+      name: default-ns-psp:restricted-root-user
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      creationTimestamp: null
+      name: default-ns-psp:unprivileged
+    ---
     apiVersion: v1
     kind: ResourceQuota
     metadata:
@@ -2578,6 +2596,16 @@ data:
       namespace: default
     ---
     apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: workspace
+      name: workspace
+      namespace: default
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
     metadata:
       creationTimestamp: null
@@ -2913,6 +2941,15 @@ data:
         component: ws-proxy
       name: ws-proxy
       namespace: default
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: image-builder-mk3
+      name: default-ns-image-builder-mk3
     ---
     apiVersion: v1
     kind: ConfigMap
@@ -4309,6 +4346,73 @@ rules:
   verbs:
   - create
 ---
+# rbac.authorization.k8s.io/v1/ClusterRole default-ns-image-builder-mk3
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: image-builder-mk3
+  name: default-ns-image-builder-mk3
+rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - default-ns-privileged-unconfined
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+---
+# rbac.authorization.k8s.io/v1/ClusterRole default-ns-psp:privileged
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: default-ns-psp:privileged
+rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - default-ns-privileged
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+---
+# rbac.authorization.k8s.io/v1/ClusterRole default-ns-psp:restricted-root-user
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: default-ns-psp:restricted-root-user
+rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - default-ns-restricted-root-user
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+---
+# rbac.authorization.k8s.io/v1/ClusterRole default-ns-psp:unprivileged
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: default-ns-psp:unprivileged
+rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - default-ns-unprivileged
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+---
 # rbac.authorization.k8s.io/v1/ClusterRole default-ns-registry-facade
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -4319,6 +4423,14 @@ metadata:
     component: registry-facade
   name: default-ns-registry-facade
 rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - default-ns-registry-facade
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
 - apiGroups:
   - ""
   resources:
@@ -4339,6 +4451,14 @@ metadata:
     component: ws-daemon
   name: default-ns-ws-daemon
 rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - default-ns-privileged-unconfined
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
 - apiGroups:
   - ""
   resources:
@@ -4718,6 +4838,14 @@ metadata:
   namespace: default
 rules:
 - apiGroups:
+  - policy
+  resourceNames:
+  - default-ns-privileged-unconfined
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+- apiGroups:
   - ""
   resources:
   - pods
@@ -4779,6 +4907,26 @@ rules:
   - update
   - patch
   - watch
+---
+# rbac.authorization.k8s.io/v1/Role workspace
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: workspace
+  name: workspace
+  namespace: default
+rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - default-ns-workspace
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
 ---
 # rbac.authorization.k8s.io/v1/Role ws-manager
 apiVersion: rbac.authorization.k8s.io/v1

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -663,6 +663,228 @@ spec:
       component: ws-manager
 status: {}
 ---
+# policy/v1beta1/PodSecurityPolicy default-ns-privileged
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  annotations:
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
+    apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+  creationTimestamp: null
+  name: default-ns-privileged
+  namespace: default
+spec:
+  allowPrivilegeEscalation: true
+  allowedCapabilities:
+  - '*'
+  fsGroup:
+    rule: RunAsAny
+  hostIPC: true
+  hostNetwork: true
+  hostPID: true
+  hostPorts:
+  - max: 65535
+    min: 0
+  privileged: true
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - '*'
+---
+# policy/v1beta1/PodSecurityPolicy default-ns-privileged-unconfined
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  annotations:
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: unconfined
+    apparmor.security.beta.kubernetes.io/defaultProfileName: unconfined
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default,unconfined
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+  creationTimestamp: null
+  name: default-ns-privileged-unconfined
+  namespace: default
+spec:
+  allowPrivilegeEscalation: true
+  allowedCapabilities:
+  - '*'
+  fsGroup:
+    rule: RunAsAny
+  hostPID: true
+  hostPorts:
+  - max: 65535
+    min: 0
+  privileged: true
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - '*'
+---
+# policy/v1beta1/PodSecurityPolicy default-ns-registry-facade
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  annotations:
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
+    apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: registry-facade
+  name: default-ns-registry-facade
+spec:
+  fsGroup:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  hostNetwork: true
+  hostPorts:
+  - max: 20000
+    min: 20000
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  volumes:
+  - configMap
+  - secret
+  - emptyDir
+  - hostPath
+---
+# policy/v1beta1/PodSecurityPolicy default-ns-restricted-root-user
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  annotations:
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
+    apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+  creationTimestamp: null
+  name: default-ns-restricted-root-user
+  namespace: default
+spec:
+  fsGroup:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  hostNetwork: true
+  hostPorts:
+  - max: 33000
+    min: 30000
+  privileged: true
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  volumes:
+  - configMap
+  - projected
+  - secret
+  - emptyDir
+  - persistentVolumeClaim
+  - hostPath
+---
+# policy/v1beta1/PodSecurityPolicy default-ns-unprivileged
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  annotations:
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
+    apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+  creationTimestamp: null
+  name: default-ns-unprivileged
+  namespace: default
+spec:
+  allowPrivilegeEscalation: false
+  fsGroup:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  requiredDropCapabilities:
+  - ALL
+  runAsUser:
+    rule: MustRunAsNonRoot
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  volumes:
+  - configMap
+  - emptyDir
+  - projected
+  - secret
+  - persistentVolumeClaim
+---
+# policy/v1beta1/PodSecurityPolicy default-ns-workspace
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  annotations:
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default,unconfined
+    apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+  creationTimestamp: null
+  name: default-ns-workspace
+  namespace: default
+spec:
+  allowPrivilegeEscalation: true
+  allowedCapabilities:
+  - AUDIT_WRITE
+  - FSETID
+  - KILL
+  - NET_BIND_SERVICE
+  - SYS_PTRACE
+  fsGroup:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  volumes:
+  - configMap
+  - projected
+  - secret
+  - hostPath
+---
 # policy/v1/PodDisruptionBudget messagebus
 # Source: rabbitmq/charts/rabbitmq/templates/pdb.yaml
 apiVersion: policy/v1
@@ -1649,6 +1871,54 @@ data:
       creationTimestamp: null
       name: default-ns-psp:unprivileged
     ---
+    apiVersion: policy/v1beta1
+    kind: PodSecurityPolicy
+    metadata:
+      annotations:
+        apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
+        apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+        seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
+        seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+      creationTimestamp: null
+      name: default-ns-privileged
+      namespace: default
+    ---
+    apiVersion: policy/v1beta1
+    kind: PodSecurityPolicy
+    metadata:
+      annotations:
+        apparmor.security.beta.kubernetes.io/allowedProfileNames: unconfined
+        apparmor.security.beta.kubernetes.io/defaultProfileName: unconfined
+        seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default,unconfined
+        seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+      creationTimestamp: null
+      name: default-ns-privileged-unconfined
+      namespace: default
+    ---
+    apiVersion: policy/v1beta1
+    kind: PodSecurityPolicy
+    metadata:
+      annotations:
+        apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
+        apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+        seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
+        seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+      creationTimestamp: null
+      name: default-ns-restricted-root-user
+      namespace: default
+    ---
+    apiVersion: policy/v1beta1
+    kind: PodSecurityPolicy
+    metadata:
+      annotations:
+        apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
+        apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+        seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
+        seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+      creationTimestamp: null
+      name: default-ns-unprivileged
+      namespace: default
+    ---
     apiVersion: v1
     kind: ResourceQuota
     metadata:
@@ -2536,6 +2806,20 @@ data:
       name: registry-facade
       namespace: default
     ---
+    apiVersion: policy/v1beta1
+    kind: PodSecurityPolicy
+    metadata:
+      annotations:
+        apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
+        apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+        seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
+        seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: registry-facade
+      name: default-ns-registry-facade
+    ---
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
@@ -2593,6 +2877,18 @@ data:
         app: gitpod
         component: workspace
       name: workspace-default
+      namespace: default
+    ---
+    apiVersion: policy/v1beta1
+    kind: PodSecurityPolicy
+    metadata:
+      annotations:
+        apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default,unconfined
+        apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+        seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+        seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+      creationTimestamp: null
+      name: default-ns-workspace
       namespace: default
     ---
     apiVersion: rbac.authorization.k8s.io/v1

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -1643,6 +1643,24 @@ data:
       creationTimestamp: null
       name: default-kube-rbac-proxy
     ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      creationTimestamp: null
+      name: default-ns-psp:privileged
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      creationTimestamp: null
+      name: default-ns-psp:restricted-root-user
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      creationTimestamp: null
+      name: default-ns-psp:unprivileged
+    ---
     apiVersion: v1
     kind: ResourceQuota
     metadata:
@@ -2590,6 +2608,16 @@ data:
       namespace: default
     ---
     apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: workspace
+      name: workspace
+      namespace: default
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
     metadata:
       creationTimestamp: null
@@ -2925,6 +2953,15 @@ data:
         component: ws-proxy
       name: ws-proxy
       namespace: default
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: image-builder-mk3
+      name: default-ns-image-builder-mk3
     ---
     apiVersion: v1
     kind: ConfigMap
@@ -4321,6 +4358,73 @@ rules:
   verbs:
   - create
 ---
+# rbac.authorization.k8s.io/v1/ClusterRole default-ns-image-builder-mk3
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: image-builder-mk3
+  name: default-ns-image-builder-mk3
+rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - default-ns-privileged-unconfined
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+---
+# rbac.authorization.k8s.io/v1/ClusterRole default-ns-psp:privileged
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: default-ns-psp:privileged
+rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - default-ns-privileged
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+---
+# rbac.authorization.k8s.io/v1/ClusterRole default-ns-psp:restricted-root-user
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: default-ns-psp:restricted-root-user
+rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - default-ns-restricted-root-user
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+---
+# rbac.authorization.k8s.io/v1/ClusterRole default-ns-psp:unprivileged
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: default-ns-psp:unprivileged
+rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - default-ns-unprivileged
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+---
 # rbac.authorization.k8s.io/v1/ClusterRole default-ns-registry-facade
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -4331,6 +4435,14 @@ metadata:
     component: registry-facade
   name: default-ns-registry-facade
 rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - default-ns-registry-facade
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
 - apiGroups:
   - ""
   resources:
@@ -4351,6 +4463,14 @@ metadata:
     component: ws-daemon
   name: default-ns-ws-daemon
 rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - default-ns-privileged-unconfined
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
 - apiGroups:
   - ""
   resources:
@@ -4730,6 +4850,14 @@ metadata:
   namespace: default
 rules:
 - apiGroups:
+  - policy
+  resourceNames:
+  - default-ns-privileged-unconfined
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+- apiGroups:
   - ""
   resources:
   - pods
@@ -4791,6 +4919,26 @@ rules:
   - update
   - patch
   - watch
+---
+# rbac.authorization.k8s.io/v1/Role workspace
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: workspace
+  name: workspace
+  namespace: default
+rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - default-ns-workspace
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
 ---
 # rbac.authorization.k8s.io/v1/Role ws-manager
 apiVersion: rbac.authorization.k8s.io/v1

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -663,6 +663,228 @@ spec:
       component: ws-manager
 status: {}
 ---
+# policy/v1beta1/PodSecurityPolicy default-ns-privileged
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  annotations:
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
+    apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+  creationTimestamp: null
+  name: default-ns-privileged
+  namespace: default
+spec:
+  allowPrivilegeEscalation: true
+  allowedCapabilities:
+  - '*'
+  fsGroup:
+    rule: RunAsAny
+  hostIPC: true
+  hostNetwork: true
+  hostPID: true
+  hostPorts:
+  - max: 65535
+    min: 0
+  privileged: true
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - '*'
+---
+# policy/v1beta1/PodSecurityPolicy default-ns-privileged-unconfined
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  annotations:
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: unconfined
+    apparmor.security.beta.kubernetes.io/defaultProfileName: unconfined
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default,unconfined
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+  creationTimestamp: null
+  name: default-ns-privileged-unconfined
+  namespace: default
+spec:
+  allowPrivilegeEscalation: true
+  allowedCapabilities:
+  - '*'
+  fsGroup:
+    rule: RunAsAny
+  hostPID: true
+  hostPorts:
+  - max: 65535
+    min: 0
+  privileged: true
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - '*'
+---
+# policy/v1beta1/PodSecurityPolicy default-ns-registry-facade
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  annotations:
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
+    apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: registry-facade
+  name: default-ns-registry-facade
+spec:
+  fsGroup:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  hostNetwork: true
+  hostPorts:
+  - max: 20000
+    min: 20000
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  volumes:
+  - configMap
+  - secret
+  - emptyDir
+  - hostPath
+---
+# policy/v1beta1/PodSecurityPolicy default-ns-restricted-root-user
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  annotations:
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
+    apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+  creationTimestamp: null
+  name: default-ns-restricted-root-user
+  namespace: default
+spec:
+  fsGroup:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  hostNetwork: true
+  hostPorts:
+  - max: 33000
+    min: 30000
+  privileged: true
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  volumes:
+  - configMap
+  - projected
+  - secret
+  - emptyDir
+  - persistentVolumeClaim
+  - hostPath
+---
+# policy/v1beta1/PodSecurityPolicy default-ns-unprivileged
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  annotations:
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
+    apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+  creationTimestamp: null
+  name: default-ns-unprivileged
+  namespace: default
+spec:
+  allowPrivilegeEscalation: false
+  fsGroup:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  requiredDropCapabilities:
+  - ALL
+  runAsUser:
+    rule: MustRunAsNonRoot
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  volumes:
+  - configMap
+  - emptyDir
+  - projected
+  - secret
+  - persistentVolumeClaim
+---
+# policy/v1beta1/PodSecurityPolicy default-ns-workspace
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  annotations:
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default,unconfined
+    apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+  creationTimestamp: null
+  name: default-ns-workspace
+  namespace: default
+spec:
+  allowPrivilegeEscalation: true
+  allowedCapabilities:
+  - AUDIT_WRITE
+  - FSETID
+  - KILL
+  - NET_BIND_SERVICE
+  - SYS_PTRACE
+  fsGroup:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  volumes:
+  - configMap
+  - projected
+  - secret
+  - hostPath
+---
 # policy/v1/PodDisruptionBudget messagebus
 # Source: rabbitmq/charts/rabbitmq/templates/pdb.yaml
 apiVersion: policy/v1
@@ -1661,6 +1883,54 @@ data:
       creationTimestamp: null
       name: default-ns-psp:unprivileged
     ---
+    apiVersion: policy/v1beta1
+    kind: PodSecurityPolicy
+    metadata:
+      annotations:
+        apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
+        apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+        seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
+        seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+      creationTimestamp: null
+      name: default-ns-privileged
+      namespace: default
+    ---
+    apiVersion: policy/v1beta1
+    kind: PodSecurityPolicy
+    metadata:
+      annotations:
+        apparmor.security.beta.kubernetes.io/allowedProfileNames: unconfined
+        apparmor.security.beta.kubernetes.io/defaultProfileName: unconfined
+        seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default,unconfined
+        seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+      creationTimestamp: null
+      name: default-ns-privileged-unconfined
+      namespace: default
+    ---
+    apiVersion: policy/v1beta1
+    kind: PodSecurityPolicy
+    metadata:
+      annotations:
+        apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
+        apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+        seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
+        seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+      creationTimestamp: null
+      name: default-ns-restricted-root-user
+      namespace: default
+    ---
+    apiVersion: policy/v1beta1
+    kind: PodSecurityPolicy
+    metadata:
+      annotations:
+        apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
+        apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+        seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
+        seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+      creationTimestamp: null
+      name: default-ns-unprivileged
+      namespace: default
+    ---
     apiVersion: v1
     kind: ResourceQuota
     metadata:
@@ -2548,6 +2818,20 @@ data:
       name: registry-facade
       namespace: default
     ---
+    apiVersion: policy/v1beta1
+    kind: PodSecurityPolicy
+    metadata:
+      annotations:
+        apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
+        apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+        seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
+        seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: registry-facade
+      name: default-ns-registry-facade
+    ---
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
@@ -2605,6 +2889,18 @@ data:
         app: gitpod
         component: workspace
       name: workspace-default
+      namespace: default
+    ---
+    apiVersion: policy/v1beta1
+    kind: PodSecurityPolicy
+    metadata:
+      annotations:
+        apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default,unconfined
+        apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+        seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+        seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+      creationTimestamp: null
+      name: default-ns-workspace
       namespace: default
     ---
     apiVersion: rbac.authorization.k8s.io/v1

--- a/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
+++ b/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
@@ -663,6 +663,228 @@ spec:
       component: ws-manager
 status: {}
 ---
+# policy/v1beta1/PodSecurityPolicy default-ns-privileged
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  annotations:
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
+    apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+  creationTimestamp: null
+  name: default-ns-privileged
+  namespace: default
+spec:
+  allowPrivilegeEscalation: true
+  allowedCapabilities:
+  - '*'
+  fsGroup:
+    rule: RunAsAny
+  hostIPC: true
+  hostNetwork: true
+  hostPID: true
+  hostPorts:
+  - max: 65535
+    min: 0
+  privileged: true
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - '*'
+---
+# policy/v1beta1/PodSecurityPolicy default-ns-privileged-unconfined
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  annotations:
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: unconfined
+    apparmor.security.beta.kubernetes.io/defaultProfileName: unconfined
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default,unconfined
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+  creationTimestamp: null
+  name: default-ns-privileged-unconfined
+  namespace: default
+spec:
+  allowPrivilegeEscalation: true
+  allowedCapabilities:
+  - '*'
+  fsGroup:
+    rule: RunAsAny
+  hostPID: true
+  hostPorts:
+  - max: 65535
+    min: 0
+  privileged: true
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - '*'
+---
+# policy/v1beta1/PodSecurityPolicy default-ns-registry-facade
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  annotations:
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
+    apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: registry-facade
+  name: default-ns-registry-facade
+spec:
+  fsGroup:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  hostNetwork: true
+  hostPorts:
+  - max: 20000
+    min: 20000
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  volumes:
+  - configMap
+  - secret
+  - emptyDir
+  - hostPath
+---
+# policy/v1beta1/PodSecurityPolicy default-ns-restricted-root-user
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  annotations:
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
+    apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+  creationTimestamp: null
+  name: default-ns-restricted-root-user
+  namespace: default
+spec:
+  fsGroup:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  hostNetwork: true
+  hostPorts:
+  - max: 33000
+    min: 30000
+  privileged: true
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  volumes:
+  - configMap
+  - projected
+  - secret
+  - emptyDir
+  - persistentVolumeClaim
+  - hostPath
+---
+# policy/v1beta1/PodSecurityPolicy default-ns-unprivileged
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  annotations:
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
+    apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+  creationTimestamp: null
+  name: default-ns-unprivileged
+  namespace: default
+spec:
+  allowPrivilegeEscalation: false
+  fsGroup:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  requiredDropCapabilities:
+  - ALL
+  runAsUser:
+    rule: MustRunAsNonRoot
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  volumes:
+  - configMap
+  - emptyDir
+  - projected
+  - secret
+  - persistentVolumeClaim
+---
+# policy/v1beta1/PodSecurityPolicy default-ns-workspace
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  annotations:
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default,unconfined
+    apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+  creationTimestamp: null
+  name: default-ns-workspace
+  namespace: default
+spec:
+  allowPrivilegeEscalation: true
+  allowedCapabilities:
+  - AUDIT_WRITE
+  - FSETID
+  - KILL
+  - NET_BIND_SERVICE
+  - SYS_PTRACE
+  fsGroup:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    ranges:
+    - max: 65535
+      min: 1
+    rule: MustRunAs
+  volumes:
+  - configMap
+  - projected
+  - secret
+  - hostPath
+---
 # policy/v1/PodDisruptionBudget messagebus
 # Source: rabbitmq/charts/rabbitmq/templates/pdb.yaml
 apiVersion: policy/v1
@@ -1634,6 +1856,72 @@ data:
       creationTimestamp: null
       name: default-kube-rbac-proxy
     ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      creationTimestamp: null
+      name: default-ns-psp:privileged
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      creationTimestamp: null
+      name: default-ns-psp:restricted-root-user
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      creationTimestamp: null
+      name: default-ns-psp:unprivileged
+    ---
+    apiVersion: policy/v1beta1
+    kind: PodSecurityPolicy
+    metadata:
+      annotations:
+        apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
+        apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+        seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
+        seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+      creationTimestamp: null
+      name: default-ns-privileged
+      namespace: default
+    ---
+    apiVersion: policy/v1beta1
+    kind: PodSecurityPolicy
+    metadata:
+      annotations:
+        apparmor.security.beta.kubernetes.io/allowedProfileNames: unconfined
+        apparmor.security.beta.kubernetes.io/defaultProfileName: unconfined
+        seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default,unconfined
+        seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+      creationTimestamp: null
+      name: default-ns-privileged-unconfined
+      namespace: default
+    ---
+    apiVersion: policy/v1beta1
+    kind: PodSecurityPolicy
+    metadata:
+      annotations:
+        apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
+        apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+        seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
+        seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+      creationTimestamp: null
+      name: default-ns-restricted-root-user
+      namespace: default
+    ---
+    apiVersion: policy/v1beta1
+    kind: PodSecurityPolicy
+    metadata:
+      annotations:
+        apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
+        apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+        seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
+        seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+      creationTimestamp: null
+      name: default-ns-unprivileged
+      namespace: default
+    ---
     apiVersion: v1
     kind: ResourceQuota
     metadata:
@@ -2521,6 +2809,20 @@ data:
       name: registry-facade
       namespace: default
     ---
+    apiVersion: policy/v1beta1
+    kind: PodSecurityPolicy
+    metadata:
+      annotations:
+        apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
+        apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+        seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
+        seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: registry-facade
+      name: default-ns-registry-facade
+    ---
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
@@ -2578,6 +2880,28 @@ data:
         app: gitpod
         component: workspace
       name: workspace-default
+      namespace: default
+    ---
+    apiVersion: policy/v1beta1
+    kind: PodSecurityPolicy
+    metadata:
+      annotations:
+        apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default,unconfined
+        apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+        seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+        seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+      creationTimestamp: null
+      name: default-ns-workspace
+      namespace: default
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: workspace
+      name: workspace
       namespace: default
     ---
     apiVersion: rbac.authorization.k8s.io/v1
@@ -2916,6 +3240,15 @@ data:
         component: ws-proxy
       name: ws-proxy
       namespace: default
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: image-builder-mk3
+      name: default-ns-image-builder-mk3
     ---
     apiVersion: v1
     kind: ConfigMap
@@ -4312,6 +4645,73 @@ rules:
   verbs:
   - create
 ---
+# rbac.authorization.k8s.io/v1/ClusterRole default-ns-image-builder-mk3
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: image-builder-mk3
+  name: default-ns-image-builder-mk3
+rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - default-ns-privileged-unconfined
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+---
+# rbac.authorization.k8s.io/v1/ClusterRole default-ns-psp:privileged
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: default-ns-psp:privileged
+rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - default-ns-privileged
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+---
+# rbac.authorization.k8s.io/v1/ClusterRole default-ns-psp:restricted-root-user
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: default-ns-psp:restricted-root-user
+rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - default-ns-restricted-root-user
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+---
+# rbac.authorization.k8s.io/v1/ClusterRole default-ns-psp:unprivileged
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: default-ns-psp:unprivileged
+rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - default-ns-unprivileged
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+---
 # rbac.authorization.k8s.io/v1/ClusterRole default-ns-registry-facade
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -4322,6 +4722,14 @@ metadata:
     component: registry-facade
   name: default-ns-registry-facade
 rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - default-ns-registry-facade
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
 - apiGroups:
   - ""
   resources:
@@ -4342,6 +4750,14 @@ metadata:
     component: ws-daemon
   name: default-ns-ws-daemon
 rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - default-ns-privileged-unconfined
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
 - apiGroups:
   - ""
   resources:
@@ -4721,6 +5137,14 @@ metadata:
   namespace: default
 rules:
 - apiGroups:
+  - policy
+  resourceNames:
+  - default-ns-privileged-unconfined
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+- apiGroups:
   - ""
   resources:
   - pods
@@ -4782,6 +5206,26 @@ rules:
   - update
   - patch
   - watch
+---
+# rbac.authorization.k8s.io/v1/Role workspace
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: workspace
+  name: workspace
+  namespace: default
+rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - default-ns-workspace
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
 ---
 # rbac.authorization.k8s.io/v1/Role ws-manager
 apiVersion: rbac.authorization.k8s.io/v1

--- a/install/installer/pkg/common/common.go
+++ b/install/installer/pkg/common/common.go
@@ -541,6 +541,10 @@ var (
 		APIVersion: "v1",
 		Kind:       "Secret",
 	}
+	TypeMetaPodSecurityPolicy = metav1.TypeMeta{
+		APIVersion: "policy/v1beta1",
+		Kind:       "PodSecurityPolicy",
+	}
 	TypeMetaResourceQuota = metav1.TypeMeta{
 		APIVersion: "v1",
 		Kind:       "ResourceQuota",

--- a/install/installer/pkg/components/cluster/clusterrole.go
+++ b/install/installer/pkg/components/cluster/clusterrole.go
@@ -6,7 +6,6 @@ package cluster
 
 import (
 	"fmt"
-
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 	v1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -28,6 +27,42 @@ func clusterrole(ctx *common.RenderContext) ([]runtime.Object, error) {
 				APIGroups: []string{"authorization.k8s.io"},
 				Resources: []string{"subjectaccessreviews"},
 				Verbs:     []string{"create"},
+			}},
+		},
+		&v1.ClusterRole{
+			TypeMeta: common.TypeMetaClusterRole,
+			ObjectMeta: metav1.ObjectMeta{
+				Name: fmt.Sprintf("%s-ns-psp:privileged", ctx.Namespace),
+			},
+			Rules: []v1.PolicyRule{{
+				APIGroups:     []string{"policy"},
+				Resources:     []string{"podsecuritypolicies"},
+				Verbs:         []string{"use"},
+				ResourceNames: []string{fmt.Sprintf("%s-ns-privileged", ctx.Namespace)},
+			}},
+		},
+		&v1.ClusterRole{
+			TypeMeta: common.TypeMetaClusterRole,
+			ObjectMeta: metav1.ObjectMeta{
+				Name: fmt.Sprintf("%s-ns-psp:restricted-root-user", ctx.Namespace),
+			},
+			Rules: []v1.PolicyRule{{
+				APIGroups:     []string{"policy"},
+				Resources:     []string{"podsecuritypolicies"},
+				Verbs:         []string{"use"},
+				ResourceNames: []string{fmt.Sprintf("%s-ns-restricted-root-user", ctx.Namespace)},
+			}},
+		},
+		&v1.ClusterRole{
+			TypeMeta: common.TypeMetaClusterRole,
+			ObjectMeta: metav1.ObjectMeta{
+				Name: fmt.Sprintf("%s-ns-psp:unprivileged", ctx.Namespace),
+			},
+			Rules: []v1.PolicyRule{{
+				APIGroups:     []string{"policy"},
+				Resources:     []string{"podsecuritypolicies"},
+				Verbs:         []string{"use"},
+				ResourceNames: []string{fmt.Sprintf("%s-ns-unprivileged", ctx.Namespace)},
 			}},
 		},
 	}, nil

--- a/install/installer/pkg/components/cluster/objects.go
+++ b/install/installer/pkg/components/cluster/objects.go
@@ -12,6 +12,7 @@ import "github.com/gitpod-io/gitpod/installer/pkg/common"
 var Objects = common.CompositeRenderFunc(
 	certmanager,
 	clusterrole,
+	podsecuritypolicies,
 	resourcequota,
 	rolebinding,
 	common.DefaultServiceAccount(NobodyComponent),

--- a/install/installer/pkg/components/cluster/podsecuritypolicies.go
+++ b/install/installer/pkg/components/cluster/podsecuritypolicies.go
@@ -1,0 +1,174 @@
+// Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package cluster
+
+import (
+	"fmt"
+
+	"github.com/gitpod-io/gitpod/installer/pkg/common"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/api/policy/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/pointer"
+)
+
+func podsecuritypolicies(ctx *common.RenderContext) ([]runtime.Object, error) {
+	return []runtime.Object{
+		&v1beta1.PodSecurityPolicy{
+			TypeMeta: common.TypeMetaPodSecurityPolicy,
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("%s-ns-privileged", ctx.Namespace),
+				Namespace: ctx.Namespace,
+				Annotations: map[string]string{
+					"apparmor.security.beta.kubernetes.io/allowedProfileNames": "runtime/default",
+					"apparmor.security.beta.kubernetes.io/defaultProfileName":  "runtime/default",
+					"seccomp.security.alpha.kubernetes.io/allowedProfileNames": "runtime/default",
+					"seccomp.security.alpha.kubernetes.io/defaultProfileName":  "runtime/default",
+				},
+			},
+			Spec: v1beta1.PodSecurityPolicySpec{
+				Privileged:               true,
+				AllowPrivilegeEscalation: pointer.Bool(true),
+				AllowedCapabilities:      []corev1.Capability{"*"},
+				Volumes:                  []v1beta1.FSType{v1beta1.All},
+				HostNetwork:              true,
+				HostPorts: []v1beta1.HostPortRange{{
+					Min: 0,
+					Max: 65535,
+				}},
+				HostIPC:            true,
+				HostPID:            true,
+				RunAsUser:          v1beta1.RunAsUserStrategyOptions{Rule: v1beta1.RunAsUserStrategyRunAsAny},
+				SELinux:            v1beta1.SELinuxStrategyOptions{Rule: v1beta1.SELinuxStrategyRunAsAny},
+				SupplementalGroups: v1beta1.SupplementalGroupsStrategyOptions{Rule: v1beta1.SupplementalGroupsStrategyRunAsAny},
+				FSGroup:            v1beta1.FSGroupStrategyOptions{Rule: v1beta1.FSGroupStrategyRunAsAny},
+			},
+		},
+		&v1beta1.PodSecurityPolicy{
+			TypeMeta: common.TypeMetaPodSecurityPolicy,
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("%s-ns-privileged-unconfined", ctx.Namespace),
+				Namespace: ctx.Namespace,
+				Annotations: map[string]string{
+					"apparmor.security.beta.kubernetes.io/allowedProfileNames": "unconfined",
+					"apparmor.security.beta.kubernetes.io/defaultProfileName":  "unconfined",
+					"seccomp.security.alpha.kubernetes.io/allowedProfileNames": "runtime/default,unconfined",
+					"seccomp.security.alpha.kubernetes.io/defaultProfileName":  "runtime/default",
+				},
+			},
+			Spec: v1beta1.PodSecurityPolicySpec{
+				Privileged:               true,
+				AllowPrivilegeEscalation: pointer.Bool(true),
+				AllowedCapabilities:      []corev1.Capability{"*"},
+				Volumes:                  []v1beta1.FSType{v1beta1.All},
+				HostNetwork:              false,
+				HostPorts: []v1beta1.HostPortRange{{
+					Min: 0,
+					Max: 65535,
+				}},
+				HostIPC:            false,
+				HostPID:            true,
+				RunAsUser:          v1beta1.RunAsUserStrategyOptions{Rule: v1beta1.RunAsUserStrategyRunAsAny},
+				SELinux:            v1beta1.SELinuxStrategyOptions{Rule: v1beta1.SELinuxStrategyRunAsAny},
+				SupplementalGroups: v1beta1.SupplementalGroupsStrategyOptions{Rule: v1beta1.SupplementalGroupsStrategyRunAsAny},
+				FSGroup:            v1beta1.FSGroupStrategyOptions{Rule: v1beta1.FSGroupStrategyRunAsAny},
+			},
+		},
+		&v1beta1.PodSecurityPolicy{
+			TypeMeta: common.TypeMetaPodSecurityPolicy,
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("%s-ns-restricted-root-user", ctx.Namespace),
+				Namespace: ctx.Namespace,
+				Annotations: map[string]string{
+					"seccomp.security.alpha.kubernetes.io/allowedProfileNames": "runtime/default",
+					"apparmor.security.beta.kubernetes.io/allowedProfileNames": "runtime/default",
+					"seccomp.security.alpha.kubernetes.io/defaultProfileName":  "runtime/default",
+					"apparmor.security.beta.kubernetes.io/defaultProfileName":  "runtime/default",
+				},
+			},
+			Spec: v1beta1.PodSecurityPolicySpec{
+				Privileged: true,
+				Volumes: []v1beta1.FSType{
+					v1beta1.ConfigMap,
+					v1beta1.Projected,
+					v1beta1.Secret,
+					v1beta1.EmptyDir,
+					v1beta1.PersistentVolumeClaim,
+					v1beta1.HostPath,
+				},
+				HostNetwork: true,
+				HostPorts: []v1beta1.HostPortRange{{
+					Min: 30000,
+					Max: 33000,
+				}},
+				HostIPC:   false,
+				HostPID:   false,
+				RunAsUser: v1beta1.RunAsUserStrategyOptions{Rule: v1beta1.RunAsUserStrategyRunAsAny},
+				SELinux:   v1beta1.SELinuxStrategyOptions{Rule: v1beta1.SELinuxStrategyRunAsAny},
+				SupplementalGroups: v1beta1.SupplementalGroupsStrategyOptions{
+					Rule: v1beta1.SupplementalGroupsStrategyMustRunAs,
+					Ranges: []v1beta1.IDRange{{
+						Min: 1,
+						Max: 65535,
+					}},
+				},
+				FSGroup: v1beta1.FSGroupStrategyOptions{
+					Rule: v1beta1.FSGroupStrategyMustRunAs,
+					Ranges: []v1beta1.IDRange{{
+						Min: 1,
+						Max: 65535,
+					}},
+				},
+				ReadOnlyRootFilesystem: false,
+			},
+		},
+		&v1beta1.PodSecurityPolicy{
+			TypeMeta: common.TypeMetaPodSecurityPolicy,
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("%s-ns-unprivileged", ctx.Namespace),
+				Namespace: ctx.Namespace,
+				Annotations: map[string]string{
+					"seccomp.security.alpha.kubernetes.io/allowedProfileNames": "runtime/default",
+					"apparmor.security.beta.kubernetes.io/allowedProfileNames": "runtime/default",
+					"seccomp.security.alpha.kubernetes.io/defaultProfileName":  "runtime/default",
+					"apparmor.security.beta.kubernetes.io/defaultProfileName":  "runtime/default",
+				},
+			},
+			Spec: v1beta1.PodSecurityPolicySpec{
+				Privileged:               false,
+				AllowPrivilegeEscalation: pointer.Bool(false),
+				RequiredDropCapabilities: []corev1.Capability{"ALL"},
+				Volumes: []v1beta1.FSType{
+					v1beta1.ConfigMap,
+					v1beta1.EmptyDir,
+					v1beta1.Projected,
+					v1beta1.Secret,
+					v1beta1.PersistentVolumeClaim,
+				},
+				HostNetwork: false,
+				HostIPC:     false,
+				HostPID:     false,
+				RunAsUser:   v1beta1.RunAsUserStrategyOptions{Rule: v1beta1.RunAsUserStrategyMustRunAsNonRoot},
+				SELinux:     v1beta1.SELinuxStrategyOptions{Rule: v1beta1.SELinuxStrategyRunAsAny},
+				SupplementalGroups: v1beta1.SupplementalGroupsStrategyOptions{
+					Rule: v1beta1.SupplementalGroupsStrategyMustRunAs,
+					Ranges: []v1beta1.IDRange{{
+						Min: 1,
+						Max: 65535,
+					}},
+				},
+				FSGroup: v1beta1.FSGroupStrategyOptions{
+					Rule: v1beta1.FSGroupStrategyMustRunAs,
+					Ranges: []v1beta1.IDRange{{
+						Min: 1,
+						Max: 65535,
+					}},
+				},
+				ReadOnlyRootFilesystem: false,
+			},
+		},
+	}, nil
+}

--- a/install/installer/pkg/components/image-builder-mk3/clusterrole.go
+++ b/install/installer/pkg/components/image-builder-mk3/clusterrole.go
@@ -2,7 +2,7 @@
 // Licensed under the GNU Affero General Public License (AGPL).
 // See License-AGPL.txt in the project root for license information.
 
-package registryfacade
+package image_builder_mk3
 
 import (
 	"fmt"
@@ -27,11 +27,7 @@ func clusterrole(ctx *common.RenderContext) ([]runtime.Object, error) {
 					APIGroups:     []string{"policy"},
 					Resources:     []string{"podsecuritypolicies"},
 					Verbs:         []string{"use"},
-					ResourceNames: []string{fmt.Sprintf("%s-ns-%s", ctx.Namespace, Component)},
-				}, {
-					APIGroups: []string{""},
-					Resources: []string{"nodes"},
-					Verbs:     []string{"get", "list", "update", "patch"},
+					ResourceNames: []string{fmt.Sprintf("%s-ns-privileged-unconfined", ctx.Namespace)},
 				},
 			},
 		},

--- a/install/installer/pkg/components/image-builder-mk3/clusterrole.go
+++ b/install/installer/pkg/components/image-builder-mk3/clusterrole.go
@@ -15,21 +15,17 @@ import (
 )
 
 func clusterrole(ctx *common.RenderContext) ([]runtime.Object, error) {
-	return []runtime.Object{
-		&rbacv1.ClusterRole{
-			TypeMeta: common.TypeMetaClusterRole,
-			ObjectMeta: metav1.ObjectMeta{
-				Name:   fmt.Sprintf("%s-ns-%s", ctx.Namespace, Component),
-				Labels: common.DefaultLabels(Component),
-			},
-			Rules: []rbacv1.PolicyRule{
-				{
-					APIGroups:     []string{"policy"},
-					Resources:     []string{"podsecuritypolicies"},
-					Verbs:         []string{"use"},
-					ResourceNames: []string{fmt.Sprintf("%s-ns-privileged-unconfined", ctx.Namespace)},
-				},
-			},
+	return []runtime.Object{&rbacv1.ClusterRole{
+		TypeMeta: common.TypeMetaClusterRole,
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   fmt.Sprintf("%s-ns-%s", ctx.Namespace, Component),
+			Labels: common.DefaultLabels(Component),
 		},
-	}, nil
+		Rules: []rbacv1.PolicyRule{{
+			APIGroups:     []string{"policy"},
+			Resources:     []string{"podsecuritypolicies"},
+			Verbs:         []string{"use"},
+			ResourceNames: []string{fmt.Sprintf("%s-ns-privileged-unconfined", ctx.Namespace)},
+		}},
+	}}, nil
 }

--- a/install/installer/pkg/components/image-builder-mk3/objects.go
+++ b/install/installer/pkg/components/image-builder-mk3/objects.go
@@ -7,6 +7,7 @@ package image_builder_mk3
 import "github.com/gitpod-io/gitpod/installer/pkg/common"
 
 var Objects = common.CompositeRenderFunc(
+	clusterrole,
 	configmap,
 	deployment,
 	networkpolicy,

--- a/install/installer/pkg/components/registry-facade/objects.go
+++ b/install/installer/pkg/components/registry-facade/objects.go
@@ -13,6 +13,7 @@ var Objects = common.CompositeRenderFunc(
 	configmap,
 	daemonset,
 	networkpolicy,
+	podsecuritypolicy,
 	rolebinding,
 	certificate,
 	common.GenerateService(Component, []common.ServicePort{

--- a/install/installer/pkg/components/registry-facade/podsecuritypolicy.go
+++ b/install/installer/pkg/components/registry-facade/podsecuritypolicy.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package registryfacade
+
+import (
+	"fmt"
+
+	"github.com/gitpod-io/gitpod/installer/pkg/common"
+
+	"k8s.io/api/policy/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func podsecuritypolicy(ctx *common.RenderContext) ([]runtime.Object, error) {
+	return []runtime.Object{&v1beta1.PodSecurityPolicy{
+		TypeMeta: common.TypeMetaPodSecurityPolicy,
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   fmt.Sprintf("%s-ns-%s", ctx.Namespace, Component),
+			Labels: common.DefaultLabels(Component),
+			Annotations: map[string]string{
+				"seccomp.security.alpha.kubernetes.io/allowedProfileNames": "runtime/default",
+				"apparmor.security.beta.kubernetes.io/allowedProfileNames": "runtime/default",
+				"seccomp.security.alpha.kubernetes.io/defaultProfileName":  "runtime/default",
+				"apparmor.security.beta.kubernetes.io/defaultProfileName":  "runtime/default",
+			},
+		},
+		Spec: v1beta1.PodSecurityPolicySpec{
+			Volumes: []v1beta1.FSType{
+				v1beta1.ConfigMap,
+				v1beta1.Secret,
+				v1beta1.EmptyDir,
+				v1beta1.HostPath,
+			},
+			HostNetwork: true,
+			HostIPC:     false,
+			HostPID:     false,
+			HostPorts: []v1beta1.HostPortRange{{
+				Min: 20000,
+				Max: 20000,
+			}},
+			RunAsUser: v1beta1.RunAsUserStrategyOptions{
+				Rule: v1beta1.RunAsUserStrategyRunAsAny,
+			},
+			SELinux: v1beta1.SELinuxStrategyOptions{
+				Rule: v1beta1.SELinuxStrategyRunAsAny,
+			},
+			SupplementalGroups: v1beta1.SupplementalGroupsStrategyOptions{
+				Rule: v1beta1.SupplementalGroupsStrategyMustRunAs,
+				Ranges: []v1beta1.IDRange{{
+					Min: 1,
+					Max: 65535,
+				}},
+			},
+			FSGroup: v1beta1.FSGroupStrategyOptions{
+				Rule: v1beta1.FSGroupStrategyMustRunAs,
+				Ranges: []v1beta1.IDRange{{
+					Min: 1,
+					Max: 65535,
+				}},
+			},
+			ReadOnlyRootFilesystem: false,
+		},
+	}}, nil
+}

--- a/install/installer/pkg/components/workspace/objects.go
+++ b/install/installer/pkg/components/workspace/objects.go
@@ -8,6 +8,7 @@ import "github.com/gitpod-io/gitpod/installer/pkg/common"
 
 var Objects = common.CompositeRenderFunc(
 	networkpolicy,
+	role,
 	rolebinding,
 	common.DefaultServiceAccount(Component),
 )

--- a/install/installer/pkg/components/workspace/objects.go
+++ b/install/installer/pkg/components/workspace/objects.go
@@ -8,6 +8,7 @@ import "github.com/gitpod-io/gitpod/installer/pkg/common"
 
 var Objects = common.CompositeRenderFunc(
 	networkpolicy,
+	podsecuritypolicies,
 	role,
 	rolebinding,
 	common.DefaultServiceAccount(Component),

--- a/install/installer/pkg/components/workspace/podsecuritypolicies.go
+++ b/install/installer/pkg/components/workspace/podsecuritypolicies.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package workspace
+
+import (
+	"fmt"
+	"github.com/gitpod-io/gitpod/installer/pkg/common"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/api/policy/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/pointer"
+)
+
+func podsecuritypolicies(ctx *common.RenderContext) ([]runtime.Object, error) {
+	return []runtime.Object{
+		&v1beta1.PodSecurityPolicy{
+			TypeMeta: common.TypeMetaPodSecurityPolicy,
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("%s-ns-workspace", ctx.Namespace),
+				Namespace: ctx.Namespace,
+				Annotations: map[string]string{
+					"seccomp.security.alpha.kubernetes.io/allowedProfileNames": "*",
+					"apparmor.security.beta.kubernetes.io/allowedProfileNames": "runtime/default,unconfined",
+					"seccomp.security.alpha.kubernetes.io/defaultProfileName":  "runtime/default",
+					"apparmor.security.beta.kubernetes.io/defaultProfileName":  "runtime/default",
+				},
+			},
+			Spec: v1beta1.PodSecurityPolicySpec{
+				Privileged:               false,
+				AllowPrivilegeEscalation: pointer.Bool(true),
+				AllowedCapabilities:      []corev1.Capability{"AUDIT_WRITE", "FSETID", "KILL", "NET_BIND_SERVICE", "SYS_PTRACE"},
+				Volumes:                  []v1beta1.FSType{v1beta1.ConfigMap, v1beta1.Projected, v1beta1.Secret, v1beta1.HostPath},
+				HostNetwork:              false,
+				HostIPC:                  false,
+				HostPID:                  false,
+				RunAsUser:                v1beta1.RunAsUserStrategyOptions{Rule: v1beta1.RunAsUserStrategyRunAsAny},
+				SELinux:                  v1beta1.SELinuxStrategyOptions{Rule: v1beta1.SELinuxStrategyRunAsAny},
+				SupplementalGroups: v1beta1.SupplementalGroupsStrategyOptions{
+					Rule: v1beta1.SupplementalGroupsStrategyMustRunAs,
+					Ranges: []v1beta1.IDRange{{
+						Min: 1,
+						Max: 65535,
+					}},
+				},
+				FSGroup: v1beta1.FSGroupStrategyOptions{
+					Rule: v1beta1.FSGroupStrategyMustRunAs,
+					Ranges: []v1beta1.IDRange{{
+						Min: 1,
+						Max: 65535,
+					}},
+				},
+				ReadOnlyRootFilesystem: false,
+			},
+		},
+	}, nil
+}

--- a/install/installer/pkg/components/workspace/role.go
+++ b/install/installer/pkg/components/workspace/role.go
@@ -2,11 +2,10 @@
 // Licensed under the GNU Affero General Public License (AGPL).
 // See License-AGPL.txt in the project root for license information.
 
-package agentsmith
+package workspace
 
 import (
 	"fmt"
-
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -27,12 +26,7 @@ func role(ctx *common.RenderContext) ([]runtime.Object, error) {
 				APIGroups:     []string{"policy"},
 				Resources:     []string{"podsecuritypolicies"},
 				Verbs:         []string{"use"},
-				ResourceNames: []string{fmt.Sprintf("%s-ns-privileged-unconfined", ctx.Namespace)},
-			},
-			{
-				APIGroups: []string{""},
-				Resources: []string{"pods"},
-				Verbs:     []string{"get", "update"},
+				ResourceNames: []string{fmt.Sprintf("%s-ns-workspace", ctx.Namespace)},
 			},
 		},
 	}}, nil

--- a/install/installer/pkg/components/ws-daemon/clusterrole.go
+++ b/install/installer/pkg/components/ws-daemon/clusterrole.go
@@ -24,23 +24,26 @@ func clusterrole(ctx *common.RenderContext) ([]runtime.Object, error) {
 				Name:   fmt.Sprintf("%s-ns-%s", ctx.Namespace, Component),
 				Labels: labels,
 			},
-			Rules: []rbacv1.PolicyRule{
-				{
-					APIGroups: []string{""},
-					Resources: []string{"nodes"},
-					Verbs:     []string{"get", "list", "update", "patch"},
+			Rules: []rbacv1.PolicyRule{{
+				APIGroups: []string{"policy"},
+				Resources: []string{"podsecuritypolicies"},
+				Verbs:     []string{"use"},
+				ResourceNames: []string{
+					fmt.Sprintf("%s-ns-privileged-unconfined", ctx.Namespace),
 				},
-				{
-					APIGroups: []string{""},
-					Resources: []string{"pods", "services"},
-					Verbs:     []string{"get", "list", "watch"},
-				},
-				{
-					APIGroups: []string{""},
-					Resources: []string{"pods"},
-					Verbs:     []string{"delete", "update", "patch"},
-				},
-			},
+			}, {
+				APIGroups: []string{""},
+				Resources: []string{"nodes"},
+				Verbs:     []string{"get", "list", "update", "patch"},
+			}, {
+				APIGroups: []string{""},
+				Resources: []string{"pods", "services"},
+				Verbs:     []string{"get", "list", "watch"},
+			}, {
+				APIGroups: []string{""},
+				Resources: []string{"pods"},
+				Verbs:     []string{"delete", "update", "patch"},
+			}},
 		},
 	}, nil
 }

--- a/install/kots/manifests/gitpod-installation-status.yaml
+++ b/install/kots/manifests/gitpod-installation-status.yaml
@@ -30,7 +30,7 @@ spec:
       containers:
         - name: installation-status
           # This will normally be the release tag
-          image: "eu.gcr.io/gitpod-core-dev/build/installer:sje-installer-psp-removal.5"
+          image: "eu.gcr.io/gitpod-core-dev/build/installer:sje-kots-backup.33"
           command:
             - /bin/sh
             - -c

--- a/install/kots/manifests/gitpod-installer-job.yaml
+++ b/install/kots/manifests/gitpod-installer-job.yaml
@@ -39,7 +39,7 @@ spec:
       containers:
         - name: installer
           # This will normally be the release tag
-          image: "eu.gcr.io/gitpod-core-dev/build/installer:sje-installer-psp-removal.5"
+          image: "eu.gcr.io/gitpod-core-dev/build/installer:sje-kots-backup.33"
           volumeMounts:
             - mountPath: /config-patch
               name: config-patch


### PR DESCRIPTION
Reverts gitpod-io/gitpod#12173

Caused issue in SaaS due to GKE having PodSecurityPolicies enabled on cluster - see [channel](https://gitpod.slack.com/archives/C03UQ58RG0M)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Revert "[installer]: remove all podsecuritypolicies" #12313
```