### PR TITLE
[content-service] Additional tracing for prebuild init

### DIFF
--- a/components/content-service/pkg/storage/gcloud.go
+++ b/components/content-service/pkg/storage/gcloud.go
@@ -197,6 +197,7 @@ func (rs *DirectGCPStorage) download(ctx context.Context, destination string, bk
 	var wg sync.WaitGroup
 
 	wg.Add(1)
+	backupSpan := opentracing.StartSpan("downloadBackup", opentracing.ChildOf(span.Context()))
 
 	go func() {
 		defer wg.Done()
@@ -224,6 +225,7 @@ func (rs *DirectGCPStorage) download(ctx context.Context, destination string, bk
 	}()
 
 	wg.Wait()
+	tracing.FinishSpan(backupSpan, &err)
 
 	rc, err := os.Open(filepath.Join(backupDir, obj))
 	if err != nil {


### PR DESCRIPTION
## Description
Additional tracing for prebuild init

## Related Issue(s)
Related to https://github.com/gitpod-io/gitpod/issues/12345

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
