### PR TITLE
[pvc] fix prebuilds when using pvc

### DIFF
--- a/components/supervisor/pkg/supervisor/supervisor.go
+++ b/components/supervisor/pkg/supervisor/supervisor.go
@@ -1327,9 +1327,14 @@ func startContentInit(ctx context.Context, cfg *Config, wg *sync.WaitGroup, cst 
 
 	fn := "/workspace/.gitpod/content.json"
 	fnReady := "/workspace/.gitpod/ready"
-	if _, err := os.Stat("/.workspace/.gitpod/content.json"); !os.IsNotExist(err) {
+	if _, err := os.Stat("/.workspace/.gitpod/pvc"); !os.IsNotExist(err) {
 		fn = "/.workspace/.gitpod/content.json"
-		log.Info("Detected content.json in /.workspace folder, assuming PVC feature enabled")
+		fnReady = "/.workspace/.gitpod/ready"
+		log.Info("Detected pvc file in /.workspace folder, assuming PVC feature enabled")
+	} else if _, err := os.Stat("/.workspace/.gitpod/content.json"); !os.IsNotExist(err) {
+		// todo(pavel): remove this after gen65 has shipped
+		fn = "/.workspace/.gitpod/content.json"
+		log.Info("[deprecated] Detected content.json in /.workspace folder, assuming PVC feature enabled")
 	}
 
 	var contentFile *os.File


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
First, kudos to @jenting for catching this issue. :heart: 
What was happening is actually when using pvc and prebuilds, it would not know that workspace was open from prebuild, rendering prebuild useless (as it would do all the work that prebuild already done).
This PR fixes this. 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #12464 

## How to test
<!-- Provide steps to test this PR -->
Open regular workspace
Open PVC regular workspace
Open regular prebuild
Open PVC prebuild


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
none
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
