### PR TITLE
[content-service] Implement UsageReportService.DownloadURL

### DIFF
--- a/components/content-service/pkg/service/usage-report-service_test.go
+++ b/components/content-service/pkg/service/usage-report-service_test.go
@@ -38,3 +38,24 @@ func TestUploadURL(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "http://example.com/some-path", resp.Url)
 }
+
+func TestDownloadURL(t *testing.T) {
+	const (
+		fileName   = "some-report-filename"
+		bucketName = "gitpod-usage-reports"
+	)
+
+	ctrl := gomock.NewController(t)
+	s := storagemock.NewMockPresignedAccess(ctrl)
+
+	s.EXPECT().EnsureExists(gomock.Any(), bucketName).
+		Return(nil)
+	s.EXPECT().SignDownload(gomock.Any(), bucketName, fileName, gomock.Any()).
+		Return(&storage.DownloadInfo{URL: "http://example.com/some-path"}, nil)
+
+	svc := &UsageReportService{cfg: config.StorageConfig{}, s: s, bucketName: bucketName}
+	resp, err := svc.DownloadURL(context.Background(), &api.UsageReportDownloadURLRequest{Name: fileName})
+
+	require.NoError(t, err)
+	require.Equal(t, "http://example.com/some-path", resp.Url)
+}

--- a/components/content-service/pkg/storage/storage.go
+++ b/components/content-service/pkg/storage/storage.go
@@ -32,7 +32,7 @@ const (
 
 var (
 	// ErrNotFound is returned when an object is not found
-	ErrNotFound = xerrors.Errorf("not found")
+	ErrNotFound = fmt.Errorf("not found")
 )
 
 // BucketNamer provides names for storage buckets


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Implements DownloadURL rpc. This is needed to be able to download a usage report form the usage component.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Depends on https://github.com/gitpod-io/gitpod/pull/12300

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
