### PR TITLE
add sensible defaults to single cluster aws .tfvars

### DIFF
--- a/install/infra/single-cluster/aws/terraform.tfvars
+++ b/install/infra/single-cluster/aws/terraform.tfvars
@@ -1,8 +1,8 @@
 # the cluster_name should be of length less than 15 characters and surrounded by double quotes
-cluster_name =
+cluster_name = "gitpod"
 
 # a route53 zone and certificate request will be created for this domain; surround the domain name within double quotes
-domain_name =
+domain_name = "your_domain_name.com"
 
 region = "eu-west-1"
 
@@ -12,7 +12,8 @@ vpc_cidr = "10.100.0.0/16"
 # should be atleast 2 zones
 vpc_availability_zones = ["eu-west-1c", "eu-west-1b"]
 
-# you can find the list of UBUNTU AMIs here corresponding to the k8s version and your region
+# !important!: You need to make sure the image_id below matches your region.
+# You can find the list of UBUNTU AMIs here corresponding to the k8s version and your region via
 # https://cloud-images.ubuntu.com/docs/aws/eks/
 cluster_version = "1.22"
 image_id = "ami-0793b4124359a6ad7"


### PR DESCRIPTION
## Description
- Creates sensible defaults for domain name and cluster name in .tfvar file for the single cluster reference archtitecture terraform module. In line with [internal guidelines](https://www.notion.so/gitpod/b525670c23ee47d896802e1089808ec5#474093e901074e62bf0eef449a3792f3).
- Highlights the need to change the ami_id

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
- Check changes ensure they don't break anything

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```