### PR TITLE
[installer-tests] Update supported k8s versions for AKS and EKS

### DIFF
--- a/.werft/installer-tests.ts
+++ b/.werft/installer-tests.ts
@@ -414,7 +414,7 @@ function randK8sVersion(config: string): string {
             break;
         }
         case "STANDARD_AKS_TEST": {
-            options = ["1.21", "1.22", "1.23"]
+            options = ["1.22", "1.23", "1.24"]
             break;
         }
         case "STANDARD_EKS_TEST": {

--- a/install/tests/Makefile
+++ b/install/tests/Makefile
@@ -68,17 +68,11 @@ gke-standard-cluster: check-env-cluster-version
 	terraform apply -target=module.gke -var kubeconfig=${KUBECONFIG} --auto-approve
 	@echo "Done creating GKE cluster"
 
-ami_id_120 := "ami-0ecb917eb4fbf4387"
-
 ami_id_121 := "ami-0d57fb01036fac543"
 
 ami_id_122 := "ami-0b306cb7e98db98e4"
 
-ami_id_120 := "ami-0ecb917eb4fbf4387"
-
-ami_id_121 := "ami-0d57fb01036fac543"
-
-ami_id_122 := "ami-0b306cb7e98db98e4"
+ami_id_123 := "ami-05ec8881b9c2740d4"
 
 .PHONY:
 ## eks-standard-cluster: Creates an EKS cluster
@@ -242,7 +236,7 @@ db-config-incluster:
 registry-config-incluster:
 	@echo "Nothing to do"
 
-torage ?= incluster
+storage ?= incluster
 registry ?= incluster
 db ?= incluster
 .PHONY:


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PR updates the supported Kubernetes versions for automated tests. AKS 1.21 has reached its end of life in July and hence we support AKS versions 1.22 through 1.24. 

In the case of EKS, We had a bug introduced previously by adding `1.23` before official ubuntu image was out. Now that it is, this PR adds that too.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
You can try running the following
```
werft run github -j .werft/eks-installer-tests.yaml -a skipTests=true
werft run github -j .werft/aks-installer-tests.yaml -a skipTests=true
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
