### PR TITLE
Build speed: components/supervisor:docker and glitpod-cli

### DIFF
--- a/components/gitpod-cli/BUILD.yaml
+++ b/components/gitpod-cli/BUILD.yaml
@@ -13,17 +13,13 @@ packages:
       - components/supervisor-api/go:lib
       - components/gitpod-protocol/go:lib
       - components/common-go:lib
-    argdeps:
-      - version
     config:
       packaging: app
     prep:
       - ["cp", "_deps/components-gitpod-cli--version/version.txt", "pkg/gitpod/version.txt"]
   - name: version
     type: generic
-    argdeps:
-      - version
     config:
       commands:
-        - ["sh", "-c", "echo '${version}' > version.txt"]
-        - ["echo", "Gitpod-CLI Version: ${version}"]
+        - ["sh", "-c", "echo '${__git_commit}' > version.txt"]
+        - ["echo", "Gitpod-CLI Version: ${__git_commit}"]


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This uses the Leeway package version when populating `versions.txt` - the motivation for this change is to improve build speed. When we use `argdeps` the package build cache will be invalidated whenever the argument changes. So having an argdeps on `version` means that we'll rebuild `components/gitpod-cli:version` and `components/gitpod-cli:app` on every CI build. Because `components/supervisor:docker` depends on `components/gitpod-cli:app` it means we'll rebuild that every time too.

This will reduce our build speeds by 38s (based on the example shown below).

**Discussion**: I went with using the Leeway package version. We could also use the git commit (`__git_commit`) or even use `version` but then just know it will only be bumped when the package is actually modified. We could also include all three. 
⬆️  **Update**: We decided on using the git commit instead [here](https://gitpod.slack.com/archives/C01KGM9BH54/p1663924153343129?thread_ts=1663924067.185089&cid=C01KGM9BH54). 

## Related Issue(s)

Fixes https://github.com/gitpod-io/gitpod/issues/12823

## How to test
<!-- Provide steps to test this PR -->

With the changes in this PR I triggered two commits to show that it no longer rebuilds components that didn't change. The arrows in the *before* images indicate what we'll no longer be rebuilding every time.

<table>
<tr>
<td>
<strong>Before</strong>: Logs
<img src="https://user-images.githubusercontent.com/83561/191926891-a1adaa14-56b1-493e-a9bf-638d630b6a5e.png" />

<strong>Before</strong>: Images
<img src="https://user-images.githubusercontent.com/83561/191926258-eeaa56ad-b5c1-429f-8fdb-8592a90c3daf.png" />

</td>
<td>
<strong>After</strong>: Logs
<img src="https://user-images.githubusercontent.com/83561/191926115-93742f30-679a-40a8-939d-5998eda757d8.png" />

<strong>After</strong>: Images
<img src="https://user-images.githubusercontent.com/83561/191926153-2d7be27b-402b-495a-be42-d1df984357d5.png" />

</td>
</tr>
</table>

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
