### PR TITLE
Improve layer caching by moving apk commands up

### DIFF
--- a/install/installer/leeway.Dockerfile
+++ b/install/installer/leeway.Dockerfile
@@ -4,10 +4,10 @@
 
 FROM alpine:3.16
 COPY --from=alpine/helm:3.8.0 /usr/bin/helm /usr/bin/helm
-COPY install-installer--app/installer install-installer--app/provenance-bundle.jsonl /app/
-COPY scripts/*.sh /app/scripts/
 RUN apk add --no-cache curl jq openssh-keygen yq  \
     && curl -L "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" -o /usr/local/bin/kubectl \
     && chmod +x /usr/local/bin/kubectl
+COPY install-installer--app/installer install-installer--app/provenance-bundle.jsonl /app/
+COPY scripts/*.sh /app/scripts/
 ENTRYPOINT [ "/app/installer" ]
 CMD [ "help" ]


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This moves the `apk` above the `COPY` instructions so that we don't invalidate the layers whenever the contents of the files changes ☺️

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/12828

## How to test
<!-- Provide steps to test this PR -->

The Werft build should still succeed.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A


## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
