### PR TITLE
preview env: create two workspace classes default and small

### DIFF
--- a/.werft/jobs/build/installer/installer.ts
+++ b/.werft/jobs/build/installer/installer.ts
@@ -157,6 +157,39 @@ EOF`);
         exec(`yq w -i ${this.options.installerConfigPath} workspace.resources.requests.memory "256Mi"`, {
             slice: slice,
         });
+
+        // create two workspace classes (default and small) in server-config configmap
+        exec(`yq w -i ${this.options.installerConfigPath} experimental.webapp.workspaceClasses[+].id "default"`, { slice: slice });
+        exec(`yq w -i ${this.options.installerConfigPath} experimental.webapp.workspaceClasses[0].category "GENERAL PURPOSE"`, { slice: slice });
+        exec(`yq w -i ${this.options.installerConfigPath} experimental.webapp.workspaceClasses[0].displayName "Default"`, { slice: slice });
+        exec(`yq w -i ${this.options.installerConfigPath} experimental.webapp.workspaceClasses[0].description "Default workspace class (30GB disk)"`, { slice: slice });
+        exec(`yq w -i ${this.options.installerConfigPath} experimental.webapp.workspaceClasses[0].powerups 1`, { slice: slice });
+        exec(`yq w -i ${this.options.installerConfigPath} experimental.webapp.workspaceClasses[0].isDefault true`, { slice: slice });
+        exec(`yq w -i ${this.options.installerConfigPath} experimental.webapp.workspaceClasses[0].deprecated false`, { slice: slice });
+
+        exec(`yq w -i ${this.options.installerConfigPath} experimental.webapp.workspaceClasses[+].id "small"`, { slice: slice });
+        exec(`yq w -i ${this.options.installerConfigPath} experimental.webapp.workspaceClasses[1].category "GENERAL PURPOSE"`, { slice: slice });
+        exec(`yq w -i ${this.options.installerConfigPath} experimental.webapp.workspaceClasses[1].displayName "Small"`, { slice: slice });
+        exec(`yq w -i ${this.options.installerConfigPath} experimental.webapp.workspaceClasses[1].description "Small workspace class (20GB disk)"`, { slice: slice });
+        exec(`yq w -i ${this.options.installerConfigPath} experimental.webapp.workspaceClasses[1].powerups 2`, { slice: slice });
+        exec(`yq w -i ${this.options.installerConfigPath} experimental.webapp.workspaceClasses[1].isDefault false`, { slice: slice });
+        exec(`yq w -i ${this.options.installerConfigPath} experimental.webapp.workspaceClasses[1].deprecated false`, { slice: slice });
+        exec(`yq w -i ${this.options.installerConfigPath} experimental.webapp.workspaceClasses[1].marker.moreResources true`, { slice: slice });
+
+        // create two workspace classes (default and small) in ws-manager configmap
+        exec(`yq w -i ${this.options.installerConfigPath} experimental.workspace.classes["default"].name "default"`, { slice: slice });
+        exec(`yq w -i ${this.options.installerConfigPath} experimental.workspace.classes["default"].resources.requests.cpu 100m`, { slice: slice });
+        exec(`yq w -i ${this.options.installerConfigPath} experimental.workspace.classes["default"].resources.requests.memory 128Mi`, { slice: slice });
+        exec(`yq w -i ${this.options.installerConfigPath} experimental.workspace.classes["default"].pvc.size 30Gi`, { slice: slice });
+        exec(`yq w -i ${this.options.installerConfigPath} experimental.workspace.classes["default"].pvc.storageClass rook-ceph-block`, { slice: slice });
+        exec(`yq w -i ${this.options.installerConfigPath} experimental.workspace.classes["default"].pvc.snapshotClass csi-rbdplugin-snapclass`, { slice: slice });
+
+        exec(`yq w -i ${this.options.installerConfigPath} experimental.workspace.classes["small"].name "small"`, { slice: slice });
+        exec(`yq w -i ${this.options.installerConfigPath} experimental.workspace.classes["small"].resources.requests.cpu 100m`, { slice: slice });
+        exec(`yq w -i ${this.options.installerConfigPath} experimental.workspace.classes["small"].resources.requests.memory 128Mi`, { slice: slice });
+        exec(`yq w -i ${this.options.installerConfigPath} experimental.workspace.classes["small"].pvc.size 20Gi`, { slice: slice });
+        exec(`yq w -i ${this.options.installerConfigPath} experimental.workspace.classes["small"].pvc.storageClass rook-ceph-block`, { slice: slice });
+        exec(`yq w -i ${this.options.installerConfigPath} experimental.workspace.classes["small"].pvc.snapshotClass csi-rbdplugin-snapclass`, { slice: slice });
     }
 
     private configureObjectStorage(slice: string) {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Create two workspace classes in the preview environment so we can test workspace classes in the preview environment.
- Default workspace class with 30Gi disk
- Small workspace class with 20Gi disk

<img width="693" alt="image" src="https://user-images.githubusercontent.com/49380831/192561689-bd20570b-b6db-49cd-972f-7d4e31443655.png">

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related to #12638

## How to test
<!-- Provide steps to test this PR -->
- Open the workspace preview.
- Enable the feature flag PVC.
- Open the workspace, and check the PVC size is 30Gi.
- Change your workspace class preference to 20Gi
- Open a new workspace, and check the PVC size is 20Gi.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
None

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
