### PR TITLE
[UBP] Remove team specific Stripe APIs from `server` JSON-RPC API

### DIFF
--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -294,8 +294,6 @@ export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, 
     getStripePortalUrl(attributionId: string): Promise<string>;
     getUsageLimit(attributionId: string): Promise<number | undefined>;
     setUsageLimit(attributionId: string, usageLimit: number): Promise<void>;
-    getUsageLimitForTeam(teamId: string): Promise<number | undefined>;
-    setUsageLimitForTeam(teamId: string, spendingLimit: number): Promise<void>;
 
     listUsage(req: ListUsageRequest): Promise<ListUsageResponse>;
 

--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -291,7 +291,6 @@ export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, 
     createOrUpdateStripeCustomerForTeam(teamId: string, currency: string): Promise<void>;
     createOrUpdateStripeCustomerForUser(currency: string): Promise<void>;
     subscribeToStripe(attributionId: string, setupIntentId: string): Promise<void>;
-    subscribeTeamToStripe(teamId: string, setupIntentId: string): Promise<void>;
     getStripePortalUrl(attributionId: string): Promise<string>;
     getStripePortalUrlForTeam(teamId: string): Promise<string>;
     getUsageLimit(attributionId: string): Promise<number | undefined>;

--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -292,7 +292,6 @@ export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, 
     createOrUpdateStripeCustomerForUser(currency: string): Promise<void>;
     subscribeToStripe(attributionId: string, setupIntentId: string): Promise<void>;
     getStripePortalUrl(attributionId: string): Promise<string>;
-    getStripePortalUrlForTeam(teamId: string): Promise<string>;
     getUsageLimit(attributionId: string): Promise<number | undefined>;
     setUsageLimit(attributionId: string, usageLimit: number): Promise<void>;
     getUsageLimitForTeam(teamId: string): Promise<number | undefined>;

--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -287,7 +287,6 @@ export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, 
     getStripePublishableKey(): Promise<string>;
     getStripeSetupIntentClientSecret(): Promise<string>;
     findStripeSubscriptionId(attributionId: string): Promise<string | undefined>;
-    findStripeSubscriptionIdForTeam(teamId: string): Promise<string | undefined>;
     createOrUpdateStripeCustomerForTeam(teamId: string, currency: string): Promise<void>;
     createOrUpdateStripeCustomerForUser(currency: string): Promise<void>;
     subscribeToStripe(attributionId: string, setupIntentId: string): Promise<void>;

--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -2269,17 +2269,6 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
         this.messageBus.notifyOnSubscriptionUpdate(ctx, attrId).catch();
     }
 
-    async getUsageLimitForTeam(ctx: TraceContext, teamId: string): Promise<number | undefined> {
-        const attributionId: AttributionId = { kind: "team", teamId: teamId };
-
-        return this.getUsageLimit(ctx, AttributionId.render(attributionId));
-    }
-
-    async setUsageLimitForTeam(ctx: TraceContext, teamId: string, usageLimit: number): Promise<void> {
-        const attributionId: AttributionId = { kind: "team", teamId: teamId };
-        return this.setUsageLimit(ctx, AttributionId.render(attributionId), usageLimit);
-    }
-
     async getNotifications(ctx: TraceContext): Promise<string[]> {
         const result = await super.getNotifications(ctx);
         const user = this.checkAndBlockUser("getNotifications");

--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -2087,11 +2087,6 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
         }
     }
 
-    async findStripeSubscriptionIdForTeam(ctx: TraceContext, teamId: string): Promise<string | undefined> {
-        const attributionId: AttributionId = { kind: "team", teamId: teamId };
-        return this.findStripeSubscriptionId(ctx, AttributionId.render(attributionId));
-    }
-
     async createOrUpdateStripeCustomerForTeam(ctx: TraceContext, teamId: string, currency: string): Promise<void> {
         const user = this.checkAndBlockUser("createOrUpdateStripeCustomerForTeam");
         const team = await this.guardTeamOperation(teamId, "update");

--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -2175,11 +2175,6 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
         }
     }
 
