### PR TITLE
[UBP] Add server method to create a stripe customers for an individual user

### DIFF
--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -292,6 +292,7 @@ export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, 
     getStripeSetupIntentClientSecret(): Promise<string>;
     findStripeSubscriptionIdForTeam(teamId: string): Promise<string | undefined>;
     createOrUpdateStripeCustomerForTeam(teamId: string, currency: string): Promise<void>;
+    createOrUpdateStripeCustomerForUser(currency: string): Promise<void>;
     subscribeTeamToStripe(teamId: string, setupIntentId: string): Promise<void>;
     getStripePortalUrlForTeam(teamId: string): Promise<string>;
     getUsageLimitForTeam(teamId: string): Promise<number | undefined>;

--- a/components/server/ee/src/user/stripe-service.ts
+++ b/components/server/ee/src/user/stripe-service.ts
@@ -33,21 +33,17 @@ export class StripeService {
     }
 
     async findCustomerByUserId(userId: string): Promise<Stripe.Customer | undefined> {
-        const result = await this.getStripe().customers.search({
-            query: `metadata['userId']:'${userId}'`,
-        });
-        if (result.data.length > 1) {
-            throw new Error(`Found more than one Stripe customer for user '${userId}'`);
-        }
-        return result.data[0];
+        return this.findCustomerByQuery(`metadata['userId']:'${userId}'`);
     }
 
     async findCustomerByTeamId(teamId: string): Promise<Stripe.Customer | undefined> {
-        const result = await this.getStripe().customers.search({
-            query: `metadata['teamId']:'${teamId}'`,
-        });
+        return this.findCustomerByQuery(`metadata['teamId']:'${teamId}'`);
+    }
+
+    async findCustomerByQuery(query: string): Promise<Stripe.Customer | undefined> {
+        const result = await this.getStripe().customers.search({ query });
         if (result.data.length > 1) {
-            throw new Error(`Found more than one Stripe customer for team '${teamId}'`);
+            throw new Error(`Found more than one Stripe customer for query '${query}'`);
         }
         return result.data[0];
     }

--- a/components/server/src/auth/rate-limiter.ts
+++ b/components/server/src/auth/rate-limiter.ts
@@ -207,6 +207,7 @@ const defaultFunctions: FunctionsConfig = {
     getStripeSetupIntentClientSecret: { group: "default", points: 1 },
     findStripeSubscriptionIdForTeam: { group: "default", points: 1 },
     createOrUpdateStripeCustomerForTeam: { group: "default", points: 1 },
+    createOrUpdateStripeCustomerForUser: { group: "default", points: 1 },
     subscribeTeamToStripe: { group: "default", points: 1 },
     getStripePortalUrlForTeam: { group: "default", points: 1 },
     listUsage: { group: "default", points: 1 },

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -3221,6 +3221,9 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
     async createOrUpdateStripeCustomerForTeam(ctx: TraceContext, teamId: string, currency: string): Promise<void> {
         throw new ResponseError(ErrorCodes.SAAS_FEATURE, `Not implemented in this version`);
     }
+    async createOrUpdateStripeCustomerForUser(ctx: TraceContext, currency: string): Promise<void> {
+        throw new ResponseError(ErrorCodes.SAAS_FEATURE, `Not implemented in this version`);
+    }
     async subscribeTeamToStripe(ctx: TraceContext, teamId: string, setupIntentId: string): Promise<void> {
         throw new ResponseError(ErrorCodes.SAAS_FEATURE, `Not implemented in this version`);
     }


### PR DESCRIPTION
## Description

Add a `createOrUpdateStripeCustomerForUser` method to `server` to allow the creation of Stripe customers for individual users. Previously we had only the `createOrUpdateStripeCustomerForTeam` method which would create a Stripe customer for a Gitpod team.

The only difference between the `createOrUpdateStripeCustomerForUser` and `createOrUpdateStripeCustomerForTeam` methods is the metadata in the resulting Stripe customer object. For teams we store `[teamId]: foo` and for users we store `[userId]: bar`.

## Related Issue(s)

Part of https://github.com/gitpod-io/gitpod/issues/12685

## How to test
* Set the billing mode to UBP for your user in the preview environment by creating a team with `Gitpod` in the name.
* In the developer console run:
```js
await window._gp.gitpodService.server.createOrUpdateStripeCustomerForUser("EUR")
```
* Visit the Stripe dashboard and see the new customer (without payment method or subscription) with the userId in the metadata.

## Release Notes

```release-note
NONE
```

## Documentation


## Werft options:
- [x] /werft with-preview
- [x] /werft with-payment
