### PR TITLE
Bump leeway to v0.3.1

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
-image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-upfi.0
+image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-bump-leeway.36
 workspaceLocation: gitpod/gitpod-ws.code-workspace
 checkoutLocation: gitpod
 ports:

--- a/.werft/aks-installer-tests.yaml
+++ b/.werft/aks-installer-tests.yaml
@@ -61,7 +61,7 @@ pod:
       secretName: sh-playground-dns-perm
   containers:
   - name: nightly-test
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-upfi.0
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-bump-leeway.36
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/build.yaml
+++ b/.werft/build.yaml
@@ -75,7 +75,7 @@ pod:
     - name: MYSQL_TCP_PORT
       value: 23306
   - name: build
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-upfi.0
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-bump-leeway.36
     workingDir: /workspace
     imagePullPolicy: IfNotPresent
     resources:

--- a/.werft/cleanup-installer-tests.yaml
+++ b/.werft/cleanup-installer-tests.yaml
@@ -24,7 +24,7 @@ pod:
       secretName: aks-credentials
   containers:
   - name: nightly-test
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-upfi.0
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-bump-leeway.36
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/debug.yaml
+++ b/.werft/debug.yaml
@@ -53,7 +53,7 @@ pod:
     - name: MYSQL_TCP_PORT
       value: 23306
   - name: build
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-upfi.0
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-bump-leeway.36
     workingDir: /workspace
     imagePullPolicy: IfNotPresent
     volumeMounts:

--- a/.werft/eks-installer-tests.yaml
+++ b/.werft/eks-installer-tests.yaml
@@ -61,7 +61,7 @@ pod:
       secretName: sh-playground-dns-perm
   containers:
   - name: nightly-test
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-upfi.0
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-bump-leeway.36
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/gke-installer-tests.yaml
+++ b/.werft/gke-installer-tests.yaml
@@ -61,7 +61,7 @@ pod:
         secretName: sh-playground-dns-perm
   containers:
     - name: nightly-test
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-upfi.0
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-bump-leeway.36
       workingDir: /workspace
       imagePullPolicy: Always
       volumeMounts:

--- a/.werft/ide-integration-tests-startup.yaml
+++ b/.werft/ide-integration-tests-startup.yaml
@@ -16,7 +16,7 @@ pod:
         secretName: github-token-gitpod-bot
   containers:
     - name: gcloud
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-upfi.0
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-bump-leeway.36
       workingDir: /workspace
       imagePullPolicy: IfNotPresent
       env:

--- a/.werft/k3s-installer-tests.yaml
+++ b/.werft/k3s-installer-tests.yaml
@@ -64,7 +64,7 @@ pod:
       secretName: self-hosted-github-oauth
   containers:
   - name: nightly-test
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-upfi.0
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-bump-leeway.36
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/platform-delete-preview-environment.yaml
+++ b/.werft/platform-delete-preview-environment.yaml
@@ -24,7 +24,7 @@ pod:
         secretName: harvester-vm-ssh-keys
   containers:
     - name: build
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-upfi.0
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-bump-leeway.36
       workingDir: /workspace
       imagePullPolicy: IfNotPresent
       volumeMounts:

--- a/.werft/platform-delete-preview-environments-cron.yaml
+++ b/.werft/platform-delete-preview-environments-cron.yaml
@@ -28,7 +28,7 @@ pod:
         secretName: github-token-gitpod-bot
   containers:
     - name: build
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-upfi.0
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-bump-leeway.36
       workingDir: /workspace
       imagePullPolicy: IfNotPresent
       volumeMounts:

--- a/.werft/platform-trigger-werft-cleanup.yaml
+++ b/.werft/platform-trigger-werft-cleanup.yaml
@@ -21,7 +21,7 @@ pod:
         secretName: gcp-sa-gitpod-dev-deployer
   containers:
     - name: build
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-upfi.0
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-bump-leeway.36
       workingDir: /workspace
       imagePullPolicy: IfNotPresent
       volumeMounts:

--- a/.werft/workspace-run-integration-tests.yaml
+++ b/.werft/workspace-run-integration-tests.yaml
@@ -21,7 +21,7 @@ pod:
         secretName: github-token-gitpod-bot
   containers:
     - name: gcloud
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-upfi.0
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:cw-bump-leeway.36
       workingDir: /workspace
       imagePullPolicy: IfNotPresent
       env:

--- a/dev/image/Dockerfile
+++ b/dev/image/Dockerfile
@@ -58,7 +58,7 @@ RUN cd /usr/bin && curl -fsSL https://github.com/praetorian-inc/gokart/releases/
 
 # leeway
 ENV LEEWAY_MAX_PROVENANCE_BUNDLE_SIZE=8388608
-RUN cd /usr/bin && curl -fsSL https://github.com/gitpod-io/leeway/releases/download/v0.2.21/leeway_0.2.21_Linux_x86_64.tar.gz | tar xz
+RUN cd /usr/bin && curl -fsSL https://github.com/gitpod-io/leeway/releases/download/v0.3.1/leeway_0.3.1_Linux_x86_64.tar.gz | tar xz
 
 # evans (gRPC client)
 RUN cd /usr/bin && curl -fsSL https://github.com/ktr0731/evans/releases/download/v0.10.6/evans_linux_amd64.tar.gz | tar xz evans


### PR DESCRIPTION
## Description
This PR bumps leeway to the latest release to prepare for Go workspaces.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
