### PR TITLE
previews: Add attribute to spans so they can be filtered in Honeycomb

### DIFF
--- a/.werft/observability/manifests/monitoring-satellite.yaml
+++ b/.werft/observability/manifests/monitoring-satellite.yaml
@@ -3,6 +3,8 @@ tracing:
   install: true
   honeycombAPIKey: ${HONEYCOMB_API_KEY}
   honeycombDataset: preview-environments
+  extraSpanAttributes:
+    preview.name: ${PREVIEW_NAME}
 certmanager:
   installServiceMonitors: true
 pyrra:


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Following up from https://github.com/gitpod-io/observability/pull/323, this PR adds an attribute to traces that are emitted by Gitpod in preview environments. This is being done so engineers can filter spans in Honeycomb that are specific for the preview environment they're working on.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
* Start a workspace from this PR
* Spin up a preview environment
* Start a workspace from the preview just to create some spans
* Search for traces where `preview.name = <your preview name>`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
