### PR TITLE
[usage] make tests robust

### DIFF
--- a/components/usage/pkg/db/usage_test.go
+++ b/components/usage/pkg/db/usage_test.go
@@ -144,8 +144,19 @@ func TestInsertUsageRecords(t *testing.T) {
 
 	drafts, err := db.FindAllDraftUsage(context.Background(), conn)
 	require.NoError(t, err)
-	require.Equal(t, 1, len(drafts))
-	require.NotEqual(t, updatedDesc, drafts[0].Description)
+	cleaned := filter(drafts, attributionID)
+	require.Equal(t, 1, len(cleaned))
+	require.NotEqual(t, updatedDesc, cleaned[0].Description)
+}
+
+func filter(drafts []db.Usage, attributionID db.AttributionID) []db.Usage {
+	var cleaned []db.Usage
+	for _, draft := range drafts {
+		if draft.AttributionID == attributionID {
+			cleaned = append(cleaned, draft)
+		}
+	}
+	return cleaned
 }
 
 func TestUpdateUsageRecords(t *testing.T) {
@@ -168,8 +179,9 @@ func TestUpdateUsageRecords(t *testing.T) {
 
 	drafts, err := db.FindAllDraftUsage(context.Background(), conn)
 	require.NoError(t, err)
-	require.Equal(t, 1, len(drafts))
-	require.Equal(t, updatedDesc, drafts[0].Description)
+	cleaned := filter(drafts, attributionID)
+	require.Equal(t, 1, len(cleaned))
+	require.Equal(t, updatedDesc, cleaned[0].Description)
 }
 
 func TestFindAllDraftUsage(t *testing.T) {
@@ -197,8 +209,9 @@ func TestFindAllDraftUsage(t *testing.T) {
 	dbtest.CreateUsageRecords(t, conn, usage1, usage2, usage3)
 	drafts, err := db.FindAllDraftUsage(context.Background(), conn)
 	require.NoError(t, err)
-	require.Equal(t, 2, len(drafts))
-	for _, usage := range drafts {
+	cleaned := filter(drafts, attributionID)
+	require.Equal(t, 2, len(cleaned))
+	for _, usage := range cleaned {
 		require.True(t, usage.Draft)
 	}
 
@@ -208,8 +221,9 @@ func TestFindAllDraftUsage(t *testing.T) {
 
 	drafts, err = db.FindAllDraftUsage(context.Background(), conn)
 	require.NoError(t, err)
-	require.Equal(t, 1, len(drafts))
-	for _, usage := range drafts {
+	cleaned = filter(drafts, attributionID)
+	require.Equal(t, 1, len(cleaned))
+	for _, usage := range cleaned {
 		require.True(t, usage.Draft)
 	}
 }


### PR DESCRIPTION
Make tess robust against parallel DB changes

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
