### PR TITLE
[grafana] gRPC dashboard filters requests started on selected method

### DIFF
--- a/operations/observability/mixins/cross-teams/dashboards/gitpod-grpc-server.json
+++ b/operations/observability/mixins/cross-teams/dashboards/gitpod-grpc-server.json
@@ -126,7 +126,7 @@
             "uid": "P4169E866C3094E38"
           },
           "editorMode": "code",
-          "expr": "sum(increase(grpc_server_started_total{grpc_service=~\"$service\", grpc_type=~\"$type\"}[1m])) by (grpc_service, grpc_method)",
+          "expr": "sum(increase(grpc_server_started_total{grpc_service=~\"$service\", grpc_method=~\"$method\", grpc_type=~\"$type\"}[1m])) by (grpc_service, grpc_method)",
           "legendFormat": "{{grpc_service}}.{{grpc_method}}",
           "range": true,
           "refId": "A"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Previously the `requests started` dashboard would ignore the selected `method` variable

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
