### PR TITLE
Fix AccountStatementProvider 

### DIFF
--- a/components/gitpod-protocol/src/util/garbage-collected-cache.ts
+++ b/components/gitpod-protocol/src/util/garbage-collected-cache.ts
@@ -37,6 +37,11 @@ export class GarbageCollectedCache<T> {
         if (!entry) {
             return undefined;
         }
+        // Still valid?
+        if (entry.expiryDate < Date.now()) {
+            this.store.delete(entry.key);
+            return undefined;
+        }
         return entry.value;
     }
 

--- a/components/server/ee/src/billing/entitlement-service-chargebee.ts
+++ b/components/server/ee/src/billing/entitlement-service-chargebee.ts
@@ -79,7 +79,7 @@ export class EntitlementServiceChargebee implements EntitlementService {
         runningInstances: Promise<WorkspaceInstance[]>,
     ): Promise<boolean> {
         // As retrieving a full AccountStatement is expensive we want to cache it as much as possible.
-        const cachedAccountStatement = this.accountStatementProvider.getCachedStatement();
+        const cachedAccountStatement = this.accountStatementProvider.getCachedStatement(userId);
         const lowerBound = this.getRemainingUsageHoursLowerBound(cachedAccountStatement, date.toISOString());
         if (lowerBound && (lowerBound === "unlimited" || lowerBound > Accounting.MINIMUM_CREDIT_FOR_OPEN_IN_HOURS)) {
             return true;
@@ -108,7 +108,7 @@ export class EntitlementServiceChargebee implements EntitlementService {
             return "unlimited";
         }
 
-        const diffInMillis = new Date(cachedStatement.endDate).getTime() - new Date(date).getTime();
+        const diffInMillis = Math.max(0, new Date(cachedStatement.endDate).getTime() - new Date(date).getTime());
         const maxPossibleUsage = millisecondsToHours(diffInMillis) * MAX_PARALLEL_WORKSPACES;
         return cachedStatement.remainingHours - maxPossibleUsage;
     }

--- a/components/server/ee/src/billing/entitlement-service-chargebee.ts
+++ b/components/server/ee/src/billing/entitlement-service-chargebee.ts
@@ -57,12 +57,7 @@ export class EntitlementServiceChargebee implements EntitlementService {
             hasHitParallelWorkspaceLimit(),
         ]);
 
-        const result = enoughCredits && !hitParallelWorkspaceLimit;
-
-        console.log("mayStartWorkspace > hitParallelWorkspaceLimit " + hitParallelWorkspaceLimit);
-
         return {
-            mayStart: result,
             oufOfCredits: !enoughCredits,
             hitParallelWorkspaceLimit,
         };
@@ -87,7 +82,6 @@ export class EntitlementServiceChargebee implements EntitlementService {
         const cachedAccountStatement = this.accountStatementProvider.getCachedStatement();
         const lowerBound = this.getRemainingUsageHoursLowerBound(cachedAccountStatement, date.toISOString());
         if (lowerBound && (lowerBound === "unlimited" || lowerBound > Accounting.MINIMUM_CREDIT_FOR_OPEN_IN_HOURS)) {
-            console.log("checkEnoughCreditForWorkspaceStart > unlimited");
             return true;
         }
 
@@ -96,7 +90,6 @@ export class EntitlementServiceChargebee implements EntitlementService {
             date.toISOString(),
             runningInstances,
         );
-        console.log("checkEnoughCreditForWorkspaceStart > remainingUsageHours " + remainingUsageHours);
         return remainingUsageHours > Accounting.MINIMUM_CREDIT_FOR_OPEN_IN_HOURS;
     }
 

--- a/components/server/ee/src/billing/entitlement-service-license.ts
+++ b/components/server/ee/src/billing/entitlement-service-license.ts
@@ -30,7 +30,7 @@ export class EntitlementServiceLicense implements EntitlementService {
         runningInstances: Promise<WorkspaceInstance[]>,
     ): Promise<MayStartWorkspaceResult> {
         // if payment is not enabled users can start as many parallel workspaces as they want
-        return { mayStart: true };
+        return {};
     }
 
     async maySetTimeout(user: User, date: Date): Promise<boolean> {

--- a/components/server/ee/src/billing/entitlement-service-ubp.ts
+++ b/components/server/ee/src/billing/entitlement-service-ubp.ts
@@ -57,9 +57,7 @@ export class EntitlementServiceUBP implements EntitlementService {
             this.checkSpendingLimitReached(user, date),
             hasHitParallelWorkspaceLimit(),
         ]);
-        const result = !spendingLimitReachedOnCostCenter && !hitParallelWorkspaceLimit;
         return {
-            mayStart: result,
             spendingLimitReachedOnCostCenter,
             hitParallelWorkspaceLimit,
         };

