### PR TITLE
[observability] add cluster selector for browser overview dashboard

### DIFF
--- a/operations/observability/mixins/IDE/dashboards.libsonnet
+++ b/operations/observability/mixins/IDE/dashboards.libsonnet
@@ -11,6 +11,7 @@
     'gitpod-component-openvsx-proxy.json': (import 'dashboards/components/openvsx-proxy.json'),
     'gitpod-component-ssh-gateway.json': (import 'dashboards/components/ssh-gateway.json'),
     'gitpod-component-jb.json': (import 'dashboards/components/jb.json'),
+    'gitpod-component-browser-overview.json': (import 'dashboards/components/browser-overview.json'),
 
   },
 }

--- a/operations/observability/mixins/IDE/dashboards/components/browser-overview.json
+++ b/operations/observability/mixins/IDE/dashboards/components/browser-overview.json
@@ -98,8 +98,12 @@
       "id": 1,
       "options": {
         "legend": {
-          "calcs": [],
-          "displayMode": "list",
+          "calcs": [
+            "max",
+            "mean",
+            "last"
+          ],
+          "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
         },
@@ -115,10 +119,9 @@
             "uid": "P4169E866C3094E38"
           },
           "editorMode": "code",
-          "expr": "sum(rate(gitpod_supervisor_frontend_error_total[2m])) by (error, resource)/sum(rate(gitpod_supervisor_frontend_client_total[2m]))",
-          "instant": true,
-          "key": "Q-cd2b24a6-efd9-497d-9899-79b25341167e-0",
-          "legendFormat": "__auto",
+          "expr": "sum(rate(gitpod_supervisor_frontend_error_total{cluster=~\"$cluster\"}[2m])) by (error, resource) / sum(rate(gitpod_supervisor_frontend_client_total{cluster=~\"$cluster\"}[2m]))",
+          "hide": false,
+          "legendFormat": "{{error}} - {{resource}}",
           "range": true,
           "refId": "A"
         }
@@ -131,7 +134,39 @@
   "style": "dark",
   "tags": [],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "P4169E866C3094E38"
+        },
+        "definition": "label_values(up{job=\"ide-metrics\"}, cluster)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Cluster",
+        "multi": true,
+        "name": "cluster",
+        "options": [],
+        "query": {
+          "query": "label_values(up{job=\"ide-metrics\"}, cluster)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      }
+    ]
   },
   "time": {
     "from": "now-6h",
@@ -141,6 +176,6 @@
   "timezone": "",
   "title": "Browser Overview",
   "uid": "2wGfMlWVz",
-  "version": 1,
+  "version": 2,
   "weekStart": ""
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
[observability] add cluster selector for browser overview dashboard

Cluster: `All` can show sum of all cluster result

<img width="862" alt="image" src="https://user-images.githubusercontent.com/20944364/187745269-e94c66ee-a08c-45cd-a846-f8d76499c8b3.png">


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
See template grafana dashboard [here](https://grafana.gitpod.io/d/2wGfMlWVz/browser-overview?orgId=1&var-cluster=All), their JSON data should be the same

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
