### PR TITLE
[UBP] Add `getStripePortalUrl` method to server

### DIFF
--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -295,6 +295,7 @@ export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, 
     createOrUpdateStripeCustomerForTeam(teamId: string, currency: string): Promise<void>;
     createOrUpdateStripeCustomerForUser(currency: string): Promise<void>;
     subscribeTeamToStripe(teamId: string, setupIntentId: string): Promise<void>;
+    getStripePortalUrl(attributionId: string): Promise<string>;
     getStripePortalUrlForTeam(teamId: string): Promise<string>;
     getUsageLimitForTeam(teamId: string): Promise<number | undefined>;
     setUsageLimitForTeam(teamId: string, spendingLimit: number): Promise<void>;

--- a/components/server/ee/src/user/stripe-service.ts
+++ b/components/server/ee/src/user/stripe-service.ts
@@ -130,6 +130,18 @@ export class StripeService {
         return session.url;
     }
 
+    async getPortalUrlForUser(user: User): Promise<string> {
+        const customer = await this.findCustomerByUserId(user.id);
+        if (!customer) {
+            throw new Error(`No Stripe Customer ID found for user '${user.id}'`);
+        }
+        const session = await this.getStripe().billingPortal.sessions.create({
+            customer: customer.id,
+            return_url: this.config.hostUrl.with(() => ({ pathname: `/billing` })).toString(),
+        });
+        return session.url;
+    }
+
     async findUncancelledSubscriptionByCustomer(customerId: string): Promise<Stripe.Subscription | undefined> {
         const result = await this.getStripe().subscriptions.list({
             customer: customerId,

--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -2188,19 +2188,8 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
     }
 
     async getStripePortalUrlForTeam(ctx: TraceContext, teamId: string): Promise<string> {
-        this.checkAndBlockUser("getStripePortalUrlForTeam");
-        const team = await this.guardTeamOperation(teamId, "update");
-        await this.ensureStripeApiIsAllowed({ team });
-        try {
-            const url = await this.stripeService.getPortalUrlForTeam(team!);
-            return url;
-        } catch (error) {
-            log.error(`Failed to get Stripe portal URL for team '${teamId}'`, error);
-            throw new ResponseError(
-                ErrorCodes.INTERNAL_SERVER_ERROR,
-                `Failed to get Stripe portal URL for team '${teamId}'`,
-            );
-        }
+        const attributionId: AttributionId = { kind: "team", teamId: teamId };
+        return this.getStripePortalUrl(ctx, AttributionId.render(attributionId));
     }
 
     async getUsageLimitForTeam(ctx: TraceContext, teamId: string): Promise<number | undefined> {

--- a/components/server/src/auth/rate-limiter.ts
+++ b/components/server/src/auth/rate-limiter.ts
@@ -211,6 +211,7 @@ const defaultFunctions: FunctionsConfig = {
     createOrUpdateStripeCustomerForTeam: { group: "default", points: 1 },
     createOrUpdateStripeCustomerForUser: { group: "default", points: 1 },
     subscribeTeamToStripe: { group: "default", points: 1 },
+    getStripePortalUrl: { group: "default", points: 1 },
     getStripePortalUrlForTeam: { group: "default", points: 1 },
     listUsage: { group: "default", points: 1 },
     getBillingModeForTeam: { group: "default", points: 1 },

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -3236,6 +3236,9 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
     async getStripePortalUrlForTeam(ctx: TraceContext, teamId: string): Promise<string> {
         throw new ResponseError(ErrorCodes.SAAS_FEATURE, `Not implemented in this version`);
     }
+    async getStripePortalUrl(ctx: TraceContext, attributionId: string): Promise<string> {
+        throw new ResponseError(ErrorCodes.SAAS_FEATURE, `Not implemented in this version`);
+    }
 
     async listUsage(ctx: TraceContext, req: ListUsageRequest): Promise<ListUsageResponse> {
         throw new ResponseError(ErrorCodes.SAAS_FEATURE, `Not implemented in this version`);


### PR DESCRIPTION
## Description

Add a new `getStripePortalUrl` method to `server`'s JSON-RPC API.

The method generates a Stripe portal URL that is used during the billing signup flow for both teams and individual users - it replaces the existing `getStripePortalUrlForTeam` method which only worked for team signup.


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of https://github.com/gitpod-io/gitpod/issues/12685

## How to test

1. Create a team called `Gitpod-xxx`
2. Sign the team up for UBP.
3. Create a new Stripe customer for your individual user:
```js
await window._gp.gitpodService.server.createOrUpdateStripeCustomerForUser("EUR")
```
3. Get the portal URL for the user:
```js
await window._gp.gitpodService.server.getStripePortalUrl("user:<your user id>")
```

Using the returned URL should take you to some Stripe UI.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
- [x] /werft with-payment
