### PR TITLE
Enable configuration of core dump behavior

### DIFF
--- a/components/gitpod-protocol/data/gitpod-schema.json
+++ b/components/gitpod-protocol/data/gitpod-schema.json
@@ -282,6 +282,25 @@
             "type": "boolean",
             "deprecationMessage": "The 'experimentalNetwork' property is deprecated.",
             "description": "Experimental network configuration in workspaces (deprecated). Enabled by default"
+        },
+        "coreDump": {
+            "type": "object",
+            "description": "Configure the default action of certain signals is to cause a process to terminate and produce a core dump file, a file containing an image of the process's memory at the time of termination. Disabled by default.",
+            "deprecationMessage": "The 'coreDump' property is experimental.",
+            "additionalProperties": false,
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "softLimit": {
+                    "type": "number",
+                    "description": "upper limit on the size of the core dump file that will be produced if it receives a core dump signal"
+                },
+                "hardLimit": {
+                    "type": "number",
+                    "description": "the hard limit acts as a ceiling for the soft limit. For more details please check https://man7.org/linux/man-pages/man2/getrlimit.2.html"
+                }
+            }
         }
     },
     "additionalProperties": false,

--- a/components/gitpod-protocol/go/gitpod-config-types.go
+++ b/components/gitpod-protocol/go/gitpod-config-types.go
@@ -23,6 +23,17 @@ type AdditionalRepositoriesItems struct {
 	Url string `yaml:"url"`
 }
 
+// CoreDump Configure the default action of certain signals is to cause a process to terminate and produce a core dump file, a file containing an image of the process's memory at the time of termination. Disabled by default.
+type CoreDump struct {
+	Enabled bool `yaml:"enabled,omitempty"`
+
+	// the hard limit acts as a ceiling for the soft limit. For more details please check https://man7.org/linux/man-pages/man2/getrlimit.2.html
+	HardLimit float64 `yaml:"hardLimit,omitempty"`
+
+	// upper limit on the size of the core dump file that will be produced if it receives a core dump signal
+	SoftLimit float64 `yaml:"softLimit,omitempty"`
+}
+
 // Env Environment variables to set.
 type Env struct {
 }
