### PR TITLE
Rename beta label on the usage page

### DIFF
--- a/components/dashboard/src/components/UsageView.tsx
+++ b/components/dashboard/src/components/UsageView.tsx
@@ -185,7 +185,7 @@ function UsageView({ attributionId, billingMode }: UsageViewProps) {
                                                     type="warn"
                                                     className="font-semibold mt-2 ml-0 py-0.5 px-1 self-center"
                                                 >
-                                                    <span className="text-xs">Beta</span>
+                                                    <span className="text-xs">Early Access</span>
                                                 </PillLabel>
                                                 <br />
                                                 <a


### PR DESCRIPTION
## Description

Following up from https://github.com/gitpod-io/gitpod/pull/12412#issuecomment-1246678522, since https://github.com/gitpod-io/website/pull/2715 is now merged, this will rename the _Beta_ label on the usage page to _Early Access_.

## How to test

1. Enable usage-based pricing for a team.
2. Go to team usage page.
3. Notice the new Early Access label on the left sidebar. 👀 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [X] /werft with-preview
- [X] /werft with-payment
