### PR TITLE
Enable connection limiting for free tier

### DIFF
--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -295,6 +295,7 @@ export const WorkspaceFeatureFlags = {
     persistent_volume_claim: undefined,
     protected_secrets: undefined,
     workspace_class_limiting: undefined,
+    workspace_connection_limiting: undefined,
 };
 export type NamedWorkspaceFeatureFlag = keyof typeof WorkspaceFeatureFlags;
 


### PR DESCRIPTION
## Description
This instructs ws-manager to limit the rate of network connections for non paying customers. Note that this currently only audits (i.e. it records packets that would have been dropped but does not actually drop them). We will use this to refine the limits.

## Related Issue(s)
Fixes https://github.com/gitpod-io/gitpod/issues/13041

## How to test
- User on free tier
  - Make yourself admin in the preview environment
  - Ensure that you are on the free open source plan
  - Start a workspace
  - The workspace should have the `gitpod.io/netConnLimitPerMinute` annotation
  - The other parts of this have already been covered by [other PRs](https://github.com/gitpod-io/gitpod/issues?q=label%3Afeature%3Aconnection-limiting+is%3Aclosed). If you want to be sure, check the logs of ws-daemon (it should contain `will limit network connections`. You can also ssh into the node and then enter the network namespace of the pod with `nsenter -t pid -n`. nft list ruleset should show you a bunch of rules in that namespace.

- Paying customer
  - Ensure that you are on the professional open source plan
  - Start a workspace
  - The workspace should **not** have the `gitpod.io/netConnLimitPerMinute` annotation
  - The other parts should be missing as well

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
