### PR TITLE
[usage] store more data for in usage entry

### DIFF
--- a/components/gitpod-protocol/src/usage.ts
+++ b/components/gitpod-protocol/src/usage.ts
@@ -117,6 +117,7 @@ export interface WorkspaceInstanceUsageData {
     contextURL: string;
     startTime: string;
     endTime?: string;
+    userId: string;
     userName: string;
     userAvatarURL: string;
 }

--- a/components/usage/pkg/apiv1/usage.go
+++ b/components/usage/pkg/apiv1/usage.go
@@ -434,11 +434,12 @@ func newUsageFromInstance(instance db.WorkspaceInstanceForUsage, pricer *Workspa
 		WorkspaceId:    instance.WorkspaceID,
 		WorkspaceType:  instance.Type,
 		WorkspaceClass: instance.WorkspaceClass,
-		ContextURL:     "",
+		ContextURL:     instance.ContextURL,
 		StartTime:      startedTime,
 		EndTime:        endTime,
-		UserName:       "",
-		UserAvatarURL:  "",
+		UserID:         instance.UserID,
+		UserName:       instance.UserName,
+		UserAvatarURL:  instance.UserAvatarURL,
 	})
 	if err != nil {
 		return db.Usage{}, fmt.Errorf("failed to serialize workspace instance metadata: %w", err)

--- a/components/usage/pkg/apiv1/usage_test.go
+++ b/components/usage/pkg/apiv1/usage_test.go
@@ -7,11 +7,8 @@ package apiv1
 import (
 	"context"
 	"database/sql"
-	"reflect"
 	"testing"
 	"time"
-
-	"github.com/gitpod-io/gitpod/usage/pkg/contentservice"
 
 	"github.com/gitpod-io/gitpod/common-go/baseserver"
 	v1 "github.com/gitpod-io/gitpod/usage-api/v1"
@@ -375,182 +372,6 @@ func TestInstanceToUsageRecords(t *testing.T) {
 	}
 }
 
-func TestReportGenerator_GenerateUsageReport(t *testing.T) {
-	startOfMay := time.Date(2022, 05, 1, 0, 00, 00, 00, time.UTC)
-	startOfJune := time.Date(2022, 06, 1, 0, 00, 00, 00, time.UTC)
-
-	teamID := uuid.New()
-	scenarioRunTime := time.Date(2022, 05, 31, 23, 00, 00, 00, time.UTC)
-
-	instances := []db.WorkspaceInstance{
-		// Ran throughout the reconcile period
-		dbtest.NewWorkspaceInstance(t, db.WorkspaceInstance{
-			ID:                 uuid.New(),
-			UsageAttributionID: db.NewTeamAttributionID(teamID.String()),
-			StartedTime:        db.NewVarcharTime(time.Date(2022, 05, 1, 00, 01, 00, 00, time.UTC)),
-			StoppingTime:       db.NewVarcharTime(time.Date(2022, 06, 1, 1, 0, 0, 0, time.UTC)),
-		}),
-		// Still running
-		dbtest.NewWorkspaceInstance(t, db.WorkspaceInstance{
-			ID:                 uuid.New(),
-			UsageAttributionID: db.NewTeamAttributionID(teamID.String()),
-			StartedTime:        db.NewVarcharTime(time.Date(2022, 05, 30, 00, 01, 00, 00, time.UTC)),
-		}),
-		// No creation time, invalid record, ignored
-		dbtest.NewWorkspaceInstance(t, db.WorkspaceInstance{
-			ID:                 uuid.New(),
-			UsageAttributionID: db.NewTeamAttributionID(teamID.String()),
-			StoppingTime:       db.NewVarcharTime(time.Date(2022, 06, 1, 1, 0, 0, 0, time.UTC)),
-		}),
-	}
-
-	conn := dbtest.ConnectForTests(t)
-	dbtest.CreateWorkspaceInstances(t, conn, instances...)
-
-	nowFunc := func() time.Time { return scenarioRunTime }
-	generator := &ReportGenerator{
-		nowFunc: nowFunc,
-		conn:    conn,
-		pricer:  DefaultWorkspacePricer,
-	}
-
-	report, err := generator.GenerateUsageReport(context.Background(), startOfMay, startOfJune)
-	require.NoError(t, err)
-
-	require.Equal(t, nowFunc(), report.GenerationTime)
-	require.Equal(t, startOfMay, report.From)
-	// require.Equal(t, startOfJune, report.To) TODO(gpl) This is not true anymore - does it really make sense to test for it?
-	require.Len(t, report.InvalidSessions, 0)
-	require.Len(t, report.UsageRecords, 2)
-}
-
-func TestReportGenerator_GenerateUsageReportTable(t *testing.T) {
-	teamID := uuid.New()
-	instanceID := uuid.New()
-
-	Must := func(ti db.VarcharTime, err error) db.VarcharTime {
-		if err != nil {
-			t.Fatal(err)
-		}
-		return ti
-	}
-	Timestamp := func(timestampAsStr string) db.VarcharTime {
-		return Must(db.NewVarcharTimeFromStr(timestampAsStr))
-	}
-	type Expectation struct {
-		custom       func(t *testing.T, report contentservice.UsageReport)
-		usageRecords []db.WorkspaceInstanceUsage
-	}
-
-	type TestCase struct {
-		name        string
-		from        time.Time
-		to          time.Time
-		runtime     time.Time
-		instances   []db.WorkspaceInstance
-		expectation Expectation
-	}
-	tests := []TestCase{
-		{
-			name:    "real example taken from DB: runtime _before_ instance.startedTime",
-			from:    time.Date(2022, 8, 1, 0, 00, 00, 00, time.UTC),
-			to:      time.Date(2022, 9, 1, 0, 00, 00, 00, time.UTC),
-			runtime: Timestamp("2022-08-17T09:38:28Z").Time(),
-			instances: []db.WorkspaceInstance{
-				dbtest.NewWorkspaceInstance(t, db.WorkspaceInstance{
-					ID:                 instanceID,
-					UsageAttributionID: db.NewTeamAttributionID(teamID.String()),
-					CreationTime:       Timestamp("2022-08-17T09:40:47.316Z"),
-					StartedTime:        Timestamp("2022-08-17T09:40:53.115Z"),
-					StoppingTime:       Timestamp("2022-08-17T09:42:36.292Z"),
-					StoppedTime:        Timestamp("2022-08-17T09:43:04.874Z"),
-				}),
-			},
-			expectation: Expectation{
-				usageRecords: nil,
-				// usageRecords: []db.WorkspaceInstanceUsage{
-				// 	{
-				// 		InstanceID: instanceID,
-				// 		AttributionID: db.NewTeamAttributionID(teamID.String()),
-				// 		StartedAt: Timestamp("2022-08-17T09:40:53.115Z").Time(),
-				// 		StoppedAt: sql.NullTime{ Time: Timestamp("2022-08-17T09:43:04.874Z").Time(), Valid: true },
-				// 		WorkspaceClass: "default",
-				// 		CreditsUsed: 3.0,
-				// 	},
-				// },
-			},
-		},
-		{
-			name:    "same as above, but with runtime _after_ startedTime",
-			from:    time.Date(2022, 8, 1, 0, 00, 00, 00, time.UTC),
-			to:      time.Date(2022, 9, 1, 0, 00, 00, 00, time.UTC),
-			runtime: Timestamp("2022-08-17T09:41:00Z").Time(),
-			instances: []db.WorkspaceInstance{
-				dbtest.NewWorkspaceInstance(t, db.WorkspaceInstance{
-					ID:                 instanceID,
-					UsageAttributionID: db.NewTeamAttributionID(teamID.String()),
-					CreationTime:       Timestamp("2022-08-17T09:40:47.316Z"),
-					StartedTime:        Timestamp("2022-08-17T09:40:53.115Z"),
-					StoppingTime:       Timestamp("2022-08-17T09:42:36.292Z"),
-					StoppedTime:        Timestamp("2022-08-17T09:43:04.874Z"),
-				}),
-			},
-			expectation: Expectation{
-				usageRecords: []db.WorkspaceInstanceUsage{
-					{
-						InstanceID:     instanceID,
-						AttributionID:  db.NewTeamAttributionID(teamID.String()),
-						StartedAt:      Timestamp("2022-08-17T09:40:53.115Z").Time(),
-						StoppedAt:      sql.NullTime{Time: Timestamp("2022-08-17T09:41:00Z").Time(), Valid: true},
-						WorkspaceClass: "default",
-						CreditsUsed:    0.019444444444444445,
-					},
-				},
-			},
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			conn := dbtest.ConnectForTests(t)
-			dbtest.CreateWorkspaceInstances(t, conn, test.instances...)
-
-			nowFunc := func() time.Time { return test.runtime }
-			generator := &ReportGenerator{
-				nowFunc: nowFunc,
-				conn:    conn,
-				pricer:  DefaultWorkspacePricer,
-			}
-
-			report, err := generator.GenerateUsageReport(context.Background(), test.from, test.to)
-			require.NoError(t, err)
-
-			require.Equal(t, test.runtime, report.GenerationTime)
-			require.Equal(t, test.from, report.From)
-			// require.Equal(t, test.to, report.To) TODO(gpl) This is not true anymore - does it really make sense to test for it?
-
-			// These invariants should always be true:
-			// 1. No negative usage
-			for _, rec := range report.UsageRecords {
-				if rec.CreditsUsed < 0 {
-					t.Error("Got report with negative credits!")
-				}
-			}
-
-			if !reflect.DeepEqual(test.expectation.usageRecords, report.UsageRecords) {
-				t.Errorf("report.UsageRecords: expected %v but got %v", test.expectation.usageRecords, report.UsageRecords)
-			}
-
-			// Custom expectations
-			customTestFunction := test.expectation.custom
-			if customTestFunction != nil {
-				customTestFunction(t, report)
-				require.NoError(t, err)
-			}
-		})
-	}
-}
-
 func TestUsageService_ReconcileUsageWithLedger(t *testing.T) {
 	dbconn := dbtest.ConnectForTests(t)
 	from := time.Date(2022, 05, 1, 0, 00, 00, 00, time.UTC)
@@ -673,11 +494,11 @@ func TestReconcileWithLedger(t *testing.T) {
 			WorkspaceId:    instance.WorkspaceID,
 			WorkspaceType:  instance.Type,
 			WorkspaceClass: instance.WorkspaceClass,
-			ContextURL:     "",
+			ContextURL:     instance.ContextURL,
 			StartTime:      db.TimeToISO8601(instance.StartedTime.Time()),
 			EndTime:        "",
-			UserName:       "",
-			UserAvatarURL:  "",
+			UserName:       instance.UserName,
+			UserAvatarURL:  instance.UserAvatarURL,
 		}))
 		require.EqualValues(t, expectedUsage, inserts[0])
 	})
