### PR TITLE
[public-api] Validate incoming stripe webhooks

### DIFF
--- a/components/public-api-server/pkg/server/server.go
+++ b/components/public-api-server/pkg/server/server.go
@@ -5,8 +5,13 @@
 package server
 
 import (
+	"encoding/json"
 	"fmt"
+	"github.com/gitpod-io/gitpod/common-go/log"
+	"net/http"
 	"net/url"
+	"os"
+	"strings"
 
 	"github.com/gitpod-io/gitpod/public-api/config"
 	"github.com/gorilla/handlers"
@@ -48,9 +53,18 @@ func Start(logger *logrus.Entry, cfg *config.Configuration) error {
 		}
 	}
 
-	srv.HTTPMux().Handle("/stripe/invoices/webhook",
-		handlers.ContentTypeHandler(webhooks.NewStripeWebhookHandler(billingService), "application/json"),
-	)
+	var stripeWebhookHandler http.Handler = webhooks.NewNoopWebhookHandler()
+	if cfg.StripeWebhookSigningSecretPath != "" {
+		stripeWebhookSecret, err := readStripeWebhookSecret(cfg.StripeWebhookSigningSecretPath)
+		if err != nil {
+			return fmt.Errorf("failed to read stripe secret: %w", err)
+		}
+		stripeWebhookHandler = webhooks.NewStripeWebhookHandler(billingService, stripeWebhookSecret)
+	} else {
+		log.Info("No stripe webhook secret is configured, endpoints will return NotImplemented")
+	}
+
+	srv.HTTPMux().Handle("/stripe/invoices/webhook", handlers.ContentTypeHandler(stripeWebhookHandler, "application/json"))
 
 	if registerErr := register(srv, gitpodAPI, registry); registerErr != nil {
 		return fmt.Errorf("failed to register services: %w", registerErr)
@@ -72,4 +86,19 @@ func register(srv *baseserver.Server, serverAPIURL *url.URL, registry *prometheu
 	v1.RegisterPrebuildsServiceServer(srv.GRPC(), v1.UnimplementedPrebuildsServiceServer{})
 
 	return nil
+}
+
+func readStripeWebhookSecret(path string) (string, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("failed to read stripe webhook secret: %w", err)
+	}
+
+	var stripeSecret string
+	err = json.Unmarshal(b, &stripeSecret)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse stripe webhook secret: %w", err)
+	}
+
+	return strings.TrimSpace(stripeSecret), nil
 }

--- a/components/public-api-server/pkg/webhooks/stripe_noop.go
+++ b/components/public-api-server/pkg/webhooks/stripe_noop.go
@@ -1,0 +1,21 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package webhooks
+
+import (
+	"github.com/gitpod-io/gitpod/common-go/log"
+	"net/http"
+)
+
+func NewNoopWebhookHandler() *noopWebhookHandler {
+	return &noopWebhookHandler{}
+}
+
+type noopWebhookHandler struct{}
+
+func (h *noopWebhookHandler) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
+	log.Info("Received Stripe webhook handler, but running in no-op mode so will not be handing it.")
+	w.WriteHeader(http.StatusNotImplemented)
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Implements validation of Stripe Webhooks.

Uses secret already mounted to the public-api-server to perform the validation as per Stripe documentaiton.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Depends on https://github.com/gitpod-io/gitpod/pull/12462

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
