### PR TITLE
ws-manager: fix event workers hang forever

### DIFF
--- a/components/ws-manager/pkg/manager/manager.go
+++ b/components/ws-manager/pkg/manager/manager.go
@@ -453,8 +453,9 @@ func (m *Manager) restoreVolumeSnapshotFromHandle(ctx context.Context, id, handl
 	snapshotContentName := "restored-" + id
 	volumeSnapshot := &volumesnapshotv1.VolumeSnapshot{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      id,
-			Namespace: m.Config.Namespace,
+			Name:        id,
+			Namespace:   m.Config.Namespace,
+			Annotations: map[string]string{workspaceIDAnnotation: id},
 		},
 		Spec: volumesnapshotv1.VolumeSnapshotSpec{
 			Source: volumesnapshotv1.VolumeSnapshotSource{

--- a/components/ws-manager/pkg/manager/monitor.go
+++ b/components/ws-manager/pkg/manager/monitor.go
@@ -200,11 +200,10 @@ func (m *Monitor) onVolumesnapshotEvent(evt watch.Event) error {
 	}
 
 	m.notifyPodMapLock.Lock()
-	if m.notifyPod[podName] == nil {
-		m.notifyPod[podName] = make(chan string)
+	if m.notifyPod[podName] != nil {
+		m.notifyPod[podName] <- vsc
 	}
 	m.notifyPodMapLock.Unlock()
-	m.notifyPod[podName] <- vsc
 
 	return nil
 }

--- a/components/ws-manager/pkg/manager/monitor.go
+++ b/components/ws-manager/pkg/manager/monitor.go
@@ -1128,9 +1128,10 @@ func (m *Monitor) finalizeWorkspaceContent(ctx context.Context, wso *workspaceOb
 				// create snapshot object out of PVC
 				volumeSnapshot := &volumesnapshotv1.VolumeSnapshot{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      pvcVolumeSnapshotName,
-						Namespace: m.manager.Config.Namespace,
-						Labels:    wso.Pod.Labels,
+						Name:        pvcVolumeSnapshotName,
+						Namespace:   m.manager.Config.Namespace,
+						Annotations: map[string]string{workspaceIDAnnotation: workspaceID},
+						Labels:      wso.Pod.Labels,
 					},
 					Spec: volumesnapshotv1.VolumeSnapshotSpec{
 						Source: volumesnapshotv1.VolumeSnapshotSource{

--- a/components/ws-manager/pkg/manager/volume_snapshot_controller.go
+++ b/components/ws-manager/pkg/manager/volume_snapshot_controller.go
@@ -37,6 +37,11 @@ func (r *VolumeSnapshotReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		return reconcile.Result{}, nil
 	}
 
+	queue := vs.Annotations[workspaceIDAnnotation]
+	if queue == "" {
+		return ctrl.Result{}, nil
+	}
+
 	r.Monitor.eventpool.Add(vs.Name, watch.Event{
 		Type:   watch.Modified,
 		Object: &vs,


### PR DESCRIPTION
Fix workers hang if there are over 100 VolumeSnapshot is ready, and we restart the ws-manager.
The `m.notifyPod` channel is no receiver, and it causes the 100 event workers to hang forever.
So, the ws-manager can't handle any workspace pod event and volume snapshot event changes.

## Description
<!-- Describe your changes in detail -->
Fix event workers hang if there are 100+ VolumeSnapshot ready and ws-manager restarts.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #13007

## How to test
<!-- Provide steps to test this PR -->
- Prepare Pod yaml manifest and save it as `pod.yaml`.
    ```yaml
    apiVersion: v1
    kind: Pod
    metadata:
      name: test
    spec:
      containers:
      - name: test
        image: alpine:latest
        volumeMounts:
        - name: volv
          mountPath: /data
      volumes:
      - name: volv
        persistentVolumeClaim:
          claimName: test
    ```
- Prepare PVC yaml manifest and save it as `pvc.yaml`.
    ```yaml
    apiVersion: v1
    kind: PersistentVolumeClaim
    metadata:
      name: test
    spec:
      accessModes:
        - ReadWriteOnce
      storageClassName: rook-ceph-block
      resources:
        requests:
          storage: 1Mi
    ```

- Prepare VolumeSnapshot yaml manifest and save it as `vs-0.yaml`.
    ```yaml
    apiVersion: snapshot.storage.k8s.io/v1
    kind: VolumeSnapshot
    metadata:
      name: test-0
      annotations:
        gitpod/id: test-0
    spec:
      volumeSnapshotClassName: csi-rbdplugin-snapclass
      source:
        persistentVolumeClaimName: test
    ```

- Prepare 100 VolumeSnapshot yaml manifest.
   ```console
   for i in {1..100}; do cp vs-0.yaml vs-${i}.yaml; sed -i "s/-0/-${i}/g" vs-${i}.yaml; done
   ```

- Prepare Pod and PVC.
   ```console
   kubectl create -f pod.yaml -f pvc.yaml
   ```

- Wait the Pod is running and PVC is bound.

- Prepare 100 VolumeSnapshots.
   ```console
   for i in {1..100}; do kubectl apply -f vs-${i}.yaml; done
   ```

- Waits for all the 100 VolumeSnapshots become ready.
    ```console
    kubectl get vs | grep true | wc -l
    ```

- Restart ws-manager
   ```console
   kubectl rollout restart deploy ws-manager
   ```

- Make sure the workspace can start.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
None

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
