### PR TITLE
[codeowners] Remove individuals from ownership of content-service-api

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,7 +6,7 @@
 
 /components/blobserve @gitpod-io/engineering-ide
 /components/common-go @gitpod-io/engineering-workspace @gitpod-io/engineering-webapp
-/components/content-service-api @csweichel @geropl @corneliusludmann
+/components/content-service-api @gitpod-io/engineering-workspace
 /components/content-service @gitpod-io/engineering-workspace
 /components/dashboard @gitpod-io/engineering-webapp
 /components/docker-up @gitpod-io/engineering-workspace


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This PR removes individuals from codeowners of the content service. Depending on individuals is suboptimal as it introduces a bus factor when individuals are unavailable or on holidays.

This removes @geropl, @corneliusludmann and @csweichel and instead makes Team Workspace the owner.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
