### PR TITLE
[Admin] Show BillingMode on Team-/UserDetails pages

### DIFF
--- a/components/dashboard/src/admin/TeamDetail.tsx
+++ b/components/dashboard/src/admin/TeamDetail.tsx
@@ -13,10 +13,13 @@ import DropDown from "../components/DropDown";
 import { Link } from "react-router-dom";
 import Label from "./Label";
 import Property from "./Property";
+import { AttributionId } from "@gitpod/gitpod-protocol/lib/attribution";
+import { BillingMode } from "@gitpod/gitpod-protocol/lib/billing-mode";
 
 export default function TeamDetail(props: { team: Team }) {
     const { team } = props;
     const [teamMembers, setTeamMembers] = useState<TeamMemberInfo[] | undefined>(undefined);
+    const [billingMode, setBillingMode] = useState<BillingMode | undefined>(undefined);
     const [searchText, setSearchText] = useState<string>("");
 
     useEffect(() => {
@@ -26,6 +29,9 @@ export default function TeamDetail(props: { team: Team }) {
                 setTeamMembers(members);
             }
         })();
+        getGitpodService()
+            .server.adminGetBillingMode(AttributionId.render({ kind: "team", teamId: props.team.id }))
+            .then((bm) => setBillingMode(bm));
     }, [team]);
 
     const filteredMembers = teamMembers?.filter((m) => {
@@ -59,6 +65,7 @@ export default function TeamDetail(props: { team: Team }) {
             </div>
             <div className="flex mt-6">
                 {!team.markedDeleted && teamMembers && <Property name="Members">{teamMembers.length}</Property>}
+                {!team.markedDeleted && <Property name="BillingMode">{billingMode?.mode || "---"}</Property>}
             </div>
             <div className="flex mt-4">
                 <div className="flex">

--- a/components/dashboard/src/admin/UserDetail.tsx
+++ b/components/dashboard/src/admin/UserDetail.tsx
@@ -158,6 +158,51 @@ export default function UserDetail(p: { user: User }) {
                         <div className="flex w-full mt-6">
                             <Property name="Sign Up Date">{moment(user.creationDate).format("MMM D, YYYY")}</Property>
                             <Property
+                                name="Feature Flags"
+                                actions={[
+                                    {
+                                        label: "Edit Feature Flags",
+                                        onClick: () => {
+                                            setEditFeatureFlags(true);
+                                        },
+                                    },
+                                ]}
+                            >
+                                {user.featureFlags?.permanentWSFeatureFlags?.join(", ") || "---"}
+                            </Property>
+                            <Property
+                                name="Roles"
+                                actions={[
+                                    {
+                                        label: "Edit Roles",
+                                        onClick: () => {
+                                            setEditRoles(true);
+                                        },
+                                    },
+                                ]}
+                            >
+                                {user.rolesOrPermissions?.join(", ") || "---"}
+                            </Property>
+                        </div>
+                        <div className="flex w-full mt-6">
+                            <Property
+                                name="Student"
+                                actions={
+                                    !isStudent &&
+                                    emailDomain &&
+                                    !["gmail.com", "yahoo.com", "hotmail.com"].includes(emailDomain)
+                                        ? [
+                                              {
+                                                  label: `Make '${emailDomain}' a student domain`,
+                                                  onClick: addStudentDomain,
+                                              },
+                                          ]
+                                        : undefined
+                                }
+                            >
+                                {isStudent === undefined ? "---" : isStudent ? "Enabled" : "Disabled"}
+                            </Property>
+                            <Property
                                 name="Remaining Hours"
                                 actions={
                                     accountStatement && [
@@ -207,51 +252,6 @@ export default function UserDetail(p: { user: User }) {
                                           .map((s) => Plans.getById(s.planId)?.name)
                                           .join(", ")
                                     : "---"}
-                            </Property>
-                        </div>
-                        <div className="flex w-full mt-6">
-                            <Property
-                                name="Feature Flags"
-                                actions={[
-                                    {
-                                        label: "Edit Feature Flags",
-                                        onClick: () => {
-                                            setEditFeatureFlags(true);
-                                        },
-                                    },
-                                ]}
-                            >
-                                {user.featureFlags?.permanentWSFeatureFlags?.join(", ") || "---"}
-                            </Property>
-                            <Property
-                                name="Roles"
-                                actions={[
-                                    {
-                                        label: "Edit Roles",
-                                        onClick: () => {
-                                            setEditRoles(true);
-                                        },
-                                    },
-                                ]}
-                            >
-                                {user.rolesOrPermissions?.join(", ") || "---"}
-                            </Property>
-                            <Property
-                                name="Student"
-                                actions={
-                                    !isStudent &&
-                                    emailDomain &&
-                                    !["gmail.com", "yahoo.com", "hotmail.com"].includes(emailDomain)
-                                        ? [
-                                              {
-                                                  label: `Make '${emailDomain}' a student domain`,
-                                                  onClick: addStudentDomain,
-                                              },
-                                          ]
-                                        : undefined
-                                }
-                            >
-                                {isStudent === undefined ? "---" : isStudent ? "Enabled" : "Disabled"}
                             </Property>
                         </div>
                     </div>

--- a/components/gitpod-protocol/src/admin-protocol.ts
+++ b/components/gitpod-protocol/src/admin-protocol.ts
@@ -12,6 +12,7 @@ import { WorkspaceInstance, WorkspaceInstancePhase } from "./workspace-instance"
 import { RoleOrPermission } from "./permission";
 import { AccountStatement } from "./accounting-protocol";
 import { InstallationAdminSettings } from "./installation-admin-protocol";
+import { BillingMode } from "./billing-mode";
 
 export interface AdminServer {
     adminGetUsers(req: AdminGetListRequest<User>): Promise<AdminGetListResult<User>>;
@@ -49,6 +50,7 @@ export interface AdminServer {
     adminIsStudent(userId: string): Promise<boolean>;
     adminAddStudentEmailDomain(userId: string, domain: string): Promise<void>;
     adminGrantExtraHours(userId: string, extraHours: number): Promise<void>;
+    adminGetBillingMode(attributionId: string): Promise<BillingMode>;
 
     adminGetSettings(): Promise<InstallationAdminSettings>;
     adminUpdateSettings(settings: InstallationAdminSettings): Promise<void>;

--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -2374,6 +2374,21 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
         await this.subscriptionService.addCredit(userId, extraHours, new Date().toISOString());
     }
 
+    async adminGetBillingMode(ctx: TraceContextWithSpan, attributionId: string): Promise<BillingMode> {
+        traceAPIParams(ctx, { attributionId });
+
+        const user = this.checkAndBlockUser("adminGetBillingMode");
+        if (!this.authorizationService.hasPermission(user, Permission.ADMIN_USERS)) {
+            throw new ResponseError(ErrorCodes.PERMISSION_DENIED, "not allowed");
+        }
+
+        const parsedAttributionId = AttributionId.parse(attributionId);
+        if (!parsedAttributionId) {
+            throw new ResponseError(ErrorCodes.BAD_REQUEST, "Unable to parse attributionId");
+        }
+        return this.billingModes.getBillingMode(parsedAttributionId, new Date());
+    }
+
     // various
     async sendFeedback(ctx: TraceContext, feedback: string): Promise<string | undefined> {
         traceAPIParams(ctx, {}); // feedback is not interesting here, any may contain names

--- a/components/server/src/auth/rate-limiter.ts
+++ b/components/server/src/auth/rate-limiter.ts
@@ -163,6 +163,7 @@ const defaultFunctions: FunctionsConfig = {
     adminGetBlockedRepositories: { group: "default", points: 1 },
     adminCreateBlockedRepository: { group: "default", points: 1 },
     adminDeleteBlockedRepository: { group: "default", points: 1 },
+    adminGetBillingMode: { group: "default", points: 1 },
 
     validateLicense: { group: "default", points: 1 },
     getLicenseInfo: { group: "default", points: 1 },

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -3098,6 +3098,9 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
     async adminGrantExtraHours(ctx: TraceContext, userId: string, extraHours: number): Promise<void> {
         throw new ResponseError(ErrorCodes.SAAS_FEATURE, `Not implemented in this version`);
     }
+    async adminGetBillingMode(ctx: TraceContextWithSpan, attributionId: string): Promise<BillingMode> {
+        throw new ResponseError(ErrorCodes.SAAS_FEATURE, `Not implemented in this version`);
+    }
     async isStudent(ctx: TraceContext): Promise<boolean> {
         throw new ResponseError(ErrorCodes.SAAS_FEATURE, `Not implemented in this version`);
     }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
- [signup](https://gpl-12674-bm.preview.gitpod-dev.com/workspaces)
- ping me for admin rights (or get them through DB)
- Search for you [user details page](https://gpl-12674-bm.preview.gitpod-dev.com/admin/users) and see that:
  - BillingMode is displayed and shows "Chargebee"
  - Chargebee stuff is displayed as well (credits, etc.)
 
![image](https://user-images.githubusercontent.com/32448529/189287894-dd212c61-2735-4d8f-8e41-5abff7f6259b.png)

- create a team starting with `Gitpod-xxx`
- Go back to User Details and see that:
  - BillingMode is displayed and shows "usage-based"
  - Chargebee related info and actions is gone
![image](https://user-images.githubusercontent.com/32448529/189287980-abf757c6-205c-4af8-9091-7850a7f43f5e.png)

- go to your teams details page and see that:
  - BillingMode is displayed and shows "usage-based"

![image](https://user-images.githubusercontent.com/32448529/189291965-2e13e591-a198-4d23-a56b-c05902591b7a.png)


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
- [x] /werft with-payment
