### PR TITLE
[dashboard] reenable attribution to personal account

### DIFF
--- a/components/dashboard/src/components/BillingAccountSelector.tsx
+++ b/components/dashboard/src/components/BillingAccountSelector.tsx
@@ -82,7 +82,7 @@ export function BillingAccountSelector(props: { onSelected?: () => void }) {
                 <div>
                     <p>Associate all my usage with the billing account below.</p>
                     <div className="mt-4 max-w-2xl grid grid-cols-3 gap-3">
-                        {/* <SelectableCardSolid
+                        <SelectableCardSolid
                             className="h-18"
                             title="(myself)"
                             selected={
@@ -94,7 +94,7 @@ export function BillingAccountSelector(props: { onSelected?: () => void }) {
                             <div className="flex-grow flex items-end px-1">
                                 <span className="text-sm text-gray-400">Personal Account</span>
                             </div>
-                        </SelectableCardSolid> */}
+                        </SelectableCardSolid>
                         {teamsWithBillingEnabled.length === 0 && (
                             <span className="col-span-3">
                                 Please enable billing for one of your teams, or create a new team and enable billing for


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
- [x] /werft with-payment
