### PR TITLE
[UBP] Show "running" for instances with no end time in the usage view

### DIFF
--- a/components/dashboard/src/teams/TeamUsage.tsx
+++ b/components/dashboard/src/teams/TeamUsage.tsx
@@ -105,12 +105,10 @@ function TeamUsage() {
     };
 
     const getMinutes = (usage: ExtendedBillableSession) => {
-        let end;
         if (!usage.endTime) {
-            end = new Date(Date.now()).getTime();
-        } else {
-            end = new Date(usage.endTime).getTime();
+            return "running";
         }
+        const end = new Date(usage.endTime).getTime();
         const start = new Date(usage.startTime).getTime();
         const lengthOfUsage = Math.floor(end - start);
         const inMinutes = (lengthOfUsage / (1000 * 60)).toFixed(1);


### PR DESCRIPTION
## Description
Using the current time as the end time for usage records without an end time (ie running instances) is problematic because it can cause the usage view to show an instance as having run for longer than it really did. This makes it looks like the credits calculation for the instance is incorrect.

For running usage records, simply return "running" rather than inventing a stopped time for them.

See also related discussion on [Slack (internal)](https://gitpod.slack.com/archives/C02EN94AEPL/p1661946710590939).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of https://github.com/gitpod-io/gitpod/issues/12064

## How to test

* Create a team with 'Gitpod' in the name in the preview env and enable usage based billing for the team
* Start a workspace
* Visit the usage view and see that the workspace is marked as 'running'.
<img width="1077" alt="image" src="https://user-images.githubusercontent.com/8225907/187854351-5a8fbf62-5a44-4d7a-b1a3-51b6937ad920.png">


* Stop the workspace
* Wait for usage reconciliation to run.
* Visit the usage view and see that the workspace has a runtime duration.
<img width="1065" alt="image" src="https://user-images.githubusercontent.com/8225907/187854762-0ff78af9-7b8c-4ebc-9d04-f4f23addf0d0.png">

## Release Notes

```release-note
NONE
```

## Documentation

## Werft options:
- [x] /werft with-preview
- [x] /werft with-payment
