### PR TITLE
[ws-daemon] when WaitForInit ensure that state is indeed ready

### DIFF
--- a/components/ws-daemon/pkg/internal/session/workspace.go
+++ b/components/ws-daemon/pkg/internal/session/workspace.go
@@ -122,7 +122,8 @@ func (s *Workspace) WaitForInit(ctx context.Context) (ready bool) {
 
 	s.operatingCondition.L.Lock()
 	s.operatingCondition.Wait()
-	ready = true
+	// make sure that state is indeed ready when done waiting
+	ready = s.state == WorkspaceReady
 	s.operatingCondition.L.Unlock()
 	return
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This was quite fun to hunt it down.

When calling WaitForInit we will wait for `operatingCondition` to broadcast to unlock us.
There are two places where broadcast is being done:
`MarkInitDone` that changes `state` to `WorkspaceReady`
`Dispose` that changes `state` to `WorkspaceDisposed`
If workspace fails during `InitWorkspace`, then its state will be disposed. 
We call InitWorkspace during `CREATING` phase, and then we `WaitForInit` in `INITIALIZING` state.
So if InitWorkspace failed, we incorrectly would mark workspace as ready, causing all types of issues down the line.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #12357
Fixes #11713

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
none
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
