### PR TITLE
[installer]: delete old kots serviceaccount/clusterrolebinding

### DIFF
--- a/install/installer/scripts/kots-install.sh
+++ b/install/installer/scripts/kots-install.sh
@@ -111,6 +111,11 @@ EOF
         return 0
     fi
 
+    # Delete old serviceaccount/clusterrolebinding
+    echo "Deleting pre-2022.9.0 serviceaccount/clusterrolebinding"
+    kubectl delete serviceaccounts -n "${NAMESPACE}" installer || true
+    kubectl delete clusterrolebindings -n "${NAMESPACE}" installer || true
+
     # Combine the pull secrets
     echo "${LOCAL_REGISTRY_IMAGE_PULL_DOCKER_CONFIG_JSON}" > /tmp/kotsregistry.json
     if [ "${REGISTRY_INCLUSTER_ENABLED}" = "1" ]; then


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Delete service account and cluster role binding in the Installer script. KOTS doesn't delete old manifests that have been removed during upgrades, so we have to do it ourselves

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[installer]: delete old kots serviceaccount/clusterrolebinding
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
