### PR TITLE
[db] Add index to d_b_workspace_instance on startedTime & stoppingTime

### DIFF
--- a/components/gitpod-db/src/typeorm/migration/1664441455556-WorkspaceInstanceStartedStoppingIndex.ts
+++ b/components/gitpod-db/src/typeorm/migration/1664441455556-WorkspaceInstanceStartedStoppingIndex.ts
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { indexExists } from "./helper/helper";
+
+export class WorkspaceInstanceStartedStoppingIndex1662491259313 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const TABLE_NAME = "d_b_workspace_instance";
+
+        const startedTimeIndex = "IDX_workspace_instance__started_time";
+        if (!(await indexExists(queryRunner, TABLE_NAME, startedTimeIndex))) {
+            await queryRunner.query(`CREATE INDEX ${startedTimeIndex} ON ${TABLE_NAME} (startedTime)`);
+        }
+
+        const stoppingTimeIndex = "IDX_workspace_instance__stopping_time";
+        if (!(await indexExists(queryRunner, TABLE_NAME, stoppingTimeIndex))) {
+            await queryRunner.query(`CREATE INDEX ${stoppingTimeIndex} ON ${TABLE_NAME} (stoppingTime)`);
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {}
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Adds missing indices to avoid full table scan.

[Internal Context](https://gitpod.slack.com/archives/C02EN94AEPL/p1662471052279859?thread_ts=1662468125.845989&cid=C02EN94AEPL)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Relates to #13060

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview

/hold to run this manually as it is a long-running migration.