### PR TITLE
[JetBrains Backend Plugin] Allow specifying the test-repository when running launch-dev-server.sh

### DIFF
--- a/components/ide/jetbrains/backend-plugin/launch-dev-server.sh
+++ b/components/ide/jetbrains/backend-plugin/launch-dev-server.sh
@@ -20,13 +20,20 @@ GITPOD_PLUGIN_DIR=/workspace/gitpod/components/ide/jetbrains/backend-plugin
 $GITPOD_PLUGIN_DIR/gradlew buildPlugin
 
 # TODO(ak) actually should be gradle task to make use of output
-GITPOD_PLUGIN_DIST="$GITPOD_PLUGIN_DIR/build/distributions/gitpod-remote-0.0.1.zip"
+GITPOD_PLUGIN_DIST="$GITPOD_PLUGIN_DIR/build/distributions/gitpod-remote.zip"
 unzip $GITPOD_PLUGIN_DIST -d $TEST_PLUGINS_DIR
 
-TEST_REPO=https://github.com/gitpod-io/spring-petclinic
-TEST_DIR=/workspace/spring-petclinic
+TEST_DIR=/workspace/test-repo
 if [ ! -d "$TEST_DIR" ]; then
-  git clone $TEST_REPO $TEST_DIR
+  TEST_REPO=https://github.com/gitpod-io/spring-petclinic
+  while getopts "r:" OPTION
+  do
+     case $OPTION in
+         r) TEST_REPO=$OPTARG ;;
+         *) ;;
+       esac
+  done
+  git clone "$TEST_REPO" $TEST_DIR
 fi
 
 export JB_DEV=true


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Allow passing a test-repository URL via parameter `-r` when running launch-dev-server.sh for JetBrains Backend Plugin development.

If the parameter is not passed, it will use the default test-repository: <https://github.com/gitpod-io/spring-petclinic>.

This PR also updates the plugin's path, which is now built with the name "gitpod-remote.zip".

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Resolves #10286

## How to test
<!-- Provide steps to test this PR -->
1. Open the branch of this PR in gitpod.io
2. Navigate to `/workspace/gitpod/components/ide/jetbrains/backend-plugin`
3. Run `./launch-dev-server.sh -r https://github.com/gitpod-io/.github`
4. Confirm it has opened the test environment with https://github.com/gitpod-io/.github repository.
5. Stop the test environment and run `rm -rf /workspace/test-repo`.
6. Run `./launch-dev-server.sh`
7. Confirm it has opened the test environment with https://github.com/gitpod-io/spring-petclinic repository.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE.
```

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
