### PR TITLE
[jetbrains] apply vmoptions while installing plugins

### DIFF
--- a/components/ide/jetbrains/image/status/main.go
+++ b/components/ide/jetbrains/image/status/main.go
@@ -82,6 +82,20 @@ func main() {
 	if err != nil {
 		log.WithError(err).Error("failed to parse .gitpod.yml")
 	}
+
+	// configure vmoptions
+	idePrefix := alias
+	if alias == "intellij" {
+		idePrefix = "idea"
+	}
+	// [idea64|goland64|pycharm64|phpstorm64].vmoptions
+	vmOptionsPath := fmt.Sprintf("/ide-desktop/backend/bin/%s64.vmoptions", idePrefix)
+	err = configureVMOptions(gitpodConfig, alias, vmOptionsPath)
+	if err != nil {
+		log.WithError(err).Error("failed to configure vmoptions")
+	}
+
+	// install project plugins
 	version_2022_1, _ := version.NewVersion("2022.1")
 	if version_2022_1.LessThanOrEqual(backendVersion) {
 		err = installPlugins(repoRoot, gitpodConfig, alias)
@@ -93,17 +107,7 @@ func main() {
 		}
 	}
 
-	idePrefix := alias
-	if alias == "intellij" {
-		idePrefix = "idea"
-	}
-	// [idea64|goland64|pycharm64|phpstorm64].vmoptions
-	vmOptionsPath := fmt.Sprintf("/ide-desktop/backend/bin/%s64.vmoptions", idePrefix)
-
-	err = configureVMOptions(gitpodConfig, alias, vmOptionsPath)
-	if err != nil {
-		log.WithError(err).Error("failed to configure vmoptions")
-	}
+	// install gitpod plugin
 	err = linkRemotePlugin()
 	if err != nil {
 		log.WithError(err).Error("failed to install gitpod-remote plugin")


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

A user should be able to apply vmoptions to configure different proxies and custom repositories to install plugins in restricted networks or to bring proprietary plugins.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Internal discussion [[1](https://gitpod.slack.com/archives/C02CBKZEVS8/p1663324410457839)]

## How to test
<!-- Provide steps to test this PR -->

- configure **latest** IntelliJ IDEA as IDE: https://ak-plugins-vmoptions.preview.gitpod-dev.com/preferences
- configure VM options and plugins in .gitpod.yml: https://github.com/gitpod-io/spring-petclinic/blob/ak/vmoptions_test/.gitpod.yml#L18
- start a workspace: https://ak-plugins-vmoptions.preview.gitpod-dev.com#https://github.com/gitpod-io/spring-petclinic/tree/ak/vmoptions_test
- open logs in VS Code Browser: `/workspace/.cache/JetBrains-latest/RemoteDev-IU/_workspace_spring-petclinic/log/idea.log`
- check that VM options are present during headless start to install plugins, i.e. search for **foo=bar**, you should see it twice for first start to install plugins and then for second start of actual IDE

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
JetBrains: VM options to install plugins

It allows to configure custom repositories [[1](https://plugins.jetbrains.com/docs/intellij/custom-plugin-repository.html)] or java proxy settings [[2](https://www.jetbrains.com/help/idea/settings-http-proxy.html)] before starting IDE backend, i.e.
``yaml
jetbrains:
  intellij:
    # proxy and custom repositories configurations 
    vmoptions: '-Dhttp.proxyHost=webcache.example.com -Dhttp.proxyPort=8080 -Dhttp.nonProxyHosts="localhost|host.example.com" -Didea.plugin.hosts="http://plugins.example.com:8080/updatePlugins.xml"'
    plugins:
      - org.toml.lang, 
      - com.intellij.kubernetes
      # plugin id from a custom plugin repository
      - localPluginId
``

One also configure IDE vmoptions in the docker image, like:
``bash
INTELLIJ_VMOPTIONS=-Dhttp.proxyHost=webcache.example.com -Dhttp.proxyPort=8080 -Dhttp.nonProxyHosts="localhost|host.example.com" -Didea.plugin.hosts="http://plugins.example.com:8080/updatePlugins.xml"
``
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
- [x] /werft with-large-vm