### PR TITLE
[db] fix d_b_workspace_instance_usage.startedAt and add ind_dbsync

### DIFF
--- a/components/gitpod-db/src/typeorm/migration/1662027342962-WorkspaceInstanceUsageUpdate.ts
+++ b/components/gitpod-db/src/typeorm/migration/1662027342962-WorkspaceInstanceUsageUpdate.ts
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { columnExists } from "./helper/helper";
+
+const TABLE_NAME = "d_b_workspace_instance_usage";
+const COLUMN_NAME = "startedAt";
+
+export class WorkspaceInstanceUsageUpdate1662027342962 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        if (await columnExists(queryRunner, TABLE_NAME, COLUMN_NAME)) {
+            await queryRunner.query(
+                `ALTER TABLE ${TABLE_NAME} MODIFY COLUMN ${COLUMN_NAME} timestamp(6) NULL, ALGORITHM=INPLACE, LOCK=NONE`,
+            );
+        }
+        await queryRunner.query("CREATE INDEX `ind_dbsync` ON `d_b_workspace_instance_usage` (_lastModified)");
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query("ALTER TABLE `d_b_workspace_instance_usage` DROP INDEX `ind_dbsync`");
+    }
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
check the db of the preview env using `describe d_b_workspace_instance_usage;` to include an index on `_lastModified` and no `on update` extra for `startedAt`.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
