### PR TITLE
[installer]: config detects shiftfs and containerd values

### DIFF
--- a/install/installer/cmd/config.go
+++ b/install/installer/cmd/config.go
@@ -5,6 +5,7 @@ package cmd
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -33,6 +34,19 @@ func configFileExists() (*bool, error) {
 	} else {
 		return nil, err
 	}
+}
+
+// configFileExistsAndInit checks if the config file exists, if not it returns a "run config init" error
+func configFileExistsAndInit() (*bool, error) {
+	// Check file is present
+	exists, err := configFileExists()
+	if err != nil {
+		return nil, err
+	}
+	if !*exists {
+		return nil, fmt.Errorf(`file %s does not exist - please run "config init"`, configOpts.ConfigFile)
+	}
+	return exists, nil
 }
 
 // saveConfigFile converts the config to YAML and saves to disk

--- a/install/installer/cmd/config_cluster.go
+++ b/install/installer/cmd/config_cluster.go
@@ -1,0 +1,93 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
+package cmd
+
+import (
+	"context"
+	"path/filepath"
+
+	"github.com/gitpod-io/gitpod/common-go/log"
+	"github.com/spf13/cobra"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/util/homedir"
+)
+
+var configClusterOpts struct {
+	Kube            kubeConfig
+	Namespace       string
+	EnsureNamespace bool
+}
+
+// configClusterCmd represents the validate command
+var configClusterCmd = &cobra.Command{
+	Use:   "cluster",
+	Short: "Perform configuration tasks against the cluster",
+	Long: `Perform configuration tasks against the cluster
+
+These will be deployed and run as Kubernetes resources.`,
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		log.Debugf("EnsureNamespace: %t", configClusterOpts.EnsureNamespace)
+
+		if !configClusterOpts.EnsureNamespace {
+			return nil
+		}
+
+		log.Infof("Ensuring namespace exists %s", configClusterOpts.Namespace)
+		_, clientset, err := authClusterOrKubeconfig(configClusterOpts.Kube.Config)
+		if err != nil {
+			return err
+		}
+
+		_, err = clientset.CoreV1().Namespaces().Create(
+			context.TODO(),
+			&v1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: configClusterOpts.Namespace,
+				},
+			},
+			metav1.CreateOptions{},
+		)
+
+		if errors.IsAlreadyExists(err) {
+			log.Debug("Namespace already exists")
+			return nil
+		}
+
+		return err
+	},
+}
+
+func init() {
+	configCmd.AddCommand(configClusterCmd)
+
+	configClusterCmd.Flags().StringVar(&configClusterOpts.Kube.Config, "kubeconfig", filepath.Join(homedir.HomeDir(), ".kube", "config"), "path to the kubeconfig file")
+	configClusterCmd.PersistentFlags().StringVarP(&configClusterOpts.Namespace, "namespace", "n", getEnvvar("NAMESPACE", "default"), "namespace to deploy to")
+	configClusterCmd.PersistentFlags().BoolVar(&configClusterOpts.EnsureNamespace, "ensure-namespace", true, "ensure that the namespace exists")
+}
+
+func authClusterOrKubeconfig(kubeconfig string) (*rest.Config, *kubernetes.Clientset, error) {
+	// Try authenticating in-cluster with serviceaccount
+	log.Debug("Attempting to authenticate with ServiceAccount")
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		// Try authenticating out-of-cluster with kubeconfig
+		log.Debug("ServiceAccount failed - using KubeConfig")
+		config, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return config, clientset, nil
+}

