### PR TITLE
[dashboard] Use new usage API for team-usage

### DIFF
--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -2194,7 +2194,7 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
         const timestampTo = to ? Timestamp.fromDate(new Date(to)) : undefined;
 
         const usageClient = this.usageServiceClientProvider.getDefault();
-        const request = new usage_grpc.ListBilledUsageRequest();
+        const request = new usage_grpc.ListUsageRequest();
         request.setAttributionId(attributionId);
         request.setFrom(timestampFrom);
         if (to) {

--- a/components/usage/pkg/db/dbtest/usage.go
+++ b/components/usage/pkg/db/dbtest/usage.go
@@ -70,7 +70,9 @@ func CreateUsageRecords(t *testing.T, conn *gorm.DB, entries ...db.Usage) []db.U
 
 	require.NoError(t, db.InsertUsage(context.Background(), conn, entries...))
 	t.Cleanup(func() {
-		require.NoError(t, conn.Where(ids).Delete(&db.Usage{}).Error)
+		if len(ids) > 0 {
+			require.NoError(t, conn.Where(ids).Delete(&db.Usage{}).Error)
+		}
 	})
 
 	return records

--- a/components/usage/pkg/db/usage_test.go
+++ b/components/usage/pkg/db/usage_test.go
@@ -53,7 +53,7 @@ func TestFindUsageInRange(t *testing.T) {
 	require.Equal(t, []db.Usage{entryInside}, listResult)
 }
 
-func TestFindUsageMetadata(t *testing.T) {
+func TestGetUsageSummary(t *testing.T) {
 	conn := dbtest.ConnectForTests(t)
 
 	start := time.Date(2022, 7, 1, 0, 0, 0, 0, time.UTC)
@@ -140,7 +140,7 @@ func TestInsertUsageRecords(t *testing.T) {
 	updatedDesc := "Updated Description"
 	usage.Description = updatedDesc
 
-	dbtest.CreateUsageRecords(t, conn, usage)
+	require.NoError(t, db.InsertUsage(context.Background(), conn, usage))
 
 	drafts, err := db.FindAllDraftUsage(context.Background(), conn)
 	require.NoError(t, err)
@@ -299,7 +299,6 @@ func TestListBalance(t *testing.T) {
 
 	balances, err := db.ListBalance(context.Background(), conn)
 	require.NoError(t, err)
-	require.Len(t, balances, 2)
 	require.Contains(t, balances, db.Balance{
 		AttributionID: teamAttributionID,
 		CreditCents:   1000,

--- a/components/usage/pkg/db/workspace_instance_test.go
+++ b/components/usage/pkg/db/workspace_instance_test.go
@@ -97,6 +97,19 @@ func TestFindStoppedWorkspaceInstancesInRange(t *testing.T) {
 	require.Len(t, retrieved, len(valid))
 }
 
+func filterByWorkspaceIds(toBeFiltered []db.WorkspaceInstanceForUsage, wsid ...string) []db.WorkspaceInstanceForUsage {
+	result := []db.WorkspaceInstanceForUsage{}
+	// filter out all workspaces that don't belong to this test
+	for _, id := range wsid {
+		for _, wsi := range toBeFiltered {
+			if wsi.WorkspaceID == id {
+				result = append(result, wsi)
+			}
+		}
+	}
+	return result
+}
+
 func TestListWorkspaceInstancesInRange_Fields(t *testing.T) {
 
 	t.Run("no project results in empty string", func(t *testing.T) {
@@ -115,7 +128,9 @@ func TestListWorkspaceInstancesInRange_Fields(t *testing.T) {
 
 		retrieved := dbtest.ListWorkspaceInstancesInRange(t, conn, startOfMay, startOfJune, workspace.ID)
 
-		require.Len(t, retrieved, 1)
+		cleaned := filterByWorkspaceIds(retrieved, workspace.ID)
+
+		require.Len(t, cleaned, 1)
 		require.Equal(t, db.WorkspaceInstanceForUsage{
 			ID:                 instance.ID,
 			WorkspaceID:        instance.WorkspaceID,
@@ -130,7 +145,7 @@ func TestListWorkspaceInstancesInRange_Fields(t *testing.T) {
 			UserAvatarURL:      user.AvatarURL,
 			StartedTime:        instance.StartedTime,
 			StoppingTime:       instance.StoppingTime,
-		}, retrieved[0])
+		}, cleaned[0])
 	})
 
 	t.Run("with project", func(t *testing.T) {


### PR DESCRIPTION
## Description
Connects the team usage view with the new usage API.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
 - [join our team](https://se-usage-view.preview.gitpod-dev.com/teams/join?inviteId=8509ec09-164c-4b63-8ef9-1282d640816d)
  - [check usage page ](https://se-usage-view.preview.gitpod-dev.com/t/gitpod/usage)


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
- [x] /werft with-payment