### PR TITLE
[UBP] Add `findStripeSubscriptionId` method to server

### DIFF
--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -290,6 +290,7 @@ export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, 
 
     getStripePublishableKey(): Promise<string>;
     getStripeSetupIntentClientSecret(): Promise<string>;
+    findStripeSubscriptionId(attributionId: string): Promise<string | undefined>;
     findStripeSubscriptionIdForTeam(teamId: string): Promise<string | undefined>;
     createOrUpdateStripeCustomerForTeam(teamId: string, currency: string): Promise<void>;
     createOrUpdateStripeCustomerForUser(currency: string): Promise<void>;

--- a/components/server/src/auth/rate-limiter.ts
+++ b/components/server/src/auth/rate-limiter.ts
@@ -206,6 +206,7 @@ const defaultFunctions: FunctionsConfig = {
     tsReassignSlot: { group: "default", points: 1 },
     getStripePublishableKey: { group: "default", points: 1 },
     getStripeSetupIntentClientSecret: { group: "default", points: 1 },
+    findStripeSubscriptionId: { group: "default", points: 1 },
     findStripeSubscriptionIdForTeam: { group: "default", points: 1 },
     createOrUpdateStripeCustomerForTeam: { group: "default", points: 1 },
     createOrUpdateStripeCustomerForUser: { group: "default", points: 1 },

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -3218,6 +3218,9 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
     async getStripeSetupIntentClientSecret(ctx: TraceContext): Promise<string> {
         throw new ResponseError(ErrorCodes.SAAS_FEATURE, `Not implemented in this version`);
     }
+    async findStripeSubscriptionId(ctx: TraceContext, attributionId: string): Promise<string | undefined> {
+        throw new ResponseError(ErrorCodes.SAAS_FEATURE, `Not implemented in this version`);
+    }
     async findStripeSubscriptionIdForTeam(ctx: TraceContext, teamId: string): Promise<string | undefined> {
         throw new ResponseError(ErrorCodes.SAAS_FEATURE, `Not implemented in this version`);
     }


### PR DESCRIPTION
## Description

Add a general method `findStripeSubscriptionId` for finding the Stripe subscription id for a given attribution id. 

Implement the existing `findStripeSubscriptionIdForTeam` method in terms of the new method.

The more general method will be used to look up subscription ids for individual users in subsequent PRs.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of https://github.com/gitpod-io/gitpod/issues/12685 

## How to test

The flow to sign a team up for UBP still works:

1. Create a team with `Gitpod` in the name.
2. Sign the team up for UBP from the billing tab on the team settings page.


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation


## Werft options:

- [ ] /werft with-preview
- [ ] /werft with-payment