--- a/install/installer/cmd/config_cluster_shiftfs.go
+++ b/install/installer/cmd/config_cluster_shiftfs.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
+package cmd
+
+import (
+	"time"
+
+	"github.com/gitpod-io/gitpod/common-go/log"
+	"github.com/gitpod-io/gitpod/installer/pkg/common"
+	configv1 "github.com/gitpod-io/gitpod/installer/pkg/config/v1"
+	"github.com/gitpod-io/gitpod/installer/pkg/shiftfs"
+	"github.com/spf13/cobra"
+)
+
+var configClusterShiftfsOpts struct {
+	ServiceAccountName string
+	Timeout            int
+}
+
+// configClusterShiftfsCmd represents the validate command
+var configClusterShiftfsCmd = &cobra.Command{
+	Use:   "shiftfs",
+	Short: "Detects if a cluster can support ShiftFS",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if _, err := configFileExistsAndInit(); err != nil {
+			return err
+		}
+
+		_, _, cfg, err := loadConfig(configOpts.ConfigFile)
+		if err != nil {
+			return err
+		}
+
+		versionMF, err := getVersionManifest()
+		if err != nil {
+			return err
+		}
+
+		gitpodCtx, err := common.NewRenderContext(*cfg, *versionMF, configClusterOpts.Namespace)
+		if err != nil {
+			return err
+		}
+
+		_, clientset, err := authClusterOrKubeconfig(configClusterOpts.Kube.Config)
+		if err != nil {
+			return err
+		}
+
+		log.Infof("Deploying ShiftFS check to %s namespace with timeout of %d seconds", configClusterOpts.Namespace, configClusterShiftfsOpts.Timeout)
+		supported, err := shiftfs.IsSupported(
+			gitpodCtx,
+			configClusterShiftfsOpts.ServiceAccountName,
+			clientset,
+			time.Duration(configClusterShiftfsOpts.Timeout)*time.Second,
+		)
+		if err != nil {
+			return err
+		}
+
+		if *supported {
+			log.Info("ShiftFS is supported")
+			cfg.Workspace.Runtime.FSShiftMethod = configv1.FSShiftShiftFS
+		} else {
+			log.Info("ShiftFS is not supported - use Fuse instead")
+			cfg.Workspace.Runtime.FSShiftMethod = configv1.FSShiftFuseFS
+		}
+
+		return saveConfigFile(cfg)
+	},
+}
+
+func init() {
+	configClusterCmd.AddCommand(configClusterShiftfsCmd)
+
+	configClusterShiftfsCmd.Flags().StringVar(&configClusterShiftfsOpts.ServiceAccountName, "serviceAccount", getEnvvar("SERVICE_ACCOUNT", "default"), "service account name to use for the job - this requires full cluster access")
+	configClusterShiftfsCmd.Flags().IntVar(&configClusterShiftfsOpts.Timeout, "timeout", 10, "timeout in sec")
+}

--- a/install/installer/cmd/config_files.go
+++ b/install/installer/cmd/config_files.go
@@ -1,0 +1,28 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var configFilesOpts struct {
+	MountPath string
+}
+
+// configFilesCmd represents the validate command
+var configFilesCmd = &cobra.Command{
+	Use:   "files",
+	Short: "Perform configuration tasks against the cluster's file system",
+	Long: `Perform configuration tasks against the cluster's file system
+
+These can be run either directly on the cluster nodes or
+by mounting volumes to a pod.`,
+}
+
+func init() {
+	configCmd.AddCommand(configFilesCmd)
+
+	configFilesCmd.PersistentFlags().StringVar(&configFilesOpts.MountPath, "mount-path", getEnvvar("MOUNT_PATH", "/"), "prepends a mount path to the file locations - for use in a pod")
+}

--- a/install/installer/cmd/config_files_containerd.go
+++ b/install/installer/cmd/config_files_containerd.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
+package cmd
+
+import (
+	"github.com/gitpod-io/gitpod/common-go/log"
+	"github.com/gitpod-io/gitpod/installer/pkg/containerd"
+	"github.com/spf13/cobra"
+)
+
+// configNodeContainerdCmd represents the validate command
+var configNodeContainerdCmd = &cobra.Command{
+	Use:   "containerd",
+	Short: "Detects the containerd settings for a cluster",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if _, err := configFileExistsAndInit(); err != nil {
+			return err
+		}
+
+		_, _, cfg, err := loadConfig(configOpts.ConfigFile)
+		if err != nil {
+			return err
+		}
+
+		containerd, socket, err := containerd.Detect(configFilesOpts.MountPath)
+		if err != nil {
+			return err
+		}
+		log.Infof("containerd location detected as %s", *containerd)
+		log.Infof("containerd socket location detected as %s", *socket)
+
+		cfg.Workspace.Runtime.ContainerDRuntimeDir = containerd.String()
+		cfg.Workspace.Runtime.ContainerDSocket = socket.String()
+
+		return saveConfigFile(cfg)
+	},
+}
+
+func init() {
+	configFilesCmd.AddCommand(configNodeContainerdCmd)
+}

