### PR TITLE
fix(jetbrains): gateway plugin hands on auth issue

### DIFF
--- a/components/gitpod-protocol/java/src/main/java/io/gitpod/gitpodprotocol/api/GitpodServerLauncher.java
+++ b/components/gitpod-protocol/java/src/main/java/io/gitpod/gitpodprotocol/api/GitpodServerLauncher.java
@@ -82,6 +82,10 @@ public class GitpodServerLauncher {
             }
         }
         ClientContainer container = new ClientContainer(httpClient);
+
+        // stop container immediately since we close only when a session is already gone
+        container.setStopTimeout(0);
+
         // allow clientContainer to own httpClient (for start/stop lifecycle)
         container.getClient().addManaged(httpClient);
         container.start();


### PR DESCRIPTION
## Description
This PR aims to improve the user experience when connecting to a workspace using an expired token: The JB Gateway plugin refreshes the token, however while handling the first failed request exepction, the `ClientContainer` will hang for about 30 seconds while stopping.

After investigating deep into the implementation, we believe that the time is given to any existing client connection to be shutdown gracefully. By setting the stop timeout to zero, we effectively revoke this opportunity, however, in our case, we are confident that there are no more active connections so we can safely remove this period of time, which only slows down the opening of the IDE.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #12862 

## How to test
0. Install [this](https://plugins.jetbrains.com/plugin/18438-gitpod-gateway/versions/Dev/227116) version of the JB Gateway Plugin
1. Start a workspace in this prev env
2. Open the workspace with any JetBrains IDE (any version)
3. Observe how everything works as expected
4. Now open a workspace for gitpod in gitpod.io
5. Connect to the prev env database and delete the token
6. Close the JB Gateway and therefore any IDE windows
7.  Delete the token from the database
8. Re-open the prev env workspace and observe how it re-opens without any delays. Especially once the JetBrains Gateway opens, there should not be any unexpected delay before the IDE opens. 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
JetBrains Gateway: Avoid 30 seconds delay when connecting to a workspace using an expired token
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
- [x] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
