### PR TITLE
[gpctl] Add node to workspace list output

### DIFF
--- a/dev/gpctl/cmd/workspaces-list.go
+++ b/dev/gpctl/cmd/workspaces-list.go
@@ -41,6 +41,7 @@ var workspacesListCmd = &cobra.Command{
 			Type        string
 			Pod         string
 			Active      bool
+			Node        string
 		}
 
 		var out []PrintWorkspace
@@ -65,12 +66,13 @@ var workspacesListCmd = &cobra.Command{
 				Type:        w.GetSpec().GetType().String(),
 				Pod:         pod,
 				Active:      w.GetConditions().FirstUserActivity != nil,
+				Node:        w.Runtime.NodeName,
 			})
 		}
 
-		tpl := `OWNER	WORKSPACE	INSTANCE	PHASE	TYPE	POD	ACTIVE
+		tpl := `OWNER	WORKSPACE	INSTANCE	PHASE	TYPE	POD	ACTIVE	NODE
 {{- range . }}
-{{ .Owner }}	{{ .WorkspaceID }}	{{ .Instance }}	{{ .Phase }}	{{ .Type }}	{{ .Pod }}	{{ .Active -}}
+{{ .Owner }}	{{ .WorkspaceID }}	{{ .Instance }}	{{ .Phase }}	{{ .Type }}	{{ .Pod }}	{{ .Active }}	{{ .Node -}}
 {{ end }}
 `
 		err = getOutputFormat(tpl, "{.id}").Print(out)


### PR DESCRIPTION
## Description
Add node to workspace list output to make it easier to identify when failing workspaces cluster on a specific node.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
n.a.

## How to test
`gpctl workspaces list `

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
