### PR TITLE
[code] update stable browser code to `1.71.2` release

### DIFF
--- a/install/installer/cmd/testdata/render/aws-setup/output.golden
+++ b/install/installer/cmd/testdata/render/aws-setup/output.golden
@@ -4337,7 +4337,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-ed7742cb06974f16fed3c6eab36ec746d94d774e",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2d7f400a0046e9793b88b28ce569e5ef02fa8ba2",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/azure-setup/output.golden
+++ b/install/installer/cmd/testdata/render/azure-setup/output.golden
@@ -4201,7 +4201,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-ed7742cb06974f16fed3c6eab36ec746d94d774e",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2d7f400a0046e9793b88b28ce569e5ef02fa8ba2",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -5143,7 +5143,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-ed7742cb06974f16fed3c6eab36ec746d94d774e",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2d7f400a0046e9793b88b28ce569e5ef02fa8ba2",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -4388,7 +4388,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-ed7742cb06974f16fed3c6eab36ec746d94d774e",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2d7f400a0046e9793b88b28ce569e5ef02fa8ba2",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/gcp-setup/output.golden
+++ b/install/installer/cmd/testdata/render/gcp-setup/output.golden
@@ -4162,7 +4162,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-ed7742cb06974f16fed3c6eab36ec746d94d774e",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2d7f400a0046e9793b88b28ce569e5ef02fa8ba2",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/http-proxy/output.golden
+++ b/install/installer/cmd/testdata/render/http-proxy/output.golden
@@ -4611,7 +4611,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-ed7742cb06974f16fed3c6eab36ec746d94d774e",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2d7f400a0046e9793b88b28ce569e5ef02fa8ba2",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -4608,7 +4608,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-ed7742cb06974f16fed3c6eab36ec746d94d774e",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2d7f400a0046e9793b88b28ce569e5ef02fa8ba2",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -4620,7 +4620,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-ed7742cb06974f16fed3c6eab36ec746d94d774e",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2d7f400a0046e9793b88b28ce569e5ef02fa8ba2",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
+++ b/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
@@ -4941,7 +4941,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-ed7742cb06974f16fed3c6eab36ec746d94d774e",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2d7f400a0046e9793b88b28ce569e5ef02fa8ba2",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
+++ b/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
@@ -4611,7 +4611,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-ed7742cb06974f16fed3c6eab36ec746d94d774e",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2d7f400a0046e9793b88b28ce569e5ef02fa8ba2",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/pkg/components/workspace/ide/constants.go
+++ b/install/installer/pkg/components/workspace/ide/constants.go
@@ -6,7 +6,7 @@ package ide
 
 const (
 	CodeIDEImage                = "ide/code"
-	CodeIDEImageStableVersion   = "commit-ed7742cb06974f16fed3c6eab36ec746d94d774e" // stable version that will be updated manually on demand
+	CodeIDEImageStableVersion   = "commit-2d7f400a0046e9793b88b28ce569e5ef02fa8ba2" // stable version that will be updated manually on demand
 	CodeDesktopIDEImage         = "ide/code-desktop"
 	CodeDesktopInsidersIDEImage = "ide/code-desktop-insiders"
 	IntelliJDesktopIDEImage     = "ide/intellij"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Upstream endgame https://github.com/microsoft/vscode/issues/160943. Also bring
- Extension installation metrics
- Resources load error report

commit hash comes from [werft job](https://werft.gitpod-dev.com/job/gitpod-build-hw-build-1712.0/results)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Relates https://github.com/gitpod-io/gitpod/issues/12470

## How to test
<!-- Provide steps to test this PR -->
- Open workspace in prev env with stable browser code as IDE
- Check if it works and commit hash should be `9ae312771e40d3399bac2b7b43c5bb4a1514517c` (In Browser VSCode About)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Update stable Browser Code to `1.71.2` release
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
