### PR TITLE
tests: Retry when image-builder is unavailable for some reason

### DIFF
--- a/test/tests/components/image-builder/builder_test.go
+++ b/test/tests/components/image-builder/builder_test.go
@@ -13,6 +13,8 @@ import (
 
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/xerrors"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/features"
 
@@ -75,6 +77,9 @@ func TestBaseImageBuild(t *testing.T) {
 				}
 
 				if err != nil {
+					if st, ok := status.FromError(err); ok && st.Code() == codes.Unavailable {
+						continue
+					}
 					t.Fatal(err)
 				}
 
@@ -84,7 +89,7 @@ func TestBaseImageBuild(t *testing.T) {
 				} else if msg.Status == imgapi.BuildStatus_done_failure {
 					t.Fatalf("image build failed: %s", msg.Message)
 				} else {
-					t.Logf("build output: %s", msg.Message)
+					t.Logf("build output: %s, %s", msg.Message, msg.Info)
 				}
 			}
 			if ref == "" {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Retry when image-builder is unavailable for some reason. I guess lack of resource.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Relates #12248

## How to test
<!-- Provide steps to test this PR -->

Pass TestBaseImageBuild/database/it_should_build_a_base_image on the preview env

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
none
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
