### PR TITLE
[usage] Include drafts when listing usage summary

### DIFF
--- a/components/usage/pkg/apiv1/usage.go
+++ b/components/usage/pkg/apiv1/usage.go
@@ -78,8 +78,9 @@ func (s *UsageService) ListUsage(ctx context.Context, in *v1.ListUsageRequest) (
 	if in.GetPagination().GetPage() > 1 {
 		page = in.GetPagination().GetPage()
 	}
-	var offset int64 = perPage * (page - 1)
+	var offset = perPage * (page - 1)
 
+	excludeDrafts := false
 	listUsageResult, err := db.FindUsage(ctx, s.conn, &db.FindUsageParams{
 		AttributionId: db.AttributionID(in.GetAttributionId()),
 		From:          from,
@@ -87,6 +88,7 @@ func (s *UsageService) ListUsage(ctx context.Context, in *v1.ListUsageRequest) (
 		Order:         order,
 		Offset:        offset,
 		Limit:         perPage,
+		ExcludeDrafts: excludeDrafts,
 	})
 	logger := log.Log.
 		WithField("attribution_id", in.AttributionId).
@@ -124,7 +126,7 @@ func (s *UsageService) ListUsage(ctx context.Context, in *v1.ListUsageRequest) (
 		attributionId,
 		from,
 		to,
-		true,
+		excludeDrafts,
 	)
 
 	if err != nil {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

We need to use the same draft flags between ListUsage and ListUsageSummary, else the metadata about pagination does not match.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
