### PR TITLE
image-builder-bob: Introduce backoff to connect to buildkit

### DIFF
--- a/components/image-builder-bob/pkg/builder/builder.go
+++ b/components/image-builder-bob/pkg/builder/builder.go
@@ -251,6 +251,7 @@ func StartBuildkit(socketPath string) (cl *client.Client, teardown func() error,
 }
 
 func connectToBuildkitd(socketPath string) (cl *client.Client, err error) {
+	backoff := 1 * time.Second
 	for i := 0; i < maxConnectionAttempts; i++ {
 		ctx, cancel := context.WithTimeout(context.Background(), initialConnectionTimeout)
 
@@ -262,7 +263,8 @@ func connectToBuildkitd(socketPath string) (cl *client.Client, err error) {
 			}
 
 			cancel()
-			time.Sleep(1 * time.Second)
+			time.Sleep(backoff)
+			backoff = 2 * backoff
 			continue
 		}
 
@@ -273,7 +275,8 @@ func connectToBuildkitd(socketPath string) (cl *client.Client, err error) {
 			}
 
 			cancel()
-			time.Sleep(1 * time.Second)
+			time.Sleep(backoff)
+			backoff = 2 * backoff
 			continue
 		}
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

The retry to connect to the buildkit was too fast. At least in the current preview environment resources sometimes gave up before the buildkit was up and running.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Relates #12248

## How to test
<!-- Provide steps to test this PR -->

Pass `TestBaseImageBuild/database/it_should_build_a_base_image` on the preview env
(Maybe the test doesn't pass, but at least it fails not a connection error to buildkit)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
More reliably connect to buildkit during image builds
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
