### PR TITLE
[UBP] Fix negative credit value in usage calculations

### DIFF
--- a/components/usage/pkg/apiv1/usage_test.go
+++ b/components/usage/pkg/apiv1/usage_test.go
@@ -411,7 +411,7 @@ func TestReportGenerator_GenerateUsageReport(t *testing.T) {
 		dbtest.NewWorkspaceInstance(t, db.WorkspaceInstance{
 			ID:                 uuid.New(),
 			UsageAttributionID: db.NewTeamAttributionID(teamID.String()),
-			StartedTime:        db.NewVarcharTime(time.Date(2022, 06, 1, 1, 1, 0, 0, time.UTC)),
+			StartedTime:        db.NewVarcharTime(time.Date(2022, 05, 1, 00, 01, 00, 00, time.UTC)),
 			StoppingTime:       db.NewVarcharTime(time.Date(2022, 06, 1, 1, 0, 0, 0, time.UTC)),
 			StoppedTime:        db.NewVarcharTime(time.Date(2022, 06, 1, 1, 1, 0, 0, time.UTC)),
 		}),

--- a/components/usage/pkg/db/workspace_instance.go
+++ b/components/usage/pkg/db/workspace_instance.go
@@ -79,8 +79,8 @@ func ListWorkspaceInstancesInRange(ctx context.Context, conn *gorm.DB, from, to 
 		Where(
 			conn.Where("wsi.stoppingTime >= ?", TimeToISO8601(from)).Or("wsi.stoppingTime = ?", ""),
 		).
-		Where("wsi.creationTime < ?", TimeToISO8601(to)).
 		Where("wsi.startedTime != ?", "").
+		Where("wsi.startedTime < ?", TimeToISO8601(to)).
 		Where("wsi.usageAttributionId != ?", "").
 		FindInBatches(&instancesInBatch, 1000, func(_ *gorm.DB, _ int) error {
 			instances = append(instances, instancesInBatch...)


### PR DESCRIPTION
## Description

Fix the issue that causes some workspace instances to have negative credits in the usage view. We need to consider instances that *started* within a specified range rather than those that were created.

## Related Issue(s)
Part of https://github.com/gitpod-io/gitpod/issues/12064

## How to test

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation

## Werft options:
- [x] /werft with-preview
- [x] /werft with-payment
