### PR TITLE
[server] Purge 5k instances at a time

### DIFF
--- a/install/installer/cmd/testdata/render/aws-setup/output.golden
+++ b/install/installer/cmd/testdata/render/aws-setup/output.golden
@@ -4253,7 +4253,7 @@ data:
         "contentRetentionPeriodDays": 21,
         "contentChunkLimit": 1000,
         "purgeRetentionPeriodDays": 730,
-        "purgeChunkLimit": 1000
+        "purgeChunkLimit": 5000
       },
       "authProviderConfigFiles": [],
       "incrementalPrebuilds": {
@@ -8389,7 +8389,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 65e23bb77e8a1542e50114317fe7c1eb04cec9a5f4c82b11f8cf2a8d3b20c511
+        gitpod.io/checksum_config: 5e83195e3b26814469c129377371253ea302cf69070d509383e968ec5d7a7ce9
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/azure-setup/output.golden
+++ b/install/installer/cmd/testdata/render/azure-setup/output.golden
@@ -4117,7 +4117,7 @@ data:
         "contentRetentionPeriodDays": 21,
         "contentChunkLimit": 1000,
         "purgeRetentionPeriodDays": 730,
-        "purgeChunkLimit": 1000
+        "purgeChunkLimit": 5000
       },
       "authProviderConfigFiles": [],
       "incrementalPrebuilds": {
@@ -8241,7 +8241,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 65e23bb77e8a1542e50114317fe7c1eb04cec9a5f4c82b11f8cf2a8d3b20c511
+        gitpod.io/checksum_config: 5e83195e3b26814469c129377371253ea302cf69070d509383e968ec5d7a7ce9
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -5054,7 +5054,7 @@ data:
         "contentRetentionPeriodDays": 21,
         "contentChunkLimit": 1000,
         "purgeRetentionPeriodDays": 730,
-        "purgeChunkLimit": 1000
+        "purgeChunkLimit": 5000
       },
       "authProviderConfigFiles": [],
       "incrementalPrebuilds": {
@@ -9799,7 +9799,7 @@ spec:
     metadata:
       annotations:
         gitpod.io: hello
-        gitpod.io/checksum_config: 57e826b6b832dd75e184270a64128d56d5122d45fa529acec7928ac6f640299d
+        gitpod.io/checksum_config: 1c78430996bb02767dd4d5056d285a4921476ee7d787fc03289271172e680e4f
         hello: world
       creationTimestamp: null
       labels:

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -4304,7 +4304,7 @@ data:
         "contentRetentionPeriodDays": 21,
         "contentChunkLimit": 1000,
         "purgeRetentionPeriodDays": 730,
-        "purgeChunkLimit": 1000
+        "purgeChunkLimit": 5000
       },
       "authProviderConfigFiles": [],
       "incrementalPrebuilds": {
@@ -8667,7 +8667,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 5730cba43c5427db3f15e751144001295b81609822685e3baa945000fe1f6a32
+        gitpod.io/checksum_config: 2aeb669de68663a5b2c623f39956d06e8fe065ce6ab3497364969412346267a2
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/gcp-setup/output.golden
+++ b/install/installer/cmd/testdata/render/gcp-setup/output.golden
@@ -4078,7 +4078,7 @@ data:
         "contentRetentionPeriodDays": 21,
         "contentChunkLimit": 1000,
         "purgeRetentionPeriodDays": 730,
-        "purgeChunkLimit": 1000
+        "purgeChunkLimit": 5000
       },
       "authProviderConfigFiles": [],
       "incrementalPrebuilds": {
@@ -8170,7 +8170,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 966d2e2fee61a2269e648d2a2705eb7ccfc48460e97533ee77c7c857ffb1bb6b
+        gitpod.io/checksum_config: e815e4561d4c745651c63b726706a527b86b8a7eec74049d42415aef264b61a1
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/http-proxy/output.golden
+++ b/install/installer/cmd/testdata/render/http-proxy/output.golden
@@ -4527,7 +4527,7 @@ data:
         "contentRetentionPeriodDays": 21,
         "contentChunkLimit": 1000,
         "purgeRetentionPeriodDays": 730,
-        "purgeChunkLimit": 1000
+        "purgeChunkLimit": 5000
       },
       "authProviderConfigFiles": [],
       "incrementalPrebuilds": {
@@ -10088,7 +10088,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 5730cba43c5427db3f15e751144001295b81609822685e3baa945000fe1f6a32
+        gitpod.io/checksum_config: 2aeb669de68663a5b2c623f39956d06e8fe065ce6ab3497364969412346267a2
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -4524,7 +4524,7 @@ data:
         "contentRetentionPeriodDays": 21,
         "contentChunkLimit": 1000,
         "purgeRetentionPeriodDays": 730,
-        "purgeChunkLimit": 1000
+        "purgeChunkLimit": 5000
       },
       "authProviderConfigFiles": [],
       "incrementalPrebuilds": {
@@ -9042,7 +9042,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 5730cba43c5427db3f15e751144001295b81609822685e3baa945000fe1f6a32
+        gitpod.io/checksum_config: 2aeb669de68663a5b2c623f39956d06e8fe065ce6ab3497364969412346267a2
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -4536,7 +4536,7 @@ data:
         "contentRetentionPeriodDays": 21,
         "contentChunkLimit": 1000,
         "purgeRetentionPeriodDays": 730,
-        "purgeChunkLimit": 1000
+        "purgeChunkLimit": 5000
       },
       "authProviderConfigFiles": [],
       "incrementalPrebuilds": {
@@ -9054,7 +9054,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 5730cba43c5427db3f15e751144001295b81609822685e3baa945000fe1f6a32
+        gitpod.io/checksum_config: 2aeb669de68663a5b2c623f39956d06e8fe065ce6ab3497364969412346267a2
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
+++ b/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
@@ -4857,7 +4857,7 @@ data:
         "contentRetentionPeriodDays": 21,
         "contentChunkLimit": 1000,
         "purgeRetentionPeriodDays": 730,
-        "purgeChunkLimit": 1000
+        "purgeChunkLimit": 5000
       },
       "authProviderConfigFiles": [],
       "incrementalPrebuilds": {
@@ -9486,7 +9486,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 5730cba43c5427db3f15e751144001295b81609822685e3baa945000fe1f6a32
+        gitpod.io/checksum_config: 2aeb669de68663a5b2c623f39956d06e8fe065ce6ab3497364969412346267a2
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
+++ b/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
@@ -4527,7 +4527,7 @@ data:
         "contentRetentionPeriodDays": 21,
         "contentChunkLimit": 1000,
         "purgeRetentionPeriodDays": 730,
-        "purgeChunkLimit": 1000
+        "purgeChunkLimit": 5000
       },
       "authProviderConfigFiles": [],
       "incrementalPrebuilds": {
@@ -9045,7 +9045,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 5730cba43c5427db3f15e751144001295b81609822685e3baa945000fe1f6a32
+        gitpod.io/checksum_config: 2aeb669de68663a5b2c623f39956d06e8fe065ce6ab3497364969412346267a2
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/pkg/components/server/configmap.go
+++ b/install/installer/pkg/components/server/configmap.go
@@ -194,7 +194,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 			ContentRetentionPeriodDays: 21,
 			ContentChunkLimit:          1000,
 			PurgeRetentionPeriodDays:   365 * 2,
-			PurgeChunkLimit:            1000,
+			PurgeChunkLimit:            5000,
 		},
 		EnableLocalApp: enableLocalApp,
 		AuthProviderConfigFiles: func() []string {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

We currently start > 1k instances per hour. The current rate would just barely keep up. This results in more delates every half hour.

You can see current number of purged records [here](https://grafana.gitpod.io/explore?orgId=1&left=%7B%22datasource%22:%22P4169E866C3094E38%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22editorMode%22:%22code%22,%22expr%22:%22sum%28gitpod_server_workspaces_purged_total%29%22,%22legendFormat%22:%22__auto%22,%22range%22:true,%22instant%22:true%7D%5D,%22range%22:%7B%22from%22:%22now-1h%22,%22to%22:%22now%22%7D%7D)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
