### PR TITLE
[ws-manager-bridge] Don't report workspace instance update failures as both a failure and a success

### DIFF
--- a/components/ws-manager-bridge/src/bridge.ts
+++ b/components/ws-manager-bridge/src/bridge.ts
@@ -205,16 +205,15 @@ export class WorkspaceManagerBridge implements Disposable {
             );
             log.error(logCtx, "Failed to complete WorkspaceInstance status update", e);
             throw e;
-        } finally {
-            const durationMs = performance.now() - start;
-            this.prometheusExporter.reportWorkspaceInstanceUpdateCompleted(
-                durationMs / 1000,
-                writeToDB,
-                this.cluster.name,
-                status.spec.type,
-            );
-            log.info(logCtx, "Successfully completed WorkspaceInstance status update");
         }
+        const durationMs = performance.now() - start;
+        this.prometheusExporter.reportWorkspaceInstanceUpdateCompleted(
+            durationMs / 1000,
+            writeToDB,
+            this.cluster.name,
+            status.spec.type,
+        );
+        log.info(logCtx, "Successfully completed WorkspaceInstance status update");
     }
 
     private async statusUpdate(ctx: TraceContext, rawStatus: WorkspaceStatus, writeToDB: boolean) {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Currently, when we fail to update a workspace instance in ws-manager-bridge, we report it once as a failure (in the `catch`), then again as a success (in the `finally`, which always gets called regardless of whether errors happened):

https://github.com/gitpod-io/gitpod/blob/7a0efe9999c3cc31ffc63c79fe9d8334620bee37/components/ws-manager-bridge/src/bridge.ts#L190-L217

I think it would make more sense to report errors as errors, and only successes as successes.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
