### PR TITLE
test: Workspace testing does not guarantee branch name creation

### DIFF
--- a/test/tests/workspace/contexts_test.go
+++ b/test/tests/workspace/contexts_test.go
@@ -6,7 +6,6 @@ package workspace
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"testing"
 	"time"
@@ -43,12 +42,10 @@ func TestGitHubContexts(t *testing.T) {
 			ExpectedBranch: "integration-test-1",
 		},
 		{
+			// Branch name decisions are not tested in the workspace as it is the server side logic
 			Name:          "open issue",
 			ContextURL:    "github.com/gitpod-io/gitpod-test-repo/issues/88",
 			WorkspaceRoot: "/workspace/gitpod-test-repo",
-			ExpectedBranchFunc: func(username string) string {
-				return fmt.Sprintf("%s/integration-88", username)
-			},
 		},
 		{
 			Name:           "open tag",
@@ -94,9 +91,6 @@ func TestGitLabContexts(t *testing.T) {
 			Name:          "open issue",
 			ContextURL:    "gitlab.com/AlexTugarev/gp-test/issues/1",
 			WorkspaceRoot: "/workspace/gp-test",
-			ExpectedBranchFunc: func(username string) string {
-				return fmt.Sprintf("%s/write-a-readme-1", username)
-			},
 		},
 		{
 			Name:           "open tag",
@@ -163,6 +157,10 @@ func runContextTests(t *testing.T, tests []ContextTest) {
 						}
 						defer rsa.Close()
 						integration.DeferCloser(t, closer)
+
+						if test.ExpectedBranch == "" && test.ExpectedBranchFunc == nil {
+							return
+						}
 
 						// get actual from workspace
 						git := common.Git(rsa)

--- a/test/tests/workspace/contexts_test.go
+++ b/test/tests/workspace/contexts_test.go
@@ -32,8 +32,8 @@ func TestGitHubContexts(t *testing.T) {
 	tests := []ContextTest{
 		{
 			Name:           "open repository",
-			ContextURL:     "github.com/gitpod-io/gitpod",
-			WorkspaceRoot:  "/workspace/gitpod",
+			ContextURL:     "github.com/gitpod-io/template-golang-cli",
+			WorkspaceRoot:  "/workspace/template-golang-cli",
 			ExpectedBranch: "main",
 		},
 		{


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

The branch name will vary depending on the user name and other factors. And this logic is written in the server, so it is not tested in the workspace.
https://github.com/gitpod-io/gitpod/blob/45f13cf8e9214db664adc23a418e53d92364fbb7/components/server/src/workspace/context-parser.ts#L106-L121

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Relates https://github.com/gitpod-io/gitpod/issues/12248

## How to test
<!-- Provide steps to test this PR -->

Run the test

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
