### PR TITLE
Track git branches during initial checkout

### DIFF
--- a/components/content-service/pkg/git/git.go
+++ b/components/content-service/pkg/git/git.go
@@ -195,6 +195,8 @@ func (c *Client) GitWithOutput(ctx context.Context, ignoreErr *string, subcomman
 		env = append(env, fmt.Sprintf("GIT_SSL_CAINFO=%s", v))
 	}
 
+	span.LogKV("args", fullArgs)
+
 	cmd := exec.Command("git", fullArgs...)
 	cmd.Dir = c.Location
 	cmd.Env = env

--- a/test/tests/workspace/contexts_test.go
+++ b/test/tests/workspace/contexts_test.go
@@ -51,7 +51,7 @@ func TestGitHubContexts(t *testing.T) {
 			Name:           "open tag",
 			ContextURL:     "github.com/gitpod-io/gitpod-test-repo/tree/integration-test-context-tag",
 			WorkspaceRoot:  "/workspace/gitpod-test-repo",
-			ExpectedBranch: "a89cab1135a2d05901ca3021d1608f24a0400932",
+			ExpectedBranch: "HEAD",
 		},
 		{
 			Name:           "Git LFS support",


### PR DESCRIPTION
## Description

Partially reverts #13053 due to not tracking remote branches, something that impacts the commit used in the workspace (not the last one)

Internal report https://gitpod.slack.com/archives/C01KGM9BH54/p1663846572842519

## How to test
- Open a workspace using a branch [https://github.com/gitpod-io/spring-petclinic/tree/ak/vmoptions_test](https://ak-plugins-vmoptions.preview.gitpod-dev.com/#https://github.com/gitpod-io/spring-petclinic/tree/ak/vmoptions_test)
## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-integration-tests=workspace
      Valid options are `all`, `workspace`, `webapp`, `ide`
