### PR TITLE
Revert "[stripe] Use AttributionID metadat when querying for customers"

### DIFF
--- a/components/server/ee/src/user/stripe-service.ts
+++ b/components/server/ee/src/user/stripe-service.ts
@@ -13,8 +13,6 @@ import { AttributionId } from "@gitpod/gitpod-protocol/lib/attribution";
 const POLL_CREATED_CUSTOMER_INTERVAL_MS = 1000;
 const POLL_CREATED_CUSTOMER_MAX_ATTEMPTS = 30;
 
-const ATTRIBUTION_ID_METADATA_KEY = "attributionId";
-
 @injectable()
 export class StripeService {
     @inject(Config) protected readonly config: Config;
@@ -36,15 +34,11 @@ export class StripeService {
     }
 
     async findCustomerByUserId(userId: string): Promise<Stripe.Customer | undefined> {
-        return this.findCustomerByQuery(
-            `metadata['${ATTRIBUTION_ID_METADATA_KEY}']:'${AttributionId.render({ kind: "user", userId })}'`,
-        );
+        return this.findCustomerByQuery(`metadata['userId']:'${userId}'`);
     }
 
     async findCustomerByTeamId(teamId: string): Promise<Stripe.Customer | undefined> {
-        return this.findCustomerByQuery(
-            `metadata['${ATTRIBUTION_ID_METADATA_KEY}']:'${AttributionId.render({ kind: "team", teamId })}'`,
-        );
+        return this.findCustomerByQuery(`metadata['teamId']:'${teamId}'`);
     }
 
     async findCustomerByQuery(query: string): Promise<Stripe.Customer | undefined> {
@@ -64,7 +58,9 @@ export class StripeService {
             email: User.getPrimaryEmail(user),
             name: User.getName(user),
             metadata: {
-                ATTRIBUTION_ID_METADATA_KEY: AttributionId.render({ kind: "user", userId: user.id }),
+                // userId is deprecated, use attributionId where possible
+                userId: user.id,
+                attributionId: AttributionId.render({ kind: "user", userId: user.id }),
             },
         });
         // Wait for the customer to show up in Stripe search results before proceeding
@@ -88,7 +84,9 @@ export class StripeService {
             email: User.getPrimaryEmail(user),
             name: userName ? `${userName} (${team.name})` : team.name,
             metadata: {
-                ATTRIBUTION_ID_METADATA_KEY: AttributionId.render({ kind: "team", teamId: team.id }),
+                // teamId is deprecated, use attributionId where possible
+                teamId: team.id,
+                attributionId: AttributionId.render({ kind: "team", teamId: team.id }),
             },
         });
         // Wait for the customer to show up in Stripe search results before proceeding


### PR DESCRIPTION
This reverts commit 05141becb5f677263f8ad4553c88076f19db2a4c.
Reverting due to https://github.com/gitpod-io/gitpod/pull/12762#discussion_r965712834

## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
