### PR TITLE
[server] Improve logging/tracing on failed instance start

### DIFF
--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -595,10 +595,15 @@ export class WorkspaceStarter {
                 throw err;
             } else {
                 TraceContext.setError({ span }, err);
-                log.error({ userId: user.id, instanceId: instance.id }, "error starting instance", err);
+                let reason: FailedInstanceStartReason | undefined = undefined;
                 if (err instanceof StartInstanceError) {
+                    reason = err.reason;
                     increaseFailedInstanceStartCounter(err.reason);
                 }
+                log.error({ userId: user.id, instanceId: instance.id }, "error starting instance", err, {
+                    failedInstanceStartReason: reason,
+                });
+                span.setTag("failedInstanceStartReason", reason);
             }
 
             return { instanceID: instance.id };


### PR DESCRIPTION
## Description
Small PR to conditionall log & trace `failedInstanceStartReason` if there is one to enable easy querying in logs or traces for alerts

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
