### PR TITLE
[server] remove unused `isBillingModeEnabled`

### DIFF
--- a/components/server/ee/src/billing/billing-mode.spec.db.ts
+++ b/components/server/ee/src/billing/billing-mode.spec.db.ts
@@ -496,7 +496,6 @@ class BillingModeSpec {
                         () =>
                             new ConfigCatClientMock({
                                 isUsageBasedBillingEnabled: test.config.usageBasedPricingEnabled,
-                                isBillingModeEnabled: true,
                             }),
                     );
                 }),

--- a/components/server/ee/src/billing/billing-mode.ts
+++ b/components/server/ee/src/billing/billing-mode.ts
@@ -63,25 +63,10 @@ export class BillingModesImpl implements BillingModes {
         }
     }
 
-    protected async isBillingModeEnabled(subject: { user?: User; team?: Team }): Promise<boolean> {
-        // This is a double safety-net to smoothen and de-risk the rollout of BillingMode, because it not only affects
-        // new behavior which is in focus and subject to test anyway (usage-based), but also old behavior (chargebee).
-        const teams = subject.user ? await this.teamDB.findTeamsByUser(subject.user.id) : undefined;
-        return await this.configCatClientFactory().getValueAsync("isBillingModeEnabled", false, {
-            user: subject.user,
-            teams,
-            teamId: subject.team?.id,
-            teamName: subject.team?.name,
-        });
-    }
-
     async getBillingModeForUser(user: User, now: Date): Promise<BillingMode> {
         if (!this.config.enablePayment) {
             // Payment is not enabled. E.g. Self-Hosted.
             return { mode: "none" };
-        }
-        if (!(await this.isBillingModeEnabled({ user }))) {
-            return { mode: "chargebee" };
         }
 
         // Is Usage Based Billing enabled for this user or not?
@@ -166,9 +151,6 @@ export class BillingModesImpl implements BillingModes {
         if (!this.config.enablePayment) {
             // Payment is not enabled. E.g. Self-Hosted.
             return { mode: "none" };
-        }
-        if (!(await this.isBillingModeEnabled({ team }))) {
-            return { mode: "chargebee" };
         }
         const now = _now.toISOString();
 

--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -114,7 +114,6 @@ import { AttributionId } from "@gitpod/gitpod-protocol/lib/attribution";
 import { EntitlementService, MayStartWorkspaceResult } from "../../../src/billing/entitlement-service";
 import { BillingMode } from "@gitpod/gitpod-protocol/lib/billing-mode";
 import { BillingModes } from "../billing/billing-mode";
-import { getExperimentsClientForBackend } from "@gitpod/gitpod-protocol/lib/experiments/configcat-server";
 import { BillingService } from "../billing/billing-service";
 import Stripe from "stripe";
 import { UsageServiceDefinition } from "@gitpod/usage-api/lib/usage/v1/usage.pb";
@@ -2010,14 +2009,6 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
             throw err;
         }
         return subscription;
-    }
-
-    protected async isUsageBasedFeatureFlagEnabled(user: User): Promise<boolean> {
-        const teams = await this.teamDB.findTeamsByUser(user.id);
-        return await getExperimentsClientForBackend().getValueAsync("isUsageBasedBillingEnabled", false, {
-            user,
-            teams: teams,
-        });
     }
 
     protected async ensureChargebeeApiIsAllowed(sub: { user?: User; team?: Team }): Promise<void> {


### PR DESCRIPTION
## Description
Removes unused method and a feature flag for billing mode.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
