### PR TITLE
[server][github] fix file provider for self-managed GHE

### DIFF
--- a/components/server/src/github/api.ts
+++ b/components/server/src/github/api.ts
@@ -156,7 +156,7 @@ export class GitHubRestApi {
     }
 
     protected get userAgent() {
-        return new URL(this.config.oauth!.callBackUrl).hostname;
+        return (this.config.oauth && new URL(this.config.oauth?.callBackUrl)?.hostname) || "GitPod unknown";
     }
 
     /**

--- a/components/server/src/github/github-file-provider.spec.ts
+++ b/components/server/src/github/github-file-provider.spec.ts
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { User } from "@gitpod/gitpod-protocol";
+import { skipIfEnvVarNotSet } from "@gitpod/gitpod-protocol/lib/util/skip-if";
+import { expect } from "chai";
+import { Container, ContainerModule } from "inversify";
+import { suite, retries, test, timeout } from "mocha-typescript";
+import { AuthProviderParams } from "../auth/auth-provider";
+import { DevData } from "../dev/dev-data";
+import { TokenProvider } from "../user/token-provider";
+import { GitHubRestApi } from "./api";
+
+import { GithubFileProvider } from "./file-provider";
+import { GitHubTokenHelper } from "./github-token-helper";
+
+@suite(timeout(10000), retries(2), skipIfEnvVarNotSet("GITPOD_TEST_TOKEN_GITHUB"))
+class TestFileProvider {
+    static readonly AUTH_HOST_CONFIG: Partial<AuthProviderParams> = {
+        id: "Public-GitHub",
+        type: "GitHub",
+        verified: true,
+        description: "",
+        icon: "",
+        host: "github.com",
+    };
+
+    protected fileProvider: GithubFileProvider;
+    protected user: User;
+    protected container: Container;
+
+    public before() {
+        this.container = new Container();
+        this.container.load(
+            new ContainerModule((bind, unbind, isBound, rebind) => {
+                bind(GitHubRestApi).toSelf().inSingletonScope();
+                bind(AuthProviderParams).toConstantValue(TestFileProvider.AUTH_HOST_CONFIG);
+                bind(GitHubTokenHelper).toSelf().inSingletonScope();
+                bind(TokenProvider).toConstantValue(<TokenProvider>{
+                    getTokenForHost: async () => DevData.createGitHubTestToken(),
+                    getFreshPortAuthenticationToken: async (user: User, workspaceId: string) =>
+                        DevData.createPortAuthTestToken(workspaceId),
+                });
+                bind(GithubFileProvider).toSelf().inSingletonScope();
+            }),
+        );
+        this.fileProvider = this.container.get(GithubFileProvider);
+        this.user = DevData.createTestUser();
+    }
+
+    @test public async testFileContent() {
+        const result = await this.fileProvider.getFileContent(
+            {
+                repository: {
+                    owner: "gitpod-io",
+                    name: "gitpod",
+                    host: "github.com",
+                    cloneUrl: "unused in test",
+                },
+                revision: "af51739d341bb2245598e275336ae9f730e3b41a",
+            },
+            this.user,
+            "License.txt",
+        );
+        expect(result).to.not.be.undefined;
+        expect(result).to.contain(`To determine under which license you may use a file from the Gitpod source code,
+please resort to the header of that file.`);
+    }
+}
+
+module.exports = new TestFileProvider();


### PR DESCRIPTION
## Description
This PR removes URL construction for reading file contents, instead rely on supported REST API. 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #9253

## How to test
Though this claims to fix an GHE issue, it can be verified with GitHub SaaS as well, because the core issue was that we'd used to craft the download URL, but here we're changing to supported means of fetching contents via REST API. That said, if should be sufficient to test .gitpod.yml being read from any GitHub repo in a prebuild of a project.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Fix reading .gitpod.yml for self-managed GHE instances.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