--- a/install/installer/pkg/components/ws-daemon/daemonset.go
+++ b/install/installer/pkg/components/ws-daemon/daemonset.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gitpod-io/gitpod/installer/pkg/cluster"
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 	config "github.com/gitpod-io/gitpod/installer/pkg/config/v1"
+	"github.com/gitpod-io/gitpod/installer/pkg/shiftfs"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -95,16 +96,7 @@ fi
 	}
 
 	if cfg.Workspace.Runtime.FSShiftMethod == config.FSShiftShiftFS {
-		initContainers = append(initContainers, corev1.Container{
-			Name:  "shiftfs-module-loader",
-			Image: ctx.ImageName(cfg.Repository, "shiftfs-module-loader", ctx.VersionManifest.Components.WSDaemon.UserNamespaces.ShiftFSModuleLoader.Version),
-			VolumeMounts: []corev1.VolumeMount{{
-				Name:      "node-linux-src",
-				ReadOnly:  true,
-				MountPath: "/usr/src_node",
-			}},
-			SecurityContext: &corev1.SecurityContext{Privileged: pointer.Bool(true)},
-		})
+		initContainers = append(initContainers, shiftfs.Container(ctx))
 	}
 
 	podSpec := corev1.PodSpec{

--- a/install/installer/pkg/config/v1/config.go
+++ b/install/installer/pkg/config/v1/config.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gitpod-io/gitpod/common-go/util"
 	"github.com/gitpod-io/gitpod/installer/pkg/config"
 	"github.com/gitpod-io/gitpod/installer/pkg/config/v1/experimental"
+	"github.com/gitpod-io/gitpod/installer/pkg/containerd"
 	"github.com/gitpod-io/gitpod/ws-daemon/pkg/cpulimit"
 
 	corev1 "k8s.io/api/core/v1"
@@ -62,8 +63,8 @@ func (v version) Defaults(in interface{}) error {
 		corev1.ResourceMemory: resource.MustParse("2Gi"),
 	}
 	cfg.Workspace.Runtime.FSShiftMethod = FSShiftFuseFS
-	cfg.Workspace.Runtime.ContainerDSocket = "/run/containerd/containerd.sock"
-	cfg.Workspace.Runtime.ContainerDRuntimeDir = "/var/lib/containerd/io.containerd.runtime.v2.task/k8s.io"
+	cfg.Workspace.Runtime.ContainerDSocket = containerd.ContainerdSocketLocationDefault.String()
+	cfg.Workspace.Runtime.ContainerDRuntimeDir = containerd.ContainerdLocationDefault.String()
 	cfg.Workspace.MaxLifetime = util.Duration(36 * time.Hour)
 	cfg.Workspace.PVC.Size = resource.MustParse("30Gi")
 	cfg.Workspace.PVC.StorageClass = ""

--- a/install/installer/pkg/containerd/amazon_linux.go
+++ b/install/installer/pkg/containerd/amazon_linux.go
@@ -1,0 +1,13 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
+package containerd
+
+// Amazon Linux only requires a different containerd location - the socket is same as default
+const (
+	ContainerdLocationAmazonLinux ContainerdLocation = "/run/containerd/io.containerd.runtime.v2.task/k8s.io"
+)
+
+func init() {
+	loc.AddContainerd(ContainerdLocationAmazonLinux)
+}

--- a/install/installer/pkg/containerd/k3s.go
+++ b/install/installer/pkg/containerd/k3s.go
@@ -1,0 +1,15 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
+package containerd
+
+// k3s stores both socket and containerd in a different location
+const (
+	ContainerdLocationK3s       ContainerdLocation       = "/run/k3s/containerd/io.containerd.runtime.v2.task/k8s.io"
+	ContainerdSocketLocationK3s ContainerdSocketLocation = "/run/k3s/containerd/containerd.sock"
+)
+
+func init() {
+	loc.AddContainerd(ContainerdLocationK3s)
+	loc.AddSocket(ContainerdSocketLocationK3s)
+}

--- a/install/installer/pkg/containerd/location.go
+++ b/install/installer/pkg/containerd/location.go
@@ -1,0 +1,107 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
+package containerd
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path"
+)
+
+var (
+	ErrContainerDLocation       = errors.New("cannot detect containerd location")
+	ErrContainerDSocketLocation = errors.New("cannot detect containerd socket location")
+)
+
+// This is the default location - this will be used for most installations
+const (
+	ContainerdSocketLocationDefault ContainerdSocketLocation = "/run/containerd/containerd.sock"
+	ContainerdLocationDefault       ContainerdLocation       = "/var/lib/containerd/io.containerd.runtime.v2.task/k8s.io"
+)
+
+type ContainerdSocketLocation string
+type ContainerdLocation string
+
+func (s ContainerdSocketLocation) String() string {
+	return string(s)
+}
+
+func (s ContainerdLocation) String() string {
+	return string(s)
+}
+
+var loc locations
+
+type locations struct {
+	socket     []ContainerdSocketLocation
+	containerd []ContainerdLocation
+}
+
+func (l *locations) AddContainerd(containerd ContainerdLocation) {
+	l.containerd = append(l.containerd, containerd)
+}
+
+func (l *locations) AddSocket(socket ContainerdSocketLocation) {
+	l.socket = append(l.socket, socket)
+}
+
+// GetContainerdList return the containerd locations with the default location appended
+func (l *locations) GetContainerdList() []ContainerdLocation {
+	c := l.containerd
+	c = append(c, ContainerdLocationDefault)
+	return c
+}
+
+// GetSocketList return the socket locations with the default location appended
+func (l *locations) GetSocketList() []ContainerdSocketLocation {
+	s := l.socket
+	s = append(s, ContainerdSocketLocationDefault)
+	return s
+}
+
+func detectContainerdLocation(mountPath string) (*ContainerdLocation, error) {
+	for _, location := range loc.GetContainerdList() {
+		// Ignore errors - the only error we're interested in is if cannot detect a location
+		fileInfo, err := os.Stat(path.Join(mountPath, location.String()))
+		if err != nil || !fileInfo.IsDir() {
+			// Not a directory - go to the next one
+			continue
+		}
+
+		// We have a winner
+		return &location, nil
+	}
+
+	return nil, ErrContainerDLocation
+}
+
+func detectContainerdSocketLocation(mountPath string) (*ContainerdSocketLocation, error) {
+	for _, location := range loc.GetSocketList() {
+		// Ignore errors - the only error we're interested in is if cannot detect a location
+		fileInfo, err := os.Stat(path.Join(mountPath, location.String()))
+		if err != nil || fileInfo.Mode().Type() != fs.ModeSocket {
+			// Not a socket - go to the next one
+			continue
+		}
+
+		// We have a winner
+		return &location, nil
+	}
+
+	return nil, ErrContainerDSocketLocation
+}
+
+func Detect(mountPath string) (*ContainerdLocation, *ContainerdSocketLocation, error) {
+	containerd, err := detectContainerdLocation(mountPath)
+	if err != nil {
+		return nil, nil, err
+	}
+	socket, err := detectContainerdSocketLocation(mountPath)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return containerd, socket, nil
+}

