### PR TITLE
[server] Purge records older than 1 year from content deletion

### DIFF
--- a/install/installer/cmd/testdata/render/aws-setup/output.golden
+++ b/install/installer/cmd/testdata/render/aws-setup/output.golden
@@ -4374,7 +4374,7 @@ data:
         "minAgePrebuildDays": 7,
         "contentRetentionPeriodDays": 21,
         "contentChunkLimit": 1000,
-        "purgeRetentionPeriodDays": 730,
+        "purgeRetentionPeriodDays": 365,
         "purgeChunkLimit": 5000
       },
       "authProviderConfigFiles": [],
@@ -8511,7 +8511,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 32e2cd87294b477e4686b3523a87690f8c0116f6bf824310de31a839a523eea7
+        gitpod.io/checksum_config: 995570947a2f55d5a098f8b0a2bfb24c210784db8d69664f6ac4f9b1f3107e24
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/azure-setup/output.golden
+++ b/install/installer/cmd/testdata/render/azure-setup/output.golden
@@ -4238,7 +4238,7 @@ data:
         "minAgePrebuildDays": 7,
         "contentRetentionPeriodDays": 21,
         "contentChunkLimit": 1000,
-        "purgeRetentionPeriodDays": 730,
+        "purgeRetentionPeriodDays": 365,
         "purgeChunkLimit": 5000
       },
       "authProviderConfigFiles": [],
@@ -8363,7 +8363,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 32e2cd87294b477e4686b3523a87690f8c0116f6bf824310de31a839a523eea7
+        gitpod.io/checksum_config: 995570947a2f55d5a098f8b0a2bfb24c210784db8d69664f6ac4f9b1f3107e24
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -5185,7 +5185,7 @@ data:
         "minAgePrebuildDays": 7,
         "contentRetentionPeriodDays": 21,
         "contentChunkLimit": 1000,
-        "purgeRetentionPeriodDays": 730,
+        "purgeRetentionPeriodDays": 365,
         "purgeChunkLimit": 5000
       },
       "authProviderConfigFiles": [],
@@ -9931,7 +9931,7 @@ spec:
     metadata:
       annotations:
         gitpod.io: hello
-        gitpod.io/checksum_config: c90cd959e46212ec8bc505415b69d1340af10b1938cad4a1e717a9d2a76479ed
+        gitpod.io/checksum_config: 35452a9f4990442ea17f71d2d9e729d67c7e68b199c17018489a68e758d3727e
         hello: world
       creationTimestamp: null
       labels:

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -4425,7 +4425,7 @@ data:
         "minAgePrebuildDays": 7,
         "contentRetentionPeriodDays": 21,
         "contentChunkLimit": 1000,
-        "purgeRetentionPeriodDays": 730,
+        "purgeRetentionPeriodDays": 365,
         "purgeChunkLimit": 5000
       },
       "authProviderConfigFiles": [],
@@ -8789,7 +8789,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3212e0147834123027630e72c4dc6d60d6de7bb4f9143aebc173248f1d3e46a6
+        gitpod.io/checksum_config: bf68cc4a7116d9616d776cb6f70b478533681e14350d22f09083c96ab2ab1983
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/gcp-setup/output.golden
+++ b/install/installer/cmd/testdata/render/gcp-setup/output.golden
@@ -4199,7 +4199,7 @@ data:
         "minAgePrebuildDays": 7,
         "contentRetentionPeriodDays": 21,
         "contentChunkLimit": 1000,
-        "purgeRetentionPeriodDays": 730,
+        "purgeRetentionPeriodDays": 365,
         "purgeChunkLimit": 5000
       },
       "authProviderConfigFiles": [],
@@ -8292,7 +8292,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 95f202b0069bd8027c0de410a88e31fdfbd82ac5c9ed999407d479cd2bc421cf
+        gitpod.io/checksum_config: f494f4b9ea8f35ead669c76cc215ace1626a68609c5fd5451de5e364c6367a9b
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/http-proxy/output.golden
+++ b/install/installer/cmd/testdata/render/http-proxy/output.golden
@@ -4648,7 +4648,7 @@ data:
         "minAgePrebuildDays": 7,
         "contentRetentionPeriodDays": 21,
         "contentChunkLimit": 1000,
