### PR TITLE
[gitpod-protocol] add missing method in golang

### DIFF
--- a/components/gitpod-protocol/go/gitpod-service.go
+++ b/components/gitpod-protocol/go/gitpod-service.go
@@ -82,6 +82,7 @@ type APIInterface interface {
 	GetLayout(ctx context.Context, workspaceID string) (res string, err error)
 	GuessGitTokenScopes(ctx context.Context, params *GuessGitTokenScopesParams) (res *GuessedGitTokenScopes, err error)
 	TrackEvent(ctx context.Context, event *RemoteTrackMessage) (err error)
+	GetSupportedWorkspaceClasses(ctx context.Context) (res []*SupportedWorkspaceClass, err error)
 
 	InstanceUpdates(ctx context.Context, instanceID string) (<-chan *WorkspaceInstance, error)
 }
@@ -206,6 +207,8 @@ const (
 	FunctionGuessGitTokenScope FunctionName = "guessGitTokenScopes"
 	// FunctionTrackEvent is the name of the trackEvent function
 	FunctionTrackEvent FunctionName = "trackEvent"
+	// FunctionGetSupportedWorkspaceClasses is the name of the getSupportedWorkspaceClasses function
+	FunctionGetSupportedWorkspaceClasses FunctionName = "getSupportedWorkspaceClasses"
 
 	// FunctionOnInstanceUpdate is the name of the onInstanceUpdate callback function
 	FunctionOnInstanceUpdate = "onInstanceUpdate"
@@ -1434,6 +1437,16 @@ func (gp *APIoverJSONRPC) TrackEvent(ctx context.Context, params *RemoteTrackMes
 	return
 }
 
+func (gp *APIoverJSONRPC) GetSupportedWorkspaceClasses(ctx context.Context) (res []*SupportedWorkspaceClass, err error) {
+	if gp == nil {
+		err = errNotConnected
+		return
+	}
+	_params := []interface{}{}
+	err = gp.C.Call(ctx, "getSupportedWorkspaceClasses", _params, &res)
+	return
+}
+
 // PermissionName is the name of a permission
 type PermissionName string
 
@@ -1935,6 +1948,16 @@ type GitToken struct {
 type GuessedGitTokenScopes struct {
 	Scopes  []string `json:"scopes,omitempty"`
 	Message string   `json:"message,omitempty"`
+}
+
+// SupportedWorkspaceClass is the GetSupportedWorkspaceClasses message type
+type SupportedWorkspaceClass struct {
+	ID          string `json:"id,omitempty"`
+	Category    string `json:"category,omitempty"`
+	DisplayName string `json:"displayName,omitempty"`
+	Description string `json:"description,omitempty"`
+	Powerups    int    `json:"powerups,omitempty"`
+	IsDefault   bool   `json:"isDefault,omitempty"`
 }
 
 type RemoteTrackMessage struct {

--- a/components/gitpod-protocol/go/mock.go
+++ b/components/gitpod-protocol/go/mock.go
@@ -464,6 +464,21 @@ func (mr *MockAPIInterfaceMockRecorder) GetSnapshots(ctx, workspaceID interface{
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSnapshots", reflect.TypeOf((*MockAPIInterface)(nil).GetSnapshots), ctx, workspaceID)
 }
 
+// GetSupportedWorkspaceClasses mocks base method.
+func (m *MockAPIInterface) GetSupportedWorkspaceClasses(ctx context.Context) ([]*SupportedWorkspaceClass, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSupportedWorkspaceClasses", ctx)
+	ret0, _ := ret[0].([]*SupportedWorkspaceClass)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetSupportedWorkspaceClasses indicates an expected call of GetSupportedWorkspaceClasses.
+func (mr *MockAPIInterfaceMockRecorder) GetSupportedWorkspaceClasses(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSupportedWorkspaceClasses", reflect.TypeOf((*MockAPIInterface)(nil).GetSupportedWorkspaceClasses), ctx)
+}
+
 // GetToken mocks base method.
 func (m *MockAPIInterface) GetToken(ctx context.Context, query *GetTokenSearchOptions) (*Token, error) {
 	m.ctrl.T.Helper()

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -1548,6 +1548,7 @@ export class WorkspaceStarter {
             "function:addSSHPublicKey",
             "function:deleteSSHPublicKey",
             "function:trackEvent",
+            "function:getSupportedWorkspaceClasses",
 
             "resource:" +
                 ScopedResourceGuard.marshalResourceScope({


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Add missing function `getSupportedWorkspaceClasses` for golang lib

Previous PR of PR https://github.com/gitpod-io/gitpod/pull/12338

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
Test in PR https://github.com/gitpod-io/gitpod/pull/12338 which based on this branch `hw/ws-cls`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
