### PR TITLE
Fix default workspace class is not selected

### DIFF
--- a/components/dashboard/src/service/service-mock.ts
+++ b/components/dashboard/src/service/service-mock.ts
@@ -5,6 +5,7 @@
  */
 
 import { createServiceMock, Event, Project, Team, User } from "@gitpod/gitpod-protocol";
+import { BillingMode } from "@gitpod/gitpod-protocol/lib/billing-mode";
 
 const u1: User = {
     id: "1234",
@@ -218,7 +219,7 @@ const gitpodServiceMock = createServiceMock({
                 displayName: "Standard",
                 description: "Up to 4 vCPU, 8GB memory, 30GB disk",
                 powerups: 1,
-                isDefault: true,
+                isSelected: true,
             },
             {
                 id: "g1-large",
@@ -226,7 +227,7 @@ const gitpodServiceMock = createServiceMock({
                 displayName: "Large",
                 description: "Up to 8 vCPU, 16GB memory, 50GB disk",
                 powerups: 2,
-                isDefault: false,
+                isSelected: false,
             },
         ];
     },
@@ -264,6 +265,9 @@ const gitpodServiceMock = createServiceMock({
                 },
             },
         };
+    },
+    getBillingModeForUser: async () => {
+        return BillingMode.NONE;
     },
 });
 

--- a/components/dashboard/src/settings/selectClass.tsx
+++ b/components/dashboard/src/settings/selectClass.tsx
@@ -45,7 +45,7 @@ export default function SelectWorkspaceClass(props: SelectWorkspaceClassProps) {
             setSupportedClasses(classes);
 
             if (!workspaceClass) {
-                setWorkspaceClass(supportedClasses.find((c) => c.isDefault)?.id || "");
+                setWorkspaceClass(classes.find((c) => c.isSelected)?.id || "");
             }
         };
 

--- a/components/gitpod-protocol/src/workspace-class.ts
+++ b/components/gitpod-protocol/src/workspace-class.ts
@@ -10,5 +10,5 @@ export interface SupportedWorkspaceClass {
     displayName: string;
     description: string;
     powerups: number;
-    isDefault: boolean;
+    isSelected: boolean;
 }


### PR DESCRIPTION
## Description
Show the workspace class that will be used if no workspace class has been selected yet by the user. 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/12435

## How to test
- Open the workspace settings in the preview environment
- Check that Default is selected even though now workspace class has been selected yet

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
