### PR TITLE
Fix: remove global S3 access policy

### DIFF
--- a/install/infra/modules/eks/storage.tf
+++ b/install/infra/modules/eks/storage.tf
@@ -57,12 +57,6 @@ resource "aws_iam_user_policy_attachment" "attachment" {
   policy_arn = aws_iam_policy.policy[0].arn
 }
 
-resource "aws_iam_user_policy_attachment" "full_access_attachment" {
-  count      = var.create_external_storage ? 1 : 0
-  user       = aws_iam_user.bucket_storage[0].name
-  policy_arn = "arn:aws:iam::aws:policy/AmazonS3FullAccess"
-}
-
 resource "aws_iam_access_key" "bucket_storage_user" {
   count = var.create_external_storage ? 1 : 0
   user  = aws_iam_user.bucket_storage[0].name
@@ -127,12 +121,6 @@ resource "aws_iam_user_policy_attachment" "registry_attachment" {
   count      = var.create_external_storage_for_registry_backend ? 1 : 0
   user       = aws_iam_user.bucket_registry[count.index].name
   policy_arn = aws_iam_policy.policy_registry[count.index].arn
-}
-
-resource "aws_iam_user_policy_attachment" "full_access_registry_attachment" {
-  count      = var.create_external_storage_for_registry_backend ? 1 : 0
-  user       = aws_iam_user.bucket_registry[count.index].name
-  policy_arn = "arn:aws:iam::aws:policy/AmazonS3FullAccess"
 }
 
 resource "aws_iam_access_key" "bucket_registry_user" {


### PR DESCRIPTION
## Description
Fixes https://github.com/gitpod-io/gitpod/issues/12964

We no longer need to attach these policies to the S3 users we create in our terraform modules.

```release-note
No longer attaches `arn:aws:iam::aws:policy/AmazonS3FullAccess` to the IAM user accounts created in our AWS terraform reference infrastructure. This level of access is no longer required now that one can provide an S3 bucket to be used for object storage.
```