### PR TITLE
[kots]: ensure log-collector directory on node at startup

### DIFF
--- a/install/kots/manifests/gitpod-log-collector.yaml
+++ b/install/kots/manifests/gitpod-log-collector.yaml
@@ -31,11 +31,10 @@ spec:
             - sh
             - -c
           args:
-            - while true; do echo "waiting" && sleep 60; done
+            - mkdir -p /gitpod/log-collector && while true; do echo "waiting" && sleep 60; done
           volumeMounts:
             - name: collector
               mountPath: /gitpod
-              readOnly: true
 
       labels:
         app: gitpod


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This ensures that the `/gitpod/log-collector` directory exists on every node at FluentBit startup. Previously, this directory was only created when a log was added which meant that the `log-collector` section in a support bundle was full of `configmap-errors` saying that the directory didn't exist.

Now, this only adds files into the support bundle if there are files to add, meaning that it's much easier to search for things to look through.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #13095

## How to test
<!-- Provide steps to test this PR -->
Install via KOTS and generate a support bundle

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[kots]: ensure log-collector directory on node at startup
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
