### PR TITLE
[usage] Add database functions for new usage control loop

### DIFF
--- a/components/usage/pkg/apiv1/report-generator.go
+++ b/components/usage/pkg/apiv1/report-generator.go
@@ -7,8 +7,9 @@ package apiv1
 import (
 	"context"
 	"fmt"
-	"github.com/gitpod-io/gitpod/usage/pkg/contentservice"
 	"time"
+
+	"github.com/gitpod-io/gitpod/usage/pkg/contentservice"
 
 	"github.com/gitpod-io/gitpod/common-go/log"
 	"github.com/gitpod-io/gitpod/usage/pkg/db"
@@ -76,15 +77,15 @@ func validateInstances(instances []db.WorkspaceInstanceForUsage) (valid []db.Wor
 		instance := i
 
 		// Each instance must have a start time, without it, we do not have a baseline for usage computation.
-		if !instance.CreationTime.IsSet() {
+		if !instance.StartedTime.IsSet() {
 			invalid = append(invalid, contentservice.InvalidSession{
-				Reason:  "missing creation time",
+				Reason:  "missing started time",
 				Session: instance,
 			})
 			continue
 		}
 
-		start := instance.CreationTime.Time()
+		start := instance.StartedTime.Time()
 
 		// Currently running instances do not have a stopped time set, so we ignore these.
 		if instance.StoppingTime.IsSet() {

--- a/components/usage/pkg/apiv1/usage_test.go
+++ b/components/usage/pkg/apiv1/usage_test.go
@@ -7,10 +7,11 @@ package apiv1
 import (
 	"context"
 	"database/sql"
-	"github.com/gitpod-io/gitpod/usage/pkg/contentservice"
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/gitpod-io/gitpod/usage/pkg/contentservice"
 
 	"github.com/gitpod-io/gitpod/common-go/baseserver"
 	v1 "github.com/gitpod-io/gitpod/usage-api/v1"
@@ -104,7 +105,6 @@ func TestUsageService_ListBilledUsage(t *testing.T) {
 			start := time.Date(2022, 07, 1, 13, 0, 0, 0, time.UTC)
 			attrID := db.NewTeamAttributionID(uuid.New().String())
 			var instances []db.WorkspaceInstanceUsage
-			var instanceIDs []string
 			for i := 0; i < 3; i++ {
 				instance := dbtest.NewWorkspaceInstanceUsage(t, db.WorkspaceInstanceUsage{
 					AttributionID: attrID,
@@ -115,8 +115,6 @@ func TestUsageService_ListBilledUsage(t *testing.T) {
 					},
 				})
 				instances = append(instances, instance)
-
-				instanceIDs = append(instanceIDs, instance.InstanceID.String())
 			}
 
 			return Scenario{
@@ -395,25 +393,20 @@ func TestReportGenerator_GenerateUsageReport(t *testing.T) {
 		dbtest.NewWorkspaceInstance(t, db.WorkspaceInstance{
 			ID:                 uuid.New(),
 			UsageAttributionID: db.NewTeamAttributionID(teamID.String()),
-			CreationTime:       db.NewVarcharTime(time.Date(2022, 05, 1, 00, 00, 00, 00, time.UTC)),
 			StartedTime:        db.NewVarcharTime(time.Date(2022, 05, 1, 00, 01, 00, 00, time.UTC)),
 			StoppingTime:       db.NewVarcharTime(time.Date(2022, 06, 1, 1, 0, 0, 0, time.UTC)),
-			StoppedTime:        db.NewVarcharTime(time.Date(2022, 06, 1, 1, 1, 0, 0, time.UTC)),
 		}),
 		// Still running
 		dbtest.NewWorkspaceInstance(t, db.WorkspaceInstance{
 			ID:                 uuid.New(),
 			UsageAttributionID: db.NewTeamAttributionID(teamID.String()),
-			CreationTime:       db.NewVarcharTime(time.Date(2022, 05, 30, 00, 00, 00, 00, time.UTC)),
 			StartedTime:        db.NewVarcharTime(time.Date(2022, 05, 30, 00, 01, 00, 00, time.UTC)),
 		}),
 		// No creation time, invalid record
 		dbtest.NewWorkspaceInstance(t, db.WorkspaceInstance{
 			ID:                 uuid.New(),
 			UsageAttributionID: db.NewTeamAttributionID(teamID.String()),
-			StartedTime:        db.NewVarcharTime(time.Date(2022, 06, 1, 1, 1, 0, 0, time.UTC)),
 			StoppingTime:       db.NewVarcharTime(time.Date(2022, 06, 1, 1, 0, 0, 0, time.UTC)),
-			StoppedTime:        db.NewVarcharTime(time.Date(2022, 06, 1, 1, 1, 0, 0, time.UTC)),
 		}),
 	}
 

--- a/components/usage/pkg/db/dbtest/usage.go
+++ b/components/usage/pkg/db/dbtest/usage.go
@@ -5,6 +5,7 @@
 package dbtest
 
 import (
+	"context"
 	"testing"
 
 	"github.com/gitpod-io/gitpod/usage/pkg/db"
@@ -67,8 +68,7 @@ func CreateUsageRecords(t *testing.T, conn *gorm.DB, entries ...db.Usage) []db.U
 		ids = append(ids, record.ID.String())
 	}
 
-	require.NoError(t, conn.CreateInBatches(&records, 1000).Error)
-
+	require.NoError(t, db.InsertUsage(context.Background(), conn, entries...))
 	t.Cleanup(func() {
 		require.NoError(t, conn.Where(ids).Delete(&db.Usage{}).Error)
 	})

--- a/components/usage/pkg/db/dbtest/workspace_instance.go
+++ b/components/usage/pkg/db/dbtest/workspace_instance.go
@@ -6,12 +6,13 @@ package dbtest
 
 import (
 	"database/sql"
+	"testing"
+	"time"
+
 	"github.com/gitpod-io/gitpod/usage/pkg/db"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	"gorm.io/gorm"
-	"testing"
-	"time"
 )
 
 var (
@@ -34,6 +35,8 @@ func NewWorkspaceInstance(t *testing.T, instance db.WorkspaceInstance) db.Worksp
 	creationTime := db.VarcharTime{}
 	if instance.CreationTime.IsSet() {
 		creationTime = instance.CreationTime
+	} else if instance.StartedTime.IsSet() {
+		creationTime = instance.StartedTime
 	}
 
 	startedTime := db.VarcharTime{}
@@ -49,6 +52,8 @@ func NewWorkspaceInstance(t *testing.T, instance db.WorkspaceInstance) db.Worksp
 	stoppedTime := db.VarcharTime{}
 	if instance.StoppedTime.IsSet() {
 		stoppedTime = instance.StoppedTime
+	} else if instance.StoppingTime.IsSet() {
+		creationTime = instance.StoppingTime
 	}
 
 	stoppingTime := db.VarcharTime{}


### PR DESCRIPTION
## Description
This PR adds ways to retrieve and store records from `d_b_usage` as well as functions to retrieve workspace instances to consider in a control loop.

The anticipated control loop would work as follows:

1) select drafts from `d_b_usage`
2) select workspaces instances where stopping is in a given time range (passed to the control loop)
3) select workspace instances where still running
4) select workspace instances where `workspaceInstanceId` exists in drafts
5) update usage for every instance that exists in drafts (might turn it into non-draft or not)
6) insert usage for all other instances (with do-nothing policy on conflict)

We could potentially combine 2,3,4 in one query but we should also allow for only running Step 2) to seed the past without considering running instances.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
