### PR TITLE
workspace integration test: add missing PVC feature flag

### DIFF
--- a/test/tests/components/ws-manager/tasks_test.go
+++ b/test/tests/components/ws-manager/tasks_test.go
@@ -46,16 +46,19 @@ func TestRegularWorkspaceTasks(t *testing.T) {
 			Name:        "pvc-init",
 			Task:        gitpod.TasksItems{Init: "touch /workspace/gitpod/init-ran; exit"},
 			LookForFile: "init-ran",
+			FF:          []wsmanapi.WorkspaceFeatureFlag{wsmanapi.WorkspaceFeatureFlag_PERSISTENT_VOLUME_CLAIM},
 		},
 		{
 			Name:        "pvc-before",
 			Task:        gitpod.TasksItems{Before: "touch /workspace/gitpod/before-ran; exit"},
 			LookForFile: "before-ran",
+			FF:          []wsmanapi.WorkspaceFeatureFlag{wsmanapi.WorkspaceFeatureFlag_PERSISTENT_VOLUME_CLAIM},
 		},
 		{
 			Name:        "pvc-command",
 			Task:        gitpod.TasksItems{Command: "touch /workspace/gitpod/command-ran; exit"},
 			LookForFile: "command-ran",
+			FF:          []wsmanapi.WorkspaceFeatureFlag{wsmanapi.WorkspaceFeatureFlag_PERSISTENT_VOLUME_CLAIM},
 		},
 	}
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Add missing PVC feature flag when testing against TestRegularWorkspaceTasks.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #12497

## How to test
<!-- Provide steps to test this PR -->
Run integration test

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
None

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
