### PR TITLE
add addional tracing for remoteContentStorage Download fn

### DIFF
--- a/components/ws-daemon/pkg/content/initializer.go
+++ b/components/ws-daemon/pkg/content/initializer.go
@@ -379,11 +379,17 @@ func (rs *remoteContentStorage) EnsureExists(ctx context.Context) error {
 
 // Download always returns false and does nothing
 func (rs *remoteContentStorage) Download(ctx context.Context, destination string, name string, mappings []archive.IDMapping) (exists bool, err error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "remoteContentStorage.Download")
+	span.SetTag("destination", destination)
+	span.SetTag("name", name)
+	defer tracing.FinishSpan(span, &err)
+
 	info, exists := rs.RemoteContent[name]
 	if !exists {
 		return false, nil
 	}
 
+	span.SetTag("URL", info.URL)
 	resp, err := http.Get(info.URL)
 	if err != nil {
 		return true, err


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
add addional tracing for remoteContentStorage Download function (after viewing some traces, realized I am missing that info to build better picture of what is going on).
Related to https://github.com/gitpod-io/gitpod/issues/12345

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
none
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
