### PR TITLE
[obs] Fix display of network limiting stats

### DIFF
--- a/operations/observability/mixins/workspace/dashboards/network-limiting.json
+++ b/operations/observability/mixins/workspace/dashboards/network-limiting.json
@@ -1,35 +1,4 @@
 {
-  "__inputs": [
-    {
-      "name": "DS_PROMETHEUS",
-      "label": "prometheus",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "prometheus",
-      "pluginName": "Prometheus"
-    }
-  ],
-  "__elements": {},
-  "__requires": [
-    {
-      "type": "grafana",
-      "id": "grafana",
-      "name": "Grafana",
-      "version": "9.1.0"
-    },
-    {
-      "type": "datasource",
-      "id": "prometheus",
-      "name": "Prometheus",
-      "version": "1.0.0"
-    },
-    {
-      "type": "panel",
-      "id": "timeseries",
-      "name": "Time series",
-      "version": ""
-    }
-  ],
   "annotations": {
     "list": [
       {
@@ -56,14 +25,13 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": null,
   "links": [],
   "liveNow": false,
   "panels": [
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -140,26 +108,13 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(gitpod_ws_daemon_netlimit_connections_dropped_packets{node=~\"$node\", workspace=~\"$workspace\"}) by (node, workspace)\n",
-          "interval": "",
+          "expr": "sum(gitpod_ws_daemon_netlimit_connections_dropped_packets{node=~\"$node\", workspace=~\"$workspace\"}) by(node, workspace)",
           "legendFormat": "{{workspace}}",
           "range": true,
           "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "builder",
-          "expr": "",
-          "hide": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "B"
         }
       ],
       "title": "Dropped packets",
@@ -168,7 +123,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -245,7 +200,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "sum(gitpod_ws_daemon_netlimit_connections_dropped_bytes{node=~\"$node\", workspace=~\"$workspace\"}) by (node, workspace)",
@@ -266,15 +221,16 @@
       {
         "current": {
           "selected": false,
-          "text": "prometheus",
-          "value": "prometheus"
+          "text": "VictoriaMetrics",
+          "value": "VictoriaMetrics"
         },
-        "hide": 0,
+        "hide": 2,
         "includeAll": false,
         "multi": false,
         "name": "datasource",
         "options": [],
         "query": "prometheus",
+        "queryValue": "",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -284,9 +240,9 @@
         "current": {},
         "datasource": {
           "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
+          "uid": "${datasource}"
         },
-        "definition": "label_values(kube_node_labels{nodepool=\"workspace-pool\"}, node)",
+        "definition": "label_values(gitpod_ws_daemon_netlimit_connections_dropped_bytes,node)",
         "hide": 0,
         "includeAll": false,
         "label": "Node",
@@ -294,7 +250,7 @@
         "name": "node",
         "options": [],
         "query": {
-          "query": "label_values(kube_node_labels{nodepool=\"workspace-pool\"}, node)",
+          "query": "label_values(gitpod_ws_daemon_netlimit_connections_dropped_bytes,node)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,
@@ -307,17 +263,17 @@
         "current": {},
         "datasource": {
           "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
+          "uid": "${datasource}"
         },
-        "definition": "label_values(kube_pod_labels{component=\"workspace\"}, pod)",
+        "definition": "label_values(gitpod_ws_daemon_netlimit_connections_dropped_bytes{node=\"$node\"},workspace)",
         "hide": 0,
         "includeAll": true,
         "label": "Workspace",
-        "multi": false,
+        "multi": true,
         "name": "workspace",
         "options": [],
         "query": {
-          "query": "label_values(kube_pod_labels{component=\"workspace\"}, pod)",
+          "query": "label_values(gitpod_ws_daemon_netlimit_connections_dropped_bytes{node=\"$node\"},workspace)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,
@@ -336,6 +292,6 @@
   "timezone": "",
   "title": "Network limiting",
   "uid": "-q-ZCsW4z",
-  "version": 24,
+  "version": 1,
   "weekStart": ""
 }


### PR DESCRIPTION
## Description
- Ensure data source is selected
- Use network limiting stats for sourcing workspace and node labels

## Related Issue(s)
n.a.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
