### PR TITLE
[bridge] Stop stuck workspace instances

### DIFF
--- a/components/ws-manager-bridge/src/bridge.ts
+++ b/components/ws-manager-bridge/src/bridge.ts
@@ -512,8 +512,6 @@ export class WorkspaceManagerBridge implements Disposable {
 
             for (const [instanceId, ri] of runningInstancesIdx.entries()) {
                 const instance = ri.latestInstance;
-                // This ensures that the workspace instance is not in a
-                // non-running phase for longer than the max time
                 if (
                     !(
                         instance.status.phase === "running" ||
@@ -614,11 +612,10 @@ export class WorkspaceManagerBridge implements Disposable {
 
     protected async markWorkspaceInstanceAsStopped(ctx: TraceContext, info: RunningWorkspaceInfo, now: Date) {
         const nowISO = now.toISOString();
+        info.latestInstance.status.phase = "stopped";
         info.latestInstance.stoppingTime = nowISO;
         info.latestInstance.stoppedTime = nowISO;
-        info.latestInstance.status.phase = "stopped";
         await this.workspaceDB.trace(ctx).storeInstance(info.latestInstance);
-
         await this.messagebus.notifyOnInstanceUpdate(ctx, info.workspace.ownerId, info.latestInstance);
         await this.prebuildUpdater.stopPrebuildInstance(ctx, info.latestInstance);
     }

--- a/components/ws-manager-bridge/src/bridge.ts
+++ b/components/ws-manager-bridge/src/bridge.ts
@@ -436,7 +436,6 @@ export class WorkspaceManagerBridge implements Disposable {
         clientProvider: ClientProvider,
         controllerIntervalSeconds: number,
         controllerMaxDisconnectSeconds: number,
-        maxTimeToRunningPhaseSeconds = 60 * 60,
     ) {
         let disconnectStarted = Number.MAX_SAFE_INTEGER;
         this.disposables.push(
@@ -457,7 +456,7 @@ export class WorkspaceManagerBridge implements Disposable {
                             ctx,
                             runningInstances,
                             clientProvider,
-                            maxTimeToRunningPhaseSeconds,
+                            this.config.maxTimeToRunningPhaseSeconds,
                         );
 
                         disconnectStarted = Number.MAX_SAFE_INTEGER; // Reset disconnect period

--- a/components/ws-manager-bridge/src/config.ts
+++ b/components/ws-manager-bridge/src/config.ts
@@ -38,4 +38,7 @@ export interface Configuration {
 
     // clusterSyncIntervalSeconds configures how often we sync workspace cluster information
     clusterSyncIntervalSeconds: number;
+
+    // maxTimeToRunningPhaseSeconds is the timeout duration
+    maxTimeToRunningPhaseSeconds: number;
 }

--- a/install/installer/cmd/testdata/render/aws-setup/output.golden
+++ b/install/installer/cmd/testdata/render/aws-setup/output.golden
@@ -4576,7 +4576,8 @@ data:
         "buildingPhaseSeconds": 3600,
         "unknownPhaseSeconds": 600
       },
-      "clusterSyncIntervalSeconds": 60
+      "clusterSyncIntervalSeconds": 60,
+      "maxTimeToRunningPhaseSeconds": 3600
     }
 kind: ConfigMap
 metadata:
@@ -8439,7 +8440,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: f5d95af2308e35194d44403c42e269fbe9e4c596d138796fa95f705ec3b4d352
+        gitpod.io/checksum_config: 846469058fd082ae195479935c67054553bb448d05cf029a19af738503147aa7
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/azure-setup/output.golden
+++ b/install/installer/cmd/testdata/render/azure-setup/output.golden
@@ -4436,7 +4436,8 @@ data:
         "buildingPhaseSeconds": 3600,
         "unknownPhaseSeconds": 600
       },
-      "clusterSyncIntervalSeconds": 60
+      "clusterSyncIntervalSeconds": 60,
+      "maxTimeToRunningPhaseSeconds": 3600
     }
 kind: ConfigMap
 metadata:
@@ -8285,7 +8286,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: f5d95af2308e35194d44403c42e269fbe9e4c596d138796fa95f705ec3b4d352
+        gitpod.io/checksum_config: 846469058fd082ae195479935c67054553bb448d05cf029a19af738503147aa7
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -5363,7 +5363,8 @@ data:
         "buildingPhaseSeconds": 3600,
         "unknownPhaseSeconds": 600
       },
-      "clusterSyncIntervalSeconds": 60
+      "clusterSyncIntervalSeconds": 60,
+      "maxTimeToRunningPhaseSeconds": 3600
     }
 kind: ConfigMap
 metadata:
@@ -9817,7 +9818,7 @@ spec:
     metadata:
       annotations:
         gitpod.io: hello
-        gitpod.io/checksum_config: fdb0c0adb6ea187bd587fb7c286084b4853439fdfafa7f32bbdcacee744e5c3e
+        gitpod.io/checksum_config: 1af8949463afb559e837a140ecdb4ca73db58e3da8fb0680570a1cdada3c3abe
         hello: world
       creationTimestamp: null
       labels:

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -4623,7 +4623,8 @@ data:
         "buildingPhaseSeconds": 3600,
         "unknownPhaseSeconds": 600
       },
