### PR TITLE
[ws-manager] do not error out if encountering unknown feature flag

### DIFF
--- a/components/ws-manager/pkg/manager/create.go
+++ b/components/ws-manager/pkg/manager/create.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/gitpod-io/gitpod/common-go/kubernetes"
 	wsk8s "github.com/gitpod-io/gitpod/common-go/kubernetes"
+	"github.com/gitpod-io/gitpod/common-go/log"
 	"github.com/gitpod-io/gitpod/common-go/tracing"
 	"github.com/gitpod-io/gitpod/common-go/util"
 	csapi "github.com/gitpod-io/gitpod/content-service/api"
@@ -626,7 +627,7 @@ func (m *Manager) createDefiniteWorkspacePod(startContext *startWorkspaceContext
 			annotations[kubernetes.WorkspaceNetConnLimitAnnotation] = util.BooleanTrueString
 
 		default:
-			return nil, xerrors.Errorf("unknown feature flag: %v", feature)
+			log.Warnf("Unknown feature flag %v", feature)
 		}
 	}
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
I do not think there is any need to fail StartWorkspace if it enouncounters unknown feature flag and makes roll out of new feature flags cumbersome due to need to wait for new workspace cluster to be rolled out.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
none
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
