### PR TITLE
[installer-tests] avoid cleaning up preview setup for release branches

### DIFF
--- a/.werft/jobs/build/self-hosted-upgrade-tests.ts
+++ b/.werft/jobs/build/self-hosted-upgrade-tests.ts
@@ -49,7 +49,7 @@ export async function triggerUpgradeTests(werft: Werft, config: JobConfig, usern
     // the following bit make sure that the subdomain stays the same upon multiple runs, and always start with release
     const regex = /[\/,\.]/g;
     const subdomain: string = config.repository.branch.replace(regex, '-')
-    annotation = annotation.concat(`-a subdomain=${subdomain}`)
+    annotation = annotation.concat(` -a subdomain=${subdomain}`)
 
     for (let phase in phases) {
         const upgradeConfig = phases[phase];

--- a/.werft/jobs/build/self-hosted-upgrade-tests.ts
+++ b/.werft/jobs/build/self-hosted-upgrade-tests.ts
@@ -46,6 +46,11 @@ export async function triggerUpgradeTests(werft: Werft, config: JobConfig, usern
     exec(`git config --global user.name "${username}"`);
     var annotation = `-a version=${config.fromVersion} -a upgrade=true -a channel=${channel} -a preview=true -a skipTests=true`;
 
+    // the following bit make sure that the subdomain stays the same upon multiple runs, and always start with release
+    const regex = /[\/,\.]/g;
+    const subdomain: string = config.repository.branch.replace(regex, '-')
+    annotation = annotation.concat(`-a subdomain=${subdomain}`)
+
     for (let phase in phases) {
         const upgradeConfig = phases[phase];
 

--- a/install/tests/cleanup.sh
+++ b/install/tests/cleanup.sh
@@ -25,6 +25,7 @@ for i in $(gsutil ls gs://nightly-tests/tf-state); do
     cloud=$(echo "$TF_VAR_TEST_ID" | sed 's/\(.*\)-/\1 /' | xargs | awk '{print $2}')
 
     if [[ "$TF_VAR_TEST_ID" == gitpod-* ]] ; then echo "$TF_VAR_TEST_ID has the pattern gitpod-*, skipping"; continue; fi
+    if [[ "$TF_VAR_TEST_ID" == release-* ]] ; then echo "$TF_VAR_TEST_ID has the pattern gitpod-*, skipping"; continue; fi
 
     if [ "$TF_VAR_TEST_ID" = "default" ] || [ "$TF_VAR_TEST_ID" = "" ]; then continue; fi
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
During the upcoming release, we are changing the process to have preview setups with the latest version up for the whole week or until explicitly cleaned up. This is a temporary solution that avoids cleaning up of resources, if the terraform state(or the subdomain) starts with a `release-` prefix.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
Try running the following:
```
werft run github -j .werft/k3s-installer-tests.yaml -a subdomain=release-tests-abc -a preview=true
```
you will see that the setup do not get cleaned up after 10 hours.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
