### PR TITLE
[server] Add new individual Stripe Price IDs to Gitpod's configuration

### DIFF
--- a/.werft/jobs/build/payment/stripe-configmap.yaml
+++ b/.werft/jobs/build/payment/stripe-configmap.yaml
@@ -9,5 +9,13 @@ data:
       "usageProductPriceIds": {
         "EUR": "price_1LiId7GadRXm50o3OayAS2y4",
         "USD": "price_1LiIdbGadRXm50o3ylg5S44r"
+      },
+      "individualUsagePriceIds": {
+        "EUR": "price_1LmFcFGadRXm50o3XUrEuajK",
+        "USD": "price_1LmFclGadRXm50o3mWTkir9g"
+      },
+      "teamUsagePriceIds": {
+        "EUR": "price_1LiId7GadRXm50o3OayAS2y4",
+        "USD": "price_1LiIdbGadRXm50o3ylg5S44r"
       }
     }

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -817,8 +817,8 @@ export interface RepositoryCloneInformation {
 
 export interface CoreDumpConfig {
     enabled?: boolean;
-	softLimit?: number;
-	hardLimit?: number;
+    softLimit?: number;
+    hardLimit?: number;
 }
 
 export interface WorkspaceConfig {
@@ -1520,6 +1520,12 @@ export interface Terms {
     readonly updateMessage: string;
     readonly content: string;
     readonly formElements?: object;
+}
+
+export interface StripeConfig {
+    usageProductPriceIds: { [currency: string]: string };
+    individualUsagePriceIds?: { [currency: string]: string };
+    teamUsagePriceIds?: { [currency: string]: string };
 }
 
 export type BillingStrategy = "other" | "stripe";

--- a/components/server/src/config.ts
+++ b/components/server/src/config.ts
@@ -7,7 +7,7 @@
 import { GitpodHostUrl } from "@gitpod/gitpod-protocol/lib/util/gitpod-host-url";
 import { AuthProviderParams, normalizeAuthProviderParams } from "./auth/auth-provider";
 
-import { NamedWorkspaceFeatureFlag } from "@gitpod/gitpod-protocol";
+import { NamedWorkspaceFeatureFlag, StripeConfig } from "@gitpod/gitpod-protocol";
 
 import { RateLimiterConfig } from "./auth/rate-limiter";
 import { CodeSyncConfig } from "./code-sync/code-sync-service";
@@ -27,7 +27,7 @@ export type Config = Omit<
     workspaceDefaults: WorkspaceDefaults;
     chargebeeProviderOptions?: ChargebeeProviderOptions;
     stripeSecrets?: { publishableKey: string; secretKey: string };
-    stripeConfig?: { usageProductPriceIds: { [currency: string]: string } };
+    stripeConfig?: StripeConfig;
     builtinAuthProvidersConfigured: boolean;
     inactivityPeriodForRepos?: number;
 };
@@ -266,7 +266,7 @@ export namespace ConfigFile {
                 log.error("Could not load Stripe secrets", error);
             }
         }
-        let stripeConfig: { usageProductPriceIds: { EUR: string; USD: string } } | undefined;
+        let stripeConfig: StripeConfig | undefined;
         if (config.enablePayment && config.stripeConfigFile) {
             try {
                 stripeConfig = JSON.parse(fs.readFileSync(filePathTelepresenceAware(config.stripeConfigFile), "utf-8"));


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

In the context of https://github.com/gitpod-io/gitpod/issues/13301, we want to add the new Individual Stripe Price IDs to our configuration, alongside the existing Team Stripe Price IDs (simply renamed in this PR).

Note: We're not actually using the new IDs anywhere yet. This will happen as a follow-up in https://github.com/gitpod-io/gitpod/issues/13302.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/13307

## How to test
<!-- Provide steps to test this PR -->

1. Should build

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