--- a/components/server/ee/src/billing/entitlement-service.ts
+++ b/components/server/ee/src/billing/entitlement-service.ts
@@ -48,24 +48,19 @@ export class EntitlementServiceImpl implements EntitlementService {
                 };
             }
             const billingMode = await this.billingModes.getBillingModeForUser(user, date);
-            let result;
             switch (billingMode.mode) {
                 case "none":
-                    result = await this.license.mayStartWorkspace(user, date, runningInstances);
-                    break;
+                    return this.license.mayStartWorkspace(user, date, runningInstances);
                 case "chargebee":
-                    result = await this.chargebee.mayStartWorkspace(user, date, runningInstances);
-                    break;
+                    return this.chargebee.mayStartWorkspace(user, date, runningInstances);
                 case "usage-based":
-                    result = await this.ubp.mayStartWorkspace(user, date, runningInstances);
-                    break;
+                    return this.ubp.mayStartWorkspace(user, date, runningInstances);
                 default:
                     throw new Error("Unsupported billing mode: " + (billingMode as any).mode); // safety net
             }
-            return result;
         } catch (err) {
             log.error({ userId: user.id }, "EntitlementService error: mayStartWorkspace", err);
-            throw err;
+            return {}; // When there is an EntitlementService error, we never want to break workspace starts
         }
     }
 

--- a/components/server/ee/src/billing/entitlement-service.ts
+++ b/components/server/ee/src/billing/entitlement-service.ts
@@ -43,7 +43,6 @@ export class EntitlementServiceImpl implements EntitlementService {
             const verification = await this.verificationService.needsVerification(user);
             if (verification) {
                 return {
-                    mayStart: false,
                     needsVerification: true,
                 };
             }

--- a/components/server/ee/src/container-module.ts
+++ b/components/server/ee/src/container-module.ts
@@ -94,13 +94,13 @@ export const productionEEContainerModule = new ContainerModule((bind, unbind, is
     // GitpodServerImpl (stateful per user)
     rebind(GitpodServerImpl).to(GitpodServerEEImpl).inRequestScope();
     bind(EligibilityService).toSelf().inRequestScope();
-    bind(AccountStatementProvider).toSelf().inRequestScope();
 
     // various
     rebind(HostContainerMapping).to(HostContainerMappingEE).inSingletonScope();
     bind(EMailDomainService).to(EMailDomainServiceImpl).inSingletonScope();
     rebind(BlockedUserFilter).toService(EMailDomainService);
     bind(SnapshotService).toSelf().inSingletonScope();
+    bind(AccountStatementProvider).toSelf().inSingletonScope();
 
     bind(UserDeletionServiceEE).toSelf().inSingletonScope();
     rebind(UserDeletionService).to(UserDeletionServiceEE).inSingletonScope();

--- a/components/server/src/billing/entitlement-service.ts
+++ b/components/server/src/billing/entitlement-service.ts
@@ -14,10 +14,7 @@ import { AttributionId } from "@gitpod/gitpod-protocol/lib/attribution";
 import { injectable } from "inversify";
 
 export interface MayStartWorkspaceResult {
-    mayStart: boolean;
-
     hitParallelWorkspaceLimit?: HitParallelWorkspaceLimit;
-
     oufOfCredits?: boolean;
 
     needsVerification?: boolean;
@@ -83,7 +80,7 @@ export class CommunityEntitlementService implements EntitlementService {
         date: Date,
         runningInstances: Promise<WorkspaceInstance[]>,
     ): Promise<MayStartWorkspaceResult> {
-        return { mayStart: true };
+        return {};
     }
 
     async maySetTimeout(user: User, date: Date): Promise<boolean> {


### PR DESCRIPTION
## Description
Fixes caching issue withing AccountStatementProvider. The reasons for this PR is a refactoring 2 weeks back which slightly broke the credit limit check; this PR is meant to bring it back.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
 - [signup](https://gpl-fix-ac6f1a002ea6.preview.gitpod-dev.com/workspaces) with user A
 - start a workspace
 - signup with user B
 - add negative credits to the accounting table for user A so user A should no longer be able to start workspaces
    - `INSERT INTO d_b_account_entry SET uid = '<some-id>', userId = '<your-userId>', amount = -50, date = '2022-08-26T13:47:36.360Z', expiryDate ='2022-10-26T13:47:36.360Z', kind = 'credit';`
    @AlexTugarev Already did this for [your user](https://gpl-fix-ac6f1a002ea6.preview.gitpod-dev.com/admin/users/c8d4457f-ee0f-4220-9af7-e87360a59669)
 - check that:
   - user A can indeed no longer start workspaces :heavy_check_mark: 
   - user B still can :heavy_check_mark: 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
- [x] /werft with-payment
