### PR TITLE
Previews: Add required flag to install monitoring-satellite

### DIFF
--- a/.werft/observability/install-satellite.sh
+++ b/.werft/observability/install-satellite.sh
@@ -29,7 +29,7 @@ mv installer observability-installer
 
 tmpdir=$(mktemp -d)
 
-envsubst <"${SCRIPT_PATH}/manifests/monitoring-satellite.yaml" | ./observability-installer render --output-split-files "${tmpdir}" --config -
+envsubst <"${SCRIPT_PATH}/manifests/monitoring-satellite.yaml" | ./observability-installer render --app monitoring-satellite --output-split-files "${tmpdir}" --config -
 
 pushd "${tmpdir}"
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
In preparation for https://github.com/gitpod-io/observability/pull/326, this PR adds the required flag to install monitoring-satellite

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/ops/issues/5207

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
