### PR TITLE
[supervisor] add 7,8 bucket for cpu perf analytics

### DIFF
--- a/components/supervisor/pkg/supervisor/supervisor.go
+++ b/components/supervisor/pkg/supervisor/supervisor.go
@@ -1565,7 +1565,7 @@ func analysePerfChanges(ctx context.Context, wscfg *Config, w analytics.Writer, 
 		})
 	}
 
-	cpuAnalyzer := &PerfAnalyzer{label: "cpu", defs: []int{1, 2, 3, 4, 5, 6}}
+	cpuAnalyzer := &PerfAnalyzer{label: "cpu", defs: []int{1, 2, 3, 4, 5, 6, 7, 8}}
 	memoryAnalyzer := &PerfAnalyzer{label: "memory", defs: []int{1, 2, 4, 8, 16}}
 	ticker := time.NewTicker(1 * time.Second)
 	for {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Add `7` `8` bucket for CPU as we have defined `8 vCPU` workspace class.

See [internal chat](https://gitpod.slack.com/archives/C01KGM9BH54/p1662560918666619?thread_ts=1662550498.543589&cid=C01KGM9BH54)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
No need

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
