### PR TITLE
[dashboards] Fix gRPC/Server variable selection

### DIFF
--- a/operations/observability/mixins/cross-teams/dashboards/gitpod-grpc-server.json
+++ b/operations/observability/mixins/cross-teams/dashboards/gitpod-grpc-server.json
@@ -25,7 +25,6 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "id": 72,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -700,7 +699,7 @@
           "type": "prometheus",
           "uid": "P4169E866C3094E38"
         },
-        "definition": "label_values(grpc_server_started_total, grpc_method)",
+        "definition": "label_values(grpc_server_started_total{grpc_service=~\"$service\"}, grpc_method)",
         "description": "gRPC Method Name",
         "hide": 0,
         "includeAll": true,
@@ -709,7 +708,7 @@
         "name": "method",
         "options": [],
         "query": {
-          "query": "label_values(grpc_server_started_total, grpc_method)",
+          "query": "label_values(grpc_server_started_total{grpc_service=~\"$service\"}, grpc_method)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,
@@ -733,7 +732,7 @@
           "type": "prometheus",
           "uid": "P4169E866C3094E38"
         },
-        "definition": "label_values(grpc_server_started_total, grpc_type)",
+        "definition": "label_values(grpc_server_started_total{grpc_service=~\"$service\", grpc_method=~\"$method\"}, grpc_type)",
         "description": "gRPC request type - bidirectional stream, server stream, unary, client_stream",
         "hide": 0,
         "includeAll": true,
@@ -742,7 +741,7 @@
         "name": "type",
         "options": [],
         "query": {
-          "query": "label_values(grpc_server_started_total, grpc_type)",
+          "query": "label_values(grpc_server_started_total{grpc_service=~\"$service\", grpc_method=~\"$method\"}, grpc_type)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,
@@ -772,6 +771,6 @@
   "timezone": "utc",
   "title": "gRPC / Server",
   "uid": "fDH4_QMVk",
-  "version": 5,
+  "version": 1,
   "weekStart": "monday"
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Update `gRPC / Server` dashboard to make variable selection dependant on each other. That is, if you pick the UsageService, you should only see RPCs which exist on the Usage Service.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
