### PR TITLE
[usage] Enable usage view with feature flag

### DIFF
--- a/components/dashboard/src/Menu.tsx
+++ b/components/dashboard/src/Menu.tsx
@@ -27,6 +27,7 @@ import { PaymentContext } from "./payment-context";
 import FeedbackFormModal from "./feedback-form/FeedbackModal";
 import { inResource, isGitpodIo } from "./utils";
 import { BillingMode } from "@gitpod/gitpod-protocol/lib/billing-mode";
+import { FeatureFlagContext } from "./contexts/FeatureFlagContext";
 
 interface Entry {
     title: string;
@@ -36,6 +37,7 @@ interface Entry {
 
 export default function Menu() {
     const { user, userBillingMode, refreshUserBillingMode } = useContext(UserContext);
+    const { showUsageView } = useContext(FeatureFlagContext);
     const { teams } = useContext(TeamsContext);
     const location = useLocation();
     const team = getCurrentTeam(location, teams);
@@ -199,7 +201,7 @@ export default function Menu() {
                     link: `/t/${team.slug}/members`,
                 },
             ];
-            if (teamBillingMode && teamBillingMode.mode === "usage-based") {
+            if (showUsageView || (teamBillingMode && teamBillingMode.mode === "usage-based")) {
                 teamSettingsList.push({
                     title: "Usage",
                     link: `/t/${team.slug}/usage`,
@@ -221,12 +223,12 @@ export default function Menu() {
             title: "Projects",
             link: "/projects",
         });
-        // if (userBillingMode?.mode === "usage-based") {
-        //     userMenu.push({
-        //         title: "Usage",
-        //         link: "/usage",
-        //     });
-        // }
+        if (showUsageView) {
+            userMenu.push({
+                title: "Usage",
+                link: "/usage",
+            });
+        }
         userMenu.push({
             title: "Settings",
             link: "/settings",

--- a/components/dashboard/src/contexts/FeatureFlagContext.tsx
+++ b/components/dashboard/src/contexts/FeatureFlagContext.tsx
@@ -18,9 +18,11 @@ interface FeatureFlagConfig {
 const FeatureFlagContext = createContext<{
     showWorkspaceClassesUI: boolean;
     showPersistentVolumeClaimUI: boolean;
+    showUsageView: boolean;
 }>({
     showWorkspaceClassesUI: false,
     showPersistentVolumeClaimUI: false,
+    showUsageView: false,
 });
 
 const FeatureFlagContextProvider: React.FC = ({ children }) => {
@@ -31,15 +33,16 @@ const FeatureFlagContextProvider: React.FC = ({ children }) => {
     const team = getCurrentTeam(location, teams);
     const [showWorkspaceClassesUI, setShowWorkspaceClassesUI] = useState<boolean>(false);
     const [showPersistentVolumeClaimUI, setShowPersistentVolumeClaimUI] = useState<boolean>(false);
-
-    const featureFlags: FeatureFlagConfig = {
-        workspace_classes: { defaultValue: true, setter: setShowWorkspaceClassesUI },
-        persistent_volume_claim: { defaultValue: true, setter: setShowPersistentVolumeClaimUI },
-    };
+    const [showUsageView, setShowUsageView] = useState<boolean>(false);
 
     useEffect(() => {
         if (!user) return;
         (async () => {
+            const featureFlags: FeatureFlagConfig = {
+                workspace_classes: { defaultValue: true, setter: setShowWorkspaceClassesUI },
+                persistent_volume_claim: { defaultValue: true, setter: setShowPersistentVolumeClaimUI },
+                usage_view: { defaultValue: true, setter: setShowUsageView },
+            };
             for (const [flagName, config] of Object.entries(featureFlags)) {
                 const flagValue = await getExperimentsClient().getValueAsync(flagName, config.defaultValue, {
                     user,
@@ -54,7 +57,7 @@ const FeatureFlagContextProvider: React.FC = ({ children }) => {
     }, [user, teams, team, project]);
 
     return (
-        <FeatureFlagContext.Provider value={{ showWorkspaceClassesUI, showPersistentVolumeClaimUI }}>
+        <FeatureFlagContext.Provider value={{ showWorkspaceClassesUI, showPersistentVolumeClaimUI, showUsageView }}>
             {children}
         </FeatureFlagContext.Provider>
     );


### PR DESCRIPTION
## Description
Since we have discoupled "usage" from stripe now, we can allow all users to use the usage view in order to understand how they use Gitpod (and where their hours go). This is also helpful to get a forecast of how many credits I'd need next month in case I want to switch to usage-based pricing.
This change enabled the usage view for everyone (depending on a feature flag, which is currently disabled for everyone in prod).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
Login to the preview environment and see usage view on your individual account and all team accounts.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Added a usage view that displays past workspace sessions on individual and team accounts.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
- [x] /werft with-payment 
