### PR TITLE
Change definition of k8s version support to point to prod comp matrix

### DIFF
--- a/install/infra/single-cluster/aws/README.md
+++ b/install/infra/single-cluster/aws/README.md
@@ -86,7 +86,7 @@ are kubernetes version and region specific. You can find a list of AMI IDs
 [here](https://cloud-images.ubuntu.com/docs/aws/eks/).
 
 Make sure you provide the corresponding kubernetes version as a value to the
-variable `cluster_version`. We officially support kubernetes versions >= `1.20`.
+variable `cluster_version`. Please see the [Gitpod Compatibility Matrix](https://www.gitpod.io/docs/references/product-compatibility-matrix?admin) for officially supported Kubernetes versions.
 
 ### Domain name configuration
 

--- a/install/infra/single-cluster/azure/README.md
+++ b/install/infra/single-cluster/azure/README.md
@@ -65,8 +65,8 @@ includes a mysql database, a Azure block storage account and an Azure container 
 
 ### Kubernetes version
 
-Make sure you provide an [Azure supported kubernetes version](https://docs.microsoft.com/en-us/azure/aks/supported-kubernetes-versions) as a value to the
-variable `cluster_version`. We officially support kubernetes versions >= `1.21`.
+Make sure you provide an [Azure supported Kubernetes version](https://docs.microsoft.com/en-us/azure/aks/supported-kubernetes-versions) as a value to the
+variable `cluster_version`. Please see the [Gitpod Compatibility Matrix](https://www.gitpod.io/docs/references/product-compatibility-matrix?admin) for officially supported Kubernetes versions.
 
 ### Domain name configuration
 

--- a/install/infra/single-cluster/gcp/README.md
+++ b/install/infra/single-cluster/gcp/README.md
@@ -84,7 +84,7 @@ created resources of choice.
 ### Kubernetes version
 
 Make sure you provide the corresponding kubernetes version as a value to the
-variable `cluster_version`. We officially support kubernetes versions >= `1.20`.
+variable `cluster_version`. Please see the [Gitpod Compatibility Matrix](https://www.gitpod.io/docs/references/product-compatibility-matrix?admin) for officially supported Kubernetes versions.
 
 ### Domain name configuration
 


### PR DESCRIPTION
## Description
Changes mention of which k8s versions are support to instead point to the compatibility matrix in the docs. 


## How to test
Read through files changed

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
