### PR TITLE
Align GCP Single Cluster TF Database Output with Installation UI

### DIFF
--- a/install/infra/single-cluster/gcp/Makefile
+++ b/install/infra/single-cluster/gcp/Makefile
@@ -71,9 +71,9 @@ output-database:
 	@echo ""
 	@echo "Database:"
 	@echo "========"
+	@echo "Tick the option 'Use Google Cloud SQL Proxy' if using this database"
 	@terraform output -json database | jq
 	@echo ""
-	@echo "Tick the option 'Use Google Cloud SQL Proxy', if using this database"
 
 output-issuer:
 	@echo ""


### PR DESCRIPTION
## Description
Reorders the output of the `make output` command for the GCP single cluster terraform config. Specifically, the "tick Google Cloud SQL proxy" instruction is moved to the top of the database section, because this is also where it is in the UI itself.


## How to test
- Look at changed files :) 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

