### PR TITLE
[installer] Add netlimit to configmap

### DIFF
--- a/install/installer/cmd/testdata/render/aws-setup/output.golden
+++ b/install/installer/cmd/testdata/render/aws-setup/output.golden
@@ -3719,8 +3719,8 @@ data:
         "procLimit": 0,
         "netlimit": {
           "enabled": false,
-          "connectionsPerMinute": 0,
-          "bucketSize": 0
+          "connectionsPerMinute": 3000,
+          "bucketSize": 1000
         },
         "hosts": {
           "enabled": true,
@@ -5799,7 +5799,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 2637738dcbbd000d46ae324ed58957395e25e1bcf6ffda1e178812dbaaf355b7
+        gitpod.io/checksum_config: 531cd94d43e48d4295f80353ac56f7748a9f678b8ade59cbabc14d1c3fb43395
         seccomp.security.alpha.kubernetes.io/shiftfs-module-loader: unconfined
       creationTimestamp: null
       labels:

--- a/install/installer/cmd/testdata/render/azure-setup/output.golden
+++ b/install/installer/cmd/testdata/render/azure-setup/output.golden
@@ -3581,8 +3581,8 @@ data:
         "procLimit": 0,
         "netlimit": {
           "enabled": false,
-          "connectionsPerMinute": 0,
-          "bucketSize": 0
+          "connectionsPerMinute": 3000,
+          "bucketSize": 1000
         },
         "hosts": {
           "enabled": true,
@@ -5645,7 +5645,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3f49d25e1369c3d94ed6b8eb44ff0dac997e313a8ca5bda4d8d6daf4950c66f4
+        gitpod.io/checksum_config: 6fd7f9d2c27fa657c0818d37d1d048b00bd4c1127d732232ca76fd04810136be
         seccomp.security.alpha.kubernetes.io/shiftfs-module-loader: unconfined
       creationTimestamp: null
       labels:

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -4498,8 +4498,8 @@ data:
         "procLimit": 0,
         "netlimit": {
           "enabled": false,
-          "connectionsPerMinute": 0,
-          "bucketSize": 0
+          "connectionsPerMinute": 3000,
+          "bucketSize": 1000
         },
         "hosts": {
           "enabled": true,
@@ -6833,7 +6833,7 @@ spec:
     metadata:
       annotations:
         gitpod.io: hello
-        gitpod.io/checksum_config: 6504b7d23f02369f2f0d5894e4fed21dd5ec7c1fdf535ef288b6a11ff9cec4f2
+        gitpod.io/checksum_config: 4e24adf25fa6c788ea607f2b6e87d4d46c00cdaa8d3891f50feebde06ac6b4c3
         hello: world
         seccomp.security.alpha.kubernetes.io/shiftfs-module-loader: unconfined
       creationTimestamp: null

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -3768,8 +3768,8 @@ data:
         "procLimit": 0,
         "netlimit": {
           "enabled": false,
-          "connectionsPerMinute": 0,
-          "bucketSize": 0
+          "connectionsPerMinute": 3000,
+          "bucketSize": 1000
         },
         "hosts": {
           "enabled": true,
@@ -5927,7 +5927,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3f49d25e1369c3d94ed6b8eb44ff0dac997e313a8ca5bda4d8d6daf4950c66f4
+        gitpod.io/checksum_config: 6fd7f9d2c27fa657c0818d37d1d048b00bd4c1127d732232ca76fd04810136be
         seccomp.security.alpha.kubernetes.io/shiftfs-module-loader: unconfined
       creationTimestamp: null
       labels:

--- a/install/installer/cmd/testdata/render/gcp-setup/output.golden
+++ b/install/installer/cmd/testdata/render/gcp-setup/output.golden
@@ -3541,8 +3541,8 @@ data:
         "procLimit": 0,
         "netlimit": {
           "enabled": false,
-          "connectionsPerMinute": 0,
-          "bucketSize": 0
+          "connectionsPerMinute": 3000,
+          "bucketSize": 1000
         },
         "hosts": {
           "enabled": true,
@@ -5619,7 +5619,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: a65e43f706d3d7ba60e82636b6dde415022403f8d0345fcdf00e15f28472374b
+        gitpod.io/checksum_config: 5df9f8dc1dd20d39ae253cd9f977d948fcf75a7375165a9b82ecfd9852e343f3
         seccomp.security.alpha.kubernetes.io/shiftfs-module-loader: unconfined
       creationTimestamp: null
       labels:

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -3988,8 +3988,8 @@ data:
         "procLimit": 0,
         "netlimit": {
           "enabled": false,
-          "connectionsPerMinute": 0,
-          "bucketSize": 0
+          "connectionsPerMinute": 3000,
+          "bucketSize": 1000
         },
         "hosts": {
           "enabled": true,
@@ -6207,7 +6207,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3f49d25e1369c3d94ed6b8eb44ff0dac997e313a8ca5bda4d8d6daf4950c66f4
+        gitpod.io/checksum_config: 6fd7f9d2c27fa657c0818d37d1d048b00bd4c1127d732232ca76fd04810136be
         seccomp.security.alpha.kubernetes.io/shiftfs-module-loader: unconfined
       creationTimestamp: null
       labels:

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -4000,8 +4000,8 @@ data:
         "procLimit": 0,
         "netlimit": {
           "enabled": false,
-          "connectionsPerMinute": 0,
-          "bucketSize": 0
+          "connectionsPerMinute": 3000,
+          "bucketSize": 1000
         },
         "hosts": {
           "enabled": true,
@@ -6219,7 +6219,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3f49d25e1369c3d94ed6b8eb44ff0dac997e313a8ca5bda4d8d6daf4950c66f4
+        gitpod.io/checksum_config: 6fd7f9d2c27fa657c0818d37d1d048b00bd4c1127d732232ca76fd04810136be
         seccomp.security.alpha.kubernetes.io/shiftfs-module-loader: unconfined
       creationTimestamp: null
       labels:

--- a/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
+++ b/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
@@ -4321,8 +4321,8 @@ data:
         "procLimit": 0,
         "netlimit": {
           "enabled": false,
-          "connectionsPerMinute": 0,
-          "bucketSize": 0
+          "connectionsPerMinute": 3000,
+          "bucketSize": 1000
         },
         "hosts": {
           "enabled": true,
@@ -6651,7 +6651,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3f49d25e1369c3d94ed6b8eb44ff0dac997e313a8ca5bda4d8d6daf4950c66f4
+        gitpod.io/checksum_config: 6fd7f9d2c27fa657c0818d37d1d048b00bd4c1127d732232ca76fd04810136be
         seccomp.security.alpha.kubernetes.io/shiftfs-module-loader: unconfined
       creationTimestamp: null
       labels:

--- a/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
+++ b/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
@@ -3991,8 +3991,8 @@ data:
         "procLimit": 0,
         "netlimit": {
           "enabled": false,
-          "connectionsPerMinute": 0,
-          "bucketSize": 0
+          "connectionsPerMinute": 3000,
+          "bucketSize": 1000
         },
         "hosts": {
           "enabled": true,
@@ -6210,7 +6210,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3f49d25e1369c3d94ed6b8eb44ff0dac997e313a8ca5bda4d8d6daf4950c66f4
+        gitpod.io/checksum_config: 6fd7f9d2c27fa657c0818d37d1d048b00bd4c1127d732232ca76fd04810136be
         seccomp.security.alpha.kubernetes.io/shiftfs-module-loader: unconfined
       creationTimestamp: null
       labels:

--- a/install/installer/pkg/components/ws-daemon/configmap.go
+++ b/install/installer/pkg/components/ws-daemon/configmap.go
@@ -135,6 +135,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 			CPULimit:  cpuLimitConfig,
 			IOLimit:   ioLimitConfig,
 			ProcLimit: procLimit,
+			NetLimit:  networkLimitConfig,
 			Hosts: hosts.Config{
 				Enabled:       true,
 				NodeHostsFile: "/mnt/hosts",


### PR DESCRIPTION
## Description
Add netlimit to configmap

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
n.a.
## How to test
- Create installer config with 
```
    networkLimits: 
      enabled: true
      connectionsPerMinute: 3000
      bucketSize: 1000
```
- gitpod-installer render --config deploy/workspace/installer-values.yaml --use-experimental-config > /tmp/render.yaml
- Check output

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
