### PR TITLE
[server] Add name of blocked account when trying to run prebuilds

### DIFF
--- a/components/server/ee/src/prebuilds/prebuild-manager.ts
+++ b/components/server/ee/src/prebuilds/prebuild-manager.ts
@@ -95,7 +95,7 @@ export class PrebuildManager {
 
         try {
             if (user.blocked) {
-                throw new Error("Blocked users cannot start prebuilds.");
+                throw new Error(`Blocked users cannot start prebuilds (${user.name})`);
             }
             const existingPB = await this.workspaceDB
                 .trace({ span })


### PR DESCRIPTION
## Description

Error log for blocked accounts do not show any detail `Error: Blocked users cannot start prebuilds`

## How to test
- Use a blocked account to run a prebuild
- Search the logs. The message should include the name

## Release Notes
```release-note
NONE
```

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
