### PR TITLE
Enforce no-unused-locals in .werft

### DIFF
--- a/.werft/installer-tests.ts
+++ b/.werft/installer-tests.ts
@@ -479,7 +479,6 @@ export function sendFailureSlackAlert(phase: string, err: Error, hook: string): 
         return
     }
 
-    const repo = context.Repository.host + "/" + context.Repository.owner + "/" + context.Repository.repo;
     const data = JSON.stringify({
         blocks: [
             {

--- a/.werft/jobs/build/installer/installer.ts
+++ b/.werft/jobs/build/installer/installer.ts
@@ -6,7 +6,6 @@ import { renderPayment } from "../payment/render";
 import { CORE_DEV_KUBECONFIG_PATH } from "../const";
 
 const BLOCK_NEW_USER_CONFIG_PATH = "./blockNewUsers";
-const WORKSPACE_SIZE_CONFIG_PATH = "./workspaceSizing";
 const PROJECT_NAME = "gitpod-core-dev";
 const CONTAINER_REGISTRY_URL = `eu.gcr.io/${PROJECT_NAME}/build/`;
 const CONTAINERD_RUNTIME_DIR = "/var/lib/containerd/io.containerd.runtime.v2.task/k8s.io";

--- a/.werft/jobs/build/prepare.ts
+++ b/.werft/jobs/build/prepare.ts
@@ -117,7 +117,6 @@ function createVM(werft: Werft, config: JobConfig) {
 }
 
 function applyLoadBalancer(option: { name: string }) {
-    const namespace = `preview-${option.name}`;
     function kubectlApplyManifest(manifest: string, options?: { validate?: boolean }) {
         exec(`
             cat <<EOF | kubectl --kubeconfig ${CORE_DEV_KUBECONFIG_PATH} apply --validate=${!!options?.validate} -f -

--- a/.werft/observability/monitoring-satellite.ts
+++ b/.werft/observability/monitoring-satellite.ts
@@ -1,4 +1,4 @@
-import { exec, ExecResult } from "../util/shell";
+import { exec } from "../util/shell";
 import { getGlobalWerftInstance, Werft } from "../util/werft";
 import * as fs from "fs";
 import { ObservabilityInstallationMethod } from "../jobs/build/job-config";

--- a/.werft/tsconfig.json
+++ b/.werft/tsconfig.json
@@ -2,6 +2,7 @@
     "compilerOptions": {
         "target": "es2019",
         "skipLibCheck": true,
-        "moduleResolution": "node"
+        "moduleResolution": "node",
+        "noUnusedLocals": true
     }
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This enabled the `no-unused-locals` TypeScript compiler option and then removes all the unused local variables form the code.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
No issue

## How to test
<!-- Provide steps to test this PR -->

`tsc --noEmit` in .werft is still successful. I triggered the job manually [here](https://werft.gitpod-dev.com/job/gitpod-build-mads-no-unused-locals.2) to ensure the my code was executed by werft.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
none
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
