### PR TITLE
[installer]: show deprecation warning if using podsecuritypolicies

### DIFF
--- a/install/installer/pkg/config/v1/config.go
+++ b/install/installer/pkg/config/v1/config.go
@@ -79,50 +79,56 @@ func (v version) CheckDeprecated(rawCfg interface{}) (map[string]interface{}, []
 	conflicts := make([]string, 0)
 	cfg := rawCfg.(*Config)
 
-	if cfg.Experimental != nil && cfg.Experimental.WebApp != nil {
-		// service type of proxy is now configurable from main config
-		if cfg.Experimental.WebApp.ProxyConfig != nil && cfg.Experimental.WebApp.ProxyConfig.ServiceType != nil {
-			warnings["experimental.webapp.proxy.serviceType"] = *cfg.Experimental.WebApp.ProxyConfig.ServiceType
-
-			if cfg.Components != nil && cfg.Components.Proxy != nil && cfg.Components.Proxy.Service != nil && cfg.Components.Proxy.Service.ServiceType != nil {
-				conflicts = append(conflicts, "Cannot set proxy service type in both components and experimental")
-			} else {
-				// Promote the experimental value to the components
-				if cfg.Components == nil {
-					cfg.Components = &Components{}
-				}
-				if cfg.Components.Proxy == nil {
-					cfg.Components.Proxy = &ProxyComponent{}
-				}
-				if cfg.Components.Proxy.Service == nil {
-					cfg.Components.Proxy.Service = &ComponentTypeService{}
-				}
-				cfg.Components.Proxy.Service.ServiceType = cfg.Experimental.WebApp.ProxyConfig.ServiceType
-			}
+	if cfg.Experimental != nil {
+		if cfg.Experimental.Common != nil && cfg.Experimental.Common.UsePodSecurityPolicies {
+			warnings["experimental.common.usePodSecurityPolicies"] = "true"
 		}
 
-		// default workspace base image is now configurable from main config
-		if cfg.Experimental.WebApp.Server != nil {
+		if cfg.Experimental.WebApp != nil {
+			// service type of proxy is now configurable from main config
+			if cfg.Experimental.WebApp.ProxyConfig != nil && cfg.Experimental.WebApp.ProxyConfig.ServiceType != nil {
+				warnings["experimental.webapp.proxy.serviceType"] = *cfg.Experimental.WebApp.ProxyConfig.ServiceType
 
-			workspaceImage := cfg.Experimental.WebApp.Server.WorkspaceDefaults.WorkspaceImage
-			if workspaceImage != "" {
-				warnings["experimental.webapp.server.workspaceDefaults.workspaceImage"] = workspaceImage
-
-				if cfg.Workspace.WorkspaceImage != "" {
-					conflicts = append(conflicts, "Cannot set default workspace image in both workspaces and experimental")
+				if cfg.Components != nil && cfg.Components.Proxy != nil && cfg.Components.Proxy.Service != nil && cfg.Components.Proxy.Service.ServiceType != nil {
+					conflicts = append(conflicts, "Cannot set proxy service type in both components and experimental")
 				} else {
-					cfg.Workspace.WorkspaceImage = workspaceImage
+					// Promote the experimental value to the components
+					if cfg.Components == nil {
+						cfg.Components = &Components{}
+					}
+					if cfg.Components.Proxy == nil {
+						cfg.Components.Proxy = &ProxyComponent{}
+					}
+					if cfg.Components.Proxy.Service == nil {
+						cfg.Components.Proxy.Service = &ComponentTypeService{}
+					}
+					cfg.Components.Proxy.Service.ServiceType = cfg.Experimental.WebApp.ProxyConfig.ServiceType
 				}
 			}
 
-			registryAllowList := cfg.Experimental.WebApp.Server.DefaultBaseImageRegistryWhiteList
-			if registryAllowList != nil {
-				warnings["experimental.webapp.server.defaultBaseImageRegistryWhitelist"] = registryAllowList
+			// default workspace base image is now configurable from main config
+			if cfg.Experimental.WebApp.Server != nil {
 
-				if len(cfg.ContainerRegistry.PrivateBaseImageAllowList) > 0 {
-					conflicts = append(conflicts, "Cannot set allow list for private base image in both containerRegistry and experimental")
-				} else {
-					cfg.ContainerRegistry.PrivateBaseImageAllowList = registryAllowList
+				workspaceImage := cfg.Experimental.WebApp.Server.WorkspaceDefaults.WorkspaceImage
+				if workspaceImage != "" {
+					warnings["experimental.webapp.server.workspaceDefaults.workspaceImage"] = workspaceImage
+
+					if cfg.Workspace.WorkspaceImage != "" {
+						conflicts = append(conflicts, "Cannot set default workspace image in both workspaces and experimental")
+					} else {
+						cfg.Workspace.WorkspaceImage = workspaceImage
+					}
+				}
+
+				registryAllowList := cfg.Experimental.WebApp.Server.DefaultBaseImageRegistryWhiteList
+				if registryAllowList != nil {
+					warnings["experimental.webapp.server.defaultBaseImageRegistryWhitelist"] = registryAllowList
+
+					if len(cfg.ContainerRegistry.PrivateBaseImageAllowList) > 0 {
+						conflicts = append(conflicts, "Cannot set allow list for private base image in both containerRegistry and experimental")
+					} else {
+						cfg.ContainerRegistry.PrivateBaseImageAllowList = registryAllowList
+					}
 				}
 			}
 		}

--- a/install/installer/pkg/config/v1/experimental/experimental.go
+++ b/install/installer/pkg/config/v1/experimental/experimental.go
@@ -39,7 +39,8 @@ type TelemetryConfig struct {
 type CommonConfig struct {
 	PodConfig                map[string]*PodConfig `json:"podConfig,omitempty"`
 	StaticMessagebusPassword string                `json:"staticMessagebusPassword"`
-	UsePodSecurityPolicies   bool                  `json:"usePodSecurityPolicies"`
+	// @deprecated PodSecurityPolicies are deprecated in k8s 1.21 and removed in 1.25
+	UsePodSecurityPolicies bool `json:"usePodSecurityPolicies"`
 }
 
 type PodConfig struct {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Marks the `experimental.common.usePodSecurityPolicies` as deprecated and shows a warning if enabled.

```bash
Deprecated config parameter: experimental.common.usePodSecurityPolicies=true
```

## How to test
<!-- Provide steps to test this PR -->
Render the YAML

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[installer]: show deprecation warning if using podsecuritypolicies
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
