### PR TITLE
Use go to install latest obs-installer

### DIFF
--- a/.werft/observability/install-satellite.sh
+++ b/.werft/observability/install-satellite.sh
@@ -25,10 +25,11 @@ if ! command -v envsubst; then
 fi
 
 GOBIN=$(pwd) go install github.com/gitpod-io/observability/installer@main
+mv installer observability-installer
 
 tmpdir=$(mktemp -d)
 
-envsubst <"${SCRIPT_PATH}/manifests/monitoring-satellite.yaml" | ./installer render --output-split-files "${tmpdir}" --config -
+envsubst <"${SCRIPT_PATH}/manifests/monitoring-satellite.yaml" | ./observability-installer render --output-split-files "${tmpdir}" --config -
 
 pushd "${tmpdir}"
 
@@ -43,3 +44,5 @@ kubectl --kubeconfig "${KUBE_PATH}" apply --server-side -f .
 kubectl --kubeconfig "${KUBE_PATH}" patch deployments.apps -n monitoring-satellite grafana --type=json -p="[{'op': 'remove', 'path': '/spec/template/spec/nodeSelector'}]"
 
 popd
+
+rm observability-installer

--- a/.werft/observability/install-satellite.sh
+++ b/.werft/observability/install-satellite.sh
@@ -24,14 +24,11 @@ if ! command -v envsubst; then
   go install github.com/a8m/envsubst/cmd/envsubst@latest
 fi
 
-obsDir="${SCRIPT_PATH}/observability"
-mkdir -p "${obsDir}"
-git clone https://roboquat:"$(cat /mnt/secrets/monitoring-satellite-preview-token/token)"@github.com/gitpod-io/observability.git "${obsDir}"
-cd "${obsDir}/installer"
+GOBIN=$(pwd) go install github.com/gitpod-io/observability/installer@main
 
 tmpdir=$(mktemp -d)
 
-envsubst <"${SCRIPT_PATH}/manifests/monitoring-satellite.yaml" | go run main.go render --output-split-files "${tmpdir}" --config -
+envsubst <"${SCRIPT_PATH}/manifests/monitoring-satellite.yaml" | ./installer render --output-split-files "${tmpdir}" --config -
 
 pushd "${tmpdir}"
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
https://github.com/gitpod-io/gitpod/pull/12989 fixed the issue with installing the obs-installer, so we no longer need to clone the repository anymore.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
