### PR TITLE
Revert "previews: Trigger artificial traffic every 2 hours"

### DIFF
--- a/.werft/platform-trigger-artificial-job.yaml
+++ b/.werft/platform-trigger-artificial-job.yaml
@@ -45,4 +45,4 @@ pod:
         - .werft/platform-trigger-artificial-job.sh
 
 plugins:
-  cron: "0 */2 * * *" # Every 2 hours
+  cron: "*/30 * * * *" # Every 30 minutes


### PR DESCRIPTION
Now that https://github.com/gitpod-io/gitpod/pull/12784 got merged, we can revert gitpod-io/gitpod#12928

```release-note
NONE
```