### PR TITLE
[bridge] Marks stuck stopping and pending instances as stopped

### DIFF
--- a/components/ws-manager-bridge/src/config.ts
+++ b/components/ws-manager-bridge/src/config.ts
@@ -31,6 +31,8 @@ export interface Configuration {
         preparingPhaseSeconds: number;
         buildingPhaseSeconds: number;
         unknownPhaseSeconds: number;
+        pendingPhaseSeconds: number;
+        stoppingPhaseSeconds: number;
     };
 
     // emulatePreparingIntervalSeconds configures how often we check for Workspaces in phase "preparing" for clusters we do not govern

--- a/install/installer/cmd/testdata/render/aws-setup/output.golden
+++ b/install/installer/cmd/testdata/render/aws-setup/output.golden
@@ -4855,7 +4855,9 @@ data:
       "timeouts": {
         "preparingPhaseSeconds": 3600,
         "buildingPhaseSeconds": 3600,
-        "unknownPhaseSeconds": 600
+        "unknownPhaseSeconds": 600,
+        "pendingPhaseSeconds": 3600,
+        "stoppingPhaseSeconds": 3600
       },
       "clusterSyncIntervalSeconds": 60
     }
@@ -8929,7 +8931,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: f5d95af2308e35194d44403c42e269fbe9e4c596d138796fa95f705ec3b4d352
+        gitpod.io/checksum_config: eb3706cacfc9d2ff32216e0f3564bf211676885e1511d13147c812cb94000ee0
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/azure-setup/output.golden
+++ b/install/installer/cmd/testdata/render/azure-setup/output.golden
@@ -4714,7 +4714,9 @@ data:
       "timeouts": {
         "preparingPhaseSeconds": 3600,
         "buildingPhaseSeconds": 3600,
-        "unknownPhaseSeconds": 600
+        "unknownPhaseSeconds": 600,
+        "pendingPhaseSeconds": 3600,
+        "stoppingPhaseSeconds": 3600
       },
       "clusterSyncIntervalSeconds": 60
     }
@@ -8774,7 +8776,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: f5d95af2308e35194d44403c42e269fbe9e4c596d138796fa95f705ec3b4d352
+        gitpod.io/checksum_config: eb3706cacfc9d2ff32216e0f3564bf211676885e1511d13147c812cb94000ee0
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -5681,7 +5681,9 @@ data:
       "timeouts": {
         "preparingPhaseSeconds": 3600,
         "buildingPhaseSeconds": 3600,
-        "unknownPhaseSeconds": 600
+        "unknownPhaseSeconds": 600,
+        "pendingPhaseSeconds": 3600,
+        "stoppingPhaseSeconds": 3600
       },
       "clusterSyncIntervalSeconds": 60
     }
@@ -10360,7 +10362,7 @@ spec:
     metadata:
       annotations:
         gitpod.io: hello
-        gitpod.io/checksum_config: fdb0c0adb6ea187bd587fb7c286084b4853439fdfafa7f32bbdcacee744e5c3e
+        gitpod.io/checksum_config: 2d645aacfa07b22cc2e8f2a80d3b797031f470a1af284ab923fc9678ff81efac
         hello: world
       creationTimestamp: null
       labels:

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -4901,7 +4901,9 @@ data:
       "timeouts": {
         "preparingPhaseSeconds": 3600,
         "buildingPhaseSeconds": 3600,
-        "unknownPhaseSeconds": 600
+        "unknownPhaseSeconds": 600,
+        "pendingPhaseSeconds": 3600,
+        "stoppingPhaseSeconds": 3600
       },
       "clusterSyncIntervalSeconds": 60
     }
