### PR TITLE
[kots]: remove the "require min RBAC" boolean

### DIFF
--- a/install/kots/manifests/kots-app.yaml
+++ b/install/kots/manifests/kots-app.yaml
@@ -10,7 +10,6 @@ spec:
   icon: ""
   allowRollback: true
   kubectlVersion: ">= 1.21.0"
-  requireMinimalRBACPrivileges: true
   # daemonsets are not supported yet
   statusInformers:
     - deployment/blobserve


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This prevents the preflight checks from being run in some environments (eg, EKS) as there are elevated privileges required to interrogate nodes etc.

There was a misunderstanding from the KOTS docs made in #13168 which I thought created the `kotsadm` service account. This service account appears to always be created, but this boolean limits it's capabilities (in retrospect, that's obvious. But it wasn't at the time - we caught it before it was released to the public anyway).

## How to test
<!-- Provide steps to test this PR -->
Deploy via KOTS on AWS. Preflight checks should run - previously, they were not running due to lack of cluster role permissions. With this fix, they should run.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[kots]: remove the "require min RBAC" boolean
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
