### PR TITLE
Revert "Add clarification for werft annotations in the PR description"

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -33,12 +33,6 @@ Does this PR require updates to the documentation at www.gitpod.io/docs?
 <!--
 Optional annotations to add to the werft job.
 
-If you would like to add additional annotations, each one has to be on a separate line:
-/werft with-preview
-/werft with-payment
-Not:
-/werft with-preview with-payment
-
 * with-preview - whether to create a preview environment for this PR
 -->
 - [ ] /werft with-preview


### PR DESCRIPTION
Reverts gitpod-io/gitpod#12432

Turns out that Werft parses the attributes made in comments, so the PR means we add "with-payment", "with-preview" and "with-payment with-preview" by default (see example [job](https://werft.gitpod-dev.com/job/gitpod-build-aledbf-vm.4) from this [PR](https://github.com/gitpod-io/gitpod/pull/12483))

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
none
```