### PR TITLE
[server] Don't count "Professional Open Source" as personal subscription

### DIFF
--- a/components/server/ee/src/billing/billing-mode.ts
+++ b/components/server/ee/src/billing/billing-mode.ts
@@ -108,7 +108,9 @@ export class BillingModesImpl implements BillingModes {
         }
         const cbSubscriptions = await this.subscriptionSvc.getActivePaidSubscription(user.id, now);
         const cbTeamSubscriptions = cbSubscriptions.filter((s) => isTeamSubscription(s));
-        const cbPersonalSubscriptions = cbSubscriptions.filter((s) => !isTeamSubscription(s));
+        const cbPersonalSubscriptions = cbSubscriptions.filter(
+            (s) => !isTeamSubscription(s) && s.planId !== Plans.FREE_OPEN_SOURCE.chargebeeId,
+        );
         let canUpgradeToUBB = false;
         if (cbPersonalSubscriptions.length > 0) {
             if (cbPersonalSubscriptions.every((s) => Subscription.isCancelled(s, now.toISOString()))) {


### PR DESCRIPTION
## Description
Don't count "Professional Open Source" as personal subscription when calculating billing mode.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #12672

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
