### PR TITLE
[db-sync] Remove duplicate entry for `d_b_prebuilt_workspace`

### DIFF
--- a/components/gitpod-db/src/tables.ts
+++ b/components/gitpod-db/src/tables.ts
@@ -133,11 +133,6 @@ export class GitpodTableDescriptionProvider implements TableDescriptionProvider 
             timeColumn: "_lastModified",
         },
         {
-            name: "d_b_prebuilt_workspace",
-            primaryKeys: ["id"],
-            timeColumn: "_lastModified",
-        },
-        {
             name: "d_b_app_installation",
             primaryKeys: ["platform", "installationID", "state"],
             timeColumn: "creationTime",


### PR DESCRIPTION
## Description

Remove a duplicate entry for the `d_b_prebuilt_workspace` table from the `db-sync` config. 

The removed entry is the same as the remaining one but lacked the `deletionColumn` definition. 

Looking at the EU failover we have many entries in `d_b_prebuilt_workspace`  for which `deleted = 1`, which would indicate that only the entry without the `deletionColumn` was ever respected. Merging this will therefore delete those records permanently.

## Related Issue(s)
Relates to https://github.com/gitpod-io/gitpod/issues/9198

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
