### PR TITLE
[server] Refactor StripeService.getPortalUrl to take an attributionId instead of a userId or teamId

### DIFF
--- a/components/server/ee/src/user/stripe-service.ts
+++ b/components/server/ee/src/user/stripe-service.ts
@@ -6,9 +6,7 @@
 
 import { inject, injectable } from "inversify";
 import Stripe from "stripe";
-import { Team, User } from "@gitpod/gitpod-protocol";
 import { Config } from "../../../src/config";
-import { AttributionId } from "@gitpod/gitpod-protocol/lib/attribution";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 
 const POLL_CREATED_CUSTOMER_INTERVAL_MS = 1000;
@@ -87,26 +85,10 @@ export class StripeService {
         });
     }
 
-    async getPortalUrlForTeam(team: Team): Promise<string> {
-        const customerId = await this.findCustomerByAttributionId(
-            AttributionId.render({ kind: "team", teamId: team.id }),
-        );
+    async getPortalUrlForAttributionId(attributionId: string): Promise<string> {
+        const customerId = await this.findCustomerByAttributionId(attributionId);
         if (!customerId) {
-            throw new Error(`No Stripe Customer ID found for team '${team.id}'`);
-        }
-        const session = await this.getStripe().billingPortal.sessions.create({
-            customer: customerId,
-            return_url: this.config.hostUrl.with(() => ({ pathname: `/t/${team.slug}/billing` })).toString(),
-        });
-        return session.url;
-    }
-
-    async getPortalUrlForUser(user: User): Promise<string> {
-        const customerId = await this.findCustomerByAttributionId(
-            AttributionId.render({ kind: "user", userId: user.id }),
-        );
-        if (!customerId) {
-            throw new Error(`No Stripe Customer ID found for user '${user.id}'`);
+            throw new Error(`No Stripe Customer ID found for '${attributionId}'`);
         }
         const session = await this.getStripe().billingPortal.sessions.create({
             customer: customerId,

--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -2168,30 +2168,21 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
 
         const user = this.checkAndBlockUser("getStripePortalUrl");
 
-        let url: string;
         if (attrId.kind === "user") {
             await this.ensureStripeApiIsAllowed({ user });
-            try {
-                url = await this.stripeService.getPortalUrlForUser(user);
-            } catch (error) {
-                log.error(`Failed to get Stripe portal URL for user '${user.id}'`, error);
-                throw new ResponseError(
-                    ErrorCodes.INTERNAL_SERVER_ERROR,
-                    `Failed to get Stripe portal URL for user '${user.id}'`,
-                );
-            }
         } else {
             const team = await this.guardTeamOperation(attrId.teamId, "update");
             await this.ensureStripeApiIsAllowed({ team });
-            try {
-                url = await this.stripeService.getPortalUrlForTeam(team);
-            } catch (error) {
-                log.error(`Failed to get Stripe portal URL for team '${team.id}'`, error);
-                throw new ResponseError(
-                    ErrorCodes.INTERNAL_SERVER_ERROR,
-                    `Failed to get Stripe portal URL for team '${team.id}'`,
-                );
-            }
+        }
+        let url: string;
+        try {
+            url = await this.stripeService.getPortalUrlForAttributionId(attributionId);
+        } catch (error) {
+            log.error(`Failed to get Stripe portal URL for '${attributionId}'`, error);
+            throw new ResponseError(
+                ErrorCodes.INTERNAL_SERVER_ERROR,
+                `Failed to get Stripe portal URL for '${attributionId}'`,
+            );
         }
         return url;
     }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Refactor `StripeService.getPortalUrl` to take an `attributionId` instead of a `userId` or `teamId`.

Note: I know that we may want to eventually move `StripeService` over to the `usage` component (or, maybe better, to a dedicated `billing` component) as per https://github.com/gitpod-io/gitpod/issues/13198. However, this at least gives a cleaner API that could be migrated as is (i.e. no user- or team-specific methods, only attributionIds).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

1. Subscribe to Stripe
2. Opening the Stripe customer portal should still work

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-payment
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
