### PR TITLE
Revert "[usage] Use DefaultClientOptions when creating grpc client connection

### DIFF
--- a/components/usage/pkg/server/server.go
+++ b/components/usage/pkg/server/server.go
@@ -6,7 +6,6 @@ package server
 
 import (
 	"fmt"
-	gitpod_grpc "github.com/gitpod-io/gitpod/common-go/grpc"
 	"net"
 	"os"
 	"time"
@@ -71,11 +70,15 @@ func Start(cfg Config, version string) error {
 	if err != nil {
 		return fmt.Errorf("failed to register grpc client metrics: %w", err)
 	}
-	selfConnection, err := grpc.Dial(srv.GRPCAddress(), append(
-		gitpod_grpc.DefaultClientOptions(),
+	selfConnection, err := grpc.Dial(srv.GRPCAddress(),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpcDialerWithInitialDelay(1*time.Second))...,
-	)
+		grpcDialerWithInitialDelay(1*time.Second),
+		grpc.WithUnaryInterceptor(grpcClientMetrics.UnaryClientInterceptor()),
+		grpc.WithStreamInterceptor(grpcClientMetrics.StreamClientInterceptor()),
+		grpc.WithDefaultCallOptions(
+			grpc.MaxCallRecvMsgSize(100*1024*1024),
+			grpc.MaxCallSendMsgSize(100*1024*1024),
+		))
 	if err != nil {
 		return fmt.Errorf("failed to create self-connection to grpc server: %w", err)
 	}


### PR DESCRIPTION
This reverts commit 0f5d689ce5af15e87f2c16a82f644c66b531cbd4.

## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
