### PR TITLE
Show personal Usage page

### DIFF
--- a/components/dashboard/src/App.tsx
+++ b/components/dashboard/src/App.tsx
@@ -35,6 +35,7 @@ import {
     settingsPathTeamsNew,
     settingsPathVariables,
     settingsPathSSHKeys,
+    usagePathMain,
 } from "./settings/settings.routes";
 import {
     projectsPathInstallGitHubApp,
@@ -90,6 +91,7 @@ const ProjectsSearch = React.lazy(() => import(/* webpackPrefetch: true */ "./ad
 const TeamsSearch = React.lazy(() => import(/* webpackPrefetch: true */ "./admin/TeamsSearch"));
 const OAuthClientApproval = React.lazy(() => import(/* webpackPrefetch: true */ "./OauthClientApproval"));
 const License = React.lazy(() => import(/* webpackPrefetch: true */ "./admin/License"));
+const Usage = React.lazy(() => import(/* webpackPrefetch: true */ "./Usage"));
 
 function Loading() {
     return <></>;
@@ -377,6 +379,7 @@ function App() {
                     <Route path="/setup" exact component={Setup} />
                     <Route path={workspacesPathMain} exact component={Workspaces} />
                     <Route path={settingsPathAccount} exact component={Account} />
+                    <Route path={usagePathMain} exact component={Usage} />
                     <Route path={settingsPathIntegrations} exact component={Integrations} />
                     <Route path={settingsPathNotifications} exact component={Notifications} />
                     <Route path={settingsPathBilling} exact component={Billing} />

--- a/components/dashboard/src/Menu.tsx
+++ b/components/dashboard/src/Menu.tsx
@@ -222,12 +222,12 @@ export default function Menu() {
             title: "Projects",
             link: "/projects",
         });
-        if (userBillingMode?.mode === "usage-based") {
-            userMenu.push({
-                title: "Usage",
-                link: "/usage",
-            });
-        }
+        // if (userBillingMode?.mode === "usage-based") {
+        //     userMenu.push({
+        //         title: "Usage",
+        //         link: "/usage",
+        //     });
+        // }
         userMenu.push({
             title: "Settings",
             link: "/settings",

--- a/components/dashboard/src/Menu.tsx
+++ b/components/dashboard/src/Menu.tsx
@@ -217,17 +217,23 @@ export default function Menu() {
             return teamSettingsList;
         }
         // User menu
-        return [
-            {
-                title: "Projects",
-                link: "/projects",
-            },
-            {
-                title: "Settings",
-                link: "/settings",
-                alternatives: getSettingsMenu({ userBillingMode }).flatMap((e) => e.link),
-            },
-        ];
+        const userMenu = [];
+        userMenu.push({
+            title: "Projects",
+            link: "/projects",
+        });
+        if (userBillingMode?.mode === "usage-based") {
+            userMenu.push({
+                title: "Usage",
+                link: "/usage",
+            });
+        }
+        userMenu.push({
+            title: "Settings",
+            link: "/settings",
+            alternatives: getSettingsMenu({ userBillingMode }).flatMap((e) => e.link),
+        });
+        return userMenu;
     })();
     const rightMenu: Entry[] = [
         ...(user?.rolesOrPermissions?.includes("admin")

--- a/components/dashboard/src/Usage.tsx
+++ b/components/dashboard/src/Usage.tsx
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { useContext, useEffect, useState } from "react";
+
+import { getGitpodService, gitpodHostUrl } from "./service/service";
+import { BillingMode } from "@gitpod/gitpod-protocol/lib/billing-mode";
+import UsageView from "./components/UsageView";
+import { AttributionId } from "@gitpod/gitpod-protocol/lib/attribution";
+import { UserContext } from "./user-context";
+
+function TeamUsage() {
+    const { user } = useContext(UserContext);
+    const [billingMode, setBillingMode] = useState<BillingMode | undefined>(undefined);
+    const [attributionId, setAttributionId] = useState<AttributionId | undefined>();
+
+    useEffect(() => {
+        if (!user) {
+            return;
+        }
+        setAttributionId({ kind: "user", userId: user.id });
+        (async () => {
+            const billingMode = await getGitpodService().server.getBillingModeForUser();
+            setBillingMode(billingMode);
+        })();
+    }, [user]);
+
+    useEffect(() => {
+        if (!billingMode) {
+            return;
+        }
+        if (!BillingMode.showUsageBasedBilling(billingMode)) {
+            window.location.href = gitpodHostUrl.asDashboard().toString();
+        }
+    }, [billingMode]);
+
+    if (!billingMode || !attributionId) {
+        return <></>;
+    }
+
+    return <UsageView billingMode={billingMode} attributionId={attributionId} />;
+}
+
+export default TeamUsage;

--- a/components/dashboard/src/components/UsageView.tsx
+++ b/components/dashboard/src/components/UsageView.tsx
@@ -1,0 +1,316 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { useEffect, useState } from "react";
+import { getGitpodService, gitpodHostUrl } from "../service/service";
+import {
+    ListUsageRequest,
+    Ordering,
+    ListUsageResponse,
+    WorkspaceInstanceUsageData,
+    Usage,
+} from "@gitpod/gitpod-protocol/lib/usage";
+import { AttributionId } from "@gitpod/gitpod-protocol/lib/attribution";
+import { Item, ItemField, ItemsList } from "../components/ItemsList";
+import Pagination from "../Pagination/Pagination";
+import Header from "../components/Header";
+import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
+import { ReactComponent as CreditsSvg } from "../images/credits.svg";
+import { ReactComponent as Spinner } from "../icons/Spinner.svg";
+import { ReactComponent as UsageIcon } from "../images/usage-default.svg";
+import { BillingMode } from "@gitpod/gitpod-protocol/lib/billing-mode";
+import { toRemoteURL } from "../projects/render-utils";
+import { WorkspaceType } from "@gitpod/gitpod-protocol";
+
+interface UsageViewProps {
+    attributionId: AttributionId;
+    billingMode: BillingMode;
+}
+
+function UsageView({ attributionId, billingMode }: UsageViewProps) {
+    const [usagePage, setUsagePage] = useState<ListUsageResponse | undefined>(undefined);
+    const [errorMessage, setErrorMessage] = useState("");
+    const today = new Date();
+    const startOfCurrentMonth = new Date(today.getFullYear(), today.getMonth(), 1);
+    const timestampStartOfCurrentMonth = startOfCurrentMonth.getTime();
+    const [startDateOfBillMonth, setStartDateOfBillMonth] = useState(timestampStartOfCurrentMonth);
+    const [endDateOfBillMonth, setEndDateOfBillMonth] = useState(Date.now());
+    const [totalCreditsUsed, setTotalCreditsUsed] = useState<number>(0);
+    const [isLoading, setIsLoading] = useState<boolean>(true);
+
+    useEffect(() => {
+        loadPage(1);
+    }, [startDateOfBillMonth, endDateOfBillMonth]);
+
+    const loadPage = async (page: number = 1) => {
+        if (usagePage === undefined) {
+            setIsLoading(true);
+            setTotalCreditsUsed(0);
+        }
+        const request: ListUsageRequest = {
+            attributionId: AttributionId.render(attributionId),
+            from: startDateOfBillMonth,
+            to: endDateOfBillMonth,
+            order: Ordering.ORDERING_DESCENDING,
+            pagination: {
+                perPage: 50,
+                page,
+            },
+        };
+        try {
+            const page = await getGitpodService().server.listUsage(request);
+            setUsagePage(page);
+            setTotalCreditsUsed(Math.ceil(page.creditBalanceAtEnd));
+        } catch (error) {
+            if (error.code === ErrorCodes.PERMISSION_DENIED) {
+                setErrorMessage("Access to usage details is restricted to team owners.");
+            } else {
+                setErrorMessage(`Error: ${error?.message}`);
+            }
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    const getType = (type: WorkspaceType) => {
+        if (type === "regular") {
+            return "Workspace";
+        }
+        return "Prebuild";
+    };
+
+    const getMinutes = (usage: Usage) => {
+        if (usage.kind !== "workspaceinstance") {
+            return "";
+        }
+        const metaData = usage.metadata as WorkspaceInstanceUsageData;
+        if (!metaData.endTime) {
+            return "running";
+        }
+        const end = new Date(metaData.endTime).getTime();
+        const start = new Date(metaData.startTime).getTime();
+        const lengthOfUsage = Math.floor(end - start);
+        const inMinutes = (lengthOfUsage / (1000 * 60)).toFixed(1);
+        return inMinutes + " min";
+    };
+
+    const handleMonthClick = (start: any, end: any) => {
+        setStartDateOfBillMonth(start);
+        setEndDateOfBillMonth(end);
+    };
+
+    const getBillingHistory = () => {
+        let rows = [];
+        // This goes back 6 months from the current month
+        for (let i = 1; i < 7; i++) {
+            const endDateVar = i - 1;
+            const startDate = new Date(today.getFullYear(), today.getMonth() - i);
+            const endDate = new Date(today.getFullYear(), today.getMonth() - endDateVar, 0);
+            const timeStampOfStartDate = startDate.getTime();
+            const timeStampOfEndDate = endDate.getTime();
+            rows.push(
+                <div
+                    key={`billing${i}`}
+                    className="text-sm text-blue-500 hover:text-blue-600 dark:text-blue-400 dark:hover:text-blue-500 truncate cursor-pointer gp-link"
+                    onClick={() => handleMonthClick(timeStampOfStartDate, timeStampOfEndDate)}
+                >
+                    {startDate.toLocaleString("default", { month: "long" })} {startDate.getFullYear()}
+                </div>,
+            );
+        }
+        return rows;
+    };
+
+    const displayTime = (time: string | number) => {
+        const options: Intl.DateTimeFormatOptions = {
+            day: "numeric",
+            month: "short",
+            year: "numeric",
+            hour: "numeric",
+            minute: "numeric",
+        };
+        return new Date(time).toLocaleDateString(undefined, options).replace("at ", "");
+    };
+
+    const currentPaginatedResults = usagePage?.usageEntriesList ?? [];
+
+    return (
+        <>
+            <Header title="Usage" subtitle="View usage details (updated every 15 minutes)." />
+            <div className="app-container pt-5">
+                {errorMessage && <p className="text-base">{errorMessage}</p>}
+                {!errorMessage && (
+                    <div className="flex space-x-16">
+                        <div className="flex">
+                            <div className="space-y-8 mb-6" style={{ width: "max-content" }}>
+                                <div className="flex flex-col truncate">
+                                    <div className="text-base text-gray-500 truncate">Current Month</div>
+                                    <div
+                                        className="text-sm text-blue-500 hover:text-blue-600 dark:text-blue-400 dark:hover:text-blue-500 truncate cursor-pointer mb-5"
+                                        onClick={() => handleMonthClick(timestampStartOfCurrentMonth, Date.now())}
+                                    >
+                                        {startOfCurrentMonth.toLocaleString("default", { month: "long" })}{" "}
+                                        {startOfCurrentMonth.getFullYear()}
+                                    </div>
+                                    <div className="text-base text-gray-500 truncate">Previous Months</div>
+                                    {getBillingHistory()}
+                                </div>
+                                {!isLoading && (
+                                    <div className="flex flex-col truncate">
+                                        <div className="text-base text-gray-500">Total usage</div>
+                                        <div className="flex text-lg text-gray-600 font-semibold">
+                                            <CreditsSvg className="my-auto mr-1" />
+                                            <span>{totalCreditsUsed} Credits</span>
+                                        </div>
+                                    </div>
+                                )}
+                            </div>
+                        </div>
+                        {!isLoading && usagePage === undefined && !errorMessage && (
+                            <div className="flex flex-col w-full mb-8">
+                                <h3 className="text-center text-gray-500 mt-8">No sessions found.</h3>
+                                <p className="text-center text-gray-500 mt-1">
+                                    Have you started any
+                                    <a className="gp-link" href={gitpodHostUrl.asWorkspacePage().toString()}>
+                                        {" "}
+                                        workspaces
+                                    </a>{" "}
+                                    in{" "}
+                                    {new Date(startDateOfBillMonth).toLocaleString("default", {
+                                        month: "long",
+                                    })}{" "}
+                                    {new Date(startDateOfBillMonth).getFullYear()} or checked your other teams?
+                                </p>
+                            </div>
+                        )}
+                        {isLoading && (
+                            <div className="flex flex-col place-items-center align-center w-full">
+                                <div className="uppercase text-sm text-gray-400 dark:text-gray-500 mb-5">
+                                    Fetching usage...
+                                </div>
+                                <Spinner className="m-2 h-5 w-5 animate-spin" />
+                            </div>
+                        )}
+                        {!isLoading && currentPaginatedResults.length > 0 && (
+                            <div className="flex flex-col w-full mb-8">
+                                <ItemsList className="mt-2 text-gray-400 dark:text-gray-500">
+                                    <Item
+                                        header={false}
+                                        className="grid grid-cols-12 gap-x-3 bg-gray-100 dark:bg-gray-800"
+                                    >
+                                        <ItemField className="col-span-2 my-auto ">
+                                            <span>Type</span>
+                                        </ItemField>
+                                        <ItemField className="col-span-5 my-auto">
+                                            <span>ID</span>
+                                        </ItemField>
+                                        <ItemField className="my-auto">
+                                            <span>Credits</span>
+                                        </ItemField>
+                                        <ItemField className="my-auto" />
+                                        <ItemField className="col-span-3 my-auto cursor-pointer">
+                                            <span>Timestamp</span>
+                                        </ItemField>
+                                    </Item>
+                                    {currentPaginatedResults &&
+                                        currentPaginatedResults.map((usage) => {
+                                            return (
+                                                <div
+                                                    key={usage.workspaceInstanceId}
+                                                    className="flex p-3 grid grid-cols-12 gap-x-3 justify-between transition ease-in-out rounded-xl"
+                                                >
+                                                    <div className="flex flex-col col-span-2 my-auto">
+                                                        <span className="text-gray-600 dark:text-gray-100 text-md font-medium">
+                                                            {getType(
+                                                                (usage.metadata as WorkspaceInstanceUsageData)
+                                                                    .workspaceType,
+                                                            )}
+                                                        </span>
+                                                        <span className="text-sm text-gray-400 dark:text-gray-500">
+                                                            {
+                                                                (usage.metadata as WorkspaceInstanceUsageData)
+                                                                    .workspaceClass
+                                                            }
+                                                        </span>
+                                                    </div>
+                                                    <div className="flex flex-col col-span-5 my-auto">
+                                                        <span className="truncate text-gray-600 dark:text-gray-100 text-md font-medium">
+                                                            {(usage.metadata as WorkspaceInstanceUsageData).workspaceId}
+                                                        </span>
+                                                        <span className="text-sm truncate text-gray-400 dark:text-gray-500">
+                                                            {(usage.metadata as WorkspaceInstanceUsageData)
+                                                                .contextURL &&
+                                                                toRemoteURL(
+                                                                    (usage.metadata as WorkspaceInstanceUsageData)
+                                                                        .contextURL,
+                                                                )}
+                                                        </span>
+                                                    </div>
+                                                    <div className="flex flex-col my-auto">
+                                                        <span className="text-right text-gray-500 dark:text-gray-400 font-medium">
+                                                            {usage.credits.toFixed(1)}
+                                                        </span>
+                                                        <span className="text-right truncate text-sm text-gray-400 dark:text-gray-500">
+                                                            {getMinutes(usage)}
+                                                        </span>
+                                                    </div>
+                                                    <div className="my-auto" />
+                                                    <div className="flex flex-col col-span-3 my-auto">
+                                                        <span className="text-gray-400 dark:text-gray-500 truncate font-medium">
+                                                            {displayTime(usage.effectiveTime!)}
+                                                        </span>
+                                                        <div className="flex">
+                                                            {(usage.metadata as WorkspaceInstanceUsageData)
+                                                                .workspaceType === "prebuild" ? (
+                                                                <UsageIcon className="my-auto w-4 h-4 mr-1" />
+                                                            ) : (
+                                                                ""
+                                                            )}
+                                                            {(usage.metadata as WorkspaceInstanceUsageData)
+                                                                .workspaceType === "prebuild" ? (
+                                                                <span className="text-sm text-gray-400 dark:text-gray-500">
+                                                                    Gitpod
+                                                                </span>
+                                                            ) : (
+                                                                <div className="flex">
+                                                                    <img
+                                                                        className="my-auto rounded-full w-4 h-4 inline-block align-text-bottom mr-1 overflow-hidden"
+                                                                        src={
+                                                                            (
+                                                                                usage.metadata as WorkspaceInstanceUsageData
+                                                                            ).userAvatarURL || ""
+                                                                        }
+                                                                        alt="user avatar"
+                                                                    />
+                                                                    <span className="text-sm text-gray-400 dark:text-gray-500">
+                                                                        {(usage.metadata as WorkspaceInstanceUsageData)
+                                                                            .userName || ""}
+                                                                    </span>
+                                                                </div>
+                                                            )}
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            );
+                                        })}
+                                </ItemsList>
+                                {usagePage && usagePage.pagination && usagePage.pagination.totalPages > 1 && (
+                                    <Pagination
+                                        currentPage={usagePage.pagination.page}
+                                        setPage={(page) => loadPage(page)}
+                                        totalNumberOfPages={usagePage.pagination.totalPages}
+                                    />
+                                )}
+                            </div>
+                        )}
+                    </div>
+                )}
+            </div>
+        </>
+    );
+}
+
+export default UsageView;

--- a/components/dashboard/src/settings/settings.routes.ts
+++ b/components/dashboard/src/settings/settings.routes.ts
@@ -5,6 +5,7 @@
  */
 
 export const settingsPathMain = "/settings";
+export const usagePathMain = "/usage";
 
 export const settingsPathAccount = "/account";
 export const settingsPathIntegrations = "/integrations";

--- a/components/dashboard/src/teams/TeamUsage.tsx
+++ b/components/dashboard/src/teams/TeamUsage.tsx
@@ -8,336 +8,42 @@ import { useContext, useEffect, useState } from "react";
 import { useLocation } from "react-router";
 import { getCurrentTeam, TeamsContext } from "./teams-context";
 import { getGitpodService, gitpodHostUrl } from "../service/service";
-import {
-    ListUsageRequest,
-    Ordering,
-    ListUsageResponse,
-    WorkspaceInstanceUsageData,
-    Usage,
-} from "@gitpod/gitpod-protocol/lib/usage";
-import { AttributionId } from "@gitpod/gitpod-protocol/lib/attribution";
-import { Item, ItemField, ItemsList } from "../components/ItemsList";
-import Pagination from "../Pagination/Pagination";
-import Header from "../components/Header";
-import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
-import { ReactComponent as CreditsSvg } from "../images/credits.svg";
-import { ReactComponent as Spinner } from "../icons/Spinner.svg";
-import { ReactComponent as UsageIcon } from "../images/usage-default.svg";
 import { BillingMode } from "@gitpod/gitpod-protocol/lib/billing-mode";
-import { toRemoteURL } from "../projects/render-utils";
-import { WorkspaceType } from "@gitpod/gitpod-protocol";
+import UsageView from "../components/UsageView";
+import { AttributionId } from "@gitpod/gitpod-protocol/lib/attribution";
 
 function TeamUsage() {
     const { teams } = useContext(TeamsContext);
     const location = useLocation();
     const team = getCurrentTeam(location, teams);
-    const [teamBillingMode, setTeamBillingMode] = useState<BillingMode | undefined>(undefined);
-    const [usagePage, setUsagePage] = useState<ListUsageResponse | undefined>(undefined);
-    const [errorMessage, setErrorMessage] = useState("");
-    const today = new Date();
-    const startOfCurrentMonth = new Date(today.getFullYear(), today.getMonth(), 1);
-    const timestampStartOfCurrentMonth = startOfCurrentMonth.getTime();
-    const [startDateOfBillMonth, setStartDateOfBillMonth] = useState(timestampStartOfCurrentMonth);
-    const [endDateOfBillMonth, setEndDateOfBillMonth] = useState(Date.now());
-    const [totalCreditsUsed, setTotalCreditsUsed] = useState<number>(0);
-    const [isLoading, setIsLoading] = useState<boolean>(true);
+    const [billingMode, setBillingMode] = useState<BillingMode | undefined>(undefined);
+    const [attributionId, setAttributionId] = useState<AttributionId | undefined>();
 
     useEffect(() => {
         if (!team) {
             return;
         }
+        setAttributionId({ kind: "team", teamId: team.id });
         (async () => {
-            const teamBillingMode = await getGitpodService().server.getBillingModeForTeam(team.id);
-            setTeamBillingMode(teamBillingMode);
+            const billingMode = await getGitpodService().server.getBillingModeForTeam(team.id);
+            setBillingMode(billingMode);
         })();
     }, [team]);
 
     useEffect(() => {
-        if (!team) {
+        if (!billingMode) {
             return;
         }
-        loadPage(1);
-    }, [team, startDateOfBillMonth, endDateOfBillMonth]);
-
-    useEffect(() => {
-        if (!teamBillingMode) {
-            return;
-        }
-        if (!BillingMode.showUsageBasedBilling(teamBillingMode)) {
+        if (!BillingMode.showUsageBasedBilling(billingMode)) {
             window.location.href = gitpodHostUrl.asDashboard().toString();
         }
-    }, [teamBillingMode]);
+    }, [billingMode]);
 
-    const loadPage = async (page: number = 1) => {
-        if (!team) {
-            return;
-        }
-        if (usagePage === undefined) {
-            setIsLoading(true);
-            setTotalCreditsUsed(0);
-        }
-        const attributionId = AttributionId.render({ kind: "team", teamId: team.id });
-        const request: ListUsageRequest = {
-            attributionId,
-            from: startDateOfBillMonth,
-            to: endDateOfBillMonth,
-            order: Ordering.ORDERING_DESCENDING,
-            pagination: {
-                perPage: 50,
-                page,
-            },
-        };
-        try {
-            const page = await getGitpodService().server.listUsage(request);
-            setUsagePage(page);
-            setTotalCreditsUsed(Math.ceil(page.creditBalanceAtEnd));
-        } catch (error) {
-            if (error.code === ErrorCodes.PERMISSION_DENIED) {
-                setErrorMessage("Access to usage details is restricted to team owners.");
-            } else {
-                setErrorMessage(`Error: ${error?.message}`);
-            }
-        } finally {
-            setIsLoading(false);
-        }
-    };
+    if (!billingMode || !attributionId) {
+        return <></>;
+    }
 
-    const getType = (type: WorkspaceType) => {
-        if (type === "regular") {
-            return "Workspace";
-        }
-        return "Prebuild";
-    };
-
-    const getMinutes = (usage: Usage) => {
-        if (usage.kind !== "workspaceinstance") {
-            return "";
-        }
-        const metaData = usage.metadata as WorkspaceInstanceUsageData;
-        if (!metaData.endTime) {
-            return "running";
-        }
-        const end = new Date(metaData.endTime).getTime();
-        const start = new Date(metaData.startTime).getTime();
-        const lengthOfUsage = Math.floor(end - start);
-        const inMinutes = (lengthOfUsage / (1000 * 60)).toFixed(1);
-        return inMinutes + " min";
-    };
-
-    const handleMonthClick = (start: any, end: any) => {
-        setStartDateOfBillMonth(start);
-        setEndDateOfBillMonth(end);
-    };
-
-    const getBillingHistory = () => {
-        let rows = [];
-        // This goes back 6 months from the current month
-        for (let i = 1; i < 7; i++) {
-            const endDateVar = i - 1;
-            const startDate = new Date(today.getFullYear(), today.getMonth() - i);
-            const endDate = new Date(today.getFullYear(), today.getMonth() - endDateVar, 0);
-            const timeStampOfStartDate = startDate.getTime();
-            const timeStampOfEndDate = endDate.getTime();
-            rows.push(
-                <div
-                    key={`billing${i}`}
-                    className="text-sm text-blue-500 hover:text-blue-600 dark:text-blue-400 dark:hover:text-blue-500 truncate cursor-pointer gp-link"
-                    onClick={() => handleMonthClick(timeStampOfStartDate, timeStampOfEndDate)}
-                >
-                    {startDate.toLocaleString("default", { month: "long" })} {startDate.getFullYear()}
-                </div>,
-            );
-        }
-        return rows;
-    };
-
-    const displayTime = (time: string | number) => {
-        const options: Intl.DateTimeFormatOptions = {
-            day: "numeric",
-            month: "short",
-            year: "numeric",
-            hour: "numeric",
-            minute: "numeric",
-        };
-        return new Date(time).toLocaleDateString(undefined, options).replace("at ", "");
-    };
-
-    const currentPaginatedResults = usagePage?.usageEntriesList ?? [];
-
-    return (
-        <>
-            <Header title="Usage" subtitle="View usage details (updated every 15 minutes)." />
-            <div className="app-container pt-5">
-                {errorMessage && <p className="text-base">{errorMessage}</p>}
-                {!errorMessage && (
-                    <div className="flex space-x-16">
-                        <div className="flex">
-                            <div className="space-y-8 mb-6" style={{ width: "max-content" }}>
-                                <div className="flex flex-col truncate">
-                                    <div className="text-base text-gray-500 truncate">Current Month</div>
-                                    <div
-                                        className="text-sm text-blue-500 hover:text-blue-600 dark:text-blue-400 dark:hover:text-blue-500 truncate cursor-pointer mb-5"
-                                        onClick={() => handleMonthClick(timestampStartOfCurrentMonth, Date.now())}
-                                    >
-                                        {startOfCurrentMonth.toLocaleString("default", { month: "long" })}{" "}
-                                        {startOfCurrentMonth.getFullYear()}
-                                    </div>
-                                    <div className="text-base text-gray-500 truncate">Previous Months</div>
-                                    {getBillingHistory()}
-                                </div>
-                                {!isLoading && (
-                                    <div className="flex flex-col truncate">
-                                        <div className="text-base text-gray-500">Total usage</div>
-                                        <div className="flex text-lg text-gray-600 font-semibold">
-                                            <CreditsSvg className="my-auto mr-1" />
-                                            <span>{totalCreditsUsed} Credits</span>
-                                        </div>
-                                    </div>
-                                )}
-                            </div>
-                        </div>
-                        {!isLoading && usagePage === undefined && !errorMessage && (
-                            <div className="flex flex-col w-full mb-8">
-                                <h3 className="text-center text-gray-500 mt-8">No sessions found.</h3>
-                                <p className="text-center text-gray-500 mt-1">
-                                    Have you started any
-                                    <a className="gp-link" href={gitpodHostUrl.asWorkspacePage().toString()}>
-                                        {" "}
-                                        workspaces
-                                    </a>{" "}
-                                    in{" "}
-                                    {new Date(startDateOfBillMonth).toLocaleString("default", {
-                                        month: "long",
-                                    })}{" "}
-                                    {new Date(startDateOfBillMonth).getFullYear()} or checked your other teams?
-                                </p>
-                            </div>
-                        )}
-                        {isLoading && (
-                            <div className="flex flex-col place-items-center align-center w-full">
-                                <div className="uppercase text-sm text-gray-400 dark:text-gray-500 mb-5">
-                                    Fetching usage...
-                                </div>
-                                <Spinner className="m-2 h-5 w-5 animate-spin" />
-                            </div>
-                        )}
-                        {!isLoading && currentPaginatedResults.length > 0 && (
-                            <div className="flex flex-col w-full mb-8">
-                                <ItemsList className="mt-2 text-gray-400 dark:text-gray-500">
-                                    <Item
-                                        header={false}
-                                        className="grid grid-cols-12 gap-x-3 bg-gray-100 dark:bg-gray-800"
-                                    >
-                                        <ItemField className="col-span-2 my-auto ">
-                                            <span>Type</span>
-                                        </ItemField>
-                                        <ItemField className="col-span-5 my-auto">
-                                            <span>ID</span>
-                                        </ItemField>
-                                        <ItemField className="my-auto">
-                                            <span>Credits</span>
-                                        </ItemField>
-                                        <ItemField className="my-auto" />
-                                        <ItemField className="col-span-3 my-auto cursor-pointer">
-                                            <span>Timestamp</span>
-                                        </ItemField>
-                                    </Item>
-                                    {currentPaginatedResults &&
-                                        currentPaginatedResults.map((usage) => {
-                                            return (
-                                                <div
-                                                    key={usage.workspaceInstanceId}
-                                                    className="flex p-3 grid grid-cols-12 gap-x-3 justify-between transition ease-in-out rounded-xl"
-                                                >
-                                                    <div className="flex flex-col col-span-2 my-auto">
-                                                        <span className="text-gray-600 dark:text-gray-100 text-md font-medium">
-                                                            {getType(
-                                                                (usage.metadata as WorkspaceInstanceUsageData)
-                                                                    .workspaceType,
-                                                            )}
-                                                        </span>
-                                                        <span className="text-sm text-gray-400 dark:text-gray-500">
-                                                            {
-                                                                (usage.metadata as WorkspaceInstanceUsageData)
-                                                                    .workspaceClass
-                                                            }
-                                                        </span>
-                                                    </div>
-                                                    <div className="flex flex-col col-span-5 my-auto">
-                                                        <span className="truncate text-gray-600 dark:text-gray-100 text-md font-medium">
-                                                            {(usage.metadata as WorkspaceInstanceUsageData).workspaceId}
-                                                        </span>
-                                                        <span className="text-sm truncate text-gray-400 dark:text-gray-500">
-                                                            {(usage.metadata as WorkspaceInstanceUsageData)
-                                                                .contextURL &&
-                                                                toRemoteURL(
-                                                                    (usage.metadata as WorkspaceInstanceUsageData)
-                                                                        .contextURL,
-                                                                )}
-                                                        </span>
-                                                    </div>
-                                                    <div className="flex flex-col my-auto">
-                                                        <span className="text-right text-gray-500 dark:text-gray-400 font-medium">
-                                                            {usage.credits.toFixed(1)}
-                                                        </span>
-                                                        <span className="text-right truncate text-sm text-gray-400 dark:text-gray-500">
-                                                            {getMinutes(usage)}
-                                                        </span>
-                                                    </div>
-                                                    <div className="my-auto" />
-                                                    <div className="flex flex-col col-span-3 my-auto">
-                                                        <span className="text-gray-400 dark:text-gray-500 truncate font-medium">
-                                                            {displayTime(usage.effectiveTime!)}
-                                                        </span>
-                                                        <div className="flex">
-                                                            {(usage.metadata as WorkspaceInstanceUsageData)
-                                                                .workspaceType === "prebuild" ? (
-                                                                <UsageIcon className="my-auto w-4 h-4 mr-1" />
-                                                            ) : (
-                                                                ""
-                                                            )}
-                                                            {(usage.metadata as WorkspaceInstanceUsageData)
-                                                                .workspaceType === "prebuild" ? (
-                                                                <span className="text-sm text-gray-400 dark:text-gray-500">
-                                                                    Gitpod
-                                                                </span>
-                                                            ) : (
-                                                                <div className="flex">
-                                                                    <img
-                                                                        className="my-auto rounded-full w-4 h-4 inline-block align-text-bottom mr-1 overflow-hidden"
-                                                                        src={
-                                                                            (
-                                                                                usage.metadata as WorkspaceInstanceUsageData
-                                                                            ).userAvatarURL || ""
-                                                                        }
-                                                                        alt="user avatar"
-                                                                    />
-                                                                    <span className="text-sm text-gray-400 dark:text-gray-500">
-                                                                        {(usage.metadata as WorkspaceInstanceUsageData)
-                                                                            .userName || ""}
-                                                                    </span>
-                                                                </div>
-                                                            )}
-                                                        </div>
-                                                    </div>
-                                                </div>
-                                            );
-                                        })}
-                                </ItemsList>
-                                {usagePage && usagePage.pagination && usagePage.pagination.totalPages > 1 && (
-                                    <Pagination
-                                        currentPage={usagePage.pagination.page}
-                                        setPage={(page) => loadPage(page)}
-                                        totalNumberOfPages={usagePage.pagination.totalPages}
-                                    />
-                                )}
-                            </div>
-                        )}
-                    </div>
-                )}
-            </div>
-        </>
-    );
+    return <UsageView billingMode={billingMode} attributionId={attributionId} />;
 }
 
 export default TeamUsage;


### PR DESCRIPTION
## Description
This PR reuses the existing Usage page to show personal usage. 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
First part of #12686 (adding the Usage page "as is")

## How to test
🤷🏻 
No idea yet how to attribute personal account.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Show personal Usage page.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
- [x] /werft with-payment