### PR TITLE
[terraform] Add k3s setup for tests

### DIFF
--- a/install/infra/modules/k3s/output.tf
+++ b/install/infra/modules/k3s/output.tf
@@ -4,6 +4,25 @@ output "database" {
     instance            = "${var.gcp_project}:${var.gcp_region}:${google_sql_database_instance.gitpod.name}"
     username            = "${google_sql_user.users.name}"
     password            = random_password.password.result
-    service_account_key = "Upload the JSON file corresponding the service account credentials"
+    service_account_key_path = var.credentials
   }, "No database created")
+}
+
+output "registry" {
+  sensitive = true
+  value = try({
+    url      = "gcr.io/${var.gcp_project}"
+    server   = "gcr.io"
+    username = "_json_key"
+    password_file_path = var.credentials
+  }, "No container registry created")
+}
+
+output "storage" {
+  sensitive = true
+  value = try({
+    region      = var.gcp_region
+    project     = var.gcp_project
+    service_account_key_path = var.credentials
+  }, "No GCS bucket created for object storage")
 }

--- a/install/infra/single-cluster/k3s/Makefile
+++ b/install/infra/single-cluster/k3s/Makefile
@@ -1,0 +1,123 @@
+##
+# Terraform AWS reference architecture
+#
+
+.PHONY: init
+init:
+	@terraform init
+
+touch-kubeconfig:
+	@touch kubeconfig
+
+cleanup-kubeconfig:
+	@rm kubeconfig
+
+.PHONY: plan
+plan: touch-kubeconfig plan-cluster plan-cm-edns cleanup-kubeconfig
+
+.PHONY: apply
+apply: apply-cluster apply-tools
+
+.PHONY: destroy
+destroy: destroy-tools destroy-cluster
+
+.PHONY: refresh
+refresh:
+	@echo "Refreshing terraform state"
+	@terraform refresh
+	@echo ""
+	@echo "Done!"
+
+.PHONY: output
+output: refresh output-done-msg output-url output-registry output-database output-storage output-issuer
+
+output-done-msg:
+	@echo ""
+	@echo ""
+	@echo "=========================="
+	@echo "🎉🥳🔥🧡🚀"
+	@echo "Your cloud infrastructure is ready to install Gitpod. Please visit"
+	@echo "https://www.gitpod.io/docs/self-hosted/latest/getting-started#step-4-install-gitpod"
+	@echo "for your next steps."
+	@echo "================="
+	@echo "Config Parameters"
+	@echo "================="
+
+output-url:
+	@echo ""
+	@echo "Gitpod domain name:"
+	@echo "================="
+	@terraform output -json url | jq
+
+output-storage:
+	@echo ""
+	@echo "Object storage:"
+	@echo "=============="
+	@terraform output -json storage | jq
+
+output-registry:
+	@echo ""
+	@echo "GCR registry:"
+	@echo "=================="
+	@terraform output -json registry | jq
+
+output-database:
+	@echo ""
+	@echo "Database:"
+	@echo "========"
+	@echo "Tick the option 'Use Google Cloud SQL Proxy' if using this database"
+	@terraform output -json database | jq
+	@echo ""
+
+output-issuer:
+	@echo ""
+	@echo "ClusterIssuer name:"
+	@echo "================="
+	@terraform output -json cluster_issuer | jq
+
+.PHONY: plan-cluster
+plan-cluster:
+	@terraform plan -target=module.k3s
+
+.PHONY: plan-tools
+plan-tools: plan-cm-edns plan-cluster-issuer
+
+.PHONY: plan-cm-edns
+plan-cm-edns:
+	@terraform plan -target=module.certmanager -target=module.externaldns
+
+.PHONY: plan-cluster-issuer
+plan-cluster-issuer:
+	@terraform plan -target=module.cluster-issuer
+
+.PHONY: apply-cluster
+apply-cluster:
+	@terraform apply -target=module.k3s --auto-approve
+
+.PHONY: apply-tools
+apply-tools: install-cm-edns install-cluster-issuer
+
+.PHONY: install-cm-edns
+install-cm-edns:
+	@terraform apply -target=module.certmanager -target=module.externaldns --auto-approve
+
+.PHONY: install-cluster-issuer
+install-cluster-issuer:
+	@terraform apply -target=module.cluster-issuer  --auto-approve
+
+.PHONY: destroy-cluster
+destroy-cluster:
+	@terraform destroy -target=module.k3s --auto-approve
+
+.PHONY: destroy-tools
+destroy-tools: destroy-cluster-issuer destroy-cm-edns
+
+.PHONY: destroy-cm-edns
+destroy-cm-edns:
+	@terraform destroy -target=module.certmanager  -target=module.externaldns --auto-approve
+
+.PHONY: destroy-cluster-issuer
+destroy-cluster-issuer:
+	@terraform destroy -target=module.cluster-issuer  --auto-approve || echo "Could not remove cluster-issuer"
+
+# end

