### PR TITLE
[UBP] Add `getUsageLimit` and `setUsageLimit` methods to server

### DIFF
--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -293,6 +293,8 @@ export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, 
     subscribeTeamToStripe(teamId: string, setupIntentId: string): Promise<void>;
     getStripePortalUrl(attributionId: string): Promise<string>;
     getStripePortalUrlForTeam(teamId: string): Promise<string>;
+    getUsageLimit(attributionId: string): Promise<number | undefined>;
+    setUsageLimit(attributionId: string, usageLimit: number): Promise<void>;
     getUsageLimitForTeam(teamId: string): Promise<number | undefined>;
     setUsageLimitForTeam(teamId: string, spendingLimit: number): Promise<void>;
 

--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -2246,15 +2246,6 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
         }
 
         const user = this.checkAndBlockUser("setUsageLimit");
-        switch (attrId.kind) {
-            case "team":
-                const team = await this.guardTeamOperation(attrId.teamId, "update");
-                await this.ensureStripeApiIsAllowed({ team });
-                break;
-            case "user":
-                await this.ensureStripeApiIsAllowed({ user });
-                break;
-        }
         await this.guardCostCenterAccess(ctx, user.id, attrId, "update");
 
         const response = await this.usageService.getCostCenter({ attributionId });

--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -2218,42 +2218,71 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
         return this.getStripePortalUrl(ctx, AttributionId.render(attributionId));
     }
 
