### PR TITLE
[server] mark prebuild as failed when image build fails

### DIFF
--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -51,7 +51,6 @@ import {
     WorkspaceInstanceStatus,
     WorkspaceProbeContext,
     Permission,
-    HeadlessWorkspaceEvent,
     HeadlessWorkspaceEventType,
     DisposableCollection,
     AdditionalContentContext,
@@ -718,21 +717,7 @@ export class WorkspaceStarter {
             await this.messageBus.notifyOnInstanceUpdate(workspace.ownerId, instance);
 
             // If we just attempted to start a workspace for a prebuild - and that failed, we have to fail the prebuild itself.
-            if (workspace.type === "prebuild") {
-                const prebuild = await this.workspaceDb.trace({ span }).findPrebuildByWorkspaceID(workspace.id);
-                if (prebuild && prebuild.state !== "failed") {
-                    prebuild.state = "failed";
-                    prebuild.error = err.toString();
-
-                    await this.workspaceDb.trace({ span }).storePrebuiltWorkspace(prebuild);
-                    await this.messageBus.notifyHeadlessUpdate({ span }, workspace.ownerId, workspace.id, <
-                        HeadlessWorkspaceEvent
-                    >{
-                        type: HeadlessWorkspaceEventType.Failed,
-                        // TODO: `workspaceID: workspace.id` not needed here? (found in ee/src/prebuilds/prebuild-queue-maintainer.ts and ee/src/bridge.ts)
-                    });
-                }
-            }
+            await this.failPrebuildWorkspace({ span }, err, workspace);
         } catch (err) {
             TraceContext.setError({ span }, err);
             log.error(
@@ -740,6 +725,31 @@ export class WorkspaceStarter {
                 "cannot properly fail workspace instance during start",
                 err,
             );
+        } finally {
+            span.finish();
+        }
+    }
+
+    protected async failPrebuildWorkspace(ctx: TraceContext, err: Error, workspace: Workspace) {
+        const span = TraceContext.startSpan("failInstanceStart", ctx);
+        try {
+            if (workspace.type === "prebuild") {
+                const prebuild = await this.workspaceDb.trace({ span }).findPrebuildByWorkspaceID(workspace.id);
+                if (prebuild && prebuild.state !== "failed") {
+                    prebuild.state = "failed";
+                    prebuild.error = err.toString();
+
+                    await this.workspaceDb.trace({ span }).storePrebuiltWorkspace(prebuild);
+                    await this.messageBus.notifyHeadlessUpdate({ span }, workspace.ownerId, workspace.id, {
+                        type: HeadlessWorkspaceEventType.Failed,
+                        workspaceID: workspace.id, // required in prebuild-queue-maintainer.ts
+                        text: "",
+                    });
+                }
+            }
+        } catch (err) {
+            TraceContext.setError({ span }, err);
+            throw err;
         } finally {
             span.finish();
         }
@@ -1277,6 +1287,11 @@ export class WorkspaceStarter {
                 stoppedTime: now,
                 stoppingTime: now,
             });
+
+            // Mark the PrebuildWorkspace as failed
+            await this.failPrebuildWorkspace({ span }, err, workspace);
+
+            // Push updated workspace instance over messagebus
             await this.messageBus.notifyOnInstanceUpdate(workspace.ownerId, instance);
 
             TraceContext.setError({ span }, err);
@@ -1410,14 +1425,16 @@ export class WorkspaceStarter {
 
         if (workspace.config.coreDump?.enabled) {
             // default core dump size is 262144 blocks (if blocksize is 4096)
-            const defaultLimit:number=1073741824;
+            const defaultLimit: number = 1073741824;
 
             const rLimitCore = new EnvironmentVariable();
             rLimitCore.setName("GITPOD_RLIMIT_CORE");
-            rLimitCore.setValue(JSON.stringify({
-                softLimit: workspace.config.coreDump?.softLimit || defaultLimit,
-                hardLimit: workspace.config.coreDump?.hardLimit || defaultLimit,
-            }));
+            rLimitCore.setValue(
+                JSON.stringify({
+                    softLimit: workspace.config.coreDump?.softLimit || defaultLimit,
+                    hardLimit: workspace.config.coreDump?.hardLimit || defaultLimit,
+                }),
+            );
             envvars.push(rLimitCore);
         }
 

--- a/components/ws-manager-bridge/ee/src/prebuild-updater-db.ts
+++ b/components/ws-manager-bridge/ee/src/prebuild-updater-db.ts
@@ -7,7 +7,6 @@
 import { inject, injectable } from "inversify";
 import { TraceContext } from "@gitpod/gitpod-protocol/lib/util/tracing";
 import { WorkspaceStatus, WorkspaceType } from "@gitpod/ws-manager/lib";
-import { HeadlessWorkspaceEvent } from "@gitpod/gitpod-protocol/lib/headless-workspace-log";
 import { WorkspaceInstance } from "@gitpod/gitpod-protocol";
 import { log, LogContext } from "@gitpod/gitpod-protocol/lib/util/logging";
 import { PrebuildStateMapper } from "../../src/prebuild-state-mapper";
@@ -98,9 +97,10 @@ export class PrebuildUpdaterDB implements PrebuildUpdater {
 
                 // notify updates
                 // headless update
-                await this.messagebus.notifyHeadlessUpdate({ span }, userId, workspaceId, <HeadlessWorkspaceEvent>{
+                await this.messagebus.notifyHeadlessUpdate({ span }, userId, workspaceId, {
                     type: update.type,
                     workspaceID: workspaceId,
+                    text: "",
                 });
 
                 // prebuild info


### PR DESCRIPTION
## Description
Before this PR, if an image build started for a prebuild errored, e.g. due to issues with the .Dockerfile, it would mark the workspace instance as stopped, but leave the prebuild workspace entry in "PENDING" state. That causes the UI to remain in same state, which is worsened by the fact that image build logs are not persisted. 
This PR adds the missing update to the prebuild workspace entry, which will produce UI state updates as well.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #13207

## How to test
Try with prebuilds for a repo with .Dockerfile build and simple errors in it, e.g. `apt-get install NOT-FOUND`, see the prebuilds is rendered as failed and does not remain in PENDING state.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Fail prebuild if image build fails.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
