### PR TITLE
[server][prebuild] assert no prebuild is running for same commit

### DIFF
--- a/components/server/ee/src/workspace/workspace-factory.ts
+++ b/components/server/ee/src/workspace/workspace-factory.ts
@@ -89,18 +89,29 @@ export class WorkspaceFactoryEE extends WorkspaceFactory {
             const { project, branch } = context;
 
             const commitContext: CommitContext = context.actual;
-            const existingPWS = await this.db
-                .trace({ span })
-                .findPrebuiltWorkspaceByCommit(
-                    commitContext.repository.cloneUrl,
-                    CommitContext.computeHash(commitContext),
-                );
-            if (existingPWS) {
+
+            const assertNoPrebuildIsRunningForSameCommit = async () => {
+                const existingPWS = await this.db
+                    .trace({ span })
+                    .findPrebuiltWorkspaceByCommit(
+                        commitContext.repository.cloneUrl,
+                        CommitContext.computeHash(commitContext),
+                    );
+                if (!existingPWS) {
+                    return;
+                }
+                log.debug("Found existing prebuild in createForStartPrebuild.", {
+                    context,
+                    cloneUrl: commitContext.repository.cloneUrl,
+                    commit: CommitContext.computeHash(commitContext),
+                });
                 const wsInstance = await this.db.trace({ span }).findRunningInstance(existingPWS.buildWorkspaceId);
                 if (wsInstance) {
                     throw new Error("A prebuild is already running for this commit.");
                 }
-            }
+            };
+
+            await assertNoPrebuildIsRunningForSameCommit();
 
             const { config } = await this.configProvider.fetchConfig({ span }, user, context.actual);
             const imageSource = await this.imageSourceProvider.getImageSource(ctx, user, context.actual, config);
@@ -142,6 +153,12 @@ export class WorkspaceFactoryEE extends WorkspaceFactory {
                         originalContext: commitContext,
                         prebuiltWorkspace: recentPrebuild.prebuild,
                     };
+
+                    // repeated assertion on prebuilds triggered for same commit here, in order to
+                    // reduce likelihood of duplicates if for instance handled by two different
+                    // server pods.
+                    await assertNoPrebuildIsRunningForSameCommit();
+
                     ws = await this.createForPrebuiltWorkspace(
                         { span },
                         user,
@@ -160,6 +177,12 @@ export class WorkspaceFactoryEE extends WorkspaceFactory {
                     break;
                 }
             }
+
+            // repeated assertion on prebuilds triggered for same commit here, in order to
+            // reduce likelihood of duplicates if for instance handled by two different
+            // server pods.
+            await assertNoPrebuildIsRunningForSameCommit();
+
             if (!ws) {
                 // No suitable parent prebuild was found -- create a (fresh) full prebuild.
                 ws = await this.createForCommit({ span }, user, commitContext, normalizedContextURL);


### PR DESCRIPTION
## Description
The process of triggering a prebuild is async and competing events may cause a race which results in two prebuilds being started for the same commit. This practical PR introduces repeated check for already started prebuild to reduce the likelihood of prebuilds started for the same commit.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #11757

## How to test
Note, this is easier to verify with https://github.com/gitpod-io/gitpod/pull/13292 been merged before, because one can inspect webhook events and compare with prebuild triggered.

Nevertheless, to verify a single prebuild is produced one needs:
* setup a project for a repo
* create a PR on that test repo which would produce a prebuild, see a prebuild is running
* verify that a PR update (force pushing a significant change, to produce a new build) is also triggering just a single prebuild per commit

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Avoid second prebuild been triggered on same commit.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
