### PR TITLE
[db-sync] Sync `d_b_volume_snapshot` table

### DIFF
--- a/components/gitpod-db/src/typeorm/entity/db-volume-snapshot.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-volume-snapshot.ts
@@ -13,6 +13,7 @@ import { Transformer } from "../transformer";
 @Entity()
 @Index("ind_dbsync", ["creationTime"]) // DBSync
 @Index("ind_workspaceId_creationTime", ["workspaceId", "creationTime"]) // findVolumeSnapshotForGCByWorkspaceId
+// on DB but not Typeorm: @Index("ind_lastModified", ["_lastModified"])   // DBSync
 export class DBVolumeSnapshot implements VolumeSnapshot {
     @PrimaryColumn(TypeORM.WORKSPACE_ID_COLUMN_TYPE)
     id: string;

--- a/components/gitpod-db/src/typeorm/migration/1664205442175-AddLastModifiedToVolumeSnapshots.ts
+++ b/components/gitpod-db/src/typeorm/migration/1664205442175-AddLastModifiedToVolumeSnapshots.ts
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { columnExists, indexExists } from "./helper/helper";
+
+const TABLE_NAME = "d_b_volume_snapshot";
+const DELETED_COLUMN_NAME = "deleted";
+const MODIFIED_COLUMN_NAME = "_lastModified";
+const LAST_MODIFIED_INDEX_NAME = "ind_lastModified";
+
+export class AddLastModifiedToVolumeSnapshots1664205442175 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        if (!(await columnExists(queryRunner, TABLE_NAME, DELETED_COLUMN_NAME))) {
+            await queryRunner.query(
+                `ALTER TABLE ${TABLE_NAME} ADD COLUMN \`${DELETED_COLUMN_NAME}\` tinyint(4) NOT NULL DEFAULT '0', ALGORITHM=INPLACE, LOCK=NONE`,
+            );
+        }
+
+        if (!(await columnExists(queryRunner, TABLE_NAME, MODIFIED_COLUMN_NAME))) {
+            await queryRunner.query(
+                `ALTER TABLE ${TABLE_NAME} ADD COLUMN ${MODIFIED_COLUMN_NAME} timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6), ALGORITHM=INPLACE, LOCK=NONE `,
+            );
+        }
+
+        if (!(await indexExists(queryRunner, TABLE_NAME, LAST_MODIFIED_INDEX_NAME))) {
+            await queryRunner.query(
+                `CREATE INDEX \`${LAST_MODIFIED_INDEX_NAME}\` ON \`${TABLE_NAME}\` (${MODIFIED_COLUMN_NAME})`,
+            );
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {}
+}


### PR DESCRIPTION
## Description

Make the `db_volume_snapshot` table able to be synced between clusters.

* Add a migration so that the table has `_lastModified` and `deleted` fields.

Records are currently hard-deleted from this table, so the `deleted` field will not be used in practice:

https://github.com/gitpod-io/gitpod/blob/99e86333318deb096044e0f25d6000293e46f26d/components/gitpod-db/src/typeorm/workspace-db-impl.ts#L776-L779

## Related Issue(s)
Part of https://github.com/gitpod-io/gitpod/issues/9198

## How to test


## Release Notes
```release-note
NONE
```

## Documentation


## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
