### PR TITLE
tests: Clean a workspace even if a test failed

### DIFF
--- a/test/tests/workspace/docker_test.go
+++ b/test/tests/workspace/docker_test.go
@@ -32,6 +32,13 @@ func TestRunDocker(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
+			t.Cleanup(func() {
+				err = integration.DeleteWorkspace(ctx, api, ws.Req.Id)
+				if err != nil {
+					t.Fatal(err)
+				}
+				_, _ = integration.WaitForWorkspaceStop(ctx, api, ws.Req.Id)
+			})
 
 			rsa, closer, err := integration.Instrument(integration.ComponentWorkspace, "workspace", cfg.Namespace(), kubeconfig, cfg.Client(), integration.WithInstanceID(ws.Req.Id), integration.WithWorkspacekitLift(true))
 			if err != nil {
@@ -55,11 +62,6 @@ func TestRunDocker(t *testing.T) {
 
 			if resp.ExitCode != 0 {
 				t.Fatalf("docker run failed: %s\n%s", resp.Stdout, resp.Stderr)
-			}
-
-			err = integration.DeleteWorkspace(ctx, api, ws.Req.Id)
-			if err != nil {
-				t.Fatal(err)
 			}
 
 			return ctx


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Remaining workspace will affect the performance of subsequent tests

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Relates https://github.com/gitpod-io/gitpod/issues/12248

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
