### PR TITLE
[content-service] Add snapshot initializer to walkInitializer

### DIFF
--- a/components/content-service-api/go/initializer_test.go
+++ b/components/content-service-api/go/initializer_test.go
@@ -105,6 +105,17 @@ func TestGetCheckoutLocationsFromInitializer(t *testing.T) {
 		{
 			Name: "nil initializer",
 		},
+		{
+			Name: "snapshot initializer",
+			Initializer: &api.WorkspaceInitializer{
+				Spec: &api.WorkspaceInitializer_Snapshot{
+					Snapshot: &api.SnapshotInitializer{
+						Snapshot:           "foo",
+						FromVolumeSnapshot: true,
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
## Description
Adds the snapshot initializer to the `walkInitializer` function.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #12554

## How to test
See unit test

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
