### PR TITLE
Minor improvements to Werft slices

### DIFF
--- a/.werft/build.yaml
+++ b/.werft/build.yaml
@@ -228,19 +228,32 @@ pod:
         sleep 1
         set -Eeuo pipefail
 
-        sudo chown gitpod:gitpod $GOCACHE
         export GITHUB_TOKEN=$(echo $GITHUB_TOKEN | xargs)
-
         export DOCKER_HOST=tcp://$NODENAME:2375
-        sudo chown -R gitpod:gitpod /workspace
 
-        mkdir /workspace/.ssh
-        cp /mnt/secrets/harvester-vm-ssh-keys/id_rsa /workspace/.ssh/id_rsa_harvester_vm
-        cp /mnt/secrets/harvester-vm-ssh-keys/id_rsa.pub /workspace/.ssh/id_rsa_harvester_vm.pub
-        sudo chmod 600 /workspace/.ssh/id_rsa_harvester_vm
-        sudo chmod 644 /workspace/.ssh/id_rsa_harvester_vm.pub
+        echo "Job is running on node $NODENAME" | werft log slice "Node information"
 
-        (cd .werft && yarn install && mv node_modules ..) | werft log slice prep
+        ( \
+          sudo chown gitpod:gitpod $GOCACHE && \
+          sudo chown -R gitpod:gitpod /workspace && \
+          echo "done" \
+        ) | werft log slice "chowning /workspace and $GOCACHE"
+
+        ( \
+          mkdir -p /workspace/.ssh && \
+          cp /mnt/secrets/harvester-vm-ssh-keys/id_rsa /workspace/.ssh/id_rsa_harvester_vm && \
+          cp /mnt/secrets/harvester-vm-ssh-keys/id_rsa.pub /workspace/.ssh/id_rsa_harvester_vm.pub && \
+          sudo chmod 600 /workspace/.ssh/id_rsa_harvester_vm && \
+          sudo chmod 644 /workspace/.ssh/id_rsa_harvester_vm.pub && \
+          echo "done" \
+        ) | werft log slice "Prepare SSH keys"
+
+        ( \
+          cd .werft && \
+          yarn install && \
+          mv node_modules .. \
+        ) | werft log slice "Installing dependencies"
+
         printf '{{ toJson . }}' > context.json
 
         npx ts-node .werft/build.ts

--- a/.werft/jobs/build/job-config.ts
+++ b/.werft/jobs/build/job-config.ts
@@ -150,7 +150,8 @@ export function jobConfig(werft: Werft, context: any): JobConfig {
         withLargeVM,
     };
 
-    werft.log("job config", JSON.stringify(jobConfig));
+    werft.logOutput(sliceId, JSON.stringify(jobConfig, null, 2));
+    werft.log(sliceId, "Expand to see the parsed configuration")
     const globalAttributes = Object.fromEntries(
         Object.entries(jobConfig).map((kv) => {
             const [key, value] = kv;


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This PR contains a few improvements to Werft slices

- More granular slices for the "job preparation" phase. These are mostly interesting as they provide more detailed traces.
- Added a slice that contains information about what node the job was scheduled on. This can help when you're debugging caching issues as the docker layer caching is node dependant
- Pretty-printed the JSON configuration and "hid" it behind a "Expand to see the parsed configuration". This makes it less noisy visually, and more readable when you actually care about the contents of the config

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
No issue. Friday fun times.

## How to test
<!-- Provide steps to test this PR -->

Before

<img width="1508" alt="Screenshot 2022-09-09 at 16 55 10" src="https://user-images.githubusercontent.com/83561/189379716-e614baed-6632-4683-a4b9-314e2e60b05e.png">

After

<img width="1507" alt="Screenshot 2022-09-09 at 16 54 58" src="https://user-images.githubusercontent.com/83561/189379746-843fb939-a7e7-4311-a07e-5138b1fbde94.png">


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
