### PR TITLE
[server] use Buffer.from properly

### DIFF
--- a/components/gitpod-protocol/src/encryption/encryption-engine.spec.ts
+++ b/components/gitpod-protocol/src/encryption/encryption-engine.spec.ts
@@ -24,7 +24,7 @@ class TestEncryptionEngineImpl {
 
     @test basicSymmetry() {
         const plaintext = "12345678901234567890";
-        const key = new Buffer(this.testkey, "base64");
+        const key = Buffer.from(this.testkey, "base64");
 
         const cut = new EncryptionEngineImpl();
         const encryptedData = cut.encrypt(plaintext, key);

--- a/components/gitpod-protocol/src/encryption/encryption-engine.ts
+++ b/components/gitpod-protocol/src/encryption/encryption-engine.ts
@@ -40,7 +40,7 @@ export class EncryptionEngineImpl {
     encrypt(data: string, key: Buffer): EncryptedData {
         const iv = crypto.randomBytes(16);
         const cipher = crypto.createCipheriv(this.algorithm, key, iv);
-        const encrypted = cipher.update(new Buffer(data, "utf8"));
+        const encrypted = cipher.update(Buffer.from(data, "utf8"));
         const finalEncrypted = Buffer.concat([encrypted, cipher.final()]);
         return {
             data: finalEncrypted.toString(this.enc),
@@ -51,8 +51,12 @@ export class EncryptionEngineImpl {
     }
 
     decrypt(encryptedData: EncryptedData, key: Buffer): string {
-        const decipher = crypto.createDecipheriv(this.algorithm, key, new Buffer(encryptedData.keyParams.iv, this.enc));
-        let decrypted = decipher.update(new Buffer(encryptedData.data, this.enc));
+        const decipher = crypto.createDecipheriv(
+            this.algorithm,
+            key,
+            Buffer.from(encryptedData.keyParams.iv, this.enc),
+        );
+        let decrypted = decipher.update(Buffer.from(encryptedData.data, this.enc));
         const finalDecrypted = Buffer.concat([decrypted, decipher.final()]);
         return finalDecrypted.toString("utf8");
     }

--- a/components/gitpod-protocol/src/encryption/key-provider.ts
+++ b/components/gitpod-protocol/src/encryption/key-provider.ts
@@ -71,7 +71,7 @@ export class KeyProviderImpl implements KeyProvider {
                 name: config.name,
                 version: config.version,
             },
-            material: new Buffer(config.material, "base64"),
+            material: Buffer.from(config.material, "base64"),
         };
     }
 }

--- a/components/ws-manager-bridge/src/messagebus-integration.ts
+++ b/components/ws-manager-bridge/src/messagebus-integration.ts
@@ -44,7 +44,7 @@ export class MessageBusIntegration extends AbstractMessageBusIntegration {
             await super.publish(
                 MessageBusHelperImpl.WORKSPACE_EXCHANGE_LOCAL,
                 topic,
-                new Buffer(JSON.stringify(instance)),
+                Buffer.from(JSON.stringify(instance)),
                 {
                     trace: { span },
                 },
@@ -63,7 +63,7 @@ export class MessageBusIntegration extends AbstractMessageBusIntegration {
         }
 
         const topic = this.messageBusHelper.getWsTopicForPublishing(userId, workspaceId, "headless-log");
-        const msg = new Buffer(JSON.stringify(evt));
+        const msg = Buffer.from(JSON.stringify(evt));
         await this.messageBusHelper.assertWorkspaceExchange(this.channel);
         await super.publish(MessageBusHelperImpl.WORKSPACE_EXCHANGE_LOCAL, topic, msg, {
             trace: ctx,


### PR DESCRIPTION
Trying to get rid of deprecation log entries.

## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [x] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
