### PR TITLE
[workspacekit] Fix empty JSON deserialization error

### DIFF
--- a/components/workspacekit/cmd/rings.go
+++ b/components/workspacekit/cmd/rings.go
@@ -834,11 +834,14 @@ var ring2Cmd = &cobra.Command{
 			Max uint64 `json:"hardLimit"`
 		}
 
-		rLimitValue := os.Getenv("GITPOD_RLIMIT_CORE")
 		var rLimitCore fakeRlimit
-		err = json.Unmarshal([]byte(rLimitValue), &rLimitCore)
-		if err != nil {
-			log.WithError(err).WithField("data", rLimitValue).Error("cannot deserialize GITPOD_RLIMIT_CORE")
+
+		rLimitValue := os.Getenv("GITPOD_RLIMIT_CORE")
+		if len(rLimitValue) != 0 {
+			err = json.Unmarshal([]byte(rLimitValue), &rLimitCore)
+			if err != nil {
+				log.WithError(err).WithField("data", rLimitValue).Error("cannot deserialize GITPOD_RLIMIT_CORE")
+			}
 		}
 
 		// we either set a limit or explicitly disable core dumps by setting 0 as values


### PR DESCRIPTION
## Description

If `GITPOD_RLIMIT_CORE` env variable it's empty we should not attempt to deserialize an empty string

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://cloudlogging.app.goo.gl/QYQWPUhwnjeTQiXD7

## How to test
- Open a workspace
- Check there are no `cannot deserialize GITPOD_RLIMIT_CORE` errors.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [X] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
