### PR TITLE
Only lint in install/kots:lint if env vars are set

### DIFF
--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -14,6 +14,8 @@ defaultArgs:
   golandDownloadUrl: "https://download.jetbrains.com/go/goland-2022.2.3.tar.gz"
   pycharmDownloadUrl: "https://download.jetbrains.com/python/pycharm-professional-2022.2.2.tar.gz"
   phpstormDownloadUrl: "https://download.jetbrains.com/webide/PhpStorm-2022.2.2.tar.gz"
+  REPLICATED_API_TOKEN: ""
+  REPLICATED_APP: ""
 provenance:
   enabled: true
   slsa: true

--- a/install/kots/BUILD.yaml
+++ b/install/kots/BUILD.yaml
@@ -11,4 +11,4 @@ packages:
       - REPLICATED_APP
     config:
       commands:
-        - ["make", "helm", "lint"]
+        - ["make", "helm", "lint", "REPLICATED_API_TOKEN=${REPLICATED_API_TOKEN}", "REPLICATED_APP=${REPLICATED_APP}"]

--- a/install/kots/Makefile
+++ b/install/kots/Makefile
@@ -62,5 +62,9 @@ logo:
 .PHONY: logo
 
 lint:
-	replicated release lint --yaml-dir ${YAML_DIR}
+	@if [ "${REPLICATED_API_TOKEN}" != "" ] && [ "${REPLICATED_APP}" != "" ]; then \
+		replicated release lint --yaml-dir ${YAML_DIR}; \
+	else \
+		echo "REPLICATED_API_TOKEN and REPLICATED_APP are not set. Skipping"; \
+	fi
 .PHONY: lint


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

I'm trying to make it easier to run a full `leeway` build from a Gitpod workspace in https://github.com/gitpod-io/ops/issues/5411. This PR sets default values for REPLICATED_API_TOKEN and REPLICATED_APP to be the empty string and changes `install/kots:lint` such that it will skip linting if the values are not set.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

Part of https://github.com/gitpod-io/ops/issues/5411

## How to test
<!-- Provide steps to test this PR -->

With this change you can run `leeway build install/kots:lint` and it will skip the linting which means the package builds:

```
leeway build install/kots:lint
```

```
☁️  checking remote cache for past build artifacts
🔧  build  install/kots:lint  (version 797e97ea2f4b8781d619ecf20e14d2beff0da576)

[install/kots:lint] build started (version 797e97ea2f4b8781d619ecf20e14d2beff0da576)
[install/kots:lint] Installing Helm dependencies
[install/kots:lint] Getting updates for unmanaged Helm repositories...
[install/kots:lint] ...Successfully got an update from the "https://fluent.github.io/helm-charts" chart repository
[install/kots:lint] Saving 1 charts
[install/kots:lint] Downloading fluent-bit from repo https://fluent.github.io/helm-charts
[install/kots:lint] Deleting outdated charts
[install/kots:lint] Successfully packaged chart and saved it to: ../../manifests/fluent-bit-0.20.2.tgz
[install/kots:lint] /tmp/build/install-kots--lint.797e97ea2f4b8781d619ecf20e14d2beff0da576
[install/kots:lint] REPLICATED_API_TOKEN and REPLICATED_APP are not set. Skipping
[install/kots:lint] package build succeded (0.55s)
☁️  uploading build artifacts to remote cache

build succeded
```

If you specify the build args then it will try to lint (but fail, as I don't have the right credentials)

```
leeway build install/kots:lint -DREPLICATED_API_TOKEN="a" -DREPLICATED_APP="b"
```

```
☁️  checking remote cache for past build artifacts
🔧  build  install/kots:lint  (version bb4493b88597d7cba568f0b1a6a9df10efd2cd14)

[install/kots:lint] build started (version bb4493b88597d7cba568f0b1a6a9df10efd2cd14)
[install/kots:lint] Installing Helm dependencies
[install/kots:lint] Getting updates for unmanaged Helm repositories...
[install/kots:lint] ...Successfully got an update from the "https://fluent.github.io/helm-charts" chart repository
[install/kots:lint] Saving 1 charts
[install/kots:lint] Downloading fluent-bit from repo https://fluent.github.io/helm-charts
[install/kots:lint] Deleting outdated charts
[install/kots:lint] Successfully packaged chart and saved it to: ../../manifests/fluent-bit-0.20.2.tgz
[install/kots:lint] /tmp/build/install-kots--lint.bb4493b88597d7cba568f0b1a6a9df10efd2cd14
[install/kots:lint] Error: list channels: GET https://api.replicated.com/vendor/v3/apps 401: 
[install/kots:lint] make: *** [Makefile:65: lint] Error 1
[install/kots:lint] package build failed
[install/kots:lint] Reason: exit status 2
☁️  uploading build artifacts to remote cache
build failed
Reason: build failed
FATA[0005] build failed     
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
