### PR TITLE
[admin] avoid global workspace queries in SaaS

### DIFF
--- a/components/dashboard/src/admin/WorkspacesSearch.tsx
+++ b/components/dashboard/src/admin/WorkspacesSearch.tsx
@@ -25,6 +25,7 @@ import { getProject, WorkspaceStatusIndicator } from "../workspaces/WorkspaceEnt
 import WorkspaceDetail from "./WorkspaceDetail";
 import { PageWithAdminSubMenu } from "./PageWithAdminSubMenu";
 import Alert from "../components/Alert";
+import { isGitpodIo } from "../utils";
 
 interface Props {
     user?: User;
@@ -78,6 +79,11 @@ export function WorkspaceSearch(props: Props) {
     }
 
     const search = async () => {
+        // Disables empty search on the workspace search page
+        if (isGitpodIo() && !props.user && queryTerm.length === 0) {
+            return;
+        }
+
         setSearching(true);
         try {
             const query: AdminGetWorkspacesQuery = {
@@ -87,6 +93,9 @@ export function WorkspaceSearch(props: Props) {
                 query.instanceIdOrWorkspaceId = queryTerm;
             } else if (matchesNewWorkspaceIdExactly(queryTerm)) {
                 query.workspaceId = queryTerm;
+            }
+            if (isGitpodIo() && !query.ownerId && !query.instanceIdOrWorkspaceId && !query.workspaceId) {
+                return;
             }
 
             const result = await getGitpodService().server.adminGetWorkspaces({


### PR DESCRIPTION
## Description
This change disables workspace queries without a workspace or instance id for Saas.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #13208

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
