### PR TITLE
Cleanup after #13093

### DIFF
--- a/components/BUILD.yaml
+++ b/components/BUILD.yaml
@@ -13,7 +13,6 @@ packages:
       - :publish-api
       - dev:all-app
       - install/installer:docker
-      - install/preview:docker
       - install/kots:lint
       - components/gitpod-protocol:all
   - name: docker-versions


### PR DESCRIPTION
## Description
Removes reference to `install/preview:docker` build target

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Context: previous PR removing said target:  #13093

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
