### PR TITLE
Use different Stripe Price IDs when subscribing individuals vs teams

### DIFF
--- a/.werft/jobs/build/payment/stripe-configmap.yaml
+++ b/.werft/jobs/build/payment/stripe-configmap.yaml
@@ -6,10 +6,6 @@ metadata:
 data:
   config: |
     {
-      "usageProductPriceIds": {
-        "EUR": "price_1LiId7GadRXm50o3OayAS2y4",
-        "USD": "price_1LiIdbGadRXm50o3ylg5S44r"
-      },
       "individualUsagePriceIds": {
         "EUR": "price_1LmYVxGadRXm50o3AiLq0Qmo",
         "USD": "price_1LmYWRGadRXm50o3Ym8PLqnG"

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -1512,9 +1512,8 @@ export interface Terms {
 }
 
 export interface StripeConfig {
-    usageProductPriceIds: { [currency: string]: string };
-    individualUsagePriceIds?: { [currency: string]: string };
-    teamUsagePriceIds?: { [currency: string]: string };
+    individualUsagePriceIds: { [currency: string]: string };
+    teamUsagePriceIds: { [currency: string]: string };
 }
 
 export type BillingStrategy = "other" | "stripe";

--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -2138,7 +2138,7 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
             }
 
             await this.stripeService.setDefaultPaymentMethodForCustomer(customerId, setupIntentId);
-            await this.stripeService.createSubscriptionForCustomer(customerId);
+            await this.stripeService.createSubscriptionForCustomer(customerId, attributionId);
 
             // Creating a cost center for this customer
             await this.usageService.setCostCenter({


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Use different Stripe Price IDs when subscribing individuals vs teams.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/13302

## How to test
<!-- Provide steps to test this PR -->

1. Subscribe to usage-based as a team
2. In the Stripe admin dashboard, your team's subscription should be linked to a "Team" price (pay-as-you-go)
3. Subscribe to usage-based as an individual
4. In the Stripe admin dashboard, your user's subscription should be linked to an "Individual" price (discounted flat rate + pay-as-you-go)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-payment
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
