### PR TITLE
[code browser] measure all sessions vs errored sessions

### DIFF
--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -7,7 +7,7 @@ defaultArgs:
   jbMarketplacePublishTrigger: "false"
   publishToJBMarketplace: true
   localAppVersion: unknown
-  codeCommit: 43d126af25499c63c7462d0b7a961dfd797f896e
+  codeCommit: e2c3ab18a37bed1b4e43609a2c5a771ed4f07dbc
   codeQuality: stable
   noVerifyJBPlugin: false
   intellijDownloadUrl: "https://download.jetbrains.com/idea/ideaIU-2022.2.2.tar.gz"

--- a/components/ide/code/leeway.Dockerfile
+++ b/components/ide/code/leeway.Dockerfile
@@ -71,7 +71,8 @@ RUN yarn --cwd extensions compile \
 # Check pkg/blobserve/blobserve.go, `inlineVars` method
 RUN cp /vscode-web/out/vs/gitpod/browser/workbench/workbench.html /vscode-web/index.html \
     && cp /vscode-web/out/vs/gitpod/browser/workbench/callback.html /vscode-web/callback.html \
-    && sed -i -e 's#static/##g' /vscode-web/index.html
+    && sed -i -e 's#static/##g' /vscode-web/index.html \
+    && sed -i -e "s/{{VERSION}}/$CODE_QUALITY-$CODE_COMMIT/g" /vscode-web/index.html
 
 # cli config: alises to gitpod-code
 RUN cp /vscode-reh-linux-x64/bin/remote-cli/gitpod-code /vscode-reh-linux-x64/bin/remote-cli/code \

--- a/components/supervisor/frontend/src/ide/ide-metrics-service-client.ts
+++ b/components/supervisor/frontend/src/ide/ide-metrics-service-client.ts
@@ -10,7 +10,8 @@ const commit = require('../../config.json').commit;
 
 export enum MetricsName {
     SupervisorFrontendClientTotal = "gitpod_supervisor_frontend_client_total",
-    SupervisorFrontendErrorTotal = "gitpod_supervisor_frontend_error_total"
+    SupervisorFrontendErrorTotal = "gitpod_supervisor_frontend_error_total",
+    SupervisorFrontendLoadTotal = "gitpod_vscode_web_load_total",
 }
 
 const MetricsUrl = serverUrl.asIDEMetrics().toString();

--- a/install/installer/cmd/testdata/render/aws-setup/output.golden
+++ b/install/installer/cmd/testdata/render/aws-setup/output.golden
@@ -3277,6 +3277,20 @@ data:
             ]
           },
           {
+            "name": "gitpod_vscode_web_load_total",
+            "help": "Total count of attempts to load VS Code Web workbench",
+            "labels": [
+              {
+                "name": "status",
+                "allowValues": [
+                  "loading",
+                  "failed"
+                ],
+                "defaultValue": ""
+              }
+            ]
+          },
+          {
             "name": "gitpod_supervisor_frontend_client_total",
             "help": "Total count of supervisor frontend client",
             "labels": null
@@ -7654,7 +7668,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 5f647d019f026f04a85e04ad8e695083db2a70f97ee7199143859879d5d40ebe
+        gitpod.io/checksum_config: 9294988d9eda9035b1f1feabbe3743d7f56366a821fe43a1736c209bcce70c85
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/aws-setup/output.golden
+++ b/install/installer/cmd/testdata/render/aws-setup/output.golden
@@ -3896,7 +3896,8 @@ data:
         ],
         "errorReporting": {
           "allowComponents": [
-            "supervisor-frontend"
+            "supervisor-frontend",
+            "vscode-workbench"
           ]
         }
       },
@@ -7668,7 +7669,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 9294988d9eda9035b1f1feabbe3743d7f56366a821fe43a1736c209bcce70c85
+        gitpod.io/checksum_config: 38daf6eb90ea9693d49597f331d3fcbc68a6b62961fa86096d1fd7e8f67af33c
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/azure-setup/output.golden
+++ b/install/installer/cmd/testdata/render/azure-setup/output.golden
@@ -3814,7 +3814,8 @@ data:
         ],
         "errorReporting": {
           "allowComponents": [
-            "supervisor-frontend"
+            "supervisor-frontend",
+            "vscode-workbench"
           ]
         }
       },
@@ -7502,7 +7503,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 9294988d9eda9035b1f1feabbe3743d7f56366a821fe43a1736c209bcce70c85
+        gitpod.io/checksum_config: 38daf6eb90ea9693d49597f331d3fcbc68a6b62961fa86096d1fd7e8f67af33c
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/azure-setup/output.golden
+++ b/install/installer/cmd/testdata/render/azure-setup/output.golden
@@ -3195,6 +3195,20 @@ data:
             ]
           },
           {
+            "name": "gitpod_vscode_web_load_total",
+            "help": "Total count of attempts to load VS Code Web workbench",
+            "labels": [
+              {
+                "name": "status",
+                "allowValues": [
+                  "loading",
+                  "failed"
+                ],
+                "defaultValue": ""
+              }
+            ]
+          },
+          {
             "name": "gitpod_supervisor_frontend_client_total",
             "help": "Total count of supervisor frontend client",
             "labels": null
@@ -7488,7 +7502,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 5f647d019f026f04a85e04ad8e695083db2a70f97ee7199143859879d5d40ebe
+        gitpod.io/checksum_config: 9294988d9eda9035b1f1feabbe3743d7f56366a821fe43a1736c209bcce70c85
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -4621,7 +4621,8 @@ data:
         ],
         "errorReporting": {
           "allowComponents": [
-            "supervisor-frontend"
+            "supervisor-frontend",
+            "vscode-workbench"
           ]
         }
       },
@@ -8930,7 +8931,7 @@ spec:
     metadata:
       annotations:
         gitpod.io: hello
-        gitpod.io/checksum_config: b695fb30daae66c21c8b635c69ee8bf1d4460bdefea1d9fc91a611b4c550fa1d
+        gitpod.io/checksum_config: 0d75796644892a36da75b624bf044967e89dc5da8a59facaee2aa094372e7e79
         hello: world
       creationTimestamp: null
       labels:

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -4002,6 +4002,20 @@ data:
             ]
           },
           {
+            "name": "gitpod_vscode_web_load_total",
+            "help": "Total count of attempts to load VS Code Web workbench",
+            "labels": [
+              {
+                "name": "status",
+                "allowValues": [
+                  "loading",
+                  "failed"
+                ],
+                "defaultValue": ""
+              }
+            ]
+          },
+          {
             "name": "gitpod_supervisor_frontend_client_total",
             "help": "Total count of supervisor frontend client",
             "labels": null
@@ -8916,7 +8930,7 @@ spec:
     metadata:
       annotations:
         gitpod.io: hello
-        gitpod.io/checksum_config: 8beda82ff6c689641e3e3d74cfa333942daf49ba5617133a5c6ec21a44408f22
+        gitpod.io/checksum_config: b695fb30daae66c21c8b635c69ee8bf1d4460bdefea1d9fc91a611b4c550fa1d
         hello: world
       creationTimestamp: null
       labels:

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -3955,7 +3955,8 @@ data:
         ],
         "errorReporting": {
           "allowComponents": [
-            "supervisor-frontend"
+            "supervisor-frontend",
+            "vscode-workbench"
           ]
         }
       },
@@ -7943,7 +7944,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 9294988d9eda9035b1f1feabbe3743d7f56366a821fe43a1736c209bcce70c85
+        gitpod.io/checksum_config: 38daf6eb90ea9693d49597f331d3fcbc68a6b62961fa86096d1fd7e8f67af33c
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -3336,6 +3336,20 @@ data:
             ]
           },
           {
+            "name": "gitpod_vscode_web_load_total",
+            "help": "Total count of attempts to load VS Code Web workbench",
+            "labels": [
+              {
+                "name": "status",
+                "allowValues": [
+                  "loading",
+                  "failed"
+                ],
+                "defaultValue": ""
+              }
+            ]
+          },
+          {
             "name": "gitpod_supervisor_frontend_client_total",
             "help": "Total count of supervisor frontend client",
             "labels": null
@@ -7929,7 +7943,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 5f647d019f026f04a85e04ad8e695083db2a70f97ee7199143859879d5d40ebe
+        gitpod.io/checksum_config: 9294988d9eda9035b1f1feabbe3743d7f56366a821fe43a1736c209bcce70c85
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/gcp-setup/output.golden
+++ b/install/installer/cmd/testdata/render/gcp-setup/output.golden
@@ -3785,7 +3785,8 @@ data:
         ],
         "errorReporting": {
           "allowComponents": [
-            "supervisor-frontend"
+            "supervisor-frontend",
+            "vscode-workbench"
           ]
         }
       },
@@ -7557,7 +7558,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 9294988d9eda9035b1f1feabbe3743d7f56366a821fe43a1736c209bcce70c85
+        gitpod.io/checksum_config: 38daf6eb90ea9693d49597f331d3fcbc68a6b62961fa86096d1fd7e8f67af33c
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/gcp-setup/output.golden
+++ b/install/installer/cmd/testdata/render/gcp-setup/output.golden
@@ -3166,6 +3166,20 @@ data:
             ]
           },
           {
+            "name": "gitpod_vscode_web_load_total",
+            "help": "Total count of attempts to load VS Code Web workbench",
+            "labels": [
+              {
+                "name": "status",
+                "allowValues": [
+                  "loading",
+                  "failed"
+                ],
+                "defaultValue": ""
+              }
+            ]
+          },
+          {
             "name": "gitpod_supervisor_frontend_client_total",
             "help": "Total count of supervisor frontend client",
             "labels": null
@@ -7543,7 +7557,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 5f647d019f026f04a85e04ad8e695083db2a70f97ee7199143859879d5d40ebe
+        gitpod.io/checksum_config: 9294988d9eda9035b1f1feabbe3743d7f56366a821fe43a1736c209bcce70c85
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/http-proxy/output.golden
+++ b/install/installer/cmd/testdata/render/http-proxy/output.golden
@@ -4124,7 +4124,8 @@ data:
         ],
         "errorReporting": {
           "allowComponents": [
-            "supervisor-frontend"
+            "supervisor-frontend",
+            "vscode-workbench"
           ]
         }
       },
@@ -8908,7 +8909,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 9294988d9eda9035b1f1feabbe3743d7f56366a821fe43a1736c209bcce70c85
+        gitpod.io/checksum_config: 38daf6eb90ea9693d49597f331d3fcbc68a6b62961fa86096d1fd7e8f67af33c
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/http-proxy/output.golden
+++ b/install/installer/cmd/testdata/render/http-proxy/output.golden
@@ -3505,6 +3505,20 @@ data:
             ]
           },
           {
+            "name": "gitpod_vscode_web_load_total",
+            "help": "Total count of attempts to load VS Code Web workbench",
+            "labels": [
+              {
+                "name": "status",
+                "allowValues": [
+                  "loading",
+                  "failed"
+                ],
+                "defaultValue": ""
+              }
+            ]
+          },
+          {
             "name": "gitpod_supervisor_frontend_client_total",
             "help": "Total count of supervisor frontend client",
             "labels": null
@@ -8894,7 +8908,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 5f647d019f026f04a85e04ad8e695083db2a70f97ee7199143859879d5d40ebe
+        gitpod.io/checksum_config: 9294988d9eda9035b1f1feabbe3743d7f56366a821fe43a1736c209bcce70c85
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -3502,6 +3502,20 @@ data:
             ]
           },
           {
+            "name": "gitpod_vscode_web_load_total",
+            "help": "Total count of attempts to load VS Code Web workbench",
+            "labels": [
+              {
+                "name": "status",
+                "allowValues": [
+                  "loading",
+                  "failed"
+                ],
+                "defaultValue": ""
+              }
+            ]
+          },
+          {
             "name": "gitpod_supervisor_frontend_client_total",
             "help": "Total count of supervisor frontend client",
             "labels": null
@@ -8209,7 +8223,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 5f647d019f026f04a85e04ad8e695083db2a70f97ee7199143859879d5d40ebe
+        gitpod.io/checksum_config: 9294988d9eda9035b1f1feabbe3743d7f56366a821fe43a1736c209bcce70c85
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -4121,7 +4121,8 @@ data:
         ],
         "errorReporting": {
           "allowComponents": [
-            "supervisor-frontend"
+            "supervisor-frontend",
+            "vscode-workbench"
           ]
         }
       },
@@ -8223,7 +8224,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 9294988d9eda9035b1f1feabbe3743d7f56366a821fe43a1736c209bcce70c85
+        gitpod.io/checksum_config: 38daf6eb90ea9693d49597f331d3fcbc68a6b62961fa86096d1fd7e8f67af33c
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -4133,7 +4133,8 @@ data:
         ],
         "errorReporting": {
           "allowComponents": [
-            "supervisor-frontend"
+            "supervisor-frontend",
+            "vscode-workbench"
           ]
         }
       },
@@ -8235,7 +8236,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 9294988d9eda9035b1f1feabbe3743d7f56366a821fe43a1736c209bcce70c85
+        gitpod.io/checksum_config: 38daf6eb90ea9693d49597f331d3fcbc68a6b62961fa86096d1fd7e8f67af33c
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -3514,6 +3514,20 @@ data:
             ]
           },
           {
+            "name": "gitpod_vscode_web_load_total",
+            "help": "Total count of attempts to load VS Code Web workbench",
+            "labels": [
+              {
+                "name": "status",
+                "allowValues": [
+                  "loading",
+                  "failed"
+                ],
+                "defaultValue": ""
+              }
+            ]
+          },
+          {
             "name": "gitpod_supervisor_frontend_client_total",
             "help": "Total count of supervisor frontend client",
             "labels": null
@@ -8221,7 +8235,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 5f647d019f026f04a85e04ad8e695083db2a70f97ee7199143859879d5d40ebe
+        gitpod.io/checksum_config: 9294988d9eda9035b1f1feabbe3743d7f56366a821fe43a1736c209bcce70c85
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
+++ b/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
@@ -4454,7 +4454,8 @@ data:
         ],
         "errorReporting": {
           "allowComponents": [
-            "supervisor-frontend"
+            "supervisor-frontend",
+            "vscode-workbench"
           ]
         }
       },
