### PR TITLE
previews: Trigger artificial traffic every 2 hours

### DIFF
--- a/.werft/platform-trigger-artificial-job.yaml
+++ b/.werft/platform-trigger-artificial-job.yaml
@@ -45,4 +45,4 @@ pod:
         - .werft/platform-trigger-artificial-job.sh
 
 plugins:
-  cron: "*/30 * * * *" # Every 30 minutes
+  cron: "0 */2 * * *" # Every 2 hours


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
We're currently having trouble with our clean-up jobs. It has been failing for the last 2 days. With us creating new previews every 30 minutes, we're saturating all our bare-metal VMs too quickly. 

This PR decreases the frequency we create artificial previews just for the sake of not overloading the underlying infrastructure until we fix our clean-up job.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
