### PR TITLE
Unset GOFLAGS from Dockerfile and update images

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
-image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:pd-dev-upgrade.0
+image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aa-unset-goflags.0
 workspaceLocation: gitpod/gitpod-ws.code-workspace
 checkoutLocation: gitpod
 ports:

--- a/.werft/aks-installer-tests.yaml
+++ b/.werft/aks-installer-tests.yaml
@@ -53,7 +53,7 @@ pod:
       secretName: sh-playground-dns-perm
   containers:
   - name: nightly-test
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:pd-dev-upgrade.0
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aa-unset-goflags.0
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/build.yaml
+++ b/.werft/build.yaml
@@ -75,7 +75,7 @@ pod:
     - name: MYSQL_TCP_PORT
       value: 23306
   - name: build
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:pd-dev-upgrade.0
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aa-unset-goflags.0
     workingDir: /workspace
     imagePullPolicy: IfNotPresent
     resources:

--- a/.werft/cleanup-installer-tests.yaml
+++ b/.werft/cleanup-installer-tests.yaml
@@ -24,7 +24,7 @@ pod:
       secretName: aks-credentials
   containers:
   - name: nightly-test
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:pd-dev-upgrade.0
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aa-unset-goflags.0
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/debug.yaml
+++ b/.werft/debug.yaml
@@ -53,7 +53,7 @@ pod:
     - name: MYSQL_TCP_PORT
       value: 23306
   - name: build
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:pd-dev-upgrade.0
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aa-unset-goflags.0
     workingDir: /workspace
     imagePullPolicy: IfNotPresent
     volumeMounts:

--- a/.werft/eks-installer-tests.yaml
+++ b/.werft/eks-installer-tests.yaml
@@ -53,7 +53,7 @@ pod:
       secretName: sh-playground-dns-perm
   containers:
   - name: nightly-test
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:pd-dev-upgrade.0
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aa-unset-goflags.0
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/gke-installer-tests.yaml
+++ b/.werft/gke-installer-tests.yaml
@@ -53,7 +53,7 @@ pod:
         secretName: sh-playground-dns-perm
   containers:
     - name: nightly-test
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:pd-dev-upgrade.0
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aa-unset-goflags.0
       workingDir: /workspace
       imagePullPolicy: Always
       volumeMounts:

--- a/.werft/ide-integration-tests-startup.yaml
+++ b/.werft/ide-integration-tests-startup.yaml
@@ -16,7 +16,7 @@ pod:
         secretName: github-token-gitpod-bot
   containers:
     - name: gcloud
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:pd-dev-upgrade.0
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aa-unset-goflags.0
       workingDir: /workspace
       imagePullPolicy: IfNotPresent
       env:

--- a/.werft/k3s-installer-tests.yaml
+++ b/.werft/k3s-installer-tests.yaml
@@ -53,7 +53,7 @@ pod:
       secretName: sh-playground-dns-perm
   containers:
   - name: nightly-test
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:pd-dev-upgrade.0
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aa-unset-goflags.0
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/platform-delete-preview-environments-cron.yaml
+++ b/.werft/platform-delete-preview-environments-cron.yaml
@@ -24,7 +24,7 @@ pod:
         secretName: harvester-vm-ssh-keys
   containers:
     - name: build
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:pd-dev-upgrade.0
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aa-unset-goflags.0
       workingDir: /workspace
       imagePullPolicy: IfNotPresent
       volumeMounts:

--- a/.werft/platform-trigger-werft-cleanup.yaml
+++ b/.werft/platform-trigger-werft-cleanup.yaml
@@ -21,7 +21,7 @@ pod:
         secretName: gcp-sa-gitpod-dev-deployer
   containers:
     - name: build
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:pd-dev-upgrade.0
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aa-unset-goflags.0
       workingDir: /workspace
       imagePullPolicy: IfNotPresent
       volumeMounts:

--- a/.werft/run-integration-tests.yaml
+++ b/.werft/run-integration-tests.yaml
@@ -22,7 +22,7 @@ pod:
       emptyDir: {}
   initContainers:
     - name: gcloud
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:pd-dev-upgrade.0
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aa-unset-goflags.0
       workingDir: /workspace
       imagePullPolicy: IfNotPresent
       volumeMounts:

--- a/.werft/workspace-run-integration-tests.yaml
+++ b/.werft/workspace-run-integration-tests.yaml
@@ -21,7 +21,7 @@ pod:
         secretName: github-token-gitpod-bot
   containers:
     - name: gcloud
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:pd-dev-upgrade.0
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aa-unset-goflags.0
       workingDir: /workspace
       imagePullPolicy: IfNotPresent
       env:

--- a/dev/image/Dockerfile
+++ b/dev/image/Dockerfile
@@ -137,9 +137,6 @@ RUN bash -c ". .nvm/nvm.sh \
     && npm install -g typescript yarn"
 ENV PATH=/home/gitpod/.nvm/versions/node/v${GITPOD_NODE_VERSION}/bin:$PATH
 
-# Go
-ENV GOFLAGS="-mod=readonly"
-
 ## Register leeway autocompletion in bashrc
 RUN bash -c "echo . \<\(leeway bash-completion\) >> ~/.bashrc"
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
`-mod=readonly` is the default option (since 1.14) if there is no vendor directory present (and we don't vendor anything from what I can see). This flag was set [~2y ago](https://github.com/gitpod-io/gitpod/commit/206fcf90c16c94593bcc60878f8aa65c7c9d2df9).

Not entirely sure the exact interaction which leads to the issue - I imagine it might be some weird combination of `gitpod-io/gitpod` being a monorepo with multiple `go.mod` files and not using workspaces ¯\_(ツ)_/¯ But ultimately it does fix installing/updating packages that rely on 1.18+

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://gitpod.slack.com/archives/C032A46PWR0/p1663224067876619

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