-        "purgeRetentionPeriodDays": 730,
+        "purgeRetentionPeriodDays": 365,
         "purgeChunkLimit": 5000
       },
       "authProviderConfigFiles": [],
@@ -10210,7 +10210,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3212e0147834123027630e72c4dc6d60d6de7bb4f9143aebc173248f1d3e46a6
+        gitpod.io/checksum_config: bf68cc4a7116d9616d776cb6f70b478533681e14350d22f09083c96ab2ab1983
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -4645,7 +4645,7 @@ data:
         "minAgePrebuildDays": 7,
         "contentRetentionPeriodDays": 21,
         "contentChunkLimit": 1000,
-        "purgeRetentionPeriodDays": 730,
+        "purgeRetentionPeriodDays": 365,
         "purgeChunkLimit": 5000
       },
       "authProviderConfigFiles": [],
@@ -9164,7 +9164,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3212e0147834123027630e72c4dc6d60d6de7bb4f9143aebc173248f1d3e46a6
+        gitpod.io/checksum_config: bf68cc4a7116d9616d776cb6f70b478533681e14350d22f09083c96ab2ab1983
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -4657,7 +4657,7 @@ data:
         "minAgePrebuildDays": 7,
         "contentRetentionPeriodDays": 21,
         "contentChunkLimit": 1000,
-        "purgeRetentionPeriodDays": 730,
+        "purgeRetentionPeriodDays": 365,
         "purgeChunkLimit": 5000
       },
       "authProviderConfigFiles": [],
@@ -9176,7 +9176,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3212e0147834123027630e72c4dc6d60d6de7bb4f9143aebc173248f1d3e46a6
+        gitpod.io/checksum_config: bf68cc4a7116d9616d776cb6f70b478533681e14350d22f09083c96ab2ab1983
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
+++ b/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
@@ -4978,7 +4978,7 @@ data:
         "minAgePrebuildDays": 7,
         "contentRetentionPeriodDays": 21,
         "contentChunkLimit": 1000,
-        "purgeRetentionPeriodDays": 730,
+        "purgeRetentionPeriodDays": 365,
         "purgeChunkLimit": 5000
       },
       "authProviderConfigFiles": [],
@@ -9608,7 +9608,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3212e0147834123027630e72c4dc6d60d6de7bb4f9143aebc173248f1d3e46a6
+        gitpod.io/checksum_config: bf68cc4a7116d9616d776cb6f70b478533681e14350d22f09083c96ab2ab1983
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
+++ b/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
@@ -4648,7 +4648,7 @@ data:
         "minAgePrebuildDays": 7,
         "contentRetentionPeriodDays": 21,
         "contentChunkLimit": 1000,
-        "purgeRetentionPeriodDays": 730,
+        "purgeRetentionPeriodDays": 365,
         "purgeChunkLimit": 5000
       },
       "authProviderConfigFiles": [],
@@ -9167,7 +9167,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3212e0147834123027630e72c4dc6d60d6de7bb4f9143aebc173248f1d3e46a6
+        gitpod.io/checksum_config: bf68cc4a7116d9616d776cb6f70b478533681e14350d22f09083c96ab2ab1983
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/pkg/components/server/configmap.go
+++ b/install/installer/pkg/components/server/configmap.go
@@ -193,7 +193,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 			ChunkLimit:                 1000,
 			ContentRetentionPeriodDays: 21,
 			ContentChunkLimit:          1000,
-			PurgeRetentionPeriodDays:   365 * 2,
+			PurgeRetentionPeriodDays:   365,
 			PurgeChunkLimit:            5000,
 		},
 		EnableLocalApp: enableLocalApp,


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

We've nearly gone through all the records from > 2 years

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
