### PR TITLE
Force all the values redacted once one of the values matches redact fields

### DIFF
--- a/components/common-go/log/redact.go
+++ b/components/common-go/log/redact.go
@@ -64,6 +64,7 @@ func redactArray(data *[]interface{}) {
 
 func redactObject(data *map[string]interface{}) {
 	var forceRedact bool
+loop:
 	for k, v := range *data {
 		for _, prohibited := range redactedFields {
 			if strings.Contains(strings.ToLower(fmt.Sprintf("%v", k)), prohibited) {
@@ -81,8 +82,9 @@ func redactObject(data *map[string]interface{}) {
 			was := (*data)[k]
 			(*data)[k] = redactValue(&v)
 			if !reflect.DeepEqual(was, (*data)[k]) {
-				// force the rest values to redact
+				// force all the values redacted
 				forceRedact = true
+				goto loop
 			}
 		}
 	}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Since the map ordering is random, not by sequence or alphabetical order. Thank @svenefftinge points out.
So, we have to force all the values redacted once one of the values matches redact fields

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/security/issues/64

## How to test
<!-- Provide steps to test this PR -->
Check the unit test.
```console
cd component/common-go

# keep re-run this multiple times to make sure all test pass
go test -covermode atomic -run ^TestRedactJSON\$ github.com/gitpod-io/gitpod/common-go/log -timeout=60s -count=1 -race -v
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
None

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
