### PR TITLE
[installer-tests] Surround  the GCP password with quotes

### DIFF
--- a/install/tests/manifests/kots-config-gcp-db.yaml
+++ b/install/tests/manifests/kots-config-gcp-db.yaml
@@ -18,5 +18,5 @@ spec:
         value: ${DB_USER}
         data: "db_username"
       db_password:
-        value: ${DB_PASSWORD}
+        value: "${DB_PASSWORD}"
         data: "db_password"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PR fixes the occasional GCP database connection failures that happen in running automated tests. Since we allow special characters, sometimes this causes errors in `yq m` command we use to merge configs.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
```
werft run github -j .werft/gke-installer-tests.yaml -a deps=external
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
