### PR TITLE
[supervisor] gracefully sigterm child processes

### DIFF
--- a/components/supervisor/pkg/process/process.go
+++ b/components/supervisor/pkg/process/process.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package process
+
+import (
+	"github.com/prometheus/procfs"
+)
+
+// SigTerm does a depth-first traversion over a process tree
+func VisitProcessTree(processID int, visitFunction func(process procfs.Proc) error) error {
+	processes, err := procfs.AllProcs()
+	if err != nil {
+		return err
+	}
+	return visitProcessTreeRec(processID, processes, visitFunction)
+}
+
+func visitProcessTreeRec(processID int, processes []procfs.Proc, visitFunction func(process procfs.Proc) error) error {
+	for _, p := range processes {
+		stat, err := p.Stat()
+		if err != nil {
+			return err
+		}
+		if stat.PPID == processID {
+			err := visitProcessTreeRec(stat.PID, processes, visitFunction)
+			if err != nil {
+				return err
+			}
+		} else if stat.PID == processID {
+			defer visitFunction(p)
+		}
+	}
+	return nil
+}

--- a/components/supervisor/pkg/process/process_test.go
+++ b/components/supervisor/pkg/process/process_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2020 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package process
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/prometheus/procfs"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVisitProcessTree(t *testing.T) {
+	cmd := exec.Command("/bin/sleep", "1000")
+	err := cmd.Start()
+	require.NoError(t, err)
+	expectation := []int{cmd.Process.Pid, os.Getpid()}
+	visitedProcessIds := []int{}
+	VisitProcessTree(os.Getpid(), func(process procfs.Proc) error {
+		visitedProcessIds = append(visitedProcessIds, process.PID)
+		return nil
+	})
+	require.Equal(t, expectation, visitedProcessIds)
+}


### PR DESCRIPTION
## Description
Gracefully send sigterm to process tree depth-first

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

Start a workspace on https://github.com/svenefftinge/termination-test

Run 
```
./ignoresigterm > out_disown.txt &
disown $1
./ignoresigterm > out_bg.txt &
./ignoresigterm > out.txt
```
and stop the workspace.
With this preview environment you should see log output like below in all three files
```
awaiting signal

Received signal
terminated

Ignored for 0 seconds.
Ignored for 1 seconds.
Ignored for 2 seconds.
Ignored for 3 seconds.
Ignored for 4 seconds.
Ignored for 5 seconds.
Ignored for 6 seconds.
Ignored for 7 seconds.
Ignored for 8 seconds.
Ignored for 9 seconds.
```
> ATTENTION: It does only work for the disowned process atm!

With gitpod.io you will see only (i.e. the processes never received SIGINT):
```
awaiting signal
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
