### PR TITLE
[usage] Alert on Usage and Invoice Reconciliations

### DIFF
--- a/operations/observability/mixins/meta/rules/usage.yaml
+++ b/operations/observability/mixins/meta/rules/usage.yaml
@@ -14,13 +14,24 @@ spec:
   groups:
   - name: usage
     rules:
-    - alert: GitpodUsageScheduledReconciliationFailures'
-      expr: sum(increase(gitpod_usage_reconcile_completed_duration_seconds_count{outcome!="success"}[1h])) > 1
+    - alert: GitpodUsageReconcileUsageFailures'
+      expr: sum(increase(grpc_server_handled_total{grpc_service="usage.v1.UsageService", grpc_method="ReconcileUsage", grpc_code!="OK"})) > 1
       for: 30m
       labels:
         severity: warning
         team: webapp
       annotations:
-        runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodUsageScheduledReconciliationFailures.md
-        summary: There are failed scheduled reconciliations in the usage component.
-        description: We have accumulated {{ printf "%.2f" $value }} failures. This affects how stale usage data is and/or updating invoices in Stripe.
+        runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodUsageReconcileUsageFailures.md
+        summary: There are failed usage reconciliations.
+        description: We have accumulated {{ printf "%.2f" $value }} failures. This affects how up-to-date usage data is.
+
+    - alert: GitpodUsageReconcileInvoicesFailures'
+      expr: sum(increase(grpc_server_handled_total{grpc_service="usage.v1.BillingService", grpc_method="ReconcileInvoices", grpc_code!="OK"})) > 1
+      for: 30m
+      labels:
+        severity: warning
+        team: webapp
+      annotations:
+        runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodUsageReconcileInvoicesFailures.md
+        summary: There are failed Stripe invoice reconciliations.
+        description: We have accumulated {{ printf "%.2f" $value }} failures. This affects how much customers will be billed.


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Alert on the two core RPCs used in usage reconciliation. 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Soft depends on https://github.com/gitpod-io/gitpod/pull/12917

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
