### PR TITLE
[observability] - clean-up Overview Dashboard's Workspace Phases panel

### DIFF
--- a/operations/observability/mixins/cross-teams/dashboards/gitpod-overview.libsonnet
+++ b/operations/observability/mixins/cross-teams/dashboards/gitpod-overview.libsonnet
@@ -189,7 +189,7 @@ local workspacePhasesGraph =
     min=0,
     repeat='cluster',
   )
-  .addTarget(prometheus.target('gitpod_ws_manager_workspace_phase_total{%(clusterLabel)s=~"$cluster", phase!="RUNNING"}' % _config, legendFormat='{{type}} - {{phase}}'))
+  .addTarget(prometheus.target('sum by (type, phase)(gitpod_ws_manager_workspace_phase_total{%(clusterLabel)s=~"$cluster", phase!="RUNNING"})' % _config, legendFormat='{{type}} - {{phase}}'))
   // Regular use different levels of green
   .addSeriesOverride({ alias: 'REGULAR - INITIALIZING', color: '#C8F2C2' })
   .addSeriesOverride({ alias: 'REGULAR - CREATING', color: '#96D98D' })


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
The `Workspace Phases` section of the overview dashboard is hard to read, because type and phase values are not grouped. This started when we introduced additional node pools that host the same type and phase for workspaces.

Before:
![image](https://user-images.githubusercontent.com/1272076/186711636-5645e132-667c-4e2b-8889-32b4ab95adfc.png)

After (notice the `type, phase` do not repeat, and have been summed together):
![image](https://user-images.githubusercontent.com/1272076/186712107-96973aad-f5e7-4aca-95f9-8426519650d4.png)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes # n/a

## How to test
<!-- Provide steps to test this PR -->
Compare the output of before:
`gitpod_ws_manager_workspace_phase_total{cluster=~"eu63", phase!="RUNNING"}`

With after:
`sum by (type, phase)(gitpod_ws_manager_workspace_phase_total{cluster=~"eu63", phase!="RUNNING"})`

Also, here you can see I started 8 workspaces in this preview environment, stopped them all, and 8 showed as stopping:
![image](https://user-images.githubusercontent.com/1272076/186720157-f8680ad9-81b2-4178-97aa-23c60e75e3f7.png)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
