### PR TITLE
[UBP] Use `findStripeSubscriptionId` in `BillingAccountSelector` component

### DIFF
--- a/components/dashboard/src/components/BillingAccountSelector.tsx
+++ b/components/dashboard/src/components/BillingAccountSelector.tsx
@@ -27,7 +27,8 @@ export function BillingAccountSelector(props: { onSelected?: () => void }) {
         const teamsWithBilling: Team[] = [];
         Promise.all(
             teams.map(async (t) => {
-                const subscriptionId = await getGitpodService().server.findStripeSubscriptionIdForTeam(t.id);
+                const attributionId: string = AttributionId.render({ kind: "team", teamId: t.id });
+                const subscriptionId = await getGitpodService().server.findStripeSubscriptionId(attributionId);
                 if (subscriptionId) {
                     teamsWithBilling.push(t);
                 }


### PR DESCRIPTION
## Description

Use the more general `findStripeSubscriptionId` API rather than `findStripeSubscriptionIdForTeam` to allow the latter to be safely removed from the server JSON-RPC API in a subsequent PR.

The `BillingAccountSelector` component is used on the individual user settings page:

<img width="764" alt="image" src="https://user-images.githubusercontent.com/8225907/190142237-bcbdadd0-e539-4d1c-8da4-5c9c81b05b81.png">


## Related Issue(s)

Part of https://github.com/gitpod-io/gitpod/issues/12685

## How to test

1. Create some `Gitpod-something` teams in the preview environment and sign them up for UBP.
2. Visit your billing settings page and use the billing account selector controls to define your cost center.

The selected cost center is respected. (Easiest way to verify this is to examine the `d_b_users.usageAttributionId` field in the db). 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
- [x] /werft with-payment
