### PR TITLE
Self hosted documentation changes

### DIFF
--- a/install/infra/single-cluster/gcp/README.md
+++ b/install/infra/single-cluster/gcp/README.md
@@ -223,6 +223,20 @@ gcloud auth activate-service-account --key-file=/path/to/account/key.json
 gcloud container clusters get-credentials <cluster_name> --region <region> --zone <zone> --project <project>
 ```
 
+### Failed to install helm charts to the cluster
+
+If you see errors like:
+
+```
+Error: clusterroles.rbac.authorization.k8s.io is forbidden: User "xxxxx@developer.gserviceaccount.com" cannot create resource "clusterroles" in API group "rbac.authorization.k8s.io" at the cluster scope: requires one of ["container.clusterRoles.create"] permission(s).
+│
+│   with module.certmanager.helm_release.cert,
+│   on ../../modules/tools/cert-manager/main.tf line 17, in resource "helm_release" "cert":
+│   17: resource "helm_release" "cert" {
+│
+```
+After running `make apply`, ensure that the service account you are using has the `Kubernetes Engine Admin` role. See the [GCP IAM documentation](https://cloud.google.com/iam/docs/granting-changing-revoking-access) to learn how to associate roles with a service account.
+
 ## Cleanup
 
 Make sure you first delete the `gitpod` resources in the cluster so things like load balancer created by the k8s `service` gets deleted. Otherwise terraform will not be able to delete the VPC.

--- a/install/kots/manifests/kots-preflight.yaml
+++ b/install/kots/manifests/kots-preflight.yaml
@@ -128,7 +128,7 @@ spec:
               when: == openshift
               message: OpenShift is not supported
           - pass:
-              message: The cluster is using a support distribution
+              message: The cluster is using a supported distribution
     - nodeResources:
         checkName: At least one node must "gitpod.io/workload_meta" label
         filters:


### PR DESCRIPTION
## Description

* Add a new troubleshooting section to the `README` accompanying the GCP terraform.
* Fix a typo in the `kots` preflight yaml.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

## How to test

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
