### PR TITLE
[public-api] Fix stripe webhook secret mounting

### DIFF
--- a/components/public-api-server/pkg/server/server.go
+++ b/components/public-api-server/pkg/server/server.go
@@ -5,7 +5,6 @@
 package server
 
 import (
-	"encoding/json"
 	"fmt"
 	"github.com/gitpod-io/gitpod/common-go/log"
 	"net/http"
@@ -94,11 +93,5 @@ func readStripeWebhookSecret(path string) (string, error) {
 		return "", fmt.Errorf("failed to read stripe webhook secret: %w", err)
 	}
 
-	var stripeSecret string
-	err = json.Unmarshal(b, &stripeSecret)
-	if err != nil {
-		return "", fmt.Errorf("failed to parse stripe webhook secret: %w", err)
-	}
-
-	return strings.TrimSpace(stripeSecret), nil
+	return strings.TrimSpace(string(b)), nil
 }

--- a/install/installer/pkg/components/public-api-server/configmap.go
+++ b/install/installer/pkg/components/public-api-server/configmap.go
@@ -95,6 +95,7 @@ func getStripeConfig(cfg *experimental.Config) (corev1.Volume, corev1.VolumeMoun
 	mount = corev1.VolumeMount{
 		Name:      "stripe-secret",
 		MountPath: stripeSecretMountPath,
+		SubPath:   "stripe-webhook-secret",
 		ReadOnly:  true,
 	}
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Ensures that only the key `stripe-webhook-secret` from the secret `stripe-webhook-secret` is mounted as a file, not as a directory with all keys in the secret.

See https://stackoverflow.com/questions/65399714/what-is-the-difference-between-subpath-and-mountpath-in-kubernetes

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
