### PR TITLE
[server] Only alert on explicit system failures

### DIFF
--- a/components/server/src/prometheus-metrics.ts
+++ b/components/server/src/prometheus-metrics.ts
@@ -148,7 +148,11 @@ const instanceStartsFailedTotal = new prometheusClient.Counter({
     registers: [prometheusClient.register],
 });
 
-export type FailedInstanceStartReason = "clusterSelectionFailed" | "startOnClusterFailed" | "other";
+export type FailedInstanceStartReason =
+    | "clusterSelectionFailed"
+    | "startOnClusterFailed"
+    | "imageBuildFailed"
+    | "other";
 export function increaseFailedInstanceStartCounter(reason: FailedInstanceStartReason) {
     instanceStartsFailedTotal.inc({ reason });
 }


### PR DESCRIPTION
## Description
Reduce the noise on metric `gitpod_server_instance_starts_failed_total`

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

If you would like to add additional annotations, each one has to be on a separate line:
/werft with-preview
/werft with-payment
Not:
/werft with-preview with-payment

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
