### PR TITLE
[kots]: configure support bundle to get KOTS configmaps

### DIFF
--- a/install/kots/manifests/kots-support-bundle.yaml
+++ b/install/kots/manifests/kots-support-bundle.yaml
@@ -102,6 +102,11 @@ spec:
           - app=gitpod
         namespace: '{{repl Namespace }}'
         includeAllData: true
+    - configMap:
+        selector:
+          - kots.io/kotsadm=true
+        namespace: '{{repl Namespace }}'
+        includeAllData: true
     - secret:
         selector:
           - app=gitpod


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Add configuration to collect KOTS configmaps. This is to get more information about how the KOTS app is configured, including the redactors (Gitpod and custom).

See an example support bundle

- [kotsadm-gitpod-redact-spec.json](http://localhost:8800/app/gitpod/troubleshoot/analyze/2fmq3zro4ug7bphv0ego3odikvn/contents/configmaps/gitpod/kotsadm-gitpod-redact-spec.json)
- [kotsadm-redact-spec.json](http://localhost:8800/app/gitpod/troubleshoot/analyze/2fmq3zro4ug7bphv0ego3odikvn/contents/configmaps/gitpod/kotsadm-redact-spec.json)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #13374

## How to test
<!-- Provide steps to test this PR -->
Deploy via KOTS, trigger a support bundle and check the files in `configmaps/gitpod`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
 [kots]: configure support bundle to get KOTS configmaps
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
