### PR TITLE
[code] upgrade stable code to 1.71 release

### DIFF
--- a/install/installer/cmd/testdata/render/aws-setup/output.golden
+++ b/install/installer/cmd/testdata/render/aws-setup/output.golden
@@ -3585,7 +3585,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-b86bfcbb01feb0b9c3e67a14e6ad3bb95044f51d",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-44a66f55c90b92fada502cc293e927cde62d75fc",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/azure-setup/output.golden
+++ b/install/installer/cmd/testdata/render/azure-setup/output.golden
@@ -3449,7 +3449,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-b86bfcbb01feb0b9c3e67a14e6ad3bb95044f51d",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-44a66f55c90b92fada502cc293e927cde62d75fc",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -4361,7 +4361,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-b86bfcbb01feb0b9c3e67a14e6ad3bb95044f51d",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-44a66f55c90b92fada502cc293e927cde62d75fc",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -3636,7 +3636,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-b86bfcbb01feb0b9c3e67a14e6ad3bb95044f51d",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-44a66f55c90b92fada502cc293e927cde62d75fc",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/gcp-setup/output.golden
+++ b/install/installer/cmd/testdata/render/gcp-setup/output.golden
@@ -3410,7 +3410,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-b86bfcbb01feb0b9c3e67a14e6ad3bb95044f51d",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-44a66f55c90b92fada502cc293e927cde62d75fc",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -3856,7 +3856,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-b86bfcbb01feb0b9c3e67a14e6ad3bb95044f51d",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-44a66f55c90b92fada502cc293e927cde62d75fc",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -3868,7 +3868,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-b86bfcbb01feb0b9c3e67a14e6ad3bb95044f51d",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-44a66f55c90b92fada502cc293e927cde62d75fc",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
+++ b/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
@@ -4189,7 +4189,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-b86bfcbb01feb0b9c3e67a14e6ad3bb95044f51d",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-44a66f55c90b92fada502cc293e927cde62d75fc",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
+++ b/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
@@ -3859,7 +3859,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-b86bfcbb01feb0b9c3e67a14e6ad3bb95044f51d",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-44a66f55c90b92fada502cc293e927cde62d75fc",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/pkg/components/workspace/ide/constants.go
+++ b/install/installer/pkg/components/workspace/ide/constants.go
@@ -6,7 +6,7 @@ package ide
 
 const (
 	CodeIDEImage                = "ide/code"
-	CodeIDEImageStableVersion   = "commit-b86bfcbb01feb0b9c3e67a14e6ad3bb95044f51d" // stable version that will be updated manually on demand
+	CodeIDEImageStableVersion   = "commit-44a66f55c90b92fada502cc293e927cde62d75fc" // stable version that will be updated manually on demand
 	CodeDesktopIDEImage         = "ide/code-desktop"
 	CodeDesktopInsidersIDEImage = "ide/code-desktop-insiders"
 	IntelliJDesktopIDEImage     = "ide/intellij"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Upgrade stable code to `1.71`, image comes from [Werft result](https://werft.gitpod-dev.com/job/gitpod-build-hw-build-vs.2) of previous PR https://github.com/gitpod-io/gitpod/pull/12603

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Relates https://github.com/gitpod-io/gitpod/issues/12470

## How to test
<!-- Provide steps to test this PR -->
- Open workspace with stable code in preview env
- Check if commit hash is `a6661898efdac3fa0f6bea841044bffe58f502f3`

others tested in previous PR https://github.com/gitpod-io/gitpod/pull/12603

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Update stable VSCode Browser to `1.71`
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
