### PR TITLE
[usage] Fix alerting rules

### DIFF
--- a/operations/observability/mixins/meta/rules/usage.yaml
+++ b/operations/observability/mixins/meta/rules/usage.yaml
@@ -15,7 +15,7 @@ spec:
   - name: usage
     rules:
     - alert: GitpodUsageReconcileUsageFailures
-      expr: sum(increase(grpc_server_handled_total{grpc_service="usage.v1.UsageService", grpc_method="ReconcileUsage", grpc_code!="OK"})) > 1
+      expr: sum(increase(grpc_server_handled_total{grpc_service="usage.v1.UsageService", grpc_method="ReconcileUsage", grpc_code!="OK"}[1m])) > 1
       for: 30m
       labels:
         severity: warning
@@ -26,7 +26,7 @@ spec:
         description: We have accumulated {{ printf "%.2f" $value }} failures. This affects how up-to-date usage data is.
 
     - alert: GitpodUsageReconcileInvoicesFailures
-      expr: sum(increase(grpc_server_handled_total{grpc_service="usage.v1.BillingService", grpc_method="ReconcileInvoices", grpc_code!="OK"})) > 1
+      expr: sum(increase(grpc_server_handled_total{grpc_service="usage.v1.BillingService", grpc_method="ReconcileInvoices", grpc_code!="OK"}[1m])) > 1
       for: 30m
       labels:
         severity: warning
@@ -37,7 +37,7 @@ spec:
         description: We have accumulated {{ printf "%.2f" $value }} failures. This affects how much customers will be billed.
 
     - alert: GitpodUsageBillingServiceFinalizeInvoiceFailures
-      expr: sum(increase(grpc_server_handled_total{grpc_service="usage.v1.BillingService", grpc_method="FinalizeInvoice", grpc_code!="OK"})) > 1
+      expr: sum(increase(grpc_server_handled_total{grpc_service="usage.v1.BillingService", grpc_method="FinalizeInvoice", grpc_code!="OK"}[1m])) > 1
       for: 30m
       labels:
         severity: warning
@@ -59,7 +59,7 @@ spec:
         description: We have not executed scheduled usage reconciliation for {{ printf "%.2f" $value }} seconds. We expect the data to update every 15 minutes to avoid stale usage records and stale invoices.
 
     - alert: GitpodUsageStripeWebhookFailures
-      expr: sum(increase(gitpod_http_request_duration_seconds_count{handler="/stripe/invoices/webhook", code=~"5.*"})) > 0
+      expr: sum(increase(gitpod_http_request_duration_seconds_count{handler="/stripe/invoices/webhook", code=~"5.*"}[1m])) > 0
       for: 30m
       labels:
         severity: warning


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Prometheus operator has been failing with this error:
```
range vector in call to function \"increase\", got instant vector"
level=info ts=2022-09-23T13:31:35.581579042Z caller=rules.go:340 component=prometheusoperator msg="Invalid rule" err="35:11: group \"usage\", rule 3, \"GitpodUsageBillingServiceFinalizeInvoiceFailures\": could not parse expression: 1:14: parse error: expected type range vector in call to function \"increase\", got instant vector"
level=info ts=2022-09-23T13:31:35.581586956Z caller=rules.go:340 component=prometheusoperator msg="Invalid rule" err="61:11: group \"usage\", rule 5, \"GitpodUsageStripeWebhookFailures\": could not parse expression: 1:14: parse error: expected type range vector in call to function \"increase\", got instant vector"
level=error ts=2022-09-23T13:31:35.600973771Z caller=klog.go:116 component=k8s_client_runtime func=ErrorDepth msg="sync \"monitoring-satellite/k8s\" failed: Invalid rule"
level=info ts=2022-09-23T13:31:35.601067883Z caller=operator.go:1559 component=prometheusoperator key=monitoring-satellite/k8s msg="update prometheus status"
```
This change should fix the issue.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
