### PR TITLE
[kots]: delete workspace pods before installing Gitpod

### DIFF
--- a/install/installer/BUILD.yaml
+++ b/install/installer/BUILD.yaml
@@ -60,6 +60,7 @@ packages:
       - "scripts/*.sh"
     deps:
       - :app
+      - dev/gpctl:app
     argdeps:
       - imageRepoBase
     config:

--- a/install/installer/leeway.Dockerfile
+++ b/install/installer/leeway.Dockerfile
@@ -8,6 +8,7 @@ RUN apk add --no-cache bash curl jq openssh-keygen yq  \
     && curl -L "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" -o /usr/local/bin/kubectl \
     && chmod +x /usr/local/bin/kubectl
 COPY install-installer--app/installer install-installer--app/provenance-bundle.jsonl /app/
+COPY dev-gpctl--app/gpctl /app/
 COPY scripts/*.sh /app/scripts/
 ENTRYPOINT [ "/app/installer" ]
 CMD [ "help" ]

--- a/install/kots/manifests/gitpod-installation-status.yaml
+++ b/install/kots/manifests/gitpod-installation-status.yaml
@@ -30,7 +30,7 @@ spec:
       containers:
         - name: installation-status
           # This will normally be the release tag
-          image: "eu.gcr.io/gitpod-core-dev/build/installer:tar-installer-env-refactor.2"
+          image: "eu.gcr.io/gitpod-core-dev/build/installer:sje-installer-kill-workspaces.14"
           envFrom:
             - configMapRef:
                 name: gitpod-kots-config

--- a/install/kots/manifests/gitpod-installer-job.yaml
+++ b/install/kots/manifests/gitpod-installer-job.yaml
@@ -39,7 +39,7 @@ spec:
       containers:
         - name: installer
           # This will normally be the release tag
-          image: "eu.gcr.io/gitpod-core-dev/build/installer:tar-installer-env-refactor.2"
+          image: "eu.gcr.io/gitpod-core-dev/build/installer:sje-installer-kill-workspaces.14"
           volumeMounts:
             - mountPath: /mnt/node0
               name: node-fs0

--- a/install/kots/manifests/kots-preflight.yaml
+++ b/install/kots/manifests/kots-preflight.yaml
@@ -13,6 +13,9 @@ spec:
         namespace: '{{repl Namespace }}'
         podSpec:
           containers: []
+    - clusterResources:
+        namespaces:
+          - '{{repl Namespace }}'
     - run:
         collectorName: database
         image: eu.gcr.io/gitpod-core-dev/build/kots-config-check/database:sje-kots-config-check.9
@@ -429,3 +432,14 @@ spec:
               message: Registry is accessible
           - fail:
               message: Registry is inaccessible. Please check your network and firewall settings
+    - textAnalyze:
+        checkName: Check running workspaces
+        fileName: cluster-resources/pods/{{repl Namespace }}.json
+        regex: '"component": "workspace"'
+        outcomes:
+          - pass:
+              when: "false"
+              message: No running workspaces. Any workspaces started during the deployment process will be stopped.
+          - fail:
+              when: "true"
+              message: There are running workspaces. These will be stopped during the deployment process.


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Adds a preflight check to see if there are any workspaces/image-builds running. It fails if there is one (the `textAnalyzer` doesn't allow for `warn`, which is very annoying as this isn't really a failure, but a warning).

It also stops any running workspaces/image-builds prior to the `helm upgrade` function being executed.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #13147

## How to test
<!-- Provide steps to test this PR -->
Try installing via KOTS both with and without a workspace running.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[kots]: delete workspace pods before installing Gitpod
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
