### PR TITLE
content-service: fix incorrect user:group after git operation

### DIFF
--- a/components/content-service/pkg/initializer/git.go
+++ b/components/content-service/pkg/initializer/git.go
@@ -110,7 +110,11 @@ func (ws *GitInitializer) Run(ctx context.Context, mappings []archive.IDMapping)
 		return src, xerrors.Errorf("git initializer gitClone: %w", err)
 	}
 
-	if ws.Chown {
+	defer func() {
+		span.SetTag("Chown", ws.Chown)
+		if !ws.Chown {
+			return
+		}
 		// TODO (aledbf): refactor to remove the need of manual chown
 		args := []string{"-R", "-L", "gitpod", ws.Location}
 		cmd := exec.Command("chown", args...)
@@ -124,7 +128,8 @@ func (ws *GitInitializer) Run(ctx context.Context, mappings []archive.IDMapping)
 			}
 			return
 		}
-	}
+	}()
+
 	if err := ws.realizeCloneTarget(ctx); err != nil {
 		return src, xerrors.Errorf("git initializer clone: %w", err)
 	}

--- a/components/supervisor/pkg/supervisor/supervisor.go
+++ b/components/supervisor/pkg/supervisor/supervisor.go
@@ -1325,11 +1325,9 @@ func startContentInit(ctx context.Context, cfg *Config, wg *sync.WaitGroup, cst 
 
 	fn := "/workspace/.gitpod/content.json"
 	fnReady := "/workspace/.gitpod/ready"
-	doChown := true
 	if _, err := os.Stat("/.workspace/.gitpod/content.json"); !os.IsNotExist(err) {
 		fn = "/.workspace/.gitpod/content.json"
 		fnReady = "/.workspace/.gitpod/ready"
-		doChown = false // cannot chown when using PVC as it is owned by 133332 user
 		log.Info("Detected content.json in /.workspace folder, assuming PVC feature enabled")
 	}
 
@@ -1378,7 +1376,7 @@ func startContentInit(ctx context.Context, cfg *Config, wg *sync.WaitGroup, cst 
 
 	log.Info("supervisor: running content service executor with content descriptor")
 	var src csapi.WorkspaceInitSource
-	src, err = executor.Execute(ctx, "/workspace", contentFile, doChown)
+	src, err = executor.Execute(ctx, "/workspace", contentFile, true)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
- Revert the https://github.com/gitpod-io/gitpod/pull/12238/commits/32a0f897780ac0e7f5dc5e9a5d90ae9e1a8c1d8f
- Fix the files _user:group_ is  `root:gitpod` after `git checkout` operation.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #12420

## How to test
<!-- Provide steps to test this PR -->
- Open preview env and enable the PVC feature flag
- Launch a workspace by PR
- Check all the files and directories under `.git/` folder, the `user:group` is `gitpod:gitpod`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
experimental: enable the feature flag PVC, the files/folders under .git/ folder user:group permission is incorrect
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview