### PR TITLE
Update dev/ssh-load-test and dev/changelog go mod versions

### DIFF
--- a/dev/changelog/go.mod
+++ b/dev/changelog/go.mod
@@ -1,10 +1,22 @@
 module github.com/gitpod-io/gitpod/changelog
 
-go 1.16
+go 1.18
 
 require (
 	github.com/google/go-github/v38 v38.1.0
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.4.0
 	golang.org/x/oauth2 v0.0.0-20210819190943-2bc19b11175f
+)
+
+require (
+	github.com/golang/protobuf v1.4.2 // indirect
+	github.com/google/go-querystring v1.0.0 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 // indirect
+	golang.org/x/net v0.0.0-20200822124328-c89045814202 // indirect
+	golang.org/x/sys v0.0.0-20200803210538-64077c9b5642 // indirect
+	google.golang.org/appengine v1.6.6 // indirect
+	google.golang.org/protobuf v1.25.0 // indirect
 )

--- a/dev/ssh-load-test/go.mod
+++ b/dev/ssh-load-test/go.mod
@@ -1,8 +1,15 @@
 module test
 
-go 1.16
+go 1.18
 
 require (
 	github.com/helloyi/go-sshclient v1.1.0
 	github.com/spf13/cobra v1.4.0
+)
+
+require (
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad // indirect
+	golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 // indirect
 )


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
`GOCACHE` gets corrupted due to old package versions that are being built and put in the cache at some point.

I'm **almost** certain that this should solve the problem.

@gitpod-io/engineering-workspace how is the cache populated? Is it done during a prebuild step? And is there a way to clean it?

## How to test
<!-- Provide steps to test this PR -->
Open a workspace and run:
```bash
 go install github.com/gitpod-io/observability/installer@main

# sigs.k8s.io/json/internal/golang/encoding/json
../go/pkg/mod/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2/internal/golang/encoding/json/encode.go:158:16: predeclared any requires go1.18 or later (-lang was set to go1.16; check go.mod)

# github.com/google/btree
../go/pkg/mod/github.com/google/btree@v1.1.2/btree_generic.go:89:16: type parameter requires go1.18 or later (-lang was set to go1.16; check go.mod)
```

This succeeds (takes a while):
```bash
GOCACHE=$(pwd)/cache go install -v github.com/gitpod-io/observability/installer@main
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
