### PR TITLE
[installer] change blobserve node to workload_ide

### DIFF
--- a/install/installer/cmd/testdata/render/aws-setup/output.golden
+++ b/install/installer/cmd/testdata/render/aws-setup/output.golden
@@ -30,19 +30,7 @@ metadata:
   namespace: default
 spec:
   ingress:
-    - from:
-        - podSelector:
-            matchLabels:
-              component: proxy
-        - podSelector:
-            matchLabels:
-              component: ws-proxy
-        - podSelector:
-            matchLabels:
-              component: ide-proxy
-      ports:
-        - port: 32224
-          protocol: TCP
+    - {}
   podSelector:
     matchLabels:
       app: gitpod

--- a/install/installer/cmd/testdata/render/aws-setup/output.golden
+++ b/install/installer/cmd/testdata/render/aws-setup/output.golden
@@ -6497,7 +6497,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: gitpod.io/workload_workspace_services
+              - key: gitpod.io/workload_ide
                 operator: Exists
       containers:
       - args:

--- a/install/installer/cmd/testdata/render/azure-setup/output.golden
+++ b/install/installer/cmd/testdata/render/azure-setup/output.golden
@@ -6337,7 +6337,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: gitpod.io/workload_workspace_services
+              - key: gitpod.io/workload_ide
                 operator: Exists
       containers:
       - args:

--- a/install/installer/cmd/testdata/render/azure-setup/output.golden
+++ b/install/installer/cmd/testdata/render/azure-setup/output.golden
@@ -30,19 +30,7 @@ metadata:
   namespace: default
 spec:
   ingress:
-    - from:
-        - podSelector:
-            matchLabels:
-              component: proxy
-        - podSelector:
-            matchLabels:
-              component: ws-proxy
-        - podSelector:
-            matchLabels:
-              component: ide-proxy
-      ports:
-        - port: 32224
-          protocol: TCP
+    - {}
   podSelector:
     matchLabels:
       app: gitpod

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -30,19 +30,7 @@ metadata:
   namespace: default
 spec:
   ingress:
-    - from:
-        - podSelector:
-            matchLabels:
-              component: proxy
-        - podSelector:
-            matchLabels:
-              component: ws-proxy
-        - podSelector:
-            matchLabels:
-              component: ide-proxy
-      ports:
-        - port: 32224
-          protocol: TCP
+    - {}
   podSelector:
     matchLabels:
       app: gitpod

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -7705,7 +7705,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: gitpod.io/workload_workspace_services
+              - key: gitpod.io/workload_ide
                 operator: Exists
       containers:
       - args:

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -6778,7 +6778,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: gitpod.io/workload_workspace_services
+              - key: gitpod.io/workload_ide
                 operator: Exists
       containers:
       - args:

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -30,19 +30,7 @@ metadata:
   namespace: default
 spec:
   ingress:
-    - from:
-        - podSelector:
-            matchLabels:
-              component: proxy
-        - podSelector:
-            matchLabels:
-              component: ws-proxy
-        - podSelector:
-            matchLabels:
-              component: ide-proxy
-      ports:
-        - port: 32224
-          protocol: TCP
+    - {}
   podSelector:
     matchLabels:
       app: gitpod

--- a/install/installer/cmd/testdata/render/gcp-setup/output.golden
+++ b/install/installer/cmd/testdata/render/gcp-setup/output.golden
@@ -30,19 +30,7 @@ metadata:
   namespace: default
 spec:
   ingress:
-    - from:
-        - podSelector:
-            matchLabels:
-              component: proxy
-        - podSelector:
-            matchLabels:
-              component: ws-proxy
-        - podSelector:
-            matchLabels:
-              component: ide-proxy
-      ports:
-        - port: 32224
-          protocol: TCP
+    - {}
   podSelector:
     matchLabels:
       app: gitpod

--- a/install/installer/cmd/testdata/render/gcp-setup/output.golden
+++ b/install/installer/cmd/testdata/render/gcp-setup/output.golden
@@ -6317,7 +6317,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: gitpod.io/workload_workspace_services
+              - key: gitpod.io/workload_ide
                 operator: Exists
       containers:
       - args:

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -30,19 +30,7 @@ metadata:
   namespace: default
 spec:
   ingress:
-    - from:
-        - podSelector:
-            matchLabels:
-              component: proxy
-        - podSelector:
-            matchLabels:
-              component: ws-proxy
-        - podSelector:
-            matchLabels:
-              component: ide-proxy
-      ports:
-        - port: 32224
-          protocol: TCP
+    - {}
   podSelector:
     matchLabels:
       app: gitpod

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -7058,7 +7058,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: gitpod.io/workload_workspace_services
+              - key: gitpod.io/workload_ide
                 operator: Exists
       containers:
       - args:

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -7070,7 +7070,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: gitpod.io/workload_workspace_services
+              - key: gitpod.io/workload_ide
                 operator: Exists
       containers:
       - args:

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -30,19 +30,7 @@ metadata:
   namespace: default
 spec:
   ingress:
