### PR TITLE
[server] Remove handling of Probe Workspaces

### DIFF
--- a/components/ee/payment-endpoint/src/accounting/account-service-impl.ts
+++ b/components/ee/payment-endpoint/src/accounting/account-service-impl.ts
@@ -288,11 +288,6 @@ export class AccountServiceImpl implements AccountService {
             return true;
         }
 
-        // no probe workspaces get billed (shouldn't matter - they're never on the account of a "real" user anyways)
-        if (s.workspace.type == "probe") {
-            return false;
-        }
-
         // no prebuilds get billed
         if (s.workspace.type == "prebuild") {
             return false;

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -728,7 +728,7 @@ export interface Workspace {
 
 export type WorkspaceSoftDeletion = "user" | "gc";
 
-export type WorkspaceType = "regular" | "prebuild" | "probe"; // TODO(gpl) Removed prove here
+export type WorkspaceType = "regular" | "prebuild";
 
 export namespace Workspace {
     export function getFullRepositoryName(ws: Workspace): string | undefined {
@@ -1162,17 +1162,6 @@ export interface WithEnvvarsContext extends WorkspaceContext {
 export namespace WithEnvvarsContext {
     export function is(context: any): context is WithEnvvarsContext {
         return context && "envvars" in context;
-    }
-}
-
-export interface WorkspaceProbeContext extends WorkspaceContext {
-    responseURL: string;
-    responseToken: string;
-}
-
-export namespace WorkspaceProbeContext {
-    export function is(context: any): context is WorkspaceProbeContext {
-        return context && "responseURL" in context && "responseToken" in context;
     }
 }
 

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -49,7 +49,6 @@ import {
     WorkspaceInstance,
     WorkspaceInstanceConfiguration,
     WorkspaceInstanceStatus,
-    WorkspaceProbeContext,
     Permission,
     HeadlessWorkspaceEventType,
     DisposableCollection,
@@ -493,8 +492,6 @@ export class WorkspaceStarter {
             let type: WorkspaceType = WorkspaceType.REGULAR;
             if (workspace.type === "prebuild") {
                 type = WorkspaceType.PREBUILD;
-            } else if (workspace.type === "probe") {
-                type = WorkspaceType.PROBE;
             }
 
             // create spec
@@ -1758,8 +1755,6 @@ export class WorkspaceStarter {
                 init.addGit(initializer);
             }
             result.setPrebuild(init);
-        } else if (WorkspaceProbeContext.is(context)) {
-            // workspace probes have no workspace initializer as they need no content
         } else if (CommitContext.is(context)) {
             const { initializer } = await this.createCommitInitializer(traceCtx, workspace, context, user);
             if (initializer instanceof CompositeInitializer) {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Last workspace probe was April 2021.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Relates to https://github.com/gitpod-io/gitpod/issues/11315

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
