### PR TITLE
[supervisor] add 0 bucket for perf analytics

### DIFF
--- a/components/supervisor/pkg/supervisor/supervisor.go
+++ b/components/supervisor/pkg/supervisor/supervisor.go
@@ -1565,8 +1565,8 @@ func analysePerfChanges(ctx context.Context, wscfg *Config, w analytics.Writer, 
 		})
 	}
 
-	cpuAnalyzer := &PerfAnalyzer{label: "cpu", defs: []int{1, 2, 3, 4, 5, 6}}
-	memoryAnalyzer := &PerfAnalyzer{label: "memory", defs: []int{1, 2, 4, 8, 16}}
+	cpuAnalyzer := &PerfAnalyzer{label: "cpu", defs: []int{0, 1, 2, 3, 4, 5, 6}}
+	memoryAnalyzer := &PerfAnalyzer{label: "memory", defs: []int{0, 1, 2, 4, 8, 16}}
 	ticker := time.NewTicker(1 * time.Second)
 	for {
 		select {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

We need to track if users need less than 1 CPU and 1 Gb of memory.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

- Start a workspace in prev env
- Inspect gitpod_cpu_changed and gitpod_memory_changed events in segment untrusted. I would recommend to filter by instance id. Whenever perf metrics hit a higher bucket you should see a change. If it goes down though we don't report changes.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
- [x]  /werft analytics=segment|TEZnsG4QbLSxLfHfNieLYGF4cDwyFWoe