### PR TITLE
[server] Usage-Based: Don't block slot operations on old Team Subscri…

### DIFF
--- a/components/dashboard/src/settings/Teams.tsx
+++ b/components/dashboard/src/settings/Teams.tsx
@@ -24,6 +24,7 @@ import { Disposable } from "@gitpod/gitpod-protocol";
 import { PaymentContext } from "../payment-context";
 import { PageWithSettingsSubMenu } from "./PageWithSettingsSubMenu";
 import { UserContext } from "../user-context";
+import { BillingMode } from "@gitpod/gitpod-protocol/lib/billing-mode";
 
 export default function Teams() {
     return (
@@ -604,10 +605,8 @@ function AllTeams() {
         </React.Fragment>
     );
 
-    const showTeamPlans =
-        userBillingMode &&
-        (userBillingMode.mode === "chargebee" ||
-            (userBillingMode.mode === "usage-based" && !!userBillingMode.hasChargebeeTeamPlan));
+    // TOOD(gpl) We might want to reduce visibility of those actions similarly to how we guard access to that API, cmp.: https://github.com/gitpod-io/gitpod/blob/db90aefb9f7dc1d062e9cb73241c1fda2eccee4b/components/server/ee/src/workspace/gitpod-server-impl.ts#L2011
+    const showTeamPlans = BillingMode.showTeamSubscriptionUI(userBillingMode);
     return (
         <div>
             {showTeamPlans ? (

--- a/components/dashboard/src/settings/settings-menu.ts
+++ b/components/dashboard/src/settings/settings-menu.ts
@@ -73,7 +73,7 @@ function renderBillingMenuEntries(billingMode?: BillingMode) {
                     link: [settingsPathBilling],
                 },
                 // We need to allow access to "Team Plans" here, at least for owners.
-                ...(billingMode.hasChargebeeTeamSubscription
+                ...(BillingMode.showTeamSubscriptionUI(billingMode)
                     ? [
                           {
                               title: "Team Plans",

--- a/components/gitpod-protocol/src/billing-mode.ts
+++ b/components/gitpod-protocol/src/billing-mode.ts
@@ -26,6 +26,16 @@ export namespace BillingMode {
         );
     }
 
+    export function showTeamSubscriptionUI(billingMode?: BillingMode): boolean {
+        if (!billingMode) {
+            return false;
+        }
+        return (
+            billingMode.mode === "chargebee" ||
+            (billingMode.mode === "usage-based" && !!billingMode.hasChargebeeTeamSubscription)
+        );
+    }
+
     export function canSetWorkspaceClass(billingMode?: BillingMode): boolean {
         if (!billingMode) {
             return false;
@@ -62,6 +72,6 @@ interface UsageBased {
     /** User is already converted, but is member with at least one Chargebee-based "Team Plan" */
     hasChargebeeTeamPlan?: boolean;
 
-    /** User is already converted, but is member in at least one Chargebee-based "Team Subscription" */
+    /** User is already converted, but is member or owner in at least one Chargebee-based "Team Subscription" */
     hasChargebeeTeamSubscription?: boolean;
 }

--- a/components/server/ee/src/billing/billing-mode.ts
+++ b/components/server/ee/src/billing/billing-mode.ts
@@ -147,8 +147,7 @@ export class BillingModesImpl implements BillingModes {
         const hasCbTeamSeat = cbTeamSubscriptions.length > 0;
         const hasCbTeamSubscription = cbOwnedTeamSubscriptions.length > 0;
 
-        if (hasUbbPaidTeam || hasUbbPersonal) {
-            // UBB is greedy: once a user has at least a paid team membership, they should benefit from it!
+        function usageBased() {
             const result: BillingMode = { mode: "usage-based" };
             if (hasCbTeam) {
                 result.hasChargebeeTeamPlan = true;
@@ -158,6 +157,11 @@ export class BillingModesImpl implements BillingModes {
             }
             return result;
         }
+
+        if (hasUbbPaidTeam || hasUbbPersonal) {
+            // UBB is greedy: once a user has at least a paid team membership, they should benefit from it!
+            return usageBased();
+        }
         if (hasCbTeam || hasCbTeamSeat || canUpgradeToUBB) {
             // TODO(gpl): Q: How to test the free-tier, then? A: Make sure you have no CB seats anymore
             // For that we could add a new field here, which lists all seats that are "blocking" you, and display them in the UI somewhere.
@@ -165,7 +169,7 @@ export class BillingModesImpl implements BillingModes {
         }
 
         // UBB free tier
-        return { mode: "usage-based" };
+        return usageBased();
     }
 
     async getBillingModeForTeam(team: Team, _now: Date): Promise<BillingMode> {

--- a/components/server/ee/src/billing/billing-mode.ts
+++ b/components/server/ee/src/billing/billing-mode.ts
@@ -13,10 +13,10 @@ import { Subscription } from "@gitpod/gitpod-protocol/lib/accounting-protocol";
 import { Config } from "../../../src/config";
 import { StripeService } from "../user/stripe-service";
 import { BillingMode } from "@gitpod/gitpod-protocol/lib/billing-mode";
-import { TeamDB, TeamSubscription2DB, UserDB } from "@gitpod/gitpod-db/lib";
+import { TeamDB, TeamSubscription2DB, TeamSubscriptionDB, UserDB } from "@gitpod/gitpod-db/lib";
 import { Plans } from "@gitpod/gitpod-protocol/lib/plans";
 import { AttributionId } from "@gitpod/gitpod-protocol/lib/attribution";
-import { TeamSubscription2 } from "@gitpod/gitpod-protocol/lib/team-subscription-protocol";
+import { TeamSubscription, TeamSubscription2 } from "@gitpod/gitpod-protocol/lib/team-subscription-protocol";
 
 export const BillingModes = Symbol("BillingModes");
 export interface BillingModes {
@@ -42,6 +42,7 @@ export class BillingModesImpl implements BillingModes {
     @inject(ConfigCatClientFactory) protected readonly configCatClientFactory: ConfigCatClientFactory;
     @inject(SubscriptionService) protected readonly subscriptionSvc: SubscriptionService;
     @inject(StripeService) protected readonly stripeSvc: StripeService;
+    @inject(TeamSubscriptionDB) protected readonly teamSubscriptionDb: TeamSubscriptionDB;
     @inject(TeamSubscription2DB) protected readonly teamSubscription2Db: TeamSubscription2DB;
     @inject(TeamDB) protected readonly teamDB: TeamDB;
     @inject(UserDB) protected readonly userDB: UserDB;
@@ -111,6 +112,10 @@ export class BillingModesImpl implements BillingModes {
         const cbPersonalSubscriptions = cbSubscriptions.filter(
             (s) => !isTeamSubscription(s) && s.planId !== Plans.FREE_OPEN_SOURCE.chargebeeId,
         );
+        const cbOwnedTeamSubscriptions = (
+            await this.teamSubscriptionDb.findTeamSubscriptions({ userId: user.id })
+        ).filter((ts) => TeamSubscription.isActive(ts, now.toISOString()));
+
         let canUpgradeToUBB = false;
         if (cbPersonalSubscriptions.length > 0) {
             if (cbPersonalSubscriptions.every((s) => Subscription.isCancelled(s, now.toISOString()))) {
@@ -140,6 +145,7 @@ export class BillingModesImpl implements BillingModes {
         const hasUbbPaidTeam = teamsModes.some((tm) => tm.mode === "usage-based" && !!tm.paid);
         const hasCbTeam = teamsModes.some((tm) => tm.mode === "chargebee");
         const hasCbTeamSeat = cbTeamSubscriptions.length > 0;
+        const hasCbTeamSubscription = cbOwnedTeamSubscriptions.length > 0;
 
         if (hasUbbPaidTeam || hasUbbPersonal) {
             // UBB is greedy: once a user has at least a paid team membership, they should benefit from it!
@@ -147,7 +153,7 @@ export class BillingModesImpl implements BillingModes {
             if (hasCbTeam) {
                 result.hasChargebeeTeamPlan = true;
             }
-            if (hasCbTeamSeat) {
+            if (hasCbTeamSeat || hasCbTeamSubscription) {
                 result.hasChargebeeTeamSubscription = true;
             }
             return result;

--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -1656,7 +1656,6 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
 
         const user = this.checkAndBlockUser("tsAddSlots");
         const ts = await this.internalGetTeamSubscription(teamSubscriptionId, user.id);
-        await this.ensureChargebeeApiIsAllowedTS(ts);
 
         if (addQuantity <= 0) {
             const err = new Error(`Invalid quantity!`);
@@ -1690,7 +1689,6 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
         const user = this.checkAndBlockUser("tsAssignSlot");
         // assigning a slot can be done by third users
         const ts = await this.internalGetTeamSubscription(teamSubscriptionId, identityStr ? user.id : undefined);
-        await this.ensureChargebeeApiIsAllowedTS(ts);
         const logCtx = { userId: user.id };
 
         try {
@@ -1771,7 +1769,6 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
 
         const user = this.checkAndBlockUser("tsReassignSlot");
         const ts = await this.internalGetTeamSubscription(teamSubscriptionId, user.id);
-        await this.ensureChargebeeApiIsAllowedTS(ts);
         const logCtx = { userId: user.id };
         const assigneeInfo = await this.findAssignee(logCtx, newIdentityStr);
 
@@ -1855,7 +1852,6 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
 
         const user = this.checkAndBlockUser("tsReactivateSlot");
         const ts = await this.internalGetTeamSubscription(teamSubscriptionId, user.id);
-        await this.ensureChargebeeApiIsAllowedTS(ts);
 
         this.updateTeamSubscriptionQueue
             .enqueue(async () => {
@@ -1873,14 +1869,6 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
             .catch((err) => {
                 /** ignore */
             });
-    }
-
-    protected async ensureChargebeeApiIsAllowedTS(ts: TeamSubscription): Promise<void> {
-        const tsOwner = await this.userDB.findUserById(ts.userId);
-        if (!tsOwner) {
-            throw new ResponseError(ErrorCodes.INTERNAL_SERVER_ERROR, "Cannot find TeamSubscription owner!");
-        }
-        await this.ensureChargebeeApiIsAllowed({ user: tsOwner });
     }
 
     async getGithubUpgradeUrls(ctx: TraceContext): Promise<GithubUpgradeURL[]> {


### PR DESCRIPTION
…ptions

 1. Instead, we just block signin up for new Team Subscriptions.
 2. Fixes an issue with displaying Team Subscriptions to owners who have no seat with their own subscription

## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #13105 

## How to test
 - sign up for an old Chargebee Team Subscription
 - create a team with Gitpod in it's name, and upgrade to UBP
 - try to modify the old Chargebee-based Team Subscription (e.g., try to assign yourself a seat)
 - note how it works :heavy_check_mark: 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
- [x] /werft with-payment
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
