### PR TITLE
[dashboard] Remove unused state/params from UsageView

### DIFF
--- a/components/dashboard/src/Usage.tsx
+++ b/components/dashboard/src/Usage.tsx
@@ -4,44 +4,19 @@
  * See License-AGPL.txt in the project root for license information.
  */
 
-import { useContext, useEffect, useState } from "react";
+import { useContext } from "react";
 
-import { getGitpodService, gitpodHostUrl } from "./service/service";
-import { BillingMode } from "@gitpod/gitpod-protocol/lib/billing-mode";
 import UsageView from "./components/UsageView";
-import { AttributionId } from "@gitpod/gitpod-protocol/lib/attribution";
 import { UserContext } from "./user-context";
 
 function TeamUsage() {
     const { user } = useContext(UserContext);
-    const [billingMode, setBillingMode] = useState<BillingMode | undefined>(undefined);
-    const [attributionId, setAttributionId] = useState<AttributionId | undefined>();
 
-    useEffect(() => {
-        if (!user) {
-            return;
-        }
-        setAttributionId({ kind: "user", userId: user.id });
-        (async () => {
-            const billingMode = await getGitpodService().server.getBillingModeForUser();
-            setBillingMode(billingMode);
-        })();
-    }, [user]);
-
-    useEffect(() => {
-        if (!billingMode) {
-            return;
-        }
-        if (!BillingMode.showUsageBasedBilling(billingMode)) {
-            window.location.href = gitpodHostUrl.asDashboard().toString();
-        }
-    }, [billingMode]);
-
-    if (!billingMode || !attributionId) {
+    if (!user) {
         return <></>;
     }
 
-    return <UsageView billingMode={billingMode} attributionId={attributionId} />;
+    return <UsageView attributionId={{ kind: "user", userId: user.id }} />;
 }
 
 export default TeamUsage;

--- a/components/dashboard/src/components/UsageView.tsx
+++ b/components/dashboard/src/components/UsageView.tsx
@@ -21,17 +21,15 @@ import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
 import { ReactComponent as CreditsSvg } from "../images/credits.svg";
 import { ReactComponent as Spinner } from "../icons/Spinner.svg";
 import { ReactComponent as UsageIcon } from "../images/usage-default.svg";
-import { BillingMode } from "@gitpod/gitpod-protocol/lib/billing-mode";
 import { toRemoteURL } from "../projects/render-utils";
 import { WorkspaceType } from "@gitpod/gitpod-protocol";
 import PillLabel from "./PillLabel";
 
 interface UsageViewProps {
     attributionId: AttributionId;
-    billingMode: BillingMode;
 }
 
-function UsageView({ attributionId, billingMode }: UsageViewProps) {
+function UsageView({ attributionId }: UsageViewProps) {
     const [usagePage, setUsagePage] = useState<ListUsageResponse | undefined>(undefined);
     const [errorMessage, setErrorMessage] = useState("");
     const today = new Date();

--- a/components/dashboard/src/teams/TeamUsage.tsx
+++ b/components/dashboard/src/teams/TeamUsage.tsx
@@ -4,46 +4,27 @@
  * See License-AGPL.txt in the project root for license information.
  */
 
-import { useContext, useEffect, useState } from "react";
+import { useContext } from "react";
 import { useLocation } from "react-router";
 import { getCurrentTeam, TeamsContext } from "./teams-context";
-import { getGitpodService, gitpodHostUrl } from "../service/service";
-import { BillingMode } from "@gitpod/gitpod-protocol/lib/billing-mode";
 import UsageView from "../components/UsageView";
-import { AttributionId } from "@gitpod/gitpod-protocol/lib/attribution";
 
 function TeamUsage() {
     const { teams } = useContext(TeamsContext);
     const location = useLocation();
     const team = getCurrentTeam(location, teams);
-    const [billingMode, setBillingMode] = useState<BillingMode | undefined>(undefined);
-    const [attributionId, setAttributionId] = useState<AttributionId | undefined>();
-
-    useEffect(() => {
-        if (!team) {
-            return;
-        }
-        setAttributionId({ kind: "team", teamId: team.id });
-        (async () => {
-            const billingMode = await getGitpodService().server.getBillingModeForTeam(team.id);
-            setBillingMode(billingMode);
-        })();
-    }, [team]);
-
-    useEffect(() => {
-        if (!billingMode) {
-            return;
-        }
-        if (!BillingMode.showUsageBasedBilling(billingMode)) {
-            window.location.href = gitpodHostUrl.asDashboard().toString();
-        }
-    }, [billingMode]);
-
-    if (!billingMode || !attributionId) {
+    if (!team) {
         return <></>;
     }
 
-    return <UsageView billingMode={billingMode} attributionId={attributionId} />;
+    return (
+        <UsageView
+            attributionId={{
+                kind: "team",
+                teamId: team.id,
+            }}
+        />
+    );
 }
 
 export default TeamUsage;


### PR DESCRIPTION
## Description
Removes unused state/parameters from UsageView.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
