### PR TITLE
Build speed: glitpod-cli/local-app

### DIFF
--- a/components/gitpod-cli/BUILD.yaml
+++ b/components/gitpod-cli/BUILD.yaml
@@ -9,17 +9,9 @@ packages:
       - CGO_ENABLED=0
       - GOOS=linux
     deps:
-      - :version
       - components/supervisor-api/go:lib
       - components/gitpod-protocol/go:lib
       - components/common-go:lib
     config:
       packaging: app
-    prep:
-      - ["cp", "_deps/components-gitpod-cli--version/version.txt", "pkg/gitpod/version.txt"]
-  - name: version
-    type: generic
-    config:
-      commands:
-        - ["sh", "-c", "echo '${__git_commit}' > version.txt"]
-        - ["echo", "Gitpod-CLI Version: ${__git_commit}"]
+      buildCommand: ["go", "build", "-trimpath", "-ldflags", "-buildid= -w -s -X 'github.com/gitpod-io/gitpod/gitpod-cli/pkg/gitpod.Version=commit-${__git_commit}'"]

--- a/components/gitpod-cli/pkg/gitpod/server.go
+++ b/components/gitpod-cli/pkg/gitpod/server.go
@@ -6,8 +6,6 @@ package server
 
 import (
 	"context"
-	_ "embed"
-	"strings"
 
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/xerrors"
@@ -20,10 +18,8 @@ import (
 )
 
 var (
-	// Version : current version
-	Version string = strings.TrimSpace(version)
-	//go:embed version.txt
-	version string
+	// Version - set during build
+	Version = "dev"
 )
 
 func GetWSInfo(ctx context.Context) (*supervisor.WorkspaceInfoResponse, error) {

--- a/components/gitpod-cli/pkg/gitpod/version.txt
+++ b/components/gitpod-cli/pkg/gitpod/version.txt
@@ -1,1 +1,0 @@
-set-during-build

--- a/components/local-app/BUILD.yaml
+++ b/components/local-app/BUILD.yaml
@@ -18,7 +18,6 @@ packages:
       - go.sum
       - "**/*.go"
     deps:
-      - :version
       - components/supervisor-api/go:lib
       - components/gitpod-protocol/go:lib
       - components/local-app-api/go:lib
@@ -26,10 +25,9 @@ packages:
       - CGO_ENABLED=0
       - GOOS=linux
       - GOARCH=amd64
-    prep:
-      - ["cp", "_deps/components-local-app--version/version.txt", "version.txt"]
     config:
       packaging: app
+      buildCommand: ["go", "build", "-trimpath", "-ldflags", "-buildid= -w -s -X 'github.com/gitpod-io/local-app.Version=commit-${__git_commit}'"]
   - name: app-linux-arm64
     type: go
     srcs:
@@ -37,7 +35,6 @@ packages:
       - go.sum
       - "**/*.go"
     deps:
-      - :version
       - components/supervisor-api/go:lib
       - components/gitpod-protocol/go:lib
       - components/local-app-api/go:lib
@@ -45,10 +42,9 @@ packages:
       - CGO_ENABLED=0
       - GOOS=linux
       - GOARCH=arm64
-    prep:
-      - ["cp", "_deps/components-local-app--version/version.txt", "version.txt"]
     config:
       packaging: app
+      buildCommand: ["go", "build", "-trimpath", "-ldflags", "-buildid= -w -s -X 'github.com/gitpod-io/local-app.Version=commit-${__git_commit}'"]
   - name: app-darwin-amd64
     type: go
     srcs:
@@ -56,7 +52,6 @@ packages:
       - go.sum
       - "**/*.go"
     deps:
-      - :version
       - components/supervisor-api/go:lib
       - components/gitpod-protocol/go:lib
       - components/local-app-api/go:lib
@@ -64,10 +59,9 @@ packages:
       - CGO_ENABLED=0
       - GOOS=darwin
       - GOARCH=amd64
-    prep:
-      - ["cp", "_deps/components-local-app--version/version.txt", "version.txt"]
     config:
       packaging: app
+      buildCommand: ["go", "build", "-trimpath", "-ldflags", "-buildid= -w -s -X 'github.com/gitpod-io/local-app.Version=commit-${__git_commit}'"]
   - name: app-darwin-arm64
     type: go
     srcs:
@@ -75,7 +69,6 @@ packages:
       - go.sum
       - "**/*.go"
     deps:
-      - :version
       - components/supervisor-api/go:lib
       - components/gitpod-protocol/go:lib
       - components/local-app-api/go:lib
@@ -83,10 +76,9 @@ packages:
       - CGO_ENABLED=0
       - GOOS=darwin
       - GOARCH=arm64
-    prep:
-      - ["cp", "_deps/components-local-app--version/version.txt", "version.txt"]
     config:
       packaging: app
+      buildCommand: ["go", "build", "-trimpath", "-ldflags", "-buildid= -w -s -X 'github.com/gitpod-io/local-app.Version=commit-${__git_commit}'"]
   - name: app-windows-amd64
     type: go
     srcs:
@@ -94,7 +86,6 @@ packages:
       - go.sum
       - "**/*.go"
     deps:
-      - :version
       - components/supervisor-api/go:lib
       - components/gitpod-protocol/go:lib
       - components/local-app-api/go:lib
@@ -102,10 +93,9 @@ packages:
       - CGO_ENABLED=0
       - GOOS=windows
       - GOARCH=amd64
-    prep:
-      - ["cp", "_deps/components-local-app--version/version.txt", "version.txt"]
     config:
       packaging: app
+      buildCommand: ["go", "build", "-trimpath", "-ldflags", "-buildid= -w -s -X 'github.com/gitpod-io/local-app.Version=commit-${__git_commit}'"]
   - name: app-windows-386
     type: go
     srcs:
@@ -113,7 +103,6 @@ packages:
       - go.sum
       - "**/*.go"
     deps:
-      - :version
       - components/supervisor-api/go:lib
       - components/gitpod-protocol/go:lib
       - components/local-app-api/go:lib
@@ -121,10 +110,9 @@ packages:
       - CGO_ENABLED=0
       - GOOS=windows
       - GOARCH=386
-    prep:
-      - ["cp", "_deps/components-local-app--version/version.txt", "version.txt"]
     config:
       packaging: app
+      buildCommand: ["go", "build", "-trimpath", "-ldflags", "-buildid= -w -s -X 'github.com/gitpod-io/local-app.Version=commit-${__git_commit}'"]
   - name: app-windows-arm64
     type: go
     srcs:
@@ -132,7 +120,6 @@ packages:
       - go.sum
       - "**/*.go"
     deps:
-      - :version
       - components/supervisor-api/go:lib
       - components/gitpod-protocol/go:lib
       - components/local-app-api/go:lib
@@ -140,18 +127,9 @@ packages:
       - CGO_ENABLED=0
       - GOOS=windows
       - GOARCH=arm64
-    prep:
-      - ["cp", "_deps/components-local-app--version/version.txt", "version.txt"]
     config:
       packaging: app
-  - name: version
-    type: generic
-    argdeps:
-      - localAppVersion
-    config:
-      commands:
-        - ["sh", "-c", "echo '${localAppVersion}' > version.txt"]
-        - ["echo", "Local App Version: ${localAppVersion}"]
+      buildCommand: ["go", "build", "-trimpath", "-ldflags", "-buildid= -w -s -X 'github.com/gitpod-io/local-app.Version=commit-${__git_commit}'"]
   - name: docker
     type: docker
     deps:

--- a/components/local-app/main.go
+++ b/components/local-app/main.go
@@ -5,7 +5,6 @@
 package main
 
 import (
-	_ "embed"
 	"path/filepath"
 	"strconv"
 	"time"
@@ -29,10 +28,8 @@ import (
 )
 
 var (
-	// Version : current version
-	Version = strings.TrimSpace(version)
-	//go:embed version.txt
-	version string
+	// Version - set during build
+	Version = "dev"
 )
 
 func main() {

--- a/components/local-app/version.txt
+++ b/components/local-app/version.txt
@@ -1,1 +1,0 @@
-set-during-build


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PR is follow up https://github.com/gitpod-io/gitpod/pull/13228

1. make the version generate simply
2. change local-app version generate function

<img width="1517" alt="image" src="https://user-images.githubusercontent.com/8299500/192692267-023b4a71-b734-49a3-8e36-52ec20cf4095.png">

no sure how to do with jetbrains backend plugin


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
