### PR TITLE
[content-service] Fix git checkout

### DIFF
--- a/components/content-service/pkg/git/git.go
+++ b/components/content-service/pkg/git/git.go
@@ -330,7 +330,7 @@ func (c *Client) Clone(ctx context.Context) (err error) {
 		log.WithError(err).Error("cannot create clone location")
 	}
 
-	args := []string{"--depth=1", c.RemoteURI}
+	args := []string{"--depth=1", "--shallow-submodules", c.RemoteURI}
 
 	for key, value := range c.Config {
 		args = append(args, "--config")

--- a/components/content-service/pkg/initializer/git.go
+++ b/components/content-service/pkg/initializer/git.go
@@ -175,7 +175,7 @@ func (ws *GitInitializer) realizeCloneTarget(ctx context.Context) (err error) {
 	switch ws.TargetMode {
 	case RemoteBranch:
 		// check remote branch exists before git checkout
-		gitout, err := ws.GitWithOutput(ctx, nil, "ls-remote", "origin", ws.CloneTarget)
+		gitout, err := ws.GitWithOutput(ctx, nil, "ls-remote", "--exit-code", "origin", ws.CloneTarget)
 		if err != nil || len(gitout) == 0 {
 			log.WithError(err).WithField("remoteURI", ws.RemoteURI).WithField("branch", ws.CloneTarget).Error("Remote branch doesn't exist.")
 			return err
@@ -186,13 +186,13 @@ func (ws *GitInitializer) realizeCloneTarget(ctx context.Context) (err error) {
 			return err
 		}
 
-		if err := ws.Git(ctx, "checkout", "--track", "-B", ws.CloneTarget, "origin/"+ws.CloneTarget); err != nil {
+		if err := ws.Git(ctx, "checkout", ws.CloneTarget); err != nil {
 			log.WithError(err).WithField("remoteURI", ws.RemoteURI).WithField("branch", ws.CloneTarget).Error("Cannot fetch remote branch")
 			return err
 		}
 	case LocalBranch:
 		// checkout local branch based on remote HEAD
-		if err := ws.Git(ctx, "checkout", "-B", ws.CloneTarget, "origin/HEAD", "--no-track"); err != nil {
+		if err := ws.Git(ctx, "checkout", "origin/HEAD", "--no-track"); err != nil {
 			return err
 		}
 	case RemoteCommit:
@@ -204,7 +204,7 @@ func (ws *GitInitializer) realizeCloneTarget(ctx context.Context) (err error) {
 		}
 
 		// checkout specific commit
-		if err := ws.Git(ctx, "checkout", "--track", "-B", ws.CloneTarget, "origin/"+ws.CloneTarget); err != nil {
+		if err := ws.Git(ctx, "checkout", ws.CloneTarget); err != nil {
 			return err
 		}
 	default:


### PR DESCRIPTION
## Description

Avoid reverting the changes https://github.com/gitpod-io/gitpod/pull/13210 and https://github.com/gitpod-io/gitpod/pull/13053

## Test

Open different workspaces that triggered the changes

- https://aledbf-git.preview.gitpod-dev.com/#https://github.com/gitpod-io/dazzle
- https://aledbf-git.preview.gitpod-dev.com/#https://github.com/gitpod-io/dazzle/commit/ddbf82c1a4dc95bda26c9f299d8e3b8f84eb659d
- https://aledbf-git.preview.gitpod-dev.com/#prebuild/https://github.com/gitpod-io/dazzle
- https://aledbf-git.preview.gitpod-dev.com/#https://github.com/NixOS/nixpkgs
- https://aledbf-git.preview.gitpod-dev.com/#prebuild/https://github.com/NixOS/nixpkgs
- https://aledbf-git.preview.gitpod-dev.com/#https://github.com/gitpod-io/spring-petclinic/tree/ak/vmoptions_test
- https://gitpodio-empty-qkchjpk699u.ws.aledbf-git.preview.gitpod-dev.com/
- https://aledbf-git.preview.gitpod-dev.com#prebuild/https://github.com/gitpod-io/empty

## Release Notes
```release-note
NONE
```

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
