### PR TITLE
[public-api] Fix Stripe Webhook Secret mount path

### DIFF
--- a/components/public-api/go/config/config.go
+++ b/components/public-api/go/config/config.go
@@ -16,7 +16,3 @@ type Configuration struct {
 
 	Server *baseserver.Configuration `json:"server,omitempty"`
 }
-
-type StripeSecret struct {
-	WebhookSigningKey string `json:"signingKey"`
-}

--- a/install/installer/pkg/components/public-api-server/configmap.go
+++ b/install/installer/pkg/components/public-api-server/configmap.go
@@ -9,7 +9,6 @@ import (
 	"github.com/gitpod-io/gitpod/installer/pkg/config/v1/experimental"
 	"k8s.io/utils/pointer"
 	"net"
-	"path/filepath"
 	"strconv"
 
 	"github.com/gitpod-io/gitpod/common-go/baseserver"
@@ -81,6 +80,7 @@ func getStripeConfig(cfg *experimental.Config) (corev1.Volume, corev1.VolumeMoun
 	}
 
 	stripeSecret := cfg.WebApp.PublicAPI.StripeSecretName
+	path = stripeSecretMountPath
 
 	volume = corev1.Volume{
 		Name: "stripe-secret",
@@ -97,8 +97,6 @@ func getStripeConfig(cfg *experimental.Config) (corev1.Volume, corev1.VolumeMoun
 		MountPath: stripeSecretMountPath,
 		ReadOnly:  true,
 	}
-
-	path = filepath.Join(secretsDirectory, stripeSecretMountPath)
 
 	return volume, mount, path, true
 }

--- a/install/installer/pkg/components/public-api-server/constants.go
+++ b/install/installer/pkg/components/public-api-server/constants.go
@@ -14,6 +14,5 @@ const (
 	HTTPServicePort   = 9002
 	HTTPPortName      = "http"
 
-	secretsDirectory      = "secrets"
-	stripeSecretMountPath = "stripe-secret"
+	stripeSecretMountPath = "/secrets/stripe-webhook-secret"
 )


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

The current implementation would mount the secret under `/stripe-secret/stripe-webhook-secret` but would set the config path to `secrets/stripe-secret`. This fixes that issue by fixing the path.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
