### PR TITLE
[dashboard][protocol] Remove unused params from CreateProjectParams

### DIFF
--- a/components/dashboard/src/projects/NewProject.tsx
+++ b/components/dashboard/src/projects/NewProject.tsx
@@ -226,8 +226,6 @@ export default function NewProject() {
                 name: repo.name,
                 slug: repoSlug,
                 cloneUrl: repo.cloneUrl,
-                account: repo.account,
-                provider: selectedProviderHost,
                 ...(User.is(teamOrUser) ? { userId: teamOrUser.id } : { teamId: teamOrUser.id }),
                 appInstallationId: String(repo.installationId),
             });

--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -331,9 +331,7 @@ export interface RateLimiterError {
 
 export interface CreateProjectParams {
     name: string;
-    slug?: string;
-    account: string;
-    provider: string;
+    slug: string;
     cloneUrl: string;
     teamId?: string;
     userId?: string;


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

While reverse-engineering our `createProject` flow to identify [this workaround](https://github.com/gitpod-io/gitpod/issues/12970#issuecomment-1247024832), I noticed that we were populating two fields in `CreateProjectParams` that are not even read or stored anywhere. Thus, we can save ourselves the trouble.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

1. Creating Projects still works

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
