### PR TITLE
[git] Mark generated proto files as regenerate to fold them

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,8 @@
+# installer test output
 install/installer/cmd/testdata/render/**/*.golden linguist-generated=true
+
+# gRPC and Protobuf
+components/**/*.pb.go linguist-generated=true
+components/**/*_pb.js linguist-generated=true
+components/**/*_pb.ts linguist-generated=true
+components/**/*_pb.d.ts linguist-generated=true


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Automatically fold and not display grpc & proto generated files

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