@@ -731,11 +552,11 @@ func TestReconcileWithLedger(t *testing.T) {
 			WorkspaceId:    instance.WorkspaceID,
 			WorkspaceType:  instance.Type,
 			WorkspaceClass: instance.WorkspaceClass,
-			ContextURL:     "",
+			ContextURL:     instance.ContextURL,
 			StartTime:      db.TimeToISO8601(instance.StartedTime.Time()),
 			EndTime:        "",
-			UserName:       "",
-			UserAvatarURL:  "",
+			UserName:       instance.UserName,
+			UserAvatarURL:  instance.UserAvatarURL,
 		}))
 		require.EqualValues(t, expectedUsage, updates[0])
 	})

--- a/components/usage/pkg/db/dbtest/user.go
+++ b/components/usage/pkg/db/dbtest/user.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package dbtest
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gitpod-io/gitpod/usage/pkg/db"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+type User struct {
+	ID           uuid.UUID      `gorm:"primary_key;column:id;type:char;size:36;"`
+	AvatarURL    string         `gorm:"column:avatarUrl;type:char;size:255;"`
+	Name         string         `gorm:"column:name;type:char;size:255;"`
+	FullName     string         `gorm:"column:fullName;type:char;size:255;"`
+	CreationDate db.VarcharTime `gorm:"column:creationDate;type:varchar;size:255;"`
+
+	// user has more field but we don't care here as they are just used in tests.
+}
+
+func (user *User) TableName() string {
+	return "d_b_user"
+}
+
+func NewUser(t *testing.T, user User) User {
+	t.Helper()
+
+	result := User{
+		ID:           uuid.New(),
+		AvatarURL:    "https://avatars.githubusercontent.com/u/9071",
+		Name:         "HomerJSimpson",
+		FullName:     "Homer Simpson",
+		CreationDate: db.NewVarcharTime(time.Now()),
+	}
+
+	if user.ID != uuid.Nil {
+		result.ID = user.ID
+	}
+
+	if user.AvatarURL != "" {
+		result.AvatarURL = user.AvatarURL
+	}
+	if user.Name != "" {
+		result.Name = user.Name
+	}
+	if user.FullName != "" {
+		result.FullName = user.FullName
+	}
+
+	return result
+}
+
+func CreatUser(t *testing.T, conn *gorm.DB, user ...User) []User {
+	t.Helper()
+
+	var records []User
+	var ids []uuid.UUID
+	for _, u := range user {
+		record := NewUser(t, u)
+		records = append(records, record)
+		ids = append(ids, record.ID)
+	}
+
+	require.NoError(t, conn.CreateInBatches(&records, 1000).Error)
+
+	t.Cleanup(func() {
+		require.NoError(t, conn.Where(ids).Delete(&User{}).Error)
+	})
+
+	return records
+}

