### PR TITLE
[installer-tests] make domain name configurable

### DIFF
--- a/.werft/aks-installer-tests.yaml
+++ b/.werft/aks-installer-tests.yaml
@@ -4,6 +4,10 @@ args:
   desc: "Subdomain to use. A terraform workspace of same name will be used"
   required: false
   default: ""
+- name: domain
+  desc: "domain to use. Make sure there is a DNS zone by the same name ('.' replaces by '-' under the project 'dns-for-playgrounds')"
+  required: false
+  default: "tests.gitpod-self-hosted.com"
 - name: channel
   desc: "Replicated channel to use"
   required: false

--- a/.werft/eks-installer-tests.yaml
+++ b/.werft/eks-installer-tests.yaml
@@ -4,6 +4,10 @@ args:
   desc: "Subdomain to use. A terraform workspace of same name will be used"
   required: false
   default: ""
+- name: domain
+  desc: "domain to use. Make sure there is a DNS zone by the same name ('.' replaces by '-' under the project 'dns-for-playgrounds')"
+  required: false
+  default: "tests.gitpod-self-hosted.com"
 - name: channel
   desc: "Replicated channel to use"
   required: false

--- a/.werft/gke-installer-tests.yaml
+++ b/.werft/gke-installer-tests.yaml
@@ -4,6 +4,10 @@ args:
   desc: "Subdomain to use. A terraform workspace of same name will be used"
   required: false
   default: ""
+- name: domain
+  desc: "domain to use. Make sure there is a DNS zone by the same name ('.' replaces by '-' under the project 'dns-for-playgrounds')"
+  required: false
+  default: "tests.gitpod-self-hosted.com"
 - name: channel
   desc: "Replicated channel to use"
   required: false

--- a/.werft/installer-tests.ts
+++ b/.werft/installer-tests.ts
@@ -22,7 +22,8 @@ const skipTests: string = annotations.skipTests || "false"; // setting to true s
 const selfSigned: Boolean = annotations.selfSigned === "true";
 const deps: string = annotations.deps || ""; // options: ["external", "internal"] setting to `external` will ensure that all resource dependencies(storage, db, registry) will be external. if unset, a random selection will be used
 
