### PR TITLE
[supervisor] support ssh gateway on not gitpod base image

### DIFF
--- a/components/supervisor/pkg/supervisor/services.go
+++ b/components/supervisor/pkg/supervisor/services.go
@@ -675,10 +675,7 @@ func (is *InfoService) WorkspaceInfo(context.Context, *api.WorkspaceInfoRequest)
 		}
 	}
 
-	resp.UserHome, err = os.UserHomeDir()
-	if err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
-	}
+	resp.UserHome = "/home/gitpod"
 
 	endpoint, host, err := is.cfg.GitpodAPIEndpoint()
 	if err != nil {
@@ -715,7 +712,7 @@ func (c *ControlService) ExposePort(ctx context.Context, req *api.ExposePortRequ
 
 // CreateSSHKeyPair create a ssh key pair for the workspace.
 func (ss *ControlService) CreateSSHKeyPair(context.Context, *api.CreateSSHKeyPairRequest) (response *api.CreateSSHKeyPairResponse, err error) {
-	home, _ := os.UserHomeDir()
+	home := "/home/gitpod/"
 	if ss.privateKey != "" && ss.publicKey != "" {
 		checkKey := func() error {
 			data, err := os.ReadFile(filepath.Join(home, ".ssh/authorized_keys"))

--- a/components/supervisor/pkg/supervisor/ssh.go
+++ b/components/supervisor/pkg/supervisor/ssh.go
@@ -190,13 +190,10 @@ func prepareSSHKey(ctx context.Context, sshkey string) error {
 }
 
 func writeSSHEnv(cfg *Config, envvars []string) error {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return err
-	}
+	home := "/home/gitpod"
 
 	d := filepath.Join(home, ".ssh")
-	err = os.MkdirAll(d, 0o700)
+	err := os.MkdirAll(d, 0o700)
 	if err != nil {
 		return xerrors.Errorf("cannot create $HOME/.ssh: %w", err)
 	}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
[supervisor] support ssh gateway on not gitpod base image

In gitpod base docker image, we write HOME environment, but if user use none gitpod base image, the HOME environment is not set or set other value, which causes public key didn't write in correct path
|not gitpod base image|gitpod base image|
|---|---|
|<img width="762" alt="image" src="https://user-images.githubusercontent.com/8299500/187359508-182e4824-bd73-4e4a-acae-1b056a1fcf23.png">|<img width="647" alt="image" src="https://user-images.githubusercontent.com/8299500/187359722-77e0dfe0-e63f-4d06-b9c3-86c4126cfeb5.png">|

This PR change use hard code `/home/gitpod` as HOME dir

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #12265
Fixes #12143

## How to test
<!-- Provide steps to test this PR -->
1. open this example repo in preview environment https://github.com/spring-projects/spring-petclinic
2. connect to workspace via ssh gateway (copy/paste ssh command or upload your public key)
3. it should be connected

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[supervisor] support ssh gateway on not gitpod base image
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
