### PR TITLE
[stripe] Create customers with attributionId

### DIFF
--- a/components/server/ee/src/user/stripe-service.ts
+++ b/components/server/ee/src/user/stripe-service.ts
@@ -8,6 +8,7 @@ import { inject, injectable } from "inversify";
 import Stripe from "stripe";
 import { Team, User } from "@gitpod/gitpod-protocol";
 import { Config } from "../../../src/config";
+import { AttributionId } from "@gitpod/gitpod-protocol/lib/attribution";
 
 const POLL_CREATED_CUSTOMER_INTERVAL_MS = 1000;
 const POLL_CREATED_CUSTOMER_MAX_ATTEMPTS = 30;
@@ -61,7 +62,9 @@ export class StripeService {
             email: User.getPrimaryEmail(user),
             name: User.getName(user),
             metadata: {
+                // userId is deprecated, use attributionId where possible
                 userId: user.id,
+                attributionId: AttributionId.render({ kind: "user", userId: user.id }),
             },
         });
         // Wait for the customer to show up in Stripe search results before proceeding
@@ -85,7 +88,9 @@ export class StripeService {
             email: User.getPrimaryEmail(user),
             name: userName ? `${userName} (${team.name})` : team.name,
             metadata: {
+                // teamId is deprecated, use attributionId where possible
                 teamId: team.id,
+                attributionId: AttributionId.render({ kind: "team", teamId: team.id }),
             },
         });
         // Wait for the customer to show up in Stripe search results before proceeding


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Create customers (user/team) with an AttributionID instead of user/team ID. We cannot yet update the find queries to use this field as we have customers in Stripe without the attributionID property.

Once this has propagated enough, we can also kill the user/team specific methods and use the Attribution ID only.


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
