### PR TITLE
Add ide-metrics allowed components for vscode

### DIFF
--- a/install/installer/cmd/testdata/render/aws-setup/output.golden
+++ b/install/installer/cmd/testdata/render/aws-setup/output.golden
@@ -4015,7 +4015,9 @@ data:
         "errorReporting": {
           "allowComponents": [
             "supervisor-frontend",
-            "vscode-workbench"
+            "vscode-workbench",
+            "vscode-server",
+            "vscode-web"
           ]
         }
       },
@@ -7788,7 +7790,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 38daf6eb90ea9693d49597f331d3fcbc68a6b62961fa86096d1fd7e8f67af33c
+        gitpod.io/checksum_config: 261a9080da877b0199c3588c8342e2bf262b31768577d9149ad91decc34870d1
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/azure-setup/output.golden
+++ b/install/installer/cmd/testdata/render/azure-setup/output.golden
@@ -3933,7 +3933,9 @@ data:
         "errorReporting": {
           "allowComponents": [
             "supervisor-frontend",
-            "vscode-workbench"
+            "vscode-workbench",
+            "vscode-server",
+            "vscode-web"
           ]
         }
       },
@@ -7622,7 +7624,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 38daf6eb90ea9693d49597f331d3fcbc68a6b62961fa86096d1fd7e8f67af33c
+        gitpod.io/checksum_config: 261a9080da877b0199c3588c8342e2bf262b31768577d9149ad91decc34870d1
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -4750,7 +4750,9 @@ data:
         "errorReporting": {
           "allowComponents": [
             "supervisor-frontend",
-            "vscode-workbench"
+            "vscode-workbench",
+            "vscode-server",
+            "vscode-web"
           ]
         }
       },
@@ -9060,7 +9062,7 @@ spec:
     metadata:
       annotations:
         gitpod.io: hello
-        gitpod.io/checksum_config: 0d75796644892a36da75b624bf044967e89dc5da8a59facaee2aa094372e7e79
+        gitpod.io/checksum_config: b38c9ab42d890627d631b81f9f714127b1246ebb1f89b0153bf18351c9d2f9c8
         hello: world
       creationTimestamp: null
       labels:

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -4074,7 +4074,9 @@ data:
         "errorReporting": {
           "allowComponents": [
             "supervisor-frontend",
-            "vscode-workbench"
+            "vscode-workbench",
+            "vscode-server",
+            "vscode-web"
           ]
         }
       },
@@ -8063,7 +8065,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 38daf6eb90ea9693d49597f331d3fcbc68a6b62961fa86096d1fd7e8f67af33c
+        gitpod.io/checksum_config: 261a9080da877b0199c3588c8342e2bf262b31768577d9149ad91decc34870d1
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/gcp-setup/output.golden
+++ b/install/installer/cmd/testdata/render/gcp-setup/output.golden
@@ -3904,7 +3904,9 @@ data:
         "errorReporting": {
           "allowComponents": [
             "supervisor-frontend",
-            "vscode-workbench"
+            "vscode-workbench",
+            "vscode-server",
+            "vscode-web"
           ]
         }
       },
@@ -7677,7 +7679,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 38daf6eb90ea9693d49597f331d3fcbc68a6b62961fa86096d1fd7e8f67af33c
+        gitpod.io/checksum_config: 261a9080da877b0199c3588c8342e2bf262b31768577d9149ad91decc34870d1
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/http-proxy/output.golden
+++ b/install/installer/cmd/testdata/render/http-proxy/output.golden
@@ -4243,7 +4243,9 @@ data:
         "errorReporting": {
           "allowComponents": [
             "supervisor-frontend",
-            "vscode-workbench"
+            "vscode-workbench",
+            "vscode-server",
+            "vscode-web"
           ]
         }
       },
@@ -9028,7 +9030,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 38daf6eb90ea9693d49597f331d3fcbc68a6b62961fa86096d1fd7e8f67af33c
+        gitpod.io/checksum_config: 261a9080da877b0199c3588c8342e2bf262b31768577d9149ad91decc34870d1
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -4240,7 +4240,9 @@ data:
         "errorReporting": {
           "allowComponents": [
             "supervisor-frontend",
-            "vscode-workbench"
+            "vscode-workbench",
+            "vscode-server",
+            "vscode-web"
           ]
         }
       },
@@ -8343,7 +8345,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 38daf6eb90ea9693d49597f331d3fcbc68a6b62961fa86096d1fd7e8f67af33c
+        gitpod.io/checksum_config: 261a9080da877b0199c3588c8342e2bf262b31768577d9149ad91decc34870d1
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -4252,7 +4252,9 @@ data:
         "errorReporting": {
           "allowComponents": [
             "supervisor-frontend",
-            "vscode-workbench"
+            "vscode-workbench",
+            "vscode-server",
+            "vscode-web"
           ]
         }
       },
@@ -8355,7 +8357,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 38daf6eb90ea9693d49597f331d3fcbc68a6b62961fa86096d1fd7e8f67af33c
+        gitpod.io/checksum_config: 261a9080da877b0199c3588c8342e2bf262b31768577d9149ad91decc34870d1
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
+++ b/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
@@ -4573,7 +4573,9 @@ data:
         "errorReporting": {
           "allowComponents": [
             "supervisor-frontend",
-            "vscode-workbench"
+            "vscode-workbench",
+            "vscode-server",
+            "vscode-web"
           ]
         }
       },
@@ -8787,7 +8789,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 38daf6eb90ea9693d49597f331d3fcbc68a6b62961fa86096d1fd7e8f67af33c
+        gitpod.io/checksum_config: 261a9080da877b0199c3588c8342e2bf262b31768577d9149ad91decc34870d1
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
+++ b/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
@@ -4243,7 +4243,9 @@ data:
         "errorReporting": {
           "allowComponents": [
             "supervisor-frontend",
-            "vscode-workbench"
+            "vscode-workbench",
+            "vscode-server",
+            "vscode-web"
           ]
         }
       },
@@ -8346,7 +8348,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 38daf6eb90ea9693d49597f331d3fcbc68a6b62961fa86096d1fd7e8f67af33c
+        gitpod.io/checksum_config: 261a9080da877b0199c3588c8342e2bf262b31768577d9149ad91decc34870d1
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/pkg/components/ide-metrics/configmap.go
+++ b/install/installer/pkg/components/ide-metrics/configmap.go
@@ -123,6 +123,8 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		AllowComponents: []string{
 			"supervisor-frontend",
 			"vscode-workbench",
+			"vscode-server",
+			"vscode-web",
 		},
 	}
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Add ide-metrics allowed components for vscode

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
No need

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
