### PR TITLE
[dashboard] (pagination) make sure next page is selectable

### DIFF
--- a/components/dashboard/src/Pagination/getPagination.spec.ts
+++ b/components/dashboard/src/Pagination/getPagination.spec.ts
@@ -7,14 +7,30 @@
 import { getPaginationNumbers } from "./getPagination";
 
 test("getPagination", () => {
-    const totalNumberOfPages = 15;
-    const currentPage = 1;
+    expect(getPaginationNumbers(15, 1)).toStrictEqual([1, 2, 3, "...", 15]);
 
-    expect(getPaginationNumbers(totalNumberOfPages, currentPage)).toStrictEqual([1, 2, 3, "...", 15]);
+    expect(getPaginationNumbers(37, 4)).toStrictEqual([1, 2, 3, 4, 5, "...", 37]);
 
-    expect(getPaginationNumbers(37, 4)).toStrictEqual([1, "...", 3, 4, 5, "...", 37]);
-
+    // navigating 7 --> 4
+    // ensure there is a selectable page next to current
     expect(getPaginationNumbers(28, 7)).toStrictEqual([1, "...", 6, 7, 8, "...", 28]);
+    expect(getPaginationNumbers(28, 6)).toStrictEqual([1, "...", 5, 6, 7, "...", 28]);
+    expect(getPaginationNumbers(28, 5)).toStrictEqual([1, "...", 4, 5, 6, "...", 28]);
+    // ellipsis should not replace a single page number
+    expect(getPaginationNumbers(28, 4)).toStrictEqual([1, 2, 3, 4, 5, "...", 28]);
+
+    // ensure there is a selectable page next to current
+    expect(getPaginationNumbers(28, 24)).toStrictEqual([1, "...", 23, 24, 25, "...", 28]);
+    expect(getPaginationNumbers(28, 25)).toStrictEqual([1, "...", 24, 25, 26, 27, 28]);
 
     expect(getPaginationNumbers(5, 1)).toStrictEqual([1, 2, 3, 4, 5]);
+
+    expect(getPaginationNumbers(9, 2)).toStrictEqual([1, 2, 3, "...", 9]);
+    expect(getPaginationNumbers(9, 3)).toStrictEqual([1, 2, 3, 4, "...", 9]);
+    expect(getPaginationNumbers(6, 3)).toStrictEqual([1, 2, 3, 4, 5, 6]);
+    expect(getPaginationNumbers(7, 3)).toStrictEqual([1, 2, 3, 4, "...", 7]);
+    expect(getPaginationNumbers(7, 3)).toStrictEqual([1, 2, 3, 4, "...", 7]);
+
+    expect(getPaginationNumbers(10, 8)).toStrictEqual([1, "...", 7, 8, 9, 10]);
+    expect(getPaginationNumbers(10, 7)).toStrictEqual([1, "...", 6, 7, 8, 9, 10]);
 });

--- a/components/dashboard/src/Pagination/getPagination.ts
+++ b/components/dashboard/src/Pagination/getPagination.ts
@@ -6,6 +6,7 @@
 
 export function getPaginationNumbers(totalNumberOfPages: number, currentPage: number) {
     const adjacentToCurrentPage = 1; // This is the number(s) we see next to the currentPage
+    const numberOfPagesToShowOnTheSide = 3;
     const totalNumbersShownInPagination = 6;
     let calculatedPagination: number[] = [];
 
@@ -24,16 +25,21 @@ export function getPaginationNumbers(totalNumberOfPages: number, currentPage: nu
     const toTheLeftOfCurrent = Math.max(currentPage - adjacentToCurrentPage, 1);
 
     const showRightEllipsis = toTheRightOfCurrent < totalNumberOfPages - minimumAmountInBetweenToShowEllipsis; // e.g. "1 2 3 ... 7"
-    const showLeftEllipsis = toTheLeftOfCurrent > minimumAmountInBetweenToShowEllipsis; // e.g. 1 ... 5 6 7"
+    const showLeftEllipsis =
+        currentPage > numberOfPagesToShowOnTheSide + adjacentToCurrentPage &&
+        toTheLeftOfCurrent > minimumAmountInBetweenToShowEllipsis; // e.g. 1 ... 5 6 7"
 
     if (showRightEllipsis && !showLeftEllipsis) {
-        let leftSideNumbers = 3;
+        let leftSideNumbers = Math.max(numberOfPagesToShowOnTheSide, currentPage + adjacentToCurrentPage);
         let leftPageNumbersAsArray = pageNumbersAsArray(1, leftSideNumbers);
         return [...leftPageNumbersAsArray, "...", totalNumberOfPages];
     }
 
     if (showLeftEllipsis && !showRightEllipsis) {
-        let rightSideNumbers = 3;
+        let rightSideNumbers = Math.max(
+            numberOfPagesToShowOnTheSide,
+            totalNumberOfPages - currentPage + adjacentToCurrentPage,
+        );
         let rightPageNumbersAsArray = pageNumbersAsArray(totalNumberOfPages - rightSideNumbers, totalNumberOfPages);
         return [1, "...", ...rightPageNumbersAsArray];
     }


### PR DESCRIPTION
## Description
Fixes pagination, where the page next to current was not selectable.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #12804

## How to test
```
cd components/dashboard
yarn test:unit getPagination
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
- [x] /werft with-payment
