### PR TITLE
[ws-daemon] Prevent divide by zero error

### DIFF
--- a/components/common-go/cgroups/v2/cpu.go
+++ b/components/common-go/cgroups/v2/cpu.go
@@ -43,7 +43,7 @@ func (c *Cpu) Max() (quota uint64, period uint64, err error) {
 	path := filepath.Join(c.path, "cpu.max")
 	content, err := os.ReadFile(path)
 	if err != nil {
-		return 0, 0, nil
+		return 0, 0, err
 	}
 
 	values := strings.Split(strings.TrimSpace(string(content)), " ")

--- a/components/ws-daemon/pkg/iws/iws.go
+++ b/components/ws-daemon/pkg/iws/iws.go
@@ -7,6 +7,7 @@ package iws
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -1104,13 +1105,16 @@ func getCpuResourceInfoV2(mountPoint, cgroupPath string) (*api.Cpu, error) {
 	used := cpuUsage / totalTime * 1000
 
 	quota, period, err := cpu.Max()
-	if err != nil {
+	if errors.Is(err, os.ErrNotExist) {
+		quota = math.MaxUint64
+	} else if err != nil {
 		return nil, err
 	}
 
 	// if no cpu limit has been specified, use the number of cores
 	var limit uint64
 	if quota == math.MaxUint64 {
+		// TODO(toru): we have to check a parent cgroup instead of a host resources
 		cpuInfo, err := linuxproc.ReadCPUInfo("/proc/cpuinfo")
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
## Description
Prevent divide by zero error

## Related Issue(s)
Fixes https://github.com/gitpod-io/gitpod/issues/12295

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Prevent divide by zero error in workspace info service
```

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
