### PR TITLE
observability: assign default zero if no data found

### DIFF
--- a/operations/observability/mixins/cross-teams/dashboards/gitpod-overview.libsonnet
+++ b/operations/observability/mixins/cross-teams/dashboards/gitpod-overview.libsonnet
@@ -170,7 +170,7 @@ local workspaceFailuresGraph =
     |||
       sum(
         rate(gitpod_ws_manager_workspace_stops_total{%(clusterLabel)s=~"$cluster", reason="failed"}[5m])
-      ) by (%(clusterLabel)s, type)
+      ) by (%(clusterLabel)s, type) OR on() vector(0)
     ||| % _config, legendFormat='{{type}}'
   ))
   .addSeriesOverride({ alias: 'REGULAR', color: '#73BF69' })


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
No data is shown if there is no data found, check the existing eu63 cluster.

was: 
<img width="717" alt="image" src="https://user-images.githubusercontent.com/49380831/186610923-ae0b63d6-89ea-43ba-90ff-7447d8eca30c.png">

is:
<img width="1437" alt="image" src="https://user-images.githubusercontent.com/49380831/186611688-97a93bb6-0e2d-4037-b9d2-9ecd4a8959b8.png">

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
None

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
None

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
