### PR TITLE
[obs] Fix dashboard import error

### DIFF
--- a/operations/observability/mixins/workspace/dashboards.libsonnet
+++ b/operations/observability/mixins/workspace/dashboards.libsonnet
@@ -20,7 +20,7 @@
     'gitpod-node-swap.json': (import 'dashboards/node-swap.json'),
     'gitpod-node-ephemeral-storage.json': (import 'dashboards/ephemeral-storage.json'),
     'gitpod-node-problem-detector.json': (import 'dashboards/node-problem-detector.json'),
-    'gitpod-network-limiting.json': (import 'dashboards/network-limiting.json')
+    'gitpod-network-limiting.json': (import 'dashboards/network-limiting.json'),
     'gitpod-component-image-builder.json': (import 'dashboards/components/image-builder.json'),
   },
 }


### PR DESCRIPTION
## Description
Fix dashboard import error. For context see [here](https://github.com/gitpod-io/gitpod/commit/30cffea01aeb84965c50de0c49650a174ca34ce8) and [here](https://github.com/gitpod-io/observability/actions/runs/3088698598/jobs/4995483631#step:4:155).

## Related Issue(s)
n.a.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
