### PR TITLE
Fix for Webhook Event GC

### DIFF
--- a/components/gitpod-db/src/typeorm/webhook-event-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/webhook-event-db-impl.ts
@@ -58,10 +58,10 @@ export class WebhookEventDBImpl implements WebhookEventDB {
         d.setDate(d.getDate() - ageInDays);
         const expirationDate = d.toISOString();
         const query = repo
-            .createQueryBuilder("event")
+            .createQueryBuilder()
             .update()
             .set({ deleted: true })
-            .where("event.creationTime < :expirationDate", { expirationDate });
+            .where("creationTime <= :expirationDate", { expirationDate });
         if (typeof limit === "number") {
             query.limit(limit);
         }

--- a/components/gitpod-db/src/webhook-event-db.spec.db.ts
+++ b/components/gitpod-db/src/webhook-event-db.spec.db.ts
@@ -52,6 +52,22 @@ export class WebhookEventDBSpec {
         expect(updated.type, "type should not be updated").to.equal("push");
         expect(updated.rawEvent, "rawEvent should not be updated").to.equal("payload as string");
     }
+
+    @test public async testDeleteOldEvents() {
+        const cloneUrl = "http://gitlab.local/project/repo";
+        await this.db.createEvent({
+            rawEvent: "payload as string",
+            status: "received",
+            type: "push",
+            cloneUrl,
+        });
+
+        await this.db.deleteOldEvents(0, 1);
+
+        const event = (await this.db.findByCloneUrl(cloneUrl))[0];
+        expect(event, "should be found").to.be.not.undefined;
+        expect((event as DBWebhookEvent).deleted, "should be marked as deleted").to.be.true;
+    }
 }
 
 module.exports = WebhookEventDBSpec;


### PR DESCRIPTION
Fixing DB query with test. This is currently broken on main/prod :-(

Aftermath of https://github.com/gitpod-io/gitpod/pull/12472#discussion_r958152783

### how to test
run db-test or check the test logs of the werft job and find the ✔️ passing test in there
```
[components/gitpod-db:dbtest]   WebhookEventDBSpec
...
[components/gitpod-db:dbtest]     ✓ testDeleteOldEvents
```

```release-notes
NONE
```

 - [x] /werft with-preview