### PR TITLE
update the AMI image for k8s 1.22

### DIFF
--- a/install/infra/modules/eks/variables.tf
+++ b/install/infra/modules/eks/variables.tf
@@ -17,9 +17,7 @@ variable "kubeconfig" {
 
 variable "image_id" {
   type        = string
-  description = "AMI Image ID specific to the region"
-  // latest ubuntu image for 1.22 k8s for eu-west-1 region, refer https://cloud-images.ubuntu.com/docs/aws/eks/
-  default = "ami-0793b4124359a6ad7"
+  description = "AMI Image ID specific to the region, refer https://cloud-images.ubuntu.com/docs/aws/eks/"
 }
 
 variable "service_machine_type" {

--- a/install/infra/single-cluster/aws/terraform.tfvars
+++ b/install/infra/single-cluster/aws/terraform.tfvars
@@ -16,7 +16,8 @@ vpc_availability_zones = ["eu-west-1c", "eu-west-1b"]
 # You can find the list of UBUNTU AMIs here corresponding to the k8s version and your region via
 # https://cloud-images.ubuntu.com/docs/aws/eks/
 cluster_version = "1.22"
-image_id = "ami-0793b4124359a6ad7"
+
+image_id =
 
 create_external_database = true
 create_external_storage  = true

--- a/install/infra/single-cluster/aws/variables.tf
+++ b/install/infra/single-cluster/aws/variables.tf
@@ -10,9 +10,7 @@ variable "kubeconfig" {
 
 variable "image_id" {
   type        = string
-  description = "AMI Image ID specific to the region"
-  // latest ubuntu image for 1.22 k8s for eu-west-1 region, refer https://cloud-images.ubuntu.com/docs/aws/eks/
-  default = "ami-0793b4124359a6ad7"
+  description = "AMI Image ID specific to the region, refer https://cloud-images.ubuntu.com/docs/aws/eks/"
 }
 
 variable "region" {

--- a/install/infra/single-cluster/gcp/terraform.tfvars
+++ b/install/infra/single-cluster/gcp/terraform.tfvars
@@ -1,8 +1,8 @@
 # the cluster_name should be of length less than 15 characters and surrounded by double quotes
-cluster_name =
+cluster_name = "gitpod"
 
 # a cloudDNS zone and certificate request will be created for this domain; surround the domain name within double quotes
-domain_name =
+domain_name = "your_domain_here.com"
 
 region      = "europe-west1"
 zone        = "europe-west1-d"

--- a/install/infra/single-cluster/gcp/terraform.tfvars
+++ b/install/infra/single-cluster/gcp/terraform.tfvars
@@ -2,7 +2,7 @@
 cluster_name = "gitpod"
 
 # a cloudDNS zone and certificate request will be created for this domain; surround the domain name within double quotes
-domain_name = "your_domain_here.com"
+domain_name = "your_domain_name.com"
 
 region      = "europe-west1"
 zone        = "europe-west1-d"

--- a/install/tests/main.tf
+++ b/install/tests/main.tf
@@ -13,9 +13,7 @@ variable "project" { default = "sh-automated-tests" }
 variable "sa_creds" { default = null }
 variable "dns_sa_creds" { default = null }
 
-variable "eks_node_image_id" {
-  default = "ami-0793b4124359a6ad7" // this AMI is regional
-}
+variable "eks_node_image_id" {}
 
 variable "k3s_node_image_id" {
   default = null


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PR updates the default image provided in .tfvars file for EKS. You can find all the latest supported AMIs here https://cloud-images.ubuntu.com/docs/aws/eks/

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test

```
werft run github -j .werft/eks-installer-tests.yaml -a skipTests=true -a deps=external
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
