### PR TITLE
[server] fix GitHub Education API call

### DIFF
--- a/components/server/ee/src/user/eligibility-service.ts
+++ b/components/server/ee/src/user/eligibility-service.ts
@@ -94,8 +94,9 @@ export class EligibilityService {
                     logCtx,
                     `fetching the GitHub Education API failed with status ${rawResponse.status}: ${rawResponse.statusText}`,
                 );
+                return { student: false, faculty: false };
             }
-            const result: GitHubEducationPack = JSON.parse(await rawResponse.text());
+            const result: GitHubEducationPack = await rawResponse.json();
             if (result.student && result.faculty) {
                 // That violates the API contract: `student` and `faculty` need to be mutually exclusive
                 log.warn(


### PR DESCRIPTION
## Description
This PR fixes parse errors when the GH Edu API call errors. 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #12203

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
