### PR TITLE
[usage] Remove stopped without stopping time detector, temporarily

### DIFF
--- a/components/usage/pkg/server/server.go
+++ b/components/usage/pkg/server/server.go
@@ -98,18 +98,7 @@ func Start(cfg Config) error {
 		stripeClient = c
 	}
 
-	stoppedWithoutStoppingTimeSpec, err := scheduler.NewPeriodicJobSpec(
-		15*time.Minute,
-		"stopped_without_stopping_time",
-		scheduler.WithoutConcurrentRun(scheduler.NewStoppedWithoutStoppingTimeDetectorSpec(conn)),
-	)
-	if err != nil {
-		return fmt.Errorf("failed to setup stopped without a stopping time detector: %w", err)
-	}
-
-	schedulerJobSpecs := []scheduler.JobSpec{
-		stoppedWithoutStoppingTimeSpec,
-	}
+	var schedulerJobSpecs []scheduler.JobSpec
 
 	if cfg.ControllerSchedule != "" {
 		// we do not run the controller if there is no schedule defined.


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Removes the detector until we land https://github.com/gitpod-io/gitpod/pull/12706 because the query is too slow without those indices.

Currently, it throws `github.com/gitpod-io/gitpod/usage/pkg/db/workspace_instance.go:252 context deadline exceeded` because the query runs for more than 10m.

Will be re-added (removal reverted) once the indices are in place.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
