### PR TITLE
[server] Purge workspaces which are older than 2 years

### DIFF
--- a/install/installer/cmd/testdata/render/aws-setup/output.golden
+++ b/install/installer/cmd/testdata/render/aws-setup/output.golden
@@ -4255,7 +4255,7 @@ data:
         "minAgePrebuildDays": 7,
         "contentRetentionPeriodDays": 21,
         "contentChunkLimit": 1000,
-        "purgeRetentionPeriodDays": 1095,
+        "purgeRetentionPeriodDays": 730,
         "purgeChunkLimit": 1000
       },
       "authProviderConfigFiles": [],
@@ -8392,7 +8392,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 49fb17d3a5da86da4235edbf6ed37500f9b781371f6d605ee504e295f23d0aae
+        gitpod.io/checksum_config: 65e23bb77e8a1542e50114317fe7c1eb04cec9a5f4c82b11f8cf2a8d3b20c511
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/azure-setup/output.golden
+++ b/install/installer/cmd/testdata/render/azure-setup/output.golden
@@ -4119,7 +4119,7 @@ data:
         "minAgePrebuildDays": 7,
         "contentRetentionPeriodDays": 21,
         "contentChunkLimit": 1000,
-        "purgeRetentionPeriodDays": 1095,
+        "purgeRetentionPeriodDays": 730,
         "purgeChunkLimit": 1000
       },
       "authProviderConfigFiles": [],
@@ -8244,7 +8244,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 49fb17d3a5da86da4235edbf6ed37500f9b781371f6d605ee504e295f23d0aae
+        gitpod.io/checksum_config: 65e23bb77e8a1542e50114317fe7c1eb04cec9a5f4c82b11f8cf2a8d3b20c511
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -5056,7 +5056,7 @@ data:
         "minAgePrebuildDays": 7,
         "contentRetentionPeriodDays": 21,
         "contentChunkLimit": 1000,
-        "purgeRetentionPeriodDays": 1095,
+        "purgeRetentionPeriodDays": 730,
         "purgeChunkLimit": 1000
       },
       "authProviderConfigFiles": [],
@@ -9802,7 +9802,7 @@ spec:
     metadata:
       annotations:
         gitpod.io: hello
-        gitpod.io/checksum_config: aab520446d4937685907939b2aea9111f2a691427cb4bdbf1b586f1b15b10f08
+        gitpod.io/checksum_config: 57e826b6b832dd75e184270a64128d56d5122d45fa529acec7928ac6f640299d
         hello: world
       creationTimestamp: null
       labels:

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -4306,7 +4306,7 @@ data:
         "minAgePrebuildDays": 7,
         "contentRetentionPeriodDays": 21,
         "contentChunkLimit": 1000,
-        "purgeRetentionPeriodDays": 1095,
+        "purgeRetentionPeriodDays": 730,
         "purgeChunkLimit": 1000
       },
       "authProviderConfigFiles": [],
@@ -8670,7 +8670,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: bc10d1cc9e580a47b65956152d9caad8a870aba5ea805523e17282cb8533b8e8
+        gitpod.io/checksum_config: 5730cba43c5427db3f15e751144001295b81609822685e3baa945000fe1f6a32
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/gcp-setup/output.golden
+++ b/install/installer/cmd/testdata/render/gcp-setup/output.golden
@@ -4080,7 +4080,7 @@ data:
         "minAgePrebuildDays": 7,
         "contentRetentionPeriodDays": 21,
         "contentChunkLimit": 1000,
-        "purgeRetentionPeriodDays": 1095,
+        "purgeRetentionPeriodDays": 730,
         "purgeChunkLimit": 1000
       },
       "authProviderConfigFiles": [],
@@ -8173,7 +8173,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: be459a9d71866b87da87cd017d0063334112640ca956927773eb7adaf885c00b
+        gitpod.io/checksum_config: 966d2e2fee61a2269e648d2a2705eb7ccfc48460e97533ee77c7c857ffb1bb6b
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/http-proxy/output.golden
+++ b/install/installer/cmd/testdata/render/http-proxy/output.golden
@@ -4529,7 +4529,7 @@ data:
         "minAgePrebuildDays": 7,
         "contentRetentionPeriodDays": 21,
         "contentChunkLimit": 1000,
