### PR TITLE
[installer]: add validation rules to blockNewUsers in config block

### DIFF
--- a/install/installer/pkg/config/v1/config.go
+++ b/install/installer/pkg/config/v1/config.go
@@ -403,8 +403,9 @@ const (
 )
 
 type BlockNewUsers struct {
-	Enabled  bool     `json:"enabled"`
-	Passlist []string `json:"passlist"`
+	Enabled bool `json:"enabled"`
+	// Passlist []string `json:"passlist" validate:"min=1,unique,dive,fqdn"`
+	Passlist []string `json:"passlist" validate:"block_new_users_passlist"`
 }
 
 // AuthProviderConfigs this only contains what is necessary for validation

--- a/install/installer/pkg/config/validation.go
+++ b/install/installer/pkg/config/validation.go
@@ -55,6 +55,8 @@ func Validate(version ConfigVersion, cfg interface{}) (r *ValidationResult, err 
 					res.Fatal = append(res.Fatal, fmt.Sprintf("Field '%s' is %s '%s'", v.Namespace(), tag, v.Param()))
 				case "startswith":
 					res.Fatal = append(res.Fatal, fmt.Sprintf("Field '%s' must start with '%s'", v.Namespace(), v.Param()))
+				case "block_new_users_passlist":
+					res.Fatal = append(res.Fatal, fmt.Sprintf("Field '%s' failed. If 'Enabled = true', there must be at least one fully-qualified domain name in the passlist", v.Namespace()))
 				default:
 					// General error message
 					res.Fatal = append(res.Fatal, fmt.Sprintf("Field '%s' failed %s validation", v.Namespace(), v.Tag()))


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
If a user selects the option to limit their user registrations (which they should if on public internet), it is possible to get their Gitpod instance into a weird state where the initial admin user is blocked if they had configured no items in the passlist.

This adds a validation check to ensure that is not possible.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #13114

## How to test
<!-- Provide steps to test this PR -->
Four scenarios to check:
1. If `blockNewUsers.enabled` is set to `false` and `blockNewUsers.passlist` is set to `[]` - this should pass
2. If `blockNewUsers.enabled` is set to `true` and `blockNewUser.passlist` is set to `[]` - this should fail
3. If `blockNewUsers.enabled` is set to `true` and `blockNewUser.passlist` is set to `["somedomain"]` - this should fail
3. If `blockNewUsers.enabled` is set to `true` and `blockNewUser.passlist` is set to `["somedomain.com"]` - this should pass

Use `go run . validate config -c /path/to/config.yaml` to execute without building the binary

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[installer]: add validation rules to blockNewUsers in config block
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