@@ -8667,7 +8668,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 9294988d9eda9035b1f1feabbe3743d7f56366a821fe43a1736c209bcce70c85
+        gitpod.io/checksum_config: 38daf6eb90ea9693d49597f331d3fcbc68a6b62961fa86096d1fd7e8f67af33c
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
+++ b/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
@@ -3835,6 +3835,20 @@ data:
             ]
           },
           {
+            "name": "gitpod_vscode_web_load_total",
+            "help": "Total count of attempts to load VS Code Web workbench",
+            "labels": [
+              {
+                "name": "status",
+                "allowValues": [
+                  "loading",
+                  "failed"
+                ],
+                "defaultValue": ""
+              }
+            ]
+          },
+          {
             "name": "gitpod_supervisor_frontend_client_total",
             "help": "Total count of supervisor frontend client",
             "labels": null
@@ -8653,7 +8667,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 5f647d019f026f04a85e04ad8e695083db2a70f97ee7199143859879d5d40ebe
+        gitpod.io/checksum_config: 9294988d9eda9035b1f1feabbe3743d7f56366a821fe43a1736c209bcce70c85
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
+++ b/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
@@ -3505,6 +3505,20 @@ data:
             ]
           },
           {
+            "name": "gitpod_vscode_web_load_total",
+            "help": "Total count of attempts to load VS Code Web workbench",
+            "labels": [
+              {
+                "name": "status",
+                "allowValues": [
+                  "loading",
+                  "failed"
+                ],
+                "defaultValue": ""
+              }
+            ]
+          },
+          {
             "name": "gitpod_supervisor_frontend_client_total",
             "help": "Total count of supervisor frontend client",
             "labels": null
@@ -8212,7 +8226,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 5f647d019f026f04a85e04ad8e695083db2a70f97ee7199143859879d5d40ebe
+        gitpod.io/checksum_config: 9294988d9eda9035b1f1feabbe3743d7f56366a821fe43a1736c209bcce70c85
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
+++ b/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
@@ -4124,7 +4124,8 @@ data:
         ],
         "errorReporting": {
           "allowComponents": [
-            "supervisor-frontend"
+            "supervisor-frontend",
+            "vscode-workbench"
           ]
         }
       },
@@ -8226,7 +8227,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 9294988d9eda9035b1f1feabbe3743d7f56366a821fe43a1736c209bcce70c85
+        gitpod.io/checksum_config: 38daf6eb90ea9693d49597f331d3fcbc68a6b62961fa86096d1fd7e8f67af33c
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/pkg/components/ide-metrics/configmap.go
+++ b/install/installer/pkg/components/ide-metrics/configmap.go
@@ -122,6 +122,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 	errorReporting := config.ErrorReportingConfiguration{
 		AllowComponents: []string{
 			"supervisor-frontend",
+			"vscode-workbench",
 		},
 	}
 

--- a/install/installer/pkg/components/ide-metrics/configmap.go
+++ b/install/installer/pkg/components/ide-metrics/configmap.go
@@ -47,6 +47,16 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 			},
 		},
 		{
+			Name: "gitpod_vscode_web_load_total",
+			Help: "Total count of attempts to load VS Code Web workbench",
+			Labels: []config.LabelAllowList{
+				{
+					Name:        "status",
+					AllowValues: []string{"loading", "failed"},
+				},
+			},
+		},
+		{
 			Name: "gitpod_supervisor_frontend_client_total",
 			Help: "Total count of supervisor frontend client",
 		},


### PR DESCRIPTION
## Description

This PR advances on the changes made in https://github.com/gitpod-io/gitpod/pull/12222 and contributes a new metric field: `gitpod_vscode_web_load_total`, which will help in discovering how often (percentage-wise) errors happen in [VS Code Browser](https://www.gitpod.io/docs/ides-and-editors/vscode-browser), as described in https://github.com/gitpod-io/gitpod/issues/12107#issuecomment-1237115318.

This PR also moves all of the remaining error reporting logic found in [supervisor frontend](https://github.com/gitpod-io/gitpod/blob/main/components/supervisor/frontend/src/index.ts) to the [VS Code Browser workbench](https://github.com/gitpod-io/openvscode-server/blob/gp-code/main/src/vs/gitpod/browser/workbench/workbench.html). 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Relates https://github.com/gitpod-io/gitpod/issues/12107

Changes done in the VS Code Browser workbench: https://github.com/gitpod-io/openvscode-server/pull/428.

The query would look something like this:
```
sum(rate(gitpod_vscode_web_load_total{status='failed'}[2m]))/sum(rate(gitpod_vscode_web_load_total{status='loading'}[2m]))
```

## How to test

### Do a little bit of trolling (throw errors in VS Code Browser)

- Open the preview environment of this PR
- Select VS Code Browser (Insiders) as your IDE
- Open a workspace within the preview environment

### Verify with Grafana

- Start a new workspace with this PR
- Run `./dev/preview/portforward-monitoring-satellite.sh -c harvester`
- Open port 3000

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
