### PR TITLE
[local-preview] Reduce storage requirements

### DIFF
--- a/install/preview/entrypoint.sh
+++ b/install/preview/entrypoint.sh
@@ -181,6 +181,9 @@ yq e -i '.customCACert.kind = "secret"' config.yaml
 yq e -i '.observability.logLevel = "debug"' config.yaml
 yq e -i '.workspace.runtime.containerdSocket = "/run/k3s/containerd/containerd.sock"' config.yaml
 yq e -i '.workspace.runtime.containerdRuntimeDir = "/var/lib/rancher/k3s/agent/containerd/io.containerd.runtime.v2.task/k8s.io/"' config.yaml
+yq e -i '.workspace.pvc.size = "10Gi"' config.yaml
+yq e -i '.workspace.resources.requests.memory = "500Mi"' config.yaml
+yq e -i '.workspace.resources.requests.cpu = "500m"' config.yaml
 yq e -i '.experimental.telemetry.data.platform = "local-preview"' config.yaml
 
 echo "extracting images to download ahead..."
@@ -215,6 +218,15 @@ yq eval-all -i 'del(.spec.template.spec.initContainers[0])' /var/lib/rancher/k3s
 yq eval-all -i '.spec.template.spec.containers[0].resources.requests.memory="250Mi"' /var/lib/rancher/k3s/server/manifests/gitpod/*_DaemonSet_ws-daemon.yaml
 yq eval-all -i '.spec.template.spec.containers[0].resources.requests.cpu="250m"' /var/lib/rancher/k3s/server/manifests/gitpod/*_DaemonSet_ws-daemon.yaml
 yq eval-all -i '.spec.template.spec.containers[0].resources.requests.memory="250Mi"' /var/lib/rancher/k3s/server/manifests/gitpod/*_Deployment_minio.yaml
+
+# set storage requests to be lower
+for f in /var/lib/rancher/k3s/server/manifests/gitpod/*PersistentVolumeClaim*.yaml; do
+    yq e -i '.spec.resources.requests.storage="1Gi"' "$f";
+done
+
+for f in /var/lib/rancher/k3s/server/manifests/gitpod/*StatefulSet*.yaml; do
+    yq e -i '.spec.volumeClaimTemplates[0].spec.resources.requests.storage="1Gi"' "$f";
+done
 
 touch /var/lib/rancher/k3s/server/manifests/coredns.yaml.skip
 mv -f /app/manifests/coredns.yaml /var/lib/rancher/k3s/server/manifests/custom-coredns.yaml


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This PR reduces the storage requests across PVC's, control-plane components
and workspaces storage.

Signed-off-by: Tarun Pothulapati <tarun@gitpod.io>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of #11303 

## How to test
<!-- Provide steps to test this PR -->
Run
```
docker run -p 443:443 --privileged --name gitpod --rm -it  --mount type=volume,source=gitpod,destination=/var/gitpod eu.gcr.io/gitpod-core-dev/build/local-preview:tar-lp-lower-storage.2
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[local-preview] Reduce storage requirements
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
