### PR TITLE
Improve fetching repositories loading state

### DIFF
--- a/components/dashboard/src/projects/NewProject.tsx
+++ b/components/dashboard/src/projects/NewProject.tsx
@@ -20,6 +20,7 @@ import { UserContext } from "../user-context";
 import { trackEvent } from "../Analytics";
 import exclamation from "../images/exclamation.svg";
 import ErrorMessage from "../components/ErrorMessage";
+import Spinner from "../icons/Spinner.svg";
 
 export default function NewProject() {
     const location = useLocation();
@@ -526,7 +527,10 @@ export default function NewProject() {
                 <div className="mt-8 border rounded-xl border-gray-100 dark:border-gray-700 flex-col">
                     <div>
                         <div className="px-12 py-16 text-center text-gray-500 bg-gray-50 dark:bg-gray-800 rounded-xl w-96 h-h96 flex items-center justify-center">
-                            <h3 className="mb-2 text-gray-400 dark:text-gray-600 animate-pulse">Loading ...</h3>
+                            <div className="flex items-center justify-center space-x-2 text-gray-400 text-sm">
+                                <img className="h-4 w-4 animate-spin" src={Spinner} />
+                                <span>Fetching repositories...</span>
+                            </div>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Description

This will update the loading state when fetching repositories, and GitLab groups or GitHub orgs, based on the comment in https://github.com/gitpod-io/gitpod/issues/5075#issuecomment-1134456530, using the same pattern we use in fetching repository branches and prebuilds within a project.

## Related Issue(s)
Related to https://github.com/gitpod-io/gitpod/issues/5075

## How to test
1. Try adding a new project

## Screenshots 

| BEFORE | AFTER |
|-|-|
| <img width="1440" alt="Screenshot 2022-09-09 at 4 48 32 PM (2)" src="https://user-images.githubusercontent.com/120486/189366083-e5e65474-5cc5-40ba-b771-312a0ce85f1f.png"> | <img width="1440" alt="Screenshot 2022-09-09 at 4 48 44 PM (2)" src="https://user-images.githubusercontent.com/120486/189366089-50ccd605-1784-49d7-96c7-e3aeab0b81d9.png"> |

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Improve fetching repositories loading state
```

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [X] /werft with-preview
