### PR TITLE
[usage] Invoke ReconcileUsageWithLedger from controller

### DIFF
--- a/components/usage/pkg/server/server.go
+++ b/components/usage/pkg/server/server.go
@@ -113,8 +113,9 @@ func Start(cfg Config) error {
 			return fmt.Errorf("failed to parse schedule duration: %w", err)
 		}
 
+		usageClient := v1.NewUsageServiceClient(selfConnection)
 		ctrl, err := controller.New(schedule, controller.NewUsageAndBillingReconciler(
-			v1.NewUsageServiceClient(selfConnection),
+			usageClient,
 			v1.NewBillingServiceClient(selfConnection),
 		))
 		if err != nil {
@@ -127,7 +128,7 @@ func Start(cfg Config) error {
 		}
 		defer ctrl.Stop()
 
-		ledgerCtrl, err := controller.New(schedule, &controller.LedgerReconciler{})
+		ledgerCtrl, err := controller.New(schedule, controller.NewLedgerReconciler(usageClient))
 		if err != nil {
 			return fmt.Errorf("failed to initialize ledger controller: %w", err)
 		}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Invokes the ReconcileUsageWithLedger RPC from the controller. Currently it considers the last hour for regular reconciliation.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