-      "clusterSyncIntervalSeconds": 60
+      "clusterSyncIntervalSeconds": 60,
+      "maxTimeToRunningPhaseSeconds": 3600
     }
 kind: ConfigMap
 metadata:
@@ -8711,7 +8712,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: bacace964780fd56bdd04b997df0017c24563c2aac6bffd10962c297b54c91ba
+        gitpod.io/checksum_config: 19a15d16ea83f7cd1c61948f0e433f3f72ce175524ea639c1c050a485f17f74d
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/gcp-setup/output.golden
+++ b/install/installer/cmd/testdata/render/gcp-setup/output.golden
@@ -4395,7 +4395,8 @@ data:
         "buildingPhaseSeconds": 3600,
         "unknownPhaseSeconds": 600
       },
-      "clusterSyncIntervalSeconds": 60
+      "clusterSyncIntervalSeconds": 60,
+      "maxTimeToRunningPhaseSeconds": 3600
     }
 kind: ConfigMap
 metadata:
@@ -8208,7 +8209,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 6d44bef12145215794685e52c3139f04195bcf8e7ca1f1d7b3803da845e837eb
+        gitpod.io/checksum_config: f0b5a025d81fce48adb9fd1ad8445422fa80b136acba6b2eb69263df3388c388
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -4843,7 +4843,8 @@ data:
         "buildingPhaseSeconds": 3600,
         "unknownPhaseSeconds": 600
       },
-      "clusterSyncIntervalSeconds": 60
+      "clusterSyncIntervalSeconds": 60,
+      "maxTimeToRunningPhaseSeconds": 3600
     }
 kind: ConfigMap
 metadata:
@@ -9086,7 +9087,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: bacace964780fd56bdd04b997df0017c24563c2aac6bffd10962c297b54c91ba
+        gitpod.io/checksum_config: 19a15d16ea83f7cd1c61948f0e433f3f72ce175524ea639c1c050a485f17f74d
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -4855,7 +4855,8 @@ data:
         "buildingPhaseSeconds": 3600,
         "unknownPhaseSeconds": 600
       },
-      "clusterSyncIntervalSeconds": 60
+      "clusterSyncIntervalSeconds": 60,
+      "maxTimeToRunningPhaseSeconds": 3600
     }
 kind: ConfigMap
 metadata:
@@ -9098,7 +9099,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: bacace964780fd56bdd04b997df0017c24563c2aac6bffd10962c297b54c91ba
+        gitpod.io/checksum_config: 19a15d16ea83f7cd1c61948f0e433f3f72ce175524ea639c1c050a485f17f74d
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
+++ b/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
@@ -5176,7 +5176,8 @@ data:
         "buildingPhaseSeconds": 3600,
         "unknownPhaseSeconds": 600
       },
-      "clusterSyncIntervalSeconds": 60
+      "clusterSyncIntervalSeconds": 60,
+      "maxTimeToRunningPhaseSeconds": 3600
     }
 kind: ConfigMap
 metadata:
@@ -9530,7 +9531,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: bacace964780fd56bdd04b997df0017c24563c2aac6bffd10962c297b54c91ba
+        gitpod.io/checksum_config: 19a15d16ea83f7cd1c61948f0e433f3f72ce175524ea639c1c050a485f17f74d
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
+++ b/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
@@ -4846,7 +4846,8 @@ data:
         "buildingPhaseSeconds": 3600,
         "unknownPhaseSeconds": 600
       },
-      "clusterSyncIntervalSeconds": 60
+      "clusterSyncIntervalSeconds": 60,
+      "maxTimeToRunningPhaseSeconds": 3600
     }
 kind: ConfigMap
 metadata:
@@ -9089,7 +9090,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: bacace964780fd56bdd04b997df0017c24563c2aac6bffd10962c297b54c91ba
+        gitpod.io/checksum_config: 19a15d16ea83f7cd1c61948f0e433f3f72ce175524ea639c1c050a485f17f74d
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/pkg/components/ws-manager-bridge/configmap.go
+++ b/install/installer/pkg/components/ws-manager-bridge/configmap.go
@@ -32,6 +32,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		EmulatePreparingIntervalSeconds: 10,
 		StaticBridges:                   WSManagerList(ctx),
 		ClusterSyncIntervalSeconds:      60,
+		MaxTimeToRunningPhaseSeconds:    60 * 60,
 	}
 
 	fc, err := common.ToJSONString(wsmbcfg)

--- a/install/installer/pkg/components/ws-manager-bridge/types.go
+++ b/install/installer/pkg/components/ws-manager-bridge/types.go
@@ -15,6 +15,7 @@ type Configuration struct {
 	EmulatePreparingIntervalSeconds     int32              `json:"emulatePreparingIntervalSeconds"`
 	Timeouts                            Timeouts           `json:"timeouts"`
 	ClusterSyncIntervalSeconds          int32              `json:"clusterSyncIntervalSeconds"`
+	MaxTimeToRunningPhaseSeconds        int32              `json:"maxTimeToRunningPhaseSeconds"`
 }
 
 type ClusterService struct {


### PR DESCRIPTION
## Description
This stops instances that are stuck in a non-running phase for too long.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #11397 

## How to test
<!-- Provide steps to test this PR -->
1. Run kubectl cordon on the node.
2. Try running a workspace. It shouldn't be stuck in pending forever.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
