### PR TITLE
[admin] Allow manual user verification

### DIFF
--- a/components/dashboard/src/admin/UserDetail.tsx
+++ b/components/dashboard/src/admin/UserDetail.tsx
@@ -75,6 +75,12 @@ export default function UserDetail(p: { user: User }) {
         });
     };
 
+    const verifyUser = async () => {
+        await updateUser(async (u) => {
+            return await getGitpodService().server.adminVerifyUser(u.id);
+        });
+    };
+
     const toggleBlockUser = async () => {
         await updateUser(async (u) => {
             u.blocked = !u.blocked;
@@ -132,6 +138,11 @@ export default function UserDetail(p: { user: User }) {
                                 .join(", ")}
                         </p>
                     </div>
+                    {!user.lastVerificationTime ? (
+                        <button className="secondary danger ml-3" disabled={activity} onClick={verifyUser}>
+                            Verify User
+                        </button>
+                    ) : null}
                     <button className="secondary danger ml-3" disabled={activity} onClick={toggleBlockUser}>
                         {user.blocked ? "Unblock" : "Block"} User
                     </button>

--- a/components/gitpod-protocol/src/admin-protocol.ts
+++ b/components/gitpod-protocol/src/admin-protocol.ts
@@ -18,6 +18,7 @@ export interface AdminServer {
     adminGetUser(id: string): Promise<User>;
     adminBlockUser(req: AdminBlockUserRequest): Promise<User>;
     adminDeleteUser(id: string): Promise<void>;
+    adminVerifyUser(id: string): Promise<User>;
     adminModifyRoleOrPermission(req: AdminModifyRoleOrPermissionRequest): Promise<User>;
     adminModifyPermanentWorkspaceFeatureFlag(req: AdminModifyPermanentWorkspaceFeatureFlagRequest): Promise<User>;
 

--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -643,6 +643,23 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
         return this.censorUser(targetUser);
     }
 
+    async adminVerifyUser(ctx: TraceContext, userId: string): Promise<User> {
+        await this.requireEELicense(Feature.FeatureAdminDashboard);
+
+        await this.guardAdminAccess("adminVerifyUser", { id: userId }, Permission.ADMIN_USERS);
+        try {
+            const user = await this.userDB.findUserById(userId);
+            if (!user) {
+                throw new ResponseError(ErrorCodes.NOT_FOUND, `No user with id ${userId} found.`);
+            }
+            this.verificationService.markVerified(user);
+            await this.userDB.updateUserPartial(user);
+            return user;
+        } catch (e) {
+            throw new ResponseError(ErrorCodes.INTERNAL_SERVER_ERROR, e.toString());
+        }
+    }
+
     async adminDeleteUser(ctx: TraceContext, userId: string): Promise<void> {
         traceAPIParams(ctx, { userId });
 

--- a/components/server/src/auth/rate-limiter.ts
+++ b/components/server/src/auth/rate-limiter.ts
@@ -150,6 +150,7 @@ function getConfig(config: RateLimiterConfig): RateLimiterConfig {
         adminGetUser: { group: "default", points: 1 },
         adminBlockUser: { group: "default", points: 1 },
         adminDeleteUser: { group: "default", points: 1 },
+        adminVerifyUser: { group: "default", points: 1 },
         adminModifyRoleOrPermission: { group: "default", points: 1 },
         adminModifyPermanentWorkspaceFeatureFlag: { group: "default", points: 1 },
         adminGetTeams: { group: "default", points: 1 },

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -2695,6 +2695,10 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         throw new ResponseError(ErrorCodes.EE_FEATURE, `Admin support is implemented in Gitpod's Enterprise Edition`);
     }
 
+    async adminVerifyUser(ctx: TraceContext, _id: string): Promise<User> {
+        throw new ResponseError(ErrorCodes.EE_FEATURE, `Admin support is implemented in Gitpod's Enterprise Edition`);
+    }
+
     async adminModifyRoleOrPermission(ctx: TraceContext, req: AdminModifyRoleOrPermissionRequest): Promise<User> {
         throw new ResponseError(ErrorCodes.EE_FEATURE, `Admin support is implemented in Gitpod's Enterprise Edition`);
     }


### PR DESCRIPTION
## Description
Allows to verify a user manually.

## Related Issue(s)
fixes #12540

## How to test
Login with a new github user and use a different admin account to verify that user.

https://www.loom.com/share/eab41b81a50d4e859245de0bc3b4e469

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
