### PR TITLE
[kots]: note to explain the region limitation on registry S3 backing

### DIFF
--- a/install/kots/manifests/kots-config.yaml
+++ b/install/kots/manifests/kots-config.yaml
@@ -58,7 +58,7 @@ spec:
           required: true
           value: s3.amazonaws.com
           when: '{{repl and (ConfigOptionEquals "reg_incluster" "1") (ConfigOptionEquals "reg_incluster_storage" "s3") }}'
-          help_text: The endpoint used to connect to the S3 storage.
+          help_text: The endpoint used to connect to the S3 storage. If not using the `us-east-1` region, this should be `s3.<region>.amazonaws.com`.
 
         - name: reg_incluster_storage_s3_bucketname
           title: S3 bucket name


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
When creating an S3 backing to the in-cluster container registry, the `s3.amazonaws.com` endpoint only works if the bucket is in the `us-east-1` region. Without it, the registry healthcheck eventually reports a 503 error.

This documents the requirement in the KOTS dashboard.

## How to test
<!-- Provide steps to test this PR -->
N/A

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[kots]: note to explain the region limitation on registry S3 backing
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
