### PR TITLE
Add troubleshooting item to AWS SIngle Cluster Ref Arch Readme

### DIFF
--- a/install/infra/single-cluster/aws/README.md
+++ b/install/infra/single-cluster/aws/README.md
@@ -194,7 +194,7 @@ documentaion](https://www.gitpod.io/docs/self-hosted/latest/getting-started#step
 
 ### KOTS pods fail to deploy
 
-Sometimes, the pods deployed when executing `kubectl kots install gitpod` fail to deploy due to issues with mounting their disks.
+Sometimes, the pods deployed when executing `kubectl kots install gitpod` fail to deploy due to issues with mounting their disks:
 
 ```lucas@Lucass-MBP aws % kubectl get pods -A
 NAMESPACE      NAME                                       READY   STATUS              RESTARTS   AGE

--- a/install/infra/single-cluster/aws/README.md
+++ b/install/infra/single-cluster/aws/README.md
@@ -196,7 +196,7 @@ documentaion](https://www.gitpod.io/docs/self-hosted/latest/getting-started#step
 
 Sometimes, the pods deployed when executing `kubectl kots install gitpod` fail to deploy due to issues with mounting their disks:
 
-```lucas@Lucass-MBP aws % kubectl get pods -A
+```$ kubectl get pods -A
 NAMESPACE      NAME                                       READY   STATUS              RESTARTS   AGE
 gitpod         kotsadm-minio-0                            0/1     ContainerCreating   0          2m28s
 gitpod         kotsadm-postgres-0                         0/1     Init:0/2            0          2m28s

--- a/install/infra/single-cluster/aws/README.md
+++ b/install/infra/single-cluster/aws/README.md
@@ -192,6 +192,18 @@ documentaion](https://www.gitpod.io/docs/self-hosted/latest/getting-started#step
 
 ## Troubleshooting
 
+### KOTS pods fail to deploy
+
+Sometimes, the pods deployed when executing `kubectl kots install gitpod` fail to deploy due to issues with mounting their disks.
+
+```lucas@Lucass-MBP aws % kubectl get pods -A
+NAMESPACE      NAME                                       READY   STATUS              RESTARTS   AGE
+gitpod         kotsadm-minio-0                            0/1     ContainerCreating   0          2m28s
+gitpod         kotsadm-postgres-0                         0/1     Init:0/2            0          2m28s
+```
+
+This can happen when the wrong `image_id`  was used in the `.tfvars` file. The id needs to respect both the region as well as the Kubernetes version and can be found [here](https://cloud-images.ubuntu.com/docs/aws/eks/). 
+
 ### Some pods never start (Init state)
 
 ```sh

--- a/install/infra/single-cluster/aws/README.md
+++ b/install/infra/single-cluster/aws/README.md
@@ -202,7 +202,7 @@ gitpod         kotsadm-minio-0                            0/1     ContainerCreat
 gitpod         kotsadm-postgres-0                         0/1     Init:0/2            0          2m28s
 ```
 
-This can happen when the wrong `image_id`  was used in the `.tfvars` file. The id needs to respect both the region as well as the Kubernetes version and can be found [here](https://cloud-images.ubuntu.com/docs/aws/eks/). 
+This can happen when the wrong `image_id`  was used in the `.tfvars` file. The ID needs to respect both the region as well as the Kubernetes version and can be found [here](https://cloud-images.ubuntu.com/docs/aws/eks/). 
 
 ### Some pods never start (Init state)
 


### PR DESCRIPTION


## Description
This adds a troubleshooting item that I already ran into twice around setting the wrong image_id


## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