--- a/install/infra/single-cluster/k3s/cluster.tf
+++ b/install/infra/single-cluster/k3s/cluster.tf
@@ -1,0 +1,16 @@
+module "k3s" {
+  source = "../../modules/k3s"
+
+  name             = var.name
+  gcp_project      = var.project
+  gcp_region       = var.region
+  gcp_zone         = var.zone
+  credentials      = var.credentials_path
+  kubeconfig       = var.kubeconfig
+  dns_sa_creds     = var.credentials_path
+  dns_project      = var.project
+  managed_dns_zone = var.managed_dns_zone
+  domain_name      = var.domain_name
+  cluster_version  = var.cluster_version
+  image_id         = var.image_id
+}

--- a/install/infra/single-cluster/k3s/local.tf
+++ b/install/infra/single-cluster/k3s/local.tf
@@ -1,0 +1,3 @@
+locals {
+  credentials = "${file(var.credentials_path)}"
+}

--- a/install/infra/single-cluster/k3s/main.tf
+++ b/install/infra/single-cluster/k3s/main.tf
@@ -1,0 +1,20 @@
+terraform {
+  backend "gcs" {
+    bucket = "gitpod-tf"
+    prefix = "k3s/terraform.state"
+  }
+
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+
+    helm = {
+      source = "hashicorp/helm"
+    }
+  }
+}

--- a/install/infra/single-cluster/k3s/output.tf
+++ b/install/infra/single-cluster/k3s/output.tf
@@ -1,0 +1,22 @@
+output "database" {
+    sensitive = true
+    value = module.k3s.database
+}
+
+output "registry" {
+    sensitive = true
+    value = module.k3s.registry
+}
+
+output "storage" {
+    sensitive = true
+    value = module.k3s.storage
+}
+
+output "url" {
+  value = var.domain_name
+}
+
+output "cluster_issuer" {
+  value     = module.cluster-issuer.cluster_issuer
+}

--- a/install/infra/single-cluster/k3s/terraform.tfvars
+++ b/install/infra/single-cluster/k3s/terraform.tfvars
@@ -1,0 +1,16 @@
+name = "gitpod"
+
+domain_name =
+
+region      = "europe-west1"
+zone        = "europe-west1-b"
+project     =
+credentials_path = "key.json"
+
+cluster_version = "v1.22.12+k3s1"
+
+image_id = "ubuntu-2204-jammy-v20220712a"
+
+kubeconfig = "./kubeconfig"
+
+managed_dns_zone =

--- a/install/infra/single-cluster/k3s/tools.tf
+++ b/install/infra/single-cluster/k3s/tools.tf
@@ -1,0 +1,19 @@
+module "certmanager" {
+  source = "../../modules/tools/cert-manager"
+
+  kubeconfig  = var.kubeconfig
+}
+
+module "cluster-issuer" {
+  source              = "../../modules/tools/issuer"
+  kubeconfig          = var.kubeconfig
+  gcp_credentials     = local.credentials
+  issuer_name         = "cloudDNS"
+  cert_manager_issuer = {
+    project                 = var.project
+    serviceAccountSecretRef = {
+      name = "clouddns-dns01-solver"
+      key  = "keys.json"
+    }
+  }
+}

--- a/install/infra/single-cluster/k3s/variables.tf
+++ b/install/infra/single-cluster/k3s/variables.tf
@@ -1,0 +1,48 @@
+variable "kubeconfig" {
+  description = "The KUBECONFIG file path to store the resulting KUBECONFIG file to"
+  default     = "./kubeconfig"
+}
+
+variable "project" {
+  description = "Google cloud Region to perform operations in"
+}
+
+variable "region" {
+  description = "Google cloud Region to perform operations in"
+  default     = "europe-west1"
+}
+
+variable "zone" {
+  description = "Google cloud Zone to perform operations in"
+  default     = "europe-west1-b"
+}
+
+variable "credentials_path" {
+  description = "Path to the JSON file storing Google service account credentials"
+  default     = ""
+}
+
+variable "name" {
+  description = "Prefix name for the nodes and firewall"
+  default     = "k3s"
+}
+
+variable "image_id" {
+  description = "Node image ID to be used to provision EC2 instances"
+  default     = "ubuntu-2004-focal-v20220419"
+}
+
+variable "cluster_version" {
+  description = "Kubernetes version to use to provision the cluster"
+  default     = "v1.22.12+k3s1"
+}
+
+variable "domain_name" {
+  description = "Domain name to add to add DNS map to"
+  default     = null
+}
+
+variable "managed_dns_zone" {
+  description = "The Cloud DNS managed zone where Gitpod A records will be created"
+  default     = null
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PR adds a very rough single-cluster setup for k3s. We are adding this for consistency with Azure, AWS and GCP setups so we can consistently run the tests. We do not recommend users to use this because the underlying module still make use of `k3sup` and we have plans to move to `k3s` before suggesting this as a solution. Hence we have not included a Readme with this directory.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #12866

## How to test
<!-- Provide steps to test this PR -->
* Go to the directory `install/infra/single-cluster/k3s`.
* Edit `main.tf` to have the right bucket name.
* Edit `terraform.tfvars` to right parameters for the cluster.
Then run:
```
make init
make plan
make apply
# After testing, make sure you cleanup with:
make destroy
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
