### PR TITLE
[installer]: create config command and deprecate init command

### DIFF
--- a/.werft/jobs/build/installer/installer.ts
+++ b/.werft/jobs/build/installer/installer.ts
@@ -52,7 +52,7 @@ export class Installer {
             { slice: slice },
         );
         exec(`chmod +x /tmp/installer`, { slice: slice });
-        exec(`/tmp/installer init > ${this.options.installerConfigPath}`, { slice: slice });
+        exec(`/tmp/installer config init --overwrite --config ${this.options.installerConfigPath}`, { slice: slice });
         this.options.werft.done(slice);
     }
 

--- a/install/installer/.gitignore
+++ b/install/installer/.gitignore
@@ -2,3 +2,4 @@ installer
 dist
 versions.yaml
 !cmd/testdata/render/versions.yaml
+gitpod.config.yaml

--- a/install/installer/README.md
+++ b/install/installer/README.md
@@ -77,7 +77,7 @@ gitpod-installer version
 ## Generate the base config
 
 ```shell
-gitpod-installer init > gitpod.config.yaml
+gitpod-installer config init -c gitpod.config.yaml
 ```
 
 ## Customise your config

--- a/install/installer/cmd/config.go
+++ b/install/installer/cmd/config.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
+package cmd
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+
+	"github.com/gitpod-io/gitpod/common-go/log"
+	"github.com/gitpod-io/gitpod/installer/pkg/config"
+	"github.com/spf13/cobra"
+	"k8s.io/utils/pointer"
+)
+
+var configOpts struct {
+	ConfigFile string
+}
+
+// configCmd represents the validate command
+var configCmd = &cobra.Command{
+	Use:   "config",
+	Short: "Perform configuration tasks",
+}
+
+// configFileExists checks if the configuration file is present on disk
+func configFileExists() (*bool, error) {
+	if _, err := os.Stat(configOpts.ConfigFile); err == nil {
+		return pointer.Bool(true), nil
+	} else if errors.Is(err, os.ErrNotExist) {
+		return pointer.Bool(false), nil
+	} else {
+		return nil, err
+	}
+}
+
+// saveConfigFile converts the config to YAML and saves to disk
+func saveConfigFile(cfg interface{}) error {
+	fc, err := config.Marshal(config.CurrentVersion, cfg)
+	if err != nil {
+		return err
+	}
+
+	err = os.WriteFile(configOpts.ConfigFile, fc, 0644)
+	if err != nil {
+		return err
+	}
+
+	log.Infof("File written to %s", configOpts.ConfigFile)
+
+	return nil
+}
+
+func init() {
+	rootCmd.AddCommand(configCmd)
+
+	dir, err := os.Getwd()
+	if err != nil {
+		log.WithError(err).Fatal("Failed to get working directory")
+	}
+
+	configCmd.PersistentFlags().StringVarP(&configOpts.ConfigFile, "config", "c", getEnvvar("CONFIG_FILE", filepath.Join(dir, "gitpod.config.yaml")), "path to the configuration file")
+}

--- a/install/installer/cmd/config_init.go
+++ b/install/installer/cmd/config_init.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/gitpod-io/gitpod/installer/pkg/config"
+	"github.com/spf13/cobra"
+)
+
+var configInitOpts struct {
+	OverwriteConfig bool
+}
+
+// configInitCmd represents the validate command
+var configInitCmd = &cobra.Command{
+	Use:   "init",
+	Short: "Create a base config file",
+	Long: `Create a base config file
+
+This file contains all the credentials to install a Gitpod instance and
+be saved to a repository.`,
+	Example: `  # Save config to config.yaml.
+gitpod-installer config init -c ./gitpod.config.yaml`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		// Check file isn't present
+		exists, err := configFileExists()
+		if err != nil {
+			return err
+		}
+		if *exists && !configInitOpts.OverwriteConfig {
+			return fmt.Errorf("file %s exists - to overwrite add --overwrite flag", configOpts.ConfigFile)
+		}
+
+		cfg, err := config.NewDefaultConfig()
+		if err != nil {
+			return err
+		}
+
+		return saveConfigFile(cfg)
+	},
+}
+
+func init() {
+	configCmd.AddCommand(configInitCmd)
+
+	configInitCmd.Flags().BoolVar(&configInitOpts.OverwriteConfig, "overwrite", false, "overwrite config file if it exists")
+}

--- a/install/installer/cmd/init.go
+++ b/install/installer/cmd/init.go
@@ -13,8 +13,9 @@ import (
 
 // initCmd represents the init command
 var initCmd = &cobra.Command{
-	Use:   "init",
-	Short: "Create a base config file",
+	Use:        "init",
+	Deprecated: `use "config init" command instead`,
+	Short:      "Create a base config file",
 	Long: `Create a base config file
 
 This file contains all the credentials to install a Gitpod instance and

--- a/install/installer/cmd/root.go
+++ b/install/installer/cmd/root.go
@@ -71,3 +71,11 @@ func checkKubeConfig(kube *kubeConfig) error {
 
 	return nil
 }
+
+// getEnvvar gets an envvar and allows a default value
+func getEnvvar(key, fallback string) string {
+	if value, ok := os.LookupEnv(key); ok {
+		return value
+	}
+	return fallback
+}

--- a/install/installer/cmd/root.go
+++ b/install/installer/cmd/root.go
@@ -12,7 +12,9 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/gitpod-io/gitpod/common-go/log"
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -30,13 +32,24 @@ var rootOpts struct {
 	VersionMF         string
 	StrictConfigParse bool
 	SeedValue         int64
+	LogLevel          string
 }
 
 func init() {
-	cobra.OnInitialize(setSeed)
+	cobra.OnInitialize(setSeed, setLogLevel)
 	rootCmd.PersistentFlags().StringVar(&rootOpts.VersionMF, "debug-version-file", "", "path to a version manifest - not intended for production use")
 	rootCmd.PersistentFlags().Int64Var(&rootOpts.SeedValue, "seed", 0, "specify the seed value for randomization - if 0 it is kept as the default")
 	rootCmd.PersistentFlags().BoolVar(&rootOpts.StrictConfigParse, "strict-parse", true, "toggle strict configuration parsing")
+	rootCmd.PersistentFlags().StringVar(&rootOpts.LogLevel, "log-level", "info", "set the log level")
+}
+
+func setLogLevel() {
+	newLevel, err := logrus.ParseLevel(rootOpts.LogLevel)
+	if err != nil {
+		log.WithError(err).Errorf("cannot change log level to '%v'", rootOpts.LogLevel)
+		return
+	}
+	log.Log.Logger.SetLevel(newLevel)
 }
 
 func setSeed() {

--- a/install/installer/example-config.yaml
+++ b/install/installer/example-config.yaml
@@ -8,6 +8,7 @@ certificate:
   name: https-certificates
 containerRegistry:
   inCluster: true
+  privateBaseImageAllowList: []
 database:
   inCluster: true
 disableDefinitelyGp: true


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Create a `config init` command and deprecate the `init` command.

The two commands are functionally identical, with the exception of the new command saving the file for you (the previous command just printed the output).

This is part of a major refactoring of the configuration so that it's simpler and just config generation. See #12319 for my notepad of how it'll look eventually.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #12678
Fixes #12847

## How to test
<!-- Provide steps to test this PR -->
Run `go run . config init` and check `gitpod.config.yaml`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[installer]: create config command and deprecate init command
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
