### PR TITLE
[server] If getting usage-based notifications fails, log a warning instead of propagating the error to the dashboard

### DIFF
--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -2294,15 +2294,20 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
         const result = await super.getNotifications(ctx);
         const user = this.checkAndBlockUser("getNotifications");
 
-        const billingMode = await this.billingModes.getBillingModeForUser(user, new Date());
-        if (billingMode.mode === "usage-based") {
-            const limit = await this.billingService.checkUsageLimitReached(user);
-            if (limit.reached) {
-                result.unshift("The usage limit is reached.");
-            } else if (limit.almostReached) {
-                result.unshift("The usage limit is almost reached.");
+        try {
+            const billingMode = await this.billingModes.getBillingModeForUser(user, new Date());
+            if (billingMode.mode === "usage-based") {
+                const limit = await this.billingService.checkUsageLimitReached(user);
+                if (limit.reached) {
+                    result.unshift("The usage limit is reached.");
+                } else if (limit.almostReached) {
+                    result.unshift("The usage limit is almost reached.");
+                }
             }
+        } catch (error) {
+            log.warn({ userId: user.id }, "Could not get usage-based notifications for user", { error });
         }
+
         return result;
     }
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

If getting usage-based notifications fails, log a warning in `server` instead of propagating the error to the dashboard.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Should fix https://github.com/gitpod-io/gitpod/issues/13131

by silencing this error which happens when you have multiple teams with usage-based billing enabled:

```
Request getNotifications unsuccessful: 455/"Multiple teams have billing enabled."
```

More context [in Slack](https://gitpod.slack.com/archives/C027AUU7BC3/p1663683874566519?thread_ts=1663683642.094259&cid=C027AUU7BC3) (internal):

> > Should we display the prompt when we see this error?
> 
> I'd rather catch it locally and ignore it for now.
> The user will be prompted on next workspace start, anyway. 🧘

## How to test
<!-- Provide steps to test this PR -->

Hint: Reviewing without whitespace is easier: https://github.com/gitpod-io/gitpod/pull/13178/files?w=1

<img width="600" alt="Screenshot 2022-09-21 at 16 43 37" src="https://user-images.githubusercontent.com/599268/191535457-5b8a6732-5624-4541-a139-249e7dbc760f.png">


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
