### PR TITLE
[content-service] Fix checkout local HEAD branch

### DIFF
--- a/components/content-service/pkg/initializer/git.go
+++ b/components/content-service/pkg/initializer/git.go
@@ -192,7 +192,7 @@ func (ws *GitInitializer) realizeCloneTarget(ctx context.Context) (err error) {
 		}
 	case LocalBranch:
 		// checkout local branch based on remote HEAD
-		if err := ws.Git(ctx, "checkout", "origin/HEAD", "--no-track"); err != nil {
+		if err := ws.Git(ctx, "checkout", "-B", ws.CloneTarget, "origin/HEAD", "--no-track"); err != nil {
 			return err
 		}
 	case RemoteCommit:


### PR DESCRIPTION
## How to test
- https://aledbf-head.preview.gitpod-dev.com/#https://github.com/gitpod-io/dazzle
- https://aledbf-head.preview.gitpod-dev.com/#https://github.com/gitpod-io/dazzle/commit/ddbf82c1a4dc95bda26c9f299d8e3b8f84eb659d
- https://aledbf-head.preview.gitpod-dev.com/#prebuild/https://github.com/gitpod-io/dazzle
- https://aledbf-head.preview.gitpod-dev.com/#https://github.com/NixOS/nixpkgs
- https://aledbf-head.preview.gitpod-dev.com/#prebuild/https://github.com/NixOS/nixpkgs
- https://aledbf-head.preview.gitpod-dev.com/#https://github.com/gitpod-io/spring-petclinic/tree/ak/vmoptions_test
- https://aledbf-head.preview.gitpod-dev.com/#prebuild/https://github.com/gitpod-io/empty
- https://aledbf-head.preview.gitpod-dev.com/#github.com/gitpod-io/gitpod-test-repo/issues/88

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #13284


## Release Notes
```release-note
NONE
```

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
