### PR TITLE
Adds vscode auth callback route

### DIFF
--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -7,7 +7,7 @@ defaultArgs:
   jbMarketplacePublishTrigger: "false"
   publishToJBMarketplace: true
   localAppVersion: unknown
-  codeCommit: ca48b16256fad72bc239a27bde3dc78a369aafa6
+  codeCommit: e2c3ab18a37bed1b4e43609a2c5a771ed4f07dbc
   codeQuality: stable
   noVerifyJBPlugin: false
   intellijDownloadUrl: "https://download.jetbrains.com/idea/ideaIU-2022.2.1.tar.gz"

--- a/components/ide/code/leeway.Dockerfile
+++ b/components/ide/code/leeway.Dockerfile
@@ -70,6 +70,7 @@ RUN yarn --cwd extensions compile \
 # this custom urls will be then replaced by blobserve.
 # Check pkg/blobserve/blobserve.go, `inlineVars` method
 RUN cp /vscode-web/out/vs/gitpod/browser/workbench/workbench.html /vscode-web/index.html \
+    && cp /vscode-web/out/vs/gitpod/browser/workbench/callback.html /vscode-web/callback.html \
     && sed -i -e 's#static/##g' /vscode-web/index.html
 
 # cli config: alises to gitpod-code

--- a/components/proxy/conf/Caddyfile
+++ b/components/proxy/conf/Caddyfile
@@ -296,19 +296,18 @@ https://*.*.{$GITPOD_DOMAIN} {
 	import ssl_configuration
 	import debug_headers
 
-	@workspace_blobserve header_regexp host Host ^blobserve.ws(?P<location>-[a-z0-9]+)?.{$GITPOD_DOMAIN}
-	handle @workspace_blobserve {
-		gitpod.cors_origin {
-			base_domain {$GITPOD_DOMAIN}
-		}
-
+	# foreign content route used by vscode to serve webview and webworker resources of the form
+	# https://{{hash_base_32}}.<cluster>.<gitpod_domain> or https://v--{{hash_base_32}}.<cluster>.<gitpod_domain>
+	# e.g:
+	# https://0d9rkrj560blqb5s07q431ru9mhg19k1k4bqgd1dbprtgmt7vuhk.ws-us34xl.gitpod.io (for webviews)
+	# https://v--0d9rkrj560blqb5s07q431ru9mhg19k1k4bqgd1dbprtgmt7vuhk.ws-us34xl.gitpod.io (for webworker)
+	@foreign_content2 header_regexp host Host ^(?:v--)?[0-9a-v]+.ws(-[a-z0-9]+)?.{$GITPOD_DOMAIN}
+	handle @foreign_content2 {
 		reverse_proxy https://ws-proxy.{$KUBE_NAMESPACE}.{$KUBE_DOMAIN}:9090 {
 			import workspace_transport
 			import upstream_headers
 
 			header_up X-WSProxy-Host       {http.request.host}
-
-			header_down -access-control-allow-origin
 		}
 	}
 
@@ -331,22 +330,6 @@ https://*.*.{$GITPOD_DOMAIN} {
 			import upstream_headers
 
 			header_up X-Gitpod-WorkspaceId {re.host.workspaceID}
-			header_up X-WSProxy-Host       {http.request.host}
-		}
-	}
-
-	# foreign content route used by vscode to serve webview and webworker resources of the form
-	# https://{{hash_base_32}}.<cluster>.<gitpod_domain> or https://v--{{hash_base_32}}.<cluster>.<gitpod_domain>
-	# e.g:
-	# https://0d9rkrj560blqb5s07q431ru9mhg19k1k4bqgd1dbprtgmt7vuhk.ws-us34xl.gitpod.io (for webviews)
-	# https://v--0d9rkrj560blqb5s07q431ru9mhg19k1k4bqgd1dbprtgmt7vuhk.ws-us34xl.gitpod.io (for webworker)
-	# origin should be decoupled from the workspace (port) origin but the workspace (port) prefix should be the path root for routing
-	@foreign_content2 header_regexp host Host ^(?:v--)?[0-9a-v]+.ws(-[a-z0-9]+)?.{$GITPOD_DOMAIN}
-	handle @foreign_content2 {
-		reverse_proxy https://ws-proxy.{$KUBE_NAMESPACE}.{$KUBE_DOMAIN}:9090 {
-			import workspace_transport
-			import upstream_headers
-
 			header_up X-WSProxy-Host       {http.request.host}
 		}
 	}

