### PR TITLE
[usage] Align credits and time in usage view

### DIFF
--- a/components/dashboard/src/components/UsageView.tsx
+++ b/components/dashboard/src/components/UsageView.tsx
@@ -302,11 +302,9 @@ function UsageView({ attributionId }: UsageViewProps) {
                                                         <span className="text-right text-gray-500 dark:text-gray-400 font-medium">
                                                             {usage.credits.toFixed(1)}
                                                         </span>
-                                                        <div className="flex">
-                                                            <span className="text-right truncate text-sm text-gray-400 dark:text-gray-500">
-                                                                {getMinutes(usage)}
-                                                            </span>
-                                                        </div>
+                                                        <span className="text-right text-sm text-gray-400 dark:text-gray-500">
+                                                            {getMinutes(usage)}
+                                                        </span>
                                                     </div>
                                                     <div className="my-auto" />
                                                     <div className="flex flex-col col-span-3 my-auto">


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Right-aligns credits and time in the usage view

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* https://github.com/gitpod-io/gitpod/issues/13154

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
