### PR TITLE
[ws-daemon] Check runc download is a binary

### DIFF
--- a/components/ws-daemon/debug.Dockerfile
+++ b/components/ws-daemon/debug.Dockerfile
@@ -8,14 +8,15 @@ RUN go get -u github.com/go-delve/delve/cmd/dlv
 
 FROM alpine:3.16 as dl
 WORKDIR /dl
-RUN apk add --no-cache curl \
-  && curl -OL https://github.com/opencontainers/runc/releases/download/v1.1.3/runc.amd64 \
-  && chmod +x runc.amd64
+RUN apk add --no-cache curl file \
+  && curl -OsSL https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.amd64 \
+  && chmod +x runc.amd64 \
+  && if ! file runc.amd64 | grep -iq "ELF 64-bit LSB executable"; then echo "runc.amd64 is not a binary file"; exit 1;fi
 
 FROM ubuntu:22.04
 
 ## Installing coreutils is super important here as otherwise the loopback device creation fails!
-ARG CLOUD_SDK_VERSION=390.0.0
+ARG CLOUD_SDK_VERSION=402.0.0
 ENV CLOUD_SDK_VERSION=$CLOUD_SDK_VERSION
 ENV CLOUDSDK_CORE_DISABLE_PROMPTS=1
 

--- a/components/ws-daemon/leeway.Dockerfile
+++ b/components/ws-daemon/leeway.Dockerfile
@@ -4,14 +4,15 @@
 
 FROM alpine:3.16 as dl
 WORKDIR /dl
-RUN apk add --no-cache curl \
-  && curl -OL https://github.com/opencontainers/runc/releases/download/v1.1.3/runc.amd64 \
-  && chmod +x runc.amd64
+RUN apk add --no-cache curl file \
+  && curl -OsSL https://github.com/opencontainers/runc/releases/download/v1.1.4/runc.amd64 \
+  && chmod +x runc.amd64 \
+  && if ! file runc.amd64 | grep -iq "ELF 64-bit LSB executable"; then echo "runc.amd64 is not a binary file"; exit 1;fi
 
 FROM ubuntu:22.04
 
 ## Installing coreutils is super important here as otherwise the loopback device creation fails!
-ARG CLOUD_SDK_VERSION=390.0.0
+ARG CLOUD_SDK_VERSION=402.0.0
 ENV CLOUD_SDK_VERSION=$CLOUD_SDK_VERSION
 ENV CLOUDSDK_CORE_DISABLE_PROMPTS=1
 


### PR DESCRIPTION
## Description

Ensure download is a binary

Also update cloud SDK to v402.

## Related Issue(s)
```
root@g70c9281d74ad68b6cd195b:/home/aledbf# k exec -it -c ws-daemon ws-daemon-v7skj -- bash
root@ws-daemon-v7skj:/# which runc
/usr/bin/runc
root@ws-daemon-v7skj:/# runc
/usr/bin/runc: line 1: syntax error near unexpected token `<'
/usr/bin/runc: line 1: `<?xml version="1.0" encoding="utf-8"?><Error><Code>ServerBusy</Code><Message>Egress is over the account limit.'
root@ws-daemon-v7skj:/# 
``` 

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
