### PR TITLE
[azure] Single-cluster usage guide for AKS TF module

### DIFF
--- a/install/infra/modules/aks/database.tf
+++ b/install/infra/modules/aks/database.tf
@@ -1,18 +1,18 @@
 resource "random_integer" "db" {
-  count = var.enable_external_database ? 1 : 0
+  count = var.create_external_database ? 1 : 0
 
   min = 10000
   max = 99999
 }
 
 resource "random_password" "db" {
-  count = var.enable_external_database ? 1 : 0
+  count = var.create_external_database ? 1 : 0
 
   length = 32
 }
 
 resource "azurerm_mysql_server" "db" {
-  count = var.enable_external_database ? 1 : 0
+  count = var.create_external_database ? 1 : 0
 
   name                = "gitpod-${random_integer.db[count.index].result}"
   location            = azurerm_resource_group.gitpod.location
@@ -30,7 +30,7 @@ resource "azurerm_mysql_server" "db" {
 }
 
 resource "azurerm_mysql_firewall_rule" "db" {
-  count = var.enable_external_database ? 1 : 0
+  count = var.create_external_database ? 1 : 0
 
   name                = "Azure_Resource"
   resource_group_name = azurerm_resource_group.gitpod.name
@@ -40,7 +40,7 @@ resource "azurerm_mysql_firewall_rule" "db" {
 }
 
 resource "azurerm_mysql_database" "db" {
-  count = var.enable_external_database ? 1 : 0
+  count = var.create_external_database ? 1 : 0
 
   name                = "gitpod"
   resource_group_name = azurerm_resource_group.gitpod.name

--- a/install/infra/modules/aks/kubernetes.tf
+++ b/install/infra/modules/aks/kubernetes.tf
@@ -1,5 +1,5 @@
 resource "azurerm_role_assignment" "k8s" {
-  count = var.dns_enabled ? 1 : 0
+  count = local.dns_enabled ? 1 : 0
 
   principal_id         = azurerm_kubernetes_cluster.k8s.kubelet_identity[count.index].object_id
   role_definition_name = "DNS Zone Contributor"
@@ -7,7 +7,7 @@ resource "azurerm_role_assignment" "k8s" {
 }
 
 resource "azurerm_role_assignment" "k8s_reader" {
-  count = var.dns_enabled ? 1 : 0
+  count = local.dns_enabled ? 1 : 0
 
   principal_id         = azurerm_kubernetes_cluster.k8s.kubelet_identity[count.index].object_id
   role_definition_name = "Reader"

--- a/install/infra/modules/aks/local.tf
+++ b/install/infra/modules/aks/local.tf
@@ -7,15 +7,12 @@ locals {
     workspace_headless : "gitpod.io/workload_workspace_headless"
   })
   dns_enabled = var.domain_name != null
+
   name_format = join("-", [
-    "test",
+    var.resource_group_name,
     "%s", # name
-    local.workspace_name
   ])
-  name_format_global = join("-", [
-    "sh-test",
-    local.workspace_name
-  ])
+
   workspace_name = replace(terraform.workspace, "/[\\W\\-]/", "") # alphanumeric workspace name
   db       = "GP_Gen5_2"
   location = substr(var.location, 0, 3) # Short code for location

--- a/install/infra/modules/aks/main.tf
+++ b/install/infra/modules/aks/main.tf
@@ -14,6 +14,6 @@ provider "azurerm" {
 data "azurerm_client_config" "current" {}
 
 resource "azurerm_resource_group" "gitpod" {
-  name     = local.name_format_global
+  name     = var.resource_group_name
   location = var.location
 }

--- a/install/infra/modules/aks/networks.tf
+++ b/install/infra/modules/aks/networks.tf
@@ -13,7 +13,7 @@ resource "azurerm_subnet" "network" {
 }
 
 resource "azurerm_dns_zone" "dns" {
-  count = var.dns_enabled ? 1 : 0
+  count = local.dns_enabled ? 1 : 0
 
   name                = var.domain_name
   resource_group_name = azurerm_resource_group.gitpod.name

--- a/install/infra/modules/aks/output.tf
+++ b/install/infra/modules/aks/output.tf
@@ -88,16 +88,18 @@ output "region" {
 output "registry" {
   sensitive = true
   value = try({
+    url      = azurerm_container_registry.registry.0.login_server
     server   = azurerm_container_registry.registry.0.login_server
-    password = azurerm_container_registry.registry.0.admin_password
     username = azurerm_container_registry.registry.0.admin_username
+    password = azurerm_container_registry.registry.0.admin_password
   }, {})
 }
 
 output "storage" {
   sensitive = true
   value = try({
-    username = azurerm_storage_account.storage.0.name
-    password = azurerm_storage_account.storage.0.primary_access_key
+    storage_region = var.location
+    account_name   = azurerm_storage_account.storage.0.name
+    account_key    = azurerm_storage_account.storage.0.primary_access_key
   }, {})
 }

--- a/install/infra/modules/aks/registry.tf
+++ b/install/infra/modules/aks/registry.tf
@@ -1,12 +1,12 @@
 resource "random_integer" "registry" {
-  count = var.enable_external_registry ? 1 : 0
+  count = var.create_external_registry ? 1 : 0
 
   min = 10000
   max = 99999
 }
 
 resource "azurerm_container_registry" "registry" {
-  count = var.enable_external_registry ? 1 : 0
+  count = var.create_external_registry ? 1 : 0
 
   name                = "gitpod${random_integer.registry[count.index].result}"
   resource_group_name = azurerm_resource_group.gitpod.name
@@ -16,7 +16,7 @@ resource "azurerm_container_registry" "registry" {
 }
 
 resource "azurerm_role_assignment" "registry" {
-  count = var.enable_external_registry ? 1 : 0
+  count = var.create_external_registry ? 1 : 0
 
   principal_id                     = azurerm_kubernetes_cluster.k8s.kubelet_identity[0].object_id
   role_definition_name             = "AcrPush"

--- a/install/infra/modules/aks/storage.tf
+++ b/install/infra/modules/aks/storage.tf
@@ -1,12 +1,12 @@
 resource "random_integer" "storage" {
-  count = var.enable_external_storage ? 1 : 0
+  count = var.create_external_storage ? 1 : 0
 
   min = 10000
   max = 99999
 }
 
 resource "azurerm_storage_account" "storage" {
-  count = var.enable_external_storage ? 1 : 0
+  count = var.create_external_storage ? 1 : 0
 
   name                     = "gitpod${random_integer.storage[count.index].result}"
   resource_group_name      = azurerm_resource_group.gitpod.name

--- a/install/infra/modules/aks/variables.tf
+++ b/install/infra/modules/aks/variables.tf
@@ -7,14 +7,15 @@ variable "cluster_version" {
   description = "kubernetes version of to create the cluster with"
 }
 
-variable "dns_enabled" {}
 variable "domain_name" {}
-variable "enable_airgapped" {}
-variable "enable_external_database" {}
-variable "enable_external_registry" {}
-variable "enable_external_storage" {}
-variable "workspace_name" {
+variable "enable_airgapped" {
+  default = false
 }
+
+variable "create_external_database" {}
+variable "create_external_registry" {}
+variable "create_external_storage" {}
+variable "resource_group_name" {}
 
 // Azure-specific variables
 variable "location" {

--- a/install/infra/single-cluster/azure/.env_sample
+++ b/install/infra/single-cluster/azure/.env_sample
@@ -1,0 +1,6 @@
+export ARM_CLIENT_ID=
+export ARM_CLIENT_SECRET=
+export ARM_SUBSCRIPTION_ID=
+export ARM_TENANT_ID=
+
+export ARM_ACCESS_KEY= # Access key created for Blob Storage Account

--- a/install/infra/single-cluster/azure/Makefile
+++ b/install/infra/single-cluster/azure/Makefile
@@ -1,0 +1,129 @@
+##
+# Terraform AWS reference architecture
+#
+
+.PHONY: init
+init:
+	@terraform init
+
+touch-kubeconfig:
+	@touch kubeconfig
+
+cleanup-kubeconfig:
+	@rm kubeconfig
+
+.PHONY: plan
+plan: touch-kubeconfig plan-cluster plan-cm-edns cleanup-kubeconfig
+
+.PHONY: apply
+apply: apply-cluster apply-tools
+
+.PHONY: destroy
+destroy: destroy-tools destroy-cluster
+
+.PHONY: plan-cluster
+plan-cluster:
+	@terraform plan -target=module.aks
+
+.PHONY: plan-tools
+plan-tools: plan-cm-edns plan-cluster-issuer
+
+.PHONY: plan-cm-edns
+plan-cm-edns:
+	@terraform plan -target=module.certmanager -target=module.externaldns
+
+.PHONY: plan-cluster-issuer
+plan-cluster-issuer:
+	@terraform plan -target=module.cluster-issuer
+
+.PHONY: apply-cluster
+apply-cluster:
+	@terraform apply -target=module.aks --auto-approve
+
+.PHONY: apply-tools
+apply-tools: install-cm-edns install-cluster-issuer
+
+.PHONY: install-cm-edns
+install-cm-edns:
+	@terraform apply -target=module.certmanager -target=module.externaldns --auto-approve
+
+PHONY: install-cluster-issuer
+install-cluster-issuer:
+	@terraform apply -target=module.cluster-issuer  --auto-approve
+
+.PHONY: destroy-cluster
+destroy-cluster:
+	@terraform destroy -target=module.aks --auto-approve
+
+.PHONY: destroy-tools
+destroy-tools: destroy-cluster-issuer destroy-cm-edns
+
+.PHONY: destroy-cm-edns
+destroy-cm-edns:
+	@terraform destroy -target=module.certmanager  -target=module.externaldns --auto-approve
+
+.PHONY: destroy-cluster-issuer
+destroy-cluster-issuer:
+	@terraform destroy -target=module.cluster-issuer  --auto-approve || echo "Could not remove cluster-issuer"
+
+## Output targets
+
+.PHONY: refresh
+refresh:
+	@echo "Refreshing terraform state"
+	@terraform refresh
+	@echo ""
+	@echo "Done!"
+
+.PHONY: output
+output: refresh output-done-msg output-url output-nameservers output-registry output-database output-storage output-issuer
+
+output-done-msg:
+	@echo ""
+	@echo ""
+	@echo "=========================="
+	@echo "🎉🥳🔥🧡🚀"
+	@echo "Your AWS cloud infrastructure is ready to install Gitpod. Please visit"
+	@echo "https://www.gitpod.io/docs/self-hosted/latest/getting-started#step-4-install-gitpod"
+	@echo "for your next steps."
+	@echo "================="
+	@echo "Config Parameters"
+	@echo "================="
+
+output-url:
+	@echo ""
+	@echo "Gitpod domain name:"
+	@echo "================="
+	@terraform output -json url | jq
+
+output-nameservers:
+	@echo ""
+	@echo "Nameservers for the domain(to be added as NS records in your domain provider):"
+	@echo "================="
+	@terraform output -json nameservers | jq
+
+output-storage:
+	@echo ""
+	@echo "Azure Object storage:"
+	@echo "=============="
+	@terraform output -json storage | jq
+
+output-registry:
+	@echo ""
+	@echo "Container registry:"
+	@echo "=================="
+	@terraform output -json registry | jq
+
+output-database:
+	@echo ""
+	@echo "Database:"
+	@echo "========"
+	@terraform output -json database | jq
+
+output-issuer:
+	@echo ""
+	@echo "ClusterIssuer name:"
+	@echo "================="
+	@terraform output -json cluster_issuer | jq
+
+# end

--- a/install/infra/single-cluster/azure/README.md
+++ b/install/infra/single-cluster/azure/README.md
@@ -1,12 +1,12 @@
 # Terraform setup for AWS Single-cluster Gitpod reference architecture
 
 This directory has terraform configuration necessary to achieve a infrastructure
-corresponding to the [Single-cluster reference architecture for Gitpod on AWS](https://www.gitpod.io/docs/self-hosted/latest/reference-architecture/single-cluster-ref-arch).
+corresponding to the Single-cluster reference architecture for Gitpod on Azure.
 
 This module will do the following steps:
-- Creates the infrastructure using our [`eks` terraform module](../../modules/eks/), which does:
-  - Setup an EKS managed cluster, along with external dependencies like database, storage and registry (if chosen)
-  - Sets up route53 entries for the domain name (if chosen)
+- Creates the infrastructure using our [`aks` terraform module](../../modules/aks/), which does:
+  - Setup an AKS managed cluster, along with external dependencies like database, storage and registry (if chosen)
+  - Sets up Azure Cloud DNS entries for the domain name (if chosen)
 - Provisioning the cluster:
   - Set up cert-manager using our [`cert-manager` module](../../modules/tools/cert-manager/)
   - Set up external-dns using our [`external-dns` module](../../modules/tools/external-dns/)
@@ -16,89 +16,68 @@ This module will do the following steps:
 
 Since the entire setup requires more than one terraform target to be run due to
 dependencies (eg: helm provider depends on kubernetes cluster config, which is
-not available until the `eks` module finishes), this directory has a `Makefile`
+not available until the `aks` module finishes), this directory has a `Makefile`
 with targets binding together targeted terraform calls. This document will
 explain the execution of the terraform module in terms of these `make` targets.
 
 ## Requirements
 
 * `terraform` >= `v1.1.0`
-* `kubectl`   >= `v1.20.0`
+* `kubectl`   >= `v1.21.0`
 * [`jq`](https://stedolan.github.io/jq/download/)
 
-## Setup AWS authentication and s3 backend storage
-
-create IAM, set env vars, create backend bucket
+## Setup Azure authentication and `azurerm` backend storage
 
 Before starting the installation process, you need:
-
-* An AWS account with Administrator access
-  * [Create one now by clicking here](https://aws.amazon.com/getting-started/)
-* Setup credentials to be usable in one of the following ways:
-  * [As environmental variables](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html)
-    * Copy the file `.env_sample` to `.env` and update the values corresponding
-      to your AWS user. Run:
-      ```sh
-      source .env
-      ```
-  * [As credentials file](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html)
-* Create and configure s3 bucket for terraform backend
-  * Create an [AWS S3 bucket](https://aws.amazon.com/s3/) to store the terraform backend state
-  * Replace the name of the bucket in [`main.tf`](./main.tf) - currently it is set as `gitpod-tf`
+* An Azure account
+  - [Create one now by clicking here](https://azure.microsoft.com/en-gb/free/)
+- A user account with "Owner" IAM rights on the subscription
+* Create and configure Azure Blob storage account for terraform backend
+  * Create an [Azure blob storage account](https://azure.microsoft.com/en-in/services/storage/blobs/) and a container inside it to store terraform backend state
+  * Create an Access Key for the said Blob storage account, [as descibed in the terraform doc](https://www.terraform.io/language/settings/backends/azurerm)
+  * Replace the name of the `storage_account_name`, `container_name`, `resource_group_name`, and (optionally) `key` in [`main.tf`](./main.tf)
+* Add an `.env` file with all necessary credentials.
+  * An `.env_sample` is included, copy the file `.env_sample` to `.env`
+  * Update the values of the variables and run:
+    ```sh
+    source .env
+    ```
 
 ## Update the `terraform.tfvars` file with appropriate values
 
 The file [`terraform.tfvars`](./terraform.tfvars) with values that will be used
 by terraform to create the cluster. While some of them are fairly
-straightforward like the name of the cluster(`cluster_name`), others need a bit
-more attention:
-
-### VPC CIDR IP
-
-It is necessary to ensure that the `VPC` setup will not have conflicts with
-existing VPCs or has sufficiently large enough IP range so as to not run out of
-them. Please check under the region's VPCs if the IP range you are choosing is
-already in use. The CIDR will be split among 5 subnets and hence we recommend
-`/16` as prefix to allow sufficient IP ranges. The default value is: `10.100.0.0/16`
+straightforward like the name of the Azure resource group(`resource_group_name`), others need a bit more attention:
 
 ### External database, storage and registry backend
 
-If you wish to create cloud specific database, storage and registry backend to be used
+If you wish to create cloud specific database, storage and registry to be used
 with `Gitpod`, leave the following 3 booleans set:
 
 ``` sh
-create_external_database                     = true
-create_external_storage                      = true
-create_external_storage_for_registry_backend = true
+create_external_database = true
+create_external_storage  = true
+create_external_registry = true
 ```
 
 The corresponding resources will be created by the terraform script which
-inclustes an `RDS` mysql database, an `S3` bucket and another `S3` bucket to
-be used as registry backend. By default `create_external_storage_for_registry_backend`
-is set to `false`. One can re-use the same `S3` bucket for both object storage and registry backend.
+includes a mysql database, a Azure block storage account and an Azure container registry
 
-The expectation is that you can use the credentials to these setups(provided later
+### Kubernetes version
 
-### AMI Image ID and Kubernetes version
-
-We officially support Ubuntu images for Gitpod setup. In EKS cluster, AMI images
-are kubernetes version and region specific. You can find a list of AMI IDs
-[here](https://cloud-images.ubuntu.com/docs/aws/eks/).
-
-Make sure you provide the corresponding kubernetes version as a value to the
-variable `cluster_version`. We officially support kubernetes versions >= `1.20`.
+Make sure you provide an [Azure supported kubernetes version](https://docs.microsoft.com/en-us/azure/aks/supported-kubernetes-versions) as a value to the
+variable `cluster_version`. We officially support kubernetes versions >= `1.21`.
 
 ### Domain name configuration
 
 If you are already sure of the domain name under which you want to setup Gitpod,
 we recommend highly to provide the value as `domain_name`. This will save a lot
-of hassle in setting up `route53` records to point to the cluster and
+of hassle in setting up Azure cloudDNS records to point to the cluster and
 corresponding TLS certificate requests.
 
 ## Initialize terraform backend and confirm the plan
 
-> ⚠️  We ship 4 terraform modules here and some of them have dependencies among each other (eg: `cert-manager` module depends on `eks` module for `kubeconfig`, or the `cluster-issuer` module depends on `cert-manager` for the CRD). Hence a simple run of `terraform plan` or `terraform apply` may lead to errors. Hence we wrap [targeted `terraform` operations](https://learn.hashicorp.com/tutorials/terraform/resource-targeting) in the following make targets. If you wish you use `terraform` commands instead, please make sure you look into the Makefile to understand the target order.
-
+> ⚠️  We ship 4 terraform modules here and some of them have dependencies among each other (eg: `cert-manager` module depends on `aks` module for `kubeconfig`, or the `cluster-issuer` module depends on `cert-manager` for the CRD). Hence a simple run of `terraform plan` or `terraform apply` may lead to errors. Hence we wrap [targeted `terraform` operations](https://learn.hashicorp.com/tutorials/terraform/resource-targeting) in the following make targets. If you wish you use `terraform` commands instead, please make sure you look into the Makefile to understand the target order.
 
 * Initialize the terraform backend with:
 
@@ -121,7 +100,7 @@ If the plan looks good, now you can go ahead and create the resources:
 make apply
 ```
 
-The `apply` target calls the `terraform` apply on `eks` module, `cert-manager`
+The `apply` target calls the `terraform` apply on `aks` module, `cert-manager`
 module, `external-dns` module and `cluster-issuer` module in that exact order.
 The entire operation would take around *30 minutes* to complete.
 
@@ -145,19 +124,19 @@ make output
 
 Once the apply process has exited successfully, we can go ahead and prepare to
 setup Gitpod. If you specified the `domain_name` in the `terraform.tfvars` file,
-the terraform module registers the module with `route53` to point to the
+the terraform module registers the domain with Azure cloudDNS  point to the
 cluster. Now you have to configure whichever provider you use to host your
-domain name to route traffic to the AWS name servers. You can find these name
+domain name to route traffic to the Azure name servers. You can find these name
 servers in the `make output` command from above. It would be of the format:
 
 ```json
 Nameservers for the domain(to be added as NS records in your domain provider):
 =================
 [
-  "ns-1444.awsdns-52.org.",
-  "ns-1559.awsdns-02.co.uk.",
-  "ns-209.awsdns-26.com.",
-  "ns-969.awsdns-57.net."
+  "ns1-35.azure-dns.com.",
+  "ns2-35.azure-dns.net.",
+  "ns3-35.azure-dns.org.",
+  "ns4-35.azure-dns.info."
 ]
 ```
 
@@ -188,21 +167,9 @@ kubectl kots install gitpod/stable # you can replace `stable` with `unstable` or
 
 Upon completion, you can access `KOTS` UI in `localhost:8800`. Here you can
 proceed to configuring and intalling Gitpod. Please follow the [official
-documentaion](https://www.gitpod.io/docs/self-hosted/latest/getting-started#step-4-install-gitpod) to complete the Gitpod setup.
+documentation](https://www.gitpod.io/docs/self-hosted/latest/getting-started#step-4-install-gitpod) to complete the Gitpod setup.
 
 ## Troubleshooting
-
-### KOTS pods fail to deploy
-
-Sometimes, the pods deployed when executing `kubectl kots install gitpod` fail to deploy due to issues with mounting their disks:
-
-```$ kubectl get pods -A
-NAMESPACE      NAME                                       READY   STATUS              RESTARTS   AGE
-gitpod         kotsadm-minio-0                            0/1     ContainerCreating   0          2m28s
-gitpod         kotsadm-postgres-0                         0/1     Init:0/2            0          2m28s
-```
-
-This can happen when the wrong `image_id`  was used in the `.tfvars` file. The ID needs to respect both the region as well as the Kubernetes version and can be found [here](https://cloud-images.ubuntu.com/docs/aws/eks/).
 
 ### Some pods never start (Init state)
 
@@ -212,7 +179,7 @@ NAME                     READY   STATUS    RESTARTS   AGE
 proxy-5998488f4c-t8vkh   0/1     Init 0/1  0          5m
 ```
 
-The most likely reason is that the DNS01 challenge has yet to resolve. To fix this, make sure you have added the NS records corresponding to the `route53` zone of the `domain_name` added to your domain provider.
+The most likely reason is that the DNS01 challenge has yet to resolve. To fix this, make sure you have added the NS records corresponding to the Azure cloudDNS zone of the `domain_name` added to your domain provider.
 
 Once the DNS record has been updated, you will need to delete all Cert Manager pods to retrigger the certificate request
 
@@ -233,7 +200,8 @@ https-certificates          True    https-certificates          5m
 There is a chance that your kubeconfig has gotten expired after a specific amount of time. You can reconnect to the cluster by using:
 
 ``` sh
-aws eks --region <regon> update-kubeconfig --name <cluster_name>
+az login --service-principal -u $ARM_CLIENT_ID -p $ARM_CLIENT_SECRET --tenant $ARM_TENANT_ID
+az aks get-credentials --name <resource_group_name>-cluster --resource-group <resource_group_name> --file kubeconfig
 ```
 
 ## Cleanup

--- a/install/infra/single-cluster/azure/cluster.tf
+++ b/install/infra/single-cluster/azure/cluster.tf
@@ -1,0 +1,13 @@
+module "aks" {
+#   source = "github.com/gitpod-io/gitpod//install/infra/modules/aks?ref=main"
+  source = "../../modules/aks"
+
+  domain_name              = var.domain_name
+  create_external_database = var.create_external_database
+  create_external_registry = var.create_external_registry
+  create_external_storage  = var.create_external_storage
+  resource_group_name      = var.resource_group_name
+  kubeconfig               = var.kubeconfig
+  cluster_version          = var.cluster_version
+  location                 = var.location
+}

--- a/install/infra/single-cluster/azure/main.tf
+++ b/install/infra/single-cluster/azure/main.tf
@@ -1,0 +1,10 @@
+terraform {
+  backend "azurerm" {
+    storage_account_name =
+    container_name       =
+    resource_group_name  =
+    key = "gitpod"
+
+    use_azuread_auth     = true
+  }
+}

--- a/install/infra/single-cluster/azure/output.tf
+++ b/install/infra/single-cluster/azure/output.tf
@@ -1,0 +1,32 @@
+output "url" {
+  value = var.domain_name
+}
+
+output "cluster_name" {
+  value = module.aks.cluster_name
+}
+
+output "registry" {
+  sensitive = true
+  value     = module.aks.registry
+}
+
+output "storage" {
+  sensitive = true
+  value     = module.aks.storage
+}
+
+output "database" {
+  sensitive = true
+  value     = module.aks.database
+}
+
+output "nameservers" {
+  sensitive = false
+  value     = module.aks.domain_nameservers
+}
+
+output "cluster_issuer" {
+  sensitive = false
+  value     = module.cluster-issuer.cluster_issuer
+}

--- a/install/infra/single-cluster/azure/terraform.tfvars
+++ b/install/infra/single-cluster/azure/terraform.tfvars
@@ -1,0 +1,14 @@
+# The resource should be of length less than 12 characters and surrounded by double quotes
+# Make sure no such resource group exists
+resource_group_name =
+
+# a Azure cloud dns zone and certificate request will be created for this domain; surround the domain name within double quotes
+domain_name =
+
+location = "northeurope"
+
+cluster_version = "1.22"
+
+create_external_database = true
+create_external_storage  = true
+create_external_registry = true

--- a/install/infra/single-cluster/azure/tools.tf
+++ b/install/infra/single-cluster/azure/tools.tf
@@ -1,0 +1,23 @@
+module "certmanager" {
+  # source = "github.com/gitpod-io/gitpod//install/infra/modules/tools/cert-manager?ref=main"
+  source = "../../modules/tools/cert-manager"
+
+  kubeconfig = var.kubeconfig
+}
+
+module "externaldns" {
+  # source = "github.com/gitpod-io/gitpod//install/infra/modules/tools/externaldns?ref=main"
+  source       = "../../modules/tools/external-dns"
+  kubeconfig   = var.kubeconfig
+  settings     = module.aks.external_dns_settings
+  domain_name  = var.domain_name
+  txt_owner_id = var.resource_group_name
+}
+
+module "cluster-issuer" {
+  # source = "github.com/gitpod-io/gitpod//install/infra/modules/tools/issuer?ref=main"
+  source              = "../../modules/tools/issuer"
+  kubeconfig          = var.kubeconfig
+  cert_manager_issuer = module.aks.cert_manager_issuer
+  issuer_name         = "azureDNS"
+}

--- a/install/infra/single-cluster/azure/variables.tf
+++ b/install/infra/single-cluster/azure/variables.tf
@@ -1,0 +1,41 @@
+variable "resource_group_name" {
+  type        = string
+  description = "AKS resource group name to be created, all the resources created under will use this as prefix in their naming"
+}
+
+variable "kubeconfig" {
+  type        = string
+  description = "Path to the kubeconfig file to write the KUBECONFIG output in"
+  default     = "kubeconfig"
+}
+
+variable "location" {
+  type        = string
+  description = "Location to create the resource group in"
+  default     = "northeurope"
+}
+
+variable "domain_name" {
+  description = "Domain name to associate with the Gitpod installation, provide empty string to avoid creating Azure DNS zone"
+}
+
+variable "create_external_database" {
+  default     = true
+  description = "Create a Azure mysql Database"
+}
+
+variable "create_external_storage" {
+  default     = true
+  description = "Create an Azure Blob Storage"
+}
+
+variable "create_external_registry" {
+  default     = false
+  description = "Create an Azure Container Registry"
+}
+
+variable "cluster_version" {
+  type        = string
+  description = "Kubernetes version to create the cluster with"
+  default     = "1.22"
+}

--- a/install/tests/Makefile
+++ b/install/tests/Makefile
@@ -54,8 +54,7 @@ gcp-kubeconfig:
 azure-kubeconfig:
 	az login --service-principal -u $$ARM_CLIENT_ID -p $$ARM_CLIENT_SECRET  --tenant $$ARM_TENANT_ID
 	export KUBECONFIG=${KUBECONFIG} && \
-	export resource=$$(echo "$$TF_VAR_TEST_ID" | sed "s/[\\W\\-]//g") && \
-	az aks get-credentials --name test-cluster-$$resource --resource-group sh-test-$$resource --file ${KUBECONFIG} || echo "No cluster present"
+	az aks get-credentials --name p$$TF_VAR_TEST_ID-cluster --resource-group p$$TF_VAR_TEST_ID --file ${KUBECONFIG} || echo "No cluster present"
 
 ## aws-kubeconfig: Get the kubeconfig configuration for AWS EKS
 aws-kubeconfig:
@@ -202,14 +201,16 @@ db-config-gcp:
 
 registry-config-azure:
 	export SERVER=$$(terraform output -json azure_registry | yq r - 'server') && \
+	export URL=$$(terraform output -json azure_registry | yq r - 'url') && \
 	export PASSWORD=$$(terraform output -json azure_registry | yq r - 'password') && \
 	export USERNAME=$$(terraform output -json azure_registry | yq r - 'username') && \
 	envsubst < ./manifests/kots-config-azure-registry.yaml > tmp_2_config.yml
 	yq m -i tmp_config.yml tmp_2_config.yml
 
 storage-config-azure:
-	export PASSWORD=$$(terraform output -json azure_storage | yq r - 'password') && \
-	export USERNAME=$$(terraform output -json azure_storage | yq r - 'username') && \
+	export PASSWORD=$$(terraform output -json azure_storage | yq r - 'account_name') && \
+	export USERNAME=$$(terraform output -json azure_storage | yq r - 'account_key') && \
+	export REGION=$$(terraform output -json azure_storage | yq r - 'storage_region') && \
 	envsubst < ./manifests/kots-config-azure-storage.yaml > tmp_2_config.yml
 	yq m -i tmp_config.yml tmp_2_config.yml
 

--- a/install/tests/main.tf
+++ b/install/tests/main.tf
@@ -82,11 +82,10 @@ module "aks" {
 
   domain_name              = "${var.TEST_ID}.${var.domain}"
   enable_airgapped         = false
-  enable_external_database = true
-  enable_external_registry = true
-  enable_external_storage  = true
-  dns_enabled              = true
-  workspace_name           = var.TEST_ID
+  create_external_database = true
+  create_external_registry = true
+  create_external_storage  = true
+  resource_group_name      = "p${var.TEST_ID}"
   kubeconfig               = var.kubeconfig
   cluster_version          = var.cluster_version
 }

--- a/install/tests/manifests/kots-config-azure-registry.yaml
+++ b/install/tests/manifests/kots-config-azure-registry.yaml
@@ -6,7 +6,7 @@ spec:
         value: "0"
         data: "reg_incluster"
       reg_url:
-        value: ${SERVER}
+        value: ${URL}
         data: "reg_url"
       reg_username:
         value: ${USERNAME}

--- a/install/tests/manifests/kots-config-azure-storage.yaml
+++ b/install/tests/manifests/kots-config-azure-storage.yaml
@@ -6,7 +6,7 @@ spec:
         value: azure
         data: "store_provider"
       store_region:
-        value: "northeurope"
+        value: ${REGION}
         data: "store_region"
       store_azure_account_name:
         value: ${USERNAME}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PR adds the first iteration of single cluster terraform module for AKS. We add a new directory `install/infra/single-cluster/azure` that uses the `aks` terraform module to create a single-cluster infrastructure for setting up Gitpod.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #12867 

## How to test
<!-- Provide steps to test this PR -->
Please follow the [README.md](https://github.com/gitpod-io/gitpod/blob/nvn/azure-tf-mod/install/infra/single-cluster/azure/README.md) added as a part of this PR.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
