### PR TITLE
[installer-tests] Add SCM authentication for integration tests

### DIFF
--- a/.werft/aks-installer-tests.yaml
+++ b/.werft/aks-installer-tests.yaml
@@ -20,8 +20,8 @@ args:
   desc: "Version of gitpod to install(in the case of upgrade tests, this is the initial install version and will later get upgraded to latest"
   required: false
   default: ""
-- name: skipTests
-  desc: "Set this to true to skip integration tests"
+- name: runTests
+  desc: "Set this to true to run integration tests"
   required: false
   default: false
 - name: selfSigned
@@ -123,6 +123,21 @@ pod:
         secretKeyRef:
           name: replicated
           key: app
+    - name: ROBOQUAT_TOKEN
+      valueFrom:
+        secretKeyRef:
+          name: github-roboquat-automatic-changelog
+          key: token
+    - name: USERNAME
+      valueFrom:
+        secretKeyRef:
+          name: integration-test-user
+          key: username
+    - name: USER_TOKEN # this is for the integration tests
+      valueFrom:
+        secretKeyRef:
+          name: integration-test-user
+          key: token
     command:
       - bash
       - -c

--- a/.werft/eks-installer-tests.yaml
+++ b/.werft/eks-installer-tests.yaml
@@ -20,8 +20,8 @@ args:
   desc: "Version of gitpod to install(in the case of upgrade tests, this is the initial install version and will later get upgraded to latest"
   required: false
   default: ""
-- name: skipTests
-  desc: "Set this to true to skip integration tests"
+- name: runTests
+  desc: "Set this to true to run integration tests"
   required: false
   default: false
 - name: upgrade
@@ -118,6 +118,21 @@ pod:
         secretKeyRef:
           name: replicated
           key: app
+    - name: ROBOQUAT_TOKEN
+      valueFrom:
+        secretKeyRef:
+          name: github-roboquat-automatic-changelog
+          key: token
+    - name: USERNAME
+      valueFrom:
+        secretKeyRef:
+          name: integration-test-user
+          key: username
+    - name: USER_TOKEN # this is for the integration tests
+      valueFrom:
+        secretKeyRef:
+          name: integration-test-user
+          key: token
     command:
       - bash
       - -c

--- a/.werft/gke-installer-tests.yaml
+++ b/.werft/gke-installer-tests.yaml
@@ -20,8 +20,8 @@ args:
   desc: "Version of gitpod to install(in the case of upgrade tests, this is the initial install version and will later get upgraded to latest"
   required: false
   default: ""
-- name: skipTests
-  desc: "Set this to true to skip integration tests"
+- name: runTests
+  desc: "Set this to true to run integration tests"
   required: false
   default: false
 - name: selfSigned
@@ -105,6 +105,21 @@ pod:
             secretKeyRef:
               name: replicated
               key: app
+        - name: ROBOQUAT_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: github-roboquat-automatic-changelog
+              key: token
+        - name: USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: integration-test-user
+              key: username
+        - name: USER_TOKEN # this is for the integration tests
+          valueFrom:
+            secretKeyRef:
+              name: integration-test-user
+              key: token
       command:
         - bash
         - -c