@@ -42,6 +53,9 @@ type GitpodConfig struct {
 
 	// Path to where the repository should be checked out relative to `/workspace`. Defaults to the simple repository name.
 	CheckoutLocation string `yaml:"checkoutLocation,omitempty"`
+
+	// Configure the default action of certain signals is to cause a process to terminate and produce a core dump file, a file containing an image of the process's memory at the time of termination. Disabled by default.
+	CoreDump *CoreDump `yaml:"coreDump,omitempty"`
 
 	// Experimental network configuration in workspaces (deprecated). Enabled by default
 	ExperimentalNetwork bool `yaml:"experimentalNetwork,omitempty"`
@@ -268,6 +282,76 @@ func (strct *AdditionalRepositoriesItems) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+func (strct *CoreDump) MarshalJSON() ([]byte, error) {
+	buf := bytes.NewBuffer(make([]byte, 0))
+	buf.WriteString("{")
+	comma := false
+	// Marshal the "enabled" field
+	if comma {
+		buf.WriteString(",")
+	}
+	buf.WriteString("\"enabled\": ")
+	if tmp, err := json.Marshal(strct.Enabled); err != nil {
+		return nil, err
+	} else {
+		buf.Write(tmp)
+	}
+	comma = true
+	// Marshal the "hardLimit" field
+	if comma {
+		buf.WriteString(",")
+	}
+	buf.WriteString("\"hardLimit\": ")
+	if tmp, err := json.Marshal(strct.HardLimit); err != nil {
+		return nil, err
+	} else {
+		buf.Write(tmp)
+	}
+	comma = true
+	// Marshal the "softLimit" field
+	if comma {
+		buf.WriteString(",")
+	}
+	buf.WriteString("\"softLimit\": ")
+	if tmp, err := json.Marshal(strct.SoftLimit); err != nil {
+		return nil, err
+	} else {
+		buf.Write(tmp)
+	}
+	comma = true
+
+	buf.WriteString("}")
+	rv := buf.Bytes()
+	return rv, nil
+}
+
+func (strct *CoreDump) UnmarshalJSON(b []byte) error {
+	var jsonMap map[string]json.RawMessage
+	if err := json.Unmarshal(b, &jsonMap); err != nil {
+		return err
+	}
+	// parse all the defined properties
+	for k, v := range jsonMap {
+		switch k {
+		case "enabled":
+			if err := json.Unmarshal([]byte(v), &strct.Enabled); err != nil {
+				return err
+			}
+		case "hardLimit":
+			if err := json.Unmarshal([]byte(v), &strct.HardLimit); err != nil {
+				return err
+			}
+		case "softLimit":
+			if err := json.Unmarshal([]byte(v), &strct.SoftLimit); err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("additional property not allowed: \"" + k + "\"")
+		}
+	}
+	return nil
+}
+
 func (strct *Github) MarshalJSON() ([]byte, error) {
 	buf := bytes.NewBuffer(make([]byte, 0))
 	buf.WriteString("{")
@@ -329,6 +413,17 @@ func (strct *GitpodConfig) MarshalJSON() ([]byte, error) {
 	}
 	buf.WriteString("\"checkoutLocation\": ")
 	if tmp, err := json.Marshal(strct.CheckoutLocation); err != nil {
+		return nil, err
+	} else {
+		buf.Write(tmp)
+	}
+	comma = true
+	// Marshal the "coreDump" field
+	if comma {
+		buf.WriteString(",")
+	}
+	buf.WriteString("\"coreDump\": ")
+	if tmp, err := json.Marshal(strct.CoreDump); err != nil {
 		return nil, err
 	} else {
 		buf.Write(tmp)
@@ -464,6 +559,10 @@ func (strct *GitpodConfig) UnmarshalJSON(b []byte) error {
 			}
 		case "checkoutLocation":
 			if err := json.Unmarshal([]byte(v), &strct.CheckoutLocation); err != nil {
+				return err
+			}
+		case "coreDump":
+			if err := json.Unmarshal([]byte(v), &strct.CoreDump); err != nil {
 				return err
 			}
 		case "experimentalNetwork":

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -804,6 +804,12 @@ export interface RepositoryCloneInformation {
     checkoutLocation?: string;
 }
 
+export interface CoreDumpConfig {
+    enabled?: boolean;
+	softLimit?: number;
+	hardLimit?: number;
+}
+
 export interface WorkspaceConfig {
     mainConfiguration?: string;
     additionalRepositories?: RepositoryCloneInformation[];
@@ -816,6 +822,7 @@ export interface WorkspaceConfig {
     github?: GithubAppConfig;
     vscode?: VSCodeConfig;
     jetbrains?: JetBrainsConfig;
+    coreDump?: CoreDumpConfig;
 
     /** deprecated. Enabled by default **/
     experimentalNetwork?: boolean;

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -1417,6 +1417,19 @@ export class WorkspaceStarter {
         dotfileEnv.setValue(user.additionalData?.dotfileRepo || "");
         envvars.push(dotfileEnv);
 
+        if (workspace.config.coreDump?.enabled) {
+            // default core dump size is 262144 blocks (if blocksize is 4096)
+            const defaultLimit:number=1073741824;
+
+            const rLimitCore = new EnvironmentVariable();
+            rLimitCore.setName("GITPOD_RLIMIT_CORE");
+            rLimitCore.setValue(JSON.stringify({
+                softLimit: workspace.config.coreDump?.softLimit || defaultLimit,
+                hardLimit: workspace.config.coreDump?.hardLimit || defaultLimit,
+            }));
+            envvars.push(rLimitCore);
+        }
+
         const createGitpodTokenPromise = (async () => {
             const scopes = this.createDefaultGitpodAPITokenScopes(workspace, instance);
             const token = crypto.randomBytes(30).toString("hex");

--- a/components/workspacekit/cmd/rings.go
+++ b/components/workspacekit/cmd/rings.go
@@ -829,6 +829,14 @@ var ring2Cmd = &cobra.Command{
 			return
 		}
 
+		rlimit := syscall.Rlimit{
+			Cur: 0,
+			Max: 0,
+		}
+		if err := syscall.Setrlimit(syscall.RLIMIT_CORE, &rlimit); err != nil {
+			log.WithError(err).Error("cannot disable core dumps")
+		}
+
 		// Now that we're in our new root filesystem, including proc and all, we can load
 		// our seccomp filter, and tell our parent about it.
 		scmpFd, err := seccomp.LoadFilter()

--- a/components/ws-manager/pkg/manager/create.go
+++ b/components/ws-manager/pkg/manager/create.go
@@ -802,7 +802,8 @@ func (m *Manager) createWorkspaceEnvironment(startContext *startWorkspaceContext
 				"GITPOD_RESOLVED_EXTENSIONS",
 				"GITPOD_EXTERNAL_EXTENSIONS",
 				"GITPOD_WORKSPACE_CLASS_INFO",
-				"GITPOD_IDE_ALIAS":
+				"GITPOD_IDE_ALIAS",
+				"GITPOD_RLIMIT_CORE":
 				// these variables are allowed - don't skip them
 			default:
 				if strings.HasPrefix(e.Name, "GITPOD_") {


### PR DESCRIPTION
## Description

By default, core dumps are disabled. If we want to enable the feature, we need to update the .gitpod.yml file
```
coreDump:
  enabled: true
```

Optionally we can set custom sizes
```
coreDump:
  enabled: true
  softLimit: <bytes>
  hardLimit: <bytes>
```


## Related Issue(s)
Replaces #12814
Fixes https://github.com/gitpod-io/gitpod/issues/12453

## How to test

**Tests:**

---
1. Default behavior
- Open a workspace https://aledbf-core.preview.gitpod-dev.com/#https://github.com/gitpod-io/template-python-django
- Run `ulimit -c` and check the value is 0
- Run `sleep 900&`
- Run `kill -s SIGSEGV [pid]`
- Check no `core.*` file exist

---

2. Enable core dumps
- Open a workspace https://aledbf-core.preview.gitpod-dev.com/#https://github.com/gitpod-io/template-python-django/tree/aledbf/enable-coredump
- Run `ulimit -c` and check the value is 1048576
- Check the value of the env variable `echo $GITPOD_RLIMIT_CORE` is `{"softLimit":1073741824,"hardLimit":1073741824}`
- Run `sleep 900&`
- Run `kill -s SIGSEGV [pid]`
- Check file `core.[pid]` exists

---

3. Enable core dumps with custom sizes
- Open a workspace https://aledbf-core.preview.gitpod-dev.com/#https://github.com/gitpod-io/template-python-django/tree/aledbf/coredump-size
- Run `ulimit -c` and check the value is 9765
- Check the value of the env variable `echo $GITPOD_RLIMIT_CORE` is `{"soft-limit":10000000,"hard-limit":20000000}`
- Run `sleep 900&`
- Run `kill -s SIGSEGV [pid]`
- Check file `core.[pid]` exists and size is about `393216`



## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Enable configuration of core dump behavior in a workspace
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

xref https://github.com/gitpod-io/website/pull/2767


## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
