### PR TITLE
[db] Soft delete entries in the `db_volume_snapshot` table

### DIFF
--- a/components/gitpod-db/src/typeorm/entity/db-volume-snapshot.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-volume-snapshot.ts
@@ -31,4 +31,8 @@ export class DBVolumeSnapshot implements VolumeSnapshot {
 
     @Column("varchar")
     volumeHandle: string;
+
+    // This column triggers the db-sync deletion mechanism. It's not intended for public consumption.
+    @Column()
+    deleted: boolean;
 }

--- a/components/gitpod-db/src/typeorm/workspace-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/workspace-db-impl.ts
@@ -792,6 +792,7 @@ export abstract class AbstractTypeORMWorkspaceDBImpl implements WorkspaceDB {
         const qb = volumeSnapshotRepo
             .createQueryBuilder("vs")
             .select("vs.workspaceId", "workspaceId")
+            .where("vs.deleted = 0")
             .groupBy("vs.workspaceId")
             .having("COUNT(*) > 1")
             .limit(limit);
@@ -805,6 +806,7 @@ export abstract class AbstractTypeORMWorkspaceDBImpl implements WorkspaceDB {
         const results = await volumeSnapshotRepo
             .createQueryBuilder("vs")
             .where("vs.workspaceId = :wsId", { wsId })
+            .andWhere("vs.deleted = 0")
             .orderBy("vs.creationTime", "DESC")
             .limit(limit)
             .getMany();

--- a/components/gitpod-db/src/typeorm/workspace-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/workspace-db-impl.ts
@@ -764,7 +764,11 @@ export abstract class AbstractTypeORMWorkspaceDBImpl implements WorkspaceDB {
 
     public async findVolumeSnapshotById(volumeSnapshotId: string): Promise<VolumeSnapshot | undefined> {
         const volumeSnapshots = await this.getVolumeSnapshotRepo();
-        return volumeSnapshots.findOne(volumeSnapshotId);
+        return volumeSnapshots
+            .createQueryBuilder("vs")
+            .where("vs.deleted = 0")
+            .andWhere("vs.id = :id", { id: volumeSnapshotId })
+            .getOne();
     }
 
     public async storeVolumeSnapshot(volumeSnapshot: VolumeSnapshot): Promise<VolumeSnapshot> {

--- a/components/gitpod-db/src/typeorm/workspace-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/workspace-db-impl.ts
@@ -775,7 +775,7 @@ export abstract class AbstractTypeORMWorkspaceDBImpl implements WorkspaceDB {
 
     public async deleteVolumeSnapshot(volumeSnapshotId: string): Promise<void> {
         const volumeSnapshots = await this.getVolumeSnapshotRepo();
-        await volumeSnapshots.delete(volumeSnapshotId);
+        await volumeSnapshots.update(volumeSnapshotId, { deleted: true });
     }
 
     public async updateVolumeSnapshot(

--- a/components/gitpod-db/src/workspace-db.spec.db.ts
+++ b/components/gitpod-db/src/workspace-db.spec.db.ts
@@ -719,6 +719,16 @@ class WorkspaceDBSpec {
             workspaceId,
         });
 
+        const longBeforeNow = new Date(2018, 2, 15, 10, 0, 0).toISOString();
+        const id2b = "456b";
+        await repo.save({
+            id: id2b,
+            creationTime: longBeforeNow,
+            volumeHandle: "some-handle2b",
+            workspaceId,
+            deleted: true,
+        });
+
         const someOtherTime = new Date(2018, 2, 10, 6, 5).toISOString();
         const id3 = "789";
         const workspaceId2 = "ws-789";
@@ -727,6 +737,16 @@ class WorkspaceDBSpec {
             creationTime: someOtherTime,
             volumeHandle: "some-handle3",
             workspaceId: workspaceId2,
+        });
+
+        const yetAnotherTime = new Date(2018, 2, 10, 5, 5).toISOString();
+        const id4 = "012";
+        await repo.save({
+            id: id4,
+            creationTime: yetAnotherTime,
+            volumeHandle: "some-handle4",
+            workspaceId: workspaceId2,
+            deleted: true,
         });
     }
 

--- a/components/gitpod-db/src/workspace-db.spec.db.ts
+++ b/components/gitpod-db/src/workspace-db.spec.db.ts
@@ -664,6 +664,24 @@ class WorkspaceDBSpec {
     }
 
     @test(timeout(10000))
+    public async testCanFindVolumeSnapshotById() {
+        await this.threeVolumeSnapshotsForTwoWorkspaces();
+
+        const volSnapshot = await this.db.findVolumeSnapshotById("123");
+
+        expect(volSnapshot?.id).to.eq("123");
+    }
+
+    @test(timeout(10000))
+    public async testCantFindDeletedVolumeSnapshotById() {
+        await this.threeVolumeSnapshotsForTwoWorkspaces();
+
+        const volSnapshot = await this.db.findVolumeSnapshotById("456b");
+
+        expect(volSnapshot).to.be.undefined;
+    }
+
+    @test(timeout(10000))
     public async testFindVolumeSnapshotWorkspacesForGC() {
         await this.threeVolumeSnapshotsForTwoWorkspaces();
 

--- a/components/gitpod-db/src/workspace-db.spec.db.ts
+++ b/components/gitpod-db/src/workspace-db.spec.db.ts
@@ -682,12 +682,14 @@ class WorkspaceDBSpec {
         expect(vss).to.deep.equal([
             {
                 creationTime: "",
+                deleted: false,
                 id: "456",
                 volumeHandle: "some-handle2",
                 workspaceId: "ws-123",
             },
             {
                 creationTime: "",
+                deleted: false,
                 id: "123",
                 volumeHandle: "some-handle",
                 workspaceId: "ws-123",


### PR DESCRIPTION
## Description

Replace the existing hard-deletion of rows in the `db_volume_snapshot` table with soft-deletion.

This will allow `db-sync` to propagate deletions between clusters.

## Related Issue(s)

Follow up to https://github.com/gitpod-io/gitpod/pull/13348

Part of #9198 

## How to test

Unit tests

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
