### PR TITLE
[usage] Update usage dashboard to track scheduled jobs

### DIFF
--- a/operations/observability/mixins/meta/dashboards/components/usage.json
+++ b/operations/observability/mixins/meta/dashboards/components/usage.json
@@ -24,8 +24,6 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 68,
-  "iteration": 1658784406433,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -51,6 +49,8 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -107,7 +107,8 @@
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
           "mode": "single",
@@ -141,6 +142,8 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -197,7 +200,8 @@
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
           "mode": "single",
@@ -240,9 +244,9 @@
         "x": 0,
         "y": 9
       },
-      "id": 2,
+      "id": 14,
       "panels": [],
-      "title": "Usage Controller",
+      "title": "Scheduled jobs",
       "type": "row"
     },
     {
@@ -257,6 +261,8 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "# of events",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -312,7 +318,8 @@
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
           "mode": "single",
@@ -326,8 +333,8 @@
             "uid": "P4169E866C3094E38"
           },
           "editorMode": "code",
-          "expr": "sum(increase(gitpod_usage_reconcile_started_total{cluster=~\"$cluster\"}[1m]))",
-          "legendFormat": "Reconcile started",
+          "expr": "sum(increase(gitpod_usage_scheduler_job_started_total{cluster=~\"$cluster\"}[1m])) by (job)",
+          "legendFormat": "{{job}} started",
           "range": true,
           "refId": "A"
         },
@@ -338,15 +345,15 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(increase(gitpod_usage_reconcile_completed_duration_seconds_count{cluster=~\"$cluster\"}[1m])) by (outcome)",
+          "expr": "sum(increase(gitpod_usage_scheduler_job_completed_seconds_count{cluster=~\"$cluster\"}[1m])) by (job, outcome)",
           "hide": false,
           "instant": false,
-          "legendFormat": "Reconcile completed: {{outcome}}",
+          "legendFormat": "{{job}} completed: {{outcome}}",
           "range": true,
           "refId": "B"
         }
       ],
-      "title": "Usage Controller Ticks",
+      "title": "Scheduled jobs started & completed",
       "type": "timeseries"
     },
     {
@@ -361,6 +368,8 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisGridShow": true,
             "axisLabel": "",
             "axisPlacement": "auto",
@@ -418,7 +427,8 @@
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
           "mode": "single",
@@ -432,7 +442,7 @@
             "uid": "P4169E866C3094E38"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.5, sum(rate(gitpod_usage_reconcile_completed_duration_seconds_bucket{cluster=~\"$cluster\"}[$__rate_interval])) by (le))",
+          "expr": "histogram_quantile(0.5, sum(rate(gitpod_usage_scheduler_job_completed_seconds_bucket{cluster=~\"$cluster\"}[$__rate_interval])) by (le))",
           "legendFormat": "50th percentile",
           "range": true,
           "refId": "A"
@@ -443,18 +453,18 @@
             "uid": "P4169E866C3094E38"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.9, sum(rate(gitpod_usage_reconcile_completed_duration_seconds_bucket{cluster=~\"$cluster\"}[$__rate_interval])) by (le))",
+          "expr": "histogram_quantile(0.9, sum(rate(gitpod_usage_scheduler_job_completed_seconds_bucket{cluster=~\"$cluster\"}[$__rate_interval])) by (le))",
           "hide": false,
           "legendFormat": "90th percentile",
           "range": true,
           "refId": "B"
         }
       ],
-      "title": "Tick Duration",
+      "title": "Scheduled job duration",
       "type": "timeseries"
     }
   ],
-  "schemaVersion": 36,
+  "schemaVersion": 37,
   "style": "dark",
   "tags": [],
   "templating": {
@@ -561,6 +571,6 @@
   "timezone": "utc",
   "title": "Component: Usage",
   "uid": "8W7P-jg4z",
-  "version": 8,
+  "version": 1,
   "weekStart": "monday"
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Fixes usage dashboard to correctly report scheduled jobs on the usage component.


<img width="1611" alt="Screenshot 2022-09-14 at 14 59 39" src="https://user-images.githubusercontent.com/1419286/190160700-982d38f2-1e0a-4aab-bc46-ce402639486a.png">


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