--- a/install/installer/pkg/shiftfs/constants.go
+++ b/install/installer/pkg/shiftfs/constants.go
@@ -1,0 +1,8 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
+package shiftfs
+
+const (
+	Component = "shiftfs-module-loader"
+)

--- a/install/installer/pkg/shiftfs/job.go
+++ b/install/installer/pkg/shiftfs/job.go
@@ -1,0 +1,154 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
+package shiftfs
+
+import (
+	"context"
+	"time"
+
+	"github.com/gitpod-io/gitpod/common-go/log"
+	"github.com/gitpod-io/gitpod/installer/pkg/cluster"
+	"github.com/gitpod-io/gitpod/installer/pkg/common"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	k8s "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/utils/pointer"
+)
+
+// Container defined the actual container for the resource
+func Container(ctx *common.RenderContext) v1.Container {
+	return v1.Container{
+		Name:  Component,
+		Image: ctx.ImageName(ctx.Config.Repository, Component, ctx.VersionManifest.Components.WSDaemon.UserNamespaces.ShiftFSModuleLoader.Version),
+		SecurityContext: &v1.SecurityContext{
+			Privileged: pointer.Bool(true),
+		},
+		VolumeMounts: []corev1.VolumeMount{
+			{
+				Name:      "node-linux-src",
+				ReadOnly:  true,
+				MountPath: "/usr/src_node",
+			},
+		},
+	}
+}
+
+// IsSupported deploys the ShiftFS job to the cluster - if it runs to completion, ShiftFS is supported
+func IsSupported(gitpodCtx *common.RenderContext, serviceAccountName string, clientset *k8s.Clientset, timeout time.Duration) (*bool, error) {
+	supported := false
+	k8sCtx := context.TODO()
+
+	// Generate the ShiftFS job
+	job, err := job(gitpodCtx, serviceAccountName, timeout)
+	if err != nil {
+		return nil, err
+	}
+
+	jobClient := clientset.BatchV1().Jobs(gitpodCtx.Namespace)
+
+	// List all currently deployed jobs
+	jobList, err := jobClient.List(k8sCtx, metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	for _, j := range jobList.Items {
+		// If the job already exists, delete it
+		if j.Name == job.Name {
+			deletePolicy := metav1.DeletePropagationForeground
+			if err := jobClient.Delete(k8sCtx, j.Name, metav1.DeleteOptions{
+				PropagationPolicy: &deletePolicy,
+			}); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	// Deploy the job to the cluster
+	_, err = jobClient.Create(k8sCtx, job, metav1.CreateOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	timeoutCtx, cancel := context.WithTimeout(k8sCtx, timeout)
+
+	// Now we wait for the job to either complete successfully or fail
+	watchList := cache.NewListWatchFromClient(
+		clientset.BatchV1().RESTClient(),
+		"jobs",
+		gitpodCtx.Namespace,
+		fields.OneTermEqualSelector("metadata.name", job.Name),
+	)
+	_, controller := cache.NewInformer(
+		watchList,
+		&batchv1.Job{},
+		0,
+		cache.ResourceEventHandlerFuncs{
+			UpdateFunc: func(_, job interface{}) {
+				if job.(*batchv1.Job).Status.Succeeded > 0 {
+					// ShiftFS is supported - exit the loop
+					cancel()
+					supported = true
+				}
+			},
+		},
+	)
+
+	stop := make(chan struct{})
+	defer func() {
+		log.Info("Deleting cluster resources")
+		close(stop)
+	}()
+	go controller.Run(stop)
+
+	<-timeoutCtx.Done()
+	return pointer.Bool(supported), nil
+}
+
+// job is a standalone job which does **NOT** conform to the CompositeRenderFunc format
+func job(ctx *common.RenderContext, serviceAccountName string, timeout time.Duration) (*batchv1.Job, error) {
+	objectMeta := metav1.ObjectMeta{
+		Name:      Component,
+		Namespace: ctx.Namespace,
+		Labels:    common.DefaultLabels(Component),
+	}
+
+	return &batchv1.Job{
+		TypeMeta:   common.TypeMetaBatchJob,
+		ObjectMeta: objectMeta,
+		Spec: batchv1.JobSpec{
+			TTLSecondsAfterFinished: pointer.Int32(60),
+			ActiveDeadlineSeconds:   pointer.Int64(int64(timeout / time.Second)),
+			BackoffLimit:            pointer.Int32(1),
+			Parallelism:             pointer.Int32(1),
+			Template: v1.PodTemplateSpec{
+				ObjectMeta: objectMeta,
+				Spec: v1.PodSpec{
+					Affinity:           common.NodeAffinity(cluster.AffinityLabelWorkspacesRegular, cluster.AffinityLabelWorkspacesHeadless),
+					ServiceAccountName: serviceAccountName,
+					RestartPolicy:      v1.RestartPolicyNever,
+					Containers: []v1.Container{
+						Container(ctx),
+					},
+					Volumes: []v1.Volume{
+						{
+							Name: "node-linux-src",
+							VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{
+								Path: "/usr/src",
+								Type: func() *corev1.HostPathType {
+									r := corev1.HostPathDirectory
+									return &r
+								}(),
+							}},
+						},
+					},
+				},
+			},
+		},
+	}, nil
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This creates two new commands - `config cluster shiftfs` and `config files containerd` - designed to autodetect whether ShiftFS is supported and the location of the containerd files.

The ShiftFS command reuses the init container in `ws-daemon`.

The command `config cluster` and `config files` have been designed so that future commands can be written. The `config cluster` is designed for commands that deploy a Kubernetes resource to get the answer and the `config files` is designed for commands that are run against the file system, either on the cluster or against a mounted volume in a pod.

This is part of a major refactoring of the configuration so that it's simpler and just config generation. See https://github.com/gitpod-io/gitpod/pull/12319 for my notepad of how it'll look eventually.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #12198

## How to test
<!-- Provide steps to test this PR -->
Run the commands. This should be run on an instance that supports ShiftFS (ie, not Azure/k3s) and one that does not. The `config files containerd` command will need to be run on a cluster - you may test with the following script on your test cluster (this should run without error and set the `containerdRuntimeDir` and `containerdSocket` at the bottom:

```yaml
apiVersion: batch/v1
kind: Job
metadata:
  name: installer
  labels:
    app: gitpod
    component: gitpod-installer
spec:
  backoffLimit: 1
  ttlSecondsAfterFinished: 60
  template:
    metadata:
      labels:
        app: gitpod
        component: gitpod-installer
    spec:
      restartPolicy: OnFailure
      containers:
        - name: installer
          image: "eu.gcr.io/gitpod-core-dev/build/installer:sje-installer-config-detect.4"
          volumeMounts:
            - mountPath: /mnt/node0
              name: node-fs0
              readOnly: true
          env:
            - name: CONFIG_FILE
              value: /tmp/gitpod-config.yaml
            - name: NAMESPACE
              value: gitpod
          command:
            - /bin/sh
            - -c
          args:
            - |
              /app/installer config init
              /app/installer config files containerd --mount-path=/mnt/node0
              cat ${CONFIG_FILE}
      volumes:
        - name: node-fs0
          hostPath:
            path: /
            type: Directory
```


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[installer]: config detects shiftfs and containerd values
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
