### PR TITLE
[ops] WebApp: Fix team-specific alerts

### DIFF
--- a/operations/observability/mixins/meta/rules/components/server/alerts.libsonnet
+++ b/operations/observability/mixins/meta/rules/components/server/alerts.libsonnet
@@ -134,8 +134,9 @@
           },
           {
             alert: 'WebAppServicesCrashlooping',
-            expr: 'sum(rate(container_cpu_usage_seconds_total{container!="POD", node=~".*", pod=~"(content-service|dashboard|db|db-sync|messagebus|payment-endpoint|proxy|server|ws-manager-bridge|usage)-.*"}[5m])) by (pod, node) > 0.80',
-            'for': '15m',
+            // Reasoning: alert if any pod is restarting more than 3 times / 5 minutes.
+            expr: 'increase(kube_pod_container_status_restarts_total{container!="POD", pod=~"(content-service|dashboard|db|db-sync|messagebus|payment-endpoint|proxy|server|ws-manager-bridge|usage)-.*"}[5m]) > 3',
+            'for': '5m',
             labels: {
               // sent to the team internal channel until we fine tuned it
               severity: 'warning',

--- a/operations/observability/mixins/meta/rules/components/server/alerts.libsonnet
+++ b/operations/observability/mixins/meta/rules/components/server/alerts.libsonnet
@@ -117,22 +117,6 @@
             },
           },
           {
-            alert: 'WebAppServicesHighMemoryUsage',
-            // Reasoning: high rates of RAM consumption should only be temporary. Values based on past data (around 5-10 is constant)
-            expr: 'sum(rate(container_memory_working_set_bytes{container!="POD", node=~".*", pod=~"(server|ws-manager-bridge|usage)-.*"}[30m])) by (pod, node) > 10000000',
-            'for': '15m',
-            labels: {
-              // sent to the team internal channel until we fine tuned it
-              severity: 'warning',
-              team: 'webapp'
-            },
-            annotations: {
-              runbook_url: 'https://github.com/gitpod-io/runbooks/blob/main/runbooks/WebAppServicesHighMemoryUsage.md',
-              summary: 'WebApp services consume excessive amounts of memory. Investigation required.',
-              description: 'WebApp Services execcisve memory usage',
-            },
-          },
-          {
             alert: 'WebAppServicesHighCPUUsage',
             // Reasoning: high rates of CPU consumption should only be temporary.
             expr: 'sum(rate(container_cpu_usage_seconds_total{container!="POD", node=~".*", pod=~"(content-service|dashboard|db|db-sync|messagebus|payment-endpoint|proxy|server|ws-manager-bridge|usage)-.*"}[5m])) by (pod, node) > 0.80',

--- a/operations/observability/mixins/meta/rules/components/server/alerts.libsonnet
+++ b/operations/observability/mixins/meta/rules/components/server/alerts.libsonnet
@@ -69,8 +69,8 @@
           {
             alert: 'WebsocketConnectionRateHigh',
             // Reasoning: the values are taken from past data
-            expr: 'sum(rate(server_websocket_connection_count[2m])) > 30',
-            'for': '5m',
+            expr: 'sum(rate(gitpod_server_api_connections_total[2m])) by (pod) > 5',
+            'for': '10m',
             labels: {
               // sent to the team internal channel until we fine tuned it
               severity: 'warning',


### PR DESCRIPTION
## Description
Fixes very noisy alerts introduced with https://github.com/gitpod-io/gitpod/pull/12514, mostly because I learned that `rate(gauge)` does not work, especially not across different implementations (prometheus vs VictoriaMetrics).

## Related Issue(s)
Context: https://github.com/gitpod-io/gitpod/issues/10722

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
