### PR TITLE
Add labels to PVC and VolumeSnapshot object

### DIFF
--- a/components/ws-manager/pkg/manager/create.go
+++ b/components/ws-manager/pkg/manager/create.go
@@ -268,6 +268,7 @@ func (m *Manager) createPVCForWorkspacePod(startContext *startWorkspaceContext) 
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-%s", prefix, req.Id),
 			Namespace: m.Config.Namespace,
+			Labels:    startContext.Labels,
 		},
 		Spec: corev1.PersistentVolumeClaimSpec{
 			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},

--- a/components/ws-manager/pkg/manager/monitor.go
+++ b/components/ws-manager/pkg/manager/monitor.go
@@ -1131,6 +1131,7 @@ func (m *Monitor) finalizeWorkspaceContent(ctx context.Context, wso *workspaceOb
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      pvcVolumeSnapshotName,
 						Namespace: m.manager.Config.Namespace,
+						Labels:    wso.Pod.Labels,
 					},
 					Spec: volumesnapshotv1.VolumeSnapshotSpec{
 						Source: volumesnapshotv1.VolumeSnapshotSource{

--- a/components/ws-manager/pkg/manager/testdata/cpwp_custom_storage.golden
+++ b/components/ws-manager/pkg/manager/testdata/cpwp_custom_storage.golden
@@ -3,7 +3,20 @@
         "metadata": {
             "name": "ws-test",
             "namespace": "default",
-            "creationTimestamp": null
+            "creationTimestamp": null,
+            "labels": {
+                "app": "gitpod",
+                "component": "workspace",
+                "gitpod.io/workspaceClass": "gitpodio-pvc",
+                "gpwsman": "true",
+                "headless": "false",
+                "metaID": "foobar",
+                "owner": "tester",
+                "project": "",
+                "team": "",
+                "workspaceID": "test",
+                "workspaceType": "regular"
+            }
         },
         "spec": {
             "accessModes": [

--- a/components/ws-manager/pkg/manager/testdata/cpwp_default_storage.golden
+++ b/components/ws-manager/pkg/manager/testdata/cpwp_default_storage.golden
@@ -3,7 +3,20 @@
         "metadata": {
             "name": "ws-test",
             "namespace": "default",
-            "creationTimestamp": null
+            "creationTimestamp": null,
+            "labels": {
+                "app": "gitpod",
+                "component": "workspace",
+                "gitpod.io/workspaceClass": "gitpodio-pvc",
+                "gpwsman": "true",
+                "headless": "false",
+                "metaID": "foobar",
+                "owner": "tester",
+                "project": "",
+                "team": "",
+                "workspaceID": "test",
+                "workspaceType": "regular"
+            }
         },
         "spec": {
             "accessModes": [

--- a/components/ws-manager/pkg/manager/testdata/cpwp_from_volume_snapshot.golden
+++ b/components/ws-manager/pkg/manager/testdata/cpwp_from_volume_snapshot.golden
@@ -3,7 +3,20 @@
         "metadata": {
             "name": "ws-test",
             "namespace": "default",
-            "creationTimestamp": null
+            "creationTimestamp": null,
+            "labels": {
+                "app": "gitpod",
+                "component": "workspace",
+                "gitpod.io/workspaceClass": "gitpodio-pvc",
+                "gpwsman": "true",
+                "headless": "false",
+                "metaID": "foobar",
+                "owner": "tester",
+                "project": "",
+                "team": "",
+                "workspaceID": "test",
+                "workspaceType": "regular"
+            }
         },
         "spec": {
             "accessModes": [

--- a/components/ws-manager/pkg/manager/testdata/cpwp_no_class.golden
+++ b/components/ws-manager/pkg/manager/testdata/cpwp_no_class.golden
@@ -3,7 +3,20 @@
         "metadata": {
             "name": "ws-test",
             "namespace": "default",
-            "creationTimestamp": null
+            "creationTimestamp": null,
+            "labels": {
+                "app": "gitpod",
+                "component": "workspace",
+                "gitpod.io/workspaceClass": "default",
+                "gpwsman": "true",
+                "headless": "false",
+                "metaID": "foobar",
+                "owner": "tester",
+                "project": "",
+                "team": "",
+                "workspaceID": "test",
+                "workspaceType": "regular"
+            }
         },
         "spec": {
             "accessModes": [

--- a/components/ws-manager/pkg/manager/testdata/cpwp_no_pvc.golden
+++ b/components/ws-manager/pkg/manager/testdata/cpwp_no_pvc.golden
@@ -3,7 +3,20 @@
         "metadata": {
             "name": "ws-test",
             "namespace": "default",
-            "creationTimestamp": null
+            "creationTimestamp": null,
+            "labels": {
+                "app": "gitpod",
+                "component": "workspace",
+                "gitpod.io/workspaceClass": "gitpodio-pvc",
+                "gpwsman": "true",
+                "headless": "false",
+                "metaID": "foobar",
+                "owner": "tester",
+                "project": "",
+                "team": "",
+                "workspaceID": "test",
+                "workspaceType": "regular"
+            }
         },
         "spec": {
             "accessModes": [


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Add more labels to PVC and VolumeSnapshot, so we have more information to troubleshoot/debug to know the VolumeSnapshot belonged to which workspace ID when the workspace pod was gone.
Also, we could find the workspace ID if the PVC keeps in Pending but somehow the workspace pod was gone.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #12507

## How to test
<!-- Provide steps to test this PR -->
- Enable PVC feature flag in preview env
- Launch a workspace
- Check the PVC with labels `kubectl get pvc --show-labels`
- Stop the workspace
- Check the VolumeSnapshot with labels `kubectl get vs --show-labels`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
