### PR TITLE
Send traces from previews to Honeycomb

### DIFF
--- a/.werft/jobs/build/helm/values.tracing.yaml
+++ b/.werft/jobs/build/helm/values.tracing.yaml
@@ -1,4 +1,4 @@
 tracing:
-  endpoint: http://otel-collector:14268/api/traces
+  endpoint: http://otel-collector.monitoring-satellite.svc.cluster.local:14268/api/traces
   samplerType: const
   samplerParam: "1"

--- a/.werft/observability/monitoring-satellite.ts
+++ b/.werft/observability/monitoring-satellite.ts
@@ -67,6 +67,11 @@ export class MonitoringSatelliteInstaller {
                 "pyrra": {
                     "install": true
                 },
+                "tracing": {
+                    "install": true,
+                    "honeycombAPIKey": "${process.env.HONEYCOMB_API_KEY}",
+                    "honeycombDataset": "preview-environments",
+                },
                 "prometheus": {
                     "externalLabels": {
                         "cluster": "${previewName}",


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
In https://github.com/gitpod-io/gitpod/pull/12626, I've configured preview environments to always use our CLI installer to install monitoring-satellite. In the process, I accidentally removed the configuration that sends traces from previews to Honeycomb.

This aims to fix that.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
[Slack conversation](https://gitpod.slack.com/archives/C032A46PWR0/p1662652877057059)

## How to test
<!-- Provide steps to test this PR -->
* Create a preview from this PR
* Open a new workspace from the preview, just to generate a new trace
* [Go to honeycomb and see traces showing up for the preview](https://ui.honeycomb.io/gitpod/datasets/preview-environments/result/FNAkhZbeYeJ)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
