### PR TITLE
[bridge] Logs stuck workspace instances to validate fix

### DIFF
--- a/components/ws-manager-bridge/src/bridge.ts
+++ b/components/ws-manager-bridge/src/bridge.ts
@@ -446,13 +446,13 @@ export class WorkspaceManagerBridge implements Disposable {
                     const installation = this.cluster.name;
                     log.debug("Controlling instances...", { installation });
 
-                    const runningInstances = await this.workspaceDB
+                    const nonStoppedInstances = await this.workspaceDB
                         .trace(ctx)
                         .findRunningInstancesWithWorkspaces(installation, undefined, true);
 
                     // Control running workspace instances against ws-manager
                     try {
-                        await this.controlRunningInstances(ctx, runningInstances, clientProvider);
+                        await this.controlNonStoppedWSManagerManagedInstances(ctx, nonStoppedInstances, clientProvider);
 
                         disconnectStarted = Number.MAX_SAFE_INTEGER; // Reset disconnect period
                     } catch (err) {
@@ -466,7 +466,7 @@ export class WorkspaceManagerBridge implements Disposable {
                     }
 
                     // Control workspace instances against timeouts
-                    await this.controlInstancesTimeouts(ctx, runningInstances);
+                    await this.controlInstancesTimeouts(ctx, nonStoppedInstances);
 
                     log.debug("Done controlling instances.", { installation });
                 } catch (err) {
@@ -485,17 +485,17 @@ export class WorkspaceManagerBridge implements Disposable {
      * This methods controls all instances that we have currently marked as "running" in the DB.
      * It checks whether they are still running with their respective ws-manager, and if not, marks them as stopped in the DB.
      */
-    protected async controlRunningInstances(
+    protected async controlNonStoppedWSManagerManagedInstances(
         parentCtx: TraceContext,
         runningInstances: RunningWorkspaceInfo[],
         clientProvider: ClientProvider,
     ) {
         const installation = this.config.installation;
 
-        const span = TraceContext.startSpan("controlRunningInstances", parentCtx);
+        const span = TraceContext.startSpan("controlNonStoppedWSManagerManagedInstances", parentCtx);
         const ctx = { span };
         try {
-            log.debug("Controlling running instances...", { installation });
+            log.debug("Controlling non-stopped instances that are managed by WS Manager...", { installation });
 
             const runningInstancesIdx = new Map<string, RunningWorkspaceInfo>();
             runningInstances.forEach((i) => runningInstancesIdx.set(i.latestInstance.id, i));
@@ -504,9 +504,27 @@ export class WorkspaceManagerBridge implements Disposable {
             const actuallyRunningInstances = await client.getWorkspaces(ctx, new GetWorkspacesRequest());
             actuallyRunningInstances.getStatusList().forEach((s) => runningInstancesIdx.delete(s.getId()));
 
+            // runningInstancesIdx only contains instances that ws-manager is not aware of
             for (const [instanceId, ri] of runningInstancesIdx.entries()) {
                 const instance = ri.latestInstance;
-                if (instance.status.phase !== "running") {
+                const phase = instance.status.phase;
+                if (phase !== "running") {
+                    // This below if block is to validate the planned fix
+                    if (
+                        phase === "pending" ||
+                        phase === "creating" ||
+                        phase === "initializing" ||
+                        (phase === "stopping" &&
+                            instance.stoppingTime &&
+                            durationLongerThanSeconds(Date.parse(instance.stoppingTime), 10))
+                    ) {
+                        log.info("Logging to validate #12902. Should mark as stopped in database.", {
+                            instanceId,
+                            workspaceId: instance.workspaceId,
+                            installation,
+                            phase,
+                        });
+                    }
                     log.debug({ instanceId }, "Skipping instance", {
                         phase: instance.status.phase,
                         creationTime: instance.creationTime,
@@ -516,9 +534,8 @@ export class WorkspaceManagerBridge implements Disposable {
                 }
 
                 log.info(
-                    { instanceId, workspaceId: instance.workspaceId },
                     "Database says the instance is running, but wsman does not know about it. Marking as stopped in database.",
-                    { installation },
+                    { instanceId, workspaceId: instance.workspaceId, installation, phase },
                 );
                 await this.markWorkspaceInstanceAsStopped(ctx, ri, new Date());
             }
@@ -603,6 +620,7 @@ export class WorkspaceManagerBridge implements Disposable {
         const nowISO = now.toISOString();
         info.latestInstance.stoppingTime = nowISO;
         info.latestInstance.stoppedTime = nowISO;
+        info.latestInstance.status.message = `Stopped by ws-manager-bridge. Previously in phase ${info.latestInstance.status.phase}`;
         info.latestInstance.status.phase = "stopped";
         await this.workspaceDB.trace(ctx).storeInstance(info.latestInstance);
 


### PR DESCRIPTION
## Description
This PR checks and logs if a workspace instance that the ws-manager does not know about is in `pending`, `creating`, `initializing` states, or if it is in `stopping` for longer than 10 seconds (a guard in case of a race condition).
We will monitor the logs and validate if we can deploy the planned fix [here](https://github.com/gitpod-io/gitpod/compare/main...lau/stuck-ws-11397).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Relates #11397
Relates #12955

## How to test

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