-    async getUsageLimitForTeam(ctx: TraceContext, teamId: string): Promise<number | undefined> {
-        const user = this.checkAndBlockUser("getUsageLimitForTeam");
-        const team = await this.guardTeamOperation(teamId, "get");
-        await this.ensureStripeApiIsAllowed({ team });
+    async getUsageLimit(ctx: TraceContext, attributionId: string): Promise<number | undefined> {
+        const attrId = AttributionId.parse(attributionId);
+        if (attrId === undefined) {
+            log.error(`Invalid attribution id: ${attributionId}`);
+            throw new ResponseError(ErrorCodes.BAD_REQUEST, `Invalid attibution id: ${attributionId}`);
+        }
 
-        const attributionId: AttributionId = { kind: "team", teamId };
-        await this.guardCostCenterAccess(ctx, user.id, attributionId, "get");
+        const user = this.checkAndBlockUser("getUsageLimit");
+        await this.guardCostCenterAccess(ctx, user.id, attrId, "get");
 
-        const costCenter = await this.usageService.getCostCenter({
-            attributionId: AttributionId.render(attributionId),
-        });
+        const costCenter = await this.usageService.getCostCenter({ attributionId });
         if (costCenter?.costCenter) {
             return costCenter.costCenter.spendingLimit;
         }
         return undefined;
     }
 
-    async setUsageLimitForTeam(ctx: TraceContext, teamId: string, usageLimit: number): Promise<void> {
-        const user = this.checkAndBlockUser("setUsageLimitForTeam");
-        const team = await this.guardTeamOperation(teamId, "update");
-        await this.ensureStripeApiIsAllowed({ team });
-        if (typeof usageLimit !== "number" || usageLimit < 0) {
-            throw new ResponseError(ErrorCodes.BAD_REQUEST, "Unexpected `usageLimit` value.");
+    async setUsageLimit(ctx: TraceContext, attributionId: string, usageLimit: number): Promise<void> {
+        const attrId = AttributionId.parse(attributionId);
+        if (attrId === undefined) {
+            log.error(`Invalid attribution id: ${attributionId}`);
+            throw new ResponseError(ErrorCodes.BAD_REQUEST, `Invalid attibution id: ${attributionId}`);
         }
-        const attrId: AttributionId = { kind: "team", teamId };
+        if (typeof usageLimit !== "number" || usageLimit < 0) {
+            throw new ResponseError(ErrorCodes.BAD_REQUEST, `Unexpected usageLimit value: ${usageLimit}`);
+        }
+
+        const user = this.checkAndBlockUser("setUsageLimit");
+        switch (attrId.kind) {
+            case "team":
+                const team = await this.guardTeamOperation(attrId.teamId, "update");
+                await this.ensureStripeApiIsAllowed({ team });
+                break;
+            case "user":
+                await this.ensureStripeApiIsAllowed({ user });
+                break;
+        }
         await this.guardCostCenterAccess(ctx, user.id, attrId, "update");
-        const attributionId = AttributionId.render(attrId);
-        const costCenter = await this.usageService.getCostCenter({ attributionId });
+
+        const response = await this.usageService.getCostCenter({ attributionId });
+        if (response?.costCenter?.billingStrategy !== CostCenter_BillingStrategy.BILLING_STRATEGY_STRIPE) {
+            throw new ResponseError(
+                ErrorCodes.BAD_REQUEST,
+                `Setting a usage limit is not valid for non-Stripe billing strategies`,
+            );
+        }
         await this.usageService.setCostCenter({
             costCenter: {
                 attributionId,
                 spendingLimit: usageLimit,
                 billingStrategy:
-                    costCenter?.costCenter?.billingStrategy || CostCenter_BillingStrategy.BILLING_STRATEGY_OTHER,
+                    response?.costCenter?.billingStrategy || CostCenter_BillingStrategy.BILLING_STRATEGY_OTHER,
             },
         });
+    }
+
+    async getUsageLimitForTeam(ctx: TraceContext, teamId: string): Promise<number | undefined> {
+        const attributionId: AttributionId = { kind: "team", teamId: teamId };
+
+        return this.getUsageLimit(ctx, AttributionId.render(attributionId));
+    }
+
+    async setUsageLimitForTeam(ctx: TraceContext, teamId: string, usageLimit: number): Promise<void> {
+        const attributionId: AttributionId = { kind: "team", teamId: teamId };
+        return this.setUsageLimit(ctx, AttributionId.render(attributionId), usageLimit);
     }
 
     async getNotifications(ctx: TraceContext): Promise<string[]> {

--- a/components/server/src/auth/rate-limiter.ts
+++ b/components/server/src/auth/rate-limiter.ts
@@ -219,6 +219,8 @@ const defaultFunctions: FunctionsConfig = {
     getIDEOptions: { group: "default", points: 1 },
     getPrebuildEvents: { group: "default", points: 1 },
     setUsageAttribution: { group: "default", points: 1 },
+    getUsageLimit: { group: "default", points: 1 },
+    setUsageLimit: { group: "default", points: 1 },
     getUsageLimitForTeam: { group: "default", points: 1 },
     setUsageLimitForTeam: { group: "default", points: 1 },
     getNotifications: { group: "default", points: 1 },

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -3158,6 +3158,14 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         throw new ResponseError(ErrorCodes.SAAS_FEATURE, `Not implemented in this version`);
     }
 
+    async getUsageLimit(ctx: TraceContext, attributionId: string): Promise<number | undefined> {
+        throw new ResponseError(ErrorCodes.SAAS_FEATURE, `Not implemented in this version`);
+    }
+
+    async setUsageLimit(ctx: TraceContext, attributionId: string, usageLimit: number): Promise<void> {
+        throw new ResponseError(ErrorCodes.SAAS_FEATURE, `Not implemented in this version`);
+    }
+
     async getUsageLimitForTeam(ctx: TraceContext, teamId: string): Promise<number | undefined> {
         throw new ResponseError(ErrorCodes.SAAS_FEATURE, `Not implemented in this version`);
     }


### PR DESCRIPTION
## Description

Add two new methods to the server API for getting and setting usage limits. Both new functions take an attributionId and work for both users and teams.

For backwards compatibility, leave the `getUsageLimitForTeam` and `setUsageLimitForTeam` methods as they are still used by the dashboard, but change them to be implemented in terms of the more general `get/set` methods.

## Related Issue(s)
Part of https://github.com/gitpod-io/gitpod/issues/12685

## How to test

* Create a team with `Gitpod` in the name in the preview environment and sign the team up for usage based pricing.
* Run the following in the browser developer console:

```js
await window._gp.gitpodService.server.setUsageLimit('team:<teamId of the new team>', 90)
```

* Then:
```js
await window._gp.gitpodService.server.getUsageLimit('team:<teamId of the new team>')
```

The team usage limit can also be updated from the team billing page.

The usage limits for the team are correctly persisted. 

Setting usage limits from the the UI for individual users will be done in a later PR.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation

## Werft options:
- [x] /werft with-preview
- [x] /werft with-payment
