### PR TITLE
Port-forward directly to k3s

### DIFF
--- a/dev/preview/util/portforward-monitoring-satellite-harvester.sh
+++ b/dev/preview/util/portforward-monitoring-satellite-harvester.sh
@@ -11,8 +11,6 @@ if [[ -z "${VM_NAME:-}" ]]; then
     VM_NAME="$(preview-name-from-branch)"
 fi
 
-NAMESPACE="preview-${VM_NAME}"
-
 echo "
 Starting port-forwarding:
 
@@ -35,4 +33,4 @@ pkill -f "kubectl port-forward (.*)9090:9090"
 #   2. Deals with process termination. If you ^C this script xargs will kill the underlying
 #.     processes.
 #
-echo "3000:3000 9090:9090" | xargs  -n 1 -P 2 kubectl port-forward --context=harvester -n "${NAMESPACE}" svc/proxy
+echo "svc/grafana 3000:3000 svc/prometheus-k8s 9090:9090" | xargs  -n 2 -P 2 kubectl port-forward --context="$VM_NAME" -n "monitoring-satellite"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Port forwarding to Grafana/Prometheus in preview environments is broken at the moment. We get an error when we try to visit the page. See below:

```
gitpod /workspace/gitpod (ak/supervisor_observability) $ ./dev/preview/portforward-monitoring-satellite.sh -c harvester

Starting port-forwarding:

Prometheus:
https://9090-gitpodio-gitpod-ijwocmzi0o3.ws-eu67.gitpod.io

Grafana:
https://3000-gitpodio-gitpod-ijwocmzi0o3.ws-eu67.gitpod.io


Forwarding from 127.0.0.1:9090 -> 32001
Forwarding from [::1]:9090 -> 32001
Forwarding from 127.0.0.1:3000 -> 32000
Forwarding from [::1]:3000 -> 32000
Handling connection for 3000
E0926 13:52:32.090059   23719 portforward.go:406] an error occurred forwarding 3000 -> 32000: error forwarding port 32000 to pod 351aac1da93beb827a09a5a69754f125480d8216fde7517febfa68f7e5e64330, uid : failed to execute portforward in network namespace "/var/run/netns/cni-07716292-fde6-283c-aad7-8f84b947f878": failed to dial 32000: dial tcp4 127.0.0.1:32000: connect: connection refused
E0926 13:52:32.090520   23719 portforward.go:234] lost connection to pod
```

This PR changes it so that we don't go through svc/proxy in the Harvester cluster, but instead go directly to the k3s cluster.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
No issue. Reported [here](https://gitpod.slack.com/archives/C032A46PWR0/p1664197249172019).

## How to test
<!-- Provide steps to test this PR -->

I used this change on Antons branch and it worked.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

N/A

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
