### PR TITLE
fix: improve GoLang config inferrer

### DIFF
--- a/components/server/src/config/config-inferrer.spec.ts
+++ b/components/server/src/config/config-inferrer.spec.ts
@@ -221,7 +221,7 @@ describe("config inferrer", () => {
                     tasks: [
                         {
                             init: "go get && go build ./... && go test ./...",
-                            command: "go run",
+                            command: "go run .",
                         },
                     ],
                     vscode: {

--- a/components/server/src/config/config-inferrer.ts
+++ b/components/server/src/config/config-inferrer.ts
@@ -150,7 +150,7 @@ export class ConfigInferrer {
             this.addCommand(ctx.config, "go get", "init");
             this.addCommand(ctx.config, "go build ./...", "init");
             this.addCommand(ctx.config, "go test ./...", "init");
-            this.addCommand(ctx.config, "go run", "command");
+            this.addCommand(ctx.config, "go run .", "command");
             this.addExtension(ctx, "golang.go");
         }
     }


### PR DESCRIPTION

## Description
Currently, it runs `go run` which doesn't work. ([example repo used](https://github.com/the-eduardo/Go-Bank)). But it does, work with `go run .` (see below 👀)

![image](https://user-images.githubusercontent.com/55068936/190903521-b52bb6fe-6dca-4251-b6a6-1653daec3927.png)

_you can test out the same for other goLang based repos_

## How to test
<!-- Provide steps to test this PR -->
- Open [this repo](https://github.com/the-eduardo/Go-Bank) with new preview environment of this PR)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
improved automated code configuration service for `go`
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
Not Required

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview

---
Signed-off-by: Siddhant Khare <siddhant@gitpod.io>
