### PR TITLE
[terraform/aks] Implement separate nodepool types, node pool max sizes, machine types

### DIFF
--- a/install/infra/modules/aks/kubernetes.tf
+++ b/install/infra/modules/aks/kubernetes.tf
@@ -27,7 +27,7 @@ resource "azurerm_kubernetes_cluster" "k8s" {
 
   default_node_pool {
     name    = "services"
-    vm_size = local.machine
+    vm_size = var.services_machine_type
 
 
     node_taints = []
@@ -36,7 +36,7 @@ resource "azurerm_kubernetes_cluster" "k8s" {
 
     enable_auto_scaling  = true
     min_count            = 1
-    max_count            = 10
+    max_count            = var.max_node_count_services
     orchestrator_version = var.cluster_version
     node_labels = {
       "gitpod.io/workload_meta"               = true
@@ -66,11 +66,11 @@ resource "azurerm_kubernetes_cluster" "k8s" {
 resource "azurerm_kubernetes_cluster_node_pool" "regularws" {
   kubernetes_cluster_id = azurerm_kubernetes_cluster.k8s.id
   name                  = "regularws"
-  vm_size               = local.machine
+  vm_size               = var.workspaces_machine_type
 
   enable_auto_scaling  = true
   min_count            = 1
-  max_count            = 10
+  max_count            = var.max_node_count_regular_workspaces
   orchestrator_version = var.cluster_version
   node_labels          = { "gitpod.io/workload_workspace_regular" = true }
   vnet_subnet_id       = azurerm_subnet.network.id
@@ -79,11 +79,11 @@ resource "azurerm_kubernetes_cluster_node_pool" "regularws" {
 resource "azurerm_kubernetes_cluster_node_pool" "headlessws" {
   kubernetes_cluster_id = azurerm_kubernetes_cluster.k8s.id
   name                  = "headlessws"
-  vm_size               = local.machine
+  vm_size               = var.workspaces_machine_type
 
   enable_auto_scaling  = true
   min_count            = 1
-  max_count            = 10
+  max_count            = var.max_node_count_headless_workspaces
   orchestrator_version = var.cluster_version
   node_labels          = { "gitpod.io/workload_workspace_headless" = true }
   vnet_subnet_id       = azurerm_subnet.network.id

--- a/install/infra/modules/aks/kubernetes.tf
+++ b/install/infra/modules/aks/kubernetes.tf
@@ -26,7 +26,7 @@ resource "azurerm_kubernetes_cluster" "k8s" {
   http_application_routing_enabled = false
 
   default_node_pool {
-    name    = local.nodes.0.name
+    name    = "services"
     vm_size = local.machine
 
 
@@ -38,7 +38,11 @@ resource "azurerm_kubernetes_cluster" "k8s" {
     min_count            = 1
     max_count            = 10
     orchestrator_version = var.cluster_version
-    node_labels          = local.nodes.0.labels
+    node_labels = {
+      "gitpod.io/workload_meta"               = true
+      "gitpod.io/workload_ide"                = true
+      "gitpod.io/workload_workspace_services" = true
+    }
 
     type           = "VirtualMachineScaleSets"
     vnet_subnet_id = azurerm_subnet.network.id
@@ -59,18 +63,29 @@ resource "azurerm_kubernetes_cluster" "k8s" {
   }
 }
 
-resource "azurerm_kubernetes_cluster_node_pool" "pools" {
-  count = length(local.nodes) - 1
-
+resource "azurerm_kubernetes_cluster_node_pool" "regularws" {
   kubernetes_cluster_id = azurerm_kubernetes_cluster.k8s.id
-  name                  = local.nodes[count.index + 1].name
+  name                  = "regularws"
   vm_size               = local.machine
 
   enable_auto_scaling  = true
   min_count            = 1
   max_count            = 10
   orchestrator_version = var.cluster_version
-  node_labels          = local.nodes[count.index + 1].labels
+  node_labels          = { "gitpod.io/workload_workspace_regular" = true }
+  vnet_subnet_id       = azurerm_subnet.network.id
+}
+
+resource "azurerm_kubernetes_cluster_node_pool" "headlessws" {
+  kubernetes_cluster_id = azurerm_kubernetes_cluster.k8s.id
+  name                  = "headlessws"
+  vm_size               = local.machine
+
+  enable_auto_scaling  = true
+  min_count            = 1
+  max_count            = 10
+  orchestrator_version = var.cluster_version
+  node_labels          = { "gitpod.io/workload_workspace_headless" = true }
   vnet_subnet_id       = azurerm_subnet.network.id
 }
 
@@ -82,7 +97,8 @@ data "azurerm_resources" "k8s" {
 
   depends_on = [
     azurerm_kubernetes_cluster.k8s,
-    azurerm_kubernetes_cluster_node_pool.pools
+    azurerm_kubernetes_cluster_node_pool.regularws,
+    azurerm_kubernetes_cluster_node_pool.headlessws,
   ]
 }
 
@@ -107,7 +123,8 @@ resource "azurerm_network_security_rule" "k8s" {
 
 resource "local_file" "kubeconfig" {
   depends_on = [
-    resource.azurerm_kubernetes_cluster_node_pool.pools,
+    resource.azurerm_kubernetes_cluster_node_pool.regularws,
+    resource.azurerm_kubernetes_cluster_node_pool.headlessws,
   ]
   filename = var.kubeconfig
   content  = azurerm_kubernetes_cluster.k8s.kube_config_raw

--- a/install/infra/modules/aks/local.tf
+++ b/install/infra/modules/aks/local.tf
@@ -1,11 +1,4 @@
 locals {
-  labels = tomap({
-    workload_meta : "gitpod.io/workload_meta"
-    workload_ide : "gitpod.io/workload_ide"
-    workspace_services : "gitpod.io/workload_workspace_services"
-    workspace_regular : "gitpod.io/workload_workspace_regular"
-    workspace_headless : "gitpod.io/workload_workspace_headless"
-  })
   dns_enabled = var.domain_name != null
 
   name_format = join("-", [
@@ -75,16 +68,4 @@ locals {
       priority                   = 4096
     }
   ] : []
-  nodes = [
-    {
-      name = "services"
-      labels = {
-        lookup(local.labels, "workload_meta")      = true
-        lookup(local.labels, "workload_ide")       = true
-        lookup(local.labels, "workspace_services") = true
-        lookup(local.labels, "workspace_regular")  = true
-        lookup(local.labels, "workspace_headless") = true
-      }
-    }
-  ]
 }

--- a/install/infra/modules/aks/variables.tf
+++ b/install/infra/modules/aks/variables.tf
@@ -1,13 +1,18 @@
 // Common variables
 variable "kubeconfig" {
+  description = "Path to write the kubeconfig output to"
   default = "./kubeconfig"
 }
 
 variable "cluster_version" {
-  description = "kubernetes version of to create the cluster with"
+  description = "The AKS Kubernetes version"
 }
 
-variable "domain_name" {}
+variable "domain_name" {
+  description = "The domain name where Gitpod will create DNS records. Leave blank to disable DNS management."
+  type = string
+}
+
 variable "enable_airgapped" {
   default = false
 }
@@ -15,9 +20,43 @@ variable "enable_airgapped" {
 variable "create_external_database" {}
 variable "create_external_registry" {}
 variable "create_external_storage" {}
-variable "resource_group_name" {}
+
+variable "resource_group_name" {
+  description = "The resource group where Gitpod resources will be created."
+  type = string
+}
 
 // Azure-specific variables
 variable "location" {
   default = "northeurope"
+}
+
+variable "max_node_count_regular_workspaces" {
+  type        = number
+  description = "Maximum number of nodes in the regular workspaces NodePool. Must be >= 1."
+  default     = 50
+}
+
+variable "max_node_count_headless_workspaces" {
+  type        = number
+  description = "Maximum number of nodes in the headless workspaces NodePool. Must be >= 1."
+  default     = 50
+}
+
+variable "max_node_count_services" {
+  type        = number
+  description = "Maximum number of nodes in the services NodePool. Must be >= 1."
+  default     = 4
+}
+
+variable "workspaces_machine_type" {
+  type        = string
+  description = "The regular and headless node machine type."
+  default     = "Standard_D8_v4"
+}
+
+variable "services_machine_type" {
+  type        = string
+  description = "The services node machine type."
+  default     = "Standard_D4_v4"
 }


### PR DESCRIPTION
## Description

This pull request breaks up the AKS workloads into separate services, regular workspace, and headless workspace node pools. It also plumbs through machine type and node pool max instance counts.

## Related Issue(s)

See https://github.com/gitpod-io/gitpod/issues/12740

## How to test

Create a self-hosted preview with werft:

```
werft run github -j .werft/aks-installer-tests.yaml -a deps=external -a preview=true
```

Then configure the git integration, run a workspace, and ensure that imagebuilds/regular workspaces run on separate nodes.

## Release Notes

```release-note
[terraform/aks] Separate workloads into different pools, expose terraform variables for max node pool counts
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
