### PR TITLE
Remove deprecated sendFeedback server method

### DIFF
--- a/components/gitpod-protocol/go/gitpod-service.go
+++ b/components/gitpod-protocol/go/gitpod-service.go
@@ -73,7 +73,6 @@ type APIInterface interface {
 	GetGitpodTokens(ctx context.Context) (res []*APIToken, err error)
 	GenerateNewGitpodToken(ctx context.Context, options *GenerateNewGitpodTokenOptions) (res string, err error)
 	DeleteGitpodToken(ctx context.Context, tokenHash string) (err error)
-	SendFeedback(ctx context.Context, feedback string) (res string, err error)
 	RegisterGithubApp(ctx context.Context, installationID string) (err error)
 	TakeSnapshot(ctx context.Context, options *TakeSnapshotOptions) (res string, err error)
 	WaitForSnapshot(ctx context.Context, snapshotId string) (err error)
@@ -191,8 +190,6 @@ const (
 	FunctionGenerateNewGitpodToken FunctionName = "generateNewGitpodToken"
 	// FunctionDeleteGitpodToken is the name of the deleteGitpodToken function
 	FunctionDeleteGitpodToken FunctionName = "deleteGitpodToken"
-	// FunctionSendFeedback is the name of the sendFeedback function
-	FunctionSendFeedback FunctionName = "sendFeedback"
 	// FunctionRegisterGithubApp is the name of the registerGithubApp function
 	FunctionRegisterGithubApp FunctionName = "registerGithubApp"
 	// FunctionTakeSnapshot is the name of the takeSnapshot function
@@ -1268,26 +1265,6 @@ func (gp *APIoverJSONRPC) DeleteGitpodToken(ctx context.Context, tokenHash strin
 	if err != nil {
 		return
 	}
-
-	return
-}
-
-// SendFeedback calls sendFeedback on the server
-func (gp *APIoverJSONRPC) SendFeedback(ctx context.Context, feedback string) (res string, err error) {
-	if gp == nil {
-		err = errNotConnected
-		return
-	}
-	var _params []interface{}
-
-	_params = append(_params, feedback)
-
-	var result string
-	err = gp.C.Call(ctx, "sendFeedback", _params, &result)
-	if err != nil {
-		return
-	}
-	res = result
 
 	return
 }

--- a/components/gitpod-protocol/go/mock.go
+++ b/components/gitpod-protocol/go/mock.go
@@ -703,21 +703,6 @@ func (mr *MockAPIInterfaceMockRecorder) RegisterGithubApp(ctx, installationID in
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterGithubApp", reflect.TypeOf((*MockAPIInterface)(nil).RegisterGithubApp), ctx, installationID)
 }
 
-// SendFeedback mocks base method.
-func (m *MockAPIInterface) SendFeedback(ctx context.Context, feedback string) (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SendFeedback", ctx, feedback)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// SendFeedback indicates an expected call of SendFeedback.
-func (mr *MockAPIInterfaceMockRecorder) SendFeedback(ctx, feedback interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendFeedback", reflect.TypeOf((*MockAPIInterface)(nil).SendFeedback), ctx, feedback)
-}
-
 // SendHeartBeat mocks base method.
 func (m *MockAPIInterface) SendHeartBeat(ctx context.Context, options *SendHeartBeatOptions) error {
 	m.ctrl.T.Helper()

--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -206,7 +206,6 @@ export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, 
     deleteGitpodToken(tokenHash: string): Promise<void>;
 
     // misc
-    sendFeedback(feedback: string): Promise<string | undefined>;
     isGitHubAppEnabled(): Promise<boolean>;
     registerGithubApp(installationId: string): Promise<void>;
 

--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -90,7 +90,6 @@ import * as pThrottle from "p-throttle";
 import { formatDate } from "@gitpod/gitpod-protocol/lib/util/date-time";
 import { FindUserByIdentityStrResult, UserService } from "../../../src/user/user-service";
 import {
-    Accounting,
     AccountService,
     SubscriptionService,
     TeamSubscriptionService,
@@ -2450,22 +2449,6 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
             throw new ResponseError(ErrorCodes.BAD_REQUEST, "Unable to parse attributionId");
         }
         return this.billingModes.getBillingMode(parsedAttributionId, new Date());
-    }
-
-    // various
-    async sendFeedback(ctx: TraceContext, feedback: string): Promise<string | undefined> {
-        traceAPIParams(ctx, {}); // feedback is not interesting here, any may contain names
-
-        const user = this.checkUser("sendFeedback");
-        const now = new Date().toISOString();
-        const remainingUsageHours = await this.getRemainingUsageHours(ctx);
-        const stillEnoughCredits = remainingUsageHours > Math.max(...Accounting.LOW_CREDIT_WARNINGS_IN_HOURS);
-        log.info({ userId: user.id }, `Feedback: "${feedback}"`, { feedback, stillEnoughCredits });
-        if (stillEnoughCredits) {
-            return "Thank you for your feedback.";
-        }
-        await this.subscriptionService.addCredit(user.id, 50, now);
-        return "Thank you for you feedback. We have added 50 Gitpod Hours to your account. Have fun!";
     }
 
     // Projects

--- a/components/server/src/auth/rate-limiter.ts
+++ b/components/server/src/auth/rate-limiter.ts
@@ -122,7 +122,6 @@ const defaultFunctions: FunctionsConfig = {
     getGitpodTokens: { group: "default", points: 1 },
     generateNewGitpodToken: { group: "default", points: 1 },
     deleteGitpodToken: { group: "default", points: 1 },
-    sendFeedback: { group: "default", points: 1 },
     isGitHubAppEnabled: { group: "default", points: 1 },
     registerGithubApp: { group: "default", points: 1 },
     takeSnapshot: { group: "default", points: 1 },

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -802,7 +802,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         traceAPIParams(ctx, { workspaceId, action });
         traceWI(ctx, { workspaceId });
 
-        this.checkAndBlockUser("updateWorkspacePin");
+        this.checkAndBlockUser("updateWorkspaceUserPin");
 
         await this.workspaceDb.trace(ctx).transaction(async (db) => {
             const ws = await this.internalGetWorkspace(workspaceId, db);
@@ -1834,7 +1834,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         traceAPIParams(ctx, { workspaceId });
         traceWI(ctx, { workspaceId });
 
-        this.checkUser("storeLayout");
+        this.checkUser("getLayout");
 
         const workspace = await this.workspaceDb.trace(ctx).findById(workspaceId);
         if (!workspace) {
@@ -2948,7 +2948,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         // traceAPIParams(ctx, { event }); tracing analytics does not make much sense
 
         //Identify calls collect user informmation. If the user is unknown, we don't make a call (privacy preservation)
-        const user = this.checkUser("IdentifyUser");
+        const user = this.checkUser("identifyUser");
 
         const identifyMessage: IdentifyMessage = {
             userId: user.id,

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -1762,10 +1762,6 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         await this.userStorageResourcesDB.update(userId, uri, content);
     }
 
-    async sendFeedback(ctx: TraceContext, feedback: string): Promise<string | undefined> {
-        throw new ResponseError(ErrorCodes.EE_FEATURE, "Sending feedback is not implemented");
-    }
-
     async isGitHubAppEnabled(ctx: TraceContext): Promise<boolean> {
         this.checkAndBlockUser();
         return !!this.config.githubApp?.enabled;


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Remove deprecated `sendFeedback` server method.

**Note**: This is completely unrelated to the new dashboard feedback mechanism. 💡

In the early days of Gitpod (I think when it was still in Beta, or fresh out of Beta) there was a simple mechanism to provide general feedback about Gitpod, and in exchange you would receive a credit of 50 bonus Gitpod hours.

This feature no longer exists, and we no longer even keep track of the provided feedback (it's logged at `info` level in server, which we currently discard), but the server method is still there in our API, potentially allowing clever users to credit themselves 50 hours whenever they want.

This PR removes the old, deprecated `sendFeedback` method. Also, removing it now is a good idea, because we have a new dashboard feedback mechanism in place, and it's too easy to accidentally mistake one for the other.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

1. Build should pass
2. Gitpod should still work

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
