### PR TITLE
[usage] Add periodic job to detect invalid workspace instances in usage

### DIFF
--- a/components/usage/pkg/db/dbtest/workspace_instance.go
+++ b/components/usage/pkg/db/dbtest/workspace_instance.go
@@ -77,6 +77,11 @@ func NewWorkspaceInstance(t *testing.T, instance db.WorkspaceInstance) db.Worksp
 		workspaceClass = instance.WorkspaceClass
 	}
 
+	phasePersisted := ""
+	if instance.PhasePersisted != "" {
+		phasePersisted = instance.PhasePersisted
+	}
+
 	return db.WorkspaceInstance{
 		ID:                 id,
 		WorkspaceID:        workspaceID,
@@ -98,7 +103,7 @@ func NewWorkspaceInstance(t *testing.T, instance db.WorkspaceInstance) db.Worksp
 		StatusOld:          sql.NullString{},
 		Status:             status,
 		Phase:              sql.NullString{},
-		PhasePersisted:     "",
+		PhasePersisted:     phasePersisted,
 	}
 }
 

--- a/components/usage/pkg/scheduler/job_test.go
+++ b/components/usage/pkg/scheduler/job_test.go
@@ -5,21 +5,20 @@
 package scheduler
 
 import (
-	"context"
-	v1 "github.com/gitpod-io/gitpod/usage-api/v1"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 )
 
-func TestLedgerJob_PreventsConcurrentInvocations(t *testing.T) {
-	client := &fakeUsageClient{}
-	job := NewLedgerTrigger(client, nil)
+func TestPreventConcurrentInvocation(t *testing.T) {
+	callCount := int32(0)
+	job := WithoutConcurrentRun(JobFunc(func() error {
+		atomic.AddInt32(&callCount, 1)
+		time.Sleep(50 * time.Millisecond)
+		return nil
+	}))
 
 	invocations := 3
 	wg := sync.WaitGroup{}
@@ -32,42 +31,18 @@ func TestLedgerJob_PreventsConcurrentInvocations(t *testing.T) {
 	}
 	wg.Wait()
 
-	require.Equal(t, 1, int(client.ReconcileUsageWithLedgerCallCount))
+	require.Equal(t, int32(1), callCount)
 }
 
-func TestLedgerJob_CanRunRepeatedly(t *testing.T) {
-	client := &fakeUsageClient{}
-	job := NewLedgerTrigger(client, nil)
+func TestPreventConcurrentInvocation_CanRunRepeatedly(t *testing.T) {
+	callCount := int32(0)
+	job := WithoutConcurrentRun(JobFunc(func() error {
+		atomic.AddInt32(&callCount, 1)
+		return nil
+	}))
 
-	_ = job.Run()
-	_ = job.Run()
+	require.NoError(t, job.Run())
+	require.NoError(t, job.Run())
 
-	require.Equal(t, 2, int(client.ReconcileUsageWithLedgerCallCount))
-}
-
-type fakeUsageClient struct {
-	ReconcileUsageWithLedgerCallCount int32
-}
-
-// GetCostCenter retrieves the active cost center for the given attributionID
-func (c *fakeUsageClient) GetCostCenter(ctx context.Context, in *v1.GetCostCenterRequest, opts ...grpc.CallOption) (*v1.GetCostCenterResponse, error) {
-	return nil, status.Error(codes.Unauthenticated, "not implemented")
-}
-
-// SetCostCenter stores the given cost center
-func (c *fakeUsageClient) SetCostCenter(ctx context.Context, in *v1.SetCostCenterRequest, opts ...grpc.CallOption) (*v1.SetCostCenterResponse, error) {
-	return nil, status.Error(codes.Unauthenticated, "not implemented")
-}
-
-// Triggers reconciliation of usage with ledger implementation.
-func (c *fakeUsageClient) ReconcileUsage(ctx context.Context, in *v1.ReconcileUsageRequest, opts ...grpc.CallOption) (*v1.ReconcileUsageResponse, error) {
-	atomic.AddInt32(&c.ReconcileUsageWithLedgerCallCount, 1)
-	time.Sleep(50 * time.Millisecond)
-
-	return nil, status.Error(codes.Unauthenticated, "not implemented")
-}
-
-// ListUsage retrieves all usage for the specified attributionId and theb given time range
-func (c *fakeUsageClient) ListUsage(ctx context.Context, in *v1.ListUsageRequest, opts ...grpc.CallOption) (*v1.ListUsageResponse, error) {
-	return nil, status.Error(codes.Unauthenticated, "not implemented")
+	require.Equal(t, int32(2), callCount)
 }

--- a/components/usage/pkg/scheduler/reporter.go
+++ b/components/usage/pkg/scheduler/reporter.go
@@ -30,12 +30,20 @@ var (
 		Help:      "Histogram of job duration",
 		Buckets:   prometheus.LinearBuckets(30, 30, 10), // every 30 secs, starting at 30secs
 	}, []string{"job", "outcome"})
+
+	stoppedWithoutStoppingTime = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: namespace,
+		Subsystem: subsystem,
+		Name:      "job_stopped_instances_without_stopping_time_count",
+		Help:      "Gauge of usage records where workpsace instance is stopped but doesn't have a stopping time",
+	})
 )
 
 func RegisterMetrics(reg *prometheus.Registry) error {
 	metrics := []prometheus.Collector{
 		jobStartedSeconds,
 		jobCompletedSeconds,
+		stoppedWithoutStoppingTime,
 	}
 	for _, metric := range metrics {
 		err := reg.Register(metric)

--- a/components/usage/pkg/scheduler/scheduler_test.go
+++ b/components/usage/pkg/scheduler/scheduler_test.go
@@ -39,9 +39,3 @@ func TestScheduler(t *testing.T) {
 	require.True(t, firstRan)
 	require.True(t, secondRan)
 }
-
-type JobFunc func() error
-
-func (f JobFunc) Run() error {
-	return f()
-}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This PR does the following:
1. Adds a scheduled job (every 15m) which detects if there are any instances in the `usage` table which are for workspace instances which have stopped, but do not have a `stoppingTime` set. In this case, these instances would cause runaway credit usage for our customers.
2. When such an instance is detected, a metric is updated to allow us to alert on this.

To avoid code-duplication, the existing Ledger Job is refactored to introduce the following:
1. Wrapper which can compose a Job to enable concurrent execution prevention
2. Tests are updated to reflect this change

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
Unit tests

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
