### PR TITLE
[usage] Add link to GCP logs and grpc server dashboard

### DIFF
--- a/operations/observability/mixins/meta/dashboards/components/usage.json
+++ b/operations/observability/mixins/meta/dashboards/components/usage.json
@@ -24,7 +24,35 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "links": [],
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "cloud",
+      "includeVars": false,
+      "keepTime": false,
+      "tags": [],
+      "targetBlank": true,
+      "title": "GCP Logs",
+      "tooltip": "See usage component logs in GCP",
+      "type": "link",
+      "url": "https://cloudlogging.app.goo.gl/6en8Xwu5tz7mTex9A"
+    },
+    {
+      "asDropdown": false,
+      "icon": "dashboard",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [
+        "grpc",
+        "server"
+      ],
+      "targetBlank": true,
+      "title": "gRPC Server Metrics",
+      "tooltip": "",
+      "type": "dashboards",
+      "url": ""
+    }
+  ],
   "liveNow": false,
   "panels": [
     {
@@ -523,7 +551,7 @@
         "showThresholdLabels": false,
         "showThresholdMarkers": true
       },
-      "pluginVersion": "9.1.4",
+      "pluginVersion": "9.1.5",
       "targets": [
         {
           "datasource": {
@@ -754,6 +782,6 @@
   "timezone": "utc",
   "title": "Component: Usage",
   "uid": "8W7P-jg4z",
-  "version": 2,
+  "version": 1,
   "weekStart": "monday"
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

<img width="1605" alt="Screenshot 2022-09-20 at 11 28 24" src="https://user-images.githubusercontent.com/1419286/191222007-dd725043-2860-4e5c-ba87-3582f6f4d1d1.png">

Adds quick-links to the dashboard to jump to other relevant resources

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
