### PR TITLE
Show Team Seats that block individuals from being in the Usage-Based Free tier

### DIFF
--- a/components/dashboard/src/admin/Property.tsx
+++ b/components/dashboard/src/admin/Property.tsx
@@ -12,9 +12,9 @@ function Property(p: {
     actions?: { label: string; onClick: () => void }[];
 }) {
     return (
-        <div className="flex flex-col w-4/12 truncate">
-            <div className="text-base text-gray-500 truncate">{p.name}</div>
-            <div className="mr-3 text-lg text-gray-600 font-semibold truncate">{p.children}</div>
+        <div className="flex flex-col w-4/12">
+            <div className="text-base text-gray-500">{p.name}</div>
+            <div className="mr-3 text-lg text-gray-600 font-semibold">{p.children}</div>
             {(p.actions || []).map((a) => (
                 <div
                     className="cursor-pointer text-sm text-blue-400 dark:text-blue-600 hover:text-blue-600 dark:hover:text-blue-400 truncate"

--- a/components/dashboard/src/admin/UserDetail.tsx
+++ b/components/dashboard/src/admin/UserDetail.tsx
@@ -24,6 +24,8 @@ import Property from "./Property";
 import { PageWithAdminSubMenu } from "./PageWithAdminSubMenu";
 import { BillingMode } from "@gitpod/gitpod-protocol/lib/billing-mode";
 import { AttributionId } from "@gitpod/gitpod-protocol/lib/attribution";
+import CaretDown from "../icons/CaretDown.svg";
+import ContextMenu from "../components/ContextMenu";
 
 export default function UserDetail(p: { user: User }) {
     const [activity, setActivity] = useState(false);
@@ -147,7 +149,7 @@ export default function UserDetail(p: { user: User }) {
             >
                 {isStudent === undefined ? "---" : isStudent ? "Enabled" : "Disabled"}
             </Property>,
-            <Property name="BillingMode">{billingMode?.mode || "---"}</Property>,
+            renderBillingModeProperty(billingMode),
         ];
 
         switch (billingMode?.mode) {
@@ -325,6 +327,36 @@ export default function UserDetail(p: { user: User }) {
                 </div>
             </Modal>
         </>
+    );
+}
+
+function renderBillingModeProperty(billingMode?: BillingMode): JSX.Element {
+    const text = billingMode?.mode || "---";
+
+    let blockingTeamNames = [];
+    if (billingMode?.mode === "chargebee" && !!billingMode.teamNames && !billingMode.canUpgradeToUBB) {
+        const itemStyle = "text-gray-400 dark:text-gray-500 text-left font-normal";
+        for (const teamName of billingMode.teamNames) {
+            blockingTeamNames.push({ title: teamName, customFontStyle: itemStyle });
+        }
+    }
+    return (
+        <Property name="BillingMode">
+            <>
+                {text}
+                {blockingTeamNames.length > 0 && (
+                    <ContextMenu
+                        menuEntries={blockingTeamNames}
+                        customClasses="w-64 max-h-48 overflow-scroll mx-auto left-0 right-0"
+                    >
+                        <p className="flex justify-left text-gitpod-red">
+                            <span>UBP blocked by:</span>
+                            <img className="m-2" src={CaretDown} />
+                        </p>
+                    </ContextMenu>
+                )}
+            </>
+        </Property>
     );
 }
 

--- a/components/dashboard/src/settings/Plans.tsx
+++ b/components/dashboard/src/settings/Plans.tsx
@@ -711,6 +711,12 @@ export default function () {
                     </div>
                 )}
                 <div className="mt-4 flex justify-center space-x-3 2xl:space-x-7">{planCards}</div>
+                {assignedTs && userBillingMode?.mode === "chargebee" && !!userBillingMode.teamNames && (
+                    <Alert type="info" className="mt-10 mx-auto">
+                        <p>Assigned Team Seats</p>
+                        <ul>{userBillingMode.teamNames.join(", ")}</ul>
+                    </Alert>
+                )}
                 <InfoBox className="w-2/3 mt-14 mx-auto">
                     If you are interested in purchasing a plan for a team, purchase a Team plan with one centralized
                     billing.{" "}

--- a/components/gitpod-protocol/src/billing-mode.ts
+++ b/components/gitpod-protocol/src/billing-mode.ts
@@ -64,6 +64,9 @@ interface Chargebee {
     paid?: boolean;
 
     canUpgradeToUBB?: boolean;
+
+    /** Name of team(s) that block switching to usage-based */
+    teamNames?: string[];
 }
 
 /** Session is handld with new usage-based logic */

--- a/components/server/ee/src/billing/billing-mode.spec.db.ts
+++ b/components/server/ee/src/billing/billing-mode.spec.db.ts
@@ -157,6 +157,7 @@ class BillingModeSpec {
         function user(): User {
             return {
                 id: userId,
+                name: `user-${userId}`,
                 creationDate,
                 identities: [],
             };
@@ -312,6 +313,7 @@ class BillingModeSpec {
                 expectation: {
                     mode: "chargebee",
                     canUpgradeToUBB: true,
+                    teamNames: ["Team Subscription 'Team Unleashed' (owner: user-123)"],
                 },
             },
             {
@@ -328,6 +330,7 @@ class BillingModeSpec {
                 expectation: {
                     mode: "chargebee",
                     canUpgradeToUBB: true,
+                    teamNames: ["Team Subscription 'Team Unleashed' (owner: user-123)"],
                 },
             },
             {
@@ -461,6 +464,7 @@ class BillingModeSpec {
                 expectation: {
                     mode: "chargebee",
                     paid: true,
+                    teamNames: ["team-123"],
                 },
             },
             // team: transition chargebee -> UBB
@@ -475,6 +479,7 @@ class BillingModeSpec {
                 expectation: {
                     mode: "chargebee",
                     canUpgradeToUBB: true,
+                    teamNames: ["team-123"],
                 },
             },
             {


### PR DESCRIPTION
## Description

If users are already member of a paid Chargebee team, and not part of a UBP team yet, their move to UBP (free tier) is blocked. This PR shows the team names of those who are actually blocking.
We can use this in two ways:
 1. understand their state better ourselves when operating Gitpod (admin dashboard)
 2. explain in the docs how people can understand themselves (personal billing page)

## Related Issue(s)

Fixes #12758

## How to test
 - [signup](https://gpl-12758-list-plans.preview.gitpod-dev.com/workspaces)
 - Join [this team](https://gpl-12758-list-plans.preview.gitpod-dev.com/teams/join?inviteId=bb2a82a0-6392-49c0-aa9e-0f6a194b9367)
 - add your user id to ConfigCat [here](https://app.configcat.com/08da1258-64fb-4a8e-8a1e-51de773884f6/08da1258-6541-4fc7-8b61-c8b47f82f3a0/08da1258-6512-4ec0-80a3-3f6aa301f853)
 - go to admin page and [personal billing](https://gpl-12758-list-plans.preview.gitpod-dev.com/plans) and note the follwing:


![image](https://user-images.githubusercontent.com/32448529/198043230-a0760a77-0021-4efe-9059-9861329b02c8.png)

![image](https://user-images.githubusercontent.com/32448529/198043445-0ab2c272-17d3-444b-a9c4-4bd4367414ba.png)



## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
display the team names which block upgrade to the UBP free tier
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
- [x] /werft with-payment
- [ ] /werft with-clean-slate-deployment