@@ -9200,7 +9202,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: bacace964780fd56bdd04b997df0017c24563c2aac6bffd10962c297b54c91ba
+        gitpod.io/checksum_config: 124c0235366403cca5d28e6b8c8cb08d44991225ff7bba386100ac942b78dd48
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/gcp-setup/output.golden
+++ b/install/installer/cmd/testdata/render/gcp-setup/output.golden
@@ -4673,7 +4673,9 @@ data:
       "timeouts": {
         "preparingPhaseSeconds": 3600,
         "buildingPhaseSeconds": 3600,
-        "unknownPhaseSeconds": 600
+        "unknownPhaseSeconds": 600,
+        "pendingPhaseSeconds": 3600,
+        "stoppingPhaseSeconds": 3600
       },
       "clusterSyncIntervalSeconds": 60
     }
@@ -8697,7 +8699,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 6d44bef12145215794685e52c3139f04195bcf8e7ca1f1d7b3803da845e837eb
+        gitpod.io/checksum_config: 6901b3da5bcf091d43e67f04b108c86334788b912c8c27c18afd0f0025dcd3de
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/http-proxy/output.golden
+++ b/install/installer/cmd/testdata/render/http-proxy/output.golden
@@ -5124,7 +5124,9 @@ data:
       "timeouts": {
         "preparingPhaseSeconds": 3600,
         "buildingPhaseSeconds": 3600,
-        "unknownPhaseSeconds": 600
+        "unknownPhaseSeconds": 600,
+        "pendingPhaseSeconds": 3600,
+        "stoppingPhaseSeconds": 3600
       },
       "clusterSyncIntervalSeconds": 60
     }
@@ -10863,7 +10865,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: bacace964780fd56bdd04b997df0017c24563c2aac6bffd10962c297b54c91ba
+        gitpod.io/checksum_config: 124c0235366403cca5d28e6b8c8cb08d44991225ff7bba386100ac942b78dd48
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/insecure-s3-setup/output.golden
+++ b/install/installer/cmd/testdata/render/insecure-s3-setup/output.golden
@@ -5037,7 +5037,9 @@ data:
       "timeouts": {
         "preparingPhaseSeconds": 3600,
         "buildingPhaseSeconds": 3600,
-        "unknownPhaseSeconds": 600
+        "unknownPhaseSeconds": 600,
+        "pendingPhaseSeconds": 3600,
+        "stoppingPhaseSeconds": 3600
       },
       "clusterSyncIntervalSeconds": 60
     }
@@ -9352,7 +9354,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: bacace964780fd56bdd04b997df0017c24563c2aac6bffd10962c297b54c91ba
+        gitpod.io/checksum_config: 124c0235366403cca5d28e6b8c8cb08d44991225ff7bba386100ac942b78dd48
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -5121,7 +5121,9 @@ data:
       "timeouts": {
         "preparingPhaseSeconds": 3600,
         "buildingPhaseSeconds": 3600,
-        "unknownPhaseSeconds": 600
+        "unknownPhaseSeconds": 600,
+        "pendingPhaseSeconds": 3600,
+        "stoppingPhaseSeconds": 3600
       },
       "clusterSyncIntervalSeconds": 60
     }
@@ -9575,7 +9577,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: bacace964780fd56bdd04b997df0017c24563c2aac6bffd10962c297b54c91ba
+        gitpod.io/checksum_config: 124c0235366403cca5d28e6b8c8cb08d44991225ff7bba386100ac942b78dd48
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -5133,7 +5133,9 @@ data:
       "timeouts": {
         "preparingPhaseSeconds": 3600,
         "buildingPhaseSeconds": 3600,
-        "unknownPhaseSeconds": 600
+        "unknownPhaseSeconds": 600,
+        "pendingPhaseSeconds": 3600,
+        "stoppingPhaseSeconds": 3600
       },
       "clusterSyncIntervalSeconds": 60
     }
@@ -9587,7 +9589,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: bacace964780fd56bdd04b997df0017c24563c2aac6bffd10962c297b54c91ba
+        gitpod.io/checksum_config: 124c0235366403cca5d28e6b8c8cb08d44991225ff7bba386100ac942b78dd48
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
+++ b/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
@@ -5454,7 +5454,9 @@ data:
       "timeouts": {
         "preparingPhaseSeconds": 3600,
         "buildingPhaseSeconds": 3600,
-        "unknownPhaseSeconds": 600
+        "unknownPhaseSeconds": 600,
+        "pendingPhaseSeconds": 3600,
+        "stoppingPhaseSeconds": 3600
       },
       "clusterSyncIntervalSeconds": 60
     }
