### PR TITLE
Clean up webhook events

### DIFF
--- a/components/gitpod-db/src/typeorm/webhook-event-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/webhook-event-db-impl.ts
@@ -51,4 +51,20 @@ export class WebhookEventDBImpl implements WebhookEventDB {
         query.limit(limit);
         return query.getMany();
     }
+
+    public async deleteOldEvents(ageInDays: number, limit?: number): Promise<void> {
+        const repo = await this.getRepo();
+        const d = new Date();
+        d.setDate(d.getDate() - ageInDays);
+        const expirationDate = d.toISOString();
+        const query = repo
+            .createQueryBuilder("event")
+            .update()
+            .set({ deleted: true })
+            .where("event.creationTime < :expirationDate", { expirationDate });
+        if (typeof limit === "number") {
+            query.limit(limit);
+        }
+        await query.execute();
+    }
 }

--- a/components/gitpod-db/src/webhook-event-db.ts
+++ b/components/gitpod-db/src/webhook-event-db.ts
@@ -11,4 +11,5 @@ export interface WebhookEventDB {
     createEvent(parts: Omit<WebhookEvent, "id" | "creationTime">): Promise<WebhookEvent>;
     updateEvent(id: string, update: Partial<WebhookEvent>): Promise<void>;
     findByCloneUrl(cloneUrl: string, limit?: number): Promise<WebhookEvent[]>;
+    deleteOldEvents(ageInDays: number, limit?: number): Promise<void>;
 }

--- a/components/server/src/container-module.ts
+++ b/components/server/src/container-module.ts
@@ -115,6 +115,7 @@ import {
     getExperimentsClientForBackend,
 } from "@gitpod/gitpod-protocol/lib/experiments/configcat-server";
 import { VerificationService } from "./auth/verification-service";
+import { WebhookEventGarbageCollector } from "./projects/webhook-event-garbage-collector";
 
 export const productionContainerModule = new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(Config).toConstantValue(ConfigFile.fromFile());
@@ -287,4 +288,6 @@ export const productionContainerModule = new ContainerModule((bind, unbind, isBo
         .inSingletonScope();
 
     bind(VerificationService).toSelf().inSingletonScope();
+
+    bind(WebhookEventGarbageCollector).toSelf().inSingletonScope();
 });

--- a/components/server/src/projects/webhook-event-garbage-collector.ts
+++ b/components/server/src/projects/webhook-event-garbage-collector.ts
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { injectable, inject } from "inversify";
+import * as opentracing from "opentracing";
+import { DBWithTracing, TracedWorkspaceDB, WorkspaceDB, WebhookEventDB } from "@gitpod/gitpod-db/lib";
+import { Disposable } from "@gitpod/gitpod-protocol";
+import { ConsensusLeaderQorum } from "../consensus/consensus-leader-quorum";
+import { TraceContext } from "@gitpod/gitpod-protocol/lib/util/tracing";
+import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
+import { repeat } from "@gitpod/gitpod-protocol/lib/util/repeat";
+
+@injectable()
+export class WebhookEventGarbageCollector {
+    static readonly GC_CYCLE_INTERVAL_SECONDS = 4 * 60; // every 6 minutes
+
+    @inject(WebhookEventDB) protected readonly db: WebhookEventDB;
+
+    @inject(ConsensusLeaderQorum) protected readonly leaderQuorum: ConsensusLeaderQorum;
+    @inject(TracedWorkspaceDB) protected readonly workspaceDB: DBWithTracing<WorkspaceDB>;
+
+    public async start(intervalSeconds?: number): Promise<Disposable> {
+        const intervalSecs = intervalSeconds || WebhookEventGarbageCollector.GC_CYCLE_INTERVAL_SECONDS;
+        return repeat(async () => {
+            try {
+                if (await this.leaderQuorum.areWeLeader()) {
+                    await this.collectObsoleteWebhookEvents();
+                }
+            } catch (err) {
+                log.error("webhook event garbage collector", err);
+            }
+        }, intervalSecs * 1000);
+    }
+
+    protected async collectObsoleteWebhookEvents() {
+        const span = opentracing.globalTracer().startSpan("collectObsoleteWebhookEvents");
+        log.debug("webhook-event-gc: start collecting...");
+        try {
+            await this.db.deleteOldEvents(10 /* days */, 600 /* limit per run */);
+            log.debug("webhook-event-gc: done collecting.");
+        } catch (err) {
+            TraceContext.setError({ span }, err);
+            log.error("webhook-event-gc: error collecting webhook events: ", err);
+            throw err;
+        } finally {
+            span.finish();
+        }
+    }
+}

--- a/components/server/src/server.ts
+++ b/components/server/src/server.ts
@@ -48,6 +48,7 @@ import { DebugApp } from "@gitpod/gitpod-protocol/lib/util/debug-app";
 import { LocalMessageBroker } from "./messaging/local-message-broker";
 import { WsConnectionHandler } from "./express/ws-connection-handler";
 import { InstallationAdminController } from "./installation-admin/installation-admin-controller";
+import { WebhookEventGarbageCollector } from "./projects/webhook-event-garbage-collector";
 
 @injectable()
 export class Server<C extends GitpodClient, S extends GitpodServer> {
@@ -75,6 +76,7 @@ export class Server<C extends GitpodClient, S extends GitpodServer> {
     @inject(OneTimeSecretServer) protected readonly oneTimeSecretServer: OneTimeSecretServer;
 
     @inject(PeriodicDbDeleter) protected readonly periodicDbDeleter: PeriodicDbDeleter;
+    @inject(WebhookEventGarbageCollector) protected readonly webhookEventGarbageCollector: WebhookEventGarbageCollector;
 
     @inject(BearerAuth) protected readonly bearerAuth: BearerAuth;
 
@@ -268,6 +270,11 @@ export class Server<C extends GitpodClient, S extends GitpodServer> {
 
         // Start DB updater
         this.startDbDeleter().catch((err) => log.error("starting DB deleter", err));
+
+        // Start WebhookEvent GC
+        this.webhookEventGarbageCollector
+            .start()
+            .catch((err) => log.error("webhook-event-gc: error during startup", err));
 
         this.app = app;
         log.info("server initialized.");


### PR DESCRIPTION
by running a periodic garbage collector. This is a pattern we use for other resources.

fixes #12430

## Description
The way GC works is admittedly tricky, as it's an interplay between the periodic GC task and the `db-sync`. Periodically this will mark a bunch of entries as `deleted`, and we rely on the `db-sync` to actually delete the entries.

Because it's proven unreliable to mark entries as delete in the thousands, leaving them in the db for ever after a failure, the settings to mark as deleted periodically are: 600 entries every 6 minutes, which is a rate of ~200K/day and should not produce a lot of DB CPU usage.  

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #12430

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
