### PR TITLE
[gp-cli] add command to change ports visibility

### DIFF
--- a/components/gitpod-cli/cmd/ports-visibility.go
+++ b/components/gitpod-cli/cmd/ports-visibility.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+	"time"
+
+	gitpod "github.com/gitpod-io/gitpod/gitpod-cli/pkg/gitpod"
+	serverapi "github.com/gitpod-io/gitpod/gitpod-protocol"
+	"github.com/spf13/cobra"
+)
+
+// portsVisibilityCmd change visibility of port
+var portsVisibilityCmd = &cobra.Command{
+	Use:   "visibility <port:{private|public}>",
+	Short: "Make a port public or private",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		portVisibility := args[0]
+		s := strings.Split(portVisibility, ":")
+		if len(s) != 2 {
+			log.Fatal("cannot parse args, should be something like `3000:public` or `3000:private`")
+		}
+		port, err := strconv.Atoi(s[0])
+		if err != nil {
+			log.Fatal("port should be integer")
+		}
+		visibility := s[1]
+		if visibility != serverapi.PortVisibilityPublic && visibility != serverapi.PortVisibilityPrivate {
+			log.Fatalf("visibility should be `%s` or `%s`", serverapi.PortVisibilityPublic, serverapi.PortVisibilityPrivate)
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		wsInfo, err := gitpod.GetWSInfo(ctx)
+		if err != nil {
+			log.Fatalf("cannot get workspace info, %s", err.Error())
+		}
+		client, err := gitpod.ConnectToServer(ctx, wsInfo, []string{
+			"function:openPort",
+			"resource:workspace::" + wsInfo.WorkspaceId + "::get/update",
+		})
+		if err != nil {
+			log.Fatalf("cannot connect to server, %s", err.Error())
+		}
+		if _, err := client.OpenPort(ctx, wsInfo.WorkspaceId, &serverapi.WorkspaceInstancePort{
+			Port:       float64(port),
+			Visibility: visibility,
+		}); err != nil {
+			log.Fatalf("failed to change port visibility: %s", err.Error())
+		}
+		fmt.Printf("port %v is now %s\n", port, visibility)
+	},
+}
+
+func init() {
+	portsCmd.AddCommand(portsVisibilityCmd)
+}

--- a/components/gitpod-protocol/go/gitpod-service.go
+++ b/components/gitpod-protocol/go/gitpod-service.go
@@ -1766,6 +1766,11 @@ type WorkspaceInstancePort struct {
 	Visibility string  `json:"visibility,omitempty"`
 }
 
+const (
+	PortVisibilityPublic  = "public"
+	PortVisibilityPrivate = "private"
+)
+
 // GithubAppConfig is the GithubAppConfig message type
 type GithubAppConfig struct {
 	Prebuilds *GithubAppPrebuildConfig `json:"prebuilds,omitempty"`


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Add new gp-cli command to allow users to change ports visibility

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/10835

## How to test
<!-- Provide steps to test this PR -->

Open workspace in preview env, check with portsView to see if port is locked(private) or unlocked(public)

### Public
- Run `curl lama.sh | sh` to open port 8080
- Run `gp ports visibility 8080:public` to make it public
- Check PortsView / Visit URL of 8080 in another browser to check if it's visitable

### Private
- Run `gp ports visibility 8080:private` to make it private
- Check PortsView / Visit URL of 8080 in another browser to check if it's not visitable

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[gp-cli] add command to change ports visibility
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
- https://github.com/gitpod-io/website/issues/2804

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
