### PR TITLE
[server] Delete prebuild records when purging workspaces

### DIFF
--- a/components/gitpod-db/src/index.ts
+++ b/components/gitpod-db/src/index.ts
@@ -39,3 +39,4 @@ export * from "./project-db";
 export * from "./team-db";
 export * from "./installation-admin-db";
 export * from "./webhook-event-db";
+export * from "./typeorm/metrics";

--- a/components/gitpod-db/src/typeorm/entity/db-prebuild-info-entry.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-prebuild-info-entry.ts
@@ -31,4 +31,8 @@ export class DBPrebuildInfo {
         })(),
     })
     info: PrebuildInfo;
+
+    // This column triggers the db-sync deletion mechanism. It's not intended for public consumption.
+    @Column()
+    deleted?: boolean;
 }

--- a/components/gitpod-db/src/typeorm/entity/db-prebuilt-workspace-updatable.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-prebuilt-workspace-updatable.ts
@@ -59,4 +59,8 @@ export class DBPrebuiltWorkspaceUpdatable implements PrebuiltWorkspaceUpdatable 
         transformer: Transformer.MAP_EMPTY_STR_TO_UNDEFINED,
     })
     label?: string;
+
+    // This column triggers the db-sync deletion mechanism. It's not intended for public consumption.
+    @Column()
+    deleted?: boolean;
 }

--- a/components/gitpod-db/src/typeorm/entity/db-prebuilt-workspace.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-prebuilt-workspace.ts
@@ -77,4 +77,8 @@ export class DBPrebuiltWorkspace implements PrebuiltWorkspace {
         transformer: Transformer.MAP_BIGINT_TO_NUMBER,
     })
     statusVersion: number;
+
+    // This column triggers the db-sync deletion mechanism. It's not intended for public consumption.
+    @Column()
+    deleted?: boolean;
 }

--- a/components/gitpod-db/src/typeorm/metrics.ts
+++ b/components/gitpod-db/src/typeorm/metrics.ts
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import * as prometheusClient from "prom-client";
+
+export function registerDBMetrics(registry: prometheusClient.Registry) {
+    registry.registerMetric(workspacesPurgedTotal);
+    registry.registerMetric(prebuildWorkspacesPurgedTotal);
+    registry.registerMetric(prebuildInfoPurgedTotal);
+    registry.registerMetric(workspaceInstancePurgedTotal);
+}
+
+const workspacesPurgedTotal = new prometheusClient.Counter({
+    name: "gitpod_server_workspaces_purged_total",
+    help: "Counter of workspaces hard deleted by periodic gc.",
+});
+
+export function reportWorkspacePurged(count: number) {
+    workspacesPurgedTotal.inc(count);
+}
+
+const prebuildWorkspacesPurgedTotal = new prometheusClient.Counter({
+    name: "gitpod_server_prebuild_workspaces_purged_total",
+    help: "Counter of prebuild workspaces hard deleted by periodic gc.",
+});
+
+export function reportPrebuiltWorkspacePurged(count: number) {
+    prebuildWorkspacesPurgedTotal.inc(count);
+}
+
+const prebuildInfoPurgedTotal = new prometheusClient.Counter({
+    name: "gitpod_server_prebuild_info_purged_total",
+    help: "Counter of prebuild info records hard deleted by periodic gc.",
+});
+
+export function reportPrebuildInfoPurged(count: number) {
+    prebuildInfoPurgedTotal.inc(count);
+}
+
+const workspaceInstancePurgedTotal = new prometheusClient.Counter({
+    name: "gitpod_server_workspace_instances_purged_total",
+    help: "Counter of workspace instances records hard deleted by periodic gc.",
+});
+
+export function reportWorkspaceInstancePurged(count: number) {
+    workspaceInstancePurgedTotal.inc(count);
+}
+
+const prebuiltWorkspaceUpdatablePurgedTotal = new prometheusClient.Counter({
+    name: "gitpod_server_prebuilt_workspace_updatable_purged_total",
+    help: "Counter of prebuilt workspace updatable records hard deleted by periodic gc.",
+});
+
+export function reportPrebuiltWorkspaceUpdatablePurged(count: number) {
+    prebuiltWorkspaceUpdatablePurgedTotal.inc(count);
+}

