### PR TITLE
[server] Every time we stop a workspace instance, log the reason why

### DIFF
--- a/components/server/ee/src/prebuilds/prebuild-manager.ts
+++ b/components/server/ee/src/prebuilds/prebuild-manager.ts
@@ -72,13 +72,14 @@ export class PrebuildManager {
                     for (const instance of prebuild.instances) {
                         log.info(
                             { userId: user.id, instanceId: instance.id, workspaceId: instance.workspaceId },
-                            "Aborting Prebuild workspace because a newer commit was pushed to the same branch.",
+                            "Cancelling Prebuild workspace because a newer commit was pushed to the same branch.",
                         );
                         results.push(
                             this.workspaceStarter.stopWorkspaceInstance(
                                 { span },
                                 instance.id,
                                 instance.region,
+                                "prebuild cancelled because a newer commit was pushed to the same branch",
                                 StopWorkspacePolicy.ABORT,
                             ),
                         );

--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -634,6 +634,7 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
                     ctx,
                     instance.id,
                     instance.region,
+                    "user blocked by admin",
                     StopWorkspacePolicy.IMMEDIATELY,
                 ),
             );
@@ -867,7 +868,7 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
 
         const workspace = await this.workspaceDb.trace(ctx).findById(workspaceId);
         if (workspace) {
-            await this.internalStopWorkspace(ctx, workspace, StopWorkspacePolicy.IMMEDIATELY, true);
+            await this.internalStopWorkspace(ctx, workspace, "stopped by admin", StopWorkspacePolicy.IMMEDIATELY, true);
         }
     }
 

--- a/components/server/src/user/user-deletion-service.ts
+++ b/components/server/src/user/user-deletion-service.ts
@@ -113,6 +113,10 @@ export class UserDeletionService {
             runningWorkspaces.map(async (info) => {
                 const wsi = info.latestInstance;
 
+                log.info({ workspaceId: info.workspace.id, instanceId: wsi.id }, "Stopping workspace instance", {
+                    reason: "deleting user",
+                });
+
                 const req = new StopWorkspaceRequest();
                 req.setId(wsi.id);
                 req.setPolicy(StopWorkspacePolicy.NORMALLY);

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -439,8 +439,12 @@ export class WorkspaceStarter {
         ctx: TraceContext,
         instanceId: string,
         instanceRegion: string,
+        reason: string,
         policy?: StopWorkspacePolicy,
     ): Promise<void> {
+        ctx.span?.setTag("stopWorkspaceReason", reason);
+        log.info({ instanceId }, "Stopping workspace instance", { reason });
+
         const req = new StopWorkspaceRequest();
         req.setId(instanceId);
         req.setPolicy(policy || StopWorkspacePolicy.NORMALLY);


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Every time we stop a workspace instance, log the reason why. This should help with debugging.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/12283

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
