### PR TITLE
[installer-tests] Fix GCP database config

### DIFF
--- a/install/infra/modules/gke/main.tf
+++ b/install/infra/modules/gke/main.tf
@@ -201,7 +201,7 @@ resource "google_sql_database" "database" {
 
 resource "google_sql_user" "users" {
   count    = var.enable_external_database ? 1 : 0
-  name     = "dbuser-${var.cluster_name}-${count.index}"
+  name     = "gitpod"
   instance = google_sql_database_instance.gitpod[count.index].name
   password = random_password.password[count.index].result
 }

--- a/install/infra/modules/k3s/main.tf
+++ b/install/infra/modules/k3s/main.tf
@@ -189,10 +189,17 @@ resource "google_sql_database" "database" {
   collation = "utf8_general_ci"
 }
 
+resource "random_password" "password" {
+
+  length           = 16
+  special          = true
+  override_special = "!#$%&*()-_=+[]{}<>:?"
+}
+
 resource "google_sql_user" "users" {
   name     = "gitpod"
   instance = google_sql_database_instance.gitpod.name
-  password = "gitpod"
+  password = random_password.password.result
 }
 
 data "local_file" "kubeconfig" {

--- a/install/infra/modules/k3s/output.tf
+++ b/install/infra/modules/k3s/output.tf
@@ -1,0 +1,9 @@
+output "database" {
+  sensitive = true
+  value = try({
+    instance            = "${var.gcp_project}:${var.gcp_region}:${google_sql_database_instance.gitpod.name}"
+    username            = "${google_sql_user.users.name}"
+    password            = random_password.password.result
+    service_account_key = "Upload the JSON file corresponding the service account credentials"
+  }, "No database created")
+}

--- a/install/tests/Makefile
+++ b/install/tests/Makefile
@@ -186,6 +186,10 @@ registry-config-gcp:
 
 db-config-gcp:
 	export BASE64_GCP_KEY=$$(cat $$TF_VAR_sa_creds | tr -d '\n' | base64 -w 0) && \
+	export DB_OUTPUT=$$(terraform output -json k3s_database || terraform output -json gke_database) && \
+	export DB_INSTANCE=$$(echo $$DB_OUTPUT | yq r - 'instance') && \
+	export DB_PASSWORD=$$(echo $$DB_OUTPUT | yq r - 'password') && \
+	export DB_USER=$$(echo $$DB_OUTPUT | yq r - 'username') && \
 	envsubst < ./manifests/kots-config-gcp-db.yaml > tmp_4_config.yml
 	envsubst < tmp_4_config.yml > tmp_5_config.yml
 	yq m -i tmp_config.yml tmp_5_config.yml

--- a/install/tests/manifests/kots-config-gcp-db.yaml
+++ b/install/tests/manifests/kots-config-gcp-db.yaml
@@ -9,14 +9,14 @@ spec:
         value: "1"
         data: "db_cloudsql_enabled"
       db_cloudsql_instance:
-        value: sh-automated-tests:europe-west1:sql-${TF_VAR_TEST_ID}
+        value: "${DB_INSTANCE}"
         data: "db_cloudsql_instance"
       db_gcp_credentials:
         value: "${BASE64_GCP_KEY}"
-        data: "db_cloudsql_credentials"
-      db_gcp_username:
-        value: gitpod
+        data: "db_gcp_credentials"
+      db_username:
+        value: ${DB_USER}
         data: "db_username"
       db_password:
-        value: gitpod
+        value: ${DB_PASSWORD}
         data: "db_password"

--- a/install/tests/output.tf
+++ b/install/tests/output.tf
@@ -1,3 +1,13 @@
+output "gke_database" {
+    sensitive = true
+    value = try(module.gke.database, null)
+}
+
+output "k3s_database" {
+    sensitive = true
+    value = try(module.k3s.database, null)
+}
+
 output "aws_storage" {
     sensitive = true
     value = try(module.eks.storage, null)


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Currently the database config for GCP is buggy. The config is missing some important details and hence on nightly tests with external database as dependency, the tests fail. This PR fixes these issues. This fixes the KOTS config with the right field names and takes the output from the GKE and k3s modules to apply them respectively.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
```
werft run github -j .werft/gke-installer-tests.yaml -a skipTests=true -a deps=external
werft run github -j .werft/k3s-installer-tests.yaml -a skipTests=true -a deps=external
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