--- a/components/usage/pkg/db/usage.go
+++ b/components/usage/pkg/db/usage.go
@@ -77,6 +77,7 @@ type WorkspaceInstanceUsageData struct {
 	ContextURL     string        `json:"contextURL"`
 	StartTime      string        `json:"startTime"`
 	EndTime        string        `json:"endTime"`
+	UserID         uuid.UUID     `json:"userId"`
 	UserName       string        `json:"userName"`
 	UserAvatarURL  string        `json:"userAvatarURL"`
 }

--- a/components/usage/pkg/db/workspace_instance.go
+++ b/components/usage/pkg/db/workspace_instance.go
@@ -152,15 +152,20 @@ func queryWorkspaceInstanceForUsage(ctx context.Context, conn *gorm.DB) *gorm.DB
 		Table(fmt.Sprintf("%s as wsi", (&WorkspaceInstance{}).TableName())).
 		Select("wsi.id as id, "+
 			"ws.projectId as projectId, "+
+			"ws.contextUrl as contextUrl, "+
 			"ws.type as workspaceType, "+
 			"wsi.workspaceClass as workspaceClass, "+
 			"wsi.usageAttributionId as usageAttributionId, "+
 			"wsi.startedTime as startedTime, "+
 			"wsi.stoppingTime as stoppingTime, "+
 			"ws.ownerId as ownerId, "+
-			"ws.id as workspaceId",
+			"wsi.workspaceId as workspaceId, "+
+			"ws.ownerId as userId, "+
+			"u.name as userName, "+
+			"u.avatarURL as userAvatarURL ",
 		).
 		Joins(fmt.Sprintf("LEFT JOIN %s AS ws ON wsi.workspaceId = ws.id", (&Workspace{}).TableName())).