--- a/.werft/jobs/build/self-hosted-upgrade-tests.ts
+++ b/.werft/jobs/build/self-hosted-upgrade-tests.ts
@@ -114,7 +114,7 @@ export async function triggerSelfHostedPreview(werft: Werft, config: JobConfig, 
 
     exec(`git config --global user.name "${username}"`);
 
-    annotation = `${annotation} -a channel=${replicatedChannel} -a preview=true -a deps=external`;
+    annotation = `${annotation} -a channel=${replicatedChannel} -a preview=true -a runTests=false -a deps=external`;
 
     werft.phase("self-hosted-preview", `Create self-hosted preview in ${cluster}`);
 

--- a/.werft/jobs/build/self-hosted-upgrade-tests.ts
+++ b/.werft/jobs/build/self-hosted-upgrade-tests.ts
@@ -114,7 +114,7 @@ export async function triggerSelfHostedPreview(werft: Werft, config: JobConfig, 
 
     exec(`git config --global user.name "${username}"`);
 
-    annotation = `${annotation} -a channel=${replicatedChannel} -a preview=true -a skipTests=true -a deps=external`;
+    annotation = `${annotation} -a channel=${replicatedChannel} -a preview=true -a deps=external`;
 
     werft.phase("self-hosted-preview", `Create self-hosted preview in ${cluster}`);
 

--- a/.werft/k3s-installer-tests.yaml
+++ b/.werft/k3s-installer-tests.yaml
@@ -20,8 +20,8 @@ args:
   desc: "Version of gitpod to install(in the case of upgrade tests, this is the initial install version and will later get upgraded to latest"
   required: false
   default: ""
-- name: skipTests
-  desc: "Set this to true to skip integration tests"
+- name: runTests
+  desc: "Set this to true to run integration tests"
   required: false
   default: false
 - name: selfSigned
@@ -59,6 +59,9 @@ pod:
   - name: sh-playground-dns-perm
     secret:
       secretName: sh-playground-dns-perm
+  - name: self-hosted-github-oauth
+    secret:
+      secretName: self-hosted-github-oauth
   containers:
   - name: nightly-test
     image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-update-leeway.0
@@ -69,6 +72,8 @@ pod:
       mountPath: /mnt/secrets/sh-playground-sa-perm
     - name: sh-playground-dns-perm # this sa is used for the DNS management
       mountPath: /mnt/secrets/sh-playground-dns-perm
+    - name: self-hosted-github-oauth
+      mountPath: "/mnt/secrets/github-oauth"
     env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: "/mnt/secrets/sh-playground-sa-perm/sh-sa.json"
@@ -76,10 +81,22 @@ pod:
         value: "/mnt/secrets/sh-playground-sa-perm/sh-sa.json"
       - name: TF_VAR_dns_sa_creds
         value: "/mnt/secrets/sh-playground-dns-perm/sh-dns-sa.json"
+      - name: GITHUB_SCM_OAUTH
+        value: "/mnt/secrets/github-oauth/provider"
       - name: NODENAME
         valueFrom:
           fieldRef:
             fieldPath: spec.nodeName
+      - name: ROBOQUAT_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: github-roboquat-automatic-changelog
+            key: token
+      - name: USERNAME
+        valueFrom:
+          secretKeyRef:
+            name: integration-test-user
+            key: username
       - name: USER_TOKEN # this is for the integration tests
         valueFrom:
           secretKeyRef:

--- a/install/tests/Makefile
+++ b/install/tests/Makefile
@@ -146,10 +146,11 @@ add-ns-record: check-env-cloud
 	terraform apply -target=module.$(cloud)-add-dns-record  -var kubeconfig=${KUBECONFIG} --auto-approve
 	@echo "Done adding NS record"
 
+self_signed ?= "false"
 .PHONY:
 ## cluster-issuer: Creates a cluster issuer for the correspondign provider
 cluster-issuer: check-env-cloud
-ifneq ($(self_signed),)
+ifneq ($(self_signed), "false")
 	@echo "Skipped creating cluster issuer"
 else
 	terraform init --upgrade && \
@@ -206,8 +207,8 @@ get-kubeconfig:
 get-github-config:
 ifneq ($(GITHUB_SCM_OAUTH),)
 	export SCM_OAUTH=./manifests/github-oauth.yaml && \
-	cat $$GITHUB_SCM_OAUTH/provider > $$SCM_OAUTH && \
-	yq w -i $$SCM_OAUTH 'oauth.callBackUrl' http://${TF_VAR_TEST_ID}.${TF_VAR_domain}/auth/github.com/callback && \
+	cat $$GITHUB_SCM_OAUTH > $$SCM_OAUTH && \
+	yq w -i $$SCM_OAUTH 'oauth.callBackUrl' https://scm.${DOMAIN}/auth/github.com/callback?state=${TF_VAR_TEST_ID} && \
 	kubectl --kubeconfig=${KUBECONFIG} create namespace gitpod || echo "Gitpod namespace already exist" && \
 	kubectl --kubeconfig=${KUBECONFIG} delete secret github-oauth -n gitpod || echo "gitpod-oauth secret needs to be created" && \
 	kubectl --kubeconfig=${KUBECONFIG} create secret generic "github-oauth" --namespace gitpod --from-literal=provider="$$(cat $$SCM_OAUTH)" && \
@@ -218,7 +219,7 @@ endif
 
 KOTS_KONFIG := "./manifests/kots-config.yaml"
 
-get-base-config: get-github-config
+get-base-config:
 	export CONFIG_PATCH=./manifests/config-patch.yaml && \
 	export DOMAIN=${TF_VAR_domain} && \
 	export PATCH=$$(cat $$CONFIG_PATCH | base64 -w 0) || export PATCH="" && \
@@ -329,6 +330,8 @@ endif
 storage ?= incluster
 registry ?= incluster
 db ?= incluster
+runTests ?= "false"
+self_signed ?= "false"
 .PHONY:
 generate-kots-config: cloud_storage = $(if $(findstring external,$(storage)),$(cloud),incluster)
 generate-kots-config: cloud_registry = $(if $(findstring external,$(registry)),$(cloud),incluster)
@@ -338,9 +341,8 @@ generate-kots-config: select-workspace check-env-cloud get-base-config check-env
 	$(MAKE) storage-config-${cloud_storage}
 	$(MAKE) db-config-${cloud_db}
 	$(MAKE) registry-config-${cloud_registry}
-ifneq ($(self_signed),)
-	$(MAKE) self-signed-config
-endif
+	if [[ $$self_signed == "true" ]]; then $(MAKE) self-signed-config; fi
+	if [[ $$runTests == "true" ]]; then $(MAKE) get-github-config; fi
 
 license_community_beta := "../licenses/Community (Beta).yaml"
 license_community_stable := "../licenses/Community.yaml"

--- a/install/tests/Makefile
+++ b/install/tests/Makefile
@@ -337,12 +337,13 @@ generate-kots-config: cloud_storage = $(if $(findstring external,$(storage)),$(c
 generate-kots-config: cloud_registry = $(if $(findstring external,$(registry)),$(cloud),incluster)
 generate-kots-config: cloud_db = $(if $(findstring external,$(db)),$(cloud),incluster)
 ## generate-kots-config: Generate the kots config based on test config
-generate-kots-config: select-workspace check-env-cloud get-base-config check-env-domain check-env-sub-domain
+generate-kots-config: select-workspace check-env-cloud check-env-domain check-env-sub-domain
+	if [[ $$runTests == "true" ]]; then $(MAKE) get-github-config; fi
+	$(MAKE) get-base-config
 	$(MAKE) storage-config-${cloud_storage}
 	$(MAKE) db-config-${cloud_db}
 	$(MAKE) registry-config-${cloud_registry}
 	if [[ $$self_signed == "true" ]]; then $(MAKE) self-signed-config; fi
-	if [[ $$runTests == "true" ]]; then $(MAKE) get-github-config; fi
 
 license_community_beta := "../licenses/Community (Beta).yaml"
 license_community_stable := "../licenses/Community.yaml"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PR integrates the SCM authentication when running integration tests. The changes included here are the follows:
- Using the `GITHUB_SCM_OAUTH` env var to provide the secret in core-dev cluster that stores the github token for github app
- The secret will be appended with the `callBackURL`. This URL would point to an nginx server we have setup that will redirect to the correct subdomian specified using `state` query parameter
- The above changes are added only when integration tests are run, otherwise we expect the users to have the opportunity to connect to their preferred SCM
- The PR also changes one of the existing annotation `skipTests` to `runTests`. This is mostly because, we don't want the test running a default behavior, but an explicitly specified one. 
- The PR also updates the slack alert channel to be the corresponding team channels since potentially the fix in this PR should make the integration tests work.


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #12870 

## How to test
<!-- Provide steps to test this PR -->
You can run the command:
```
werft run github -j .werft/k3s-installer-tests.yaml -a runTests=true
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