--- a/components/ws-proxy/pkg/proxy/pass.go
+++ b/components/ws-proxy/pkg/proxy/pass.go
@@ -14,7 +14,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/gorilla/mux"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/xerrors"
 
@@ -254,24 +253,5 @@ func withXFrameOptionsFilter() proxyPassOpt {
 func withUseTargetHost() proxyPassOpt {
 	return func(cfg *proxyPassConfig) {
 		cfg.UseTargetHost = true
-	}
-}
-
-type workspaceTransport struct {
-	transport http.RoundTripper
-}
-
-func (t *workspaceTransport) RoundTrip(req *http.Request) (resp *http.Response, err error) {
-	vars := mux.Vars(req)
-	if vars[foreignPathIdentifier] != "" {
-		req = req.Clone(req.Context())
-		req.URL.Path = vars[foreignPathIdentifier]
-	}
-	return t.transport.RoundTrip(req)
-}
-
-func withWorkspaceTransport() proxyPassOpt {
-	return func(h *proxyPassConfig) {
-		h.Transport = &workspaceTransport{h.Transport}
 	}
 }

--- a/components/ws-proxy/pkg/proxy/workspacerouter_test.go
+++ b/components/ws-proxy/pkg/proxy/workspacerouter_test.go
@@ -62,19 +62,6 @@ func TestWorkspaceRouter(t *testing.T) {
 				URL:           "http://1234-amaranth-smelt-9ba20cc1.ws.gitpod.dev/",
 			},
 		},
