### PR TITLE
[server] don't allow more than three usages per phone number

### DIFF
--- a/components/gitpod-db/src/typeorm/migration/1663784254956-IndexPhoneNumber.ts
+++ b/components/gitpod-db/src/typeorm/migration/1663784254956-IndexPhoneNumber.ts
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { columnExists } from "./helper/helper";
+
+const D_B_USER = "d_b_user";
+const COL_PHONE_NUMBER = "verificationPhoneNumber";
+
+export class IndexPhoneNumber1663784254956 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        if (!(await columnExists(queryRunner, D_B_USER, COL_PHONE_NUMBER))) {
+            await queryRunner.query(
+                `ALTER TABLE ${D_B_USER} ADD INDEX (${COL_PHONE_NUMBER}), ALGORITHM=INPLACE, LOCK=NONE `,
+            );
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {}
+}

--- a/components/gitpod-db/src/typeorm/user-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/user-db-impl.ts
@@ -570,6 +570,22 @@ export class TypeORMUserDBImpl implements UserDB {
     async getByRefreshToken(refreshTokenToken: string): Promise<OAuthToken> {
         throw new Error("Not implemented");
     }
+
+    async countUsagesOfPhoneNumber(phoneNumber: string): Promise<number> {
+        return (await this.getUserRepo())
+            .createQueryBuilder()
+            .where("verificationPhoneNumber = :phoneNumber", { phoneNumber })
+            .getCount();
+    }
+
+    async isBlockedPhoneNumber(phoneNumber: string): Promise<boolean> {
+        const blockedUsers = await (await this.getUserRepo())
+            .createQueryBuilder()
+            .where("verificationPhoneNumber = :phoneNumber", { phoneNumber })
+            .andWhere("blocked = true")
+            .getCount();
+        return blockedUsers > 0;
+    }
 }
 
 export class TransactionalUserDBImpl extends TypeORMUserDBImpl {

--- a/components/gitpod-db/src/user-db.ts
+++ b/components/gitpod-db/src/user-db.ts
@@ -146,6 +146,8 @@ export interface UserDB extends OAuthUserRepository, OAuthTokenRepository {
     storeGitpodToken(token: GitpodToken & { user: DBUser }): Promise<void>;
     deleteGitpodToken(tokenHash: string): Promise<void>;
     deleteGitpodTokensNamedLike(userId: string, namePattern: string): Promise<void>;
+    countUsagesOfPhoneNumber(phoneNumber: string): Promise<number>;
+    isBlockedPhoneNumber(phoneNumber: string): Promise<boolean>;
 }
 export type PartialUserUpdate = Partial<Omit<User, "identities">> & Pick<User, "id">;
 

--- a/components/gitpod-protocol/src/messaging/error.ts
+++ b/components/gitpod-protocol/src/messaging/error.ts
@@ -94,4 +94,7 @@ export namespace ErrorCodes {
 
     // 640 Headless logs are not available (yet)
     export const HEADLESS_LOG_NOT_YET_AVAILABLE = 640;
+
+    // 650 Invalid Value
+    export const INVALID_VALUE = 650;
 }

--- a/components/server/src/user/phone-number.spec.ts
+++ b/components/server/src/user/phone-number.spec.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2020 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import * as chai from "chai";
+import { suite, test } from "mocha-typescript";
+import { formatPhoneNumber } from "./phone-numbers";
+const expect = chai.expect;
+
+@suite
+export class PhoneNumberSpec {
+    @test public testFormatPhoneNumber() {
+        const tests = [
+            ["00123234254", "+123234254"],
+            ["+1 232 34 254", "+123234254"],
+            ["001 23234-254", "+123234254"],
+            ["0012swedfkwejfew32sdf3sdvsf sdv fsdv4254", "+123234254"],
+        ];
+
+        for (const test of tests) {
+            expect(formatPhoneNumber(test[0]), "Values : " + JSON.stringify(test)).to.eq(test[1]);
+        }
+    }
+}
+module.exports = new PhoneNumberSpec();

--- a/components/server/src/user/phone-numbers.ts
+++ b/components/server/src/user/phone-numbers.ts
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+/**
+ * a simply cleaning method, that removes all non numbers and repaces a leading '00' with a leading '+' sign.
+ *
+ * @param phoneNumber
+ * @returns formatted phone number
+ */
+export function formatPhoneNumber(phoneNumber: string): string {
+    var cleanPhoneNumber = phoneNumber.trim();
+    if (cleanPhoneNumber.startsWith("+")) {
+        cleanPhoneNumber = "00" + cleanPhoneNumber.substring(1);
+    }
+    cleanPhoneNumber = cleanPhoneNumber.replace(/\D/g, "");
+    if (cleanPhoneNumber.startsWith("00")) {
+        cleanPhoneNumber = "+" + cleanPhoneNumber.substring(2);
+    }
+    return cleanPhoneNumber;
+}

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -178,6 +178,7 @@ import { VerificationService } from "../auth/verification-service";
 import { BillingMode } from "@gitpod/gitpod-protocol/lib/billing-mode";
 import { EntitlementService } from "../billing/entitlement-service";
 import { WorkspaceClasses } from "./workspace-classes";
+import { formatPhoneNumber } from "../user/phone-numbers";
 
 // shortcut
 export const traceWI = (ctx: TraceContext, wi: Omit<LogContext, "userId">) => TraceContext.setOWI(ctx, wi); // userId is already taken care of in WebsocketConnectionManager
@@ -469,16 +470,17 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         return user;
     }
 
-    public async sendPhoneNumberVerificationToken(ctx: TraceContext, phoneNumber: string): Promise<void> {
+    public async sendPhoneNumberVerificationToken(ctx: TraceContext, rawPhoneNumber: string): Promise<void> {
         this.checkUser("sendPhoneNumberVerificationToken");
-        return this.verificationService.sendVerificationToken(phoneNumber);
+        return this.verificationService.sendVerificationToken(formatPhoneNumber(rawPhoneNumber));
     }
 
     public async verifyPhoneNumberVerificationToken(
         ctx: TraceContext,
-        phoneNumber: string,
+        rawPhoneNumber: string,
         token: string,
     ): Promise<boolean> {
+        const phoneNumber = formatPhoneNumber(rawPhoneNumber);
         const user = this.checkUser("verifyPhoneNumberVerificationToken");
         const checked = await this.verificationService.verifyVerificationToken(phoneNumber, token);
         if (!checked) {


### PR DESCRIPTION
## Description
Adds checks for phone numbers being used by abusers or used too often (>3) 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #12883

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Restrict reuse of phone numbers for verification
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
