### PR TITLE
[baseserver] Add metric with version of the server, use in public api and usage

### DIFF
--- a/components/common-go/baseserver/metrics.go
+++ b/components/common-go/baseserver/metrics.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package baseserver
+
+import (
+	"fmt"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	serverVersionGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "gitpod",
+		Subsystem: "server",
+		Name:      "version",
+		Help:      "Gauge of the current version of a gitpod server",
+	}, []string{"version"})
+)
+
+func registerMetrics(reg *prometheus.Registry) error {
+	metrics := []prometheus.Collector{
+		serverVersionGauge,
+	}
+	for _, metric := range metrics {
+		err := reg.Register(metric)
+		if err != nil {
+			return fmt.Errorf("failed to register metric: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func reportServerVersion(version string) {
+	serverVersionGauge.WithLabelValues(version).Set(1)
+}

--- a/components/common-go/baseserver/options.go
+++ b/components/common-go/baseserver/options.go
@@ -19,6 +19,9 @@ import (
 type options struct {
 	logger *logrus.Entry
 
+	// version is the version of this application
+	version string
+
 	config *Configuration
 
 	// closeTimeout is the amount we allow for the server to shut down cleanly
@@ -36,7 +39,8 @@ type options struct {
 
 func defaultOptions() *options {
 	return &options{
-		logger: log.New(),
+		logger:  log.New(),
+		version: "unknown",
 		config: &Configuration{
 			Services: ServicesConfiguration{
 				GRPC: nil, // disabled by default
@@ -57,6 +61,13 @@ type Option func(opts *options) error
 func WithConfig(config *Configuration) Option {
 	return func(opts *options) error {
 		opts.config = config
+		return nil
+	}
+}
+
+func WithVersion(version string) Option {
+	return func(opts *options) error {
+		opts.version = version
 		return nil
 	}
 }

--- a/components/common-go/baseserver/options_test.go
+++ b/components/common-go/baseserver/options_test.go
@@ -32,6 +32,7 @@ func TestOptions(t *testing.T) {
 		WithMetricsRegistry(registry),
 		WithHealthHandler(health),
 		WithGRPCHealthService(grpcHealthService),
+		WithVersion("foo-bar"),
 	}
 	actual, err := evaluateOptions(defaultOptions(), opts...)
 	require.NoError(t, err)
@@ -48,6 +49,7 @@ func TestOptions(t *testing.T) {
 		metricsRegistry: registry,
 		healthHandler:   health,
 		grpcHealthCheck: grpcHealthService,
+		version:         "foo-bar",
 	}
 
 	require.Equal(t, expected, actual)

--- a/components/common-go/baseserver/server.go
+++ b/components/common-go/baseserver/server.go
@@ -320,6 +320,13 @@ func (s *Server) initializeMetrics() error {
 		return fmt.Errorf("failed to register process collectors: %w", err)
 	}
 
+	err = registerMetrics(s.MetricsRegistry())
+	if err != nil {
+		return fmt.Errorf("failed to register baseserver metrics: %w", err)
+	}
+
+	reportServerVersion(s.options.version)
+
 	return nil
 }
 

--- a/components/public-api-server/cmd/run.go
+++ b/components/public-api-server/cmd/run.go
@@ -21,7 +21,7 @@ var runCommand = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		cfg := getConfig()
 
-		if err := server.Start(log.Log, cfg); err != nil {
+		if err := server.Start(log.Log, Version, cfg); err != nil {
 			log.WithError(err).Fatal("cannot start server")
 		}
 	},

--- a/components/public-api-server/pkg/server/server.go
+++ b/components/public-api-server/pkg/server/server.go
@@ -25,7 +25,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func Start(logger *logrus.Entry, cfg *config.Configuration) error {
+func Start(logger *logrus.Entry, version string, cfg *config.Configuration) error {
 	logger.WithField("config", cfg).Info("Starting public-api.")
 
 	gitpodAPI, err := url.Parse(cfg.GitpodServiceURL)
@@ -39,6 +39,7 @@ func Start(logger *logrus.Entry, cfg *config.Configuration) error {
 		baseserver.WithLogger(logger),
 		baseserver.WithConfig(cfg.Server),
 		baseserver.WithMetricsRegistry(registry),
+		baseserver.WithVersion(version),
 	)
 	if err != nil {
 		return fmt.Errorf("failed to initialize public api server: %w", err)

--- a/components/usage/cmd/run.go
+++ b/components/usage/cmd/run.go
@@ -37,7 +37,7 @@ func run() *cobra.Command {
 				log.WithError(err).Fatal("Failed to get config. Did you specify --config correctly?")
 			}
 
-			err = server.Start(cfg)
+			err = server.Start(cfg, Version)
 			if err != nil {
 				log.WithError(err).Fatal("Failed to start usage server.")
 			}

--- a/components/usage/pkg/server/server.go
+++ b/components/usage/pkg/server/server.go
@@ -40,7 +40,7 @@ type Config struct {
 	DefaultSpendingLimit db.DefaultSpendingLimit `json:"defaultSpendingLimit"`
 }
 
-func Start(cfg Config) error {
+func Start(cfg Config, version string) error {
 	log.WithField("config", cfg).Info("Starting usage component.")
 
 	conn, err := db.Connect(db.ConnectionParams{
@@ -53,7 +53,9 @@ func Start(cfg Config) error {
 		return fmt.Errorf("failed to establish database connection: %w", err)
 	}
 
-	var serverOpts []baseserver.Option
+	serverOpts := []baseserver.Option{
+		baseserver.WithVersion(version),
+	}
 	if cfg.Server != nil {
 		serverOpts = append(serverOpts, baseserver.WithConfig(cfg.Server))
 	}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

To be able to track which version we're on in our dashboards. Will produce the following metric:

```
gitpod_server_version{version="<version>"} 1
```

Once validated, I can also add this to other instances of baseserver

The approach to the metric with version is standard, see [docs](https://www.robustperception.io/exposing-the-software-version-to-prometheus/)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
