### PR TITLE
Add default value for SEGMENT_IO_TOKEN

### DIFF
--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -15,8 +15,11 @@ defaultArgs:
   golandDownloadUrl: "https://download.jetbrains.com/go/goland-2022.2.3.tar.gz"
   pycharmDownloadUrl: "https://download.jetbrains.com/python/pycharm-professional-2022.2.2.tar.gz"
   phpstormDownloadUrl: "https://download.jetbrains.com/webide/PhpStorm-2022.2.2.tar.gz"
+  # Used by the kots installer
   REPLICATED_API_TOKEN: ""
   REPLICATED_APP: ""
+  # Used by local-preview
+  SEGMENT_IO_TOKEN: ""
 provenance:
   enabled: true
   slsa: true


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Specify a default value for `SEGMENT_IO_TOKEN` so that we can use `leeway build` in a Gitpod Workspace without specifying `-DSEGMENT_IO_TOKEN=""`

@gitpod-io/engineering-self-hosted Is is okay for this value to be empty? We always specify a value when building in CI so this is mainly if you run `leeway build` in a workspace to build the local-preview ☺️

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of https://github.com/gitpod-io/ops/issues/5411

## How to test
<!-- Provide steps to test this PR -->

```sh
leeway build install/preview:docker -Dversion="mads" -DwithLocalPreview=true
```

Should no longer error due to missing `SEGMENT_IO_TOKEN` build argument (`-DwithLocalPreview=true` is going away soon).

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
