### PR TITLE
[usage] Ignore running instances before August 2022

### DIFF
--- a/components/usage/pkg/apiv1/usage.go
+++ b/components/usage/pkg/apiv1/usage.go
@@ -121,7 +121,7 @@ func (s *UsageService) ListUsage(ctx context.Context, in *v1.ListUsageRequest) (
 	}
 
 	usageSummary, err := db.GetUsageSummary(ctx, s.conn,
-		db.AttributionID(string(attributionId)),
+		attributionId,
 		from,
 		to,
 		true,

--- a/components/usage/pkg/db/workspace_instance.go
+++ b/components/usage/pkg/db/workspace_instance.go
@@ -80,6 +80,8 @@ func FindRunningWorkspaceInstances(ctx context.Context, conn *gorm.DB) ([]Worksp
 	tx := queryWorkspaceInstanceForUsage(ctx, conn).
 		Where("wsi.stoppingTime = ?", "").
 		Where("wsi.usageAttributionId != ?", "").
+		// We cannot guarantee data quality before this date
+		Where("wsi.startedTime > ?", TimeToISO8601(time.Date(2022, 8, 1, 0, 0, 0, 0, time.UTC))).
 		FindInBatches(&instancesInBatch, 1000, func(_ *gorm.DB, _ int) error {
 			instances = append(instances, instancesInBatch...)
 			return nil

--- a/components/usage/pkg/db/workspace_instance_test.go
+++ b/components/usage/pkg/db/workspace_instance_test.go
@@ -130,16 +130,21 @@ func TestFindRunningWorkspace(t *testing.T) {
 			StartedTime:  db.NewVarcharTime(time.Date(2022, 05, 15, 12, 00, 00, 00, time.UTC)),
 			StoppingTime: db.NewVarcharTime(time.Date(2022, 05, 15, 13, 00, 00, 00, time.UTC)),
 		}),
+		// one before August 2022, excluded
+		dbtest.NewWorkspaceInstance(t, db.WorkspaceInstance{
+			WorkspaceID: workspace.ID,
+			StartedTime: db.NewVarcharTime(time.Date(2022, 05, 15, 12, 00, 00, 00, time.UTC)),
+		}),
 		// Two running instances
 		dbtest.NewWorkspaceInstance(t, db.WorkspaceInstance{
 			ID:          uuid.New(),
 			WorkspaceID: workspace.ID,
-			StartedTime: db.NewVarcharTime(time.Date(2022, 05, 1, 0, 00, 00, 00, time.UTC)),
+			StartedTime: db.NewVarcharTime(time.Date(2022, 9, 1, 0, 00, 00, 00, time.UTC)),
 		}),
 		dbtest.NewWorkspaceInstance(t, db.WorkspaceInstance{
 			ID:          uuid.New(),
 			WorkspaceID: workspace.ID,
-			StartedTime: db.NewVarcharTime(time.Date(2022, 04, 30, 23, 00, 00, 00, time.UTC)),
+			StartedTime: db.NewVarcharTime(time.Date(2022, 9, 30, 23, 00, 00, 00, time.UTC)),
 		}),
 	}
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

We've got bad data quality on workspace_instances from the past. This excludes these from our queries for running workspaces until we can fix the source of truth.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
