### PR TITLE
Move leeway vet to validate

### DIFF
--- a/.werft/jobs/build/build-and-publish.ts
+++ b/.werft/jobs/build/build-and-publish.ts
@@ -35,7 +35,7 @@ export async function buildAndPublish(werft: Werft, jobConfig: JobConfig) {
     exec(
         `LICENCE_HEADER_CHECK_ONLY=true leeway run components:update-license-header || { echo "[build|FAIL] There are some license headers missing. Please run 'leeway run components:update-license-header'."; exit 1; }`,
     );
-    exec(`leeway vet --ignore-warnings`);
+
     exec(
         `leeway build --docker-build-options network=host --werft=true -c remote ${
             dontTest ? "--dont-test" : ""

--- a/.werft/jobs/build/validate-changes.ts
+++ b/.werft/jobs/build/validate-changes.ts
@@ -5,7 +5,12 @@ import { JobConfig } from "./job-config";
 export async function validateChanges(werft: Werft, config: JobConfig) {
     werft.phase("validate-changes", "validating changes");
     try {
-        await Promise.all([branchNameCheck(werft, config), preCommitCheck(werft), typecheckWerftJobs(werft)]);
+        await Promise.all([
+            branchNameCheck(werft, config),
+            preCommitCheck(werft),
+            typecheckWerftJobs(werft),
+            leewayVet(werft),
+        ]);
     } catch (err) {
         werft.fail("validate-changes", err);
     }
@@ -57,6 +62,18 @@ export async function typecheckWerftJobs(werft: Werft) {
         werft.log(slice, "No compilation errors");
     } catch (e) {
         werft.fail(slice, e);
+    }
+    werft.done(slice);
+}
+
+export async function leewayVet(werft: Werft) {
+    const slice = "leeway vet --ignore-warnings"
+    try {
+        werft.log(slice, "Running leeway vet")
+        await exec(`leeway vet --ignore-warnings`, {slice, async: true});
+        werft.log(slice, "leeway vet successful")
+    } catch (e) {
+        werft.fail(slice, e)
     }
     werft.done(slice);
 }


### PR DESCRIPTION
## Description

This follows up on https://github.com/gitpod-io/gitpod/pull/12998 and adds `leeway vet` to the Validating changes phase too to catch such issues early on.

It also means we save 7 seconds as this was otherwise running sequentially as part of the build

<img width="1100" alt="Screenshot 2022-09-15 at 15 06 02" src="https://user-images.githubusercontent.com/83561/190411449-34e7e841-7920-4e52-9325-9f4c327e62a8.png">

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
No issue, just feeling like doing some minor cleanups.

## How to test
<!-- Provide steps to test this PR -->

```sh
werft job run github
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
