### PR TITLE
[usage] Track last compelted ledger job time

### DIFF
--- a/components/usage/pkg/scheduler/job.go
+++ b/components/usage/pkg/scheduler/job.go
@@ -5,12 +5,9 @@
 package scheduler
 
 import (
-	"context"
 	"fmt"
 	"github.com/gitpod-io/gitpod/common-go/log"
-	v1 "github.com/gitpod-io/gitpod/usage-api/v1"
 	"github.com/robfig/cron"
-	"google.golang.org/protobuf/types/known/timestamppb"
 	"time"
 )
 
@@ -35,51 +32,6 @@ func NewPeriodicJobSpec(period time.Duration, id string, job Job) (JobSpec, erro
 		ID:       id,
 		Schedule: parsed,
 	}, nil
-}
-
-func NewLedgerTriggerJobSpec(schedule time.Duration, job Job) (JobSpec, error) {
-	return NewPeriodicJobSpec(schedule, "ledger", WithoutConcurrentRun(job))
-}
-
-func NewLedgerTrigger(usageClient v1.UsageServiceClient, billingClient v1.BillingServiceClient) *LedgerJob {
-	return &LedgerJob{
-		usageClient:   usageClient,
-		billingClient: billingClient,
-	}
-}
-
-type LedgerJob struct {
-	usageClient   v1.UsageServiceClient
-	billingClient v1.BillingServiceClient
-}
-
-func (r *LedgerJob) Run() (err error) {
-	ctx := context.Background()
-	now := time.Now().UTC()
-	hourAgo := now.Add(-1 * time.Hour)
-
-	logger := log.
-		WithField("from", hourAgo).
-		WithField("to", now)
-
-	logger.Info("Running ledger job. Reconciling usage records.")
-	_, err = r.usageClient.ReconcileUsage(ctx, &v1.ReconcileUsageRequest{
-		From: timestamppb.New(hourAgo),
-		To:   timestamppb.New(now),
-	})
-	if err != nil {
-		logger.WithError(err).Errorf("Failed to reconcile usage with ledger.")
-		return fmt.Errorf("failed to reconcile usage with ledger: %w", err)
-	}
-
-	logger.Info("Starting invoice reconciliation.")
-	_, err = r.billingClient.ReconcileInvoices(ctx, &v1.ReconcileInvoicesRequest{})
-	if err != nil {
-		logger.WithError(err).Errorf("Failed to reconcile invoices.")
-		return fmt.Errorf("failed to reconcile invoices: %w", err)
-	}
-
-	return nil
 }
 
 // WithoutConcurrentRun wraps a Job and ensures the job does not concurrently

--- a/components/usage/pkg/scheduler/ledger_job.go
+++ b/components/usage/pkg/scheduler/ledger_job.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package scheduler
+
+import (
+	"context"
+	"fmt"
+	"github.com/gitpod-io/gitpod/common-go/log"
+	v1 "github.com/gitpod-io/gitpod/usage-api/v1"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"time"
+)
+
+func NewLedgerTriggerJobSpec(schedule time.Duration, job Job) (JobSpec, error) {
+	return NewPeriodicJobSpec(schedule, "ledger", WithoutConcurrentRun(job))
+}
+
+func NewLedgerTrigger(usageClient v1.UsageServiceClient, billingClient v1.BillingServiceClient) *LedgerJob {
+	return &LedgerJob{
+		usageClient:   usageClient,
+		billingClient: billingClient,
+	}
+}
+
+type LedgerJob struct {
+	usageClient   v1.UsageServiceClient
+	billingClient v1.BillingServiceClient
+}
+
+func (r *LedgerJob) Run() (err error) {
+	defer func() {
+		reportLedgerCompleted(err)
+	}()
+
+	ctx := context.Background()
+	now := time.Now().UTC()
+	hourAgo := now.Add(-1 * time.Hour)
+
+	logger := log.
+		WithField("from", hourAgo).
+		WithField("to", now)
+
+	logger.Info("Running ledger job. Reconciling usage records.")
+	_, err = r.usageClient.ReconcileUsage(ctx, &v1.ReconcileUsageRequest{
+		From: timestamppb.New(hourAgo),
+		To:   timestamppb.New(now),
+	})
+	if err != nil {
+		logger.WithError(err).Errorf("Failed to reconcile usage with ledger.")
+		return fmt.Errorf("failed to reconcile usage with ledger: %w", err)
+	}
+
+	logger.Info("Starting invoice reconciliation.")
+	_, err = r.billingClient.ReconcileInvoices(ctx, &v1.ReconcileInvoicesRequest{})
+	if err != nil {
+		logger.WithError(err).Errorf("Failed to reconcile invoices.")
+		return fmt.Errorf("failed to reconcile invoices: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Adds a Gauge metric which tracks the last time we completed a scheduled ledger reconciliation. We'll use this metric to setup an alert for when we haven't completed a run succesfully for more than 1h (which could cause us to have gaps in the data).

This metric is setup the same way as other standard kube metrics- [see example](https://grafana.gitpod.io/explore?orgId=1&left=%7B%22datasource%22:%22P4169E866C3094E38%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22kube_job_status_start_time%7Bjob_name%3D%5C%22cert-manager-startupapicheck%5C%22%7D%22%7D%5D,%22range%22:%7B%22from%22:%22now-7d%22,%22to%22:%22now%22%7D%7D)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
