### PR TITLE
Change workspaces disk size to 360 GB

### DIFF
--- a/install/infra/modules/gke/main.tf
+++ b/install/infra/modules/gke/main.tf
@@ -112,7 +112,7 @@ resource "google_container_node_pool" "services" {
     preemptible  = false
     image_type   = "UBUNTU_CONTAINERD"
     disk_type    = "pd-ssd"
-    disk_size_gb = var.disk_size_gb
+    disk_size_gb = var.services_disk_size_gb
     machine_type = var.services_machine_type
     tags         = ["gke-node", "${var.project}-gke"]
     metadata = {
@@ -153,7 +153,7 @@ resource "google_container_node_pool" "workspaces" {
     preemptible  = false
     image_type   = "UBUNTU_CONTAINERD"
     disk_type    = "pd-ssd"
-    disk_size_gb = var.disk_size_gb
+    disk_size_gb = var.workspaces_disk_size_gb
     machine_type = var.workspaces_machine_type
     tags         = ["gke-node", "${var.project}-gke"]
     metadata = {

--- a/install/infra/modules/gke/variables.tf
+++ b/install/infra/modules/gke/variables.tf
@@ -56,10 +56,16 @@ variable "max_node_count_services" {
   default     = 4
 }
 
-variable "disk_size_gb" {
+variable "services_disk_size_gb" {
   type        = number
-  description = "Size of the node's disk."
+  description = "Size of the services node's disk."
   default     = 100
+}
+
+variable "workspaces_disk_size_gb" {
+  type        = number
+  description = "Size of the workspace node's disk."
+  default     = 360
 }
 
 variable "credentials" {


### PR DESCRIPTION
## Description
in line with https://github.com/gitpod-io/website/pull/2627/files, this changes the default node size for workspace nodes to 360 GB as a temporary fix while we discuss further changes. 


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```