### PR TITLE
code-sync: store editSessions

### DIFF
--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -7,7 +7,7 @@ defaultArgs:
   jbMarketplacePublishTrigger: "false"
   publishToJBMarketplace: true
   localAppVersion: unknown
-  codeCommit: 06783e74552ddefd74c7e02cdcce19054b294469
+  codeCommit: ca48b16256fad72bc239a27bde3dc78a369aafa6
   codeQuality: stable
   intellijDownloadUrl: "https://download.jetbrains.com/idea/ideaIU-2022.2.1.tar.gz"
   golandDownloadUrl: "https://download.jetbrains.com/go/goland-2022.2.2.tar.gz"

--- a/components/gitpod-db/src/typeorm/code-sync-resource-db.spec.db.ts
+++ b/components/gitpod-db/src/typeorm/code-sync-resource-db.spec.db.ts
@@ -23,7 +23,7 @@ export class CodeSyncResourceDBSpec {
     }
 
     async after(): Promise<void> {
-        await this.db.delete(this.userId, () => Promise.resolve());
+        await this.db.deleteSettingsSyncResources(this.userId, () => Promise.resolve());
     }
 
     @test()
@@ -120,7 +120,13 @@ export class CodeSyncResourceDBSpec {
     async roundRobinInsert(): Promise<void> {
         const kind = "machines";
         const expectation: string[] = [];
-        const doInsert = async (rev: string, oldRevs: string[]) => {
+        const doInsert = async (newRev: string, oldRevs?: string[]) => {
+            expectation.unshift(newRev);
+
+            if (!oldRevs) {
+                return;
+            }
+
             for (let rev of oldRevs) {
                 await this.db.deleteResource(this.userId, kind, rev, async () => {});
             }
@@ -134,23 +140,23 @@ export class CodeSyncResourceDBSpec {
 
         await assertResources();
 
-        expectation.unshift((await this.db.insert(this.userId, kind, doInsert, { revLimit }))!);
-        expectation.unshift((await this.db.insert(this.userId, kind, doInsert, { revLimit }))!);
-        expectation.unshift((await this.db.insert(this.userId, kind, doInsert, { revLimit }))!);
+        await this.db.insert(this.userId, kind, doInsert, { revLimit, overwrite: true });
+        await this.db.insert(this.userId, kind, doInsert, { revLimit, overwrite: true });
+        await this.db.insert(this.userId, kind, doInsert, { revLimit, overwrite: true });
         await assertResources();
 
-        expectation.unshift((await this.db.insert(this.userId, kind, doInsert, { revLimit }))!);
+        await this.db.insert(this.userId, kind, doInsert, { revLimit, overwrite: true });
         expectation.length = revLimit;
         await assertResources();
 
-        expectation.unshift((await this.db.insert(this.userId, kind, doInsert, { revLimit }))!);
-        expectation.unshift((await this.db.insert(this.userId, kind, doInsert, { revLimit }))!);
+        await this.db.insert(this.userId, kind, doInsert, { revLimit, overwrite: true });
+        await this.db.insert(this.userId, kind, doInsert, { revLimit, overwrite: true });
         expectation.length = revLimit;
         await assertResources();
 
-        expectation.unshift((await this.db.insert(this.userId, kind, doInsert, { revLimit }))!);
-        expectation.unshift((await this.db.insert(this.userId, kind, doInsert, { revLimit }))!);
-        expectation.unshift((await this.db.insert(this.userId, kind, doInsert, { revLimit }))!);
+        await this.db.insert(this.userId, kind, doInsert, { revLimit, overwrite: true });
+        await this.db.insert(this.userId, kind, doInsert, { revLimit, overwrite: true });
+        await this.db.insert(this.userId, kind, doInsert, { revLimit, overwrite: true });
         expectation.length = revLimit;
         await assertResources();
     }

--- a/components/gitpod-db/src/typeorm/entity/db-code-sync-resource.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-code-sync-resource.ts
@@ -40,8 +40,8 @@ export interface IUserDataManifest {
     //readonly ref: string;
 }
 
-export type ServerResource = SyncResource | "machines";
-export const ALL_SERVER_RESOURCES: ServerResource[] = [...ALL_SYNC_RESOURCES, "machines"];
+export type ServerResource = SyncResource | "machines" | "editSessions" | "profiles";
+export const ALL_SERVER_RESOURCES: ServerResource[] = [...ALL_SYNC_RESOURCES, "machines", "editSessions", "profiles"];
 
 @Entity()
 @Index("ind_dbsync", ["created"]) // DBSync


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Store editSessions in sync server

## How to test
<!-- Provide steps to test this PR -->
1. Create workspace using latest vscode
2. Test editsessions is working https://code.visualstudio.com/updates/v1_70#_edit-sessions-across-vs-code-for-the-web-and-desktop, in our case it could used to store changes between new workspaces of the same repo 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[server] Support for storing vscode edit sessions in sync server
```

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
