### PR TITLE
Add support for JetBrains Gateway 2022.3

### DIFF
--- a/components/ide/jetbrains/gateway-plugin/build.gradle.kts
+++ b/components/ide/jetbrains/gateway-plugin/build.gradle.kts
@@ -14,7 +14,7 @@ plugins {
     // Kotlin support - check the latest version at https://plugins.gradle.org/plugin/org.jetbrains.kotlin.jvm
     id("org.jetbrains.kotlin.jvm") version "1.7.0"
     // gradle-intellij-plugin - read more: https://github.com/JetBrains/gradle-intellij-plugin
-    id("org.jetbrains.intellij") version "1.7.0"
+    id("org.jetbrains.intellij") version "1.8.1"
     // gradle-changelog-plugin - read more: https://github.com/JetBrains/gradle-changelog-plugin
     id("org.jetbrains.changelog") version "1.1.2"
     // detekt linter - read more: https://detekt.github.io/detekt/gradle.html
@@ -79,16 +79,16 @@ detekt {
 tasks {
     // Set the compatibility versions to 1.8
     withType<JavaCompile> {
-        sourceCompatibility = "11"
-        targetCompatibility = "11"
+        sourceCompatibility = "17"
+        targetCompatibility = "17"
     }
     withType<KotlinCompile> {
-        kotlinOptions.jvmTarget = "11"
+        kotlinOptions.jvmTarget = "17"
         kotlinOptions.freeCompilerArgs = listOf("-Xjvm-default=enable")
     }
 
     withType<Detekt> {
-        jvmTarget = "11"
+        jvmTarget = "17"
     }
 
     test {

--- a/components/ide/jetbrains/gateway-plugin/build.gradle.kts
+++ b/components/ide/jetbrains/gateway-plugin/build.gradle.kts
@@ -77,7 +77,7 @@ detekt {
 }
 
 tasks {
-    // Set the compatibility versions to 1.8
+    // JetBrains Gateway 2022.3+ requires Source Compatibility set to 17.
     withType<JavaCompile> {
         sourceCompatibility = "17"
         targetCompatibility = "17"

--- a/components/ide/jetbrains/gateway-plugin/gradle.properties
+++ b/components/ide/jetbrains/gateway-plugin/gradle.properties
@@ -6,15 +6,15 @@ pluginName=gitpod-gateway
 pluginVersion=0.0.1
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
-pluginSinceBuild=222.4167.26
-pluginUntilBuild=222.*
+pluginSinceBuild=223.926
+pluginUntilBuild=223.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions.
-pluginVerifierIdeVersions=2022.2
+pluginVerifierIdeVersions=2022.3
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#intellij-extension-type
 platformType=GW
 # Version from "com.jetbrains.gateway" which can be found at https://www.jetbrains.com/intellij-repository/snapshots
-platformVersion=222.4167.26-CUSTOM-SNAPSHOT
+platformVersion=223.926-CUSTOM-SNAPSHOT
 platformDownloadSources=true
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22

--- a/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodConnectorView.kt
+++ b/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodConnectorView.kt
@@ -31,7 +31,7 @@ class GitpodConnectorView(
         row {
             panel {
                 verticalAlign(VerticalAlign.BOTTOM)
-                separator(null, WelcomeScreenUIManager.getSeparatorColor())
+                separator(WelcomeScreenUIManager.getSeparatorColor())
                 indent {
                     row {
                         button("Back") {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Add support for JetBrains Gateway 2022.3.

This PR won't be merged. This was created just to build and upload it to the [Dev Channel of the Marketplace](https://plugins.jetbrains.com/plugin/18438-gitpod-gateway/versions/dev).

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```