### PR TITLE
Previews: Always use CLI installer to install monitoring-satellite, instead of jsonnet

### DIFF
--- a/.werft/jobs/build/deploy-to-preview-environment.ts
+++ b/.werft/jobs/build/deploy-to-preview-environment.ts
@@ -212,7 +212,6 @@ export async function deployToPreviewEnvironment(werft: Werft, jobConfig: JobCon
         previewName: previewNameFromBranchName(jobConfig.repository.branch),
         stackdriverServiceAccount: STACKDRIVER_SERVICEACCOUNT,
         werft: werft,
-        installationMethod: jobConfig.observability.installationMethod,
     });
     const sliceID = "observability";
     monitoringSatelliteInstaller

--- a/.werft/jobs/build/job-config.ts
+++ b/.werft/jobs/build/job-config.ts
@@ -45,13 +45,9 @@ export interface Repository {
     branch: string;
 }
 
-export type ObservabilityInstallationMethod = "jsonnet" | "observability-installer";
-
 export interface Observability {
     // The branch of gitpod-io/observability to use
     branch: string;
-    // What tool to use to install monitoring-satellite from gitpod-io/observability
-    installationMethod: ObservabilityInstallationMethod;
 }
 
 export function jobConfig(werft: Werft, context: any): JobConfig {
@@ -115,7 +111,6 @@ export function jobConfig(werft: Werft, context: any): JobConfig {
 
     const observability: Observability = {
         branch: context.Annotations.withObservabilityBranch || "main",
-        installationMethod: context.Annotations.observabilityInstallationMethod || "jsonnet",
     };
 
     const jobConfig = {

--- a/.werft/observability/monitoring-satellite.ts
+++ b/.werft/observability/monitoring-satellite.ts
@@ -1,5 +1,5 @@
 import { exec } from "../util/shell";
-import { getGlobalWerftInstance, Werft } from "../util/werft";
+import { Werft } from "../util/werft";
 import * as fs from "fs";
 
 type MonitoringSatelliteInstallerOptions = {
@@ -26,11 +26,7 @@ export class MonitoringSatelliteInstaller {
         const {
             werft,
             branch,
-            satelliteNamespace,
-            stackdriverServiceAccount,
-            previewDomain,
             previewName,
-            nodeExporterPort,
         } = this.options;
 
         werft.log(

--- a/.werft/observability/monitoring-satellite.ts
+++ b/.werft/observability/monitoring-satellite.ts
@@ -116,5 +116,9 @@ export class MonitoringSatelliteInstaller {
                 werft.failSlice(sliceName, err)
                 return
             }
+
+            // The grafana YAML files we're importing have nodeSelector tied to a nodepool that don't exist in previews
+            // We're hot-patching the removal os such nodeSelector to make sure Grafana starts
+            exec(`kubectl patch deployments.apps -n monitoring-satellite grafana --type=json -p="[{'op': 'remove', 'path': '/spec/template/spec/nodeSelector'}]"`)
     }
 }

--- a/.werft/observability/monitoring-satellite.ts
+++ b/.werft/observability/monitoring-satellite.ts
@@ -1,7 +1,6 @@
 import { exec } from "../util/shell";
 import { getGlobalWerftInstance, Werft } from "../util/werft";
 import * as fs from "fs";
-import { ObservabilityInstallationMethod } from "../jobs/build/job-config";
 
 type MonitoringSatelliteInstallerOptions = {
     werft: Werft;
@@ -13,7 +12,6 @@ type MonitoringSatelliteInstallerOptions = {
     previewName: string;
     previewDomain: string;
     stackdriverServiceAccount: any;
-    installationMethod: ObservabilityInstallationMethod;
 };
 
 const sliceName = "observability";
@@ -33,12 +31,11 @@ export class MonitoringSatelliteInstaller {
             previewDomain,
             previewName,
             nodeExporterPort,
-            installationMethod,
         } = this.options;
 
         werft.log(
             sliceName,
-            `Cloning observability repository - Branch: ${branch} Installation method: ${installationMethod}`,
+            `Cloning observability repository - Branch: ${branch}`,
         );
         exec(
             `git clone --branch ${branch} https://roboquat:$(cat /mnt/secrets/monitoring-satellite-preview-token/token)@github.com/gitpod-io/observability.git`,
@@ -60,7 +57,6 @@ export class MonitoringSatelliteInstaller {
         fs.writeFileSync(`${pwd}/observability/jsonnetfile.json`, JSON.stringify(jsonnetFile));
         exec(`cd observability && jb update`, { slice: sliceName });
 
-        if (installationMethod == "observability-installer") {
             // As YAML is indentation sensitive we're using json instead so we don't have to worry about
             // getting the indentation right when formatting the code in TypeScript.
             const observabilityInstallerRenderCmd = `cd observability && \
@@ -124,132 +120,5 @@ export class MonitoringSatelliteInstaller {
                 werft.failSlice(sliceName, err)
                 return
             }
-        } else {
-            let jsonnetRenderCmd = `cd observability && jsonnet -c -J vendor -m monitoring-satellite/manifests \
-            --ext-code config="{
-                namespace: '${satelliteNamespace}',
-                clusterName: '${previewName}',
-                tracing: {
-                    honeycombAPIKey: '${process.env.HONEYCOMB_API_KEY}',
-                    honeycombDataset: 'preview-environments',
-                },
-                previewEnvironment: {
-                    domain: '${previewDomain}',
-                    nodeExporterPort: ${nodeExporterPort},
-                },
-                stackdriver: {
-                    defaultProject: '${stackdriverServiceAccount.project_id}',
-                    clientEmail: '${stackdriverServiceAccount.client_email}',
-                    privateKey: '${stackdriverServiceAccount.private_key}',
-                },
-                prometheus: {
-                    externalLabels: {
-                        environment: 'preview-environments',
-                    },
-                    resources: {
-                        requests: { memory: '200Mi', cpu: '50m' },
-                    },
-                },
-                remoteWrite: {
-                    username: '${process.env.PROM_REMOTE_WRITE_USER}',
-                    password: '${process.env.PROM_REMOTE_WRITE_PASSWORD}',
-                    urls: ['https://victoriametrics.gitpod.io/api/v1/write'],
-                    writeRelabelConfigs: [{
-                        sourceLabels: ['__name__', 'job'],
-                        separator: ';',
-                        regex: 'rest_client_requests_total.*|http_prober_.*',
-                        action: 'keep',
-                    }],
-                },
-                kubescape: {},
-                pyrra: {},
-                probe: {
-                    targets: ['http://google.com'],
-                },
-            }" \
-            monitoring-satellite/manifests/yaml-generator.jsonnet | xargs -I{} sh -c 'cat {} | gojsontoyaml > {}.yaml' -- {} && \
-            find monitoring-satellite/manifests -type f ! -name '*.yaml' ! -name '*.jsonnet'  -delete`;
-            werft.log(sliceName, "rendering YAML files using jsonnet");
-            exec(jsonnetRenderCmd, { silent: true });
-            this.postProcessManifests();
-
-            this.ensureCorrectInstallationOrder();
-            this.deployGitpodServiceMonitors();
-            await this.waitForReadiness(werft);
-        }
-    }
-
-    private ensureCorrectInstallationOrder() {
-        const { werft, kubeconfigPath } = this.options;
-
-        werft.log(sliceName, "installing monitoring-satellite");
-        exec(`cd observability && hack/deploy-satellite.sh --kubeconfig ${kubeconfigPath}`, { slice: sliceName });
-    }
-
-    private async waitForReadiness(werft: Werft) {
-        const { kubeconfigPath, satelliteNamespace } = this.options;
-
-        async function execAndLogOnError(
-            werft: Werft,
-            objectType: string,
-            objectName: string,
-            preSleep: number = 0,
-        ): Promise<void> {
-            const rc = exec(
-                `sleep ${preSleep} && kubectl --kubeconfig ${kubeconfigPath} rollout status -n ${satelliteNamespace} ${objectType} ${objectName}`,
-                {
-                    slice: sliceName,
-                    dontCheckRc: true,
-                },
-            ).code;
-            if (rc != 0) {
-                werft.log(sliceName, `Observability failed to install for ${objectName} of type ${objectType}`);
-                const statusDebug = exec(
-                    `kubectl --kubeconfig ${kubeconfigPath} -n ${satelliteNamespace} get ${objectType} ${objectName} -o jsonpath="{.status}"`,
-                    {
-                        slice: sliceName,
-                    },
-                );
-                werft.log(sliceName, `Status for ${objectName} of type ${objectType}: ${statusDebug}`);
-            }
-            return;
-        }
-
-        const checks: Promise<any>[] = [];
-        // For some reason prometheus' statefulset always take quite some time to get created
-        // Therefore we wait a couple of seconds
-        checks.push(execAndLogOnError(werft, "statefulset", "prometheus-k8s", 30));
-        checks.push(execAndLogOnError(werft, "deployment", "grafana"));
-        checks.push(execAndLogOnError(werft, "deployment", "kube-state-metrics"));
-        checks.push(execAndLogOnError(werft, "deployment", "otel-collector"));
-        // core-dev is just too unstable for node-exporter
-        // we don't guarantee that it will run at all
-        checks.push(execAndLogOnError(werft, "daemonset", "node-exporter"));
-
-        await Promise.all(checks);
-    }
-
-    private deployGitpodServiceMonitors() {
-        const { werft, kubeconfigPath } = this.options;
-
-        werft.log(sliceName, "installing gitpod ServiceMonitor resources");
-        exec(`kubectl --kubeconfig ${kubeconfigPath} apply -f observability/monitoring-satellite/manifests/gitpod/`, {
-            silent: true,
-        });
-    }
-
-    private postProcessManifests() {
-        const werft = getGlobalWerftInstance();
-
-        // We're hardcoding nodeports, so we can use them in .werft/vm/manifests.ts
-        // We'll be able to access Prometheus and Grafana's UI by port-forwarding the harvester proxy into the nodePort
-        werft.log(sliceName, "Post-processing manifests so it works on Harvester");
-        exec(`yq w -i observability/monitoring-satellite/manifests/grafana/service.yaml spec.type 'NodePort'`);
-        exec(`yq w -i observability/monitoring-satellite/manifests/prometheus/service.yaml spec.type 'NodePort'`);
-
-        exec(
-            `yq w -i observability/monitoring-satellite/manifests/prometheus/service.yaml spec.ports[0].nodePort 32001`,
-        );
-        exec(`yq w -i observability/monitoring-satellite/manifests/grafana/service.yaml spec.ports[0].nodePort 32000`);
     }
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
In https://github.com/gitpod-io/gitpod/pull/12039, we introduced two methods for installing monitoring-satellite in preview environments. This way we could let our colleagues have monitoring-satellite safely installed using the traditional Jsonnet way, while we could have a mechanism to use our CLI installer and verify that things are working as expected.

We've successfully migrated all our apps to our new installer, and previews are the last missing piece. This PR makes our CLI the default installation method for monitoring-satellite, and also removes the code for the jsonnet installation method completely.

## How to test
* Open a workspace from this PR
* Run `werft run github -f -a with-preview`
* Make sure you can see the observability stack running without problems in the `monitoring-satellite` namespace.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
