### PR TITLE
Update App Notifications

### DIFF
--- a/components/dashboard/src/AppNotifications.tsx
+++ b/components/dashboard/src/AppNotifications.tsx
@@ -78,7 +78,7 @@ function setLocalStorageObject(key: string, object: Object, expiresInSeconds: nu
     try {
         window.localStorage.setItem(
             key,
-            JSON.stringify({ expirationTime: Date.now() + expiresInSeconds * (1000 * 60), value: object }),
+            JSON.stringify({ expirationTime: Date.now() + expiresInSeconds * 1000, value: object }),
         );
     } catch (error) {
         console.error("Setting localstorage item failed", key, object, error);

--- a/components/dashboard/src/AppNotifications.tsx
+++ b/components/dashboard/src/AppNotifications.tsx
@@ -19,14 +19,21 @@ export function AppNotifications() {
             setNotifications(localState);
             return;
         }
-        (async () => {
-            const serverState = await getGitpodService().server.getNotifications();
-            setNotifications(serverState);
-            if (serverState.length > 0) {
-                setLocalStorageObject(KEY_APP_NOTIFICATIONS, serverState, /* expires in */ 60 /* seconds */);
-            }
-        })();
+        reloadNotifications().catch(console.error);
+
+        getGitpodService().registerClient({
+            onNotificationUpdated: () => reloadNotifications().catch(console.error),
+        });
     }, []);
+
+    const reloadNotifications = async () => {
+        const serverState = await getGitpodService().server.getNotifications();
+        setNotifications(serverState);
+        removeLocalStorageObject(KEY_APP_NOTIFICATIONS);
+        if (serverState.length > 0) {
+            setLocalStorageObject(KEY_APP_NOTIFICATIONS, serverState, /* expires in */ 300 /* seconds */);
+        }
+    };
 
     const topNotification = notifications[0];
     if (topNotification === undefined) {

--- a/components/gitpod-messagebus/src/messagebus.ts
+++ b/components/gitpod-messagebus/src/messagebus.ts
@@ -61,6 +61,8 @@ export interface MessageBusHelper {
      * @param topic the topic to parse
      */
     getWsInformationFromTopic(topic: string): WorkspaceTopic | undefined;
+
+    getSubscriptionUpdateTopic(attributionId?: string): string;
 }
 
 export const WorkspaceTopic = Symbol("WorkspaceTopic");
@@ -87,6 +89,10 @@ export class MessageBusHelperImpl implements MessageBusHelper {
      */
     async assertWorkspaceExchange(ch: Channel): Promise<void> {
         await ch.assertExchange(this.workspaceExchange, "topic", { durable: true });
+    }
+
+    getSubscriptionUpdateTopic(attributionId: string | undefined): string {
+        return `subscription.${attributionId || "*"}.update`;
     }
 
     /**

--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -70,6 +70,8 @@ export interface GitpodClient {
 
     onPrebuildUpdate(update: PrebuildWithStatus): void;
 
+    onNotificationUpdated(): void;
+
     onCreditAlert(creditAlert: CreditAlert): void;
 
     //#region propagating reconnection to iframe
@@ -564,6 +566,18 @@ export class GitpodCompositeClient<Client extends GitpodClient> implements Gitpo
             if (client.onCreditAlert) {
                 try {
                     client.onCreditAlert(creditAlert);
+                } catch (error) {
+                    console.error(error);
+                }
+            }
+        }
+    }
+
+    onNotificationUpdated(): void {
+        for (const client of this.clients) {
+            if (client.onNotificationUpdated) {
+                try {
+                    client.onNotificationUpdated();
                 } catch (error) {
                     console.error(error);
                 }


### PR DESCRIPTION
## Description
Dismiss Usage Limit notifications automatically on resolution, e.g. on increase of Usage Limit.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #12547

## How to test
* Have 2 accounts on a team with UB enabled.
* Decrease usage limit and drive into the limit notification. 
* Increase the spending limit on one account.
* See the notification is dismissed for both accounts.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Dismiss Usage Limit notifications automatically.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
- [x] /werft with-payment
