### PR TITLE
Add dashboard URL for KubeCPUOvercommit and KubeMemoryOvercommit

### DIFF
--- a/operations/observability/mixins/platform/rules/kubernetes/kubernetes.yaml
+++ b/operations/observability/mixins/platform/rules/kubernetes/kubernetes.yaml
@@ -53,6 +53,7 @@ spec:
       annotations:
         description: Cluster has overcommitted CPU resource requests for Pods by {{ $value }} CPU shares and cannot tolerate node failure.
         summary: Cluster has overcommitted CPU resource requests.
+        dashboard_url: https://grafana.gitpod.io/d/efa86fd1d0c121a26444b636a3f509a8
       expr: |
         sum(namespace_cpu:kube_pod_container_resource_requests:sum{}) - (sum(kube_node_status_allocatable{resource="cpu"}) - max(kube_node_status_allocatable{resource="cpu"})) > 0
         and
@@ -65,6 +66,7 @@ spec:
       annotations:
         description: Cluster has overcommitted memory resource requests for Pods by {{ $value | humanize }} bytes and cannot tolerate node failure.
         summary: Cluster has overcommitted memory resource requests.
+        dashboard_url: https://grafana.gitpod.io/d/efa86fd1d0c121a26444b636a3f509a8
       expr: |
         sum(namespace_memory:kube_pod_container_resource_requests:sum{}) - (sum(kube_node_status_allocatable{resource="memory"}) - max(kube_node_status_allocatable{resource="memory"})) > 0
         and


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PR adds an annotation to the alerts `KubeCPUOvercommit` and `KubeMemoryOvercommit` so we can make the investigation faster. Such annotation will be transformed into slack buttons by alertsmanager 🙂 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
