### PR TITLE
Make error message more detailed

### DIFF
--- a/.werft/util/kubectl.ts
+++ b/.werft/util/kubectl.ts
@@ -394,7 +394,7 @@ export async function waitUntilAllPodsAreReady(namespace: string, kubeconfig: st
 
         await sleep(3 * 1000);
     }
-    exec(`kubectl --kubeconfig ${kubeconfig} get pods -n ${namespace}`, { ...shellOpts, async: false });
+    exec(`kubectl --kubeconfig ${kubeconfig} describe pods -n ${namespace}`, { ...shellOpts, async: false });
     throw new Error(
         `Not all pods in namespace ${namespace} transitioned to 'Running' or 'Succeeded/Completed' during the expected time.`,
     );


### PR DESCRIPTION
## Description
Make the error diagnosis of pods to starting more detailed. This can happen when preview envs don't start.

## Related Issue(s)
Fixes # https://gitpod.slack.com/archives/C03E52788SU/p1661435286514459?thread_ts=1661386684.170339&cid=C03E52788SU

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
