### PR TITLE
Cronjob that creates artificial traffic for new preview environments jobs.

### DIFF
--- a/.werft/platform-trigger-artificial-job.sh
+++ b/.werft/platform-trigger-artificial-job.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+#
+# The easiest way to run this script is through Werft so you don't have to worry
+# about installing the appropraite service account etc. locally.
+#
+#   werft job run github -j .werft/platform-trigger-artificial-job.yaml -s .werft/platform-trigger-artificial-job.sh
+#
+
+sleep 1
+
+set -Eeuo pipefail
+
+werft log phase "Trigger new job with-preview" "Trigger new job with preview environment"
+sudo chown -R gitpod:gitpod /workspace
+git config --global user.name roboquat
+git config --global user.email roboquat@gitpod.io
+
+git checkout -b "platform-artificial-job-$(echo $RANDOM | md5sum | head -c 20; echo;)"
+
+werft run github -a with-preview=true

--- a/.werft/platform-trigger-artificial-job.yaml
+++ b/.werft/platform-trigger-artificial-job.yaml
@@ -45,4 +45,4 @@ pod:
         - .werft/platform-trigger-artificial-job.sh
 
 plugins:
-  cron: "15 */4 * * *"
+  cron: "*/30 * * * *" # Every 30 minutes

--- a/.werft/platform-trigger-artificial-job.yaml
+++ b/.werft/platform-trigger-artificial-job.yaml
@@ -1,0 +1,48 @@
+# This job is responsible for periodically start a new werft job that spins up
+# a preview environment. It is needed to create artificial traffic for the
+# Preview Environment starts SLO. It will help us to be more proactive
+# to identify failures in the pipeline.
+#
+#   werft job run github -j .werft/platform-trigger-artificial-job.yaml
+#
+pod:
+  serviceAccount: werft
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: dev/workload
+                operator: In
+                values:
+                  - "builds"
+  volumes:
+    - name: github-token-gitpod-bot
+      secret:
+        defaultMode: 420
+        secretName: github-token-gitpod-bot
+  containers:
+    - name: build
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-dl.1
+      workingDir: /workspace
+      imagePullPolicy: IfNotPresent
+      volumeMounts:
+        - mountPath: /mnt/secrets/github-token-gitpod-bot
+          name: github-token-gitpod-bot
+      env:
+        - name: ROBOQUAT_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: github-roboquat-automatic-changelog
+              key: token
+        # Used by the Werft CLI through werft-credential-helper.sh
+        - name: WERFT_GITHUB_TOKEN_PATH
+          value: "/mnt/secrets/github-token-gitpod-bot/token"
+        - name: WERFT_CREDENTIAL_HELPER
+          value: "/workspace/dev/preview/werft-credential-helper.sh"
+      command:
+        - bash
+        - .werft/platform-trigger-artificial-job.sh
+
+plugins:
+  cron: "15 */4 * * *"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Once ready, this PR will create a cronjob that triggers new werft jobs which, in their turn, will create new preview environments.

The final goal is that we get a little more traffic for new preview environments, so we can be more proactive when they start failing.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
