### PR TITLE
[ws-daemon] Check if the shiftfs module already exists

### DIFF
--- a/components/ws-daemon/shiftfs-module-loader/entrypoint.sh
+++ b/components/ws-daemon/shiftfs-module-loader/entrypoint.sh
@@ -14,6 +14,11 @@ if lsmod | grep $DRIVER_NAME; then
     exit 0
 fi
 
+if modprobe --quiet --dry-run $DRIVER_NAME; then
+    echo "shiftfs exists in the kernel - nothing to do here"
+    exit 0
+fi
+
 set -ex
 mkdir -p /lib/modules/"${KERNEL_RELEASE}"
 ln -s /usr/src_node/linux-headers-"${KERNEL_RELEASE}" /lib/modules/"${KERNEL_RELEASE}"/build


### PR DESCRIPTION
## Description

Disable build of `shiftfs` module if the kernel in the node already provides it.

## Release Notes
```release-note
NONE
```

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
