### PR TITLE
remove trace from retryifUnavailable

### DIFF
--- a/components/ws-manager/pkg/manager/monitor.go
+++ b/components/ws-manager/pkg/manager/monitor.go
@@ -955,12 +955,8 @@ func (m *Monitor) initializeWorkspaceContent(ctx context.Context, pod *corev1.Po
 
 // retryIfUnavailable makes multiple attempts to execute op if op returns an UNAVAILABLE gRPC status code
 func retryIfUnavailable(ctx context.Context, op func(ctx context.Context) error) (err error) {
-	span, ctx := tracing.FromContext(ctx, "retryIfUnavailable")
-	defer tracing.FinishSpan(span, &err)
-
 	for i := 0; i < wsdaemonMaxAttempts; i++ {
 		err := op(ctx)
-		span.LogKV("attempt", i)
 
 		if st, ok := grpc_status.FromError(err); ok && st.Code() == codes.Unavailable {
 			// service is unavailable - try again after some time


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
It is not needed and only makes it more difficult to understand traces.
Plus it logs errors that are not actually errors, like NotFound, which is handled by parent function.
So this should clean up filtering for traces that actually have a valid error

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
none
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
