### PR TITLE
[ws-manager-bridge] Use more reasonable duration buckets for workspace instance updates

### DIFF
--- a/components/ws-manager-bridge/src/prometheus-metrics-exporter.ts
+++ b/components/ws-manager-bridge/src/prometheus-metrics-exporter.ts
@@ -77,7 +77,7 @@ export class PrometheusMetricsExporter {
             // we track db_write because we need to be able to distinguish between outcomes which did affect the system negatively - failed to write,
             // and outcomes by read-only replicas.
             labelNames: ["db_write", "workspace_cluster", "workspace_instance_type", "outcome"],
-            buckets: prom.exponentialBuckets(2, 2, 8),
+            buckets: prom.exponentialBuckets(0.050, 2, 8),
         });
 
         this.prebuildsCompletedTotal = new prom.Counter({


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Currently, we are tracking the duration of the [`handleStatusUpdate` span](https://github.com/gitpod-io/gitpod/blob/7a0efe9999c3cc31ffc63c79fe9d8334620bee37/components/ws-manager-bridge/src/bridge.ts#L227-L432), and storing it in the following buckets:

https://github.com/gitpod-io/gitpod/blob/43e526b1d63178f4de3bcbf31b6dc01d59611fd9/components/ws-manager-bridge/src/prometheus-metrics-exporter.ts#L80

- < 2 seconds
- < 4 seconds
- < 8 seconds
- < 16 seconds
- < 32 seconds
- < 64 seconds
- < 128 seconds
- < 256 seconds
- < +Infinity

However, most of the time, this span takes actually around 50ms:

<img width="865" alt="Screenshot 2022-09-09 at 09 31 55" src="https://user-images.githubusercontent.com/599268/189298098-b6c4f080-37f2-435e-a299-c69a9b0a68c9.png">

Thus, all our measurements land in the very first "< 2 seconds" bucket, which is not very useful.

Instead, I propose that we store durations in the following buckets:

```
prom.exponentialBuckets(0.050, 2, 8)
```

- < 50ms
- < 100ms
- < 200ms
- < 400ms
- < 800ms
- < 1600ms
- < 3200ms
- < 6400ms
- < +Infinity

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
