### PR TITLE
test: Make stopWs independent of the main context and api variable

### DIFF
--- a/test/pkg/integration/workspace.go
+++ b/test/pkg/integration/workspace.go
@@ -91,7 +91,7 @@ type LaunchWorkspaceDirectlyResult struct {
 	LastStatus *wsmanapi.WorkspaceStatus
 }
 
-type stopWorkspaceFunc = func(waitForStop bool) (*wsmanapi.WorkspaceStatus, error)
+type stopWorkspaceFunc = func(waitForStop bool, api *ComponentAPI) (*wsmanapi.WorkspaceStatus, error)
 
 // LaunchWorkspaceDirectly starts a workspace pod by talking directly to ws-manager.
 // Whenever possible prefer this function over LaunchWorkspaceFromContextURL, because
@@ -201,7 +201,7 @@ func LaunchWorkspaceDirectly(t *testing.T, ctx context.Context, api *ComponentAP
 	stopWs := stopWsF(t, req.Id, api)
 	defer func() {
 		if err != nil {
-			stopWs(false)
+			stopWs(false, api)
 		}
 	}()
 
@@ -266,7 +266,7 @@ func LaunchWorkspaceFromContextURL(t *testing.T, ctx context.Context, contextURL
 	stopWs := stopWsF(t, wi.LatestInstance.ID, api)
 	defer func() {
 		if err != nil {
-			_, _ = stopWs(false)
+			_, _ = stopWs(false, api)
 		}
 	}()
 
@@ -281,7 +281,7 @@ func LaunchWorkspaceFromContextURL(t *testing.T, ctx context.Context, contextURL
 }
 
 func stopWsF(t *testing.T, instanceID string, api *ComponentAPI) stopWorkspaceFunc {
-	return func(waitForStop bool) (*wsmanapi.WorkspaceStatus, error) {
+	return func(waitForStop bool, api *ComponentAPI) (*wsmanapi.WorkspaceStatus, error) {
 		sctx, scancel := context.WithTimeout(context.Background(), perCallTimeout)
 		defer scancel()
 

--- a/test/tests/components/ws-manager/content_test.go
+++ b/test/tests/components/ws-manager/content_test.go
@@ -68,7 +68,7 @@ func TestBackup(t *testing.T) {
 						integration.WithWorkspacekitLift(true),
 					)
 					if err != nil {
-						if _, err := stopWs1(true); err != nil {
+						if _, err := stopWs1(true, api); err != nil {
 							t.Errorf("cannot stop workspace: %q", err)
 						}
 						t.Fatal(err)
@@ -83,13 +83,13 @@ func TestBackup(t *testing.T) {
 					}, &resp)
 					rsa.Close()
 					if err != nil {
-						if _, err := stopWs1(true); err != nil {
+						if _, err := stopWs1(true, api); err != nil {
 							t.Errorf("cannot stop workspace: %q", err)
 						}
 						t.Fatal(err)
 					}
 
-					lastStatusWs1, err := stopWs1(true)
+					lastStatusWs1, err := stopWs1(true, api)
 					if err != nil {
 						t.Fatal(err)
 					}
@@ -117,7 +117,7 @@ func TestBackup(t *testing.T) {
 						t.Fatal(err)
 					}
 					defer func() {
-						_, err = stopWs2(true)
+						_, err = stopWs2(true, api)
 						if err != nil {
 							t.Errorf("cannot stop workspace: %q", err)
 						}
@@ -200,7 +200,7 @@ func TestExistingWorkspaceEnablePVC(t *testing.T) {
 				integration.WithWorkspacekitLift(true),
 			)
 			if err != nil {
-				if _, err := stopWs1(true); err != nil {
+				if _, err := stopWs1(true, api); err != nil {
 					t.Errorf("cannot stop workspace: %q", err)
 				}
 				t.Fatal(err)
@@ -215,13 +215,13 @@ func TestExistingWorkspaceEnablePVC(t *testing.T) {
 			}, &resp)
 			rsa.Close()
 			if err != nil {
-				if _, err := stopWs1(true); err != nil {
+				if _, err := stopWs1(true, api); err != nil {
 					t.Errorf("cannot stop workspace: %q", err)
 				}
 				t.Fatal(err)
 			}
 
-			_, err = stopWs1(true)
+			_, err = stopWs1(true, api)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -242,7 +242,7 @@ func TestExistingWorkspaceEnablePVC(t *testing.T) {
 				t.Fatal(err)
 			}
 			t.Cleanup(func() {
-				_, err = stopWs2(true)
+				_, err = stopWs2(true, api)
 				if err != nil {
 					t.Errorf("cannot stop workspace: %q", err)
 				}
@@ -303,7 +303,7 @@ func TestMissingBackup(t *testing.T) {
 
 			wsm, err := api.WorkspaceManager()
 			if err != nil {
-				if _, err := stopWs(true); err != nil {
+				if _, err := stopWs(true, api); err != nil {
 					t.Errorf("cannot stop workspace: %q", err)
 				}
 				t.Fatal(err)
@@ -363,7 +363,7 @@ func TestMissingBackup(t *testing.T) {
 						return
 					}
 					if testws.LastStatus.Conditions.Failed == "" {
-						_, err = stopWs(true)
+						_, err = stopWs(true, api)
 						if err != nil {
 							t.Errorf("cannot stop workspace: %q", err)
 						}

--- a/test/tests/components/ws-manager/content_test.go
+++ b/test/tests/components/ws-manager/content_test.go
@@ -117,7 +117,13 @@ func TestBackup(t *testing.T) {
 						t.Fatal(err)
 					}
 					defer func() {
-						_, err = stopWs2(true, api)
+						sctx, scancel := context.WithTimeout(context.Background(), 5*time.Minute)
+						defer scancel()
+
+						sapi := integration.NewComponentAPI(sctx, cfg.Namespace(), kubeconfig, cfg.Client())
+						defer sapi.Done(t)
+
+						_, err = stopWs2(true, sapi)
 						if err != nil {
 							t.Errorf("cannot stop workspace: %q", err)
 						}
@@ -242,7 +248,12 @@ func TestExistingWorkspaceEnablePVC(t *testing.T) {
 				t.Fatal(err)
 			}
 			t.Cleanup(func() {
-				_, err = stopWs2(true, api)
+				sctx, scancel := context.WithTimeout(context.Background(), 5*time.Minute)
+				defer scancel()
+
+				sapi := integration.NewComponentAPI(sctx, cfg.Namespace(), kubeconfig, cfg.Client())
+				defer sapi.Done(t)
+				_, err = stopWs2(true, sapi)
 				if err != nil {
 					t.Errorf("cannot stop workspace: %q", err)
 				}

--- a/test/tests/components/ws-manager/multi_repo_test.go
+++ b/test/tests/components/ws-manager/multi_repo_test.go
@@ -102,7 +102,7 @@ func TestMultiRepoWorkspaceSuccess(t *testing.T) {
 		}
 
 		defer func() {
-			_, err = stopWs(true)
+			_, err = stopWs(true, api)
 			if err != nil {
 				t.Errorf("cannot stop workspace: %q", err)
 			}

--- a/test/tests/components/ws-manager/multi_repo_test.go
+++ b/test/tests/components/ws-manager/multi_repo_test.go
@@ -102,7 +102,13 @@ func TestMultiRepoWorkspaceSuccess(t *testing.T) {
 		}
 
 		defer func() {
-			_, err = stopWs(true, api)
+			sctx, scancel := context.WithTimeout(context.Background(), 5*time.Minute)
+			defer scancel()
+
+			sapi := integration.NewComponentAPI(sctx, cfg.Namespace(), kubeconfig, cfg.Client())
+			defer sapi.Done(t)
+
+			_, err = stopWs(true, sapi)
 			if err != nil {
 				t.Errorf("cannot stop workspace: %q", err)
 			}

--- a/test/tests/components/ws-manager/prebuild_test.go
+++ b/test/tests/components/ws-manager/prebuild_test.go
@@ -63,7 +63,7 @@ func TestPrebuildWorkspaceTaskSuccess(t *testing.T) {
 						t.Fatalf("cannot launch a workspace: %q", err)
 					}
 					t.Cleanup(func() {
-						_, err = stopWs(true)
+						_, err = stopWs(true, api)
 						if err != nil {
 							t.Errorf("cannot stop workspace: %q", err)
 						}
@@ -104,7 +104,7 @@ func TestPrebuildWorkspaceTaskFail(t *testing.T) {
 			}
 
 			t.Cleanup(func() {
-				_, err = stopWs(true)
+				_, err = stopWs(true, api)
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/test/tests/components/ws-manager/prebuild_test.go
+++ b/test/tests/components/ws-manager/prebuild_test.go
@@ -63,7 +63,13 @@ func TestPrebuildWorkspaceTaskSuccess(t *testing.T) {
 						t.Fatalf("cannot launch a workspace: %q", err)
 					}
 					t.Cleanup(func() {
-						_, err = stopWs(true, api)
+						sctx, scancel := context.WithTimeout(context.Background(), 5*time.Minute)
+						defer scancel()
+
+						sapi := integration.NewComponentAPI(sctx, cfg.Namespace(), kubeconfig, cfg.Client())
+						defer sapi.Done(t)
+
+						_, err = stopWs(true, sapi)
 						if err != nil {
 							t.Errorf("cannot stop workspace: %q", err)
 						}
@@ -104,7 +110,13 @@ func TestPrebuildWorkspaceTaskFail(t *testing.T) {
 			}
 
 			t.Cleanup(func() {
-				_, err = stopWs(true, api)
+				sctx, scancel := context.WithTimeout(context.Background(), 5*time.Minute)
+				defer scancel()
+
+				sapi := integration.NewComponentAPI(sctx, cfg.Namespace(), kubeconfig, cfg.Client())
+				defer sapi.Done(t)
+
+				_, err = stopWs(true, sapi)
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/test/tests/components/ws-manager/tasks_test.go
+++ b/test/tests/components/ws-manager/tasks_test.go
@@ -97,7 +97,7 @@ func TestRegularWorkspaceTasks(t *testing.T) {
 					}
 
 					defer func() {
-						if _, err = stopWs(true); err != nil {
+						if _, err = stopWs(true, api); err != nil {
 							t.Errorf("cannot stop workspace: %q", err)
 						}
 					}()

--- a/test/tests/components/ws-manager/tasks_test.go
+++ b/test/tests/components/ws-manager/tasks_test.go
@@ -97,7 +97,13 @@ func TestRegularWorkspaceTasks(t *testing.T) {
 					}
 
 					defer func() {
-						if _, err = stopWs(true, api); err != nil {
+						sctx, scancel := context.WithTimeout(context.Background(), 5*time.Minute)
+						defer scancel()
+
+						sapi := integration.NewComponentAPI(sctx, cfg.Namespace(), kubeconfig, cfg.Client())
+						defer sapi.Done(t)
+
+						if _, err = stopWs(true, sapi); err != nil {
 							t.Errorf("cannot stop workspace: %q", err)
 						}
 					}()

--- a/test/tests/ide/jetbrains/gateway_test.go
+++ b/test/tests/ide/jetbrains/gateway_test.go
@@ -108,7 +108,7 @@ func TestJetBrainsGatewayWorkspace(t *testing.T) {
 
 				t.Logf("starting workspace")
 				var nfo *protocol.WorkspaceInfo
-				var stopWs func(waitForStop bool) (*wsmanapi.WorkspaceStatus, error)
+				var stopWs func(waitForStop bool, api *integration.ComponentAPI) (*wsmanapi.WorkspaceStatus, error)
 
 				for i := 0; i < 3; i++ {
 					nfo, stopWs, err = integration.LaunchWorkspaceFromContextURL(t, ctx, "referrer:jetbrains-gateway:"+ideName+"/"+repo, username, api)
@@ -124,7 +124,7 @@ func TestJetBrainsGatewayWorkspace(t *testing.T) {
 					}
 				}
 
-				defer stopWs(true)
+				defer stopWs(true, api)
 
 				t.Logf("get oauth2 token")
 				oauthToken, err := api.CreateOAuth2Token(username, []string{

--- a/test/tests/ide/jetbrains/gateway_test.go
+++ b/test/tests/ide/jetbrains/gateway_test.go
@@ -124,7 +124,15 @@ func TestJetBrainsGatewayWorkspace(t *testing.T) {
 					}
 				}
 
-				defer stopWs(true, api)
+				defer func() {
+					sctx, scancel := context.WithTimeout(context.Background(), 5*time.Minute)
+					defer scancel()
+
+					sapi := integration.NewComponentAPI(sctx, cfg.Namespace(), kubeconfig, cfg.Client())
+					defer sapi.Done(t)
+
+					stopWs(true, sapi)
+				}()
 
 				t.Logf("get oauth2 token")
 				oauthToken, err := api.CreateOAuth2Token(username, []string{

--- a/test/tests/ide/vscode/python_ws_test.go
+++ b/test/tests/ide/vscode/python_ws_test.go
@@ -82,7 +82,7 @@ func TestPythonExtWorkspace(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			defer stopWs(true)
+			defer stopWs(true, api)
 
 			_, err = integration.WaitForWorkspaceStart(ctx, nfo.LatestInstance.ID, api)
 			if err != nil {

--- a/test/tests/ide/vscode/python_ws_test.go
+++ b/test/tests/ide/vscode/python_ws_test.go
@@ -82,7 +82,15 @@ func TestPythonExtWorkspace(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			defer stopWs(true, api)
+			defer func() {
+				sctx, scancel := context.WithTimeout(context.Background(), 5*time.Minute)
+				defer scancel()
+
+				sapi := integration.NewComponentAPI(sctx, cfg.Namespace(), kubeconfig, cfg.Client())
+				defer sapi.Done(t)
+
+				stopWs(true, sapi)
+			}()
 
 			_, err = integration.WaitForWorkspaceStart(ctx, nfo.LatestInstance.ID, api)
 			if err != nil {

--- a/test/tests/workspace/cgroup_v2_test.go
+++ b/test/tests/workspace/cgroup_v2_test.go
@@ -39,7 +39,13 @@ func TestCgroupV2(t *testing.T) {
 				t.Fatal(err)
 			}
 			t.Cleanup(func() {
-				_, err = stopWs(true, api)
+				sctx, scancel := context.WithTimeout(context.Background(), 5*time.Minute)
+				defer scancel()
+
+				sapi := integration.NewComponentAPI(sctx, cfg.Namespace(), kubeconfig, cfg.Client())
+				defer sapi.Done(t)
+
+				_, err = stopWs(true, sapi)
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/test/tests/workspace/cgroup_v2_test.go
+++ b/test/tests/workspace/cgroup_v2_test.go
@@ -39,7 +39,7 @@ func TestCgroupV2(t *testing.T) {
 				t.Fatal(err)
 			}
 			t.Cleanup(func() {
-				_, err = stopWs(true)
+				_, err = stopWs(true, api)
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/test/tests/workspace/contexts_test.go
+++ b/test/tests/workspace/contexts_test.go
@@ -149,7 +149,7 @@ func runContextTests(t *testing.T, tests []ContextTest) {
 						}
 
 						defer func() {
-							_, err := stopWs(true)
+							_, err := stopWs(true, api)
 							if err != nil {
 								t.Fatal(err)
 							}

--- a/test/tests/workspace/contexts_test.go
+++ b/test/tests/workspace/contexts_test.go
@@ -149,7 +149,13 @@ func runContextTests(t *testing.T, tests []ContextTest) {
 						}
 
 						defer func() {
-							_, err := stopWs(true, api)
+							sctx, scancel := context.WithTimeout(context.Background(), 5*time.Minute)
+							defer scancel()
+
+							sapi := integration.NewComponentAPI(sctx, cfg.Namespace(), kubeconfig, cfg.Client())
+							defer sapi.Done(t)
+
+							_, err := stopWs(true, sapi)
 							if err != nil {
 								t.Fatal(err)
 							}

--- a/test/tests/workspace/docker_test.go
+++ b/test/tests/workspace/docker_test.go
@@ -33,7 +33,13 @@ func TestRunDocker(t *testing.T) {
 				t.Fatal(err)
 			}
 			t.Cleanup(func() {
-				_, err = stopWs(true, api)
+				sctx, scancel := context.WithTimeout(context.Background(), 5*time.Minute)
+				defer scancel()
+
+				sapi := integration.NewComponentAPI(sctx, cfg.Namespace(), kubeconfig, cfg.Client())
+				defer sapi.Done(t)
+
+				_, err = stopWs(true, sapi)
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/test/tests/workspace/docker_test.go
+++ b/test/tests/workspace/docker_test.go
@@ -33,7 +33,7 @@ func TestRunDocker(t *testing.T) {
 				t.Fatal(err)
 			}
 			t.Cleanup(func() {
-				_, err = stopWs(true)
+				_, err = stopWs(true, api)
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/test/tests/workspace/example_test.go
+++ b/test/tests/workspace/example_test.go
@@ -43,7 +43,13 @@ func TestWorkspaceInstrumentation(t *testing.T) {
 				t.Fatal(err)
 			}
 			t.Cleanup(func() {
-				_, err = stopWs(true, api)
+				sctx, scancel := context.WithTimeout(context.Background(), 5*time.Minute)
+				defer scancel()
+
+				sapi := integration.NewComponentAPI(sctx, cfg.Namespace(), kubeconfig, cfg.Client())
+				defer sapi.Done(t)
+
+				_, err = stopWs(true, sapi)
 				if err != nil {
 					t.Errorf("cannot stop workspace: %q", err)
 				}
@@ -92,7 +98,13 @@ func TestLaunchWorkspaceDirectly(t *testing.T) {
 			}
 
 			t.Cleanup(func() {
-				_, err = stopWs(true, api)
+				sctx, scancel := context.WithTimeout(context.Background(), 5*time.Minute)
+				defer scancel()
+
+				sapi := integration.NewComponentAPI(sctx, cfg.Namespace(), kubeconfig, cfg.Client())
+				defer sapi.Done(t)
+
+				_, err = stopWs(true, sapi)
 				if err != nil {
 					t.Errorf("cannot stop workspace: %q", err)
 				}

--- a/test/tests/workspace/example_test.go
+++ b/test/tests/workspace/example_test.go
@@ -43,7 +43,7 @@ func TestWorkspaceInstrumentation(t *testing.T) {
 				t.Fatal(err)
 			}
 			t.Cleanup(func() {
-				_, err = stopWs(true)
+				_, err = stopWs(true, api)
 				if err != nil {
 					t.Errorf("cannot stop workspace: %q", err)
 				}
@@ -92,7 +92,7 @@ func TestLaunchWorkspaceDirectly(t *testing.T) {
 			}
 
 			t.Cleanup(func() {
-				_, err = stopWs(true)
+				_, err = stopWs(true, api)
 				if err != nil {
 					t.Errorf("cannot stop workspace: %q", err)
 				}

--- a/test/tests/workspace/git_test.go
+++ b/test/tests/workspace/git_test.go
@@ -158,12 +158,12 @@ func TestGitActions(t *testing.T) {
 							t.Fatal(err)
 						}
 
-						nfo, stopWS, err := integration.LaunchWorkspaceFromContextURL(t, ctx, test.ContextURL, username, api)
+						nfo, stopWs, err := integration.LaunchWorkspaceFromContextURL(t, ctx, test.ContextURL, username, api)
 						if err != nil {
 							t.Fatal(err)
 						}
 						t.Cleanup(func() {
-							_, err := stopWS(true)
+							_, err := stopWs(true, api)
 							if err != nil {
 								t.Fatal(err)
 							}

--- a/test/tests/workspace/git_test.go
+++ b/test/tests/workspace/git_test.go
@@ -163,7 +163,13 @@ func TestGitActions(t *testing.T) {
 							t.Fatal(err)
 						}
 						t.Cleanup(func() {
-							_, err := stopWs(true, api)
+							sctx, scancel := context.WithTimeout(context.Background(), 5*time.Minute)
+							defer scancel()
+
+							sapi := integration.NewComponentAPI(sctx, cfg.Namespace(), kubeconfig, cfg.Client())
+							defer sapi.Done(t)
+
+							_, err := stopWs(true, sapi)
 							if err != nil {
 								t.Fatal(err)
 							}

--- a/test/tests/workspace/k3s_test.go
+++ b/test/tests/workspace/k3s_test.go
@@ -40,7 +40,13 @@ func TestK3s(t *testing.T) {
 				t.Fatal(err)
 			}
 			t.Cleanup(func() {
-				_, err = stopWs(true, api)
+				sctx, scancel := context.WithTimeout(context.Background(), 5*time.Minute)
+				defer scancel()
+
+				sapi := integration.NewComponentAPI(sctx, cfg.Namespace(), kubeconfig, cfg.Client())
+				defer sapi.Done(t)
+
+				_, err = stopWs(true, sapi)
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/test/tests/workspace/k3s_test.go
+++ b/test/tests/workspace/k3s_test.go
@@ -40,7 +40,7 @@ func TestK3s(t *testing.T) {
 				t.Fatal(err)
 			}
 			t.Cleanup(func() {
-				_, err = stopWs(true)
+				_, err = stopWs(true, api)
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/test/tests/workspace/mount_proc_test.go
+++ b/test/tests/workspace/mount_proc_test.go
@@ -62,7 +62,7 @@ func TestMountProc(t *testing.T) {
 			}
 
 			t.Cleanup(func() {
-				_, err = stopWs(true)
+				_, err = stopWs(true, api)
 				if err != nil {
 					t.Errorf("cannot stop workspace: %q", err)
 				}

--- a/test/tests/workspace/mount_proc_test.go
+++ b/test/tests/workspace/mount_proc_test.go
@@ -62,7 +62,13 @@ func TestMountProc(t *testing.T) {
 			}
 
 			t.Cleanup(func() {
-				_, err = stopWs(true, api)
+				sctx, scancel := context.WithTimeout(context.Background(), 5*time.Minute)
+				defer scancel()
+
+				sapi := integration.NewComponentAPI(sctx, cfg.Namespace(), kubeconfig, cfg.Client())
+				defer sapi.Done(t)
+
+				_, err = stopWs(true, sapi)
 				if err != nil {
 					t.Errorf("cannot stop workspace: %q", err)
 				}


### PR DESCRIPTION
## Description

Make stopWs independent of the main context to have no dependence on the order of cleanUp or defer

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Relates https://github.com/gitpod-io/gitpod/issues/12248

## How to test
<!-- Provide steps to test this PR -->

Run the test

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview


