### PR TITLE
Remove `d_b_workspace_instance_usage` from TableDescriptionProvider

### DIFF
--- a/components/gitpod-db/src/tables.ts
+++ b/components/gitpod-db/src/tables.ts
@@ -287,12 +287,6 @@ export class GitpodTableDescriptionProvider implements TableDescriptionProvider 
             timeColumn: "_lastModified",
         },
         {
-            name: "d_b_workspace_instance_usage",
-            primaryKeys: ["instanceId"],
-            deletionColumn: "deleted",
-            timeColumn: "_lastModified",
-        },
-        {
             name: "d_b_usage",
             primaryKeys: ["id"],
             timeColumn: "_lastModified",


### PR DESCRIPTION
## Description

Remove `d_b_workspace_instance_usage` from the table description provider that `db-sync` uses to generate a list of tables to sync.

This table was removed from the db in #12948.

With this non-existent table present in the list `db-sync` would show a warning on every sync:

```
{"@type":"type.googleapis.com/google.devtools.clouderrorreporting.v1beta1.ReportedErrorEvent","serviceContext":{"service":"db-sync","version":"<ts-not-set>"},"component":"db-sync","severity":"WARNING","time":"2022-09-16T07:51:10.741Z","message":"table d_b_workspace_instance_usage does not exist - not replicating"}
```

## Related Issue(s)
Relates to #12948.

## How to test

Hard to test as we don't run db-sync in preview.

## Release Notes
```release-note
NONE
```

## Documentation

## Werft options:

- [ ] /werft with-preview
