### PR TITLE
[installer]: only allow config patch if advanced mode enabled

### DIFF
--- a/install/installer/pkg/config/v1/testdata/envvars/config-patch-no-advanced-mode/envvars.yaml
+++ b/install/installer/pkg/config/v1/testdata/envvars/config-patch-no-advanced-mode/envvars.yaml
@@ -2,6 +2,6 @@
 # Licensed under the MIT License. See License-MIT.txt in the project root for license information.
 
 envvars:
-  ADVANCED_MODE_ENABLED: "1"
+  # This will be ignored as advanced mode not enabled
   CONFIG_PATCH: "domain: override.gitpod.io"
   DOMAIN: gitpod.io

--- a/install/installer/pkg/config/v1/testdata/envvars/config-patch-no-advanced-mode/expect.yaml
+++ b/install/installer/pkg/config/v1/testdata/envvars/config-patch-no-advanced-mode/expect.yaml
@@ -1,7 +1,4 @@
 # Copyright (c) 2022 Gitpod GmbH. All rights reserved.
 # Licensed under the MIT License. See License-MIT.txt in the project root for license information.
 
-envvars:
-  ADVANCED_MODE_ENABLED: "1"
-  CONFIG_PATCH: "domain: override.gitpod.io"
-  DOMAIN: gitpod.io
+domain: gitpod.io


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Spotted a regression in the Installer refactoring where a config patch could be applied if advanced mode isn't enabled. This fixes it.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[installer]: only allow config patch if advanced mode enabled
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
