### PR TITLE
[ws-daemon] Ensure last tick usage is updated

### DIFF
--- a/components/ws-daemon/pkg/cpulimit/cpulimit.go
+++ b/components/ws-daemon/pkg/cpulimit/cpulimit.go
@@ -165,13 +165,13 @@ func (d *Distributor) Tick(dt time.Duration) (DistributorDebug, error) {
 	}
 
 	totalBandwidth, err := BandwithFromUsage(d.LastTickUsage, totalUsage, dt)
+	d.LastTickUsage = totalUsage
 	if err != nil {
 		return DistributorDebug{
 			BandwidthAvail: d.TotalBandwidth,
 			BandwidthUsed:  0,
 		}, err
 	}
-	d.LastTickUsage = totalUsage
 
 	// enforce limits
 	var burstBandwidth Bandwidth


### PR DESCRIPTION
## Description
[ws-daemon] Ensure last tick usage is updated. For more context see https://github.com/gitpod-io/ops/issues/5243

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/ops/issues/5243

## How to test
See https://github.com/gitpod-io/ops/issues/5243

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
