### PR TITLE
Ensure error message for failed slices stay within the slice

### DIFF
--- a/.werft/build.ts
+++ b/.werft/build.ts
@@ -1,6 +1,6 @@
 import * as fs from "fs";
 import { SpanStatusCode } from "@opentelemetry/api";
-import { Werft } from "./util/werft";
+import { FailedSliceError, Werft } from "./util/werft";
 import { reportBuildFailureInSlack } from "./util/slack";
 import * as Tracing from "./observability/tracing";
 import * as VM from "./vm/vm";
@@ -27,7 +27,12 @@ Tracing.initialize()
             message: err,
         });
 
-        console.log("Error", err);
+        if (err instanceof FailedSliceError) {
+            // This error was produced using werft.fail which means that we
+            // already handled it "gracefully"
+        } else {
+            console.log("Error", err);
+        }
 
         if (context.Repository.ref === "refs/heads/main") {
             reportBuildFailureInSlack(context, err).catch((error: Error) => {

--- a/.werft/jobs/build/validate-changes.ts
+++ b/.werft/jobs/build/validate-changes.ts
@@ -4,17 +4,12 @@ import { JobConfig } from "./job-config";
 
 export async function validateChanges(werft: Werft, config: JobConfig) {
     werft.phase("validate-changes", "validating changes");
-    try {
-        await Promise.all([
-            branchNameCheck(werft, config),
-            preCommitCheck(werft),
-            typecheckWerftJobs(werft),
-            leewayVet(werft),
-        ]);
-    } catch (err) {
-        werft.fail("validate-changes", err);
-    }
-    werft.done("validate-changes");
+    await Promise.all([
+        branchNameCheck(werft, config),
+        preCommitCheck(werft),
+        typecheckWerftJobs(werft),
+        leewayVet(werft),
+    ]);
 }
 
 // Branch names cannot be longer than 45 characters.


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

### Background

The Werft log cutter expects each line of output to follow the specific format ([docs](https://github.com/csweichel/werft#log-cutting)). If no slice is specified in a log line then it will be attached to the "default" slice for that phase (which is a slice with the same id as the phase).

As we're just `console.log`'ing strings it means it's out responsibility to ensure we don't log multiline strings.

### The change

This PR improves our handling of slices that we explicitly fail using `werft.fail` in two  important ways:

1. Previously it would not handle multi-line error messages well which meant that the error message for a slice might get split between the slice that failed and the default slice for the phase.
2. `werft.fail` throws an error which will eventually bubble up to our main `catch` handler. In that handler we would `console.log` the error which meant that the error would always end up in the default slice (see screenshot below)

With this PR any place where we use `werft.fail` we'll now ensure the error is contained to the slice, which makes it much easier to understand why a slice failed.

### Implementation details

I have introduced a new custom error type `SliceFailedError` which we use in `werft.fail`. In the main `catch` handler we then don't perform any additional logging. 

Some other notes:

- it appears that when you use `[<slice>|FAIL] <reason>` Werft won't display the reason. Because of that I updated the code so the last log output for the slice is "Failed. Expand to see why" and I have left the fail reason blank.
- You can't `fail` or `done` a phase, only slices. I've updated `validate-changes.ts` so it doesn't try to do so. There are still many other places where we can make similar changes.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
No issue. Friday Tid(a)y

## How to test
<!-- Provide steps to test this PR -->

To test this I introduced a TS error in `build.ts` and side-loaded the error to ensure that the "tsc --noEmit" slice would fail. I did this on this branch and on a branch off main to show the the difference.

```
werft job run github -s .werft/build.ts
```

Before (branch off main)

<img width="1505" alt="Screenshot 2022-09-16 at 20 54 03" src="https://user-images.githubusercontent.com/83561/190711625-dc819db9-25fa-47e7-9a8a-cb5227b1d641.png">

After (this branch)

<img width="1510" alt="Screenshot 2022-09-16 at 20 56 02" src="https://user-images.githubusercontent.com/83561/190711647-3f578d6d-05c1-48d1-9999-9cd5ee3ae2bf.png">


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
