### PR TITLE
Update obs installer config with importers

### DIFF
--- a/.werft/observability/monitoring-satellite.ts
+++ b/.werft/observability/monitoring-satellite.ts
@@ -69,22 +69,10 @@ export class MonitoringSatelliteInstaller {
             kubectl create ns monitoring-satellite --kubeconfig ${this.options.kubeconfigPath} || true && \
             cd installer && echo '
             {
-                "alerting": {
-                    "config": {}
-                },
                 "gitpod": {
                     "installServiceMonitors": true
                 },
-                "prober": {
-                    "install": true
-                },
-                "kubescape": {
-                    "install": true
-                },
                 "pyrra": {
-                    "install": true
-                },
-                "grafana": {
                     "install": true
                 },
                 "prometheus": {
@@ -108,6 +96,24 @@ export class MonitoringSatelliteInstaller {
                             "regex": "rest_client_requests_total.*|http_prober_.*",
                             "action": "keep",
                         }],
+                    }],
+                },
+                "imports": {
+                    "yaml": [{
+                            "gitURL": "https://github.com/gitpod-io/observability",
+                            "path": "monitoring-satellite/manifests/kube-prometheus-rules",
+                        },
+                        {
+                            "gitURL": "https://github.com/gitpod-io/observability",
+                            "path": "monitoring-satellite/manifests/kubescape",
+                        },
+                        {
+                            "gitURL": "https://github.com/gitpod-io/observability",
+                            "path": "monitoring-satellite/manifests/grafana",
+                        },
+                        {
+                            "gitURL": "https://github.com/gitpod-io/observability",
+                            "path": "monitoring-satellite/manifests/probers",
                     }],
                 },
             }' | go run main.go render --config - | kubectl --kubeconfig ${this.options.kubeconfigPath} apply -f -`;


### PR DESCRIPTION

## Description
<!-- Describe your changes in detail -->
We've made quite a few changes to our installer since we introduced it to preview environments. This PR adjusts the config so it works again


## How to test
<!-- Provide steps to test this PR -->
* Start a workspace from this PR
* Run a new job with `werft run github -f -a with-preview=true -a observabilityInstallationMethod=observability-installer`
* Verify that the observability stack is properly running at monitoring-satellite's namespace

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
