### PR TITLE
Reword "Spending Limit" to "Usage Limit"

### DIFF
--- a/components/dashboard/src/start/CreateWorkspace.tsx
+++ b/components/dashboard/src/start/CreateWorkspace.tsx
@@ -205,7 +205,7 @@ export default class CreateWorkspace extends React.Component<CreateWorkspaceProp
                 case ErrorCodes.PAYMENT_SPENDING_LIMIT_REACHED:
                     error = undefined; // to hide the error (otherwise rendered behind the modal)
                     phase = StartPhase.Stopped;
-                    statusMessage = <SpendingLimitReachedModal hints={this.state?.error?.data} />;
+                    statusMessage = <UsageLimitReachedModal hints={this.state?.error?.data} />;
                     break;
                 default:
                     statusMessage = (
@@ -366,7 +366,7 @@ function LimitReachedOutOfHours() {
         </LimitReachedModal>
     );
 }
-function SpendingLimitReachedModal(p: { hints: any }) {
+function UsageLimitReachedModal(p: { hints: any }) {
     const { teams } = useContext(TeamsContext);
     // const [attributionId, setAttributionId] = useState<AttributionId | undefined>();
     const [attributedTeam, setAttributedTeam] = useState<Team | undefined>();
@@ -390,7 +390,7 @@ function SpendingLimitReachedModal(p: { hints: any }) {
             </h3>
             <div className="border-t border-b border-gray-200 dark:border-gray-800 mt-4 -mx-6 px-6 py-6">
                 <Alert type="error" className="app-container rounded-md">
-                    You have reached the <strong>spending limit</strong> of your billing account.
+                    You have reached the <strong>usage limit</strong> of your billing account.
                 </Alert>
                 <p className="mt-3 text-base text-gray-600 dark:text-gray-300">
                     {"Contact a team owner "}
@@ -399,7 +399,7 @@ function SpendingLimitReachedModal(p: { hints: any }) {
                             of <strong>{attributedTeamName} </strong>
                         </>
                     )}
-                    to increase the spending limit, or change your <a href="/billing">billing settings</a>.
+                    to increase the usage limit, or change your <a href="/billing">billing settings</a>.
                 </p>
             </div>
             <div className="flex justify-end mt-6 space-x-2">

--- a/components/dashboard/src/teams/TeamUsageBasedBilling.tsx
+++ b/components/dashboard/src/teams/TeamUsageBasedBilling.tsx
@@ -31,7 +31,7 @@ export default function TeamUsageBasedBilling() {
     const [pollStripeSubscriptionTimeout, setPollStripeSubscriptionTimeout] = useState<NodeJS.Timeout | undefined>();
     const [stripePortalUrl, setStripePortalUrl] = useState<string | undefined>();
     const [showUpdateLimitModal, setShowUpdateLimitModal] = useState<boolean>(false);
-    const [spendingLimit, setSpendingLimit] = useState<number | undefined>();
+    const [usageLimit, setUsageLimit] = useState<number | undefined>();
 
     useEffect(() => {
         if (!team) {
@@ -62,10 +62,10 @@ export default function TeamUsageBasedBilling() {
         (async () => {
             const [portalUrl, spendingLimit] = await Promise.all([
                 getGitpodService().server.getStripePortalUrlForTeam(team.id),
-                getGitpodService().server.getSpendingLimitForTeam(team.id),
+                getGitpodService().server.getUsageLimitForTeam(team.id),
             ]);
             setStripePortalUrl(portalUrl);
-            setSpendingLimit(spendingLimit);
+            setUsageLimit(spendingLimit);
         })();
     }, [team, stripeSubscriptionId]);
 
@@ -155,14 +155,14 @@ export default function TeamUsageBasedBilling() {
         if (!team) {
             return;
         }
-        const oldLimit = spendingLimit;
-        setSpendingLimit(newLimit);
+        const oldLimit = usageLimit;
+        setUsageLimit(newLimit);
         try {
-            await getGitpodService().server.setSpendingLimitForTeam(team.id, newLimit);
+            await getGitpodService().server.setUsageLimitForTeam(team.id, newLimit);
         } catch (error) {
-            setSpendingLimit(oldLimit);
+            setUsageLimit(oldLimit);
             console.error(error);
-            alert(error?.message || "Failed to update spending limit. See console for error message.");
+            alert(error?.message || "Failed to update usage limit. See console for error message.");
         }
         setShowUpdateLimitModal(false);
     };
@@ -170,7 +170,7 @@ export default function TeamUsageBasedBilling() {
     return (
         <div className="mb-16">
             <h3>Usage-Based Billing</h3>
-            <h2 className="text-gray-500">Manage usage-based billing, spending limit, and payment method.</h2>
+            <h2 className="text-gray-500">Manage usage-based billing, usage limit, and payment method.</h2>
             <div className="max-w-xl flex flex-col">
                 {showSpinner && (
                     <div className="flex flex-col mt-4 h-32 p-4 rounded-xl bg-gray-100 dark:bg-gray-800">
@@ -202,10 +202,10 @@ export default function TeamUsageBasedBilling() {
                         </div>
                         <div className="flex flex-col w-72 mt-4 h-32 p-4 rounded-xl bg-gray-100 dark:bg-gray-800">
                             <div className="uppercase text-sm text-gray-400 dark:text-gray-500">
-                                Spending Limit (Credits)
+                                Usage Limit (Credits)
                             </div>
                             <div className="text-xl font-semibold flex-grow text-gray-600 dark:text-gray-400">
-                                {spendingLimit || "–"}
+                                {usageLimit || "–"}
                             </div>
                             <button className="self-end" onClick={() => setShowUpdateLimitModal(true)}>
                                 Update Limit
@@ -219,7 +219,7 @@ export default function TeamUsageBasedBilling() {
             )}
             {showUpdateLimitModal && (
                 <UpdateLimitModal
-                    currentValue={spendingLimit}
+                    currentValue={usageLimit}
                     onClose={() => setShowUpdateLimitModal(false)}
                     onUpdate={(newLimit) => doUpdateLimit(newLimit)}
                 />
@@ -245,9 +245,9 @@ function UpdateLimitModal(props: {
 
     return (
         <Modal visible={true} onClose={props.onClose}>
-            <h3 className="flex">Update Spending Limit</h3>
+            <h3 className="flex">Usage Limit</h3>
             <div className="border-t border-b border-gray-200 dark:border-gray-800 -mx-6 px-6 py-4 flex flex-col">
-                <p className="pb-4 text-gray-500 text-base">Set spending limit in total credits per month.</p>
+                <p className="pb-4 text-gray-500 text-base">Set usage limit in total credits per month.</p>
 
                 <label className="font-medium">
                     Credits

--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -294,8 +294,8 @@ export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, 
     createOrUpdateStripeCustomerForTeam(teamId: string, currency: string): Promise<void>;
     subscribeTeamToStripe(teamId: string, setupIntentId: string): Promise<void>;
     getStripePortalUrlForTeam(teamId: string): Promise<string>;
-    getSpendingLimitForTeam(teamId: string): Promise<number | undefined>;
-    setSpendingLimitForTeam(teamId: string, spendingLimit: number): Promise<void>;
+    getUsageLimitForTeam(teamId: string): Promise<number | undefined>;
+    setUsageLimitForTeam(teamId: string, spendingLimit: number): Promise<void>;
 
     listBilledUsage(req: ListBilledUsageRequest): Promise<ListBilledUsageResponse>;
     listUsage(req: ListUsageRequest): Promise<ListUsageResponse>;

--- a/components/server/ee/src/billing/billing-service.ts
+++ b/components/server/ee/src/billing/billing-service.ts
@@ -16,7 +16,7 @@ import {
 import { inject, injectable } from "inversify";
 import { UserService } from "../../../src/user/user-service";
 
-export interface SpendingLimitReachedResult {
+export interface UsageLimitReachedResult {
     reached: boolean;
     almostReached?: boolean;
     attributionId: AttributionId;
@@ -31,7 +31,7 @@ export class BillingService {
     @inject(CachingBillingServiceClientProvider)
     protected readonly billingServiceClientProvider: CachingBillingServiceClientProvider;
 
-    async checkSpendingLimitReached(user: User): Promise<SpendingLimitReachedResult> {
+    async checkUsageLimitReached(user: User): Promise<UsageLimitReachedResult> {
         const attributionId = await this.userService.getWorkspaceUsageAttributionId(user);
         const costCenter = await this.costCenterDB.findById(AttributionId.render(attributionId));
         if (!costCenter) {
@@ -47,20 +47,20 @@ export class BillingService {
         const upcomingInvoice = await this.getUpcomingInvoice(attributionId);
         const currentInvoiceCredits = upcomingInvoice.getCredits();
         if (currentInvoiceCredits >= costCenter.spendingLimit) {
-            log.info({ userId: user.id }, "Spending limit reached", {
+            log.info({ userId: user.id }, "Usage limit reached", {
                 attributionId,
                 currentInvoiceCredits,
-                spendingLimit: costCenter.spendingLimit,
+                usageLimit: costCenter.spendingLimit,
             });
             return {
                 reached: true,
                 attributionId,
             };
         } else if (currentInvoiceCredits > costCenter.spendingLimit * 0.8) {
-            log.info({ userId: user.id }, "Spending limit almost reached", {
+            log.info({ userId: user.id }, "Usage limit almost reached", {
                 attributionId,
                 currentInvoiceCredits,
-                spendingLimit: costCenter.spendingLimit,
+                usageLimit: costCenter.spendingLimit,
             });
             return {
                 reached: false,

--- a/components/server/ee/src/billing/entitlement-service-ubp.ts
+++ b/components/server/ee/src/billing/entitlement-service-ubp.ts
@@ -57,18 +57,18 @@ export class EntitlementServiceUBP implements EntitlementService {
                 return undefined;
             }
         };
-        const [spendingLimitReachedOnCostCenter, hitParallelWorkspaceLimit] = await Promise.all([
-            this.checkSpendingLimitReached(user, date),
+        const [usageLimitReachedOnCostCenter, hitParallelWorkspaceLimit] = await Promise.all([
+            this.checkUsageLimitReached(user, date),
             hasHitParallelWorkspaceLimit(),
         ]);
         return {
-            spendingLimitReachedOnCostCenter,
+            usageLimitReachedOnCostCenter: usageLimitReachedOnCostCenter,
             hitParallelWorkspaceLimit,
         };
     }
 
-    protected async checkSpendingLimitReached(user: User, date: Date): Promise<AttributionId | undefined> {
-        const result = await this.billingService.checkSpendingLimitReached(user);
+    protected async checkUsageLimitReached(user: User, date: Date): Promise<AttributionId | undefined> {
+        const result = await this.billingService.checkUsageLimitReached(user);
         if (result.reached) {
             return result.attributionId;
         }

--- a/components/server/src/auth/rate-limiter.ts
+++ b/components/server/src/auth/rate-limiter.ts
@@ -220,8 +220,8 @@ const defaultFunctions: FunctionsConfig = {
     getIDEOptions: { group: "default", points: 1 },
     getPrebuildEvents: { group: "default", points: 1 },
     setUsageAttribution: { group: "default", points: 1 },
-    getSpendingLimitForTeam: { group: "default", points: 1 },
-    setSpendingLimitForTeam: { group: "default", points: 1 },
+    getUsageLimitForTeam: { group: "default", points: 1 },
+    setUsageLimitForTeam: { group: "default", points: 1 },
     getNotifications: { group: "default", points: 1 },
     getSupportedWorkspaceClasses: { group: "default", points: 1 },
 };

--- a/components/server/src/billing/entitlement-service.ts
+++ b/components/server/src/billing/entitlement-service.ts
@@ -19,8 +19,8 @@ export interface MayStartWorkspaceResult {
 
     needsVerification?: boolean;
 
-    /** Usage-Based Pricing: AttributionId of the CostCenter that reached it's spending limit */
-    spendingLimitReachedOnCostCenter?: AttributionId;
+    /** Usage-Based Pricing: AttributionId of the CostCenter that reached it's usage limit */
+    usageLimitReachedOnCostCenter?: AttributionId;
 }
 
 export interface HitParallelWorkspaceLimit {

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -3241,10 +3241,10 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         throw new ResponseError(ErrorCodes.SAAS_FEATURE, `Not implemented in this version`);
     }
 
-    async getSpendingLimitForTeam(ctx: TraceContext, teamId: string): Promise<number | undefined> {
+    async getUsageLimitForTeam(ctx: TraceContext, teamId: string): Promise<number | undefined> {
         throw new ResponseError(ErrorCodes.SAAS_FEATURE, `Not implemented in this version`);
     }
-    async setSpendingLimitForTeam(ctx: TraceContext, teamId: string, spendingLimit: number): Promise<void> {
+    async setUsageLimitForTeam(ctx: TraceContext, teamId: string, spendingLimit: number): Promise<void> {
         throw new ResponseError(ErrorCodes.SAAS_FEATURE, `Not implemented in this version`);
     }
 


### PR DESCRIPTION
## Description
This PR relabels the usage limit checks in the UI.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #12637

## How to test
Check the sites described in https://github.com/gitpod-io/gitpod/issues/12637

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Reword "Spending Limit" to "Usage Limit"
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
- [x] /werft with-payment
