### PR TITLE
[AWS Single Cluster Ref Arch Terraform] Add  IOPS and throughput definition, changed disk size to 360GB to workspace nodes

### DIFF
--- a/install/infra/modules/eks/kubernetes.tf
+++ b/install/infra/modules/eks/kubernetes.tf
@@ -151,8 +151,8 @@ module "eks" {
         ebs = [{
           volume_size           = 360
           volume_type           = "gp3"
-          throughput            = 1000
-          iops                  = 16000
+          throughput            = 500
+          iops                  = 6000
           delete_on_termination = true
         }]
       }]

--- a/install/infra/modules/eks/kubernetes.tf
+++ b/install/infra/modules/eks/kubernetes.tf
@@ -149,7 +149,7 @@ module "eks" {
         device_name = "/dev/sda1"
 
         ebs = [{
-          volume_size           = 360
+          volume_size           = 512
           volume_type           = "gp3"
           throughput            = 500
           iops                  = 6000

--- a/install/infra/modules/eks/kubernetes.tf
+++ b/install/infra/modules/eks/kubernetes.tf
@@ -149,7 +149,11 @@ module "eks" {
         device_name = "/dev/sda1"
 
         ebs = [{
-          volume_size = 300
+          volume_size           = 360
+          volume_type           = "gp3"
+          throughput            = 1000
+          iops                  = 16000
+          delete_on_termination = true
         }]
       }]
       desired_size               = 2


### PR DESCRIPTION
## Description
- updates throughput and IOPS for workpace nodes for single cluster reference architecture in line with the [guide](https://www.gitpod.io/docs/self-hosted/latest/reference-architecture/single-cluster-ref-arch#kubernetes-cluster)
- updates disk space to 512 gb in line with https://github.com/gitpod-io/website/pull/2630

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/website/pull/2630

## How to test
- I tested this myself by spinning up infra using the terraform. module, then ensuring Gitpod installs and that the right IOPS and throughput is shown. This installation ran for about 18 h and I was able to start worksapces. 

<img width="1341" alt="Screenshot 2022-08-26 at 15 11 44" src="https://user-images.githubusercontent.com/22516873/186914415-e81d681d-e8fd-4df4-89ef-9fc8897c5088.png">

## Release Notes

<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
