### PR TITLE
[refarch] Update node size for GCP and AWS

### DIFF
--- a/install/infra/single-cluster/aws/cluster.tf
+++ b/install/infra/single-cluster/aws/cluster.tf
@@ -11,7 +11,7 @@ module "eks" {
   create_external_database = var.create_external_database
   create_external_storage  = var.create_external_storage
   service_machine_type     = "m6i.xlarge"
-  workspace_machine_type   = "m6i.2xlarge"
+  workspace_machine_type   = "m6i.4xlarge"
 
   create_external_storage_for_registry_backend = var.create_external_storage_for_registry_backend
 }

--- a/install/infra/single-cluster/gcp/cluster.tf
+++ b/install/infra/single-cluster/gcp/cluster.tf
@@ -1,12 +1,13 @@
 module "gke" {
   source = "../../modules/gke"
 
-  cluster_name    = var.cluster_name
-  kubeconfig      = var.kubeconfig
-  cluster_version = var.cluster_version
-  project         = var.project
-  region          = var.region
-  zone            = var.zone
+  cluster_name           = var.cluster_name
+  kubeconfig             = var.kubeconfig
+  cluster_version        = var.cluster_version
+  project                = var.project
+  region                 = var.region
+  zone                   = var.zone
+  workspace_machine_type = "n2d-standard-16"
 
   domain_name = var.domain_name
   enable_external_database = var.enable_external_database


### PR DESCRIPTION
## Description
Update the node size for GCP and AWS self hosted reference architectures as laid out in https://github.com/gitpod-io/website/pull/2790.

## Related Issue(s)
Related to https://github.com/gitpod-io/website/pull/2790

## How to test
Not sure, would appreciate some pointers.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Update node sizes for self hosted reference architectures
```

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
