### PR TITLE
[stripe] Use AttributionID metadata when querying for customers

### DIFF
--- a/components/server/ee/src/user/stripe-service.ts
+++ b/components/server/ee/src/user/stripe-service.ts
@@ -13,6 +13,8 @@ import { AttributionId } from "@gitpod/gitpod-protocol/lib/attribution";
 const POLL_CREATED_CUSTOMER_INTERVAL_MS = 1000;
 const POLL_CREATED_CUSTOMER_MAX_ATTEMPTS = 30;
 
+const ATTRIBUTION_ID_METADATA_KEY = "attributionId";
+
 @injectable()
 export class StripeService {
     @inject(Config) protected readonly config: Config;
@@ -34,11 +36,15 @@ export class StripeService {
     }
 
     async findCustomerByUserId(userId: string): Promise<Stripe.Customer | undefined> {
-        return this.findCustomerByQuery(`metadata['userId']:'${userId}'`);
+        return this.findCustomerByQuery(
+            `metadata['${ATTRIBUTION_ID_METADATA_KEY}']:'${AttributionId.render({ kind: "user", userId })}'`,
+        );
     }
 
     async findCustomerByTeamId(teamId: string): Promise<Stripe.Customer | undefined> {
-        return this.findCustomerByQuery(`metadata['teamId']:'${teamId}'`);
+        return this.findCustomerByQuery(
+            `metadata['${ATTRIBUTION_ID_METADATA_KEY}']:'${AttributionId.render({ kind: "team", teamId })}'`,
+        );
     }
 
     async findCustomerByQuery(query: string): Promise<Stripe.Customer | undefined> {
@@ -58,9 +64,7 @@ export class StripeService {
             email: User.getPrimaryEmail(user),
             name: User.getName(user),
             metadata: {
-                // userId is deprecated, use attributionId where possible
-                userId: user.id,
-                attributionId: AttributionId.render({ kind: "user", userId: user.id }),
+                [ATTRIBUTION_ID_METADATA_KEY]: AttributionId.render({ kind: "user", userId: user.id }),
             },
         });
         // Wait for the customer to show up in Stripe search results before proceeding
@@ -84,9 +88,7 @@ export class StripeService {
             email: User.getPrimaryEmail(user),
             name: userName ? `${userName} (${team.name})` : team.name,
             metadata: {
-                // teamId is deprecated, use attributionId where possible
-                teamId: team.id,
-                attributionId: AttributionId.render({ kind: "team", teamId: team.id }),
+                [ATTRIBUTION_ID_METADATA_KEY]: AttributionId.render({ kind: "team", teamId: team.id }),
             },
         });
         // Wait for the customer to show up in Stripe search results before proceeding


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Use `attributionId` when querying for customers, instead team/user Id

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
1. Go to preview
2. Create team with name Gitpod-something
3. Enable billing
4. See billing enables OK
5. Check in Test Stripe account customer has `attributionId:...` set

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
