### PR TITLE
[usage] Fix test for listing usage with pagination

### DIFF
--- a/components/usage/pkg/apiv1/usage_test.go
+++ b/components/usage/pkg/apiv1/usage_test.go
@@ -175,11 +175,8 @@ func TestUsageService_ListBilledUsage_Pagination(t *testing.T) {
 	ctx := context.Background()
 
 	type Expectation struct {
-		count      int64
 		total      int64
 		totalPages int64
-		page       int64
-		perPage    int64
 	}
 
 	type Scenario struct {
@@ -204,112 +201,87 @@ func TestUsageService_ListBilledUsage_Pagination(t *testing.T) {
 	}
 
 	scenarios := []Scenario{
-		(func() Scenario {
-
-			return Scenario{
-				name: "first page",
-				Request: &v1.ListBilledUsageRequest{
-					AttributionId: string(attrID),
-					From:          timestamppb.New(start),
-					To:            timestamppb.New(start.Add(20*time.Minute + 2*time.Hour)),
-					Pagination: &v1.PaginatedRequest{
-						PerPage: int64(5),
-						Page:    int64(1),
-					},
+		{
+			name: "first page",
+			Request: &v1.ListBilledUsageRequest{
+				AttributionId: string(attrID),
+				From:          timestamppb.New(start),
+				To:            timestamppb.New(start.Add(20*time.Minute + 2*time.Hour)),
+				Pagination: &v1.PaginatedRequest{
+					PerPage: int64(5),
+					Page:    int64(1),
 				},
-				Expect: Expectation{
-					count:      int64(5),
-					total:      int64(14),
-					totalPages: int64(3),
-					page:       int64(1),
-					perPage:    int64(5),
+			},
+			Expect: Expectation{
+				total:      int64(14),
+				totalPages: int64(3),
+			},
+		},
+		{
+			name: "second page",
+			Request: &v1.ListBilledUsageRequest{
+				AttributionId: string(attrID),
+				From:          timestamppb.New(start),
+				To:            timestamppb.New(start.Add(20*time.Minute + 2*time.Hour)),
+				Pagination: &v1.PaginatedRequest{
+					PerPage: int64(5),
+					Page:    int64(2),
 				},
-			}
-		})(),
-		(func() Scenario {
-
-			return Scenario{
-				name: "second page",
-				Request: &v1.ListBilledUsageRequest{
-					AttributionId: string(attrID),
-					From:          timestamppb.New(start),
-					To:            timestamppb.New(start.Add(20*time.Minute + 2*time.Hour)),
-					Pagination: &v1.PaginatedRequest{
-						PerPage: int64(5),
-						Page:    int64(2),
-					},
+			},
+			Expect: Expectation{
+				total:      int64(14),
+				totalPages: int64(3),
+			},
+		},
+		{
+			name: "third page",
+			Request: &v1.ListBilledUsageRequest{
+				AttributionId: string(attrID),
+				From:          timestamppb.New(start),
+				To:            timestamppb.New(start.Add(20*time.Minute + 2*time.Hour)),
+				Pagination: &v1.PaginatedRequest{
+					PerPage: int64(5),
+					Page:    int64(3),
 				},
-				Expect: Expectation{
-					count:      int64(5),
-					total:      int64(14),
-					totalPages: int64(3),
-					page:       int64(2),
-					perPage:    int64(5),
+			},
+			Expect: Expectation{
+				total:      int64(14),
+				totalPages: int64(3),
+			},
+		},
+		{
+			name: "fourth page",
+			Request: &v1.ListBilledUsageRequest{
+				AttributionId: string(attrID),
+				From:          timestamppb.New(start),
+				To:            timestamppb.New(start.Add(20*time.Minute + 2*time.Hour)),
+				Pagination: &v1.PaginatedRequest{
+					PerPage: int64(5),
+					Page:    int64(4),
 				},
-			}
-		})(),
-		(func() Scenario {
-
-			return Scenario{
-				name: "third page",
-				Request: &v1.ListBilledUsageRequest{
-					AttributionId: string(attrID),
-					From:          timestamppb.New(start),
-					To:            timestamppb.New(start.Add(20*time.Minute + 2*time.Hour)),
-					Pagination: &v1.PaginatedRequest{
-						PerPage: int64(5),
-						Page:    int64(3),
-					},
-				},
-				Expect: Expectation{
-					count:      int64(4),
-					total:      int64(14),
-					totalPages: int64(3),
-					page:       int64(3),
-					perPage:    int64(5),
-				},
-			}
-		})(),
-		(func() Scenario {
-
-			return Scenario{
-				name: "fourth page",
-				Request: &v1.ListBilledUsageRequest{
-					AttributionId: string(attrID),
-					From:          timestamppb.New(start),
-					To:            timestamppb.New(start.Add(20*time.Minute + 2*time.Hour)),
-					Pagination: &v1.PaginatedRequest{
-						PerPage: int64(5),
-						Page:    int64(4),
-					},
-				},
-				Expect: Expectation{
-					count:      int64(0),
-					total:      int64(14),
-					totalPages: int64(3),
-					page:       int64(4),
-					perPage:    int64(5),
-				},
-			}
-		})(),
+			},
+			Expect: Expectation{
+				total:      int64(14),
+				totalPages: int64(3),
+			},
+		},
 	}
-
-	dbconn := dbtest.ConnectForTests(t)
-	dbtest.CreateWorkspaceInstanceUsageRecords(t, dbconn, instances...)
-
-	srv := baseserver.NewForTests(t,
-		baseserver.WithGRPC(baseserver.MustUseRandomLocalAddress(t)),
-	)
-
-	generator := NewReportGenerator(dbconn, DefaultWorkspacePricer)
-	v1.RegisterUsageServiceServer(srv.GRPC(), NewUsageService(dbconn, generator, nil))
-	baseserver.StartServerForTests(t, srv)
-
-	conn, err := grpc.Dial(srv.GRPCAddress(), grpc.WithTransportCredentials(insecure.NewCredentials()))
-	require.NoError(t, err)
 
 	for _, scenario := range scenarios {
 		t.Run(scenario.name, func(t *testing.T) {
+			dbconn := dbtest.ConnectForTests(t)
+			dbtest.CreateWorkspaceInstanceUsageRecords(t, dbconn, instances...)
+
+			srv := baseserver.NewForTests(t,
+				baseserver.WithGRPC(baseserver.MustUseRandomLocalAddress(t)),
+			)
+
+			generator := NewReportGenerator(dbconn, DefaultWorkspacePricer)
+			v1.RegisterUsageServiceServer(srv.GRPC(), NewUsageService(dbconn, generator, nil))
+			baseserver.StartServerForTests(t, srv)
+
+			conn, err := grpc.Dial(srv.GRPCAddress(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+			require.NoError(t, err)
 
 			client := v1.NewUsageServiceClient(conn)
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
There are test hooks for record deletion. However, these wouldn't run after each test when the test setup up was hooked up to the top level `*testing.T` (because the hook would only run after they finished). Instead, we need to bind the hooks to each subtest.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes unit tests from https://github.com/gitpod-io/gitpod/pull/12562

## How to test
<!-- Provide steps to test this PR -->
unit tests

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
