### PR TITLE
[local-preview] Fail if M1 Mac

### DIFF
--- a/install/preview/entrypoint.sh
+++ b/install/preview/entrypoint.sh
@@ -18,11 +18,17 @@ if [ "$1" != "logging" ]; then
   exit
 fi
 
+# fail if its arm64
+if [ "$(uname -m)" = 'arm64' ]; then
+    echo "Gitpod local preview does not work on arm64 CPU's (including M1 Mac's)"
+    exit 1
+fi
+
 # check for minimum requirements
 REQUIRED_MEM_KB=$((6 * 1024 * 1024))
 total_mem_kb=$(awk '/MemTotal:/ {print $2}' /proc/meminfo)
 if [ "${total_mem_kb}" -lt "${REQUIRED_MEM_KB}" ]; then
-    echo "Preview installation of Gitpod requires a system with at least 6GB of memory"
+    echo "Gitpod local preview requires a system with at least 6GB of memory"
     exit 1
 else
   set -x
@@ -31,7 +37,7 @@ fi
 REQUIRED_CORES=4
 total_cores=$(nproc)
 if [ "${total_cores}" -lt "${REQUIRED_CORES}" ]; then
-    echo "Preview installation of Gitpod requires a system with at least 4 CPU Cores"
+    echo "Gitpod local preview requires a system with at least 4 CPU Cores"
     exit 1
 fi
 


### PR DESCRIPTION


## Description
<!-- Describe your changes in detail -->

Currently, If its a M1 Mac, The local preview instance
just continues running as the failures are in k3s. We
should instead fail earlier so that the user understands
the problem.

We already have a warning for the same in the documentation
website, but having a check seems to be useful.

Signed-off-by: Tarun Pothulapati <tarun@gitpod.io>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[local-preview] Check and exit if M1 Mac
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
