### PR TITLE
[single-cluster/aws] make `self-signed` work

### DIFF
--- a/.werft/eks-installer-tests.yaml
+++ b/.werft/eks-installer-tests.yaml
@@ -89,6 +89,8 @@ pod:
       value: "/mnt/secrets/sh-playground-sa-perm/sh-sa.json"
     - name: TF_VAR_dns_sa_creds
       value: "/mnt/secrets/sh-playground-dns-perm/sh-dns-sa.json"
+    - name: TF_VAR_sa_creds
+      value: "/mnt/secrets/sh-playground-sa-perm/sh-sa.json"
     - name: NODENAME
       valueFrom:
         fieldRef:

--- a/.werft/installer-tests.ts
+++ b/.werft/installer-tests.ts
@@ -347,6 +347,12 @@ export async function installerTests(config: TestConfig) {
             console.error("Failed to send message to Slack", error);
         });
 
+        if (selfSigned === "true") {
+            exec(
+                `werft log result -d  "Custom CA Certificate store underd GCP project 'sh-automated-tests'" url "gs://nightly-tests/tf-state/${process.env["TF_VAR_TEST_ID"]}-ca.pem"`,
+            );
+        }
+
         exec(
             `werft log result -d  "Terraform state" url "Terraform state file name is ${process.env["TF_VAR_TEST_ID"]}"`,
         );
@@ -384,10 +390,7 @@ function runIntegrationTests() {
 function callMakeTargets(phase: string, description: string, makeTarget: string, failable: boolean = false) {
     werft.log(phase, `Calling ${makeTarget}`);
     // exporting cloud env var is important for the make targets
-    var env = `export TF_VAR_cluster_version=${k8s_version} cloud=${cloud} TF_VAR_domain=${baseDomain} TF_VAR_gcp_zone=${gcpDnsZone}`;
-    if (selfSigned) {
-        env = env.concat(` self_signed=${selfSigned}`)
-    }
+    const env = `export TF_VAR_cluster_version=${k8s_version} cloud=${cloud} TF_VAR_domain=${baseDomain} TF_VAR_gcp_zone=${gcpDnsZone}`;
 
     const response = exec(
         `${env} && make -C ${makefilePath} ${makeTarget}`,

--- a/install/tests/Makefile
+++ b/install/tests/Makefile
@@ -314,6 +314,9 @@ self-signed-config:
 	envsubst < ./manifests/kots-config-self-signed.yaml > tmp_2_config.yml
 	yq m -i tmp_config.yml tmp_2_config.yml
 
+	# upload the Custom CA Cert into tf-state
+	gsutil cp ./ca.pem gs://nightly-tests/tf-state/${TF_VAR_TEST_ID}-ca.pem
+
 storage-config-incluster:
 	@echo "Nothing to do"
 
@@ -449,6 +452,9 @@ destroy-kubeconfig:
 	gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS} --project=sh-automated-tests
 	gsutil rm gs://nightly-tests/tf-state/${TF_VAR_TEST_ID}-kubeconfig || echo "No kubeconfig"
 	gsutil rm gs://nightly-tests/tf-state/${TF_VAR_TEST_ID}-creds || echo "No credentials file"
+ifeq (true,$(self_signed))
+	gsutil rm gs://nightly-tests/tf-state/${TF_VAR_TEST_ID}-ca.pem || echo "No custom CA cert file"
+endif
 	rm ${KUBECONFIG} || echo "No kubeconfig"
 
 select-workspace:


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This PR adds a new `post_bootstrap_user_data` variable to the EKS terraform modules that changes the containerd config to accept new self signed SSL Certificates, and restarting `containerd` to make the same work.

This PR also changes the `self-signed` of infra tests to upload the CA certificate into gcs for us to download and use.

Signed-off-by: Tarun Pothulapati <tarun@gitpod.io>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/12979

## How to test
<!-- Provide steps to test this PR -->
Run
```
werft run github -f -s .werft/installer-tests.ts -j .werft/eks-installer-tests.yaml -a debug=true -a selfSigned=true -a skipTests=true -a preview=true -a domain=tests.doptig.com
```

or use the `self-signed` instance at `https://f0761-aws.tests.doptig.com` while using the certificate from https://werft.gitpod-dev.com/job/gitpod-custom-tar-eks-selfsigned.6/results

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[single-cluster/aws] Make `self-signed` work
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
