### PR TITLE
test: Refresh a api client if it returns Unavailable

### DIFF
--- a/test/pkg/integration/apis.go
+++ b/test/pkg/integration/apis.go
@@ -699,6 +699,11 @@ func (c *ComponentAPI) WorkspaceManager() (wsmanapi.WorkspaceManagerClient, erro
 	return c.wsmanStatus.Client, nil
 }
 
+func (c *ComponentAPI) ClearWorkspaceManagerClientCache() {
+	c.wsmanStatus.Client = nil
+	c.wsmanStatus.Port = 0
+}
+
 // BlobService provides access to the blob service of the content service
 func (c *ComponentAPI) BlobService() (csapi.BlobServiceClient, error) {
 	if c.contentServiceStatus.BlobServiceClient != nil {
@@ -737,6 +742,11 @@ func (c *ComponentAPI) BlobService() (csapi.BlobServiceClient, error) {
 
 	c.contentServiceStatus.BlobServiceClient = csapi.NewBlobServiceClient(conn)
 	return c.contentServiceStatus.BlobServiceClient, nil
+}
+
+func (c *ComponentAPI) ClearBlobServiceClientCache() {
+	c.contentServiceStatus.BlobServiceClient = nil
+	c.contentServiceStatus.Port = 0
 }
 
 type dbOpts struct {
@@ -1040,6 +1050,11 @@ func (c *ComponentAPI) ImageBuilder(opts ...APIImageBuilderOpt) (imgbldr.ImageBu
 	return c.imgbldStatus.Client, nil
 }
 
+func (c *ComponentAPI) ClearImageBuilderClientCache() {
+	c.imgbldStatus.Client = nil
+	c.imgbldStatus.Port = 0
+}
+
 // ContentService groups content service interfaces for convenience
 type ContentService interface {
 	csapi.ContentServiceClient
@@ -1087,6 +1102,11 @@ func (c *ComponentAPI) ContentService() (ContentService, error) {
 	}
 
 	return c.contentServiceStatus.ContentService, nil
+}
+
+func (c *ComponentAPI) ClearContentServiceClientCache() {
+	c.contentServiceStatus.ContentService = nil
+	c.contentServiceStatus.Port = 0
 }
 
 func (c *ComponentAPI) Done(t *testing.T) {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Refresh client connections when they are no longer useful.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Relates https://github.com/gitpod-io/gitpod/issues/12248

## How to test
<!-- Provide steps to test this PR -->

Run the test

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview

