### PR TITLE
test: Introduction of parallelization of tests to launch workspaces

### DIFF
--- a/.werft/workspace-run-integration-tests.sh
+++ b/.werft/workspace-run-integration-tests.sh
@@ -84,7 +84,7 @@ werft log phase "build preview environment" "build preview environment"
     git checkout -B "${BRANCH}" && \
     git commit -m "${TEMP_COMMIT_MSG}" --allow-empty  && \
     git push --set-upstream origin "${BRANCH}" && \
-    werft run github -a with-preview=true
+    werft run github -a with-preview=true -a with-large-vm=true
 ) | werft log slice "build preview environment"
 
 for signal in SIGINT SIGTERM EXIT; do
@@ -160,7 +160,7 @@ args+=( "-kubeconfig=/home/gitpod/.kube/config" )
 args+=( "-namespace=default" )
 [[ "$USERNAME" != "" ]] && args+=( "-username=$USERNAME" )
 args+=( "-timeout=120m" )
-args+=( "-p=1" )
+args+=( "-p=2" )
 
 WK_TEST_LIST=(/workspace/test/tests/components/content-service /workspace/test/tests/components/image-builder /workspace/test/tests/components/ws-daemon /workspace/test/tests/components/ws-manager /workspace/test/tests/workspace)
 for TEST_PATH in "${WK_TEST_LIST[@]}"

--- a/test/tests/workspace/contexts_test.go
+++ b/test/tests/workspace/contexts_test.go
@@ -141,6 +141,8 @@ func runContextTests(t *testing.T, tests []ContextTest) {
 			for _, ff := range ffs {
 				for _, test := range tests {
 					t.Run(test.ContextURL+"_"+ff.Name, func(t *testing.T) {
+						t.Parallel()
+
 						if test.Skip {
 							t.SkipNow()
 						}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

- Introduction of parallelization of tests to launch workspaces
- Use a large workspace

Note: now the integration test is broken

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

Part of https://github.com/gitpod-io/gitpod/issues/13197

## How to test
<!-- Provide steps to test this PR -->

Run the integration test

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
No

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-integration-tests=workspacce
      Valid options are `all`, `workspace`, `webapp`, `ide`
