### PR TITLE
[server] Ensure PVC workspace class does not change on restart

### DIFF
--- a/components/server/src/workspace/workspace-classes.ts
+++ b/components/server/src/workspace/workspace-classes.ts
@@ -85,6 +85,11 @@ export namespace WorkspaceClasses {
             return getDefaultId(workspaceClasses);
         }
 
+        // todo: remove this once pvc has been rolled out
+        if (previousWorkspaceClass.endsWith("-pvc")) {
+            return previousWorkspaceClass;
+        }
+
         const config = workspaceClasses.find((c) => c.id === previousWorkspaceClass);
         if (!config) {
             log.error(
@@ -185,6 +190,11 @@ export namespace WorkspaceClasses {
 
         const current = classes.find((c) => c.id === currentClassId);
         let substitute = classes.find((c) => c.id === substituteClassId);
+
+        // todo: remove this once pvc has been rolled out
+        if (currentClassId.endsWith("-pvc")) {
+            return currentClassId;
+        }
 
         if (current?.marker?.moreResources) {
             if (substitute?.marker?.moreResources) {

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -903,9 +903,20 @@ export class WorkspaceStarter {
 
                 featureFlags = featureFlags.concat(["workspace_class_limiting"]);
             } else {
-                workspaceClass = "default";
-                if (await this.entitlementService.userGetsMoreResources(user)) {
-                    workspaceClass = "gitpodio-internal-xl";
+                // todo: remove this once pvc has been rolled out
+                const prebuildClass = await WorkspaceClasses.getFromPrebuild(
+                    ctx,
+                    workspace,
+                    this.workspaceDb.trace(ctx),
+                );
+                if (prebuildClass?.endsWith("-pvc")) {
+                    workspaceClass = prebuildClass;
+                    // ####
+                } else {
+                    workspaceClass = "default";
+                    if (await this.entitlementService.userGetsMoreResources(user)) {
+                        workspaceClass = "gitpodio-internal-xl";
+                    }
                 }
             }
 


### PR DESCRIPTION
## Description
- Ensure PVC workspace class does not change on restart
- Use pvc class if prebuild is pvc if user would get legacy pvc class

## Related Issue(s)
Fixes #12666
Fixes #12494

## How to test
- Select large workspace class in your user preferences
- Enable persistent_volume_claim feature for your user in the preview environment via administration
- Start prebuild -> prebuild should have g1-large-pvc
- Create regular workspace from prebuild (should have g1-large-pvc)
- Stop workspace
- Restart workspace (should have g1-large-pvc)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
