### PR TITLE
Correct AWS Terraform arch to contain correct S3 permissions

### DIFF
--- a/install/infra/modules/eks/storage.tf
+++ b/install/infra/modules/eks/storage.tf
@@ -31,9 +31,14 @@ data "aws_iam_policy_document" "s3_policy" {
       "s3:DeleteObject",
       "s3:AbortMultipartUpload"
     ]
-    resources = [
-      "arn:aws:s3:::${aws_s3_bucket.gitpod-storage[count.index].id}",
-    ]
+    resources = [aws_s3_bucket.gitpod-storage[count.index].arn]
+    effect    = "Allow"
+  }
+      statement {
+    actions   = ["s3:ListBucket",
+                "s3:GetBucketLocation",
+                "s3:ListBucketMultipartUploads"]
+    resources = [aws_s3_bucket.gitpod-storage[count.index].arn]
     effect    = "Allow"
   }
 }
@@ -97,9 +102,14 @@ data "aws_iam_policy_document" "s3_policy_registry" {
       "s3:DeleteObject",
       "s3:AbortMultipartUpload"
     ]
-    resources = [
-      "arn:aws:s3:::${aws_s3_bucket.gitpod-registry-backend[count.index].id}",
-    ]
+    resources = [ws_s3_bucket.gitpod-registry-backend[count.index].arn]
+    effect    = "Allow"
+  }
+  statement {
+    actions   = ["s3:ListBucket",
+                "s3:GetBucketLocation",
+                "s3:ListBucketMultipartUploads"]
+    resources = [aws_s3_bucket.gitpod-registry-backend[count.index].arn]
     effect    = "Allow"
   }
 }


### PR DESCRIPTION
## Description
When I removed the global access to fix https://github.com/gitpod-io/gitpod/issues/12964 it exposed the fact that our IAM permissions weren't correct to just use the S3 bucket.


```release-note
Attaches correct permissions to the IAM user to have correct level of access to just the single S3 bucket we create for that user.
```