### PR TITLE
Revert "track git branches"

### DIFF
--- a/components/content-service/pkg/git/git.go
+++ b/components/content-service/pkg/git/git.go
@@ -195,8 +195,6 @@ func (c *Client) GitWithOutput(ctx context.Context, ignoreErr *string, subcomman
 		env = append(env, fmt.Sprintf("GIT_SSL_CAINFO=%s", v))
 	}
 
-	span.LogKV("args", fullArgs)
-
 	cmd := exec.Command("git", fullArgs...)
 	cmd.Dir = c.Location
 	cmd.Env = env

--- a/components/content-service/pkg/initializer/git.go
+++ b/components/content-service/pkg/initializer/git.go
@@ -93,11 +93,6 @@ func (ws *GitInitializer) Run(ctx context.Context, mappings []archive.IDMapping)
 			log.WithError(err).WithField("location", ws.Location).Error("cannot configure fecth behavior")
 		}
 
-		err = ws.Git(ctx, "config", "--replace-all", "checkout.defaultRemote", "origin")
-		if err != nil {
-			log.WithError(err).WithField("location", ws.Location).Error("cannot configure checkout defaultRemote")
-		}
-
 		return nil
 	}
 	onGitCloneFailure := func(e error, d time.Duration) {
@@ -181,12 +176,7 @@ func (ws *GitInitializer) realizeCloneTarget(ctx context.Context) (err error) {
 			return err
 		}
 
-		if err := ws.Git(ctx, "fetch", "--depth=1", "origin", ws.CloneTarget); err != nil {
-			log.WithError(err).WithField("remoteURI", ws.RemoteURI).WithField("branch", ws.CloneTarget).Error("Cannot fetch remote branch")
-			return err
-		}
-
-		if err := ws.Git(ctx, "checkout", "--track", "-B", ws.CloneTarget, "origin/"+ws.CloneTarget); err != nil {
+		if err := ws.Git(ctx, "switch", "-C", ws.CloneTarget); err != nil {
 			log.WithError(err).WithField("remoteURI", ws.RemoteURI).WithField("branch", ws.CloneTarget).Error("Cannot fetch remote branch")
 			return err
 		}
@@ -204,7 +194,7 @@ func (ws *GitInitializer) realizeCloneTarget(ctx context.Context) (err error) {
 		}
 
 		// checkout specific commit
-		if err := ws.Git(ctx, "checkout", "--track", "-B", ws.CloneTarget, "origin/"+ws.CloneTarget); err != nil {
+		if err := ws.Git(ctx, "switch", "-C", ws.CloneTarget); err != nil {
 			return err
 		}
 	default:

--- a/test/tests/workspace/contexts_test.go
+++ b/test/tests/workspace/contexts_test.go
@@ -51,7 +51,7 @@ func TestGitHubContexts(t *testing.T) {
 			Name:           "open tag",
 			ContextURL:     "github.com/gitpod-io/gitpod-test-repo/tree/integration-test-context-tag",
 			WorkspaceRoot:  "/workspace/gitpod-test-repo",
-			ExpectedBranch: "HEAD",
+			ExpectedBranch: "a89cab1135a2d05901ca3021d1608f24a0400932",
 		},
 		{
 			Name:           "Git LFS support",


### PR DESCRIPTION
## Description

Revert https://github.com/gitpod-io/gitpod/pull/13210.

This could be related to a large number of image build failures [(internal)](https://gitpod.slack.com/archives/C01TNS8EVQT/p1663924548081089)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
