### PR TITLE
[supervisor] track cpu/memory usage analytics

### DIFF
--- a/components/supervisor/README.md
+++ b/components/supervisor/README.md
@@ -1,0 +1,4 @@
+### Hot deployment
+
+Run `./hot-deploy.sh` to build and publish the supervisor image from your dev workspace and
+update the IDE config map in a preview environment. After that start a new workspace in preview environment to try your changes.


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This PR adds analytics to track cpu and memory consumption by individual workspace instances. It adds 2 new events `gitpod_cpu_changed` and `gitpod_memory_changed` correspondingly. Each event has `buckets` property and reported whenever a workspace instance hit higher bucket.
- CPU buckets: 1, 2, 3, 4, 5, 6 CPUs
- Memory buckets: 1, 2, 4, 8, 16 Gb

It will allow us to segment users by perf requirements and also correlate with other event like active language to see requirements from different languages. Mixpanel is capable to breakdown arrays to individual properties. I've verified it with IDE lab project.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

- Start a workspace in prev env: https://ak-perf-anayltics.preview.gitpod-dev.com/#https://github.com/akosyakov/parcel-demo
- Inspect `gitpod_cpu_changed` and `gitpod_memory_changed` events in segment untrusted. I would recommend to filter by instance id. Whenever perf metrics hit a higher bucket you should see a change. If it goes down though we don't report changes.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
- [x] /werft analytics=segment|TEZnsG4QbLSxLfHfNieLYGF4cDwyFWoe