-    async subscribeTeamToStripe(ctx: TraceContext, teamId: string, setupIntentId: string): Promise<void> {
-        const attributionId: AttributionId = { kind: "team", teamId: teamId };
-        return this.subscribeToStripe(ctx, AttributionId.render(attributionId), setupIntentId);
-    }
-
     async getStripePortalUrl(ctx: TraceContext, attributionId: string): Promise<string> {
         const attrId = AttributionId.parse(attributionId);
         if (attrId === undefined) {

--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -2212,11 +2212,6 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
         return url;
     }
 
-    async getStripePortalUrlForTeam(ctx: TraceContext, teamId: string): Promise<string> {
-        const attributionId: AttributionId = { kind: "team", teamId: teamId };
-        return this.getStripePortalUrl(ctx, AttributionId.render(attributionId));
-    }
-
     async getUsageLimit(ctx: TraceContext, attributionId: string): Promise<number | undefined> {
         const attrId = AttributionId.parse(attributionId);
         if (attrId === undefined) {

--- a/components/server/src/auth/rate-limiter.ts
+++ b/components/server/src/auth/rate-limiter.ts
@@ -205,7 +205,6 @@ const defaultFunctions: FunctionsConfig = {
     createOrUpdateStripeCustomerForTeam: { group: "default", points: 1 },
     createOrUpdateStripeCustomerForUser: { group: "default", points: 1 },
     subscribeToStripe: { group: "default", points: 1 },
-    subscribeTeamToStripe: { group: "default", points: 1 },
     getStripePortalUrl: { group: "default", points: 1 },
     getStripePortalUrlForTeam: { group: "default", points: 1 },
     listUsage: { group: "default", points: 1 },

--- a/components/server/src/auth/rate-limiter.ts
+++ b/components/server/src/auth/rate-limiter.ts
@@ -201,7 +201,6 @@ const defaultFunctions: FunctionsConfig = {
     getStripePublishableKey: { group: "default", points: 1 },
     getStripeSetupIntentClientSecret: { group: "default", points: 1 },
     findStripeSubscriptionId: { group: "default", points: 1 },
-    findStripeSubscriptionIdForTeam: { group: "default", points: 1 },
     createOrUpdateStripeCustomerForTeam: { group: "default", points: 1 },
     createOrUpdateStripeCustomerForUser: { group: "default", points: 1 },
     subscribeToStripe: { group: "default", points: 1 },

--- a/components/server/src/auth/rate-limiter.ts
+++ b/components/server/src/auth/rate-limiter.ts
@@ -206,7 +206,6 @@ const defaultFunctions: FunctionsConfig = {
     createOrUpdateStripeCustomerForUser: { group: "default", points: 1 },
     subscribeToStripe: { group: "default", points: 1 },
     getStripePortalUrl: { group: "default", points: 1 },
-    getStripePortalUrlForTeam: { group: "default", points: 1 },
     listUsage: { group: "default", points: 1 },
     getBillingModeForTeam: { group: "default", points: 1 },
     getBillingModeForUser: { group: "default", points: 1 },

--- a/components/server/src/auth/rate-limiter.ts
+++ b/components/server/src/auth/rate-limiter.ts
@@ -218,8 +218,6 @@ const defaultFunctions: FunctionsConfig = {
     setUsageAttribution: { group: "default", points: 1 },
     getUsageLimit: { group: "default", points: 1 },
     setUsageLimit: { group: "default", points: 1 },
-    getUsageLimitForTeam: { group: "default", points: 1 },
-    setUsageLimitForTeam: { group: "default", points: 1 },
     getNotifications: { group: "default", points: 1 },
     getSupportedWorkspaceClasses: { group: "default", points: 1 },
 };

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -3158,13 +3158,6 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         throw new ResponseError(ErrorCodes.SAAS_FEATURE, `Not implemented in this version`);
     }
 
-    async getUsageLimitForTeam(ctx: TraceContext, teamId: string): Promise<number | undefined> {
-        throw new ResponseError(ErrorCodes.SAAS_FEATURE, `Not implemented in this version`);
-    }
-    async setUsageLimitForTeam(ctx: TraceContext, teamId: string, spendingLimit: number): Promise<void> {
-        throw new ResponseError(ErrorCodes.SAAS_FEATURE, `Not implemented in this version`);
-    }
-
     async setUsageAttribution(ctx: TraceContext, usageAttributionId: string): Promise<void> {
         const user = this.checkAndBlockUser("setUsageAttribution");
         try {

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -3130,9 +3130,6 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
     async findStripeSubscriptionId(ctx: TraceContext, attributionId: string): Promise<string | undefined> {
         throw new ResponseError(ErrorCodes.SAAS_FEATURE, `Not implemented in this version`);
     }
-    async findStripeSubscriptionIdForTeam(ctx: TraceContext, teamId: string): Promise<string | undefined> {
-        throw new ResponseError(ErrorCodes.SAAS_FEATURE, `Not implemented in this version`);
-    }
     async createOrUpdateStripeCustomerForTeam(ctx: TraceContext, teamId: string, currency: string): Promise<void> {
         throw new ResponseError(ErrorCodes.SAAS_FEATURE, `Not implemented in this version`);
     }

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -3139,9 +3139,6 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
     async createOrUpdateStripeCustomerForUser(ctx: TraceContext, currency: string): Promise<void> {
         throw new ResponseError(ErrorCodes.SAAS_FEATURE, `Not implemented in this version`);
     }
-    async subscribeTeamToStripe(ctx: TraceContext, teamId: string, setupIntentId: string): Promise<void> {
-        throw new ResponseError(ErrorCodes.SAAS_FEATURE, `Not implemented in this version`);
-    }
     async subscribeToStripe(ctx: TraceContext, attributionId: string, setupIntentId: string): Promise<void> {
         throw new ResponseError(ErrorCodes.SAAS_FEATURE, `Not implemented in this version`);
     }

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -3142,9 +3142,6 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
     async subscribeToStripe(ctx: TraceContext, attributionId: string, setupIntentId: string): Promise<void> {
         throw new ResponseError(ErrorCodes.SAAS_FEATURE, `Not implemented in this version`);
     }
-    async getStripePortalUrlForTeam(ctx: TraceContext, teamId: string): Promise<string> {
-        throw new ResponseError(ErrorCodes.SAAS_FEATURE, `Not implemented in this version`);
-    }
     async getStripePortalUrl(ctx: TraceContext, attributionId: string): Promise<string> {
         throw new ResponseError(ErrorCodes.SAAS_FEATURE, `Not implemented in this version`);
     }


### PR DESCRIPTION
## Description

As part of https://github.com/gitpod-io/gitpod/issues/12685, several server APIs were generalised to work on user attribution ids as well as team attribution ids:

* https://github.com/gitpod-io/gitpod/pull/12753
* https://github.com/gitpod-io/gitpod/pull/12876
* https://github.com/gitpod-io/gitpod/pull/12864
* https://github.com/gitpod-io/gitpod/pull/12767
* https://github.com/gitpod-io/gitpod/pull/12887

With https://github.com/gitpod-io/gitpod/pull/12942 and https://github.com/gitpod-io/gitpod/pull/12954, the more specific team-only APIs are no longer used by the dashboard and are safe to remove.

⚠️ https://github.com/gitpod-io/gitpod/pull/12942 and https://github.com/gitpod-io/gitpod/pull/12954 need to be deployed first ⚠️ 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

Part of https://github.com/gitpod-io/gitpod/issues/12685

## How to test

Signing up teams and individual users for UBP still works.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
- [x] /werft with-payment