### PR TITLE
[installer-tests] fix the subdomain for upgrade tests to include cloud

### DIFF
--- a/.werft/installer-tests.ts
+++ b/.werft/installer-tests.ts
@@ -313,6 +313,7 @@ export async function installerTests(config: TestConfig) {
                 new Error("Upgrade test failed"),
                 slackHook.get("self-hosted-jobs"),
             );
+            console.log("Upgrade tests have failed, please inspect!")
 
             return;
         }

--- a/.werft/jobs/build/self-hosted-upgrade-tests.ts
+++ b/.werft/jobs/build/self-hosted-upgrade-tests.ts
@@ -44,19 +44,19 @@ export async function triggerUpgradeTests(werft: Werft, config: JobConfig, usern
     const channel: string = config.replicatedChannel || "beta";
 
     exec(`git config --global user.name "${username}"`);
-    var annotation = `-a version=${config.fromVersion} -a upgrade=true -a channel=${channel} -a preview=true -a skipTests=true`;
+    var annotation = ` -a deps=external -a version=${config.fromVersion} -a upgrade=true -a channel=${channel} -a preview=true -a skipTests=true`;
 
     // the following bit make sure that the subdomain stays the same upon multiple runs, and always start with release
-    const regex = /[\/,\.]/g;
-    const subdomain: string = config.repository.branch.replace(regex, '-')
-    annotation = annotation.concat(` -a subdomain=${subdomain}`)
+    // const regex = /[\/,\.]/g;
+    // const subdomain: string = config.repository.branch.replace(regex, '-')
+    const subdomain: string = "release"
 
     for (let phase in phases) {
         const upgradeConfig = phases[phase];
 
         werft.phase(upgradeConfig.phase, upgradeConfig.description);
 
-        annotation = `${annotation} -a cluster=${phase} -a updateGitHubStatus=gitpod-io/gitpod`
+        annotation = `${annotation} -a cluster=${phase} -a updateGitHubStatus=gitpod-io/gitpod -a subdomain=${subdomain}-${upgradeConfig.cloud}`
 
         const testFile: string = `.werft/${phase}-installer-tests.yaml`;
 

--- a/install/tests/Makefile
+++ b/install/tests/Makefile
@@ -12,6 +12,12 @@ ifndef TF_VAR_TEST_ID
 	$(error TF_VAR_TEST_ID is not defined)
 endif
 
+check-env-domain:
+ifndef TF_VAR_domain
+	$(error TF_VAR_domain is not defined)
+endif
+
+
 check-env-cloud:
 ifndef cloud
 	$(error cloud is not defined)
@@ -328,7 +334,7 @@ generate-kots-config: cloud_storage = $(if $(findstring external,$(storage)),$(c
 generate-kots-config: cloud_registry = $(if $(findstring external,$(registry)),$(cloud),incluster)
 generate-kots-config: cloud_db = $(if $(findstring external,$(db)),$(cloud),incluster)
 ## generate-kots-config: Generate the kots config based on test config
-generate-kots-config: select-workspace check-env-cloud get-base-config
+generate-kots-config: select-workspace check-env-cloud get-base-config check-env-domain check-env-sub-domain
 	$(MAKE) storage-config-${cloud_storage}
 	$(MAKE) db-config-${cloud_db}
 	$(MAKE) registry-config-${cloud_registry}
@@ -352,6 +358,8 @@ kots-install: preflight-flag = $(if $(preflights:true=),--skip-preflights,)
 kots-install: license-file = $(if $(license_community_$(channel)),$(license_community_$(channel)),"../licenses/$(channel).yaml")
 kots-install: install-kots-cli
 	kubectl kots remove ${app} -n gitpod --force --kubeconfig=${KUBECONFIG} || echo "No kots app existing, Installing"
+	$(MAKE) destroy-gitpod
+	export KUBECONFIG=${KUBECONFIG} && \
 	kubectl kots install ${app}/${channel} \
 	--skip-rbac-check ${version-flag} ${preflight-flag} \
 					--wait-duration "10m" \
@@ -361,7 +369,7 @@ kots-install: install-kots-cli
                     --no-port-forward \
                     --config-values tmp_config.yml
 
-time_to_sleep_azure := 600 # azure seem to take more time to fullfil DNS propogation
+time_to_sleep_azure := 800 # azure seem to take more time to fullfil DNS propogation
 time_to_sleep := 300
 
 wait_time := 180


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
I introduced a regression earlier today, by which the terraform state names didn't include the cloud provider name. This PR fixes this

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
