### PR TITLE
[single-cluster/eks] Add `cluster-autoscaler`

### DIFF
--- a/install/infra/modules/eks/output.tf
+++ b/install/infra/modules/eks/output.tf
@@ -24,6 +24,16 @@ output "secretAccessKey" {
   value     = try("${aws_iam_access_key.edns[0].secret}", "")
 }
 
+output "oidc_provider_arn" {
+  sensitive = false
+  value     = module.eks.oidc_provider_arn
+}
+
+output "cluster_id" {
+  sensitive = false
+  value     = module.eks.cluster_id
+}
+
 output "cert_manager_issuer" {
   value = try({
     region = var.region

--- a/install/infra/modules/tools/aws-cluster-autoscaler/main.tf
+++ b/install/infra/modules/tools/aws-cluster-autoscaler/main.tf
@@ -1,0 +1,70 @@
+variable "kubeconfig" {
+  description = "Path to the KUBECONFIG file to connect to the cluster"
+  default     = "./kubeconfig"
+}
+
+variable "region" {}
+variable "cluster_name" {}
+variable "cluster_id" {}
+variable "oidc_provider_arn" {}
+
+provider "helm" {
+  kubernetes {
+    config_path = var.kubeconfig
+  }
+}
+
+module "cluster_autoscaler_irsa_role" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  version = "~> 4.12"
+
+  role_name_prefix                 = "cluster-autoscaler"
+  attach_cluster_autoscaler_policy = true
+  cluster_autoscaler_cluster_ids   = [var.cluster_id]
+
+  oidc_providers = {
+    ex = {
+      provider_arn               = var.oidc_provider_arn
+      namespace_service_accounts = ["kube-system:cluster-autoscaler"]
+    }
+  }
+}
+
+# AWS cluster auto-scaler Deployment using Helm
+resource "helm_release" "cluster_autoscaler" {
+  name       = "cluster-autoscaler"
+  repository = "https://kubernetes.github.io/autoscaler"
+  chart      = "cluster-autoscaler"
+  version    = "9.20.1"
+  namespace  = "kube-system"
+
+  values = [
+    jsonencode({
+      cloudProvider = "aws"
+      awsRegion     = var.region
+      autoDiscovery = {
+        clusterName = var.cluster_name
+      }
+
+      rbac = {
+        serviceAccount = {
+          name = "cluster-autoscaler"
+          annotations = {
+            "eks.amazonaws.com/role-arn" = module.cluster_autoscaler_irsa_role.iam_role_arn
+          }
+          create = true
+        }
+      }
+
+      securityContext = {
+        fsGroup = 65534
+      }
+      extraArgs = {
+        skip-nodes-with-local-storage = false
+        balance-similar-node-groups   = true
+      }
+
+    })
+  ]
+
+}

--- a/install/infra/single-cluster/aws/Makefile
+++ b/install/infra/single-cluster/aws/Makefile
@@ -26,7 +26,11 @@ plan-cluster:
 	@terraform plan -target=module.eks
 
 .PHONY: plan-tools
-plan-tools: plan-cm-edns plan-cluster-issuer
+plan-tools: plan-cm-edns plan-cluster-issuer plan-cluster-autoscaler
+
+.PHONY: plan-cluster-autoscaler
+plan-cluster-autoscaler:
+	@terraform plan -target=module.cluster-autoscaler
 
 .PHONY: plan-cm-edns
 plan-cm-edns:
@@ -41,7 +45,11 @@ apply-cluster:
 	@terraform apply -target=module.eks --auto-approve
 
 .PHONY: apply-tools
-apply-tools: install-cm-edns install-cluster-issuer
+apply-tools: install-cm-edns install-cluster-issuer install-cluster-autoscaler
+
+.PHONY: install-cluster-autoscaler
+install-cluster-autoscaler:
+	@terraform apply -target=module.cluster-autoscaler --auto-approve
 
 .PHONY: install-cm-edns
 install-cm-edns:
@@ -56,7 +64,11 @@ destroy-cluster:
 	@terraform destroy -target=module.eks --auto-approve
 
 .PHONY: destroy-tools
-destroy-tools: destroy-cluster-issuer destroy-cm-edns
+destroy-tools: destroy-cluster-issuer destroy-cm-edns destroy-cluster-autoscaler
+
+.PHONY: destroy-cluster-autoscaler
+destroy-cluster-autoscaler:
+	@terraform destroy -target=module.cluster-autoscaler --auto-approve
 
 .PHONY: destroy-cm-edns
 destroy-cm-edns:

--- a/install/infra/single-cluster/aws/tools.tf
+++ b/install/infra/single-cluster/aws/tools.tf
@@ -20,3 +20,12 @@ module "cluster-issuer" {
   secretAccessKey     = module.eks.secretAccessKey
   issuer_name         = "route53"
 }
+
+module "cluster-autoscaler" {
+  source            = "../../modules/tools/aws-cluster-autoscaler"
+  kubeconfig        = var.kubeconfig
+  region            = var.region
+  cluster_name      = var.cluster_name
+  cluster_id        = module.eks.cluster_id
+  oidc_provider_arn = module.eks.oidc_provider_arn
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This commit adds the `cluster-autoscaler` component into
the terraform scripts through the latest helm chart. This also uses
the `cluster_autoscaler_irsa_role` module to create the relevant
policy, and role which is also created as a service account
and then attached to the cluster-atuoscaler component

Signed-off-by: Tarun Pothulapati <tarun@gitpod.io>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[single-cluster/eks] Add `cluster-autoscaler`
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