@@ -10019,7 +10021,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: bacace964780fd56bdd04b997df0017c24563c2aac6bffd10962c297b54c91ba
+        gitpod.io/checksum_config: 124c0235366403cca5d28e6b8c8cb08d44991225ff7bba386100ac942b78dd48
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
+++ b/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
@@ -5124,7 +5124,9 @@ data:
       "timeouts": {
         "preparingPhaseSeconds": 3600,
         "buildingPhaseSeconds": 3600,
-        "unknownPhaseSeconds": 600
+        "unknownPhaseSeconds": 600,
+        "pendingPhaseSeconds": 3600,
+        "stoppingPhaseSeconds": 3600
       },
       "clusterSyncIntervalSeconds": 60
     }
@@ -9578,7 +9580,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: bacace964780fd56bdd04b997df0017c24563c2aac6bffd10962c297b54c91ba
+        gitpod.io/checksum_config: 124c0235366403cca5d28e6b8c8cb08d44991225ff7bba386100ac942b78dd48
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/pkg/components/ws-manager-bridge/configmap.go
+++ b/install/installer/pkg/components/ws-manager-bridge/configmap.go
@@ -28,6 +28,8 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 			PreparingPhaseSeconds: 3600,
 			BuildingPhaseSeconds:  3600,
 			UnknownPhaseSeconds:   600,
+			PendingPhaseSeconds:   3600,
+			StoppingPhaseSeconds:  3600,
 		},
 		EmulatePreparingIntervalSeconds: 10,
 		StaticBridges:                   WSManagerList(ctx),

--- a/install/installer/pkg/components/ws-manager-bridge/types.go
+++ b/install/installer/pkg/components/ws-manager-bridge/types.go
@@ -26,6 +26,8 @@ type Timeouts struct {
 	PreparingPhaseSeconds int32 `json:"preparingPhaseSeconds"`
 	BuildingPhaseSeconds  int32 `json:"buildingPhaseSeconds"`
 	UnknownPhaseSeconds   int32 `json:"unknownPhaseSeconds"`
+	PendingPhaseSeconds   int32 `json:"pendingPhaseSeconds"`
+	StoppingPhaseSeconds  int32 `json:"stoppingPhaseSeconds"`
 }
 
 // WorkspaceCluster from components/gitpod-protocol/src/workspace-cluster.ts


### PR DESCRIPTION
## Description
After validating through logging of the past two weeks (since 15.09.2022), this change marks `stopping` and `pending` states after the timeout duration to be stopped. 
Findings from the [logging](https://github.com/gitpod-io/gitpod/pull/12902):
1. Most of the logs were for `stopping` state, and we could not find a clear explanation whether they were cases that we want to be stopped. Instances could be in a `stopping` state for longer than we expect (in the previous PR it was 10 seconds after `stoppingTime`) because instances with a big back-up size can take longer.
2. A lot of the `pending` states were stuck in that state for days, and we do want them stopped.
3. We found a few `creating` states that ended up running, and these we should not stop. 

We are still unsure why these instances end up in these states. Therefore we:
1. Will focus on only stopping stuck instances in `pending` and `stopping` states, and after the timeout duration. These we know for sure we want stopped.
2. To understand the why, we will create an issue. 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #11397

## How to test
1. `kubectl cordon` the preview node
2. Run a workspace. It should be stuck in pending.
3. Change the creationTime in `d_b_workspace_instance` to 1 hour before (or wait 1 hour). It should be marked as stopped with a message `"Stopped by ws-manager-bridge. Previously in phase pending`.
4. Once done, `kubectl uncordon` the node, otherwise builds will fail because the node can't be scheduled.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
