### PR TITLE
[usage] remove unused GetUpcomingInvoice

### DIFF
--- a/components/usage-api/go/v1/billing.pb.go
+++ b/components/usage-api/go/v1/billing.pb.go
@@ -100,158 +100,6 @@ func (*ReconcileInvoicesResponse) Descriptor() ([]byte, []int) {
 	return file_usage_v1_billing_proto_rawDescGZIP(), []int{1}
 }
 
-type GetUpcomingInvoiceRequest struct {
-	state         protoimpl.MessageState
-	sizeCache     protoimpl.SizeCache
-	unknownFields protoimpl.UnknownFields
-
-	// Types that are assignable to Identifier:
-	//
-	//	*GetUpcomingInvoiceRequest_TeamId
-	//	*GetUpcomingInvoiceRequest_UserId
-	Identifier isGetUpcomingInvoiceRequest_Identifier `protobuf_oneof:"identifier"`
-}
-
-func (x *GetUpcomingInvoiceRequest) Reset() {
-	*x = GetUpcomingInvoiceRequest{}
-	if protoimpl.UnsafeEnabled {
-		mi := &file_usage_v1_billing_proto_msgTypes[2]
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		ms.StoreMessageInfo(mi)
-	}
-}
-
-func (x *GetUpcomingInvoiceRequest) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*GetUpcomingInvoiceRequest) ProtoMessage() {}
-
-func (x *GetUpcomingInvoiceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_usage_v1_billing_proto_msgTypes[2]
-	if protoimpl.UnsafeEnabled && x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use GetUpcomingInvoiceRequest.ProtoReflect.Descriptor instead.
-func (*GetUpcomingInvoiceRequest) Descriptor() ([]byte, []int) {
-	return file_usage_v1_billing_proto_rawDescGZIP(), []int{2}
-}
-
-func (m *GetUpcomingInvoiceRequest) GetIdentifier() isGetUpcomingInvoiceRequest_Identifier {
-	if m != nil {
-		return m.Identifier
-	}
-	return nil
-}
-
-func (x *GetUpcomingInvoiceRequest) GetTeamId() string {
-	if x, ok := x.GetIdentifier().(*GetUpcomingInvoiceRequest_TeamId); ok {
-		return x.TeamId
-	}
-	return ""
-}
-
-func (x *GetUpcomingInvoiceRequest) GetUserId() string {
-	if x, ok := x.GetIdentifier().(*GetUpcomingInvoiceRequest_UserId); ok {
-		return x.UserId
-	}
-	return ""
-}
-
-type isGetUpcomingInvoiceRequest_Identifier interface {
-	isGetUpcomingInvoiceRequest_Identifier()
-}
-
-type GetUpcomingInvoiceRequest_TeamId struct {
-	TeamId string `protobuf:"bytes,1,opt,name=team_id,json=teamId,proto3,oneof"`
-}
-
-type GetUpcomingInvoiceRequest_UserId struct {
-	UserId string `protobuf:"bytes,2,opt,name=user_id,json=userId,proto3,oneof"`
-}
-
-func (*GetUpcomingInvoiceRequest_TeamId) isGetUpcomingInvoiceRequest_Identifier() {}
-
-func (*GetUpcomingInvoiceRequest_UserId) isGetUpcomingInvoiceRequest_Identifier() {}
-
-type GetUpcomingInvoiceResponse struct {
-	state         protoimpl.MessageState
-	sizeCache     protoimpl.SizeCache
-	unknownFields protoimpl.UnknownFields
-
-	InvoiceId string  `protobuf:"bytes,1,opt,name=invoice_id,json=invoiceId,proto3" json:"invoice_id,omitempty"`
-	Currency  string  `protobuf:"bytes,2,opt,name=currency,proto3" json:"currency,omitempty"`
-	Amount    float64 `protobuf:"fixed64,3,opt,name=amount,proto3" json:"amount,omitempty"`
-	Credits   int64   `protobuf:"varint,4,opt,name=credits,proto3" json:"credits,omitempty"`
-}
-
-func (x *GetUpcomingInvoiceResponse) Reset() {
-	*x = GetUpcomingInvoiceResponse{}
-	if protoimpl.UnsafeEnabled {
-		mi := &file_usage_v1_billing_proto_msgTypes[3]
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		ms.StoreMessageInfo(mi)
-	}
-}
-
-func (x *GetUpcomingInvoiceResponse) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*GetUpcomingInvoiceResponse) ProtoMessage() {}
-
-func (x *GetUpcomingInvoiceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_usage_v1_billing_proto_msgTypes[3]
-	if protoimpl.UnsafeEnabled && x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use GetUpcomingInvoiceResponse.ProtoReflect.Descriptor instead.
-func (*GetUpcomingInvoiceResponse) Descriptor() ([]byte, []int) {
-	return file_usage_v1_billing_proto_rawDescGZIP(), []int{3}
-}
-
-func (x *GetUpcomingInvoiceResponse) GetInvoiceId() string {
-	if x != nil {
-		return x.InvoiceId
-	}
-	return ""
-}
-
-func (x *GetUpcomingInvoiceResponse) GetCurrency() string {
-	if x != nil {
-		return x.Currency
-	}
-	return ""
-}
-
-func (x *GetUpcomingInvoiceResponse) GetAmount() float64 {
-	if x != nil {
-		return x.Amount
-	}
-	return 0
-}
-
-func (x *GetUpcomingInvoiceResponse) GetCredits() int64 {
-	if x != nil {
-		return x.Credits
-	}
-	return 0
-}
-
 type FinalizeInvoiceRequest struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -263,7 +111,7 @@ type FinalizeInvoiceRequest struct {
 func (x *FinalizeInvoiceRequest) Reset() {
 	*x = FinalizeInvoiceRequest{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_usage_v1_billing_proto_msgTypes[4]
+		mi := &file_usage_v1_billing_proto_msgTypes[2]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -276,7 +124,7 @@ func (x *FinalizeInvoiceRequest) String() string {
 func (*FinalizeInvoiceRequest) ProtoMessage() {}
 
 func (x *FinalizeInvoiceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_usage_v1_billing_proto_msgTypes[4]
+	mi := &file_usage_v1_billing_proto_msgTypes[2]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -289,7 +137,7 @@ func (x *FinalizeInvoiceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FinalizeInvoiceRequest.ProtoReflect.Descriptor instead.
 func (*FinalizeInvoiceRequest) Descriptor() ([]byte, []int) {
-	return file_usage_v1_billing_proto_rawDescGZIP(), []int{4}
+	return file_usage_v1_billing_proto_rawDescGZIP(), []int{2}
 }
 
 func (x *FinalizeInvoiceRequest) GetInvoiceId() string {
@@ -308,7 +156,7 @@ type FinalizeInvoiceResponse struct {
 func (x *FinalizeInvoiceResponse) Reset() {
 	*x = FinalizeInvoiceResponse{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_usage_v1_billing_proto_msgTypes[5]
+		mi := &file_usage_v1_billing_proto_msgTypes[3]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -321,7 +169,7 @@ func (x *FinalizeInvoiceResponse) String() string {
 func (*FinalizeInvoiceResponse) ProtoMessage() {}
 
 func (x *FinalizeInvoiceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_usage_v1_billing_proto_msgTypes[5]
+	mi := &file_usage_v1_billing_proto_msgTypes[3]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -334,7 +182,7 @@ func (x *FinalizeInvoiceResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FinalizeInvoiceResponse.ProtoReflect.Descriptor instead.
 func (*FinalizeInvoiceResponse) Descriptor() ([]byte, []int) {
-	return file_usage_v1_billing_proto_rawDescGZIP(), []int{5}
+	return file_usage_v1_billing_proto_rawDescGZIP(), []int{3}
 }
 
 type CancelSubscriptionRequest struct {
@@ -348,7 +196,7 @@ type CancelSubscriptionRequest struct {
 func (x *CancelSubscriptionRequest) Reset() {
 	*x = CancelSubscriptionRequest{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_usage_v1_billing_proto_msgTypes[6]
+		mi := &file_usage_v1_billing_proto_msgTypes[4]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -361,7 +209,7 @@ func (x *CancelSubscriptionRequest) String() string {
 func (*CancelSubscriptionRequest) ProtoMessage() {}
 
 func (x *CancelSubscriptionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_usage_v1_billing_proto_msgTypes[6]
+	mi := &file_usage_v1_billing_proto_msgTypes[4]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -374,7 +222,7 @@ func (x *CancelSubscriptionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CancelSubscriptionRequest.ProtoReflect.Descriptor instead.
 func (*CancelSubscriptionRequest) Descriptor() ([]byte, []int) {
-	return file_usage_v1_billing_proto_rawDescGZIP(), []int{6}
+	return file_usage_v1_billing_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *CancelSubscriptionRequest) GetSubscriptionId() string {
@@ -393,7 +241,7 @@ type CancelSubscriptionResponse struct {
 func (x *CancelSubscriptionResponse) Reset() {
 	*x = CancelSubscriptionResponse{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_usage_v1_billing_proto_msgTypes[7]
+		mi := &file_usage_v1_billing_proto_msgTypes[5]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -406,7 +254,7 @@ func (x *CancelSubscriptionResponse) String() string {
 func (*CancelSubscriptionResponse) ProtoMessage() {}
 
 func (x *CancelSubscriptionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_usage_v1_billing_proto_msgTypes[7]
+	mi := &file_usage_v1_billing_proto_msgTypes[5]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -419,7 +267,7 @@ func (x *CancelSubscriptionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CancelSubscriptionResponse.ProtoReflect.Descriptor instead.
 func (*CancelSubscriptionResponse) Descriptor() ([]byte, []int) {
-	return file_usage_v1_billing_proto_rawDescGZIP(), []int{7}
+	return file_usage_v1_billing_proto_rawDescGZIP(), []int{5}
 }
 
 var File_usage_v1_billing_proto protoreflect.FileDescriptor
@@ -430,46 +278,25 @@ var file_usage_v1_billing_proto_rawDesc = []byte{
 	0x76, 0x31, 0x22, 0x1a, 0x0a, 0x18, 0x52, 0x65, 0x63, 0x6f, 0x6e, 0x63, 0x69, 0x6c, 0x65, 0x49,
 	0x6e, 0x76, 0x6f, 0x69, 0x63, 0x65, 0x73, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x22, 0x1b,
 	0x0a, 0x19, 0x52, 0x65, 0x63, 0x6f, 0x6e, 0x63, 0x69, 0x6c, 0x65, 0x49, 0x6e, 0x76, 0x6f, 0x69,
-	0x63, 0x65, 0x73, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x22, 0x5f, 0x0a, 0x19, 0x47,
-	0x65, 0x74, 0x55, 0x70, 0x63, 0x6f, 0x6d, 0x69, 0x6e, 0x67, 0x49, 0x6e, 0x76, 0x6f, 0x69, 0x63,
-	0x65, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x12, 0x19, 0x0a, 0x07, 0x74, 0x65, 0x61, 0x6d,
-	0x5f, 0x69, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x48, 0x00, 0x52, 0x06, 0x74, 0x65, 0x61,
-	0x6d, 0x49, 0x64, 0x12, 0x19, 0x0a, 0x07, 0x75, 0x73, 0x65, 0x72, 0x5f, 0x69, 0x64, 0x18, 0x02,
-	0x20, 0x01, 0x28, 0x09, 0x48, 0x00, 0x52, 0x06, 0x75, 0x73, 0x65, 0x72, 0x49, 0x64, 0x42, 0x0c,
-	0x0a, 0x0a, 0x69, 0x64, 0x65, 0x6e, 0x74, 0x69, 0x66, 0x69, 0x65, 0x72, 0x22, 0x89, 0x01, 0x0a,
-	0x1a, 0x47, 0x65, 0x74, 0x55, 0x70, 0x63, 0x6f, 0x6d, 0x69, 0x6e, 0x67, 0x49, 0x6e, 0x76, 0x6f,
-	0x69, 0x63, 0x65, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x12, 0x1d, 0x0a, 0x0a, 0x69,
-	0x6e, 0x76, 0x6f, 0x69, 0x63, 0x65, 0x5f, 0x69, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52,
-	0x09, 0x69, 0x6e, 0x76, 0x6f, 0x69, 0x63, 0x65, 0x49, 0x64, 0x12, 0x1a, 0x0a, 0x08, 0x63, 0x75,
-	0x72, 0x72, 0x65, 0x6e, 0x63, 0x79, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52, 0x08, 0x63, 0x75,
-	0x72, 0x72, 0x65, 0x6e, 0x63, 0x79, 0x12, 0x16, 0x0a, 0x06, 0x61, 0x6d, 0x6f, 0x75, 0x6e, 0x74,
-	0x18, 0x03, 0x20, 0x01, 0x28, 0x01, 0x52, 0x06, 0x61, 0x6d, 0x6f, 0x75, 0x6e, 0x74, 0x12, 0x18,
-	0x0a, 0x07, 0x63, 0x72, 0x65, 0x64, 0x69, 0x74, 0x73, 0x18, 0x04, 0x20, 0x01, 0x28, 0x03, 0x52,
-	0x07, 0x63, 0x72, 0x65, 0x64, 0x69, 0x74, 0x73, 0x22, 0x37, 0x0a, 0x16, 0x46, 0x69, 0x6e, 0x61,
-	0x6c, 0x69, 0x7a, 0x65, 0x49, 0x6e, 0x76, 0x6f, 0x69, 0x63, 0x65, 0x52, 0x65, 0x71, 0x75, 0x65,
-	0x73, 0x74, 0x12, 0x1d, 0x0a, 0x0a, 0x69, 0x6e, 0x76, 0x6f, 0x69, 0x63, 0x65, 0x5f, 0x69, 0x64,
-	0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x09, 0x69, 0x6e, 0x76, 0x6f, 0x69, 0x63, 0x65, 0x49,
-	0x64, 0x22, 0x19, 0x0a, 0x17, 0x46, 0x69, 0x6e, 0x61, 0x6c, 0x69, 0x7a, 0x65, 0x49, 0x6e, 0x76,
-	0x6f, 0x69, 0x63, 0x65, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x22, 0x44, 0x0a, 0x19,
-	0x43, 0x61, 0x6e, 0x63, 0x65, 0x6c, 0x53, 0x75, 0x62, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x69,
-	0x6f, 0x6e, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x12, 0x27, 0x0a, 0x0f, 0x73, 0x75, 0x62,
-	0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x5f, 0x69, 0x64, 0x18, 0x01, 0x20, 0x01,
-	0x28, 0x09, 0x52, 0x0e, 0x73, 0x75, 0x62, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x69, 0x6f, 0x6e,
-	0x49, 0x64, 0x22, 0x1c, 0x0a, 0x1a, 0x43, 0x61, 0x6e, 0x63, 0x65, 0x6c, 0x53, 0x75, 0x62, 0x73,
-	0x63, 0x72, 0x69, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65,
-	0x32, 0x90, 0x03, 0x0a, 0x0e, 0x42, 0x69, 0x6c, 0x6c, 0x69, 0x6e, 0x67, 0x53, 0x65, 0x72, 0x76,
-	0x69, 0x63, 0x65, 0x12, 0x5e, 0x0a, 0x11, 0x52, 0x65, 0x63, 0x6f, 0x6e, 0x63, 0x69, 0x6c, 0x65,
-	0x49, 0x6e, 0x76, 0x6f, 0x69, 0x63, 0x65, 0x73, 0x12, 0x22, 0x2e, 0x75, 0x73, 0x61, 0x67, 0x65,
-	0x2e, 0x76, 0x31, 0x2e, 0x52, 0x65, 0x63, 0x6f, 0x6e, 0x63, 0x69, 0x6c, 0x65, 0x49, 0x6e, 0x76,
-	0x6f, 0x69, 0x63, 0x65, 0x73, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x1a, 0x23, 0x2e, 0x75,
-	0x73, 0x61, 0x67, 0x65, 0x2e, 0x76, 0x31, 0x2e, 0x52, 0x65, 0x63, 0x6f, 0x6e, 0x63, 0x69, 0x6c,
-	0x65, 0x49, 0x6e, 0x76, 0x6f, 0x69, 0x63, 0x65, 0x73, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73,
-	0x65, 0x22, 0x00, 0x12, 0x61, 0x0a, 0x12, 0x47, 0x65, 0x74, 0x55, 0x70, 0x63, 0x6f, 0x6d, 0x69,
-	0x6e, 0x67, 0x49, 0x6e, 0x76, 0x6f, 0x69, 0x63, 0x65, 0x12, 0x23, 0x2e, 0x75, 0x73, 0x61, 0x67,
-	0x65, 0x2e, 0x76, 0x31, 0x2e, 0x47, 0x65, 0x74, 0x55, 0x70, 0x63, 0x6f, 0x6d, 0x69, 0x6e, 0x67,
-	0x49, 0x6e, 0x76, 0x6f, 0x69, 0x63, 0x65, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x1a, 0x24,
-	0x2e, 0x75, 0x73, 0x61, 0x67, 0x65, 0x2e, 0x76, 0x31, 0x2e, 0x47, 0x65, 0x74, 0x55, 0x70, 0x63,
-	0x6f, 0x6d, 0x69, 0x6e, 0x67, 0x49, 0x6e, 0x76, 0x6f, 0x69, 0x63, 0x65, 0x52, 0x65, 0x73, 0x70,
+	0x63, 0x65, 0x73, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x22, 0x37, 0x0a, 0x16, 0x46,
+	0x69, 0x6e, 0x61, 0x6c, 0x69, 0x7a, 0x65, 0x49, 0x6e, 0x76, 0x6f, 0x69, 0x63, 0x65, 0x52, 0x65,
+	0x71, 0x75, 0x65, 0x73, 0x74, 0x12, 0x1d, 0x0a, 0x0a, 0x69, 0x6e, 0x76, 0x6f, 0x69, 0x63, 0x65,
+	0x5f, 0x69, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x09, 0x69, 0x6e, 0x76, 0x6f, 0x69,
+	0x63, 0x65, 0x49, 0x64, 0x22, 0x19, 0x0a, 0x17, 0x46, 0x69, 0x6e, 0x61, 0x6c, 0x69, 0x7a, 0x65,
+	0x49, 0x6e, 0x76, 0x6f, 0x69, 0x63, 0x65, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x22,
+	0x44, 0x0a, 0x19, 0x43, 0x61, 0x6e, 0x63, 0x65, 0x6c, 0x53, 0x75, 0x62, 0x73, 0x63, 0x72, 0x69,
+	0x70, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x12, 0x27, 0x0a, 0x0f,
+	0x73, 0x75, 0x62, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x5f, 0x69, 0x64, 0x18,
+	0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x0e, 0x73, 0x75, 0x62, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74,
+	0x69, 0x6f, 0x6e, 0x49, 0x64, 0x22, 0x1c, 0x0a, 0x1a, 0x43, 0x61, 0x6e, 0x63, 0x65, 0x6c, 0x53,
+	0x75, 0x62, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x65, 0x73, 0x70, 0x6f,
+	0x6e, 0x73, 0x65, 0x32, 0xad, 0x02, 0x0a, 0x0e, 0x42, 0x69, 0x6c, 0x6c, 0x69, 0x6e, 0x67, 0x53,
+	0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x12, 0x5e, 0x0a, 0x11, 0x52, 0x65, 0x63, 0x6f, 0x6e, 0x63,
+	0x69, 0x6c, 0x65, 0x49, 0x6e, 0x76, 0x6f, 0x69, 0x63, 0x65, 0x73, 0x12, 0x22, 0x2e, 0x75, 0x73,
+	0x61, 0x67, 0x65, 0x2e, 0x76, 0x31, 0x2e, 0x52, 0x65, 0x63, 0x6f, 0x6e, 0x63, 0x69, 0x6c, 0x65,
+	0x49, 0x6e, 0x76, 0x6f, 0x69, 0x63, 0x65, 0x73, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x1a,
+	0x23, 0x2e, 0x75, 0x73, 0x61, 0x67, 0x65, 0x2e, 0x76, 0x31, 0x2e, 0x52, 0x65, 0x63, 0x6f, 0x6e,
+	0x63, 0x69, 0x6c, 0x65, 0x49, 0x6e, 0x76, 0x6f, 0x69, 0x63, 0x65, 0x73, 0x52, 0x65, 0x73, 0x70,
 	0x6f, 0x6e, 0x73, 0x65, 0x22, 0x00, 0x12, 0x58, 0x0a, 0x0f, 0x46, 0x69, 0x6e, 0x61, 0x6c, 0x69,
 	0x7a, 0x65, 0x49, 0x6e, 0x76, 0x6f, 0x69, 0x63, 0x65, 0x12, 0x20, 0x2e, 0x75, 0x73, 0x61, 0x67,
 	0x65, 0x2e, 0x76, 0x31, 0x2e, 0x46, 0x69, 0x6e, 0x61, 0x6c, 0x69, 0x7a, 0x65, 0x49, 0x6e, 0x76,
@@ -500,28 +327,24 @@ func file_usage_v1_billing_proto_rawDescGZIP() []byte {
 	return file_usage_v1_billing_proto_rawDescData
 }
 
-var file_usage_v1_billing_proto_msgTypes = make([]protoimpl.MessageInfo, 8)
+var file_usage_v1_billing_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
 var file_usage_v1_billing_proto_goTypes = []interface{}{
 	(*ReconcileInvoicesRequest)(nil),   // 0: usage.v1.ReconcileInvoicesRequest
 	(*ReconcileInvoicesResponse)(nil),  // 1: usage.v1.ReconcileInvoicesResponse
-	(*GetUpcomingInvoiceRequest)(nil),  // 2: usage.v1.GetUpcomingInvoiceRequest
-	(*GetUpcomingInvoiceResponse)(nil), // 3: usage.v1.GetUpcomingInvoiceResponse
-	(*FinalizeInvoiceRequest)(nil),     // 4: usage.v1.FinalizeInvoiceRequest
-	(*FinalizeInvoiceResponse)(nil),    // 5: usage.v1.FinalizeInvoiceResponse
-	(*CancelSubscriptionRequest)(nil),  // 6: usage.v1.CancelSubscriptionRequest
-	(*CancelSubscriptionResponse)(nil), // 7: usage.v1.CancelSubscriptionResponse
+	(*FinalizeInvoiceRequest)(nil),     // 2: usage.v1.FinalizeInvoiceRequest
+	(*FinalizeInvoiceResponse)(nil),    // 3: usage.v1.FinalizeInvoiceResponse
+	(*CancelSubscriptionRequest)(nil),  // 4: usage.v1.CancelSubscriptionRequest
+	(*CancelSubscriptionResponse)(nil), // 5: usage.v1.CancelSubscriptionResponse
 }
 var file_usage_v1_billing_proto_depIdxs = []int32{
 	0, // 0: usage.v1.BillingService.ReconcileInvoices:input_type -> usage.v1.ReconcileInvoicesRequest
-	2, // 1: usage.v1.BillingService.GetUpcomingInvoice:input_type -> usage.v1.GetUpcomingInvoiceRequest
-	4, // 2: usage.v1.BillingService.FinalizeInvoice:input_type -> usage.v1.FinalizeInvoiceRequest
-	6, // 3: usage.v1.BillingService.CancelSubscription:input_type -> usage.v1.CancelSubscriptionRequest
-	1, // 4: usage.v1.BillingService.ReconcileInvoices:output_type -> usage.v1.ReconcileInvoicesResponse
-	3, // 5: usage.v1.BillingService.GetUpcomingInvoice:output_type -> usage.v1.GetUpcomingInvoiceResponse
-	5, // 6: usage.v1.BillingService.FinalizeInvoice:output_type -> usage.v1.FinalizeInvoiceResponse
-	7, // 7: usage.v1.BillingService.CancelSubscription:output_type -> usage.v1.CancelSubscriptionResponse
-	4, // [4:8] is the sub-list for method output_type
-	0, // [0:4] is the sub-list for method input_type
+	2, // 1: usage.v1.BillingService.FinalizeInvoice:input_type -> usage.v1.FinalizeInvoiceRequest
+	4, // 2: usage.v1.BillingService.CancelSubscription:input_type -> usage.v1.CancelSubscriptionRequest
+	1, // 3: usage.v1.BillingService.ReconcileInvoices:output_type -> usage.v1.ReconcileInvoicesResponse
+	3, // 4: usage.v1.BillingService.FinalizeInvoice:output_type -> usage.v1.FinalizeInvoiceResponse
+	5, // 5: usage.v1.BillingService.CancelSubscription:output_type -> usage.v1.CancelSubscriptionResponse
+	3, // [3:6] is the sub-list for method output_type
+	0, // [0:3] is the sub-list for method input_type
 	0, // [0:0] is the sub-list for extension type_name
 	0, // [0:0] is the sub-list for extension extendee
 	0, // [0:0] is the sub-list for field type_name
@@ -558,30 +381,6 @@ func file_usage_v1_billing_proto_init() {
 			}
 		}
 		file_usage_v1_billing_proto_msgTypes[2].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*GetUpcomingInvoiceRequest); i {
-			case 0:
-				return &v.state
-			case 1:
-				return &v.sizeCache
-			case 2:
-				return &v.unknownFields
-			default:
-				return nil
-			}
-		}
-		file_usage_v1_billing_proto_msgTypes[3].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*GetUpcomingInvoiceResponse); i {
-			case 0:
-				return &v.state
-			case 1:
-				return &v.sizeCache
-			case 2:
-				return &v.unknownFields
-			default:
-				return nil
-			}
-		}
-		file_usage_v1_billing_proto_msgTypes[4].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*FinalizeInvoiceRequest); i {
 			case 0:
 				return &v.state
@@ -593,7 +392,7 @@ func file_usage_v1_billing_proto_init() {
 				return nil
 			}
 		}
-		file_usage_v1_billing_proto_msgTypes[5].Exporter = func(v interface{}, i int) interface{} {
+		file_usage_v1_billing_proto_msgTypes[3].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*FinalizeInvoiceResponse); i {
 			case 0:
 				return &v.state
@@ -605,7 +404,7 @@ func file_usage_v1_billing_proto_init() {
 				return nil
 			}
 		}
-		file_usage_v1_billing_proto_msgTypes[6].Exporter = func(v interface{}, i int) interface{} {
+		file_usage_v1_billing_proto_msgTypes[4].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*CancelSubscriptionRequest); i {
 			case 0:
 				return &v.state
@@ -617,7 +416,7 @@ func file_usage_v1_billing_proto_init() {
 				return nil
 			}
 		}
-		file_usage_v1_billing_proto_msgTypes[7].Exporter = func(v interface{}, i int) interface{} {
+		file_usage_v1_billing_proto_msgTypes[5].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*CancelSubscriptionResponse); i {
 			case 0:
 				return &v.state
@@ -630,17 +429,13 @@ func file_usage_v1_billing_proto_init() {
 			}
 		}
 	}
-	file_usage_v1_billing_proto_msgTypes[2].OneofWrappers = []interface{}{
-		(*GetUpcomingInvoiceRequest_TeamId)(nil),
-		(*GetUpcomingInvoiceRequest_UserId)(nil),
-	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: file_usage_v1_billing_proto_rawDesc,
 			NumEnums:      0,
-			NumMessages:   8,
+			NumMessages:   6,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/components/usage-api/go/v1/billing_grpc.pb.go
+++ b/components/usage-api/go/v1/billing_grpc.pb.go
@@ -29,8 +29,6 @@ type BillingServiceClient interface {
 	// ReconcileInvoices retrieves current credit balance and reflects it in billing system.
 	// Internal RPC, not intended for general consumption.
 	ReconcileInvoices(ctx context.Context, in *ReconcileInvoicesRequest, opts ...grpc.CallOption) (*ReconcileInvoicesResponse, error)
-	// GetUpcomingInvoice retrieves the latest invoice for a given query.
-	GetUpcomingInvoice(ctx context.Context, in *GetUpcomingInvoiceRequest, opts ...grpc.CallOption) (*GetUpcomingInvoiceResponse, error)
 	// FinalizeInvoice marks all sessions occurring in the given Stripe invoice as
 	// having been invoiced.
 	FinalizeInvoice(ctx context.Context, in *FinalizeInvoiceRequest, opts ...grpc.CallOption) (*FinalizeInvoiceResponse, error)
@@ -50,15 +48,6 @@ func NewBillingServiceClient(cc grpc.ClientConnInterface) BillingServiceClient {
 func (c *billingServiceClient) ReconcileInvoices(ctx context.Context, in *ReconcileInvoicesRequest, opts ...grpc.CallOption) (*ReconcileInvoicesResponse, error) {
 	out := new(ReconcileInvoicesResponse)
 	err := c.cc.Invoke(ctx, "/usage.v1.BillingService/ReconcileInvoices", in, out, opts...)
-	if err != nil {
-		return nil, err
-	}
-	return out, nil
-}
-
-func (c *billingServiceClient) GetUpcomingInvoice(ctx context.Context, in *GetUpcomingInvoiceRequest, opts ...grpc.CallOption) (*GetUpcomingInvoiceResponse, error) {
-	out := new(GetUpcomingInvoiceResponse)
-	err := c.cc.Invoke(ctx, "/usage.v1.BillingService/GetUpcomingInvoice", in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -90,8 +79,6 @@ type BillingServiceServer interface {
 	// ReconcileInvoices retrieves current credit balance and reflects it in billing system.
 	// Internal RPC, not intended for general consumption.
 	ReconcileInvoices(context.Context, *ReconcileInvoicesRequest) (*ReconcileInvoicesResponse, error)
-	// GetUpcomingInvoice retrieves the latest invoice for a given query.
-	GetUpcomingInvoice(context.Context, *GetUpcomingInvoiceRequest) (*GetUpcomingInvoiceResponse, error)
 	// FinalizeInvoice marks all sessions occurring in the given Stripe invoice as
 	// having been invoiced.
 	FinalizeInvoice(context.Context, *FinalizeInvoiceRequest) (*FinalizeInvoiceResponse, error)
@@ -107,9 +94,6 @@ type UnimplementedBillingServiceServer struct {
 
 func (UnimplementedBillingServiceServer) ReconcileInvoices(context.Context, *ReconcileInvoicesRequest) (*ReconcileInvoicesResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method ReconcileInvoices not implemented")
-}
-func (UnimplementedBillingServiceServer) GetUpcomingInvoice(context.Context, *GetUpcomingInvoiceRequest) (*GetUpcomingInvoiceResponse, error) {
-	return nil, status.Errorf(codes.Unimplemented, "method GetUpcomingInvoice not implemented")
 }
 func (UnimplementedBillingServiceServer) FinalizeInvoice(context.Context, *FinalizeInvoiceRequest) (*FinalizeInvoiceResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method FinalizeInvoice not implemented")
@@ -144,24 +128,6 @@ func _BillingService_ReconcileInvoices_Handler(srv interface{}, ctx context.Cont
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(BillingServiceServer).ReconcileInvoices(ctx, req.(*ReconcileInvoicesRequest))
-	}
-	return interceptor(ctx, in, info, handler)
-}
-
-func _BillingService_GetUpcomingInvoice_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(GetUpcomingInvoiceRequest)
-	if err := dec(in); err != nil {
-		return nil, err
-	}
-	if interceptor == nil {
-		return srv.(BillingServiceServer).GetUpcomingInvoice(ctx, in)
-	}
-	info := &grpc.UnaryServerInfo{
-		Server:     srv,
-		FullMethod: "/usage.v1.BillingService/GetUpcomingInvoice",
-	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(BillingServiceServer).GetUpcomingInvoice(ctx, req.(*GetUpcomingInvoiceRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -212,10 +178,6 @@ var BillingService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "ReconcileInvoices",
 			Handler:    _BillingService_ReconcileInvoices_Handler,
-		},
-		{
-			MethodName: "GetUpcomingInvoice",
-			Handler:    _BillingService_GetUpcomingInvoice_Handler,
 		},
 		{
 			MethodName: "FinalizeInvoice",

--- a/components/usage-api/typescript/src/usage/v1/billing.pb.ts
+++ b/components/usage-api/typescript/src/usage/v1/billing.pb.ts
@@ -5,7 +5,6 @@
  */
 
 /* eslint-disable */
-import * as Long from "long";
 import { CallContext, CallOptions } from "nice-grpc-common";
 import * as _m0 from "protobufjs/minimal";
 
@@ -15,18 +14,6 @@ export interface ReconcileInvoicesRequest {
 }
 
 export interface ReconcileInvoicesResponse {
-}
-
-export interface GetUpcomingInvoiceRequest {
-  teamId: string | undefined;
-  userId: string | undefined;
-}
-
-export interface GetUpcomingInvoiceResponse {
-  invoiceId: string;
-  currency: string;
-  amount: number;
-  credits: number;
 }
 
 export interface FinalizeInvoiceRequest {
@@ -117,140 +104,6 @@ export const ReconcileInvoicesResponse = {
 
   fromPartial(_: DeepPartial<ReconcileInvoicesResponse>): ReconcileInvoicesResponse {
     const message = createBaseReconcileInvoicesResponse();
-    return message;
-  },
-};
-
-function createBaseGetUpcomingInvoiceRequest(): GetUpcomingInvoiceRequest {
-  return { teamId: undefined, userId: undefined };
-}
-
-export const GetUpcomingInvoiceRequest = {
-  encode(message: GetUpcomingInvoiceRequest, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    if (message.teamId !== undefined) {
-      writer.uint32(10).string(message.teamId);
-    }
-    if (message.userId !== undefined) {
-      writer.uint32(18).string(message.userId);
-    }
-    return writer;
-  },
-
-  decode(input: _m0.Reader | Uint8Array, length?: number): GetUpcomingInvoiceRequest {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
-    let end = length === undefined ? reader.len : reader.pos + length;
-    const message = createBaseGetUpcomingInvoiceRequest();
-    while (reader.pos < end) {
-      const tag = reader.uint32();
-      switch (tag >>> 3) {
-        case 1:
-          message.teamId = reader.string();
-          break;
-        case 2:
-          message.userId = reader.string();
-          break;
-        default:
-          reader.skipType(tag & 7);
-          break;
-      }
-    }
-    return message;
-  },
-
-  fromJSON(object: any): GetUpcomingInvoiceRequest {
-    return {
-      teamId: isSet(object.teamId) ? String(object.teamId) : undefined,
-      userId: isSet(object.userId) ? String(object.userId) : undefined,
-    };
-  },
-
-  toJSON(message: GetUpcomingInvoiceRequest): unknown {
-    const obj: any = {};
-    message.teamId !== undefined && (obj.teamId = message.teamId);
-    message.userId !== undefined && (obj.userId = message.userId);
-    return obj;
-  },
-
-  fromPartial(object: DeepPartial<GetUpcomingInvoiceRequest>): GetUpcomingInvoiceRequest {
-    const message = createBaseGetUpcomingInvoiceRequest();
-    message.teamId = object.teamId ?? undefined;
-    message.userId = object.userId ?? undefined;
-    return message;
-  },
-};
-
-function createBaseGetUpcomingInvoiceResponse(): GetUpcomingInvoiceResponse {
-  return { invoiceId: "", currency: "", amount: 0, credits: 0 };
-}
-
-export const GetUpcomingInvoiceResponse = {
-  encode(message: GetUpcomingInvoiceResponse, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    if (message.invoiceId !== "") {
-      writer.uint32(10).string(message.invoiceId);
-    }
-    if (message.currency !== "") {
-      writer.uint32(18).string(message.currency);
-    }
-    if (message.amount !== 0) {
-      writer.uint32(25).double(message.amount);
-    }
-    if (message.credits !== 0) {
-      writer.uint32(32).int64(message.credits);
-    }
-    return writer;
-  },
-
-  decode(input: _m0.Reader | Uint8Array, length?: number): GetUpcomingInvoiceResponse {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
-    let end = length === undefined ? reader.len : reader.pos + length;
-    const message = createBaseGetUpcomingInvoiceResponse();
-    while (reader.pos < end) {
-      const tag = reader.uint32();
-      switch (tag >>> 3) {
-        case 1:
-          message.invoiceId = reader.string();
-          break;
-        case 2:
-          message.currency = reader.string();
-          break;
-        case 3:
-          message.amount = reader.double();
-          break;
-        case 4:
-          message.credits = longToNumber(reader.int64() as Long);
-          break;
-        default:
-          reader.skipType(tag & 7);
-          break;
-      }
-    }
-    return message;
-  },
-
-  fromJSON(object: any): GetUpcomingInvoiceResponse {
-    return {
-      invoiceId: isSet(object.invoiceId) ? String(object.invoiceId) : "",
-      currency: isSet(object.currency) ? String(object.currency) : "",
-      amount: isSet(object.amount) ? Number(object.amount) : 0,
-      credits: isSet(object.credits) ? Number(object.credits) : 0,
-    };
-  },
-
-  toJSON(message: GetUpcomingInvoiceResponse): unknown {
-    const obj: any = {};
-    message.invoiceId !== undefined && (obj.invoiceId = message.invoiceId);
-    message.currency !== undefined && (obj.currency = message.currency);
-    message.amount !== undefined && (obj.amount = message.amount);
-    message.credits !== undefined && (obj.credits = Math.round(message.credits));
-    return obj;
-  },
-
-  fromPartial(object: DeepPartial<GetUpcomingInvoiceResponse>): GetUpcomingInvoiceResponse {
-    const message = createBaseGetUpcomingInvoiceResponse();
-    message.invoiceId = object.invoiceId ?? "";
-    message.currency = object.currency ?? "";
-    message.amount = object.amount ?? 0;
-    message.credits = object.credits ?? 0;
     return message;
   },
 };
@@ -444,15 +297,6 @@ export const BillingServiceDefinition = {
       responseStream: false,
       options: {},
     },
-    /** GetUpcomingInvoice retrieves the latest invoice for a given query. */
-    getUpcomingInvoice: {
-      name: "GetUpcomingInvoice",
-      requestType: GetUpcomingInvoiceRequest,
-      requestStream: false,
-      responseType: GetUpcomingInvoiceResponse,
-      responseStream: false,
-      options: {},
-    },
     /**
      * FinalizeInvoice marks all sessions occurring in the given Stripe invoice as
      * having been invoiced.
@@ -489,11 +333,6 @@ export interface BillingServiceServiceImplementation<CallContextExt = {}> {
     request: ReconcileInvoicesRequest,
     context: CallContext & CallContextExt,
   ): Promise<DeepPartial<ReconcileInvoicesResponse>>;
-  /** GetUpcomingInvoice retrieves the latest invoice for a given query. */
-  getUpcomingInvoice(
-    request: GetUpcomingInvoiceRequest,
-    context: CallContext & CallContextExt,
-  ): Promise<DeepPartial<GetUpcomingInvoiceResponse>>;
   /**
    * FinalizeInvoice marks all sessions occurring in the given Stripe invoice as
    * having been invoiced.
@@ -521,11 +360,6 @@ export interface BillingServiceClient<CallOptionsExt = {}> {
     request: DeepPartial<ReconcileInvoicesRequest>,
     options?: CallOptions & CallOptionsExt,
   ): Promise<ReconcileInvoicesResponse>;
-  /** GetUpcomingInvoice retrieves the latest invoice for a given query. */
-  getUpcomingInvoice(
-    request: DeepPartial<GetUpcomingInvoiceRequest>,
-    options?: CallOptions & CallOptionsExt,
-  ): Promise<GetUpcomingInvoiceResponse>;
   /**
    * FinalizeInvoice marks all sessions occurring in the given Stripe invoice as
    * having been invoiced.
@@ -553,45 +387,12 @@ export interface DataLoaders {
   getDataLoader<T>(identifier: string, constructorFn: () => T): T;
 }
 
-declare var self: any | undefined;
-declare var window: any | undefined;
-declare var global: any | undefined;
-var globalThis: any = (() => {
-  if (typeof globalThis !== "undefined") {
-    return globalThis;
-  }
-  if (typeof self !== "undefined") {
-    return self;
-  }
-  if (typeof window !== "undefined") {
-    return window;
-  }
-  if (typeof global !== "undefined") {
-    return global;
-  }
-  throw "Unable to locate global object";
-})();
-
 type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 
 export type DeepPartial<T> = T extends Builtin ? T
   : T extends Array<infer U> ? Array<DeepPartial<U>> : T extends ReadonlyArray<infer U> ? ReadonlyArray<DeepPartial<U>>
   : T extends {} ? { [K in keyof T]?: DeepPartial<T[K]> }
   : Partial<T>;
-
-function longToNumber(long: Long): number {
-  if (long.gt(Number.MAX_SAFE_INTEGER)) {
-    throw new globalThis.Error("Value is larger than Number.MAX_SAFE_INTEGER");
-  }
-  return long.toNumber();
-}
-
-// If you get a compile-error about 'Constructor<Long> and ... have no overlap',
-// add '--ts_proto_opt=esModuleInterop=true' as a flag when calling 'protoc'.
-if (_m0.util.Long !== Long) {
-  _m0.util.Long = Long as any;
-  _m0.configure();
-}
 
 function isSet(value: any): boolean {
   return value !== null && value !== undefined;

--- a/components/usage-api/usage/v1/billing.proto
+++ b/components/usage-api/usage/v1/billing.proto
@@ -9,9 +9,6 @@ service BillingService {
   // Internal RPC, not intended for general consumption.
   rpc ReconcileInvoices(ReconcileInvoicesRequest) returns (ReconcileInvoicesResponse) {};
 
-  // GetUpcomingInvoice retrieves the latest invoice for a given query.
-  rpc GetUpcomingInvoice(GetUpcomingInvoiceRequest) returns (GetUpcomingInvoiceResponse) {};
-
   // FinalizeInvoice marks all sessions occurring in the given Stripe invoice as
   // having been invoiced.
   rpc FinalizeInvoice(FinalizeInvoiceRequest) returns (FinalizeInvoiceResponse) {};
@@ -24,20 +21,6 @@ service BillingService {
 message ReconcileInvoicesRequest {}
 
 message ReconcileInvoicesResponse {}
-
-message GetUpcomingInvoiceRequest {
-  oneof identifier {
-    string team_id = 1;
-    string user_id = 2;
-  }
-}
-
-message GetUpcomingInvoiceResponse {
-  string invoice_id = 1;
-  string currency = 2;
-  double amount = 3;
-  int64  credits = 4;
-}
 
 message FinalizeInvoiceRequest {
   string invoice_id = 1;

--- a/components/usage/pkg/stripe/stripe.go
+++ b/components/usage/pkg/stripe/stripe.go
@@ -205,31 +205,6 @@ func (c *Client) GetCustomerByUserID(ctx context.Context, userID string) (*strip
 	return customers[0], nil
 }
 
-// GetUpcomingInvoice fetches the upcoming invoice for the given team or user id.
-func (c *Client) GetUpcomingInvoice(ctx context.Context, customerID string) (*Invoice, error) {
-	invoiceParams := &stripe.InvoiceParams{
-		Params: stripe.Params{
-			Context: ctx,
-		},
-		Customer: stripe.String(customerID),
-	}
-	invoice, err := c.sc.Invoices.GetNext(invoiceParams)
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch the upcoming invoice for customer %s", customerID)
-	}
-	if len(invoice.Lines.Data) < 1 {
-		return nil, fmt.Errorf("no line items on invoice %s for customer %s", invoice.ID, customerID)
-	}
-
-	return &Invoice{
-		ID:             invoice.ID,
-		SubscriptionID: invoice.Subscription.ID,
-		Amount:         invoice.AmountRemaining,
-		Currency:       string(invoice.Currency),
-		Credits:        invoice.Lines.Data[0].Quantity,
-	}, nil
-}
-
 func (c *Client) GetInvoiceWithCustomer(ctx context.Context, invoiceID string) (*stripe.Invoice, error) {
 	if invoiceID == "" {
 		return nil, fmt.Errorf("no invoice ID specified")


### PR DESCRIPTION
## Description
Removes no longer needed `getUpcomingInvoice` API.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
