### PR TITLE
[usage] Implement ledger control loop

### DIFF
--- a/components/usage/pkg/db/usage.go
+++ b/components/usage/pkg/db/usage.go
@@ -7,6 +7,7 @@ package db
 import (
 	"context"
 	"fmt"
+	"math"
 
 	"github.com/google/uuid"
 	"gorm.io/datatypes"
@@ -21,11 +22,22 @@ const (
 	InvoiceUsageKind                     = "invoice"
 )
 
+func NewCreditCents(n float64) CreditCents {
+	inCents := n * 100
+	return CreditCents(int64(math.Round(inCents)))
+}
+
+type CreditCents int64
+
+func (cc CreditCents) ToCredits() float64 {
+	return float64(cc) / 100
+}
+
 type Usage struct {
 	ID                  uuid.UUID      `gorm:"primary_key;column:id;type:char;size:36;" json:"id"`
 	AttributionID       AttributionID  `gorm:"column:attributionId;type:varchar;size:255;" json:"attributionId"`
 	Description         string         `gorm:"column:description;type:varchar;size:255;" json:"description"`
-	CreditCents         int64          `gorm:"column:creditCents;type:bigint;" json:"creditCents"`
+	CreditCents         CreditCents    `gorm:"column:creditCents;type:bigint;" json:"creditCents"`
 	EffectiveTime       VarcharTime    `gorm:"column:effectiveTime;type:varchar;size:255;" json:"effectiveTime"`
 	Kind                UsageKind      `gorm:"column:kind;type:char;size:10;" json:"kind"`
 	WorkspaceInstanceID uuid.UUID      `gorm:"column:workspaceInstanceId;type:char;size:36;" json:"workspaceInstanceId"`

--- a/components/usage/pkg/db/usage_test.go
+++ b/components/usage/pkg/db/usage_test.go
@@ -137,3 +137,61 @@ func TestFindAllDraftUsage(t *testing.T) {
 		require.True(t, usage.Draft)
 	}
 }
+
+func TestCreditCents(t *testing.T) {
+	for _, s := range []struct {
+		value           float64
+		expected        db.CreditCents
+		expectedAsFloat float64
+	}{
+		{
+			value:           0,
+			expected:        0,
+			expectedAsFloat: 0,
+		},
+		{
+			value:           0.1,
+			expected:        10,
+			expectedAsFloat: 0.1,
+		},
+		{
+			value:           1.1111,
+			expected:        111,
+			expectedAsFloat: 1.11,
+		},
+		{
+			value:           1.4999,
+			expected:        150,
+			expectedAsFloat: 1.50,
+		},
+		{
+			value:           1.500,
+			expected:        150,
+			expectedAsFloat: 1.50,
+		},
+		{
+			value:           1.501,
+			expected:        150,
+			expectedAsFloat: 1.50,
+		},
+		{
+			value:           1.50999,
+			expected:        151,
+			expectedAsFloat: 1.51,
+		},
+		{
+			value:           1.9999,
+			expected:        200,
+			expectedAsFloat: 2.00,
+		},
+		{
+			value:           -1.9999,
+			expected:        -200,
+			expectedAsFloat: -2.00,
+		},
+	} {
+		cc := db.NewCreditCents(s.value)
+		require.Equal(t, s.expected, cc)
+		require.Equal(t, s.expectedAsFloat, cc.ToCredits())
+	}
+}

--- a/components/usage/pkg/server/server.go
+++ b/components/usage/pkg/server/server.go
@@ -157,7 +157,7 @@ func Start(cfg Config) error {
 
 	reportGenerator := apiv1.NewReportGenerator(conn, pricer)
 
-	err = registerGRPCServices(srv, conn, stripeClient, reportGenerator, contentService, *cfg.BillInstancesAfter)
+	err = registerGRPCServices(srv, conn, stripeClient, reportGenerator, contentService, pricer, *cfg.BillInstancesAfter)
 	if err != nil {
 		return fmt.Errorf("failed to register gRPC services: %w", err)
 	}
@@ -180,8 +180,8 @@ func Start(cfg Config) error {
 	return nil
 }
 
-func registerGRPCServices(srv *baseserver.Server, conn *gorm.DB, stripeClient *stripe.Client, reportGenerator *apiv1.ReportGenerator, contentSvc contentservice.Interface, billInstancesAfter time.Time) error {
-	v1.RegisterUsageServiceServer(srv.GRPC(), apiv1.NewUsageService(conn, reportGenerator, contentSvc))
+func registerGRPCServices(srv *baseserver.Server, conn *gorm.DB, stripeClient *stripe.Client, reportGenerator *apiv1.ReportGenerator, contentSvc contentservice.Interface, pricer *apiv1.WorkspacePricer, billInstancesAfter time.Time) error {
+	v1.RegisterUsageServiceServer(srv.GRPC(), apiv1.NewUsageService(conn, reportGenerator, contentSvc, pricer))
 	if stripeClient == nil {
 		v1.RegisterBillingServiceServer(srv.GRPC(), &apiv1.BillingServiceNoop{})
 	} else {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Implement main ledger control loop.

Collects instances and usage records and splits them into inserts and updates. In this PR, the records are not yet persisted but are printed out for verification. Next PR will add persistence to these.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
Unit tests

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
