### PR TITLE
[baseserver] do not log error when the server successfully closes

### DIFF
--- a/components/common-go/baseserver/server.go
+++ b/components/common-go/baseserver/server.go
@@ -413,7 +413,11 @@ func (s *builtinServices) ListenAndServe() error {
 			return err
 		}
 		s.Health.Addr = l.Addr().String()
-		return s.Health.Serve(l)
+		err = s.Health.Serve(l)
+		if err == http.ErrServerClosed {
+			return nil
+		}
+		return err
 	})
 	return eg.Wait()
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Quite false positive error, see [[1](https://console.cloud.google.com/errors/detail/CKmX-siSlbaatgE;service=ide-service;version=?project=gitpod-191109)]

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

Unit tests should pass.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