-		{
-			Name: "host-based blobserve access",
-			URL:  "http://blobserve.ws.gitpod.dev/image:version:/foo/main.js",
-			Headers: map[string]string{
-				forwardedHostnameHeader: "blobserve.ws.gitpod.dev",
-			},
-			Router:       HostBasedRouter(forwardedHostnameHeader, wsHostSuffix, wsHostRegex),
-			WSHostSuffix: wsHostSuffix,
-			Expected: Expectation{
-				Status: http.StatusOK,
-				URL:    "http://blobserve.ws.gitpod.dev/image:version:/foo/main.js",
-			},
-		},
 	}
 
 	for _, test := range tests {
@@ -162,66 +149,17 @@ func TestMatchWorkspaceHostHeader(t *testing.T) {
 			Path:       "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly@sha256:41aeea688aa0943bd746cb70c4ed378910f7c7ecf56f5f53ccb2b76c6b68e1a7/__files__/index.html",
 		},
 		{
+			Name:       "no match 3",
+			HostHeader: "v--0d9rkrj560blqb5s07q431ru9mhg19k1k4bqgd1dbprtgmt7vuhk" + wsHostSuffix,
+			Path:       "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly@sha256:41aeea688aa0943bd746cb70c4ed378910f7c7ecf56f5f53ccb2b76c6b68e1a7/__files__/index.html",
+		},
+		{
 			Name:       "workspace match",
 			HostHeader: "amaranth-smelt-9ba20cc1" + wsHostSuffix,
 			Expected: matchResult{
 				MatchesWorkspace: true,
 				WorkspaceVars: map[string]string{
 					workspaceIDIdentifier: "amaranth-smelt-9ba20cc1",
-				},
-			},
-		},
-		{
-			Name:       "unique webview workspace match 2",
-			HostHeader: "0d9rkrj560blqb5s07q431ru9mhg19k1k4bqgd1dbprtgmt7vuhk" + wsHostSuffix,
-			Path:       "/amaranth-smelt-9ba20cc1/index.html",
-			Expected: matchResult{
-				MatchesWorkspace: true,
-				WorkspaceVars: map[string]string{
-					workspaceIDIdentifier:   "amaranth-smelt-9ba20cc1",
-					foreignOriginIdentifier: "0d9rkrj560blqb5s07q431ru9mhg19k1k4bqgd1dbprtgmt7vuhk",
-					foreignPathIdentifier:   "/index.html",
-				},
-			},
-		},
-		{
-			Name:       "unique webview port match 2",
-			HostHeader: "0d9rkrj560blqb5s07q431ru9mhg19k1k4bqgd1dbprtgmt7vuhk" + wsHostSuffix,
-			Path:       "/8080-amaranth-smelt-9ba20cc1/index.html",
-			Expected: matchResult{
-				MatchesPort: true,
-				PortVars: map[string]string{
-					workspaceIDIdentifier:   "amaranth-smelt-9ba20cc1",
-					workspacePortIdentifier: "8080",
-					foreignOriginIdentifier: "0d9rkrj560blqb5s07q431ru9mhg19k1k4bqgd1dbprtgmt7vuhk",
-					foreignPathIdentifier:   "/index.html",
-				},
-			},
-		},
-		{
-			Name:       "unique webworker workspace match",
-			HostHeader: "v--0d9rkrj560blqb5s07q431ru9mhg19k1k4bqgd1dbprtgmt7vuhk" + wsHostSuffix,
-			Path:       "/amaranth-smelt-9ba20cc1/index.html",
-			Expected: matchResult{
-				MatchesWorkspace: true,
-				WorkspaceVars: map[string]string{
-					workspaceIDIdentifier:   "amaranth-smelt-9ba20cc1",
-					foreignOriginIdentifier: "v--0d9rkrj560blqb5s07q431ru9mhg19k1k4bqgd1dbprtgmt7vuhk",
-					foreignPathIdentifier:   "/index.html",
-				},
-			},
-		},
-		{
-			Name:       "unique webworker port match",
-			HostHeader: "v--0d9rkrj560blqb5s07q431ru9mhg19k1k4bqgd1dbprtgmt7vuhk" + wsHostSuffix,
-			Path:       "/8080-amaranth-smelt-9ba20cc1/index.html",
-			Expected: matchResult{
-				MatchesPort: true,
-				PortVars: map[string]string{
-					workspaceIDIdentifier:   "amaranth-smelt-9ba20cc1",
-					workspacePortIdentifier: "8080",
-					foreignOriginIdentifier: "v--0d9rkrj560blqb5s07q431ru9mhg19k1k4bqgd1dbprtgmt7vuhk",
-					foreignPathIdentifier:   "/index.html",
 				},
 			},
 		},


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Adds vscode auth callback route

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/12660

## How to test
<!-- Provide steps to test this PR -->

1. Open a workspace and install this test extension [gitpod-foo-0.0.58.zip](https://github.com/gitpod-io/gitpod/files/9538509/gitpod-foo-0.0.58.zip)
2. Update settings.json with `"gitpod.host": "https://jp-test-9.preview.gitpod-dev.com/"`
3. Run `Test FOO sign in` command
4. Check the callback page opens sucessfully, it says `You can close this page now`
5. On vscode tab login will fail, that's expected
6. Not required: If you want login to succeed, then go to this [branch](https://github.com/gitpod-io/gitpod/tree/jp/test-9) and change the redirect url to match your workspace, pointer [[1](https://github.com/gitpod-io/gitpod/commit/6b78c8c63f74956ebeba23c324f93159e41d0506)], wait for build, yeah that sucks :facepalm: 
7. Check you are logged in 
![image](https://user-images.githubusercontent.com/25115070/189439021-f1b21ddf-a99d-4323-95c8-64cd85bc1149.png)




## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
