### PR TITLE
[terraform/gcp] Split up regular and headless workspaces into separate nodepools

### DIFF
--- a/install/infra/modules/gke/variables.tf
+++ b/install/infra/modules/gke/variables.tf
@@ -44,9 +44,15 @@ variable "services_machine_type" {
   default     = "n2d-standard-4"
 }
 
-variable "max_node_count_workspaces" {
+variable "max_node_count_regular_workspaces" {
   type        = number
-  description = "Maximum number of nodes in the workspaces NodePool. Must be >= 1."
+  description = "Maximum number of nodes in the regular workspaces NodePool. Must be >= 1."
+  default     = 50
+}
+
+variable "max_node_count_headless_workspaces" {
+  type        = number
+  description = "Maximum number of nodes in the headless workspaces NodePool. Must be >= 1."
   default     = 50
 }
 


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->

## Related Issue(s)

This pull request partially fixes https://github.com/gitpod-io/gitpod/issues/12740

## How to test

```
werft run github -j .werft/aks-installer-tests.yaml -a skipTests=true -a deps=external -a preview=true
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[terraform/gcp] Run regular and headless workspaces on separate node pools
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
