### PR TITLE
add sensible defaults to single cluster aws .tfvars

### DIFF
--- a/install/infra/single-cluster/gcp/terraform.tfvars
+++ b/install/infra/single-cluster/gcp/terraform.tfvars
@@ -1,8 +1,8 @@
 # the cluster_name should be of length less than 15 characters and surrounded by double quotes
-cluster_name =
+cluster_name = "gitpod"
 
 # a cloudDNS zone and certificate request will be created for this domain; surround the domain name within double quotes
-domain_name =
+domain_name = "your_domain_here.com"
 
 region      = "europe-west1"
 zone        = "europe-west1-d"

--- a/install/infra/single-cluster/gcp/terraform.tfvars
+++ b/install/infra/single-cluster/gcp/terraform.tfvars
@@ -2,7 +2,7 @@
 cluster_name = "gitpod"
 
 # a cloudDNS zone and certificate request will be created for this domain; surround the domain name within double quotes
-domain_name = "your_domain_here.com"
+domain_name = "your_domain_name.com"
 
 region      = "europe-west1"
 zone        = "europe-west1-d"


### PR DESCRIPTION
## Description
Creates sensible defaults for domain name and cluster name in .tfvar file for the single cluster reference architecture terraform module. In line with [internal guidelines](https://www.notion.so/gitpod/b525670c23ee47d896802e1089808ec5#474093e901074e62bf0eef449a3792f3).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
[Fixes #](https://github.com/gitpod-io/gitpod/pull/12372)

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```


