### PR TITLE
fix prometheus rule for workspaces

### DIFF
--- a/operations/observability/mixins/workspace/rules/workspaces.yaml
+++ b/operations/observability/mixins/workspace/rules/workspaces.yaml
@@ -27,7 +27,7 @@ spec:
       annotations:
         runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWorkspaceStuckOnStarting.md
         summary: 5 or more workspaces are stuck on starting
-        description: "{{ printf '%.2f' $value }} regular workspaces are stuck on starting for more than 20 minutes. Current status: {{ $labels.reason }}"
+        description: '{{ printf "%.2f" $value }} regular workspaces are stuck on starting for more than 20 minutes. Current status: {{ $labels.reason }}'
       expr: |
         count(
           kube_pod_container_status_waiting_reason * on(pod) group_left kube_pod_labels{component="workspace", workspace_type="regular"}
@@ -40,7 +40,7 @@ spec:
       annotations:
         runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWorkspaceStuckOnStopping.md
         summary: 5 or more workspaces are stuck on stopping
-        description: "{{ printf '%.2f' $value }} {{ $labels.workspace_type }} workspaces are stuck on stopping for more than 20 minutes."
+        description: '{{ printf "%.2f" $value }} {{ $labels.workspace_type }} workspaces are stuck on stopping for more than 20 minutes.'
       expr: |
         sum(
           gitpod_ws_manager_workspace_phase_total{type="REGULAR", phase="STOPPING"}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
To fix this error:
`annotation \"description\": template: __alert_GitpodWorkspaceStuckOnStopping:1: malformed character constant: '%.2f'"`


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
none
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
