### PR TITLE
[kots] load dockerConfigJson reigstry names into `privateBaseImageAllowList`

### DIFF
--- a/install/kots/manifests/gitpod-installer-job.yaml
+++ b/install/kots/manifests/gitpod-installer-job.yaml
@@ -178,6 +178,15 @@ spec:
                 yq e -i ".containerRegistry.privateBaseImageAllowList += \"docker.io\"" "${CONFIG_FILE}"
               fi
 
+              if [ '{{repl ConfigOptionNotEquals "reg_docker_config" "" }}' = "true" ];
+              then
+                DOCKER_CONFIG='{{repl ConfigOptionData "reg_docker_config" | Base64Encode }}'
+                echo "${DOCKER_CONFIG}" | base64 -d  > /tmp/userconfig.json
+                # Add the registries to the server allowlist
+                yq e -i ".containerRegistry.privateBaseImageAllowList += $(cat /tmp/userconfig.json | jq '.auths' | jq -rc 'keys')" "${CONFIG_FILE}"
+                yq e -i ".containerRegistry.privateBaseImageAllowList += \"docker.io\"" "${CONFIG_FILE}"
+              fi
+
               # Output the local registry secret - this is proxy.replicated.com if user hasn't set their own
               echo "{{repl LocalRegistryImagePullSecret }}" | base64 -d > /tmp/kotsregistry.json
 
@@ -355,9 +364,6 @@ spec:
                   "${GITPOD_OBJECTS}/templates/gitpod.yaml" \
                   | base64 -d \
                   > /tmp/currentconfig.json
-
-                DOCKER_CONFIG='{{repl ConfigOptionData "reg_docker_config" | Base64Encode }}'
-                echo "${DOCKER_CONFIG}" | base64 -d  > /tmp/userconfig.json
 
                 export REGISTRY_SECRET=$(jq -s '.[0] * .[1]' /tmp/userconfig.json /tmp/currentconfig.json | base64 -w 0)
 

--- a/install/kots/manifests/kots-config.yaml
+++ b/install/kots/manifests/kots-config.yaml
@@ -119,7 +119,7 @@ spec:
           when: '{{repl ConfigOptionEquals "reg_docker_config_enable" "1" }}'
           type: file
           required: true
-          help_text: Docker [config JSON file](https://docs.docker.com/engine/reference/commandline/cli/#sample-configuration-file) with auth credentials used to access private registries, for workspace images.
+          help_text: "Docker [config JSON file](https://docs.docker.com/engine/reference/commandline/cli/#sample-configuration-file) with auth credentials used to access private registries, for workspace images. **NB.** All of the registries in the config will be automatically added to the [`privateBaseImageAllowList`](http://gitpod.io/docs/self-hosted/latest/advanced/private-registries)."
 
     - name: database
       title: Database


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Follow upto https://github.com/gitpod-io/gitpod/pull/12174

This PR updates the installer logic to also load the auth's reigstry
URL's into `.containerRegistry.privateBaseImageAllowList`.

Signed-off-by: Tarun Pothulapati <tarun@gitpod.io>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[kots] load dockerConfigJson reigstry names into `privateBaseImageAllowList`
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
