### PR TITLE
[UBP] Add a stale data warning to the Usage view

### DIFF
--- a/components/dashboard/src/teams/TeamUsage.tsx
+++ b/components/dashboard/src/teams/TeamUsage.tsx
@@ -157,7 +157,7 @@ function TeamUsage() {
 
     return (
         <>
-            <Header title="Usage" subtitle="Manage team usage." />
+            <Header title="Usage" subtitle="View usage details (updated every 15 minutes)." />
             <div className="app-container pt-5">
                 {errorMessage && <p className="text-base">{errorMessage}</p>}
                 {!errorMessage && (


### PR DESCRIPTION
## Description

Add a short message to the usage view to show that the data is not guaranteed to be up to date.

<img width="605" alt="image" src="https://user-images.githubusercontent.com/8225907/188190798-c0a8cff0-f69b-4676-91c6-0a7f99f137cc.png">


## Related Issue(s)

Part of https://github.com/gitpod-io/gitpod/issues/12064

## How to test

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation


## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
- [x] /werft with-payment
