### PR TITLE
[stripe] Finalized invoce debits, do not set credits to negative when updating

### DIFF
--- a/components/usage/pkg/apiv1/billing.go
+++ b/components/usage/pkg/apiv1/billing.go
@@ -108,7 +108,8 @@ func (s *BillingService) FinalizeInvoice(ctx context.Context, in *v1.FinalizeInv
 		ID:            uuid.New(),
 		AttributionID: attributionID,
 		Description:   fmt.Sprintf("Invoice %s finalized in Stripe", invoice.ID),
-		CreditCents:   db.NewCreditCents(float64(creditsOnInvoice)),
+		// Apply negative value of credits to reduce accrued credit usage
+		CreditCents:   db.NewCreditCents(float64(-creditsOnInvoice)),
 		EffectiveTime: db.NewVarcharTime(finalizedAt),
 		Kind:          db.InvoiceUsageKind,
 		Draft:         false,


### PR DESCRIPTION
1. We need to debit the credit amount in usage, not credit the credit amount
2. We shouldn't try to update usage to negative values. This doesn't make sense (and isn't allowed by Stripe). Instead we set it to 0. This happens when a customer has for example bought a bundle or overpaid on an invoice.

## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Depends on https://github.com/gitpod-io/gitpod/pull/12755

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
