### PR TITLE
[server] Fix return URL of Stripe Customer Portal for teams

### DIFF
--- a/components/server/ee/src/user/stripe-service.ts
+++ b/components/server/ee/src/user/stripe-service.ts
@@ -86,14 +86,14 @@ export class StripeService {
         });
     }
 
-    async getPortalUrlForAttributionId(attributionId: string): Promise<string> {
+    async getPortalUrlForAttributionId(attributionId: string, returnUrl: string): Promise<string> {
         const customerId = await this.findCustomerByAttributionId(attributionId);
         if (!customerId) {
             throw new Error(`No Stripe Customer ID found for '${attributionId}'`);
         }
         const session = await this.getStripe().billingPortal.sessions.create({
             customer: customerId,
-            return_url: this.config.hostUrl.with(() => ({ pathname: `/billing` })).toString(),
+            return_url: returnUrl,
         });
         return session.url;
     }

--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -2168,15 +2168,17 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
 
         const user = this.checkAndBlockUser("getStripePortalUrl");
 
+        let returnUrl = this.config.hostUrl.with(() => ({ pathname: `/billing` })).toString();
         if (attrId.kind === "user") {
             await this.ensureStripeApiIsAllowed({ user });
-        } else {
+        } else if (attrId.kind === "team") {
             const team = await this.guardTeamOperation(attrId.teamId, "update");
             await this.ensureStripeApiIsAllowed({ team });
+            returnUrl = this.config.hostUrl.with(() => ({ pathname: `/t/${team.slug}/billing` })).toString();
         }
         let url: string;
         try {
-            url = await this.stripeService.getPortalUrlForAttributionId(attributionId);
+            url = await this.stripeService.getPortalUrlForAttributionId(attributionId, returnUrl);
         } catch (error) {
             log.error(`Failed to get Stripe portal URL for '${attributionId}'`, error);
             throw new ResponseError(


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Follow-up to #13351, which accidentally made all Stripe customer portal return URLs be `/billing`.

`/billing` is correct for user portals, but team portals need a different, team-specific return URL. This PR brings it back by always passing the correct `returnUrl` parameter.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #13351

## How to test
<!-- Provide steps to test this PR -->

1. Subscribe to usage-based as a team
2. Click on "Manage Billing"
3. Click on "Return to Gitpod"
4. You should be back in team billing, not user billing

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-payment
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
