### PR TITLE
test: Put logging of workspace starts and stops

### DIFF
--- a/test/tests/components/ws-manager/content_test.go
+++ b/test/tests/components/ws-manager/content_test.go
@@ -42,7 +42,7 @@ func TestBackup(t *testing.T) {
 			}
 			for _, test := range tests {
 				t.Run(test.Name, func(t *testing.T) {
-					ws1, stopWs1, err := integration.LaunchWorkspaceDirectly(ctx, api, integration.WithRequestModifier(func(w *wsmanapi.StartWorkspaceRequest) error {
+					ws1, stopWs1, err := integration.LaunchWorkspaceDirectly(t, ctx, api, integration.WithRequestModifier(func(w *wsmanapi.StartWorkspaceRequest) error {
 						w.Spec.FeatureFlags = test.FF
 						w.Spec.Initializer = &csapi.WorkspaceInitializer{
 							Spec: &csapi.WorkspaceInitializer_Git{
@@ -94,7 +94,7 @@ func TestBackup(t *testing.T) {
 						t.Fatal(err)
 					}
 
-					ws2, stopWs2, err := integration.LaunchWorkspaceDirectly(ctx, api,
+					ws2, stopWs2, err := integration.LaunchWorkspaceDirectly(t, ctx, api,
 						integration.WithRequestModifier(func(w *wsmanapi.StartWorkspaceRequest) error {
 							w.ServicePrefix = ws1.Req.ServicePrefix
 							w.Metadata.MetaId = ws1.Req.Metadata.MetaId
@@ -116,12 +116,12 @@ func TestBackup(t *testing.T) {
 					if err != nil {
 						t.Fatal(err)
 					}
-					t.Cleanup(func() {
+					defer func() {
 						_, err = stopWs2(true)
 						if err != nil {
 							t.Errorf("cannot stop workspace: %q", err)
 						}
-					})
+					}()
 
 					rsa, closer, err = integration.Instrument(integration.ComponentWorkspace, "workspace", cfg.Namespace(), kubeconfig, cfg.Client(),
 						integration.WithInstanceID(ws2.Req.Id),
@@ -175,7 +175,7 @@ func TestExistingWorkspaceEnablePVC(t *testing.T) {
 			})
 
 			// Create a new workspace without the PVC feature flag
-			ws1, stopWs1, err := integration.LaunchWorkspaceDirectly(ctx, api, integration.WithRequestModifier(func(w *wsmanapi.StartWorkspaceRequest) error {
+			ws1, stopWs1, err := integration.LaunchWorkspaceDirectly(t, ctx, api, integration.WithRequestModifier(func(w *wsmanapi.StartWorkspaceRequest) error {
 				w.Spec.Initializer = &csapi.WorkspaceInitializer{
 					Spec: &csapi.WorkspaceInitializer_Git{
 						Git: &csapi.GitInitializer{
@@ -227,7 +227,7 @@ func TestExistingWorkspaceEnablePVC(t *testing.T) {
 			}
 
 			// Relaunch the workspace and enable the PVC feature flag
-			ws2, stopWs2, err := integration.LaunchWorkspaceDirectly(ctx, api,
+			ws2, stopWs2, err := integration.LaunchWorkspaceDirectly(t, ctx, api,
 				integration.WithRequestModifier(func(w *wsmanapi.StartWorkspaceRequest) error {
 					w.ServicePrefix = ws1.Req.ServicePrefix
 					w.Metadata.MetaId = ws1.Req.Metadata.MetaId
@@ -296,7 +296,7 @@ func TestMissingBackup(t *testing.T) {
 				api.Done(t)
 			})
 
-			ws, stopWs, err := integration.LaunchWorkspaceDirectly(ctx, api)
+			ws, stopWs, err := integration.LaunchWorkspaceDirectly(t, ctx, api)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -342,7 +342,7 @@ func TestMissingBackup(t *testing.T) {
 			}
 			for _, test := range tests {
 				t.Run(test.Name+"_backup_init", func(t *testing.T) {
-					testws, stopWs, err := integration.LaunchWorkspaceDirectly(ctx, api, integration.WithRequestModifier(func(w *wsmanapi.StartWorkspaceRequest) error {
+					testws, stopWs, err := integration.LaunchWorkspaceDirectly(t, ctx, api, integration.WithRequestModifier(func(w *wsmanapi.StartWorkspaceRequest) error {
 						w.ServicePrefix = ws.Req.ServicePrefix
 						w.Metadata.MetaId = ws.Req.Metadata.MetaId
 						w.Metadata.Owner = ws.Req.Metadata.Owner

--- a/test/tests/components/ws-manager/multi_repo_test.go
+++ b/test/tests/components/ws-manager/multi_repo_test.go
@@ -96,7 +96,7 @@ func TestMultiRepoWorkspaceSuccess(t *testing.T) {
 			return nil
 		}
 
-		ws, stopWs, err := integration.LaunchWorkspaceDirectly(ctx, api, integration.WithRequestModifier(multiRepoInit))
+		ws, stopWs, err := integration.LaunchWorkspaceDirectly(t, ctx, api, integration.WithRequestModifier(multiRepoInit))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -113,6 +113,9 @@ func TestMultiRepoWorkspaceSuccess(t *testing.T) {
 			integration.WithContainer("workspace"),
 			integration.WithWorkspacekitLift(true),
 		)
+		if err != nil {
+			t.Fatal(err)
+		}
 
 		integration.DeferCloser(t, closer)
 		defer rsa.Close()

--- a/test/tests/components/ws-manager/prebuild_test.go
+++ b/test/tests/components/ws-manager/prebuild_test.go
@@ -38,7 +38,7 @@ func TestPrebuildWorkspaceTaskSuccess(t *testing.T) {
 			}
 			for _, test := range tests {
 				t.Run(test.Name, func(t *testing.T) {
-					_, stopWs, err := integration.LaunchWorkspaceDirectly(ctx, api, integration.WithRequestModifier(func(req *wsmanapi.StartWorkspaceRequest) error {
+					_, stopWs, err := integration.LaunchWorkspaceDirectly(t, ctx, api, integration.WithRequestModifier(func(req *wsmanapi.StartWorkspaceRequest) error {
 						req.Type = wsmanapi.WorkspaceType_PREBUILD
 						req.Spec.Envvars = append(req.Spec.Envvars, &wsmanapi.EnvironmentVariable{
 							Name:  "GITPOD_TASKS",
@@ -91,7 +91,7 @@ func TestPrebuildWorkspaceTaskFail(t *testing.T) {
 				api.Done(t)
 			})
 
-			ws, stopWs, err := integration.LaunchWorkspaceDirectly(ctx, api, integration.WithRequestModifier(func(req *wsmanapi.StartWorkspaceRequest) error {
+			ws, stopWs, err := integration.LaunchWorkspaceDirectly(t, ctx, api, integration.WithRequestModifier(func(req *wsmanapi.StartWorkspaceRequest) error {
 				req.Type = wsmanapi.WorkspaceType_PREBUILD
 				req.Spec.Envvars = append(req.Spec.Envvars, &wsmanapi.EnvironmentVariable{
 					Name:  "GITPOD_TASKS",
@@ -106,7 +106,7 @@ func TestPrebuildWorkspaceTaskFail(t *testing.T) {
 			t.Cleanup(func() {
 				_, err = stopWs(true)
 				if err != nil {
-					t.Errorf("cannot stop workspace: %q", err)
+					t.Fatal(err)
 				}
 			})
 

--- a/test/tests/components/ws-manager/tasks_test.go
+++ b/test/tests/components/ws-manager/tasks_test.go
@@ -24,8 +24,7 @@ import (
 func TestRegularWorkspaceTasks(t *testing.T) {
 	testRepo := "https://github.com/gitpod-io/empty"
 	testRepoName := "empty"
-	wsLoc := "/workspace/empty"
-
+	wsLoc := fmt.Sprintf("/workspace/%s", testRepoName)
 	tests := []struct {
 		Name        string
 		Task        []gitpod.TasksItems
@@ -92,7 +91,7 @@ func TestRegularWorkspaceTasks(t *testing.T) {
 						return nil
 					}
 
-					nfo, stopWs, err := integration.LaunchWorkspaceDirectly(ctx, api, integration.WithRequestModifier(addInitTask))
+					nfo, stopWs, err := integration.LaunchWorkspaceDirectly(t, ctx, api, integration.WithRequestModifier(addInitTask))
 					if err != nil {
 						t.Fatal(err)
 					}

--- a/test/tests/ide/jetbrains/gateway_test.go
+++ b/test/tests/ide/jetbrains/gateway_test.go
@@ -21,6 +21,7 @@ import (
 
 	protocol "github.com/gitpod-io/gitpod/gitpod-protocol"
 	"github.com/gitpod-io/gitpod/test/pkg/integration"
+	wsmanapi "github.com/gitpod-io/gitpod/ws-manager/api"
 	"github.com/google/go-github/v42/github"
 )
 
@@ -107,10 +108,10 @@ func TestJetBrainsGatewayWorkspace(t *testing.T) {
 
 				t.Logf("starting workspace")
 				var nfo *protocol.WorkspaceInfo
-				var stopWs func(waitForStop bool)
+				var stopWs func(waitForStop bool) (*wsmanapi.WorkspaceStatus, error)
 
 				for i := 0; i < 3; i++ {
-					nfo, stopWs, err = integration.LaunchWorkspaceFromContextURL(ctx, "referrer:jetbrains-gateway:"+ideName+"/"+repo, username, api)
+					nfo, stopWs, err = integration.LaunchWorkspaceFromContextURL(t, ctx, "referrer:jetbrains-gateway:"+ideName+"/"+repo, username, api)
 					if err != nil {
 						if strings.Contains(err.Error(), "code 429 message: too many requests") {
 							t.Log(err)

--- a/test/tests/ide/vscode/python_ws_test.go
+++ b/test/tests/ide/vscode/python_ws_test.go
@@ -78,7 +78,7 @@ func TestPythonExtWorkspace(t *testing.T) {
 				t.Fatalf("cannot set ide to vscode insiders: %q", err)
 			}
 
-			nfo, stopWs, err := integration.LaunchWorkspaceFromContextURL(ctx, "github.com/gitpod-io/python-test-workspace", username, api)
+			nfo, stopWs, err := integration.LaunchWorkspaceFromContextURL(t, ctx, "github.com/gitpod-io/python-test-workspace", username, api)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/test/tests/workspace/cgroup_v2_test.go
+++ b/test/tests/workspace/cgroup_v2_test.go
@@ -34,14 +34,14 @@ func TestCgroupV2(t *testing.T) {
 				api.Done(t)
 			})
 
-			ws, stopWs, err := integration.LaunchWorkspaceDirectly(ctx, api)
+			ws, stopWs, err := integration.LaunchWorkspaceDirectly(t, ctx, api)
 			if err != nil {
 				t.Fatal(err)
 			}
 			t.Cleanup(func() {
 				_, err = stopWs(true)
 				if err != nil {
-					t.Errorf("cannot stop workspace: %q", err)
+					t.Fatal(err)
 				}
 			})
 

--- a/test/tests/workspace/contexts_test.go
+++ b/test/tests/workspace/contexts_test.go
@@ -143,13 +143,17 @@ func runContextTests(t *testing.T, tests []ContextTest) {
 							t.Fatal(err)
 						}
 
-						nfo, stopWS, err := integration.LaunchWorkspaceFromContextURL(ctx, test.ContextURL, username, api)
+						nfo, stopWs, err := integration.LaunchWorkspaceFromContextURL(t, ctx, test.ContextURL, username, api)
 						if err != nil {
 							t.Fatal(err)
 						}
-						t.Cleanup(func() {
-							stopWS(true)
-						})
+
+						defer func() {
+							_, err := stopWs(true)
+							if err != nil {
+								t.Fatal(err)
+							}
+						}()
 
 						rsa, closer, err := integration.Instrument(integration.ComponentWorkspace, "workspace", cfg.Namespace(), kubeconfig, cfg.Client(), integration.WithInstanceID(nfo.LatestInstance.ID))
 						if err != nil {

--- a/test/tests/workspace/docker_test.go
+++ b/test/tests/workspace/docker_test.go
@@ -28,14 +28,14 @@ func TestRunDocker(t *testing.T) {
 				api.Done(t)
 			})
 
-			ws, stopWs, err := integration.LaunchWorkspaceDirectly(ctx, api)
+			ws, stopWs, err := integration.LaunchWorkspaceDirectly(t, ctx, api)
 			if err != nil {
 				t.Fatal(err)
 			}
 			t.Cleanup(func() {
 				_, err = stopWs(true)
 				if err != nil {
-					t.Errorf("cannot stop workspace: %q", err)
+					t.Fatal(err)
 				}
 			})
 

--- a/test/tests/workspace/example_test.go
+++ b/test/tests/workspace/example_test.go
@@ -38,11 +38,16 @@ func TestWorkspaceInstrumentation(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			nfo, stopWs, err := integration.LaunchWorkspaceFromContextURL(ctx, "github.com/gitpod-io/gitpod", username, api)
+			nfo, stopWs, err := integration.LaunchWorkspaceFromContextURL(t, ctx, "github.com/gitpod-io/gitpod", username, api)
 			if err != nil {
 				t.Fatal(err)
 			}
-			defer stopWs(true)
+			t.Cleanup(func() {
+				_, err = stopWs(true)
+				if err != nil {
+					t.Errorf("cannot stop workspace: %q", err)
+				}
+			})
 
 			rsa, closer, err := integration.Instrument(integration.ComponentWorkspace, "workspace", cfg.Namespace(), kubeconfig, cfg.Client(), integration.WithInstanceID(nfo.LatestInstance.ID))
 			if err != nil {
@@ -81,7 +86,7 @@ func TestLaunchWorkspaceDirectly(t *testing.T) {
 				api.Done(t)
 			})
 
-			_, stopWs, err := integration.LaunchWorkspaceDirectly(ctx, api)
+			_, stopWs, err := integration.LaunchWorkspaceDirectly(t, ctx, api)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/test/tests/workspace/git_test.go
+++ b/test/tests/workspace/git_test.go
@@ -158,12 +158,15 @@ func TestGitActions(t *testing.T) {
 							t.Fatal(err)
 						}
 
-						nfo, stopWS, err := integration.LaunchWorkspaceFromContextURL(ctx, test.ContextURL, username, api)
+						nfo, stopWS, err := integration.LaunchWorkspaceFromContextURL(t, ctx, test.ContextURL, username, api)
 						if err != nil {
 							t.Fatal(err)
 						}
 						t.Cleanup(func() {
-							stopWS(true)
+							_, err := stopWS(true)
+							if err != nil {
+								t.Fatal(err)
+							}
 						})
 
 						rsa, closer, err := integration.Instrument(integration.ComponentWorkspace, "workspace", cfg.Namespace(), kubeconfig, cfg.Client(), integration.WithInstanceID(nfo.LatestInstance.ID))

--- a/test/tests/workspace/k3s_test.go
+++ b/test/tests/workspace/k3s_test.go
@@ -20,7 +20,7 @@ import (
 
 const (
 	K3S_VERSION = "1.23.4"
-	TIME_OUT    = 5 * time.Minute
+	TIME_OUT    = 10 * time.Minute
 )
 
 func TestK3s(t *testing.T) {
@@ -35,14 +35,14 @@ func TestK3s(t *testing.T) {
 				api.Done(t)
 			})
 
-			ws, stopWs, err := integration.LaunchWorkspaceDirectly(ctx, api)
+			ws, stopWs, err := integration.LaunchWorkspaceDirectly(t, ctx, api)
 			if err != nil {
 				t.Fatal(err)
 			}
 			t.Cleanup(func() {
 				_, err = stopWs(true)
 				if err != nil {
-					t.Errorf("cannot stop workspace: %q", err)
+					t.Fatal(err)
 				}
 			})
 

--- a/test/tests/workspace/mount_proc_test.go
+++ b/test/tests/workspace/mount_proc_test.go
@@ -56,7 +56,7 @@ func TestMountProc(t *testing.T) {
 				api.Done(t)
 			})
 
-			ws, stopWs, err := integration.LaunchWorkspaceDirectly(ctx, api)
+			ws, stopWs, err := integration.LaunchWorkspaceDirectly(t, ctx, api)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

test: Put logging of workspace starts and stops

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Relates https://github.com/gitpod-io/gitpod/issues/12248

## How to test
<!-- Provide steps to test this PR -->

Run the test and get logs

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
