### PR TITLE
[usage] Exclude workspace instances without a startedTime

### DIFF
--- a/components/usage/pkg/apiv1/usage_test.go
+++ b/components/usage/pkg/apiv1/usage_test.go
@@ -564,13 +564,14 @@ func TestUsageService_ReconcileUsageWithLedger(t *testing.T) {
 	// stopped instances
 	instance := dbtest.NewWorkspaceInstance(t, db.WorkspaceInstance{
 		UsageAttributionID: attributionID,
-		CreationTime:       db.NewVarcharTime(from),
+		StartedTime:        db.NewVarcharTime(from),
 		StoppingTime:       db.NewVarcharTime(to.Add(-1 * time.Minute)),
 	})
 	dbtest.CreateWorkspaceInstances(t, dbconn, instance)
 
 	// running instances
 	dbtest.CreateWorkspaceInstances(t, dbconn, dbtest.NewWorkspaceInstance(t, db.WorkspaceInstance{
+		StartedTime:        db.NewVarcharTime(to.Add(-1 * time.Minute)),
 		UsageAttributionID: attributionID,
 	}))
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Previous [PR](https://github.com/gitpod-io/gitpod/pull/12696) did this only for one of the 3 queries for Workspace Instances. This change applies to all of the queries.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
