### PR TITLE
[usage] Drop raw sessions from usage report to cut size in half

### DIFF
--- a/components/usage/pkg/apiv1/report-generator.go
+++ b/components/usage/pkg/apiv1/report-generator.go
@@ -55,7 +55,6 @@ func (g *ReportGenerator) GenerateUsageReport(ctx context.Context, from, to time
 	if err != nil {
 		return report, fmt.Errorf("failed to list instances from db: %w", err)
 	}
-	report.RawSessions = instances
 
 	valid, invalid := validateInstances(instances)
 	report.InvalidSessions = invalid

--- a/components/usage/pkg/apiv1/usage_test.go
+++ b/components/usage/pkg/apiv1/usage_test.go
@@ -461,7 +461,6 @@ func TestReportGenerator_GenerateUsageReport(t *testing.T) {
 	require.Equal(t, nowFunc(), report.GenerationTime)
 	require.Equal(t, startOfMay, report.From)
 	// require.Equal(t, startOfJune, report.To) TODO(gpl) This is not true anymore - does it really make sense to test for it?
-	require.Len(t, report.RawSessions, 3)
 	require.Len(t, report.InvalidSessions, 1)
 	require.Len(t, report.UsageRecords, 2)
 }

--- a/components/usage/pkg/contentservice/usage_report.go
+++ b/components/usage/pkg/contentservice/usage_report.go
@@ -20,8 +20,7 @@ type UsageReport struct {
 	From time.Time `json:"from"`
 	To   time.Time `json:"to"`
 
-	RawSessions     []db.WorkspaceInstanceForUsage `json:"rawSessions"`
-	InvalidSessions []InvalidSession               `json:"invalidSessions"`
+	InvalidSessions []InvalidSession `json:"invalidSessions"`
 
 	UsageRecords []db.WorkspaceInstanceUsage `json:"usageRecords"`
 }

--- a/components/usage/pkg/contentservice/usage_report_test.go
+++ b/components/usage/pkg/contentservice/usage_report_test.go
@@ -5,7 +5,6 @@
 package contentservice
 
 import (
-	"database/sql"
 	"encoding/json"
 	"github.com/gitpod-io/gitpod/usage/pkg/db"
 	"github.com/gitpod-io/gitpod/usage/pkg/db/dbtest"
@@ -20,24 +19,6 @@ func TestUsageReport_ToJSON(t *testing.T) {
 		GenerationTime: time.Now().UTC(),
 		From:           time.Now().UTC(),
 		To:             time.Now().UTC(),
-		RawSessions: []db.WorkspaceInstanceForUsage{
-			{
-				ID:          uuid.New(),
-				WorkspaceID: dbtest.GenerateWorkspaceID(),
-				OwnerID:     uuid.New(),
-				ProjectID: sql.NullString{
-					String: "project-id",
-					Valid:  true,
-				},
-				WorkspaceClass:     "workspace-class",
-				Type:               "regular",
-				UsageAttributionID: db.NewTeamAttributionID(uuid.New().String()),
-				CreationTime:       db.NewVarcharTime(time.Now()),
-				StartedTime:        db.NewVarcharTime(time.Now()),
-				StoppingTime:       db.NewVarcharTime(time.Now()),
-				StoppedTime:        db.NewVarcharTime(time.Now()),
-			},
-		},
 		InvalidSessions: []InvalidSession{
 			{
 				Reason:  "some-reason",


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Not really strictly needed. Would be nice, but we can always add later on once we're comfortable with size

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