-        "purgeRetentionPeriodDays": 1095,
+        "purgeRetentionPeriodDays": 730,
         "purgeChunkLimit": 1000
       },
       "authProviderConfigFiles": [],
@@ -10091,7 +10091,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: bc10d1cc9e580a47b65956152d9caad8a870aba5ea805523e17282cb8533b8e8
+        gitpod.io/checksum_config: 5730cba43c5427db3f15e751144001295b81609822685e3baa945000fe1f6a32
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -4526,7 +4526,7 @@ data:
         "minAgePrebuildDays": 7,
         "contentRetentionPeriodDays": 21,
         "contentChunkLimit": 1000,
-        "purgeRetentionPeriodDays": 1095,
+        "purgeRetentionPeriodDays": 730,
         "purgeChunkLimit": 1000
       },
       "authProviderConfigFiles": [],
@@ -9045,7 +9045,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: bc10d1cc9e580a47b65956152d9caad8a870aba5ea805523e17282cb8533b8e8
+        gitpod.io/checksum_config: 5730cba43c5427db3f15e751144001295b81609822685e3baa945000fe1f6a32
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -4538,7 +4538,7 @@ data:
         "minAgePrebuildDays": 7,
         "contentRetentionPeriodDays": 21,
         "contentChunkLimit": 1000,
-        "purgeRetentionPeriodDays": 1095,
+        "purgeRetentionPeriodDays": 730,
         "purgeChunkLimit": 1000
       },
       "authProviderConfigFiles": [],
@@ -9057,7 +9057,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: bc10d1cc9e580a47b65956152d9caad8a870aba5ea805523e17282cb8533b8e8
+        gitpod.io/checksum_config: 5730cba43c5427db3f15e751144001295b81609822685e3baa945000fe1f6a32
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
+++ b/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
@@ -4859,7 +4859,7 @@ data:
         "minAgePrebuildDays": 7,
         "contentRetentionPeriodDays": 21,
         "contentChunkLimit": 1000,
-        "purgeRetentionPeriodDays": 1095,
+        "purgeRetentionPeriodDays": 730,
         "purgeChunkLimit": 1000
       },
       "authProviderConfigFiles": [],
@@ -9489,7 +9489,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: bc10d1cc9e580a47b65956152d9caad8a870aba5ea805523e17282cb8533b8e8
+        gitpod.io/checksum_config: 5730cba43c5427db3f15e751144001295b81609822685e3baa945000fe1f6a32
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
+++ b/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
@@ -4529,7 +4529,7 @@ data:
         "minAgePrebuildDays": 7,
         "contentRetentionPeriodDays": 21,
         "contentChunkLimit": 1000,
-        "purgeRetentionPeriodDays": 1095,
+        "purgeRetentionPeriodDays": 730,
         "purgeChunkLimit": 1000
       },
       "authProviderConfigFiles": [],
@@ -9048,7 +9048,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: bc10d1cc9e580a47b65956152d9caad8a870aba5ea805523e17282cb8533b8e8
+        gitpod.io/checksum_config: 5730cba43c5427db3f15e751144001295b81609822685e3baa945000fe1f6a32
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/pkg/components/server/configmap.go
+++ b/install/installer/pkg/components/server/configmap.go
@@ -193,7 +193,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 			ChunkLimit:                 1000,
 			ContentRetentionPeriodDays: 21,
 			ContentChunkLimit:          1000,
-			PurgeRetentionPeriodDays:   365 * 3,
+			PurgeRetentionPeriodDays:   365 * 2,
 			PurgeChunkLimit:            1000,
 		},
 		EnableLocalApp: enableLocalApp,


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Previously we set 3 years, which had no data. Going to 2 years now.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
