### PR TITLE
[UBP] Add `subscribeToStripe` server method

### DIFF
--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -294,6 +294,7 @@ export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, 
     findStripeSubscriptionIdForTeam(teamId: string): Promise<string | undefined>;
     createOrUpdateStripeCustomerForTeam(teamId: string, currency: string): Promise<void>;
     createOrUpdateStripeCustomerForUser(currency: string): Promise<void>;
+    subscribeToStripe(attributionId: string, setupIntentId: string): Promise<void>;
     subscribeTeamToStripe(teamId: string, setupIntentId: string): Promise<void>;
     getStripePortalUrl(attributionId: string): Promise<string>;
     getStripePortalUrlForTeam(teamId: string): Promise<string>;

--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -2125,7 +2125,7 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
 
     protected defaultSpendingLimit = 100;
     async subscribeTeamToStripe(ctx: TraceContext, teamId: string, setupIntentId: string): Promise<void> {
-        this.checkAndBlockUser("subscribeUserToStripe");
+        this.checkAndBlockUser("subscribeTeamToStripe");
         const team = await this.guardTeamOperation(teamId, "update");
         await this.ensureStripeApiIsAllowed({ team });
         try {

--- a/components/server/src/auth/rate-limiter.ts
+++ b/components/server/src/auth/rate-limiter.ts
@@ -210,6 +210,7 @@ const defaultFunctions: FunctionsConfig = {
     findStripeSubscriptionIdForTeam: { group: "default", points: 1 },
     createOrUpdateStripeCustomerForTeam: { group: "default", points: 1 },
     createOrUpdateStripeCustomerForUser: { group: "default", points: 1 },
+    subscribeToStripe: { group: "default", points: 1 },
     subscribeTeamToStripe: { group: "default", points: 1 },
     getStripePortalUrl: { group: "default", points: 1 },
     getStripePortalUrlForTeam: { group: "default", points: 1 },

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -3233,6 +3233,9 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
     async subscribeTeamToStripe(ctx: TraceContext, teamId: string, setupIntentId: string): Promise<void> {
         throw new ResponseError(ErrorCodes.SAAS_FEATURE, `Not implemented in this version`);
     }
+    async subscribeToStripe(ctx: TraceContext, attributionId: string, setupIntentId: string): Promise<void> {
+        throw new ResponseError(ErrorCodes.SAAS_FEATURE, `Not implemented in this version`);
+    }
     async getStripePortalUrlForTeam(ctx: TraceContext, teamId: string): Promise<string> {
         throw new ResponseError(ErrorCodes.SAAS_FEATURE, `Not implemented in this version`);
     }


### PR DESCRIPTION
## Description

Add a general method `subscribeToStripe` to the server JSON-RPC API for  adding Stripe subscriptions to a Stripe customer, for customers representing teams or individual users.

Implement the existing `subscribeTeamToStripe` method  (which only worked for teams) in terms of the new method.

The more general method will be used to subscribe individual Stripe users in subsequent PRs.

## Related Issue(s)

<!-- List the issue(s) this PR solves -->

Part of https://github.com/gitpod-io/gitpod/issues/12685

## How to test

The flow to sign a team up for UBP still works:

1. Create a team with `Gitpod` in the name.
2. Sign the team up for UBP from the billing tab on the team settings page.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
- [x] /werft with-payment