--- a/components/server/ee/src/monitoring-endpoint-ee.ts
+++ b/components/server/ee/src/monitoring-endpoint-ee.ts
@@ -9,18 +9,26 @@ import { WorkspaceHealthMonitoring } from "./workspace/workspace-health-monitori
 import { TraceContext } from "@gitpod/gitpod-protocol/lib/util/tracing";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 import { injectable, inject } from "inversify";
-import { register } from "../../src/prometheus-metrics";
+import { registerServerMetrics } from "../../src/prometheus-metrics";
+import * as prometheusClient from "prom-client";
+import { registerDBMetrics } from "@gitpod/gitpod-db/lib";
 
 @injectable()
 export class MonitoringEndpointsAppEE extends WorkspaceHealthMonitoring {
     @inject(WorkspaceHealthMonitoring) protected readonly workspaceHealthMonitoring: WorkspaceHealthMonitoring;
 
     public create(): express.Application {
+        const registry = prometheusClient.register;
+
+        prometheusClient.collectDefaultMetrics({ register: registry });
+        registerDBMetrics(registry);
+        registerServerMetrics(registry);
+
         const monApp = express();
         monApp.get("/metrics", async (req, res) => {
             try {
-                res.set("Content-Type", register.contentType);
-                res.end(await register.metrics());
+                res.set("Content-Type", registry.contentType);
+                res.end(await registry.metrics());
             } catch (ex) {
                 res.status(500).end(ex);
             }

--- a/components/server/src/prometheus-metrics.ts
+++ b/components/server/src/prometheus-metrics.ts
@@ -10,11 +10,26 @@ import * as prometheusClient from "prom-client";
 prometheusClient.collectDefaultMetrics();
 export const register = prometheusClient.register;
 
+export function registerServerMetrics(registry: prometheusClient.Registry) {
+    registry.registerMetric(loginCounter);
+    registry.registerMetric(apiConnectionCounter);
+    registry.registerMetric(apiConnectionClosedCounter);
+    registry.registerMetric(apiCallCounter);
+    registry.registerMetric(apiCallDurationHistogram);
+    registry.registerMetric(apiCallUserCounter);
+    registry.registerMetric(httpRequestTotal);
+    registry.registerMetric(httpRequestDuration);
+    registry.registerMetric(messagebusTopicReads);
+    registry.registerMetric(gitpodVersionInfo);
+    registry.registerMetric(instanceStartsSuccessTotal);
+    registry.registerMetric(instanceStartsFailedTotal);
+    registry.registerMetric(prebuildsStartedTotal);
+}
+
 const loginCounter = new prometheusClient.Counter({
     name: "gitpod_server_login_requests_total",
     help: "Total amount of login requests",
     labelNames: ["status", "auth_host"],
-    registers: [prometheusClient.register],
 });
 
 export function increaseLoginCounter(status: string, auth_host: string) {
@@ -27,7 +42,6 @@ export function increaseLoginCounter(status: string, auth_host: string) {
 const apiConnectionCounter = new prometheusClient.Counter({
     name: "gitpod_server_api_connections_total",
     help: "Total amount of established API connections",
-    registers: [prometheusClient.register],
 });
 
 export function increaseApiConnectionCounter() {
@@ -37,7 +51,6 @@ export function increaseApiConnectionCounter() {
 const apiConnectionClosedCounter = new prometheusClient.Counter({
     name: "gitpod_server_api_connections_closed_total",
     help: "Total amount of closed API connections",
-    registers: [prometheusClient.register],
 });
 
 export function increaseApiConnectionClosedCounter() {
@@ -48,7 +61,6 @@ const apiCallCounter = new prometheusClient.Counter({
     name: "gitpod_server_api_calls_total",
     help: "Total amount of API calls per method",
     labelNames: ["method", "statusCode"],
-    registers: [prometheusClient.register],
 });
 
 export function increaseApiCallCounter(method: string, statusCode: number) {
@@ -60,7 +72,6 @@ export const apiCallDurationHistogram = new prometheusClient.Histogram({
     help: "Duration of API calls in seconds",
     labelNames: ["method"],
     buckets: [0.1, 0.5, 1, 5, 10, 15, 30],
-    registers: [prometheusClient.register],
 });
 
 export function observeAPICallsDuration(method: string, duration: number) {
@@ -71,7 +82,6 @@ const apiCallUserCounter = new prometheusClient.Counter({
     name: "gitpod_server_api_calls_user_total",
     help: "Total amount of API calls per user",
     labelNames: ["method", "user"],
-    registers: [prometheusClient.register],
 });
 
 export function increaseApiCallUserCounter(method: string, user: string) {
@@ -82,7 +92,6 @@ const httpRequestTotal = new prometheusClient.Counter({
     name: "gitpod_server_http_requests_total",
     help: "Total amount of HTTP requests per express route",
     labelNames: ["method", "route", "statusCode"],
-    registers: [prometheusClient.register],
 });
 
 export function increaseHttpRequestCounter(method: string, route: string, statusCode: number) {
@@ -94,7 +103,6 @@ const httpRequestDuration = new prometheusClient.Histogram({
     help: "Duration of HTTP requests in seconds",
     labelNames: ["method", "route", "statusCode"],
     buckets: [0.01, 0.05, 0.1, 0.5, 1, 5, 10],
-    registers: [prometheusClient.register],
 });
 
 export function observeHttpRequestDuration(
@@ -110,7 +118,6 @@ const messagebusTopicReads = new prometheusClient.Counter({
     name: "gitpod_server_topic_reads_total",
     help: "The amount of reads from messagebus topics.",
     labelNames: ["topic"],
-    registers: [prometheusClient.register],
 });
 
 export function increaseMessagebusTopicReads(topic: string) {
@@ -123,7 +130,6 @@ const gitpodVersionInfo = new prometheusClient.Gauge({
     name: "gitpod_version_info",
     help: "Gitpod's version",
     labelNames: ["gitpod_version"],
-    registers: [prometheusClient.register],
 });
 
 export function setGitpodVersion(gitpod_version: string) {
@@ -134,7 +140,6 @@ const instanceStartsSuccessTotal = new prometheusClient.Counter({
     name: "gitpod_server_instance_starts_success_total",
     help: "Total amount of successfully performed instance starts",
     labelNames: ["retries"],
-    registers: [prometheusClient.register],
 });
 
 export function increaseSuccessfulInstanceStartCounter(retries: number = 0) {
@@ -145,7 +150,6 @@ const instanceStartsFailedTotal = new prometheusClient.Counter({
     name: "gitpod_server_instance_starts_failed_total",
     help: "Total amount of failed performed instance starts",
     labelNames: ["reason"],
-    registers: [prometheusClient.register],
 });
 
 export type FailedInstanceStartReason =
@@ -160,19 +164,8 @@ export function increaseFailedInstanceStartCounter(reason: FailedInstanceStartRe
 const prebuildsStartedTotal = new prometheusClient.Counter({
     name: "gitpod_prebuilds_started_total",
     help: "Counter of total prebuilds started.",
-    registers: [prometheusClient.register],
 });
 
 export function increasePrebuildsStartedCounter() {
     prebuildsStartedTotal.inc();
-}
-
-const workspacesPurgedTotal = new prometheusClient.Counter({
-    name: "gitpod_server_workspaces_purged_total",
-    help: "Counter of workspaces hard deleted by periodic job running on server.",
-    registers: [prometheusClient.register],
-});
-
-export function reportWorkspacePurged() {
-    workspacesPurgedTotal.inc();
 }

--- a/components/server/src/workspace/workspace-deletion-service.ts
+++ b/components/server/src/workspace/workspace-deletion-service.ts
@@ -19,7 +19,6 @@ import { TraceContext } from "@gitpod/gitpod-protocol/lib/util/tracing";
 import { WorkspaceManagerClientProvider } from "@gitpod/ws-manager/lib/client-provider";
 import { DeleteVolumeSnapshotRequest } from "@gitpod/ws-manager/lib";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
-import { reportWorkspacePurged } from "../prometheus-metrics";
 
 @injectable()
 export class WorkspaceDeletionService {
@@ -57,7 +56,6 @@ export class WorkspaceDeletionService {
     public async hardDeleteWorkspace(ctx: TraceContext, workspaceId: string): Promise<void> {
         await this.db.trace(ctx).hardDeleteWorkspace(workspaceId);
         log.info(`Purged Workspace ${workspaceId} and all WorkspaceInstances for this workspace`, { workspaceId });
-        reportWorkspacePurged();
     }
 
     /**


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

When we delete Workspaces, we also need to delete corresponding prebuilds when the Workspace is based on a prebuild.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Depends on https://github.com/gitpod-io/gitpod/pull/13165

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