-    - from:
-        - podSelector:
-            matchLabels:
-              component: proxy
-        - podSelector:
-            matchLabels:
-              component: ws-proxy
-        - podSelector:
-            matchLabels:
-              component: ide-proxy
-      ports:
-        - port: 32224
-          protocol: TCP
+    - {}
   podSelector:
     matchLabels:
       app: gitpod

--- a/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
+++ b/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
@@ -30,19 +30,7 @@ metadata:
   namespace: default
 spec:
   ingress:
-    - from:
-        - podSelector:
-            matchLabels:
-              component: proxy
-        - podSelector:
-            matchLabels:
-              component: ws-proxy
-        - podSelector:
-            matchLabels:
-              component: ide-proxy
-      ports:
-        - port: 32224
-          protocol: TCP
+    - {}
   podSelector:
     matchLabels:
       app: gitpod

--- a/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
+++ b/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
@@ -7502,7 +7502,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: gitpod.io/workload_workspace_services
+              - key: gitpod.io/workload_ide
                 operator: Exists
       containers:
       - args:

--- a/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
+++ b/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
@@ -30,19 +30,7 @@ metadata:
   namespace: default
 spec:
   ingress:
-    - from:
-        - podSelector:
-            matchLabels:
-              component: proxy
-        - podSelector:
-            matchLabels:
-              component: ws-proxy
-        - podSelector:
-            matchLabels:
-              component: ide-proxy
-      ports:
-        - port: 32224
-          protocol: TCP
+    - {}
   podSelector:
     matchLabels:
       app: gitpod

--- a/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
+++ b/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
@@ -7061,7 +7061,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: gitpod.io/workload_workspace_services
+              - key: gitpod.io/workload_ide
                 operator: Exists
       containers:
       - args:

--- a/install/installer/pkg/components/blobserve/deployment.go
+++ b/install/installer/pkg/components/blobserve/deployment.go
@@ -75,7 +75,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 						}),
 					},
 					Spec: corev1.PodSpec{
-						Affinity:           common.NodeAffinity(cluster.AffinityLabelWorkspaceServices),
+						Affinity:           common.NodeAffinity(cluster.AffinityLabelIDE),
 						ServiceAccountName: Component,
 						EnableServiceLinks: pointer.Bool(false),
 						Volumes: []corev1.Volume{{

--- a/install/installer/pkg/components/blobserve/networkpolicy.go
+++ b/install/installer/pkg/components/blobserve/networkpolicy.go
@@ -6,14 +6,10 @@ package blobserve
 
 import (
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
-	ideproxy "github.com/gitpod-io/gitpod/installer/pkg/components/ide-proxy"
-	"github.com/gitpod-io/gitpod/installer/pkg/components/proxy"
-	wsproxy "github.com/gitpod-io/gitpod/installer/pkg/components/ws-proxy"
 
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 func networkpolicy(ctx *common.RenderContext) ([]runtime.Object, error) {
@@ -29,26 +25,7 @@ func networkpolicy(ctx *common.RenderContext) ([]runtime.Object, error) {
 		Spec: networkingv1.NetworkPolicySpec{
 			PodSelector: metav1.LabelSelector{MatchLabels: labels},
 			PolicyTypes: []networkingv1.PolicyType{"Ingress"},
-			Ingress: []networkingv1.NetworkPolicyIngressRule{{
-				Ports: []networkingv1.NetworkPolicyPort{{
-					Protocol: common.TCPProtocol,
-					Port:     &intstr.IntOrString{IntVal: ContainerPort},
-				}},
-				From: []networkingv1.NetworkPolicyPeer{{
-					PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
-						"component": proxy.Component,
-					}},
-				}, {
-					// TODO: (pd) delete this after all workspace cluster deployed
-					PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
-						"component": wsproxy.Component,
-					}},
-				}, {
-					PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
-						"component": ideproxy.Component,
-					}},
-				}},
-			}},
+			Ingress:     []networkingv1.NetworkPolicyIngressRule{{}},
 		},
 	}}, nil
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PR move blobserve to `workload_ide` node, because traffic through `ide-proxy`

This PR also adjust blobserve network policy, in order to support some edge case see [internal discuss](https://gitpod.slack.com/archives/C020VCB0U5A/p1661964821598319?thread_ts=1661352400.563409&cid=C020VCB0U5A)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #12366

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
