### PR TITLE
[terraform] Turn off node auto-provisioning in GKE

### DIFF
--- a/install/infra/modules/gke/main.tf
+++ b/install/infra/modules/gke/main.tf
@@ -42,22 +42,6 @@ resource "google_container_cluster" "gitpod-cluster" {
   name     = var.cluster_name
   location = var.zone == null ? var.region : var.zone
 
-  cluster_autoscaling {
-    enabled = true
-
-    resource_limits {
-      resource_type = "cpu"
-      minimum       = 2
-      maximum       = 16
-    }
-
-    resource_limits {
-      resource_type = "memory"
-      minimum       = 4
-      maximum       = 64
-    }
-  }
-
   min_master_version = var.cluster_version
 
   remove_default_node_pool = true
@@ -87,6 +71,10 @@ resource "google_container_cluster" "gitpod-cluster" {
 
     horizontal_pod_autoscaling {
       disabled = false
+    }
+
+    dns_cache_config {
+      enabled = true
     }
   }
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PR disables auto-provisioning of nodes in GKE clusters. It turns out `cluster_autoscaling` infacts turns auto provisioning on. So all that is needed to enable autoscaling of nodes in GKE is to set the `autoscaling` section in node pool resources.

I am also pushing in a small change that enables Local DNS caching. This is currently enabled in the reference architecture, and this PR makes it consistent.

Thanks a lot to @lucasvaltl for catching it!!

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #12587

## How to test
<!-- Provide steps to test this PR -->
Please follow the [README of the gcp module.](https://github.com/gitpod-io/gitpod/tree/main/install/infra/single-cluster/gcp)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
