### PR TITLE
[terraform] Add random variables to terrraform resource names

### DIFF
--- a/install/infra/modules/aks/kubernetes.tf
+++ b/install/infra/modules/aks/kubernetes.tf
@@ -15,7 +15,7 @@ resource "azurerm_role_assignment" "k8s_reader" {
 }
 
 resource "azurerm_kubernetes_cluster" "k8s" {
-  name                            = format(local.name_format, local.location, "primary")
+  name                            = format(local.name_format, "cluster")
   location                        = azurerm_resource_group.gitpod.location
   resource_group_name             = azurerm_resource_group.gitpod.name
   dns_prefix                      = "gitpod"

--- a/install/infra/modules/aks/local.tf
+++ b/install/infra/modules/aks/local.tf
@@ -8,14 +8,12 @@ locals {
   })
   dns_enabled = var.domain_name != null
   name_format = join("-", [
-    "gitpod-test",
-    "%s", # region
+    "test",
     "%s", # name
     local.workspace_name
   ])
   name_format_global = join("-", [
-    "gitpod-test",
-    "%s", # name
+    "sh-test",
     local.workspace_name
   ])
   workspace_name = replace(terraform.workspace, "/[\\W\\-]/", "") # alphanumeric workspace name

--- a/install/infra/modules/aks/main.tf
+++ b/install/infra/modules/aks/main.tf
@@ -14,6 +14,6 @@ provider "azurerm" {
 data "azurerm_client_config" "current" {}
 
 resource "azurerm_resource_group" "gitpod" {
-  name     = format(local.name_format_global, local.location)
+  name     = local.name_format_global
   location = var.location
 }

--- a/install/infra/modules/aks/monitoring.tf
+++ b/install/infra/modules/aks/monitoring.tf
@@ -1,5 +1,5 @@
 resource "azurerm_log_analytics_workspace" "monitoring" {
-  name                = format(local.name_format, var.location, "monitoring")
+  name                = format(local.name_format, "monitoring")
   location            = azurerm_resource_group.gitpod.location
   resource_group_name = azurerm_resource_group.gitpod.name
   sku                 = "PerGB2018"

--- a/install/infra/modules/aks/networks.tf
+++ b/install/infra/modules/aks/networks.tf
@@ -1,12 +1,12 @@
 resource "azurerm_virtual_network" "network" {
-  name                = format(local.name_format, local.location, "network")
+  name                = format(local.name_format, "network")
   location            = azurerm_resource_group.gitpod.location
   resource_group_name = azurerm_resource_group.gitpod.name
   address_space       = ["10.2.0.0/16"]
 }
 
 resource "azurerm_subnet" "network" {
-  name                 = format(local.name_format, local.location, "network")
+  name                 = format(local.name_format, "network")
   resource_group_name  = azurerm_resource_group.gitpod.name
   virtual_network_name = azurerm_virtual_network.network.name
   address_prefixes     = ["10.2.1.0/24"]

--- a/install/infra/modules/gke/main.tf
+++ b/install/infra/modules/gke/main.tf
@@ -172,9 +172,15 @@ resource "google_container_node_pool" "workspaces" {
   }
 }
 
+resource "random_string" "random" {
+  length           = 4
+  upper            = false
+  special          = false
+}
+
 resource "google_sql_database_instance" "gitpod" {
   count            = var.enable_external_database ? 1 : 0
-  name             = "sql-${var.cluster_name}"
+  name             = "sql-${var.cluster_name}-${random_string.random.result}" // we cannot reuse the same name for 1 week
   database_version = "MYSQL_5_7"
   region           = var.region
   settings {

--- a/install/infra/modules/k3s/main.tf
+++ b/install/infra/modules/k3s/main.tf
@@ -172,8 +172,14 @@ resource "google_dns_record_set" "gitpod-dns-3" {
   rrdatas = [google_compute_instance.k3s_master_instance.network_interface[0].access_config[0].nat_ip]
 }
 
+resource "random_string" "random" {
+  length           = 4
+  upper            = false
+  special          = false
+}
+
 resource "google_sql_database_instance" "gitpod" {
-  name             = "sql-${var.name}"
+  name             = "sql-${var.name}-${random_string.random.result}"
   database_version = "MYSQL_5_7"
   region           = var.gcp_region
   settings {

--- a/install/tests/Makefile
+++ b/install/tests/Makefile
@@ -53,8 +53,8 @@ gcp-kubeconfig:
 ## azure-kubeconfig: Get the kubeconfig configuration for Azure AKS
 azure-kubeconfig:
 	export KUBECONFIG=${KUBECONFIG} && \
-	export resource=$$(echo "$$TF_VAR_TEST_ID" | sed "s/[\\W\\-]//") && \
-	az aks get-credentials --name gitpod-test-nor-primary-$$resource --resource-group gitpod-test-nor-$$resource --file ${KUBECONFIG} || echo "No cluster present"
+	export resource=$$(echo "$$TF_VAR_TEST_ID" | sed "s/[\\W\\-]//g") && \
+	az aks get-credentials --name test-cluster-$$resource --resource-group sh-test-$$resource --file ${KUBECONFIG} || echo "No cluster present"
 
 ## aws-kubeconfig: Get the kubeconfig configuration for AWS EKS
 aws-kubeconfig:
@@ -67,7 +67,9 @@ aws-kubeconfig:
 gke-standard-cluster: check-env-cluster-version
 	terraform init --upgrade && \
 	terraform workspace new $(TF_VAR_TEST_ID) || $(MAKE) select-workspace && \
-	terraform apply -target=module.gke -var kubeconfig=${KUBECONFIG} --auto-approve
+	rm -f ${KUBECONFIG} && \
+	$(MAKE) get-kubeconfig && \
+	[[ -f ${KUBECONFIG} ]] || terraform apply -target=module.gke -var kubeconfig=${KUBECONFIG} --auto-approve
 	@echo "Done creating GKE cluster"
 
 ami_id_121 := "ami-060637af2651bc8bb"
@@ -82,7 +84,9 @@ eks-standard-cluster: ami_id = $(if $(ami_id_${TF_VAR_cluster_version//.}),$(ami
 eks-standard-cluster: check-env-cluster-version
 	terraform init --upgrade && \
 	terraform workspace new $(TF_VAR_TEST_ID) || $(MAKE) select-workspace && \
-	terraform apply -target=module.eks -var kubeconfig=${KUBECONFIG} -var eks_node_image_id=${ami_id} --auto-approve
+	rm -f ${KUBECONFIG} && \
+	$(MAKE) get-kubeconfig && \
+	[[ -f ${KUBECONFIG} ]] || terraform apply -target=module.eks -var kubeconfig=${KUBECONFIG} -var eks_node_image_id=${ami_id} --auto-approve
 	@echo "Done creating EKS cluster"
 
 .PHONY:
@@ -90,7 +94,9 @@ eks-standard-cluster: check-env-cluster-version
 aks-standard-cluster: check-env-cluster-version
 	terraform init --upgrade && \
 	terraform workspace new $(TF_VAR_TEST_ID) || $(MAKE) select-workspace && \
-	terraform apply -target=module.aks -var kubeconfig=${KUBECONFIG} --auto-approve
+	rm -f ${KUBECONFIG} && \
+	$(MAKE) get-kubeconfig && \
+	[[ -f ${KUBECONFIG} ]] || terraform apply -target=module.aks -var kubeconfig=${KUBECONFIG} --auto-approve
 	@echo "Done creating AKS cluster"
 
 .PHONY:
@@ -122,7 +128,9 @@ k3s-standard-cluster: image_id = $(if $(image_id_$(os_version)),$(image_id_$(os_
 k3s-standard-cluster: check-env-cluster-version
 	terraform init --upgrade && \
 	terraform workspace new $(TF_VAR_TEST_ID) || $(MAKE) select-workspace && \
-	terraform apply -target=module.k3s -var kubeconfig=${KUBECONFIG} -var k3s_node_image_id=${image_id} --auto-approve && \
+	rm -f ${KUBECONFIG} && \
+	$(MAKE) get-kubeconfig && \
+	[[ -f ${KUBECONFIG} ]] || terraform apply -target=module.k3s -var kubeconfig=${KUBECONFIG} -var k3s_node_image_id=${image_id} --auto-approve && \
 	$(MAKE) upload-kubeconfig-to-gcp # we upload the file to GCP since we cannot retrieve the file against without SSHing to the master
 	@echo "Done creating k3s cluster"
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This is basically the same changes @adrienthebo opened here https://github.com/gitpod-io/gitpod/pull/12321 
The PR was unfortunately merged to a different branch, and this is an effort to split up the PR again to ease the review since it ended up becoming really big.

The main goal of this change is to make sure re-using the same state continues to work.  So for starters things like database names cannot be re-used across most cloud providers for a week after the deletion, etc. Hence, the change @adrienthebo suggested adds a random variable to the end of resource names. Moreover, if a kubernetes cluster already exists by the name, the cluster creation is skipped and re-installation of KOTS is proceeded.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
