### PR TITLE
GCP Reference Arch installer minor fixes

### DIFF
--- a/install/infra/single-cluster/gcp/Makefile
+++ b/install/infra/single-cluster/gcp/Makefile
@@ -61,22 +61,22 @@ output-storage:
 	@echo "=============="
 	@echo "Choose 'GCP' Storage provider"
 	@echo ""
-	@echo "Storage region = $$(terraform output -json storage | yq r - region)"
-	@echo "Project ID     = $$(terraform output -json storage | yq r - project)"
+	@echo "Storage region = $$(terraform output -json storage | jq -r .region)"
+	@echo "Project ID     = $$(terraform output -json storage | jq -r .project)"
 	@echo "Service account key = Upload the file 'gs-credentials.json' created in this directory"
-	@terraform output -json storage | yq r - service_account_key > gs-credentials.json
+	@terraform output -json storage | jq -r .service_account_key > gs-credentials.json
 	@echo ""
 
 output-registry:
 	@echo ""
 	@echo "🟢 GCR registry:"
 	@echo "=================="
-	@echo "Container registry URL      = $$(terraform output -json registry | yq r - url)"
-	@echo "Container registry server   = $$(terraform output -json registry | yq r - server)"
-	@echo "Container registry username = $$(terraform output -json registry | yq r - username)"
+	@echo "Container registry URL      = $$(terraform output -json registry | jq -r .url)"
+	@echo "Container registry server   = $$(terraform output -json registry | jq -r .server)"
+	@echo "Container registry username = $$(terraform output -json registry | jq -r .username)"
 	@echo "Container registry password = Copy paste the following JSON key"
 	@echo ""
-	@terraform output -json registry | yq r - password
+	@terraform output -json registry | jq -r .password
 
 output-database:
 	@echo ""
@@ -84,18 +84,18 @@ output-database:
 	@echo "========"
 	@echo "Tick the option 'Use Google Cloud SQL Proxy' if using this database"
 	@echo ""
-	@echo "CloudSQL connection name = $$(terraform output -json database | yq r - instance)"
-	@echo "Username 				= $$(terraform output -json database | yq r - username)"
-	@echo "Password 				= $$(terraform output -json database | yq r - password)"
+	@echo "CloudSQL connection name = $$(terraform output -json database | jq -r .instance)"
+	@echo "Username 				= $$(terraform output -json database | jq -r .username)"
+	@echo "Password 				= $$(terraform output -json database | jq -r .password)"
 	@echo "GCP service account key  = Upload the file 'mysql-credentials.json' created in this directory"
-	@terraform output -json database | yq r - service_account_key > mysql-credentials.json
+	@terraform output -json database | jq -r .service_account_key > mysql-credentials.json
 	@echo ""
 
 output-issuer:
 	@echo ""
 	@echo "🟢 ClusterIssuer name:"
 	@echo "================="
-	@terraform output -json cluster_issuer | jq
+	@terraform output -json cluster_issuer | jq -r
 
 .PHONY: plan-cluster
 plan-cluster:

--- a/install/infra/single-cluster/gcp/README.md
+++ b/install/infra/single-cluster/gcp/README.md
@@ -32,8 +32,17 @@ explain the execution of the terraform module in terms of these `make` targets.
 
 Before starting the installation process, you need:
 
-* A GCP account with administative access
+* A GCP account and project
   * [Create one now by clicking here](https://console.cloud.google.com/freetrial)
+* Enable these APIs in the GCP project:
+  * [Kubernetes Engine API](https://console.cloud.google.com/apis/library/container.googleapis.com)
+  * [Identity and Access Management (IAM) API](https://console.developers.google.com/apis/api/iam.googleapis.com/overview)
+  * [Cloud SQL Admin API](https://console.developers.google.com/apis/api/sqladmin.googleapis.com/overview)
+  * [Cloud DNS API](https://console.developers.google.com/apis/api/dns.googleapis.com/overview)
+  * [Cloud Resource Manager API](https://console.developers.google.com/apis/api/cloudresourcemanager.googleapis.com/overview)
+* A GCP service account with administative access:
+  * Use the [default service account or create a new one here](https://console.cloud.google.com/iam-admin/serviceaccounts)
+  * Create a new JSON key for the account and download it
 * Store the JSON credentials corresponding to the service account locally in a file
 * Create and configure GCS bucket for terraform backend
   * Create a [GCS bucket](https://cloud.google.com/storage) to store the terraform backend state
@@ -117,7 +126,7 @@ If the plan looks good, now you can go ahead and create the resources:
 make apply
 ```
 
-The `apply` target calls the `terraform` apply on `eks` module, `cert-manager`
+The `apply` target calls the `terraform` apply on `gke` module, `cert-manager`
 module, `external-dns` module and `cluster-issuer` module in that exact order.
 The entire operation would take around *30 minutes* to complete.
 


### PR DESCRIPTION
## Description
Adds a few details to GCP single cluster reference architecture install. Also fixes `jq` syntax on `make output` task.

## How to test
Run `make output` on an install

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
