### PR TITLE
[usage] Return report_id from ReconcileUsage RPC

### DIFF
--- a/components/usage/pkg/apiv1/usage.go
+++ b/components/usage/pkg/apiv1/usage.go
@@ -131,6 +131,7 @@ func (s *UsageService) ReconcileUsage(ctx context.Context, req *v1.ReconcileUsag
 
 	return &v1.ReconcileUsageResponse{
 		Sessions: sessions,
+		ReportId: filename,
 	}, nil
 
 }

--- a/components/usage/pkg/controller/reconciler.go
+++ b/components/usage/pkg/controller/reconciler.go
@@ -60,10 +60,13 @@ func (r *UsageAndBillingReconciler) Reconcile() (err error) {
 	sessions := usageResp.GetSessions()
 	reportSessionsRetrievedTotal(len(sessions))
 
+	reportID := usageResp.GetReportId()
+
 	_, err = r.billingClient.UpdateInvoices(ctx, &v1.UpdateInvoicesRequest{
 		StartTime: timestamppb.New(startOfCurrentMonth),
 		EndTime:   timestamppb.New(startOfNextMonth),
 		Sessions:  sessions,
+		ReportId:  reportID,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to update invoices: %w", err)


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Implements returning of ReportID in ReconcileUsage responses.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Depends on https://github.com/gitpod-io/gitpod/pull/12333/files

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
