### PR TITLE
[jb] Update the terminal widget tab when the Gitpod Task title changes

### DIFF
--- a/components/ide/jetbrains/backend-plugin/build.gradle.kts
+++ b/components/ide/jetbrains/backend-plugin/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
     // Kotlin support - check the latest version at https://plugins.gradle.org/plugin/org.jetbrains.kotlin.jvm
     id("org.jetbrains.kotlin.jvm") version "1.7.0"
     // gradle-intellij-plugin - read more: https://github.com/JetBrains/gradle-intellij-plugin
-    id("org.jetbrains.intellij") version "1.8.0"
+    id("org.jetbrains.intellij") version "1.8.1"
     // detekt linter - read more: https://detekt.github.io/detekt/gradle.html
     id("io.gitlab.arturbosch.detekt") version "1.17.1"
     // ktlint linter - read more: https://github.com/JLLeitschuh/ktlint-gradle


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PR changes two behaviors in JetBrains IDEs:
- Update the terminal widget tab when the Gitpod Task title changes.
- Disconnect the terminal widget when Gitpod Task exits.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
- Fixes #12142
- Touches #12126 - This doesn't fix it but alleviates it because typing "exit" in a Gitpod Task Terminal now disconnects the terminal, so users aren't able to type anything else on it. [[1](https://youtrack.jetbrains.com/issue/CWM-7222/Cant-detect-that-a-terminal-widget-was-closed-on-Thin-Client)][[2](https://github.com/gitpod-io/gitpod/issues/12126#issuecomment-1228729605)]

## How to test
<!-- Provide steps to test this PR -->
1. Open the Preview Environment of this PR.
2. Open any JetBrains IDE with some workspace that contains tasks defined in .gitpod.yml (e.g. https://github.com/gitpod-io/spring-petclinic)
3. Observe the terminal tab titles changing with time (while tasks finish running, or when you start "htop" on them, for example).
4. Type "exit" in a terminal that is running a Gitpod Task and confirm it shows the message "Remote terminal closed".
    <img width="560" alt="image" src="https://user-images.githubusercontent.com/418083/186952648-f798ab48-d678-4bac-8807-ba4b0e09ff88.png">

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Terminal tabs running Gitpod Tasks now have their title updated to reflect what's currently running on it.
```

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
