### PR TITLE
Add link to support on phone verification

### DIFF
--- a/components/dashboard/src/start/VerifyModal.tsx
+++ b/components/dashboard/src/start/VerifyModal.tsx
@@ -75,7 +75,10 @@ export function VerifyModal() {
                     discourage and reduce abuse on Gitpod infrastructure.
                 </Alert>
                 <div className="text-gray-600 dark:text-gray-400 mt-2">
-                    Enter a mobile phone number you would like to use to verify your account.
+                    Enter a mobile phone number you would like to use to verify your account. Having trouble?{" "}
+                    <a className="gp-link" href="https://www.gitpod.io/contact/support">
+                        Contact support
+                    </a>
                 </div>
                 {state.message ? (
                     <Alert type={state.message.type} className="mt-4 py-3">


### PR DESCRIPTION
## Description

Following up from https://github.com/gitpod-io/gitpod/pull/12258, this will duplicate the link to support on the phone verification step when users are entering the mobile phone number, not just the verification code. The reasons behind this change:
1. We've gotten some from users in China that they are not able to use this feature using their mobile phone number. We're actively working on resolving this with the third-party service we're integrating for this feature, Twilio. See [relevant discussion](https://gitpod.slack.com/archives/C03QY10N9PZ/p1662551365578039) (internal). Cc @svenefftinge @securitymirco @KlasenK 
2. Future errors like this that prevent users from entering a mobile phone number will still end up in the same verification step, which currently doesn't include the link to support as in the next step, which is for entering the verification code.

## How to test
1. Create a new GitHub account and sign in to the preview environment.
2. Remember to unblock the user in **/admin/users**. 🎗️ 
3. Try opening a new workspace and noticed you'll be prompted to go through the phone verification process.
4. Notice there's a link to support when entering a mobile phone number.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Add link to support on phone verification
```

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [X] /werft with-preview
