### PR TITLE
feat(jetbrains): show workspace class in backend control center

### DIFF
--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/GitpodManager.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/GitpodManager.kt
@@ -223,14 +223,16 @@ class GitpodManager : Disposable {
         }
     }
 
+    var infoResponse: WorkspaceInfoResponse? = null
     val pendingInfo = CompletableFuture<WorkspaceInfoResponse>()
+
     private val infoJob = GlobalScope.launch {
         if (application.isHeadlessEnvironment) {
             return@launch
         }
         try {
             // TODO(ak) replace retry with proper handling of grpc errors
-            val infoResponse = retry(3) {
+            infoResponse = retry(3) {
                 InfoServiceGrpc
                         .newFutureStub(supervisorChannel)
                         .workspaceInfo(Info.WorkspaceInfoRequest.newBuilder().build())
@@ -391,5 +393,4 @@ class GitpodManager : Disposable {
             metricsJob.cancel()
         }
     }
-
 }

--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/GitpodMetricProvider.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/GitpodMetricProvider.kt
@@ -9,7 +9,7 @@ import com.jetbrains.rd.platform.codeWithMe.unattendedHost.metrics.Metric
 import com.jetbrains.rd.platform.codeWithMe.unattendedHost.metrics.MetricType
 import com.jetbrains.rd.platform.codeWithMe.unattendedHost.metrics.MetricsStatus
 import com.jetbrains.rd.platform.codeWithMe.unattendedHost.metrics.providers.MetricProvider
-import io.gitpod.jetbrains.remote.GitpodManager
+import io.gitpod.supervisor.api.Info.WorkspaceInfoResponse.WorkspaceClass
 import io.gitpod.supervisor.api.Status.ResourceStatusSeverity
 import kotlin.math.roundToInt
 
@@ -19,6 +19,7 @@ class GitpodMetricProvider: MetricProvider {
     override val id: String = "gitpodMetricsProvider"
     override fun getMetrics(): Map<String, Metric> {
         val resourceStatus = manager.resourceStatus
+        val info = manager.infoResponse
 
         val cpuUsed = resourceStatus?.cpu?.used?.toDouble() ?: 0.0
         val cpuTotal = resourceStatus?.cpu?.limit?.toDouble() ?: 0.0
@@ -28,9 +29,11 @@ class GitpodMetricProvider: MetricProvider {
 
         val memoryUsed = convertBytesToGB(resourceStatus?.memory?.used ?: 0)
         val memoryTotal = convertBytesToGB(resourceStatus?.memory?.limit ?: 0)
-        val memorySeverity = resourceStatus?.memory?.severity ?:ResourceStatusSeverity.normal
+        val memorySeverity = resourceStatus?.memory?.severity ?: ResourceStatusSeverity.normal
         val memoryPercentage = (memoryUsed / memoryTotal) * 100
         val memoryStatus = getSeverityStatus(memorySeverity)
+
+        val workspaceClass = formatWorkspaceClass(info?.workspaceClass)
 
         return mapOf(
                 "gitpod_workspace_cpu_used" to Metric(MetricType.PERFORMANCE, MetricsStatus.NORMAL, roundTo(cpuUsed, 0)),
@@ -38,7 +41,8 @@ class GitpodMetricProvider: MetricProvider {
                 "gitpod_workspace_cpu_percentage" to Metric(MetricType.PERFORMANCE, cpuStatus, (cpuPercentage * 1000.0).roundToInt() / 1000.0),
                 "gitpod_workspace_memory_used" to Metric(MetricType.PERFORMANCE, MetricsStatus.NORMAL, roundTo(memoryUsed, 2)),
                 "gitpod_workspace_memory_total" to Metric(MetricType.PERFORMANCE, MetricsStatus.NORMAL, roundTo(memoryTotal, 2)),
-                "gitpod_workspace_memory_percentage" to Metric(MetricType.PERFORMANCE, memoryStatus, (memoryPercentage * 1000.0).roundToInt() / 1000.0)
+                "gitpod_workspace_memory_percentage" to Metric(MetricType.PERFORMANCE, memoryStatus, (memoryPercentage * 1000.0).roundToInt() / 1000.0),
+                "gitpod_workspace_class" to Metric(MetricType.OTHER, MetricsStatus.NORMAL, workspaceClass)
         )
     }
 
@@ -58,5 +62,17 @@ class GitpodMetricProvider: MetricProvider {
         } else {
             MetricsStatus.NORMAL
         }
+    }
+
+    private fun formatWorkspaceClass(workspaceClass: WorkspaceClass?): String {
+        if (workspaceClass == null || workspaceClass.displayName == "") {
+            return ""
+        }
+
+        if (workspaceClass.description == "") {
+            return workspaceClass.displayName
+        }
+
+        return "${workspaceClass.displayName}: ${workspaceClass.description}"
     }
 }

--- a/components/ide/jetbrains/backend-plugin/src/main/resources/META-INF/plugin.xml
+++ b/components/ide/jetbrains/backend-plugin/src/main/resources/META-INF/plugin.xml
@@ -22,18 +22,26 @@
     </dependencies>
 
     <extensions defaultExtensionNs="com.intellij">
-        <applicationService serviceImplementation="io.gitpod.jetbrains.remote.services.HeartbeatService" preload="true"/>
+        <applicationService serviceImplementation="io.gitpod.jetbrains.remote.services.HeartbeatService"
+                            preload="true"/>
         <applicationService serviceImplementation="io.gitpod.jetbrains.remote.GitpodManager" preload="true"/>
         <applicationService serviceImplementation="io.gitpod.jetbrains.remote.GitpodPortsService" preload="true"/>
-        <notificationGroup id="Gitpod Notifications" displayType="BALLOON" isLogByDefault="false" />
+        <notificationGroup id="Gitpod Notifications" displayType="BALLOON" isLogByDefault="false"/>
         <httpRequestHandler implementation="io.gitpod.jetbrains.remote.GitpodCLIService"/>
-        <projectService serviceImplementation="io.gitpod.jetbrains.remote.GitpodClientProjectSessionTracker" client="guest" preload="true"/>
+        <projectService serviceImplementation="io.gitpod.jetbrains.remote.GitpodClientProjectSessionTracker"
+                        client="guest" preload="true"/>
         <projectService serviceImplementation="io.gitpod.jetbrains.remote.GitpodProjectManager" preload="true"/>
-        <projectService serviceImplementation="io.gitpod.jetbrains.remote.GitpodTerminalService" client="guest" preload="true"/>
-        <gateway.customization.name implementation="io.gitpod.jetbrains.remote.GitpodGatewayClientCustomizationProvider"/>
-        <gateway.customization.performance id="gitpodMetricsControl" order="before cpuControl" implementation="io.gitpod.jetbrains.remote.GitpodMetricControlProvider"/>
-        <gateway.customization.metrics id="gitpodMetricsProvider" implementation="io.gitpod.jetbrains.remote.GitpodMetricProvider" />
-        <registryKey key="gitpod.autoJdk.disabled" defaultValue="false" description="Disable auto-detection of JDK for the project and its modules" restartRequired="true"/>
+        <projectService serviceImplementation="io.gitpod.jetbrains.remote.GitpodTerminalService" client="guest"
+                        preload="true"/>
+        <gateway.customization.name
+                implementation="io.gitpod.jetbrains.remote.GitpodGatewayClientCustomizationProvider"/>
+        <gateway.customization.performance id="gitpodMetricsControl" order="before cpuControl"
+                                           implementation="io.gitpod.jetbrains.remote.GitpodMetricControlProvider"/>
+        <gateway.customization.metrics id="gitpodMetricsProvider"
+                                       implementation="io.gitpod.jetbrains.remote.GitpodMetricProvider"/>
+        <registryKey key="gitpod.autoJdk.disabled" defaultValue="false"
+                     description="Disable auto-detection of JDK for the project and its modules"
+                     restartRequired="true"/>
     </extensions>
 
 </idea-plugin>


### PR DESCRIPTION
## Description
This PR adds support in JetBrains Backend Control Center for displaying the Gitpod's Workspace Class, to be accessible and easily discoverable.

The PR also includes small changes to the layout of the Performance Tab to make it easier for the user to understand what metrics are related to the Workspace (relevant) and what metrics are related to the Node (less relevant for them).



| Current                                                                                                                                                              | After this PR                                                                                                                                                        | After this PR (Missing Class)                                                                                                                                        | After this PR (hover on shared node resources)                                                                                                                       |
|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| <img width="514" alt="Screenshot 2022-09-01 at 23 11 04" src="https://user-images.githubusercontent.com/2318450/188026407-4b87c3a7-b0fa-419f-a7ef-d2f761224a8b.png"> | <img width="507" alt="Screenshot 2022-09-02 at 22 58 12" src="https://user-images.githubusercontent.com/2318450/188240455-e5cfba19-5c65-493a-b8c0-0e63c34fd17b.png"> | <img width="506" alt="Screenshot 2022-09-02 at 23 03 59" src="https://user-images.githubusercontent.com/2318450/188240909-1e198a65-7951-49e9-8bfe-ebddf12e3304.png"> | <img width="507" alt="Screenshot 2022-09-02 at 22 58 08" src="https://user-images.githubusercontent.com/2318450/188240461-4d2d35eb-a8b5-4188-a29a-76877aaff7bf.png"> |

Considerations
- I also tried adding the class on its own row, below "Workspace", but it would [look odd](https://user-images.githubusercontent.com/2318450/188026745-ffbce5bc-6dca-4abd-9e09-ea1868b3130f.png)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #12160 

## How to test
1. Start a workspace with IntelliJ: https://andreafalz6b6c136ea3.preview.gitpod-dev.com/
3. Check the backend control center, you should see the workspace class as in the screenshots above

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
JetBrains: Provide workspace class info in Backend Control Center 
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
