### PR TITLE
Set default value for imageRepoBase

### DIFF
--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -1,6 +1,7 @@
 # this file makes this a leeway workspace
 defaultTarget: components:all
 defaultArgs:
+  imageRepoBase: "eu.gcr.io/gitpod-core-dev/build"
   coreYarnLockBase: ../..
   npmPublishTrigger: "false"
   publishToNPM: true


### PR DESCRIPTION
## Description

I'm trying to make it easier to run a full leeway build from a Gitpod workspace in https://github.com/gitpod-io/ops/issues/5411. This PR sets a default values `imageRepoBase` so you don't have to pass it in using `-DimageRepoBase=xxx`

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

Part of https://github.com/gitpod-io/ops/issues/5411

## How to test
<!-- Provide steps to test this PR -->

Running `leeway build` in the root not won't complain about a missing value for `imageRepoBase`.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
