### PR TITLE
Remove bradlc.vscode-tailwindcss from list of extensions

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -64,7 +64,6 @@ tasks:
     openMode: split-right
 vscode:
   extensions:
-    - bradlc.vscode-tailwindcss
     - EditorConfig.EditorConfig
     - golang.go
     - hashicorp.terraform


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PR removes bradlc.vscode-tailwindcss from the list of extensions that we install by default in our repo. The extension has for some time been displaying an error whenever we start a workspace:

<img width="493" alt="Screenshot 2022-09-06 at 09 57 03" src="https://user-images.githubusercontent.com/83561/189296896-e96e8a85-025f-43f8-ba4d-3e0b5b7df764.png">

I'm removing the extension to keep our workspace boots clean and tidy. If we want to re-add the extension we should resolve the issue.

Internal discussion [here](https://gitpod.slack.com/archives/C032A46PWR0/p1662451298450909).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
No issue, just Friday TIdying

## How to test
<!-- Provide steps to test this PR -->

Open a new workspace. The error should not appear aynmore.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

N/A

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
