### PR TITLE
[content-service] Remove git no-single-branch flag

### DIFF
--- a/components/content-service/pkg/git/git.go
+++ b/components/content-service/pkg/git/git.go
@@ -328,7 +328,7 @@ func (c *Client) Clone(ctx context.Context) (err error) {
 		log.WithError(err).Error("cannot create clone location")
 	}
 
-	args := []string{"--depth=1", "--no-single-branch", c.RemoteURI}
+	args := []string{"--depth=1", c.RemoteURI}
 
 	for key, value := range c.Config {
 		args = append(args, "--config")


### PR DESCRIPTION
## Description

The flag `--no-single-branch` was introduced in https://github.com/gitpod-io/gitpod/pull/6464 in an attempt to use `--filter=blob:none` (which didn't make it). By checking all the existing branches, even if we use `--depth=1`

xref: https://github.com/gitpod-io/gitpod/issues/12682

## How to test
- Open a workspace
- Trigger a prebuild and open the workspace
- No errors should be present
 
## Release Notes
```release-note
Do not check all existing git branches during the initial checkout
```

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview

/hold