-const baseDomain: string = "tests.gitpod-self-hosted.com";
+const baseDomain: string = annotations.domain || "tests.gitpod-self-hosted.com";
+const gcpDnsZone: string = baseDomain.replace(/\./g, '-');
 
 const slackHook = new Map<string, string>([
     ["self-hosted-jobs", process.env.SH_SLACK_NOTIFICATION_PATH.trim()],
@@ -382,7 +383,7 @@ function runIntegrationTests() {
 function callMakeTargets(phase: string, description: string, makeTarget: string, failable: boolean = false) {
     werft.log(phase, `Calling ${makeTarget}`);
     // exporting cloud env var is important for the make targets
-    var env = `export TF_VAR_cluster_version=${k8s_version} cloud=${cloud}`;
+    var env = `export TF_VAR_cluster_version=${k8s_version} cloud=${cloud} TF_VAR_domain=${baseDomain} TF_VAR_gcp_zone=${gcpDnsZone}`;
     if (selfSigned) {
         env = env.concat(` self_signed=${selfSigned}`)
     }

--- a/.werft/k3s-installer-tests.yaml
+++ b/.werft/k3s-installer-tests.yaml
@@ -4,6 +4,10 @@ args:
   desc: "Subdomain to use. A terraform workspace of same name will be used"
   required: false
   default: ""
+- name: domain
+  desc: "domain to use. Make sure there is a DNS zone by the same name ('.' replaces by '-' under the project 'dns-for-playgrounds')"
+  required: false
+  default: "tests.gitpod-self-hosted.com"
 - name: channel
   desc: "Replicated channel to use"
   required: false

--- a/install/tests/Makefile
+++ b/install/tests/Makefile
@@ -7,8 +7,6 @@ TOPDIR=$(shell pwd)
 
 KUBECONFIG := "$(TOPDIR)/kubeconfig"
 
-DOMAIN := tests.gitpod-self-hosted.com
-
 check-env-sub-domain:
 ifndef TF_VAR_TEST_ID
 	$(error TF_VAR_TEST_ID is not defined)
@@ -203,7 +201,7 @@ get-github-config:
 ifneq ($(GITHUB_SCM_OAUTH),)
 	export SCM_OAUTH=./manifests/github-oauth.yaml && \
 	cat $$GITHUB_SCM_OAUTH/provider > $$SCM_OAUTH && \
-	yq w -i $$SCM_OAUTH 'oauth.callBackUrl' http://${TF_VAR_TEST_ID}.${DOMAIN}/auth/github.com/callback && \
+	yq w -i $$SCM_OAUTH 'oauth.callBackUrl' http://${TF_VAR_TEST_ID}.${TF_VAR_domain}/auth/github.com/callback && \
 	kubectl --kubeconfig=${KUBECONFIG} create namespace gitpod || echo "Gitpod namespace already exist" && \
 	kubectl --kubeconfig=${KUBECONFIG} delete secret github-oauth -n gitpod || echo "gitpod-oauth secret needs to be created" && \
 	kubectl --kubeconfig=${KUBECONFIG} create secret generic "github-oauth" --namespace gitpod --from-literal=provider="$$(cat $$SCM_OAUTH)" && \
@@ -216,7 +214,7 @@ KOTS_KONFIG := "./manifests/kots-config.yaml"
 
 get-base-config: get-github-config
 	export CONFIG_PATCH=./manifests/config-patch.yaml && \
-	export DOMAIN=${DOMAIN} && \
+	export DOMAIN=${TF_VAR_domain} && \
 	export PATCH=$$(cat $$CONFIG_PATCH | base64 -w 0) || export PATCH="" && \
 	envsubst < ${KOTS_KONFIG} > tmp_config.yml
 
@@ -301,7 +299,7 @@ self-signed-config:
 	cat "${HOME}"/.local/share/mkcert/rootCA.pem > ./ca.pem
 	mkcert -cert-file "./ssl.crt" \
 	  -key-file "./ssl.key" \
-	  "*.ws.${TF_VAR_TEST_ID}.${DOMAIN}" "*.${TF_VAR_TEST_ID}.${DOMAIN}" "${TF_VAR_TEST_ID}.${DOMAIN}"
+	  "*.ws.${TF_VAR_TEST_ID}.${TF_VAR_domain}" "*.${TF_VAR_TEST_ID}.${TF_VAR_domain}" "${TF_VAR_TEST_ID}.${TF_VAR_domain}"
 
 	export CA_CERT=$$(cat ./ca.pem | base64 -w 0) && \
 	export SSL_CERT=$$(cat ./ssl.crt | base64 -w 0) && \
@@ -383,11 +381,11 @@ check-kots-app:
 	kubectl kots get --kubeconfig=${KUBECONFIG} app gitpod -n gitpod | grep gitpod  | awk '{print $$2}' | grep "ready" || { $(MAKE) gitpod-debug-info; exit 1; }
 
 check-gitpod-installation: delete-cm-setup check-kots-app check-env-sub-domain
-	@echo "Curling https://${TF_VAR_TEST_ID}.${DOMAIN}/api/version"
+	@echo "Curling https://${TF_VAR_TEST_ID}.${TF_VAR_domain}/api/version"
 ifneq ($(self_signed),)
 	export SSL_CERT_FILE=./ca.pem
 endif
-	curl -i -X GET https://${TF_VAR_TEST_ID}.${DOMAIN}/api/version || { echo "Curling Gitpod endpoint failed"; exit 1; }
+	curl -i -X GET https://${TF_VAR_TEST_ID}.${TF_VAR_domain}/api/version || { echo "Curling Gitpod endpoint failed"; exit 1; }
 
 define runtests
 	./tests.sh ${KUBECONFIG} $(1)


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PR makes the Domain name configurable for self hosted installer tests. The main drive here is to still run the tests even after we hit the let's encrypt cert limits. This is a very tiny workaround. The domain we provide should be registered under CloudDNS under the project `dns-for-playgrounds`(the project will change in the future) with a zone name same as the domain but `.` replaced by `-`. For eg, if the domain is `tests.doptig.com`, it expects the domain to be registered under the name `tests-doptig-com`(this is how we currently do it under `dns-for-playgrounds` project.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
You can something like the following:
```
werft run github -j .werft/k3s-installer-tests.yaml -a skipTests=true -a domain=tests.doptig.com -a subdomain=testing-abc
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
