### PR TITLE
allow to enable PVC feature flag for user via ConfigCat

### DIFF
--- a/components/server/ee/src/workspace/workspace-factory.ts
+++ b/components/server/ee/src/workspace/workspace-factory.ts
@@ -32,12 +32,15 @@ import { UserDB } from "@gitpod/gitpod-db/lib";
 import { UserCounter } from "../user/user-counter";
 import { increasePrebuildsStartedCounter } from "../../../src/prometheus-metrics";
 import { DeepPartial } from "@gitpod/gitpod-protocol/lib/util/deep-partial";
+import { EntitlementService } from "../../../src/billing/entitlement-service";
+import { getExperimentsClientForBackend } from "@gitpod/gitpod-protocol/lib/experiments/configcat-server";
 
 @injectable()
 export class WorkspaceFactoryEE extends WorkspaceFactory {
     @inject(LicenseEvaluator) protected readonly licenseEvaluator: LicenseEvaluator;
     @inject(HostContextProvider) protected readonly hostContextProvider: HostContextProvider;
     @inject(UserCounter) protected readonly userCounter: UserCounter;
+    @inject(EntitlementService) protected readonly entitlementService: EntitlementService;
 
     @inject(UserDB) protected readonly userDB: UserDB;
 
@@ -332,6 +335,18 @@ export class WorkspaceFactoryEE extends WorkspaceFactory {
 
             // Special case for PVC: While it's a workspace-persisted feature flag, we support the upgrade path (non-pvc -> pvc), so we apply it here
             if (user.featureFlags?.permanentWSFeatureFlags?.includes("persistent_volume_claim")) {
+                config._featureFlags = (config._featureFlags || []).concat(["persistent_volume_claim"]);
+            }
+            const billingTier = await this.entitlementService.getBillingTier(user);
+            const userTeams = await this.teamDB.findTeamsByUser(user.id);
+            // this allows to control user`s PVC feature flag via ConfigCat
+            if (
+                await getExperimentsClientForBackend().getValueAsync("user_pvc", false, {
+                    user,
+                    teams: userTeams,
+                    billingTier,
+                })
+            ) {
                 config._featureFlags = (config._featureFlags || []).concat(["persistent_volume_claim"]);
             }
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Instead of having to enable feature flag per user via admin panel, this allows to enable it via ConfigCat instead, as well as will allow us to roll out this feature to more users via configCat. 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #12745

## How to test
<!-- Provide steps to test this PR -->
Open preview env
Add your user id to ConfigCat non production env
Open new workspace
In terminal: `ls -la /.workspace/.gitpod/` and you should see `pvc` file in there, indicating this workspace is running using PVC feature.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
none
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
