### PR TITLE
fix: Round of the `elapsedMinutes` of prebuilds

### DIFF
--- a/components/supervisor/pkg/supervisor/tasks.go
+++ b/components/supervisor/pkg/supervisor/tasks.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"regexp"
 	"strconv"
@@ -467,7 +468,7 @@ func (tm *tasksManager) watch(task *task, term *terminal.Term) {
 
 		duration := ""
 		if elapsed >= 1*time.Minute {
-			elapsedInMinutes := strconv.Itoa(int(elapsed.Minutes()))
+			elapsedInMinutes := strconv.Itoa(int(math.Round(elapsed.Minutes())))
 			duration = "🎉 Well done on saving " + elapsedInMinutes + " minute"
 			if elapsedInMinutes != "1" {
 				duration += "s"


### PR DESCRIPTION
## Description
This PR is for rounding off the elapsed minutes while prebuilding. [More context - internal discussion](https://gitpod.slack.com/archives/C01KGM9BH54/p1660759739194689)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes [Internal fix request](https://gitpod.slack.com/archives/C01KGM9BH54/p1660811960630029?thread_ts=1660759739.194689&cid=C01KGM9BH54)

## How to test
- Open any New Workspace which has some prebuild saving with this current PR's build.
- 👀 See the Message regarding time saved in prebuild in terminal.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
No

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
