### PR TITLE
[server] 'abort' prebuilds

### DIFF
--- a/components/server/ee/src/prebuilds/prebuild-manager.ts
+++ b/components/server/ee/src/prebuilds/prebuild-manager.ts
@@ -31,6 +31,8 @@ import { secondsBefore } from "@gitpod/gitpod-protocol/lib/util/timeutil";
 
 import { inject, injectable } from "inversify";
 import * as opentracing from "opentracing";
+import { StopWorkspacePolicy } from "@gitpod/ws-manager/lib";
+import { error } from "console";
 
 export class WorkspaceRunningError extends Error {
     constructor(msg: string, public instance: WorkspaceInstance) {
@@ -66,16 +68,27 @@ export class PrebuildManager {
                 .findActivePrebuiltWorkspacesByBranch(project.id, branch);
             const results: Promise<any>[] = [];
             for (const prebuild of prebuilds) {
-                for (const instance of prebuild.instances) {
-                    log.info(
-                        { userId: user.id, instanceId: instance.id, workspaceId: instance.workspaceId },
-                        "Aborting Prebuild workspace because a newer commit was pushed to the same branch.",
-                    );
-                    results.push(this.workspaceStarter.stopWorkspaceInstance({ span }, instance.id, instance.region));
+                try {
+                    for (const instance of prebuild.instances) {
+                        log.info(
+                            { userId: user.id, instanceId: instance.id, workspaceId: instance.workspaceId },
+                            "Aborting Prebuild workspace because a newer commit was pushed to the same branch.",
+                        );
+                        results.push(
+                            this.workspaceStarter.stopWorkspaceInstance(
+                                { span },
+                                instance.id,
+                                instance.region,
+                                StopWorkspacePolicy.ABORT,
+                            ),
+                        );
+                    }
+                    prebuild.prebuild.state = "aborted";
+                    prebuild.prebuild.error = "A newer commit was pushed to the same branch.";
+                    results.push(this.workspaceDB.trace({ span }).storePrebuiltWorkspace(prebuild.prebuild));
+                } catch (err) {
+                    error("Cannot cancel prebuild", { prebuildID: prebuild.prebuild.id }, err);
                 }
-                prebuild.prebuild.state = "aborted";
-                prebuild.prebuild.error = "A newer commit was pushed to the same branch.";
-                results.push(this.workspaceDB.trace({ span }).storePrebuiltWorkspace(prebuild.prebuild));
             }
             await Promise.all(results);
         } finally {


### PR DESCRIPTION
Use the new `StopWorkspacePolicy.ABORTED` introduced with #12284 to avoid
spending resources on backing up discarded prebuilds.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #11453

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
