### PR TITLE
Draft: [bpf] respect container device cfg for allow list

### DIFF
--- a/components/ws-daemon/pkg/container/container.go
+++ b/components/ws-daemon/pkg/container/container.go
@@ -7,6 +7,7 @@ package container
 import (
 	"context"
 
+	containerdevices "github.com/opencontainers/runc/libcontainer/devices"
 	"golang.org/x/xerrors"
 )
 
@@ -47,6 +48,9 @@ type Runtime interface {
 
 	// IsContainerdReady returns is the status of containerd.
 	IsContainerdReady(ctx context.Context) (bool, error)
+
+	// ContainerExtraDeviceRules extracts cgroup device rules from a container selected by cgroup path
+	ContainerExtraDeviceRules(ctx context.Context, cgroupPath string) []*containerdevices.Rule
 }
 
 var (

--- a/components/ws-daemon/pkg/daemon/daemon.go
+++ b/components/ws-daemon/pkg/daemon/daemon.go
@@ -72,7 +72,9 @@ func NewDaemon(config Config, reg prometheus.Registerer) (*Daemon, error) {
 	cgroupPlugins, err := cgroup.NewPluginHost(config.CPULimit.CGroupBasePath,
 		&cgroup.CacheReclaim{},
 		&cgroup.FuseDeviceEnablerV1{},
-		&cgroup.FuseDeviceEnablerV2{},
+		&cgroup.FuseDeviceEnablerV2{
+			Runtime: containerRuntime,
+		},
 		cgroupV1IOLimiter,
 		cgroupV2IOLimiter,
 		&cgroup.ProcessPriorityV2{


### PR DESCRIPTION
## Description

This is a draft of custom device support as needed in #8396. I'm neither a Go-developer nor very familiar with the gitpod codebase. I just wanted to draft these changes to see if it can work and to discuss it further because we need custom device support desperately. These changes are not tested (because I wasn't able to build the service) and probably need to be redone properly. Especially the injection of the runtime due to the limited cgroup Plugin interface is unfortunate.

The issue these changes address is, that gitpod creates a very static cgroup-device-bpf-progeam since fuse CgroupV2 support landed in #8769. This disregards any device settings a Kubernetes device plugin has made to this container. These changes try to fetch the actual device allow-list from the container, combine them with the static defaults and inject the fuse rule before the BPF program is created.

## Related Issue(s)

#8769
#8396

## How to test
The easiest way is to use the [smarter-device-manager](https://gitlab.com/arm-research/smarter/smarter-device-manager) and a custom MuattingAdmissionWebhook to inject device resources into the pod manifests.

## Release Notes
```release-notes
[ws-daemon] Add support for Kubernetes device plugin allow-list
```