+		Joins(fmt.Sprintf("LEFT JOIN %s AS u ON ws.ownerId = u.id", "d_b_user")).
 		// Instances without a StartedTime never actually started, we're not interested in these.
 		Where("wsi.startedTime != ?", "")
 }
@@ -223,6 +228,10 @@ type WorkspaceInstanceForUsage struct {
 	WorkspaceClass     string         `gorm:"column:workspaceClass;type:varchar;size:255;" json:"workspaceClass"`
 	Type               WorkspaceType  `gorm:"column:workspaceType;type:char;size:16;default:regular;" json:"workspaceType"`
 	UsageAttributionID AttributionID  `gorm:"column:usageAttributionId;type:varchar;size:60;" json:"usageAttributionId"`
+	ContextURL         string         `gorm:"column:contextUrl;type:varchar;size:255;" json:"contextUrl"`
+	UserID             uuid.UUID      `gorm:"column:userId;type:varchar;size:255;" json:"userId"`
+	UserName           string         `gorm:"column:userName;type:varchar;size:255;" json:"userName"`
+	UserAvatarURL      string         `gorm:"column:userAvatarURL;type:varchar;size:255;" json:"userAvatarURL"`
 
 	StartedTime  VarcharTime `gorm:"column:startedTime;type:varchar;size:255;" json:"startedTime"`
 	StoppingTime VarcharTime `gorm:"column:stoppingTime;type:varchar;size:255;" json:"stoppingTime"`


### PR DESCRIPTION
## Description
Fetch additional data for workspace instances and store it in d_b_usage.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
