### PR TITLE
[kots]: update the support bundle to use the latest apiversion

### DIFF
--- a/install/kots/manifests/kots-support-bundle.yaml
+++ b/install/kots/manifests/kots-support-bundle.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2022 Gitpod GmbH. All rights reserved.
 # Licensed under the MIT License. See License-MIT.txt in the project root for license information.
 
-apiVersion: troubleshoot.replicated.com/v1beta1
+apiVersion: troubleshoot.sh/v1beta2
 kind: SupportBundle
 metadata:
   name: gitpod


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
As part of https://github.com/replicated-collab/replicated-gitpod/issues/52, Replicated notified us that the `troubleshoot.replicated.com/v1beta1` apiversion is deprecated.

## How to test
<!-- Provide steps to test this PR -->
Deploy via KOTS and create a support bundle, eg [this example](https://vendor.replicated.com/troubleshoot/analyze/2022-09-26@19:20) what I've just generated

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[kots]: update the support bundle to use the latest apiversion
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
