### PR TITLE
[installer]: add HTTP_PROXY envvars to the Installer

### DIFF
--- a/install/installer/cmd/testdata/render/aws-setup/output.golden
+++ b/install/installer/cmd/testdata/render/aws-setup/output.golden
@@ -1218,7 +1218,7 @@ data:
   config.json: |-
     {
       "service": {
-        "address": ":8080"
+        "address": "0.0.0.0:8080"
       },
       "storage": {
         "stage": "",
@@ -3813,7 +3813,7 @@ data:
         ]
       },
       "service": {
-        "address": ":8080",
+        "address": "0.0.0.0:8080",
         "tls": {
           "ca": "",
           "crt": "",
@@ -4059,9 +4059,9 @@ data:
       "makeNewUsersAdmin": false,
       "defaultBaseImageRegistryWhitelist": [],
       "runDbDeleter": true,
-      "contentServiceAddr": "content-service:8080",
-      "imageBuilderAddr": "image-builder-mk3:8080",
-      "usageServiceAddr": "usage:9001",
+      "contentServiceAddr": "content-service.default.svc.cluster.local:8080",
+      "imageBuilderAddr": "image-builder-mk3.default.svc.cluster.local:8080",
+      "usageServiceAddr": "usage.default.svc.cluster.local:9001",
       "vsxRegistryUrl": "https://open-vsx.gitpod.example.com",
       "chargebeeProviderOptionsFile": "/chargebee/providerOptions",
       "stripeSecretsFile": "/stripe-secret/apikeys",
@@ -4407,7 +4407,7 @@ data:
         }
       },
       "service": {
-        "address": ":8080",
+        "address": "0.0.0.0:8080",
         "tls": {
           "caPath": "/certs/ca.crt",
           "certPath": "/certs/tls.crt",
@@ -4593,8 +4593,8 @@ data:
   config.json: |-
     {
       "ingress": {
-        "httpAddress": ":8080",
-        "httpsAddress": ":9090",
+        "httpAddress": "0.0.0.0:8080",
+        "httpsAddress": "0.0.0.0:9090",
         "header": "x-wsproxy-host"
       },
       "proxy": {
@@ -6460,7 +6460,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 531cd94d43e48d4295f80353ac56f7748a9f678b8ade59cbabc14d1c3fb43395
+        gitpod.io/checksum_config: de8ed99a057f28c772db0287eeb93b12fe89401a2645f94d0b533eb0e5640654
         seccomp.security.alpha.kubernetes.io/shiftfs-module-loader: unconfined
       creationTimestamp: null
       labels:
@@ -7227,7 +7227,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 910d0b3b714a6d8b04963ee4f42d8ea370d56531b8faaa16bb819a19c4f75928
+        gitpod.io/checksum_config: 2e45691c9b7dbd15eefd950854dfc5d89500012dc70f6a624069a404c72f9010
       creationTimestamp: null
       labels:
         app: gitpod
@@ -7632,7 +7632,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 5a02760487dc021fb50bdfc0d92a3a453348b226fb74729cd57a33927d5b6e08
+        gitpod.io/checksum_config: 96743936096936609b76bcab7e6b4c5d2ae5b0cd63b73268b03984c82bdf3d3e
       creationTimestamp: null
       labels:
         app: gitpod
@@ -8032,7 +8032,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: e51ff44d9dd16219dfe3e61a9c3c4562a3ee6c31632791d43697f66569e1569f
+        gitpod.io/checksum_config: 32e8b437cc6763cf35540014d9f2d93632243e2da7bfac04edb928dbd31193e0
       creationTimestamp: null
       labels:
         app: gitpod
@@ -8679,7 +8679,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: dcbc53af67e4007a4affc029e880c338b93e4484010727f4bf0a08ad7c93a112
+        gitpod.io/checksum_config: f88055f3ce58c8eca0064866deeb5131473b6ba2980dce8bf4f9989e997f1ff5
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/azure-setup/output.golden
+++ b/install/installer/cmd/testdata/render/azure-setup/output.golden
@@ -1182,7 +1182,7 @@ data:
   config.json: |-
     {
       "service": {
-        "address": ":8080"
+        "address": "0.0.0.0:8080"
       },
       "storage": {
         "stage": "",
@@ -3731,7 +3731,7 @@ data:
         ]
       },
       "service": {
-        "address": ":8080",
+        "address": "0.0.0.0:8080",
         "tls": {
           "ca": "",
           "crt": "",
@@ -3923,9 +3923,9 @@ data:
       "makeNewUsersAdmin": false,
       "defaultBaseImageRegistryWhitelist": [],
       "runDbDeleter": true,
-      "contentServiceAddr": "content-service:8080",
-      "imageBuilderAddr": "image-builder-mk3:8080",
-      "usageServiceAddr": "usage:9001",
+      "contentServiceAddr": "content-service.default.svc.cluster.local:8080",
+      "imageBuilderAddr": "image-builder-mk3.default.svc.cluster.local:8080",
+      "usageServiceAddr": "usage.default.svc.cluster.local:9001",
       "vsxRegistryUrl": "https://open-vsx.gitpod.example.com",
       "chargebeeProviderOptionsFile": "/chargebee/providerOptions",
       "stripeSecretsFile": "/stripe-secret/apikeys",
@@ -4269,7 +4269,7 @@ data:
         }
       },
       "service": {
-        "address": ":8080",
+        "address": "0.0.0.0:8080",
         "tls": {
           "caPath": "/certs/ca.crt",
           "certPath": "/certs/tls.crt",
@@ -4453,8 +4453,8 @@ data:
   config.json: |-
     {
       "ingress": {
-        "httpAddress": ":8080",
-        "httpsAddress": ":9090",
+        "httpAddress": "0.0.0.0:8080",
+        "httpsAddress": "0.0.0.0:9090",
         "header": "x-wsproxy-host"
       },
       "proxy": {
@@ -6306,7 +6306,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 6fd7f9d2c27fa657c0818d37d1d048b00bd4c1127d732232ca76fd04810136be
+        gitpod.io/checksum_config: f39e45d788bb170ba728cfc3c69c5ca00a2b88a73a2d7288bcc1caee8e638405
         seccomp.security.alpha.kubernetes.io/shiftfs-module-loader: unconfined
       creationTimestamp: null
       labels:
@@ -7067,7 +7067,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 94e6e4829aa089a570ba9f479575cdd42a6c273877223830c790397aa40dcd99
+        gitpod.io/checksum_config: 9f2fefeff4c2a12ff62db1ffafb3d9af6b91ba0b536b6e8664b55c43a1aec3c0
       creationTimestamp: null
       labels:
         app: gitpod
@@ -7466,7 +7466,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 5be4f29bef94650edc3920952abac0e61f5a807e104428baf5d8bca92b9401d4
+        gitpod.io/checksum_config: 8034f0b96bab62afb484f300c389b9c2ed9190807d2fd7d17f21802b1d4fa0bf
       creationTimestamp: null
       labels:
         app: gitpod
@@ -7884,7 +7884,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: e51ff44d9dd16219dfe3e61a9c3c4562a3ee6c31632791d43697f66569e1569f
+        gitpod.io/checksum_config: 32e8b437cc6763cf35540014d9f2d93632243e2da7bfac04edb928dbd31193e0
       creationTimestamp: null
       labels:
         app: gitpod
@@ -8525,7 +8525,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: dcbc53af67e4007a4affc029e880c338b93e4484010727f4bf0a08ad7c93a112
+        gitpod.io/checksum_config: f88055f3ce58c8eca0064866deeb5131473b6ba2980dce8bf4f9989e997f1ff5
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -1399,7 +1399,7 @@ data:
   config.json: |-
     {
       "service": {
-        "address": ":8080"
+        "address": "0.0.0.0:8080"
       },
       "storage": {
         "stage": "",
@@ -4518,7 +4518,7 @@ data:
         ]
       },
       "service": {
-        "address": ":8080",
+        "address": "0.0.0.0:8080",
         "tls": {
           "ca": "",
           "crt": "",
@@ -4830,9 +4830,9 @@ data:
       "makeNewUsersAdmin": false,
       "defaultBaseImageRegistryWhitelist": [],
       "runDbDeleter": true,
-      "contentServiceAddr": "content-service:8080",
-      "imageBuilderAddr": "image-builder-mk3:8080",
-      "usageServiceAddr": "usage:9001",
+      "contentServiceAddr": "content-service.default.svc.cluster.local:8080",
+      "imageBuilderAddr": "image-builder-mk3.default.svc.cluster.local:8080",
+      "usageServiceAddr": "usage.default.svc.cluster.local:9001",
       "vsxRegistryUrl": "https://open-vsx.gitpod.example.com",
       "chargebeeProviderOptionsFile": "/chargebee/providerOptions",
       "stripeSecretsFile": "/stripe-secret/apikeys",
@@ -5186,7 +5186,7 @@ data:
         }
       },
       "service": {
-        "address": ":8080",
+        "address": "0.0.0.0:8080",
         "tls": {
           "caPath": "/certs/ca.crt",
           "certPath": "/certs/tls.crt",
@@ -5385,8 +5385,8 @@ data:
   config.json: |-
     {
       "ingress": {
-        "httpAddress": ":8080",
-        "httpsAddress": ":9090",
+        "httpAddress": "0.0.0.0:8080",
+        "httpsAddress": "0.0.0.0:9090",
         "header": "x-wsproxy-host"
       },
       "proxy": {
@@ -7494,7 +7494,7 @@ spec:
     metadata:
       annotations:
         gitpod.io: hello
-        gitpod.io/checksum_config: 4e24adf25fa6c788ea607f2b6e87d4d46c00cdaa8d3891f50feebde06ac6b4c3
+        gitpod.io/checksum_config: eed464cffbb7a8f5698bc1163b1e22cbc4593e154e2662c43dd2f643863c4548
         hello: world
         seccomp.security.alpha.kubernetes.io/shiftfs-module-loader: unconfined
       creationTimestamp: null
@@ -8441,7 +8441,7 @@ spec:
     metadata:
       annotations:
         gitpod.io: hello
-        gitpod.io/checksum_config: cb18d1100d11de0609bf9d7961693a7ebbc982d589014e1031bf921573afe08f
+        gitpod.io/checksum_config: d72d95c5bd425eaabe281cea259139df35cc6343145eadac5f2e95aae30360ab
         hello: world
       creationTimestamp: null
       labels:
@@ -8878,7 +8878,7 @@ spec:
     metadata:
       annotations:
         gitpod.io: hello
-        gitpod.io/checksum_config: ecd350f0d685aba1d7fb6e36ab8eed6fc4fa34f2729563a482c5685f4abce748
+        gitpod.io/checksum_config: cdff40a52db9857434bb86e8754889cbdfa317b0bb71c2fafba58f1d5a11e87b
         hello: world
       creationTimestamp: null
       labels:
@@ -9398,7 +9398,7 @@ spec:
     metadata:
       annotations:
         gitpod.io: hello
-        gitpod.io/checksum_config: abcabbe0f0755c297b38713fd5dcbdf5613cca1ecc2f5180b4c66ae59b189df5
+        gitpod.io/checksum_config: 7f31019ddffd47a37a2fa1c2688b77bbf03a774a8af3c7a289017e74a4c84a20
         hello: world
       creationTimestamp: null
       labels:
@@ -10066,7 +10066,7 @@ spec:
     metadata:
       annotations:
         gitpod.io: hello
-        gitpod.io/checksum_config: a215d15f9dc39f54db7c2553b752027cd4c905b7f30c07c0fbe0193cbf1c1df1
+        gitpod.io/checksum_config: 7cb3858d6b6cd2fbb0e4ad1dc049ff23fca40a07e41db9c74a4b6b4ecf9ac39a
         hello: world
       creationTimestamp: null
       labels:

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -1213,7 +1213,7 @@ data:
   config.json: |-
     {
       "service": {
-        "address": ":8080"
+        "address": "0.0.0.0:8080"
       },
       "storage": {
         "stage": "",
@@ -3872,7 +3872,7 @@ data:
         ]
       },
       "service": {
-        "address": ":8080",
+        "address": "0.0.0.0:8080",
         "tls": {
           "ca": "",
           "crt": "",
@@ -4110,9 +4110,9 @@ data:
       "makeNewUsersAdmin": false,
       "defaultBaseImageRegistryWhitelist": [],
       "runDbDeleter": true,
-      "contentServiceAddr": "content-service:8080",
-      "imageBuilderAddr": "image-builder-mk3:8080",
-      "usageServiceAddr": "usage:9001",
+      "contentServiceAddr": "content-service.default.svc.cluster.local:8080",
+      "imageBuilderAddr": "image-builder-mk3.default.svc.cluster.local:8080",
+      "usageServiceAddr": "usage.default.svc.cluster.local:9001",
       "vsxRegistryUrl": "https://open-vsx.gitpod.example.com",
       "chargebeeProviderOptionsFile": "/chargebee/providerOptions",
       "stripeSecretsFile": "/stripe-secret/apikeys",
@@ -4456,7 +4456,7 @@ data:
         }
       },
       "service": {
-        "address": ":8080",
+        "address": "0.0.0.0:8080",
         "tls": {
           "caPath": "/certs/ca.crt",
           "certPath": "/certs/tls.crt",
@@ -4640,8 +4640,8 @@ data:
   config.json: |-
     {
       "ingress": {
-        "httpAddress": ":8080",
-        "httpsAddress": ":9090",
+        "httpAddress": "0.0.0.0:8080",
+        "httpsAddress": "0.0.0.0:9090",
         "header": "x-wsproxy-host"
       },
       "proxy": {
@@ -6588,7 +6588,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 6fd7f9d2c27fa657c0818d37d1d048b00bd4c1127d732232ca76fd04810136be
+        gitpod.io/checksum_config: f39e45d788bb170ba728cfc3c69c5ca00a2b88a73a2d7288bcc1caee8e638405
         seccomp.security.alpha.kubernetes.io/shiftfs-module-loader: unconfined
       creationTimestamp: null
       labels:
@@ -7508,7 +7508,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 94e6e4829aa089a570ba9f479575cdd42a6c273877223830c790397aa40dcd99
+        gitpod.io/checksum_config: 9f2fefeff4c2a12ff62db1ffafb3d9af6b91ba0b536b6e8664b55c43a1aec3c0
       creationTimestamp: null
       labels:
         app: gitpod
@@ -7907,7 +7907,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3306f90f91447be560270e7f1f30b08c623b26d1a2cc2dea06fea891dd96bcbd
+        gitpod.io/checksum_config: 98f1ca15bcfd65d64c8e110b89afda269339e46c2155583e3f07fc5c01bc0d74
       creationTimestamp: null
       labels:
         app: gitpod
@@ -8310,7 +8310,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 0bc76c867af13d6037264732e25991af8de7c19a2f2e91d1fb1e64df1a9833db
+        gitpod.io/checksum_config: b2674e6368640d5a4b4ccb0f2fa8cb4e521fb3ee60c58f38d8b57272063a8bea
       creationTimestamp: null
       labels:
         app: gitpod
@@ -8951,7 +8951,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: dcbc53af67e4007a4affc029e880c338b93e4484010727f4bf0a08ad7c93a112
+        gitpod.io/checksum_config: f88055f3ce58c8eca0064866deeb5131473b6ba2980dce8bf4f9989e997f1ff5
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/gcp-setup/output.golden
+++ b/install/installer/cmd/testdata/render/gcp-setup/output.golden
@@ -1159,7 +1159,7 @@ data:
   config.json: |-
     {
       "service": {
-        "address": ":8080"
+        "address": "0.0.0.0:8080"
       },
       "storage": {
         "stage": "",
@@ -3702,7 +3702,7 @@ data:
         ]
       },
       "service": {
-        "address": ":8080",
+        "address": "0.0.0.0:8080",
         "tls": {
           "ca": "",
           "crt": "",
@@ -3884,9 +3884,9 @@ data:
       "makeNewUsersAdmin": false,
       "defaultBaseImageRegistryWhitelist": [],
       "runDbDeleter": true,
-      "contentServiceAddr": "content-service:8080",
-      "imageBuilderAddr": "image-builder-mk3:8080",
-      "usageServiceAddr": "usage:9001",
+      "contentServiceAddr": "content-service.default.svc.cluster.local:8080",
+      "imageBuilderAddr": "image-builder-mk3.default.svc.cluster.local:8080",
+      "usageServiceAddr": "usage.default.svc.cluster.local:9001",
       "vsxRegistryUrl": "https://open-vsx.gitpod.example.com",
       "chargebeeProviderOptionsFile": "/chargebee/providerOptions",
       "stripeSecretsFile": "/stripe-secret/apikeys",
@@ -4229,7 +4229,7 @@ data:
         }
       },
       "service": {
-        "address": ":8080",
+        "address": "0.0.0.0:8080",
         "tls": {
           "caPath": "/certs/ca.crt",
           "certPath": "/certs/tls.crt",
@@ -4412,8 +4412,8 @@ data:
   config.json: |-
     {
       "ingress": {
-        "httpAddress": ":8080",
-        "httpsAddress": ":9090",
+        "httpAddress": "0.0.0.0:8080",
+        "httpsAddress": "0.0.0.0:9090",
         "header": "x-wsproxy-host"
       },
       "proxy": {
@@ -6280,7 +6280,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 5df9f8dc1dd20d39ae253cd9f977d948fcf75a7375165a9b82ecfd9852e343f3
+        gitpod.io/checksum_config: f985a365ca2934d925e1510c4398f0cf27ba9a85413f34a1f119317ad098f028
         seccomp.security.alpha.kubernetes.io/shiftfs-module-loader: unconfined
       creationTimestamp: null
       labels:
@@ -7116,7 +7116,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: ecceca62309eca278c739e914d6c9aa0a0897f345dedc2bab83ebfc3e779c89e
+        gitpod.io/checksum_config: 161f3cb1cb0878446fc17e8b20667e54261e2ebe7ac8212e33a63e2674507435
       creationTimestamp: null
       labels:
         app: gitpod
@@ -7521,7 +7521,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 87ccee70973253d6ebe86990f85ebf9d8042505446db9dc98ca2baf5de2d3e29
+        gitpod.io/checksum_config: 5f4a04af2e695c2ff89d6271a3698b7de0c290d212284db8703f8a38c0668c2c
       creationTimestamp: null
       labels:
         app: gitpod
@@ -7813,7 +7813,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 0cdf98514f9d4602d3df86390d956b068545bc7df349ef99ee7dd1df8107dc44
+        gitpod.io/checksum_config: 4f66681a8061c909af839092f3667c674ae68889a700f1af87162eafb05f72ac
       creationTimestamp: null
       labels:
         app: gitpod
@@ -8436,7 +8436,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: dcbc53af67e4007a4affc029e880c338b93e4484010727f4bf0a08ad7c93a112
+        gitpod.io/checksum_config: f88055f3ce58c8eca0064866deeb5131473b6ba2980dce8bf4f9989e997f1ff5
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/http-proxy/config.yaml
+++ b/install/installer/cmd/testdata/render/http-proxy/config.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+# Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
+apiVersion: v1
+domain: gitpod.example.com
+httpProxy:
+  kind: secret
+  name: http-proxy-settings

--- a/install/installer/cmd/testdata/render/http-proxy/output.golden
+++ b/install/installer/cmd/testdata/render/http-proxy/output.golden
@@ -681,228 +681,6 @@ spec:
       component: ws-manager
 status: {}
 ---
-# policy/v1beta1/PodSecurityPolicy default-ns-privileged
-apiVersion: policy/v1beta1
-kind: PodSecurityPolicy
-metadata:
-  annotations:
-    apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
-    apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
-    seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
-    seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
-  creationTimestamp: null
-  name: default-ns-privileged
-  namespace: default
-spec:
-  allowPrivilegeEscalation: true
-  allowedCapabilities:
-  - '*'
-  fsGroup:
-    rule: RunAsAny
-  hostIPC: true
-  hostNetwork: true
-  hostPID: true
-  hostPorts:
-  - max: 65535
-    min: 0
-  privileged: true
-  runAsUser:
-    rule: RunAsAny
-  seLinux:
-    rule: RunAsAny
-  supplementalGroups:
-    rule: RunAsAny
-  volumes:
-  - '*'
----
-# policy/v1beta1/PodSecurityPolicy default-ns-privileged-unconfined
-apiVersion: policy/v1beta1
-kind: PodSecurityPolicy
-metadata:
-  annotations:
-    apparmor.security.beta.kubernetes.io/allowedProfileNames: unconfined
-    apparmor.security.beta.kubernetes.io/defaultProfileName: unconfined
-    seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default,unconfined
-    seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
-  creationTimestamp: null
-  name: default-ns-privileged-unconfined
-  namespace: default
-spec:
-  allowPrivilegeEscalation: true
-  allowedCapabilities:
-  - '*'
-  fsGroup:
-    rule: RunAsAny
-  hostPID: true
-  hostPorts:
-  - max: 65535
-    min: 0
-  privileged: true
-  runAsUser:
-    rule: RunAsAny
-  seLinux:
-    rule: RunAsAny
-  supplementalGroups:
-    rule: RunAsAny
-  volumes:
-  - '*'
----
-# policy/v1beta1/PodSecurityPolicy default-ns-registry-facade
-apiVersion: policy/v1beta1
-kind: PodSecurityPolicy
-metadata:
-  annotations:
-    apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
-    apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
-    seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
-    seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
-  creationTimestamp: null
-  labels:
-    app: gitpod
-    component: registry-facade
-  name: default-ns-registry-facade
-spec:
-  fsGroup:
-    ranges:
-    - max: 65535
-      min: 1
-    rule: MustRunAs
-  hostNetwork: true
-  hostPorts:
-  - max: 20000
-    min: 20000
-  runAsUser:
-    rule: RunAsAny
-  seLinux:
-    rule: RunAsAny
-  supplementalGroups:
-    ranges:
-    - max: 65535
-      min: 1
-    rule: MustRunAs
-  volumes:
-  - configMap
-  - secret
-  - emptyDir
-  - hostPath
----
-# policy/v1beta1/PodSecurityPolicy default-ns-restricted-root-user
-apiVersion: policy/v1beta1
-kind: PodSecurityPolicy
-metadata:
-  annotations:
-    apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
-    apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
-    seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
-    seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
-  creationTimestamp: null
-  name: default-ns-restricted-root-user
-  namespace: default
-spec:
-  fsGroup:
-    ranges:
-    - max: 65535
-      min: 1
-    rule: MustRunAs
-  hostNetwork: true
-  hostPorts:
-  - max: 33000
-    min: 30000
-  privileged: true
-  runAsUser:
-    rule: RunAsAny
-  seLinux:
-    rule: RunAsAny
-  supplementalGroups:
-    ranges:
-    - max: 65535
-      min: 1
-    rule: MustRunAs
-  volumes:
-  - configMap
-  - projected
-  - secret
-  - emptyDir
-  - persistentVolumeClaim
-  - hostPath
----
-# policy/v1beta1/PodSecurityPolicy default-ns-unprivileged
-apiVersion: policy/v1beta1
-kind: PodSecurityPolicy
-metadata:
-  annotations:
-    apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
-    apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
-    seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
-    seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
-  creationTimestamp: null
-  name: default-ns-unprivileged
-  namespace: default
-spec:
-  allowPrivilegeEscalation: false
-  fsGroup:
-    ranges:
-    - max: 65535
-      min: 1
-    rule: MustRunAs
-  requiredDropCapabilities:
-  - ALL
-  runAsUser:
-    rule: MustRunAsNonRoot
-  seLinux:
-    rule: RunAsAny
-  supplementalGroups:
-    ranges:
-    - max: 65535
-      min: 1
-    rule: MustRunAs
-  volumes:
-  - configMap
-  - emptyDir
-  - projected
-  - secret
-  - persistentVolumeClaim
----
-# policy/v1beta1/PodSecurityPolicy default-ns-workspace
-apiVersion: policy/v1beta1
-kind: PodSecurityPolicy
-metadata:
-  annotations:
-    apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default,unconfined
-    apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
-    seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
-    seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
-  creationTimestamp: null
-  name: default-ns-workspace
-  namespace: default
-spec:
-  allowPrivilegeEscalation: true
-  allowedCapabilities:
-  - AUDIT_WRITE
-  - FSETID
-  - KILL
-  - NET_BIND_SERVICE
-  - SYS_PTRACE
-  fsGroup:
-    ranges:
-    - max: 65535
-      min: 1
-    rule: MustRunAs
-  runAsUser:
-    rule: RunAsAny
-  seLinux:
-    rule: RunAsAny
-  supplementalGroups:
-    ranges:
-    - max: 65535
-      min: 1
-    rule: MustRunAs
-  volumes:
-  - configMap
-  - projected
-  - secret
-  - hostPath
----
 # policy/v1/PodDisruptionBudget messagebus
 # Source: rabbitmq/charts/rabbitmq/templates/pdb.yaml
 apiVersion: policy/v1
@@ -1614,6 +1392,9 @@ data:
       inCluster: true
     disableDefinitelyGp: true
     domain: gitpod.example.com
+    httpProxy:
+      kind: secret
+      name: http-proxy-settings
     kind: Full
     metadata:
       region: local
@@ -1876,72 +1657,6 @@ data:
     metadata:
       creationTimestamp: null
       name: default-kube-rbac-proxy
-    ---
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRole
-    metadata:
-      creationTimestamp: null
-      name: default-ns-psp:privileged
-    ---
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRole
-    metadata:
-      creationTimestamp: null
-      name: default-ns-psp:restricted-root-user
-    ---
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRole
-    metadata:
-      creationTimestamp: null
-      name: default-ns-psp:unprivileged
-    ---
-    apiVersion: policy/v1beta1
-    kind: PodSecurityPolicy
-    metadata:
-      annotations:
-        apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
-        apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
-        seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
-        seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
-      creationTimestamp: null
-      name: default-ns-privileged
-      namespace: default
-    ---
-    apiVersion: policy/v1beta1
-    kind: PodSecurityPolicy
-    metadata:
-      annotations:
-        apparmor.security.beta.kubernetes.io/allowedProfileNames: unconfined
-        apparmor.security.beta.kubernetes.io/defaultProfileName: unconfined
-        seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default,unconfined
-        seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
-      creationTimestamp: null
-      name: default-ns-privileged-unconfined
-      namespace: default
-    ---
-    apiVersion: policy/v1beta1
-    kind: PodSecurityPolicy
-    metadata:
-      annotations:
-        apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
-        apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
-        seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
-        seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
-      creationTimestamp: null
-      name: default-ns-restricted-root-user
-      namespace: default
-    ---
-    apiVersion: policy/v1beta1
-    kind: PodSecurityPolicy
-    metadata:
-      annotations:
-        apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
-        apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
-        seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
-        seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
-      creationTimestamp: null
-      name: default-ns-unprivileged
-      namespace: default
     ---
     apiVersion: v1
     kind: ResourceQuota
@@ -2840,20 +2555,6 @@ data:
       name: registry-facade
       namespace: default
     ---
-    apiVersion: policy/v1beta1
-    kind: PodSecurityPolicy
-    metadata:
-      annotations:
-        apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
-        apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
-        seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
-        seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
-      creationTimestamp: null
-      labels:
-        app: gitpod
-        component: registry-facade
-      name: default-ns-registry-facade
-    ---
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
@@ -2911,28 +2612,6 @@ data:
         app: gitpod
         component: workspace
       name: workspace-default
-      namespace: default
-    ---
-    apiVersion: policy/v1beta1
-    kind: PodSecurityPolicy
-    metadata:
-      annotations:
-        apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default,unconfined
-        apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
-        seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
-        seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
-      creationTimestamp: null
-      name: default-ns-workspace
-      namespace: default
-    ---
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: Role
-    metadata:
-      creationTimestamp: null
-      labels:
-        app: gitpod
-        component: workspace
-      name: workspace
       namespace: default
     ---
     apiVersion: rbac.authorization.k8s.io/v1
@@ -3271,15 +2950,6 @@ data:
         component: ws-proxy
       name: ws-proxy
       namespace: default
-    ---
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRole
-    metadata:
-      creationTimestamp: null
-      labels:
-        app: gitpod
-        component: image-builder-mk3
-      name: default-ns-image-builder-mk3
     ---
     apiVersion: v1
     kind: ConfigMap
@@ -5308,73 +4978,6 @@ rules:
   verbs:
   - create
 ---
-# rbac.authorization.k8s.io/v1/ClusterRole default-ns-image-builder-mk3
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  creationTimestamp: null
-  labels:
-    app: gitpod
-    component: image-builder-mk3
-  name: default-ns-image-builder-mk3
-rules:
-- apiGroups:
-  - policy
-  resourceNames:
-  - default-ns-privileged-unconfined
-  resources:
-  - podsecuritypolicies
-  verbs:
-  - use
----
-# rbac.authorization.k8s.io/v1/ClusterRole default-ns-psp:privileged
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  creationTimestamp: null
-  name: default-ns-psp:privileged
-rules:
-- apiGroups:
-  - policy
-  resourceNames:
-  - default-ns-privileged
-  resources:
-  - podsecuritypolicies
-  verbs:
-  - use
----
-# rbac.authorization.k8s.io/v1/ClusterRole default-ns-psp:restricted-root-user
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  creationTimestamp: null
-  name: default-ns-psp:restricted-root-user
-rules:
-- apiGroups:
-  - policy
-  resourceNames:
-  - default-ns-restricted-root-user
-  resources:
-  - podsecuritypolicies
-  verbs:
-  - use
----
-# rbac.authorization.k8s.io/v1/ClusterRole default-ns-psp:unprivileged
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  creationTimestamp: null
-  name: default-ns-psp:unprivileged
-rules:
-- apiGroups:
-  - policy
-  resourceNames:
-  - default-ns-unprivileged
-  resources:
-  - podsecuritypolicies
-  verbs:
-  - use
----
 # rbac.authorization.k8s.io/v1/ClusterRole default-ns-registry-facade
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -5385,14 +4988,6 @@ metadata:
     component: registry-facade
   name: default-ns-registry-facade
 rules:
-- apiGroups:
-  - policy
-  resourceNames:
-  - default-ns-registry-facade
-  resources:
-  - podsecuritypolicies
-  verbs:
-  - use
 - apiGroups:
   - ""
   resources:
@@ -5413,14 +5008,6 @@ metadata:
     component: ws-daemon
   name: default-ns-ws-daemon
 rules:
-- apiGroups:
-  - policy
-  resourceNames:
-  - default-ns-privileged-unconfined
-  resources:
-  - podsecuritypolicies
-  verbs:
-  - use
 - apiGroups:
   - ""
   resources:
@@ -5800,14 +5387,6 @@ metadata:
   namespace: default
 rules:
 - apiGroups:
-  - policy
-  resourceNames:
-  - default-ns-privileged-unconfined
-  resources:
-  - podsecuritypolicies
-  verbs:
-  - use
-- apiGroups:
   - ""
   resources:
   - pods
@@ -5869,26 +5448,6 @@ rules:
   - update
   - patch
   - watch
----
-# rbac.authorization.k8s.io/v1/Role workspace
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  creationTimestamp: null
-  labels:
-    app: gitpod
-    component: workspace
-  name: workspace
-  namespace: default
-rules:
-- apiGroups:
-  - policy
-  resourceNames:
-  - default-ns-workspace
-  resources:
-  - podsecuritypolicies
-  verbs:
-  - use
 ---
 # rbac.authorization.k8s.io/v1/Role ws-manager
 apiVersion: rbac.authorization.k8s.io/v1
@@ -7031,6 +6590,46 @@ spec:
           value: svc.cluster.local
         - name: LOG_LEVEL
           value: info
+        - name: HTTP_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: httpProxy
+              name: http-proxy-settings
+              optional: true
+        - name: http_proxy
+          valueFrom:
+            secretKeyRef:
+              key: httpProxy
+              name: http-proxy-settings
+              optional: true
+        - name: HTTPS_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: httpsProxy
+              name: http-proxy-settings
+              optional: true
+        - name: https_proxy
+          valueFrom:
+            secretKeyRef:
+              key: httpsProxy
+              name: http-proxy-settings
+              optional: true
+        - name: CUSTOM_NO_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: noProxy
+              name: http-proxy-settings
+              optional: true
+        - name: custom_no_proxy
+          valueFrom:
+            secretKeyRef:
+              key: noProxy
+              name: http-proxy-settings
+              optional: true
+        - name: NO_PROXY
+          value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
+        - name: no_proxy
+          value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
         - name: JAEGER_DISABLED
           value: "true"
         - name: NODENAME
@@ -7059,6 +6658,46 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: HTTP_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: httpProxy
+              name: http-proxy-settings
+              optional: true
+        - name: http_proxy
+          valueFrom:
+            secretKeyRef:
+              key: httpProxy
+              name: http-proxy-settings
+              optional: true
+        - name: HTTPS_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: httpsProxy
+              name: http-proxy-settings
+              optional: true
+        - name: https_proxy
+          valueFrom:
+            secretKeyRef:
+              key: httpsProxy
+              name: http-proxy-settings
+              optional: true
+        - name: CUSTOM_NO_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: noProxy
+              name: http-proxy-settings
+              optional: true
+        - name: custom_no_proxy
+          valueFrom:
+            secretKeyRef:
+              key: noProxy
+              name: http-proxy-settings
+              optional: true
+        - name: NO_PROXY
+          value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
+        - name: no_proxy
+          value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
         image: quay.io/brancz/kube-rbac-proxy:v0.12.0
         name: kube-rbac-proxy
         ports:
@@ -7146,6 +6785,46 @@ spec:
           value: svc.cluster.local
         - name: LOG_LEVEL
           value: info
+        - name: HTTP_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: httpProxy
+              name: http-proxy-settings
+              optional: true
+        - name: http_proxy
+          valueFrom:
+            secretKeyRef:
+              key: httpProxy
+              name: http-proxy-settings
+              optional: true
+        - name: HTTPS_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: httpsProxy
+              name: http-proxy-settings
+              optional: true
+        - name: https_proxy
+          valueFrom:
+            secretKeyRef:
+              key: httpsProxy
+              name: http-proxy-settings
+              optional: true
+        - name: CUSTOM_NO_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: noProxy
+              name: http-proxy-settings
+              optional: true
+        - name: custom_no_proxy
+          valueFrom:
+            secretKeyRef:
+              key: noProxy
+              name: http-proxy-settings
+              optional: true
+        - name: NO_PROXY
+          value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
+        - name: no_proxy
+          value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
         - name: JAEGER_DISABLED
           value: "true"
         - name: GRPC_GO_RETRY
@@ -7209,6 +6888,46 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: HTTP_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: httpProxy
+              name: http-proxy-settings
+              optional: true
+        - name: http_proxy
+          valueFrom:
+            secretKeyRef:
+              key: httpProxy
+              name: http-proxy-settings
+              optional: true
+        - name: HTTPS_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: httpsProxy
+              name: http-proxy-settings
+              optional: true
+        - name: https_proxy
+          valueFrom:
+            secretKeyRef:
+              key: httpsProxy
+              name: http-proxy-settings
+              optional: true
+        - name: CUSTOM_NO_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: noProxy
+              name: http-proxy-settings
+              optional: true
+        - name: custom_no_proxy
+          valueFrom:
+            secretKeyRef:
+              key: noProxy
+              name: http-proxy-settings
+              optional: true
+        - name: NO_PROXY
+          value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
+        - name: no_proxy
+          value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
         image: quay.io/brancz/kube-rbac-proxy:v0.12.0
         name: kube-rbac-proxy
         ports:
@@ -7232,6 +6951,46 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: HTTP_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: httpProxy
+              name: http-proxy-settings
+              optional: true
+        - name: http_proxy
+          valueFrom:
+            secretKeyRef:
+              key: httpProxy
+              name: http-proxy-settings
+              optional: true
+        - name: HTTPS_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: httpsProxy
+              name: http-proxy-settings
+              optional: true
+        - name: https_proxy
+          valueFrom:
+            secretKeyRef:
+              key: httpsProxy
+              name: http-proxy-settings
+              optional: true
+        - name: CUSTOM_NO_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: noProxy
+              name: http-proxy-settings
+              optional: true
+        - name: custom_no_proxy
+          valueFrom:
+            secretKeyRef:
+              key: noProxy
+              name: http-proxy-settings
+              optional: true
+        - name: NO_PROXY
+          value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
+        - name: no_proxy
+          value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
         image: eu.gcr.io/gitpod-core-dev/build/registry-facade:test
         imagePullPolicy: IfNotPresent
         lifecycle:
@@ -7251,6 +7010,47 @@ spec:
         - -c
         - set -e; update-ca-certificates -f; cp /etc/ssl/certs/* /ssl-certs; echo
           'OK'
+        env:
+        - name: HTTP_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: httpProxy
+              name: http-proxy-settings
+              optional: true
+        - name: http_proxy
+          valueFrom:
+            secretKeyRef:
+              key: httpProxy
+              name: http-proxy-settings
+              optional: true
+        - name: HTTPS_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: httpsProxy
+              name: http-proxy-settings
+              optional: true
+        - name: https_proxy
+          valueFrom:
+            secretKeyRef:
+              key: httpsProxy
+              name: http-proxy-settings
+              optional: true
+        - name: CUSTOM_NO_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: noProxy
+              name: http-proxy-settings
+              optional: true
+        - name: custom_no_proxy
+          valueFrom:
+            secretKeyRef:
+              key: noProxy
+              name: http-proxy-settings
+              optional: true
+        - name: NO_PROXY
+          value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
+        - name: no_proxy
+          value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
         image: eu.gcr.io/gitpod-core-dev/build/ca-updater:test
         imagePullPolicy: IfNotPresent
         name: update-ca-certificates
@@ -7351,6 +7151,46 @@ spec:
           value: svc.cluster.local
         - name: LOG_LEVEL
           value: info
+        - name: HTTP_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: httpProxy
+              name: http-proxy-settings
+              optional: true
+        - name: http_proxy
+          valueFrom:
+            secretKeyRef:
+              key: httpProxy
+              name: http-proxy-settings
+              optional: true
+        - name: HTTPS_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: httpsProxy
+              name: http-proxy-settings
+              optional: true
+        - name: https_proxy
+          valueFrom:
+            secretKeyRef:
+              key: httpsProxy
+              name: http-proxy-settings
+              optional: true
+        - name: CUSTOM_NO_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: noProxy
+              name: http-proxy-settings
+              optional: true
+        - name: custom_no_proxy
+          valueFrom:
+            secretKeyRef:
+              key: noProxy
+              name: http-proxy-settings
+              optional: true
+        - name: NO_PROXY
+          value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
+        - name: no_proxy
+          value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
         - name: JAEGER_DISABLED
           value: "true"
         - name: NODENAME
@@ -7420,6 +7260,46 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: HTTP_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: httpProxy
+              name: http-proxy-settings
+              optional: true
+        - name: http_proxy
+          valueFrom:
+            secretKeyRef:
+              key: httpProxy
+              name: http-proxy-settings
+              optional: true
+        - name: HTTPS_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: httpsProxy
+              name: http-proxy-settings
+              optional: true
+        - name: https_proxy
+          valueFrom:
+            secretKeyRef:
+              key: httpsProxy
+              name: http-proxy-settings
+              optional: true
+        - name: CUSTOM_NO_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: noProxy
+              name: http-proxy-settings
+              optional: true
+        - name: custom_no_proxy
+          valueFrom:
+            secretKeyRef:
+              key: noProxy
+              name: http-proxy-settings
+              optional: true
+        - name: NO_PROXY
+          value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
+        - name: no_proxy
+          value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
         image: quay.io/brancz/kube-rbac-proxy:v0.12.0
         name: kube-rbac-proxy
         ports:
@@ -7443,6 +7323,46 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: HTTP_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: httpProxy
+              name: http-proxy-settings
+              optional: true
+        - name: http_proxy
+          valueFrom:
+            secretKeyRef:
+              key: httpProxy
+              name: http-proxy-settings
+              optional: true
+        - name: HTTPS_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: httpsProxy
+              name: http-proxy-settings
+              optional: true
+        - name: https_proxy
+          valueFrom:
+            secretKeyRef:
+              key: httpsProxy
+              name: http-proxy-settings
+              optional: true
+        - name: CUSTOM_NO_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: noProxy
+              name: http-proxy-settings
+              optional: true
+        - name: custom_no_proxy
+          valueFrom:
+            secretKeyRef:
+              key: noProxy
+              name: http-proxy-settings
+              optional: true
+        - name: NO_PROXY
+          value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
+        - name: no_proxy
+          value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
         image: eu.gcr.io/gitpod-core-dev/build/ws-daemon:test
         imagePullPolicy: IfNotPresent
         lifecycle:
@@ -7474,6 +7394,47 @@ spec:
         - -a
         - /bin/bash
         - -c
+        env:
+        - name: HTTP_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: httpProxy
+              name: http-proxy-settings
+              optional: true
+        - name: http_proxy
+          valueFrom:
+            secretKeyRef:
+              key: httpProxy
+              name: http-proxy-settings
+              optional: true
+        - name: HTTPS_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: httpsProxy
+              name: http-proxy-settings
+              optional: true
+        - name: https_proxy
+          valueFrom:
+            secretKeyRef:
+              key: httpsProxy
+              name: http-proxy-settings
+              optional: true
+        - name: CUSTOM_NO_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: noProxy
+              name: http-proxy-settings
+              optional: true
+        - name: custom_no_proxy
+          valueFrom:
+            secretKeyRef:
+              key: noProxy
+              name: http-proxy-settings
+              optional: true
+        - name: NO_PROXY
+          value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
+        - name: no_proxy
+          value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
         image: docker.io/library/ubuntu:20.04
         name: disable-kube-health-monitor
         resources: {}
@@ -7982,6 +7943,46 @@ spec:
               value: svc.cluster.local
             - name: LOG_LEVEL
               value: info
+            - name: HTTP_PROXY
+              valueFrom:
+                secretKeyRef:
+                  key: httpProxy
+                  name: http-proxy-settings
+                  optional: true
+            - name: http_proxy
+              valueFrom:
+                secretKeyRef:
+                  key: httpProxy
+                  name: http-proxy-settings
+                  optional: true
+            - name: HTTPS_PROXY
+              valueFrom:
+                secretKeyRef:
+                  key: httpsProxy
+                  name: http-proxy-settings
+                  optional: true
+            - name: https_proxy
+              valueFrom:
+                secretKeyRef:
+                  key: httpsProxy
+                  name: http-proxy-settings
+                  optional: true
+            - name: CUSTOM_NO_PROXY
+              valueFrom:
+                secretKeyRef:
+                  key: noProxy
+                  name: http-proxy-settings
+                  optional: true
+            - name: custom_no_proxy
+              valueFrom:
+                secretKeyRef:
+                  key: noProxy
+                  name: http-proxy-settings
+                  optional: true
+            - name: NO_PROXY
+              value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
+            - name: no_proxy
+              value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
           image: eu.gcr.io/gitpod-core-dev/build/openvsx-proxy:test
           imagePullPolicy: IfNotPresent
           name: openvsx-proxy
@@ -8030,6 +8031,46 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
+            - name: HTTP_PROXY
+              valueFrom:
+                secretKeyRef:
+                  key: httpProxy
+                  name: http-proxy-settings
+                  optional: true
+            - name: http_proxy
+              valueFrom:
+                secretKeyRef:
+                  key: httpProxy
+                  name: http-proxy-settings
+                  optional: true
+            - name: HTTPS_PROXY
+              valueFrom:
+                secretKeyRef:
+                  key: httpsProxy
+                  name: http-proxy-settings
+                  optional: true
+            - name: https_proxy
+              valueFrom:
+                secretKeyRef:
+                  key: httpsProxy
+                  name: http-proxy-settings
+                  optional: true
+            - name: CUSTOM_NO_PROXY
+              valueFrom:
+                secretKeyRef:
+                  key: noProxy
+                  name: http-proxy-settings
+                  optional: true
+            - name: custom_no_proxy
+              valueFrom:
+                secretKeyRef:
+                  key: noProxy
+                  name: http-proxy-settings
+                  optional: true
+            - name: NO_PROXY
+              value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
+            - name: no_proxy
+              value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
           image: quay.io/brancz/kube-rbac-proxy:v0.12.0
           name: kube-rbac-proxy
           ports:
@@ -8130,6 +8171,46 @@ spec:
           value: svc.cluster.local
         - name: LOG_LEVEL
           value: info
+        - name: HTTP_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: httpProxy
+              name: http-proxy-settings
+              optional: true
+        - name: http_proxy
+          valueFrom:
+            secretKeyRef:
+              key: httpProxy
+              name: http-proxy-settings
+              optional: true
+        - name: HTTPS_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: httpsProxy
+              name: http-proxy-settings
+              optional: true
+        - name: https_proxy
+          valueFrom:
+            secretKeyRef:
+              key: httpsProxy
+              name: http-proxy-settings
+              optional: true
+        - name: CUSTOM_NO_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: noProxy
+              name: http-proxy-settings
+              optional: true
+        - name: custom_no_proxy
+          valueFrom:
+            secretKeyRef:
+              key: noProxy
+              name: http-proxy-settings
+              optional: true
+        - name: NO_PROXY
+          value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
+        - name: no_proxy
+          value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
         - name: JAEGER_DISABLED
           value: "true"
         image: eu.gcr.io/gitpod-core-dev/build/blobserve:test
@@ -8181,6 +8262,46 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: HTTP_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: httpProxy
+              name: http-proxy-settings
+              optional: true
+        - name: http_proxy
+          valueFrom:
+            secretKeyRef:
+              key: httpProxy
+              name: http-proxy-settings
+              optional: true
+        - name: HTTPS_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: httpsProxy
+              name: http-proxy-settings
+              optional: true
+        - name: https_proxy
+          valueFrom:
+            secretKeyRef:
+              key: httpsProxy
+              name: http-proxy-settings
+              optional: true
+        - name: CUSTOM_NO_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: noProxy
+              name: http-proxy-settings
+              optional: true
+        - name: custom_no_proxy
+          valueFrom:
+            secretKeyRef:
+              key: noProxy
+              name: http-proxy-settings
+              optional: true
+        - name: NO_PROXY
+          value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
+        - name: no_proxy
+          value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
         image: quay.io/brancz/kube-rbac-proxy:v0.12.0
         name: kube-rbac-proxy
         ports:
@@ -8269,6 +8390,46 @@ spec:
           value: svc.cluster.local
         - name: LOG_LEVEL
           value: info
+        - name: HTTP_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: httpProxy
+              name: http-proxy-settings
+              optional: true
+        - name: http_proxy
+          valueFrom:
+            secretKeyRef:
+              key: httpProxy
+              name: http-proxy-settings
+              optional: true
+        - name: HTTPS_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: httpsProxy
+              name: http-proxy-settings
+              optional: true
+        - name: https_proxy
+          valueFrom:
+            secretKeyRef:
+              key: httpsProxy
+              name: http-proxy-settings
+              optional: true
+        - name: CUSTOM_NO_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: noProxy
+              name: http-proxy-settings
+              optional: true
+        - name: custom_no_proxy
+          valueFrom:
+            secretKeyRef:
+              key: noProxy
+              name: http-proxy-settings
+              optional: true
+        - name: NO_PROXY
+          value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
+        - name: no_proxy
+          value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
         - name: JAEGER_DISABLED
           value: "true"
         - name: GRPC_GO_RETRY
@@ -8301,6 +8462,46 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: HTTP_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: httpProxy
+              name: http-proxy-settings
+              optional: true
+        - name: http_proxy
+          valueFrom:
+            secretKeyRef:
+              key: httpProxy
+              name: http-proxy-settings
+              optional: true
+        - name: HTTPS_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: httpsProxy
+              name: http-proxy-settings
+              optional: true
+        - name: https_proxy
+          valueFrom:
+            secretKeyRef:
+              key: httpsProxy
+              name: http-proxy-settings
+              optional: true
+        - name: CUSTOM_NO_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: noProxy
+              name: http-proxy-settings
+              optional: true
+        - name: custom_no_proxy
+          valueFrom:
+            secretKeyRef:
+              key: noProxy
+              name: http-proxy-settings
+              optional: true
+        - name: NO_PROXY
+          value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
+        - name: no_proxy
+          value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
         image: quay.io/brancz/kube-rbac-proxy:v0.12.0
         name: kube-rbac-proxy
         ports:
@@ -8381,6 +8582,46 @@ spec:
           value: svc.cluster.local
         - name: LOG_LEVEL
           value: info
+        - name: HTTP_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: httpProxy
+              name: http-proxy-settings
+              optional: true
+        - name: http_proxy
+          valueFrom:
+            secretKeyRef:
+              key: httpProxy
+              name: http-proxy-settings
+              optional: true
+        - name: HTTPS_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: httpsProxy
+              name: http-proxy-settings
+              optional: true
+        - name: https_proxy
+          valueFrom:
+            secretKeyRef:
+              key: httpsProxy
+              name: http-proxy-settings
+              optional: true
+        - name: CUSTOM_NO_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: noProxy
+              name: http-proxy-settings
+              optional: true
+        - name: custom_no_proxy
+          valueFrom:
+            secretKeyRef:
+              key: noProxy
+              name: http-proxy-settings
+              optional: true
+        - name: NO_PROXY
+          value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
+        - name: no_proxy
+          value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
         image: eu.gcr.io/gitpod-core-dev/build/dashboard:test
         imagePullPolicy: IfNotPresent
         name: dashboard
@@ -8469,6 +8710,46 @@ spec:
           value: svc.cluster.local
         - name: LOG_LEVEL
           value: info
+        - name: HTTP_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: httpProxy
+              name: http-proxy-settings
+              optional: true
+        - name: http_proxy
+          valueFrom:
+            secretKeyRef:
+              key: httpProxy
+              name: http-proxy-settings
+              optional: true
+        - name: HTTPS_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: httpsProxy
+              name: http-proxy-settings
+              optional: true
+        - name: https_proxy
+          valueFrom:
+            secretKeyRef:
+              key: httpsProxy
+              name: http-proxy-settings
+              optional: true
+        - name: CUSTOM_NO_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: noProxy
+              name: http-proxy-settings
+              optional: true
+        - name: custom_no_proxy
+          valueFrom:
+            secretKeyRef:
+              key: noProxy
+              name: http-proxy-settings
+              optional: true
+        - name: NO_PROXY
+          value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
+        - name: no_proxy
+          value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
         image: eu.gcr.io/gitpod-core-dev/build/ide-metrics:test
         imagePullPolicy: IfNotPresent
         name: ide-metrics
@@ -8500,6 +8781,46 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: HTTP_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: httpProxy
+              name: http-proxy-settings
+              optional: true
+        - name: http_proxy
+          valueFrom:
+            secretKeyRef:
+              key: httpProxy
+              name: http-proxy-settings
+              optional: true
+        - name: HTTPS_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: httpsProxy
+              name: http-proxy-settings
+              optional: true
+        - name: https_proxy
+          valueFrom:
+            secretKeyRef:
+              key: httpsProxy
+              name: http-proxy-settings
+              optional: true
+        - name: CUSTOM_NO_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: noProxy
+              name: http-proxy-settings
+              optional: true
+        - name: custom_no_proxy
+          valueFrom:
+            secretKeyRef:
+              key: noProxy
+              name: http-proxy-settings
+              optional: true
+        - name: NO_PROXY
+          value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
+        - name: no_proxy
+          value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
         image: quay.io/brancz/kube-rbac-proxy:v0.12.0
         name: kube-rbac-proxy
         ports:
@@ -8580,6 +8901,46 @@ spec:
           value: svc.cluster.local
         - name: LOG_LEVEL
           value: info
+        - name: HTTP_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: httpProxy
+              name: http-proxy-settings
+              optional: true
+        - name: http_proxy
+          valueFrom:
+            secretKeyRef:
+              key: httpProxy
+              name: http-proxy-settings
+              optional: true
+        - name: HTTPS_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: httpsProxy
+              name: http-proxy-settings
+              optional: true
+        - name: https_proxy
+          valueFrom:
+            secretKeyRef:
+              key: httpsProxy
+              name: http-proxy-settings
+              optional: true
+        - name: CUSTOM_NO_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: noProxy
+              name: http-proxy-settings
+              optional: true
+        - name: custom_no_proxy
+          valueFrom:
+            secretKeyRef:
+              key: noProxy
+              name: http-proxy-settings
+              optional: true
+        - name: NO_PROXY
+          value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
+        - name: no_proxy
+          value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
         image: eu.gcr.io/gitpod-core-dev/build/ide-proxy:test
         imagePullPolicy: IfNotPresent
         name: ide-proxy
@@ -8668,6 +9029,46 @@ spec:
           value: svc.cluster.local
         - name: LOG_LEVEL
           value: info
+        - name: HTTP_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: httpProxy
+              name: http-proxy-settings
+              optional: true
+        - name: http_proxy
+          valueFrom:
+            secretKeyRef:
+              key: httpProxy
+              name: http-proxy-settings
+              optional: true
+        - name: HTTPS_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: httpsProxy
+              name: http-proxy-settings
+              optional: true
+        - name: https_proxy
+          valueFrom:
+            secretKeyRef:
+              key: httpsProxy
+              name: http-proxy-settings
+              optional: true
+        - name: CUSTOM_NO_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: noProxy
+              name: http-proxy-settings
+              optional: true
+        - name: custom_no_proxy
+          valueFrom:
+            secretKeyRef:
+              key: noProxy
+              name: http-proxy-settings
+              optional: true
+        - name: NO_PROXY
+          value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
+        - name: no_proxy
+          value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
         - name: JAEGER_DISABLED
           value: "true"
         image: eu.gcr.io/gitpod-core-dev/build/image-builder-mk3:test
@@ -8702,6 +9103,46 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: HTTP_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: httpProxy
+              name: http-proxy-settings
+              optional: true
+        - name: http_proxy
+          valueFrom:
+            secretKeyRef:
+              key: httpProxy
+              name: http-proxy-settings
+              optional: true
+        - name: HTTPS_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: httpsProxy
+              name: http-proxy-settings
+              optional: true
+        - name: https_proxy
+          valueFrom:
+            secretKeyRef:
+              key: httpsProxy
+              name: http-proxy-settings
+              optional: true
+        - name: CUSTOM_NO_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: noProxy
+              name: http-proxy-settings
+              optional: true
+        - name: custom_no_proxy
+          valueFrom:
+            secretKeyRef:
+              key: noProxy
+              name: http-proxy-settings
+              optional: true
+        - name: NO_PROXY
+          value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
+        - name: no_proxy
+          value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
         image: quay.io/brancz/kube-rbac-proxy:v0.12.0
         name: kube-rbac-proxy
         ports:
@@ -8724,6 +9165,47 @@ spec:
         - -c
         - set -e; update-ca-certificates -f; cp /etc/ssl/certs/* /ssl-certs; echo
           'OK'
+        env:
+        - name: HTTP_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: httpProxy
+              name: http-proxy-settings
+              optional: true
+        - name: http_proxy
+          valueFrom:
+            secretKeyRef:
+              key: httpProxy
+              name: http-proxy-settings
+              optional: true
+        - name: HTTPS_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: httpsProxy
+              name: http-proxy-settings
+              optional: true
+        - name: https_proxy
+          valueFrom:
+            secretKeyRef:
+              key: httpsProxy
+              name: http-proxy-settings
+              optional: true
+        - name: CUSTOM_NO_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: noProxy
+              name: http-proxy-settings
+              optional: true
+        - name: custom_no_proxy
+          valueFrom:
+            secretKeyRef:
+              key: noProxy
+              name: http-proxy-settings
+              optional: true
+        - name: NO_PROXY
+          value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
+        - name: no_proxy
+          value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
         image: eu.gcr.io/gitpod-core-dev/build/ca-updater:test
         imagePullPolicy: IfNotPresent
         name: update-ca-certificates
@@ -8946,6 +9428,46 @@ spec:
           value: svc.cluster.local
         - name: LOG_LEVEL
           value: info
+        - name: HTTP_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: httpProxy
+              name: http-proxy-settings
+              optional: true
+        - name: http_proxy
+          valueFrom:
+            secretKeyRef:
+              key: httpProxy
+              name: http-proxy-settings
+              optional: true
+        - name: HTTPS_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: httpsProxy
+              name: http-proxy-settings
+              optional: true
+        - name: https_proxy
+          valueFrom:
+            secretKeyRef:
+              key: httpsProxy
+              name: http-proxy-settings
+              optional: true
+        - name: CUSTOM_NO_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: noProxy
+              name: http-proxy-settings
+              optional: true
+        - name: custom_no_proxy
+          valueFrom:
+            secretKeyRef:
+              key: noProxy
+              name: http-proxy-settings
+              optional: true
+        - name: NO_PROXY
+          value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
+        - name: no_proxy
+          value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
         - name: PROXY_DOMAIN
           value: gitpod.example.com
         image: eu.gcr.io/gitpod-core-dev/build/proxy:test
@@ -9162,6 +9684,46 @@ spec:
           value: svc.cluster.local
         - name: LOG_LEVEL
           value: info
+        - name: HTTP_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: httpProxy
+              name: http-proxy-settings
+              optional: true
+        - name: http_proxy
+          valueFrom:
+            secretKeyRef:
+              key: httpProxy
+              name: http-proxy-settings
+              optional: true
+        - name: HTTPS_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: httpsProxy
+              name: http-proxy-settings
+              optional: true
+        - name: https_proxy
+          valueFrom:
+            secretKeyRef:
+              key: httpsProxy
+              name: http-proxy-settings
+              optional: true
+        - name: CUSTOM_NO_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: noProxy
+              name: http-proxy-settings
+              optional: true
+        - name: custom_no_proxy
+          valueFrom:
+            secretKeyRef:
+              key: noProxy
+              name: http-proxy-settings
+              optional: true
+        - name: NO_PROXY
+          value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
+        - name: no_proxy
+          value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
         - name: DB_HOST
           valueFrom:
             secretKeyRef:
@@ -9226,6 +9788,8 @@ spec:
           value: "1"
         - name: WSMAN_CFG_MANAGERS
           value: WwogIHsKICAgICJuYW1lIjogImRlZmF1bHQiLAogICAgInVybCI6ICJkbnM6Ly8vd3MtbWFuYWdlcjo4MDgwIiwKICAgICJ0bHMiOiB7CiAgICAgICJjYSI6ICIvd3MtbWFuYWdlci1jbGllbnQtdGxzLWNlcnRzL2NhLmNydCIsCiAgICAgICJjcnQiOiAiL3dzLW1hbmFnZXItY2xpZW50LXRscy1jZXJ0cy90bHMuY3J0IiwKICAgICAgImtleSI6ICIvd3MtbWFuYWdlci1jbGllbnQtdGxzLWNlcnRzL3Rscy5rZXkiCiAgICB9LAogICAgInN0YXRlIjogImF2YWlsYWJsZSIsCiAgICAibWF4U2NvcmUiOiAxMDAsCiAgICAic2NvcmUiOiA1MCwKICAgICJnb3Zlcm4iOiB0cnVlLAogICAgImFkbWlzc2lvbkNvbnN0cmFpbnRzIjogbnVsbAogIH0KXQ==
+        - name: no_grpc_proxy
+          value: content-service.default.svc.cluster.local,image-builder-mk3.default.svc.cluster.local,usage.default.svc.cluster.local,$(NO_PROXY)
         image: eu.gcr.io/gitpod-core-dev/build/server:test
         imagePullPolicy: IfNotPresent
         name: server
@@ -9269,6 +9833,46 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: HTTP_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: httpProxy
+              name: http-proxy-settings
+              optional: true
+        - name: http_proxy
+          valueFrom:
+            secretKeyRef:
+              key: httpProxy
+              name: http-proxy-settings
+              optional: true
+        - name: HTTPS_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: httpsProxy
+              name: http-proxy-settings
+              optional: true
+        - name: https_proxy
+          valueFrom:
+            secretKeyRef:
+              key: httpsProxy
+              name: http-proxy-settings
+              optional: true
+        - name: CUSTOM_NO_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: noProxy
+              name: http-proxy-settings
+              optional: true
+        - name: custom_no_proxy
+          valueFrom:
+            secretKeyRef:
+              key: noProxy
+              name: http-proxy-settings
+              optional: true
+        - name: NO_PROXY
+          value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
+        - name: no_proxy
+          value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
         image: quay.io/brancz/kube-rbac-proxy:v0.12.0
         name: kube-rbac-proxy
         ports:
@@ -9314,6 +9918,46 @@ spec:
             secretKeyRef:
               key: encryptionKeys
               name: mysql
+        - name: HTTP_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: httpProxy
+              name: http-proxy-settings
+              optional: true
+        - name: http_proxy
+          valueFrom:
+            secretKeyRef:
+              key: httpProxy
+              name: http-proxy-settings
+              optional: true
+        - name: HTTPS_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: httpsProxy
+              name: http-proxy-settings
+              optional: true
+        - name: https_proxy
+          valueFrom:
+            secretKeyRef:
+              key: httpsProxy
+              name: http-proxy-settings
+              optional: true
+        - name: CUSTOM_NO_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: noProxy
+              name: http-proxy-settings
+              optional: true
+        - name: custom_no_proxy
+          valueFrom:
+            secretKeyRef:
+              key: noProxy
+              name: http-proxy-settings
+              optional: true
+        - name: NO_PROXY
+          value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
+        - name: no_proxy
+          value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
         image: eu.gcr.io/gitpod-core-dev/build/service-waiter:test
         name: database-waiter
         resources: {}
@@ -9349,6 +9993,46 @@ spec:
             secretKeyRef:
               key: tls.key
               name: messagebus-certificates-secret-core
+        - name: HTTP_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: httpProxy
+              name: http-proxy-settings
+              optional: true
+        - name: http_proxy
+          valueFrom:
+            secretKeyRef:
+              key: httpProxy
+              name: http-proxy-settings
+              optional: true
+        - name: HTTPS_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: httpsProxy
+              name: http-proxy-settings
+              optional: true
+        - name: https_proxy
+          valueFrom:
+            secretKeyRef:
+              key: httpsProxy
+              name: http-proxy-settings
+              optional: true
+        - name: CUSTOM_NO_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: noProxy
+              name: http-proxy-settings
+              optional: true
+        - name: custom_no_proxy
+          valueFrom:
+            secretKeyRef:
+              key: noProxy
+              name: http-proxy-settings
+              optional: true
+        - name: NO_PROXY
+          value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
+        - name: no_proxy
+          value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
         image: eu.gcr.io/gitpod-core-dev/build/service-waiter:test
         name: msgbus-waiter
         resources: {}
@@ -9434,6 +10118,46 @@ spec:
           value: svc.cluster.local
         - name: LOG_LEVEL
           value: info
+        - name: HTTP_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: httpProxy
+              name: http-proxy-settings
+              optional: true
+        - name: http_proxy
+          valueFrom:
+            secretKeyRef:
+              key: httpProxy
+              name: http-proxy-settings
+              optional: true
+        - name: HTTPS_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: httpsProxy
+              name: http-proxy-settings
+              optional: true
+        - name: https_proxy
+          valueFrom:
+            secretKeyRef:
+              key: httpsProxy
+              name: http-proxy-settings
+              optional: true
+        - name: CUSTOM_NO_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: noProxy
+              name: http-proxy-settings
+              optional: true
+        - name: custom_no_proxy
+          valueFrom:
+            secretKeyRef:
+              key: noProxy
+              name: http-proxy-settings
+              optional: true
+        - name: NO_PROXY
+          value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
+        - name: no_proxy
+          value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
         - name: JAEGER_DISABLED
           value: "true"
         - name: GRPC_GO_RETRY
@@ -9472,6 +10196,46 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: HTTP_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: httpProxy
+              name: http-proxy-settings
+              optional: true
+        - name: http_proxy
+          valueFrom:
+            secretKeyRef:
+              key: httpProxy
+              name: http-proxy-settings
+              optional: true
+        - name: HTTPS_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: httpsProxy
+              name: http-proxy-settings
+              optional: true
+        - name: https_proxy
+          valueFrom:
+            secretKeyRef:
+              key: httpsProxy
+              name: http-proxy-settings
+              optional: true
+        - name: CUSTOM_NO_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: noProxy
+              name: http-proxy-settings
+              optional: true
+        - name: custom_no_proxy
+          valueFrom:
+            secretKeyRef:
+              key: noProxy
+              name: http-proxy-settings
+              optional: true
+        - name: NO_PROXY
+          value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
+        - name: no_proxy
+          value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
         image: quay.io/brancz/kube-rbac-proxy:v0.12.0
         name: kube-rbac-proxy
         ports:
@@ -9563,6 +10327,46 @@ spec:
           value: svc.cluster.local
         - name: LOG_LEVEL
           value: info
+        - name: HTTP_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: httpProxy
+              name: http-proxy-settings
+              optional: true
+        - name: http_proxy
+          valueFrom:
+            secretKeyRef:
+              key: httpProxy
+              name: http-proxy-settings
+              optional: true
+        - name: HTTPS_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: httpsProxy
+              name: http-proxy-settings
+              optional: true
+        - name: https_proxy
+          valueFrom:
+            secretKeyRef:
+              key: httpsProxy
+              name: http-proxy-settings
+              optional: true
+        - name: CUSTOM_NO_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: noProxy
+              name: http-proxy-settings
+              optional: true
+        - name: custom_no_proxy
+          valueFrom:
+            secretKeyRef:
+              key: noProxy
+              name: http-proxy-settings
+              optional: true
+        - name: NO_PROXY
+          value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
+        - name: no_proxy
+          value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
         - name: JAEGER_DISABLED
           value: "true"
         - name: MESSAGEBUS_USERNAME
@@ -9646,6 +10450,46 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: HTTP_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: httpProxy
+              name: http-proxy-settings
+              optional: true
+        - name: http_proxy
+          valueFrom:
+            secretKeyRef:
+              key: httpProxy
+              name: http-proxy-settings
+              optional: true
+        - name: HTTPS_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: httpsProxy
+              name: http-proxy-settings
+              optional: true
+        - name: https_proxy
+          valueFrom:
+            secretKeyRef:
+              key: httpsProxy
+              name: http-proxy-settings
+              optional: true
+        - name: CUSTOM_NO_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: noProxy
+              name: http-proxy-settings
+              optional: true
+        - name: custom_no_proxy
+          valueFrom:
+            secretKeyRef:
+              key: noProxy
+              name: http-proxy-settings
+              optional: true
+        - name: NO_PROXY
+          value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
+        - name: no_proxy
+          value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
         image: quay.io/brancz/kube-rbac-proxy:v0.12.0
         name: kube-rbac-proxy
         ports:
@@ -9692,6 +10536,46 @@ spec:
             secretKeyRef:
               key: encryptionKeys
               name: mysql
+        - name: HTTP_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: httpProxy
+              name: http-proxy-settings
+              optional: true
+        - name: http_proxy
+          valueFrom:
+            secretKeyRef:
+              key: httpProxy
+              name: http-proxy-settings
+              optional: true
+        - name: HTTPS_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: httpsProxy
+              name: http-proxy-settings
+              optional: true
+        - name: https_proxy
+          valueFrom:
+            secretKeyRef:
+              key: httpsProxy
+              name: http-proxy-settings
+              optional: true
+        - name: CUSTOM_NO_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: noProxy
+              name: http-proxy-settings
+              optional: true
+        - name: custom_no_proxy
+          valueFrom:
+            secretKeyRef:
+              key: noProxy
+              name: http-proxy-settings
+              optional: true
+        - name: NO_PROXY
+          value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
+        - name: no_proxy
+          value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
         image: eu.gcr.io/gitpod-core-dev/build/service-waiter:test
         name: database-waiter
         resources: {}
@@ -9727,6 +10611,46 @@ spec:
             secretKeyRef:
               key: tls.key
               name: messagebus-certificates-secret-core
+        - name: HTTP_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: httpProxy
+              name: http-proxy-settings
+              optional: true
+        - name: http_proxy
+          valueFrom:
+            secretKeyRef:
+              key: httpProxy
+              name: http-proxy-settings
+              optional: true
+        - name: HTTPS_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: httpsProxy
+              name: http-proxy-settings
+              optional: true
+        - name: https_proxy
+          valueFrom:
+            secretKeyRef:
+              key: httpsProxy
+              name: http-proxy-settings
+              optional: true
+        - name: CUSTOM_NO_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: noProxy
+              name: http-proxy-settings
+              optional: true
+        - name: custom_no_proxy
+          valueFrom:
+            secretKeyRef:
+              key: noProxy
+              name: http-proxy-settings
+              optional: true
+        - name: NO_PROXY
+          value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
+        - name: no_proxy
+          value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
         image: eu.gcr.io/gitpod-core-dev/build/service-waiter:test
         name: msgbus-waiter
         resources: {}
@@ -9806,6 +10730,46 @@ spec:
           value: svc.cluster.local
         - name: LOG_LEVEL
           value: info
+        - name: HTTP_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: httpProxy
+              name: http-proxy-settings
+              optional: true
+        - name: http_proxy
+          valueFrom:
+            secretKeyRef:
+              key: httpProxy
+              name: http-proxy-settings
+              optional: true
+        - name: HTTPS_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: httpsProxy
+              name: http-proxy-settings
+              optional: true
+        - name: https_proxy
+          valueFrom:
+            secretKeyRef:
+              key: httpsProxy
+              name: http-proxy-settings
+              optional: true
+        - name: CUSTOM_NO_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: noProxy
+              name: http-proxy-settings
+              optional: true
+        - name: custom_no_proxy
+          valueFrom:
+            secretKeyRef:
+              key: noProxy
+              name: http-proxy-settings
+              optional: true
+        - name: NO_PROXY
+          value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
+        - name: no_proxy
+          value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
         - name: JAEGER_DISABLED
           value: "true"
         image: eu.gcr.io/gitpod-core-dev/build/ws-proxy:test
@@ -9858,6 +10822,46 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: HTTP_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: httpProxy
+              name: http-proxy-settings
+              optional: true
+        - name: http_proxy
+          valueFrom:
+            secretKeyRef:
+              key: httpProxy
+              name: http-proxy-settings
+              optional: true
+        - name: HTTPS_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: httpsProxy
+              name: http-proxy-settings
+              optional: true
+        - name: https_proxy
+          valueFrom:
+            secretKeyRef:
+              key: httpsProxy
+              name: http-proxy-settings
+              optional: true
+        - name: CUSTOM_NO_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: noProxy
+              name: http-proxy-settings
+              optional: true
+        - name: custom_no_proxy
+          valueFrom:
+            secretKeyRef:
+              key: noProxy
+              name: http-proxy-settings
+              optional: true
+        - name: NO_PROXY
+          value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
+        - name: no_proxy
+          value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
         image: quay.io/brancz/kube-rbac-proxy:v0.12.0
         name: kube-rbac-proxy
         ports:
@@ -9991,6 +10995,46 @@ spec:
             secretKeyRef:
               key: encryptionKeys
               name: mysql
+        - name: HTTP_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: httpProxy
+              name: http-proxy-settings
+              optional: true
+        - name: http_proxy
+          valueFrom:
+            secretKeyRef:
+              key: httpProxy
+              name: http-proxy-settings
+              optional: true
+        - name: HTTPS_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: httpsProxy
+              name: http-proxy-settings
+              optional: true
+        - name: https_proxy
+          valueFrom:
+            secretKeyRef:
+              key: httpsProxy
+              name: http-proxy-settings
+              optional: true
+        - name: CUSTOM_NO_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: noProxy
+              name: http-proxy-settings
+              optional: true
+        - name: custom_no_proxy
+          valueFrom:
+            secretKeyRef:
+              key: noProxy
+              name: http-proxy-settings
+              optional: true
+        - name: NO_PROXY
+          value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
+        - name: no_proxy
+          value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
         image: eu.gcr.io/gitpod-core-dev/build/service-waiter:test
         name: database-waiter
         resources: {}
@@ -10078,6 +11122,46 @@ spec:
                 secretKeyRef:
                   key: encryptionKeys
                   name: mysql
+            - name: HTTP_PROXY
+              valueFrom:
+                secretKeyRef:
+                  key: httpProxy
+                  name: http-proxy-settings
+                  optional: true
+            - name: http_proxy
+              valueFrom:
+                secretKeyRef:
+                  key: httpProxy
+                  name: http-proxy-settings
+                  optional: true
+            - name: HTTPS_PROXY
+              valueFrom:
+                secretKeyRef:
+                  key: httpsProxy
+                  name: http-proxy-settings
+                  optional: true
+            - name: https_proxy
+              valueFrom:
+                secretKeyRef:
+                  key: httpsProxy
+                  name: http-proxy-settings
+                  optional: true
+            - name: CUSTOM_NO_PROXY
+              valueFrom:
+                secretKeyRef:
+                  key: noProxy
+                  name: http-proxy-settings
+                  optional: true
+            - name: custom_no_proxy
+              valueFrom:
+                secretKeyRef:
+                  key: noProxy
+                  name: http-proxy-settings
+                  optional: true
+            - name: NO_PROXY
+              value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
+            - name: no_proxy
+              value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
             image: eu.gcr.io/gitpod-core-dev/build/service-waiter:test
             name: database-waiter
             resources: {}

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -1284,7 +1284,7 @@ data:
   config.json: |-
     {
       "service": {
-        "address": ":8080"
+        "address": "0.0.0.0:8080"
       },
       "storage": {
         "stage": "",
@@ -4038,7 +4038,7 @@ data:
         ]
       },
       "service": {
-        "address": ":8080",
+        "address": "0.0.0.0:8080",
         "tls": {
           "ca": "",
           "crt": "",
@@ -4330,9 +4330,9 @@ data:
       "makeNewUsersAdmin": false,
       "defaultBaseImageRegistryWhitelist": [],
       "runDbDeleter": true,
-      "contentServiceAddr": "content-service:8080",
-      "imageBuilderAddr": "image-builder-mk3:8080",
-      "usageServiceAddr": "usage:9001",
+      "contentServiceAddr": "content-service.default.svc.cluster.local:8080",
+      "imageBuilderAddr": "image-builder-mk3.default.svc.cluster.local:8080",
+      "usageServiceAddr": "usage.default.svc.cluster.local:9001",
       "vsxRegistryUrl": "https://open-vsx.gitpod.example.com",
       "chargebeeProviderOptionsFile": "/chargebee/providerOptions",
       "stripeSecretsFile": "/stripe-secret/apikeys",
@@ -4676,7 +4676,7 @@ data:
         }
       },
       "service": {
-        "address": ":8080",
+        "address": "0.0.0.0:8080",
         "tls": {
           "caPath": "/certs/ca.crt",
           "certPath": "/certs/tls.crt",
@@ -4860,8 +4860,8 @@ data:
   config.json: |-
     {
       "ingress": {
-        "httpAddress": ":8080",
-        "httpsAddress": ":9090",
+        "httpAddress": "0.0.0.0:8080",
+        "httpsAddress": "0.0.0.0:9090",
         "header": "x-wsproxy-host"
       },
       "proxy": {
@@ -6868,7 +6868,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 6fd7f9d2c27fa657c0818d37d1d048b00bd4c1127d732232ca76fd04810136be
+        gitpod.io/checksum_config: f39e45d788bb170ba728cfc3c69c5ca00a2b88a73a2d7288bcc1caee8e638405
         seccomp.security.alpha.kubernetes.io/shiftfs-module-loader: unconfined
       creationTimestamp: null
       labels:
@@ -7788,7 +7788,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 94e6e4829aa089a570ba9f479575cdd42a6c273877223830c790397aa40dcd99
+        gitpod.io/checksum_config: 9f2fefeff4c2a12ff62db1ffafb3d9af6b91ba0b536b6e8664b55c43a1aec3c0
       creationTimestamp: null
       labels:
         app: gitpod
@@ -8187,7 +8187,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 5a02760487dc021fb50bdfc0d92a3a453348b226fb74729cd57a33927d5b6e08
+        gitpod.io/checksum_config: 96743936096936609b76bcab7e6b4c5d2ae5b0cd63b73268b03984c82bdf3d3e
       creationTimestamp: null
       labels:
         app: gitpod
@@ -8685,7 +8685,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 0bc76c867af13d6037264732e25991af8de7c19a2f2e91d1fb1e64df1a9833db
+        gitpod.io/checksum_config: b2674e6368640d5a4b4ccb0f2fa8cb4e521fb3ee60c58f38d8b57272063a8bea
       creationTimestamp: null
       labels:
         app: gitpod
@@ -9326,7 +9326,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: dcbc53af67e4007a4affc029e880c338b93e4484010727f4bf0a08ad7c93a112
+        gitpod.io/checksum_config: f88055f3ce58c8eca0064866deeb5131473b6ba2980dce8bf4f9989e997f1ff5
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -1284,7 +1284,7 @@ data:
   config.json: |-
     {
       "service": {
-        "address": ":8080"
+        "address": "0.0.0.0:8080"
       },
       "storage": {
         "stage": "",
@@ -4050,7 +4050,7 @@ data:
         ]
       },
       "service": {
-        "address": ":8080",
+        "address": "0.0.0.0:8080",
         "tls": {
           "ca": "",
           "crt": "",
@@ -4342,9 +4342,9 @@ data:
       "makeNewUsersAdmin": false,
       "defaultBaseImageRegistryWhitelist": [],
       "runDbDeleter": true,
-      "contentServiceAddr": "content-service:8080",
-      "imageBuilderAddr": "image-builder-mk3:8080",
-      "usageServiceAddr": "usage:9001",
+      "contentServiceAddr": "content-service.default.svc.cluster.local:8080",
+      "imageBuilderAddr": "image-builder-mk3.default.svc.cluster.local:8080",
+      "usageServiceAddr": "usage.default.svc.cluster.local:9001",
       "vsxRegistryUrl": "https://open-vsx.gitpod.example.com",
       "chargebeeProviderOptionsFile": "/chargebee/providerOptions",
       "stripeSecretsFile": "/stripe-secret/apikeys",
@@ -4688,7 +4688,7 @@ data:
         }
       },
       "service": {
-        "address": ":8080",
+        "address": "0.0.0.0:8080",
         "tls": {
           "caPath": "/certs/ca.crt",
           "certPath": "/certs/tls.crt",
@@ -4872,8 +4872,8 @@ data:
   config.json: |-
     {
       "ingress": {
-        "httpAddress": ":8080",
-        "httpsAddress": ":9090",
+        "httpAddress": "0.0.0.0:8080",
+        "httpsAddress": "0.0.0.0:9090",
         "header": "x-wsproxy-host"
       },
       "proxy": {
@@ -6880,7 +6880,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 6fd7f9d2c27fa657c0818d37d1d048b00bd4c1127d732232ca76fd04810136be
+        gitpod.io/checksum_config: f39e45d788bb170ba728cfc3c69c5ca00a2b88a73a2d7288bcc1caee8e638405
         seccomp.security.alpha.kubernetes.io/shiftfs-module-loader: unconfined
       creationTimestamp: null
       labels:
@@ -7800,7 +7800,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 94e6e4829aa089a570ba9f479575cdd42a6c273877223830c790397aa40dcd99
+        gitpod.io/checksum_config: 9f2fefeff4c2a12ff62db1ffafb3d9af6b91ba0b536b6e8664b55c43a1aec3c0
       creationTimestamp: null
       labels:
         app: gitpod
@@ -8199,7 +8199,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 5a02760487dc021fb50bdfc0d92a3a453348b226fb74729cd57a33927d5b6e08
+        gitpod.io/checksum_config: 96743936096936609b76bcab7e6b4c5d2ae5b0cd63b73268b03984c82bdf3d3e
       creationTimestamp: null
       labels:
         app: gitpod
@@ -8697,7 +8697,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 0bc76c867af13d6037264732e25991af8de7c19a2f2e91d1fb1e64df1a9833db
+        gitpod.io/checksum_config: b2674e6368640d5a4b4ccb0f2fa8cb4e521fb3ee60c58f38d8b57272063a8bea
       creationTimestamp: null
       labels:
         app: gitpod
@@ -9338,7 +9338,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: dcbc53af67e4007a4affc029e880c338b93e4484010727f4bf0a08ad7c93a112
+        gitpod.io/checksum_config: f88055f3ce58c8eca0064866deeb5131473b6ba2980dce8bf4f9989e997f1ff5
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
+++ b/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
@@ -1284,7 +1284,7 @@ data:
   config.json: |-
     {
       "service": {
-        "address": ":8080"
+        "address": "0.0.0.0:8080"
       },
       "storage": {
         "stage": "",
@@ -4041,7 +4041,7 @@ data:
         ]
       },
       "service": {
-        "address": ":8080",
+        "address": "0.0.0.0:8080",
         "tls": {
           "ca": "",
           "crt": "",
@@ -4333,9 +4333,9 @@ data:
       "makeNewUsersAdmin": false,
       "defaultBaseImageRegistryWhitelist": [],
       "runDbDeleter": true,
-      "contentServiceAddr": "content-service:8080",
-      "imageBuilderAddr": "image-builder-mk3:8080",
-      "usageServiceAddr": "usage:9001",
+      "contentServiceAddr": "content-service.default.svc.cluster.local:8080",
+      "imageBuilderAddr": "image-builder-mk3.default.svc.cluster.local:8080",
+      "usageServiceAddr": "usage.default.svc.cluster.local:9001",
       "vsxRegistryUrl": "https://open-vsx.gitpod.example.com",
       "chargebeeProviderOptionsFile": "/chargebee/providerOptions",
       "stripeSecretsFile": "/stripe-secret/apikeys",
@@ -4679,7 +4679,7 @@ data:
         }
       },
       "service": {
-        "address": ":8080",
+        "address": "0.0.0.0:8080",
         "tls": {
           "caPath": "/certs/ca.crt",
           "certPath": "/certs/tls.crt",
@@ -4863,8 +4863,8 @@ data:
   config.json: |-
     {
       "ingress": {
-        "httpAddress": ":8080",
-        "httpsAddress": ":9090",
+        "httpAddress": "0.0.0.0:8080",
+        "httpsAddress": "0.0.0.0:9090",
         "header": "x-wsproxy-host"
       },
       "proxy": {
@@ -6871,7 +6871,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 6fd7f9d2c27fa657c0818d37d1d048b00bd4c1127d732232ca76fd04810136be
+        gitpod.io/checksum_config: f39e45d788bb170ba728cfc3c69c5ca00a2b88a73a2d7288bcc1caee8e638405
         seccomp.security.alpha.kubernetes.io/shiftfs-module-loader: unconfined
       creationTimestamp: null
       labels:
@@ -7791,7 +7791,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 94e6e4829aa089a570ba9f479575cdd42a6c273877223830c790397aa40dcd99
+        gitpod.io/checksum_config: 9f2fefeff4c2a12ff62db1ffafb3d9af6b91ba0b536b6e8664b55c43a1aec3c0
       creationTimestamp: null
       labels:
         app: gitpod
@@ -8190,7 +8190,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 5a02760487dc021fb50bdfc0d92a3a453348b226fb74729cd57a33927d5b6e08
+        gitpod.io/checksum_config: 96743936096936609b76bcab7e6b4c5d2ae5b0cd63b73268b03984c82bdf3d3e
       creationTimestamp: null
       labels:
         app: gitpod
@@ -8688,7 +8688,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 0bc76c867af13d6037264732e25991af8de7c19a2f2e91d1fb1e64df1a9833db
+        gitpod.io/checksum_config: b2674e6368640d5a4b4ccb0f2fa8cb4e521fb3ee60c58f38d8b57272063a8bea
       creationTimestamp: null
       labels:
         app: gitpod
@@ -9329,7 +9329,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: dcbc53af67e4007a4affc029e880c338b93e4484010727f4bf0a08ad7c93a112
+        gitpod.io/checksum_config: f88055f3ce58c8eca0064866deeb5131473b6ba2980dce8bf4f9989e997f1ff5
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/pkg/common/ca.go
+++ b/install/installer/pkg/common/ca.go
@@ -47,6 +47,7 @@ func InternalCAContainer(ctx *RenderContext, mod ...func(*corev1.Container)) *co
 				MountPath: "/usr/local/share/ca-certificates/gitpod-ca.crt",
 			},
 		},
+		Env: ProxyEnv(&ctx.Config),
 	}
 
 	for _, m := range mod {
@@ -87,11 +88,14 @@ func CustomCACertVolume(ctx *RenderContext) (vol *corev1.Volume, mnt *corev1.Vol
 		MountPath: customCAMountPath,
 		SubPath:   "ca.crt",
 	}
-	env = []corev1.EnvVar{
-		{Name: "NODE_EXTRA_CA_CERTS", Value: customCAMountPath},
-		{Name: "GIT_SSL_CAPATH", Value: certsMountPath},
-		{Name: "GIT_SSL_CAINFO", Value: customCAMountPath},
-	}
+	env = MergeEnv(
+		[]corev1.EnvVar{
+			{Name: "NODE_EXTRA_CA_CERTS", Value: customCAMountPath},
+			{Name: "GIT_SSL_CAPATH", Value: certsMountPath},
+			{Name: "GIT_SSL_CAINFO", Value: customCAMountPath},
+		},
+		ProxyEnv(&ctx.Config),
+	)
 	ok = true
 	return
 }

--- a/install/installer/pkg/common/common.go
+++ b/install/installer/pkg/common/common.go
@@ -28,6 +28,32 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
+// getProxyServerEnvvar get the proxy server envvars in both upper and lowercase form for maximum compatiblity
+func getProxyServerEnvvar(cfg *config.Config, envvarName string, key string) []corev1.EnvVar {
+	env := corev1.EnvVar{
+		Name: strings.ToUpper(envvarName),
+		ValueFrom: &corev1.EnvVarSource{
+			SecretKeyRef: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: cfg.HTTPProxy.Name,
+				},
+				Key:      key,
+				Optional: pointer.Bool(true),
+			},
+		},
+	}
+
+	return []corev1.EnvVar{
+		env,
+		func() corev1.EnvVar {
+			envLower := env.DeepCopy()
+			envLower.Name = strings.ToLower(envvarName)
+
+			return *envLower
+		}(),
+	}
+}
+
 func DefaultLabels(component string) map[string]string {
 	return map[string]string{
 		"app":       AppName,
@@ -42,25 +68,48 @@ func MergeEnv(envs ...[]corev1.EnvVar) (res []corev1.EnvVar) {
 	return
 }
 
+func ProxyEnv(cfg *config.Config) []corev1.EnvVar {
+	if cfg.HTTPProxy == nil {
+		return []corev1.EnvVar{}
+	}
+
+	// The hard-coded values are the gRPC service names and the licence server
+	noProxyValue := "ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)"
+
+	return MergeEnv(
+		getProxyServerEnvvar(cfg, "HTTP_PROXY", "httpProxy"),
+		getProxyServerEnvvar(cfg, "HTTPS_PROXY", "httpsProxy"),
+		getProxyServerEnvvar(cfg, "CUSTOM_NO_PROXY", "noProxy"),
+		[]corev1.EnvVar{
+			// This must come after the CUSTOM_NO_PROXY definition
+			{Name: "NO_PROXY", Value: noProxyValue},
+			{Name: "no_proxy", Value: noProxyValue},
+		},
+	)
+}
+
 func DefaultEnv(cfg *config.Config) []corev1.EnvVar {
 	logLevel := "info"
 	if cfg.Observability.LogLevel != "" {
 		logLevel = string(cfg.Observability.LogLevel)
 	}
 
-	return []corev1.EnvVar{
-		{Name: "GITPOD_DOMAIN", Value: cfg.Domain},
-		{Name: "GITPOD_INSTALLATION_SHORTNAME", Value: cfg.Metadata.InstallationShortname},
-		{Name: "GITPOD_REGION", Value: cfg.Metadata.Region},
-		{Name: "HOST_URL", Value: "https://" + cfg.Domain},
-		{Name: "KUBE_NAMESPACE", ValueFrom: &corev1.EnvVarSource{
-			FieldRef: &corev1.ObjectFieldSelector{
-				FieldPath: "metadata.namespace",
-			},
-		}},
-		{Name: "KUBE_DOMAIN", Value: "svc.cluster.local"},
-		{Name: "LOG_LEVEL", Value: strings.ToLower(logLevel)},
-	}
+	return MergeEnv(
+		[]corev1.EnvVar{
+			{Name: "GITPOD_DOMAIN", Value: cfg.Domain},
+			{Name: "GITPOD_INSTALLATION_SHORTNAME", Value: cfg.Metadata.InstallationShortname},
+			{Name: "GITPOD_REGION", Value: cfg.Metadata.Region},
+			{Name: "HOST_URL", Value: "https://" + cfg.Domain},
+			{Name: "KUBE_NAMESPACE", ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: "metadata.namespace",
+				},
+			}},
+			{Name: "KUBE_DOMAIN", Value: "svc.cluster.local"},
+			{Name: "LOG_LEVEL", Value: strings.ToLower(logLevel)},
+		},
+		ProxyEnv(cfg),
+	)
 }
 
 func WorkspaceTracingEnv(context *RenderContext) (res []corev1.EnvVar) {
@@ -335,6 +384,7 @@ func DatabaseWaiterContainer(ctx *RenderContext) *corev1.Container {
 		},
 		Env: MergeEnv(
 			DatabaseEnv(&ctx.Config),
+			ProxyEnv(&ctx.Config),
 		),
 	}
 }
@@ -353,6 +403,7 @@ func MessageBusWaiterContainer(ctx *RenderContext) *corev1.Container {
 		},
 		Env: MergeEnv(
 			MessageBusEnv(&ctx.Config),
+			ProxyEnv(&ctx.Config),
 		),
 	}
 }
@@ -373,16 +424,19 @@ func KubeRBACProxyContainerWithConfig(ctx *RenderContext) *corev1.Container {
 		Ports: []corev1.ContainerPort{
 			{Name: baseserver.BuiltinMetricsPortName, ContainerPort: baseserver.BuiltinMetricsPort},
 		},
-		Env: []corev1.EnvVar{
-			{
-				Name: "IP",
-				ValueFrom: &corev1.EnvVarSource{
-					FieldRef: &corev1.ObjectFieldSelector{
-						FieldPath: "status.podIP",
+		Env: MergeEnv(
+			[]corev1.EnvVar{
+				{
+					Name: "IP",
+					ValueFrom: &corev1.EnvVarSource{
+						FieldRef: &corev1.ObjectFieldSelector{
+							FieldPath: "status.podIP",
+						},
 					},
 				},
 			},
-		},
+			ProxyEnv(&ctx.Config),
+		),
 		Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse("1m"),
 			corev1.ResourceMemory: resource.MustParse("30Mi"),

--- a/install/installer/pkg/components/content-service/configmap.go
+++ b/install/installer/pkg/components/content-service/configmap.go
@@ -29,7 +29,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 
 	cscfg := config.ServiceConfig{
 		Service: baseserver.ServerConfiguration{
-			Address: fmt.Sprintf(":%d", RPCPort),
+			Address: fmt.Sprintf("0.0.0.0:%d", RPCPort),
 		},
 		Storage: common.StorageConfig(ctx),
 		UsageReports: config.UsageReportConfig{

--- a/install/installer/pkg/components/image-builder-mk3/configmap.go
+++ b/install/installer/pkg/components/image-builder-mk3/configmap.go
@@ -67,7 +67,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 			},
 		},
 		Service: config.Service{
-			Addr: fmt.Sprintf(":%d", RPCPort),
+			Addr: fmt.Sprintf("0.0.0.0:%d", RPCPort),
 		},
 		Prometheus: config.Service{
 			Addr: common.LocalhostPrometheusAddr(),

--- a/install/installer/pkg/components/public-api-server/configmap.go
+++ b/install/installer/pkg/components/public-api-server/configmap.go
@@ -6,10 +6,11 @@ package public_api_server
 
 import (
 	"fmt"
-	"github.com/gitpod-io/gitpod/installer/pkg/config/v1/experimental"
-	"k8s.io/utils/pointer"
 	"net"
 	"strconv"
+
+	"github.com/gitpod-io/gitpod/installer/pkg/config/v1/experimental"
+	"k8s.io/utils/pointer"
 
 	"github.com/gitpod-io/gitpod/common-go/baseserver"
 	"github.com/gitpod-io/gitpod/public-api/config"
@@ -36,14 +37,14 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 	cfg := config.Configuration{
 		GitpodServiceURL:               fmt.Sprintf("wss://%s/api/v1", ctx.Config.Domain),
 		StripeWebhookSigningSecretPath: stripeSecretPath,
-		BillingServiceAddress:          net.JoinHostPort(usage.Component, strconv.Itoa(usage.GRPCServicePort)),
+		BillingServiceAddress:          net.JoinHostPort(fmt.Sprintf("%s.%s.svc.cluster.local", usage.Component, ctx.Namespace), strconv.Itoa(usage.GRPCServicePort)),
 		Server: &baseserver.Configuration{
 			Services: baseserver.ServicesConfiguration{
 				GRPC: &baseserver.ServerConfiguration{
-					Address: fmt.Sprintf(":%d", GRPCContainerPort),
+					Address: fmt.Sprintf("0.0.0.0:%d", GRPCContainerPort),
 				},
 				HTTP: &baseserver.ServerConfiguration{
-					Address: fmt.Sprintf(":%d", HTTPContainerPort),
+					Address: fmt.Sprintf("0.0.0.0:%d", HTTPContainerPort),
 				},
 			},
 		},

--- a/install/installer/pkg/components/public-api-server/configmap_test.go
+++ b/install/installer/pkg/components/public-api-server/configmap_test.go
@@ -31,15 +31,15 @@ func TestConfigMap(t *testing.T) {
 
 	expectedConfiguration := config.Configuration{
 		GitpodServiceURL:               "wss://test.domain.everything.awesome.is/api/v1",
-		BillingServiceAddress:          "usage:9001",
+		BillingServiceAddress:          fmt.Sprintf("usage.%s.svc.cluster.local:9001", ctx.Namespace),
 		StripeWebhookSigningSecretPath: stripeSecretPath,
 		Server: &baseserver.Configuration{
 			Services: baseserver.ServicesConfiguration{
 				GRPC: &baseserver.ServerConfiguration{
-					Address: fmt.Sprintf(":%d", GRPCContainerPort),
+					Address: fmt.Sprintf("0.0.0.0:%d", GRPCContainerPort),
 				},
 				HTTP: &baseserver.ServerConfiguration{
-					Address: fmt.Sprintf(":%d", HTTPContainerPort),
+					Address: fmt.Sprintf("0.0.0.0:%d", HTTPContainerPort),
 				},
 			},
 		},

--- a/install/installer/pkg/components/registry-facade/daemonset.go
+++ b/install/installer/pkg/components/registry-facade/daemonset.go
@@ -307,6 +307,7 @@ func daemonset(ctx *common.RenderContext) ([]runtime.Object, error) {
 							},
 							Env: common.CustomizeEnvvar(ctx, Component, common.MergeEnv(
 								common.NodeNameEnv(ctx),
+								common.ProxyEnv(&ctx.Config),
 							)),
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							Lifecycle: &corev1.Lifecycle{

--- a/install/installer/pkg/components/server/configmap.go
+++ b/install/installer/pkg/components/server/configmap.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
+	contentservice "github.com/gitpod-io/gitpod/installer/pkg/components/content-service"
 	"github.com/gitpod-io/gitpod/installer/pkg/components/usage"
 	"github.com/gitpod-io/gitpod/installer/pkg/components/workspace"
 	"github.com/gitpod-io/gitpod/installer/pkg/config/v1/experimental"
@@ -229,9 +230,9 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 				"shareSnapshot":    {Group: "inWorkspaceUserAction"},
 			},
 		},
-		ContentServiceAddr:           "content-service:8080",
-		ImageBuilderAddr:             "image-builder-mk3:8080",
-		UsageServiceAddr:             net.JoinHostPort(usage.Component, strconv.Itoa(usage.GRPCServicePort)),
+		ContentServiceAddr:           net.JoinHostPort(fmt.Sprintf("%s.%s.svc.cluster.local", contentservice.Component, ctx.Namespace), strconv.Itoa(contentservice.RPCPort)),
+		ImageBuilderAddr:             net.JoinHostPort(fmt.Sprintf("%s.%s.svc.cluster.local", common.ImageBuilderComponent, ctx.Namespace), strconv.Itoa(common.ImageBuilderRPCPort)),
+		UsageServiceAddr:             net.JoinHostPort(fmt.Sprintf("%s.%s.svc.cluster.local", usage.Component, ctx.Namespace), strconv.Itoa(usage.GRPCServicePort)),
 		CodeSync:                     CodeSync{},
 		VSXRegistryUrl:               fmt.Sprintf("https://open-vsx.%s", ctx.Config.Domain), // todo(sje): or "https://{{ .Values.vsxRegistry.host | default "open-vsx.org" }}" if not using OpenVSX proxy
 		EnablePayment:                chargebeeSecret != "" || stripeSecret != "" || stripeConfig != "",

--- a/install/installer/pkg/components/usage/configmap.go
+++ b/install/installer/pkg/components/usage/configmap.go
@@ -21,7 +21,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		Server: &baseserver.Configuration{
 			Services: baseserver.ServicesConfiguration{
 				GRPC: &baseserver.ServerConfiguration{
-					Address: fmt.Sprintf(":%d", gRPCContainerPort),
+					Address: fmt.Sprintf("0.0.0.0:%d", gRPCContainerPort),
 				},
 			},
 		},

--- a/install/installer/pkg/components/usage/configmap_test.go
+++ b/install/installer/pkg/components/usage/configmap_test.go
@@ -26,7 +26,7 @@ func TestConfigMap_ContainsSchedule(t *testing.T) {
        "server": {
          "services": {
            "grpc": {
-             "address": ":9001"
+             "address": "0.0.0.0:9001"
            }
          }
        }

--- a/install/installer/pkg/components/ws-daemon/configmap.go
+++ b/install/installer/pkg/components/ws-daemon/configmap.go
@@ -156,7 +156,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 			},
 		},
 		Service: baseserver.ServerConfiguration{
-			Address: fmt.Sprintf(":%d", ServicePort),
+			Address: fmt.Sprintf("0.0.0.0:%d", ServicePort),
 			TLS: &baseserver.TLSConfiguration{
 				CAPath:   "/certs/ca.crt",
 				CertPath: "/certs/tls.crt",

--- a/install/installer/pkg/components/ws-daemon/daemonset.go
+++ b/install/installer/pkg/components/ws-daemon/daemonset.go
@@ -59,6 +59,7 @@ fi
 				Privileged: pointer.Bool(true),
 				ProcMount:  func() *corev1.ProcMountType { r := corev1.DefaultProcMount; return &r }(),
 			},
+			Env: common.ProxyEnv(&cfg),
 		},
 		{
 			Name:  "seccomp-profile-installer",
@@ -286,6 +287,7 @@ fi
 				},
 				Env: common.CustomizeEnvvar(ctx, Component, common.MergeEnv(
 					common.NodeNameEnv(ctx),
+					common.ProxyEnv(&ctx.Config),
 				)),
 				ImagePullPolicy: corev1.PullIfNotPresent,
 				Lifecycle: &corev1.Lifecycle{

--- a/install/installer/pkg/components/ws-proxy/configmap.go
+++ b/install/installer/pkg/components/ws-proxy/configmap.go
@@ -53,8 +53,8 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 	wspcfg := config.Config{
 		Namespace: ctx.Namespace,
 		Ingress: proxy.HostBasedIngressConfig{
-			HTTPAddress:  fmt.Sprintf(":%d", HTTPProxyPort),
-			HTTPSAddress: fmt.Sprintf(":%d", HTTPSProxyPort),
+			HTTPAddress:  fmt.Sprintf("0.0.0.0:%d", HTTPProxyPort),
+			HTTPSAddress: fmt.Sprintf("0.0.0.0:%d", HTTPSProxyPort),
 			Header:       header,
 		},
 		Proxy: proxy.Config{

--- a/install/installer/pkg/config/v1/config.go
+++ b/install/installer/pkg/config/v1/config.go
@@ -162,6 +162,8 @@ type Config struct {
 
 	Certificate ObjectRef `json:"certificate" validate:"required"`
 
+	HTTPProxy *ObjectRef `json:"httpProxy,omitempty"`
+
 	ImagePullSecrets []ObjectRef `json:"imagePullSecrets,omitempty"`
 
 	Workspace Workspace `json:"workspace" validate:"required"`

--- a/install/installer/scripts/kots-install.sh
+++ b/install/installer/scripts/kots-install.sh
@@ -76,6 +76,10 @@ yq e -i ".domain = \"${DOMAIN}\"" "${CONFIG_FILE}"
 yq e -i '.license.kind = "secret"' "${CONFIG_FILE}"
 yq e -i '.license.name = "gitpod-license"' "${CONFIG_FILE}"
 
+echo "Gitpod: Inject the HTTP_PROXY settings secret"
+yq e -i '.httpProxy.kind = "secret"' "${CONFIG_FILE}"
+yq e -i '.httpProxy.name = "http-proxy-settings"' "${CONFIG_FILE}"
+
 if [ "${OPEN_VSX_URL}" != "" ];
 then
     echo "Gitpod: Setting Open VSX Registry URL"

--- a/install/kots/manifests/gitpod-http-proxy-settings.yaml
+++ b/install/kots/manifests/gitpod-http-proxy-settings.yaml
@@ -1,0 +1,15 @@
+# Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+# Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: http-proxy-settings
+  labels:
+    app: gitpod
+    component: gitpod-installer
+type: Opaque
+data:
+  httpProxy: repl{{ HTTPProxy | Base64Encode | quote }}
+  httpsProxy: repl{{ HTTPSProxy | Base64Encode | quote }}
+  noProxy: repl{{ printf "kotsadm,.%s,%s" (ConfigOption "domain") (NoProxy) | Base64Encode | quote }}

--- a/install/kots/manifests/gitpod-installer-job.yaml
+++ b/install/kots/manifests/gitpod-installer-job.yaml
@@ -39,7 +39,7 @@ spec:
       containers:
         - name: installer
           # This will normally be the release tag
-          image: "eu.gcr.io/gitpod-core-dev/build/installer:sje-move-kots-bash-script.28"
+          image: "eu.gcr.io/gitpod-core-dev/build/installer:sje-installer-proxy-config.23"
           volumeMounts:
             - mountPath: /config-patch
               name: config-patch

--- a/install/kots/manifests/kots-preflight.yaml
+++ b/install/kots/manifests/kots-preflight.yaml
@@ -77,6 +77,13 @@ spec:
           - |
             CONNECTION="error"
 
+            export http_proxy="{{repl HTTPProxy }}"
+            export HTTP_PROXY="{{repl HTTPProxy }}"
+            export https_proxy="{{repl HTTPSProxy }}"
+            export HTTPS_PROXY="{{repl HTTPSProxy }}"
+            export no_proxy="{{repl NoProxy }}"
+            export NO_PROXY="{{repl NoProxy }}"
+
             if [ '{{repl HasLocalRegistry }}' = "true" ];
             then
               # Don't test for airgapped


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Adds preliminary support for `HTTP_PROXY` (and `HTTPS_PROXY` and `NO_PROXY`) in the Installer. This adds an optional secret which receives the proxy settings from the KOTS CLI settings - the `NO_PROXY` envvar also hard-codes some additional parameters required for the application to work.

**Important** - this is not a full feature. It is merely the initial work to enable other teams to help out in their areas of expertise. This adds the appropriate envvars to the resources and wires them all up in a fashion that allows the Gitpod stack to run without error. However, it **DOES NOT** allow an image to be built or workspace to be run. There are additional tickets in #10769 that detail these tasks

An interesting thing of note is that the `@grpc/grpc-node` library does not respect wildcard `NO_PROXY` URLs. To address that, the `server` adds an addition `no_grpc_proxy` (which is the primary envvar for this library) and changes all resources it calls to the FQDN. See [the issue](https://github.com/grpc/grpc-node/issues/1293) for more details.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #12835 
Fixes #12820 
Fixes #12821

## How to test
<!-- Provide steps to test this PR -->
> This will also need testing in a non-proxied instance to ensure no regressions are introduced

- Create a new server with [Squid](https://www.digitalocean.com/community/tutorials/how-to-set-up-squid-proxy-on-ubuntu-20-04) installed. This server must have unrestricted internet access
- Configure an airgapped installation and configure the k3s cluster to access the proxy
- Run `kubectl kots install gitpod --http-proxy <http-proxy> --https-proxy <https-proxy> --no-proxy <no-proxy>` to install Gitpod

### Configuring your cluster

A [repo](https://github.com/MrSimonEmms/gitpod-self-hosted-infrastructure) exists that will create a k3s cluster for you in Azure. Run `make azure-k3s` with the following settings in your `.auto.tfvars` file

```terraform
domain_name = "<your domain name>"
azure_k3s = true
enable_airgapped = true
http_proxy = "<your proxy settings - eg http://user:password@ip-address:3128">
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[installer]: add HTTP_PROXY envvars to the Installer
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
