### PR TITLE
Run pre-commit checks before other validation checks

### DIFF
--- a/.werft/jobs/build/validate-changes.ts
+++ b/.werft/jobs/build/validate-changes.ts
@@ -4,9 +4,11 @@ import { JobConfig } from "./job-config";
 
 export async function validateChanges(werft: Werft, config: JobConfig) {
     werft.phase("validate-changes", "validating changes");
+    // We run pre-commit checks first to avoid potential race conditions with the
+    // other validation checks.
+    await preCommitCheck(werft);
     await Promise.all([
         branchNameCheck(werft, config),
-        preCommitCheck(werft),
         typecheckWerftJobs(werft),
         leewayVet(werft),
     ]);


### PR DESCRIPTION
## Description

Run pre-commit checks before other validation checks. Since running the validation steps in parallel we've seen issues with multiple processes trying to modify .git. We think this might be a conflict between the pre-commit checks and the other validations; specifically that both pre-commit checks and `leeyway vet` run Leeway. This PR runs the pre-commit checks first, and then runs the rest in parallel.

This is mainly based on a hunch - as this is breaking builds now I decided to try a quick-fix rather than do a deep investigation.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/ops/issues/5345

## How to test
<!-- Provide steps to test this PR -->

Run without job protection to see the changes - job [here](https://werft.gitpod-dev.com/job/gitpod-build-mads-run-pre-commit-before-other-validations.2)

```sh
 werft job run github
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
