### PR TITLE
[installer-tests] fix cluster-issuer install test condition

### DIFF
--- a/install/tests/Makefile
+++ b/install/tests/Makefile
@@ -146,11 +146,11 @@ add-ns-record: check-env-cloud
 	terraform apply -target=module.$(cloud)-add-dns-record  -var kubeconfig=${KUBECONFIG} --auto-approve
 	@echo "Done adding NS record"
 
-self_signed ?= "false"
+self_signed ?= false
 .PHONY:
 ## cluster-issuer: Creates a cluster issuer for the correspondign provider
 cluster-issuer: check-env-cloud
-ifneq ($(self_signed), "true")
+ifeq (true,$(self_signed))
 	@echo "Skipped creating cluster issuer"
 else
 	terraform init --upgrade && \
@@ -391,9 +391,11 @@ gitpod-debug-info:
 check-kots-app:
 	kubectl kots get --kubeconfig=${KUBECONFIG} app gitpod -n gitpod | grep gitpod  | awk '{print $$2}' | grep "ready" || { $(MAKE) gitpod-debug-info; exit 1; }
 
+self_signed ?= false
+
 check-gitpod-installation: delete-cm-setup check-kots-app check-env-sub-domain
 	@echo "Curling https://${TF_VAR_TEST_ID}.${TF_VAR_domain}/api/version"
-ifneq ($(self_signed),)
+ifeq (true,$(self_signed))
 	export SSL_CERT_FILE=./ca.pem
 endif
 	curl -i -X GET https://${TF_VAR_TEST_ID}.${TF_VAR_domain}/api/version || { echo "Curling Gitpod endpoint failed"; exit 1; }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Currently cluster-issuer is not getting installed in test setups due to wrong condition on a Makefile. This PR fixes that issue


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
