### PR TITLE
[UBP] Add placeholder billing configuration UI to the user settings page

### DIFF
--- a/components/dashboard/src/settings/Billing.tsx
+++ b/components/dashboard/src/settings/Billing.tsx
@@ -4,11 +4,18 @@
  * See License-AGPL.txt in the project root for license information.
  */
 
+import { useContext } from "react";
 import { PageWithSettingsSubMenu } from "./PageWithSettingsSubMenu";
 import { BillingAccountSelector } from "../components/BillingAccountSelector";
+import { UserContext } from "../user-context";
 import UsageBasedBillingConfig from "../components/UsageBasedBillingConfig";
+import { AttributionId } from "@gitpod/gitpod-protocol/lib/attribution";
 
 export default function Billing() {
+    const { user } = useContext(UserContext);
+
+    const attributionId: AttributionId = { kind: "user", userId: user?.id || "" };
+
     return (
         <PageWithSettingsSubMenu title="Billing" subtitle="Usage-Based Billing.">
             <div>
@@ -16,8 +23,8 @@ export default function Billing() {
                 <BillingAccountSelector />
                 <h3 className="mt-12">Usage-Based Billing</h3>
                 <UsageBasedBillingConfig
-                    userOrTeamId={""}
-                    showSpinner={false}
+                    attributionId={attributionId}
+                    showSpinner={!user}
                     showUpgradeBilling={true}
                     showManageBilling={false}
                     doUpdateLimit={function (_: number): Promise<void> {

--- a/components/dashboard/src/settings/Billing.tsx
+++ b/components/dashboard/src/settings/Billing.tsx
@@ -6,6 +6,7 @@
 
 import { PageWithSettingsSubMenu } from "./PageWithSettingsSubMenu";
 import { BillingAccountSelector } from "../components/BillingAccountSelector";
+import UsageBasedBillingConfig from "../components/UsageBasedBillingConfig";
 
 export default function Billing() {
     return (
@@ -13,6 +14,16 @@ export default function Billing() {
             <div>
                 <h3>Billing Account</h3>
                 <BillingAccountSelector />
+                <h3 className="mt-12">Usage-Based Billing</h3>
+                <UsageBasedBillingConfig
+                    userOrTeamId={""}
+                    showSpinner={false}
+                    showUpgradeBilling={true}
+                    showManageBilling={false}
+                    doUpdateLimit={function (_: number): Promise<void> {
+                        throw new Error("Function not implemented.");
+                    }}
+                />
             </div>
         </PageWithSettingsSubMenu>
     );

--- a/components/dashboard/src/teams/TeamUsageBasedBilling.tsx
+++ b/components/dashboard/src/teams/TeamUsageBasedBilling.tsx
@@ -11,6 +11,7 @@ import { getCurrentTeam, TeamsContext } from "./teams-context";
 import { getGitpodService } from "../service/service";
 import UsageBasedBillingConfig from "../components/UsageBasedBillingConfig";
 import Alert from "../components/Alert";
+import { AttributionId } from "@gitpod/gitpod-protocol/lib/attribution";
 
 type PendingStripeSubscription = { pendingSince: number };
 
@@ -161,6 +162,8 @@ export default function TeamUsageBasedBilling() {
         }
     };
 
+    const attributionId: AttributionId = { kind: "team", teamId: team?.id || "" };
+
     return (
         <>
             {billingError && (
@@ -170,7 +173,7 @@ export default function TeamUsageBasedBilling() {
             )}
             <h3>Usage-Based Billing</h3>
             <UsageBasedBillingConfig
-                userOrTeamId={team?.id || ""}
+                attributionId={attributionId}
                 showSpinner={showSpinner}
                 showUpgradeBilling={showUpgradeBilling}
                 showManageBilling={showManageBilling}


### PR DESCRIPTION
## Description

Building on https://github.com/gitpod-io/gitpod/pull/12732 which extracted the components to make them reusable, add the UBP configuration UI widgets to the individual user billing page:

<img width="1041" alt="image" src="https://user-images.githubusercontent.com/8225907/188869027-32719e5e-2411-43ff-96b2-dc832352a9de.png">

The 'Upgrade billing' button doesn't work yet. This is fine to merge as-is because only people opted into usage based billing will see the UI (currently only Gitpod team members).

## Related Issue(s)

Part of https://github.com/gitpod-io/gitpod/issues/12685

## How to test

Visit your user settings page and see the placeholder UI

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
- [x] /werft with-payment
