### PR TITLE
[supervisor] do not change ready file to /.workspace folder

### DIFF
--- a/components/supervisor/pkg/supervisor/supervisor.go
+++ b/components/supervisor/pkg/supervisor/supervisor.go
@@ -1327,7 +1327,6 @@ func startContentInit(ctx context.Context, cfg *Config, wg *sync.WaitGroup, cst 
 	fnReady := "/workspace/.gitpod/ready"
 	if _, err := os.Stat("/.workspace/.gitpod/content.json"); !os.IsNotExist(err) {
 		fn = "/.workspace/.gitpod/content.json"
-		fnReady = "/.workspace/.gitpod/ready"
 		log.Info("Detected content.json in /.workspace folder, assuming PVC feature enabled")
 	}
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This is a bug, as ready file will never actually be placed into `/.workspace` folder, it will always be in `/workspace`

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related to #12464

## How to test
<!-- Provide steps to test this PR -->
Enable PVC feature
Start and stop workspaces (from prebuild, and normal)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
none
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
