### PR TITLE
[dashboard] add cloneUrl to repo dropdown

### DIFF
--- a/components/dashboard/src/projects/NewProject.tsx
+++ b/components/dashboard/src/projects/NewProject.tsx
@@ -397,6 +397,7 @@ export default function NewProject() {
                                     <div
                                         key={`repo-${index}-${r.account}-${r.name}`}
                                         className="flex p-3 rounded-xl hover:bg-gray-100 dark:hover:bg-gray-800 focus:bg-gitpod-kumquat-light transition ease-in-out group"
+                                        title={r.cloneUrl}
                                     >
                                         <div className="flex-grow">
                                             <div


### PR DESCRIPTION
## Description
Adds a simple HTML title to each item of the "New project" dropdown repo list, with the clone URL

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #11917

## How to test
<!-- Provide steps to test this PR -->
 - Start the dashboard app
 - Go to the "New project" page
 - Hover over an item in the repo dropdown list and wait for the title to show up

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[dashboard] While creating a new project, if you are using GitLab and have several repositories with the same exact name organized in different groups, you will now be able to tell them apart by hovering over each of them in the dropdown list.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
