### PR TITLE
[dashboard] Show error messages in the UI when upgrading with Stripe fails

### DIFF
--- a/components/dashboard/src/components/UsageBasedBillingConfig.tsx
+++ b/components/dashboard/src/components/UsageBasedBillingConfig.tsx
@@ -13,6 +13,7 @@ import { PaymentContext } from "../payment-context";
 import { getGitpodService } from "../service/service";
 import DropDown from "../components/DropDown";
 import Modal from "../components/Modal";
+import Alert from "./Alert";
 
 interface Props {
     userOrTeamId: string;
@@ -150,12 +151,14 @@ function CreditCardInputForm(props: { id: string }) {
     const elements = useElements();
     const { currency, setCurrency } = useContext(PaymentContext);
     const [isLoading, setIsLoading] = useState<boolean>(false);
+    const [billingError, setBillingError] = useState<string | undefined>();
 
     const handleSubmit = async (event: React.FormEvent) => {
         event.preventDefault();
         if (!stripe || !elements) {
             return;
         }
+        setBillingError(undefined);
         setIsLoading(true);
         try {
             // Create Stripe customer for team & currency (or update currency)
@@ -176,7 +179,7 @@ function CreditCardInputForm(props: { id: string }) {
             }
         } catch (error) {
             console.error(error);
-            alert(error?.message || "Failed to submit form. See console for error message.");
+            setBillingError(`Failed to submit form. ${error?.message || String(error)}`);
         } finally {
             setIsLoading(false);
         }
@@ -184,6 +187,11 @@ function CreditCardInputForm(props: { id: string }) {
 
     return (
         <form className="mt-4 flex-grow flex flex-col" onSubmit={handleSubmit}>
+            {billingError && (
+                <Alert className="mb-4" closable={false} showIcon={true} type="error">
+                    {billingError}
+                </Alert>
+            )}
             <PaymentElement />
             <div className="mt-4 flex-grow flex justify-end items-end">
                 <div className="flex-grow flex space-x-1">

--- a/components/dashboard/src/teams/TeamUsageBasedBilling.tsx
+++ b/components/dashboard/src/teams/TeamUsageBasedBilling.tsx
@@ -10,6 +10,7 @@ import { BillingMode } from "@gitpod/gitpod-protocol/lib/billing-mode";
 import { getCurrentTeam, TeamsContext } from "./teams-context";
 import { getGitpodService } from "../service/service";
 import UsageBasedBillingConfig from "../components/UsageBasedBillingConfig";
+import Alert from "../components/Alert";
 
 type PendingStripeSubscription = { pendingSince: number };
 
@@ -24,6 +25,7 @@ export default function TeamUsageBasedBilling() {
     const [pollStripeSubscriptionTimeout, setPollStripeSubscriptionTimeout] = useState<NodeJS.Timeout | undefined>();
     const [stripePortalUrl, setStripePortalUrl] = useState<string | undefined>();
     const [usageLimit, setUsageLimit] = useState<number | undefined>();
+    const [billingError, setBillingError] = useState<string | undefined>();
 
     useEffect(() => {
         if (!team) {
@@ -85,6 +87,7 @@ export default function TeamUsageBasedBilling() {
                 window.localStorage.removeItem(`pendingStripeSubscriptionForTeam${team.id}`);
                 clearTimeout(pollStripeSubscriptionTimeout!);
                 setPendingStripeSubscription(undefined);
+                setBillingError(`Could not subscribe team to Stripe. ${error?.message || String(error)}`);
             }
         })();
     }, [location.search, team]);
@@ -160,6 +163,11 @@ export default function TeamUsageBasedBilling() {
 
     return (
         <>
+            {billingError && (
+                <Alert className="max-w-xl mb-4" closable={false} showIcon={true} type="error">
+                    {billingError}
+                </Alert>
+            )}
             <h3>Usage-Based Billing</h3>
             <UsageBasedBillingConfig
                 userOrTeamId={team?.id || ""}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Show error messages in the UI when upgrading with Stripe fails for any reason.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/12580

## How to test
<!-- Provide steps to test this PR -->

1. Create a team called "Gitpod [Something]"
2. Try to upgrade using an invalid credit card number, or one of Stripe's [failing test cards](https://stripe.com/docs/testing#declined-payments) -- this should always show an error message
3. Upgrade using a regular test card in the currency **USD** (e.g. 4242 4242 4242 4242, 4/24, 424) -- this should work
4. Once it went through, manage and cancel your Stripe subscription
5. Upgrade again with a regular test card, but this time with the currency **EUR**
6. The payment method should go through, but on the next page you should see an error message

(Note: Currently that second step error message is redacted, and will just say that "upgrading failed" while the actual error message is hidden in `server` logs -- we can improve this UX in a follow-up step.)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
- [x] /werft with-payment
