### PR TITLE
[agent-smith] Add more details to the infringement

### DIFF
--- a/components/ee/agent-smith/pkg/agent/agent.go
+++ b/components/ee/agent-smith/pkg/agent/agent.go
@@ -184,6 +184,7 @@ func (ws InfringingWorkspace) DescribeInfringements(charCount int) string {
 type Infringement struct {
 	Description string
 	Kind        config.GradedInfringementKind
+	CommandLine []string
 }
 
 // defaultRuleset is the name ("remote origin URL") of the default enforcement rules
@@ -280,7 +281,11 @@ func (agent *Smith) Start(ctx context.Context, callback func(InfringingWorkspace
 				InstanceID:    proc.Workspace.InstanceID,
 				GitRemoteURL:  []string{proc.Workspace.GitURL},
 				Infringements: []Infringement{
-					{Kind: config.GradeKind(config.InfringementExec, common.Severity(cl.Level)), Description: fmt.Sprintf("%s: %s", cl.Classifier, cl.Message)},
+					{
+						Kind:        config.GradeKind(config.InfringementExec, common.Severity(cl.Level)),
+						Description: fmt.Sprintf("%s: %s", cl.Classifier, cl.Message),
+						CommandLine: proc.CommandLine,
+					},
 				},
 			})
 		}


### PR DESCRIPTION
## How to test

- Open a workspace that triggers an infringement rule
- Check agent-smith log. It should contains a new `CommandLine` field.

## Release Notes
```release-note
NONE
```

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
