### PR TITLE
[installer-tests] Randomly run tests against stable and unstable channels

### DIFF
--- a/.werft/installer-tests.ts
+++ b/.werft/installer-tests.ts
@@ -11,7 +11,8 @@ const annotations: any = context.Annotations || {};
 
 const testConfig: string = process.argv.length > 2 ? process.argv[2] : "STANDARD_K3S_TEST";
 
-const channel: string = annotations.channel || "unstable";
+// we can either provide the channel name of we randomly run tests against stable and unstable channels
+const channel: string = annotations.channel || randomize(["stable", "unstable"]);
 const kotsApp: string = annotations.replicatedApp || "gitpod";
 
 const version: string = annotations.version || "-";


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PR randomly runs the automated tests against unstable and stable channels on a nightly basis. This is a requirement for IDE integration tests since they would like to continue testing the `stable` version against the new marketplace publishes.
 
## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #11679

## How to test
<!-- Provide steps to test this PR -->
You can start a test by running the following command:
```
werft run github -j .werft/k3s-installer-tests.yaml
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
