### PR TITLE
[usage] Refactor creditSummary to extend return data and allow immutability

### DIFF
--- a/components/usage/pkg/apiv1/billing.go
+++ b/components/usage/pkg/apiv1/billing.go
@@ -6,6 +6,7 @@ package apiv1
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"time"
@@ -21,11 +22,12 @@ import (
 	"gorm.io/gorm"
 )
 
-func NewBillingService(stripeClient *stripe.Client, billInstancesAfter time.Time, conn *gorm.DB) *BillingService {
+func NewBillingService(stripeClient *stripe.Client, billInstancesAfter time.Time, conn *gorm.DB, usageClient v1.UsageServiceClient) *BillingService {
 	return &BillingService{
 		stripeClient:       stripeClient,
 		billInstancesAfter: billInstancesAfter,
 		conn:               conn,
+		usageClient:        usageClient,
 	}
 }
 
@@ -33,12 +35,14 @@ type BillingService struct {
 	conn               *gorm.DB
 	stripeClient       *stripe.Client
 	billInstancesAfter time.Time
+	usageClient        v1.UsageServiceClient
+	ctx                context.Context
 
 	v1.UnimplementedBillingServiceServer
 }
 
 func (s *BillingService) UpdateInvoices(ctx context.Context, in *v1.UpdateInvoicesRequest) (*v1.UpdateInvoicesResponse, error) {
-	credits, err := s.creditSummaryForTeams(in.GetSessions())
+	credits, err := s.creditSummaryForTeams(ctx, in.GetSessions())
 	if err != nil {
 		log.Log.WithError(err).Errorf("Failed to compute credit summary.")
 		return nil, status.Errorf(codes.InvalidArgument, "failed to compute credit summary")
@@ -89,8 +93,10 @@ func (s *BillingService) GetUpcomingInvoice(ctx context.Context, in *v1.GetUpcom
 	}, nil
 }
 
-func (s *BillingService) creditSummaryForTeams(sessions []*v1.BilledSession) (map[string]int64, error) {
+func (s *BillingService) creditSummaryForTeams(ctx context.Context, sessions []*v1.BilledSession) (map[string]map[string]float64, error) {
 	creditsPerTeamID := map[string]float64{}
+	var spendingLimit float64
+	var upcomingInvoice float64
 
 	for _, session := range sessions {
 		if session.StartTime.AsTime().Before(s.billInstancesAfter) {
@@ -112,11 +118,33 @@ func (s *BillingService) creditSummaryForTeams(sessions []*v1.BilledSession) (ma
 		}
 
 		creditsPerTeamID[id] += session.GetCredits()
+
+		// get additional data
+		result, err := s.usageClient.GetCostCenter(ctx, &v1.GetCostCenterRequest{AttributionId: session.AttributionId})
+		if err != nil {
+			if errors.Is(err, db.CostCenterNotFound) {
+				return nil, status.Errorf(codes.NotFound, "Cost center not found: %s", err.Error())
+			}
+			return nil, status.Errorf(codes.Internal, "Failed to get cost center %s from DB: %s", attributionID, err.Error())
+		}
+
+		invoiceResult, err := s.GetUpcomingInvoice(ctx, &v1.GetUpcomingInvoiceRequest{Identifier: &v1.GetUpcomingInvoiceRequest_TeamId{TeamId: session.TeamId}})
+		if err != nil {
+			return nil, fmt.Errorf("failed to get upcoming invoice: %w", err)
+		}
+
+		spendingLimit = float64(result.CostCenter.SpendingLimit)
+		upcomingInvoice = float64(invoiceResult.Credits)
+
 	}
 
-	rounded := map[string]int64{}
+	rounded := map[string]map[string]float64{}
 	for teamID, credits := range creditsPerTeamID {
-		rounded[teamID] = int64(math.Ceil(credits))
+		rounded[teamID] = map[string]float64{
+			"creditsUsed":     float64(math.Ceil(credits)),
+			"spendingLimit":   spendingLimit,
+			"upcomingInvoice": upcomingInvoice,
+		}
 	}
 
 	return rounded, nil

--- a/components/usage/pkg/apiv1/billing.go
+++ b/components/usage/pkg/apiv1/billing.go
@@ -22,7 +22,7 @@ import (
 	"gorm.io/gorm"
 )
 
-func NewBillingService(stripeClient *stripe.Client, billInstancesAfter time.Time, conn *gorm.DB, usageClient v1.UsageServiceClient) *BillingService {
+func NewBillingService(stripeClient StripeClient, billInstancesAfter time.Time, conn *gorm.DB, usageClient v1.UsageServiceClient) *BillingService {
 	return &BillingService{
 		stripeClient:       stripeClient,
 		billInstancesAfter: billInstancesAfter,
@@ -31,9 +31,13 @@ func NewBillingService(stripeClient *stripe.Client, billInstancesAfter time.Time
 	}
 }
 
+type StripeClient interface {
+	GetUpcomingInvoice(ctx context.Context, kind stripe.CustomerKind, id string) (*stripe.StripeInvoice, error)
+	UpdateUsage(ctx context.Context, creditsPerTeam map[string]map[string]float64) error
+}
 type BillingService struct {
 	conn               *gorm.DB
-	stripeClient       *stripe.Client
+	stripeClient       StripeClient
 	billInstancesAfter time.Time
 	usageClient        v1.UsageServiceClient
 	ctx                context.Context

--- a/components/usage/pkg/apiv1/billing.go
+++ b/components/usage/pkg/apiv1/billing.go
@@ -32,15 +32,16 @@ func NewBillingService(stripeClient StripeClient, billInstancesAfter time.Time, 
 }
 
 type StripeClient interface {
-	GetUpcomingInvoice(ctx context.Context, kind stripe.CustomerKind, id string) (*stripe.StripeInvoice, error)
+	GetUpcomingInvoice(ctx context.Context, customerID string) (*stripe.Invoice, error)
 	UpdateUsage(ctx context.Context, creditsPerTeam map[string]map[string]float64) error
+	GetCustomerByTeamID(ctx context.Context, teamID string) (*stripesdk.Customer, error)
+	GetCustomerByUserID(ctx context.Context, userID string) (*stripesdk.Customer, error)
 }
 type BillingService struct {
 	conn               *gorm.DB
 	stripeClient       StripeClient
 	billInstancesAfter time.Time
 	usageClient        v1.UsageServiceClient
-	ctx                context.Context
 
 	v1.UnimplementedBillingServiceServer
 }

--- a/components/usage/pkg/apiv1/billing_test.go
+++ b/components/usage/pkg/apiv1/billing_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gitpod-io/gitpod/usage/pkg/stripe"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
+	stripesdk "github.com/stripe/stripe-go/v72"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
@@ -181,9 +182,8 @@ func TestCreditSummaryForTeams(t *testing.T) {
 
 type testStripeClient struct{}
 
-func (c *testStripeClient) GetUpcomingInvoice(ctx context.Context, kind stripe.CustomerKind, id string) (*stripe.StripeInvoice, error) {
-
-	return &stripe.StripeInvoice{
+func (c *testStripeClient) GetUpcomingInvoice(ctx context.Context, id string) (*stripe.Invoice, error) {
+	return &stripe.Invoice{
 		ID:             "invoice.ID",
 		SubscriptionID: "invoice.Subscription.ID",
 		Amount:         100,
@@ -194,4 +194,12 @@ func (c *testStripeClient) GetUpcomingInvoice(ctx context.Context, kind stripe.C
 
 func (c *testStripeClient) UpdateUsage(ctx context.Context, creditsPerTeam map[string]map[string]float64) error {
 	return nil
+}
+
+func (c *testStripeClient) GetCustomerByTeamID(ctx context.Context, teamID string) (*stripesdk.Customer, error) {
+	return &stripesdk.Customer{}, nil
+}
+
+func (c *testStripeClient) GetCustomerByUserID(ctx context.Context, userID string) (*stripesdk.Customer, error) {
+	return &stripesdk.Customer{}, nil
 }

--- a/components/usage/pkg/apiv1/size_test.go
+++ b/components/usage/pkg/apiv1/size_test.go
@@ -23,12 +23,13 @@ func TestServerCanReceiveLargeMessages(t *testing.T) {
 	srv := baseserver.NewForTests(t,
 		baseserver.WithGRPC(baseserver.MustUseRandomLocalAddress(t)),
 	)
-
-	v1.RegisterBillingServiceServer(srv.GRPC(), NewBillingService(&stripe.Client{}, time.Time{}, &gorm.DB{}))
-	baseserver.StartServerForTests(t, srv)
-
 	conn, err := grpc.Dial(srv.GRPCAddress(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	require.NoError(t, err)
+
+	usageClient := v1.NewUsageServiceClient(conn)
+
+	v1.RegisterBillingServiceServer(srv.GRPC(), NewBillingService(&stripe.Client{}, time.Time{}, &gorm.DB{}, usageClient))
+	baseserver.StartServerForTests(t, srv)
 
 	client := v1.NewBillingServiceClient(conn)
 

--- a/components/usage/pkg/apiv1/size_test.go
+++ b/components/usage/pkg/apiv1/size_test.go
@@ -27,8 +27,9 @@ func TestServerCanReceiveLargeMessages(t *testing.T) {
 	require.NoError(t, err)
 
 	usageClient := v1.NewUsageServiceClient(conn)
+	billingClient := v1.NewBillingServiceClient(conn)
 
-	v1.RegisterBillingServiceServer(srv.GRPC(), NewBillingService(&stripe.Client{}, time.Time{}, &gorm.DB{}, usageClient))
+	v1.RegisterBillingServiceServer(srv.GRPC(), NewBillingService(&stripe.Client{}, time.Time{}, &gorm.DB{}, usageClient, billingClient))
 	baseserver.StartServerForTests(t, srv)
 
 	client := v1.NewBillingServiceClient(conn)

--- a/components/usage/pkg/server/server.go
+++ b/components/usage/pkg/server/server.go
@@ -136,7 +136,7 @@ func Start(cfg Config) error {
 
 	reportGenerator := apiv1.NewReportGenerator(conn, pricer)
 
-	err = registerGRPCServices(srv, conn, stripeClient, reportGenerator, contentService, *cfg.BillInstancesAfter)
+	err = registerGRPCServices(srv, conn, stripeClient, reportGenerator, contentService, *cfg.BillInstancesAfter, v1.NewUsageServiceClient(selfConnection))
 	if err != nil {
 		return fmt.Errorf("failed to register gRPC services: %w", err)
 	}
@@ -159,12 +159,12 @@ func Start(cfg Config) error {
 	return nil
 }
 
-func registerGRPCServices(srv *baseserver.Server, conn *gorm.DB, stripeClient *stripe.Client, reportGenerator *apiv1.ReportGenerator, contentSvc contentservice.Interface, billInstancesAfter time.Time) error {
+func registerGRPCServices(srv *baseserver.Server, conn *gorm.DB, stripeClient *stripe.Client, reportGenerator *apiv1.ReportGenerator, contentSvc contentservice.Interface, billInstancesAfter time.Time, usageClient v1.UsageServiceClient) error {
 	v1.RegisterUsageServiceServer(srv.GRPC(), apiv1.NewUsageService(conn, reportGenerator, contentSvc))
 	if stripeClient == nil {
 		v1.RegisterBillingServiceServer(srv.GRPC(), &apiv1.BillingServiceNoop{})
 	} else {
-		v1.RegisterBillingServiceServer(srv.GRPC(), apiv1.NewBillingService(stripeClient, billInstancesAfter, conn))
+		v1.RegisterBillingServiceServer(srv.GRPC(), apiv1.NewBillingService(stripeClient, billInstancesAfter, conn, usageClient))
 	}
 	return nil
 }

--- a/components/usage/pkg/stripe/stripe.go
+++ b/components/usage/pkg/stripe/stripe.go
@@ -7,7 +7,6 @@ package stripe
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -80,7 +79,7 @@ func (c *Client) UpdateUsage(ctx context.Context, creditsPerTeam map[string]map[
 			teamID := customer.Metadata["teamId"]
 			log.Infof("Found customer %q for teamId %q", customer.Name, teamID)
 
-			_, err := c.updateUsageForCustomer(ctx, customer, creditsPerTeam[teamID]["creditsUsed"])
+			_, err := c.updateUsageForCustomer(ctx, customer, int64(creditsPerTeam[teamID]["creditsUsed"]))
 			if err != nil {
 				log.WithField("customer_id", customer.ID).
 					WithField("customer_name", customer.Name).


### PR DESCRIPTION
## Description
This PR extends the return type of creditSummaryForTeams so that we don't mutate the credits.
It is purposefully separated into different commits.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Relates #12264

## How to test
Unit tests

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
