### PR TITLE
Update Stripe price IDs used for individuals in Werft preview environments

### DIFF
--- a/.werft/jobs/build/payment/stripe-configmap.yaml
+++ b/.werft/jobs/build/payment/stripe-configmap.yaml
@@ -11,8 +11,8 @@ data:
         "USD": "price_1LiIdbGadRXm50o3ylg5S44r"
       },
       "individualUsagePriceIds": {
-        "EUR": "price_1LmFcFGadRXm50o3XUrEuajK",
-        "USD": "price_1LmFclGadRXm50o3mWTkir9g"
+        "EUR": "price_1LmYVxGadRXm50o3AiLq0Qmo",
+        "USD": "price_1LmYWRGadRXm50o3Ym8PLqnG"
       },
       "teamUsagePriceIds": {
         "EUR": "price_1LiId7GadRXm50o3OayAS2y4",


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Update Stripe price IDs used for individuals in Werft preview environments.

This slightly simplifies the pricing tiers for individuals. [Context](https://gitpod.slack.com/archives/C027AUU7BC3/p1664209231957839?thread_ts=1664191425.697079&cid=C027AUU7BC3) (internal)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
