### PR TITLE
tests: Fix a bug in the calculation of the # of tests.

### DIFF
--- a/.werft/workspace-run-integration-tests.sh
+++ b/.werft/workspace-run-integration-tests.sh
@@ -143,6 +143,7 @@ for TEST_PATH in "${WK_TEST_LIST[@]}"
 do
     TEST_NAME=$(basename "${TEST_PATH}")
     echo "running integration for ${TEST_NAME}" | werft log slice "test-${TEST_NAME}"
+    RUN_COUNT=$((RUN_COUNT+1))
 
     cd "${TEST_PATH}"
     set +e
@@ -150,7 +151,6 @@ do
     RC=${PIPESTATUS[0]}
     set -e
 
-    RUN_COUNT=$((RUN_COUNT+1))
     if [ "${RC}" -ne "0" ]; then
       FAILURE_COUNT=$((FAILURE_COUNT+1))
       FAILURE_TESTS["${TEST_NAME}"]=$(grep "\-\-\- FAIL: " "${TEST_PATH}"/"${TEST_NAME}".log)


### PR DESCRIPTION
## Description

Fix error message that VM is not ready if the first test fails due to panic
e.g. [internal link](https://gitpod.slack.com/archives/C03E52788SU/p1661732967697299)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Relates #12248 

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
