### PR TITLE
[usage] don't show usage in self-hosted yet

### DIFF
--- a/components/dashboard/src/contexts/FeatureFlagContext.tsx
+++ b/components/dashboard/src/contexts/FeatureFlagContext.tsx
@@ -41,7 +41,7 @@ const FeatureFlagContextProvider: React.FC = ({ children }) => {
             const featureFlags: FeatureFlagConfig = {
                 workspace_classes: { defaultValue: true, setter: setShowWorkspaceClassesUI },
                 persistent_volume_claim: { defaultValue: true, setter: setShowPersistentVolumeClaimUI },
-                usage_view: { defaultValue: true, setter: setShowUsageView },
+                usage_view: { defaultValue: false, setter: setShowUsageView },
             };
             for (const [flagName, config] of Object.entries(featureFlags)) {
                 const flagValue = await getExperimentsClient().getValueAsync(flagName, config.defaultValue, {


### PR DESCRIPTION
## Description
Don't show the usage view on self-hosted, yet.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #13390

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [x] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
