### PR TITLE
[usage] Remove default controller schedule of 1h

### DIFF
--- a/install/installer/pkg/components/usage/configmap.go
+++ b/install/installer/pkg/components/usage/configmap.go
@@ -5,8 +5,6 @@ package usage
 
 import (
 	"fmt"
-	"time"
-
 	"github.com/gitpod-io/gitpod/common-go/baseserver"
 	"github.com/gitpod-io/gitpod/usage/pkg/server"
 
@@ -19,7 +17,7 @@ import (
 
 func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 	cfg := server.Config{
-		ControllerSchedule: time.Hour.String(),
+		ControllerSchedule: "", // By default controller is disabled
 		Server: &baseserver.Configuration{
 			Services: baseserver.ServicesConfiguration{
 				GRPC: &baseserver.ServerConfiguration{

--- a/install/installer/pkg/components/usage/configmap_test.go
+++ b/install/installer/pkg/components/usage/configmap_test.go
@@ -49,7 +49,6 @@ func TestConfigMap_ContainsBillInstancesAfter(t *testing.T) {
 
 	require.JSONEq(t,
 		`{
-       "controllerSchedule": "1h0m0s",
        "billInstancesAfter": "2022-08-04T00:00:00Z",
        "stripeCredentialsFile": "stripe-secret/apikeys",
        "server": {


### PR DESCRIPTION
The default config prevented from actually disabling the controller in the US.

We already set it to disabled in https://github.com/gitpod-io/ops/blob/main/deploy/production/meta-us02/app/installer-config.yaml#L168, however when the config is parsed, it's treated as unset and the default from the installer is used.

We remove the default to prevent this behaviour.

## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
Unit tests

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
