### PR TITLE
Don't apply csi-driver from k3s image

### DIFF
--- a/.werft/vm/manifests.ts
+++ b/.werft/vm/manifests.ts
@@ -342,10 +342,6 @@ write_files:
       kubectl apply -f /var/lib/gitpod/manifests/cert-manager.yaml
       kubectl apply -f /var/lib/gitpod/manifests/metrics-server.yaml
 
-      # install CSI snapshotter CRDs and snapshot controller
-      kubectl apply -f /var/lib/gitpod/manifests/csi-driver.yaml
-      kubectl apply -f /var/lib/gitpod/manifests/csi-config.yaml
-
       cat <<EOF >> /etc/bash.bashrc
       export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
       EOF


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

In preview envs we use [rook](https://github.com/gitpod-io/gitpod/tree/main/.werft/vm/manifests/rook-ceph), so there's no need to apply the one from the image.

```bash
storage        csi-gce-pd-controller-6956df9894-jnn2w       0/5     ContainerCreating   0              10m
storage        csi-gce-pd-node-99hgn                        0/2     CrashLoopBackOff    14 (91s ago)   10m
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
