### PR TITLE
[installer-tests] Cleanup the self-hosted test crons

### DIFF
--- a/.werft/aks-installer-tests.yaml
+++ b/.werft/aks-installer-tests.yaml
@@ -20,8 +20,8 @@ args:
   desc: "Version of gitpod to install(in the case of upgrade tests, this is the initial install version and will later get upgraded to latest"
   required: false
   default: ""
-- name: runTests
-  desc: "Set this to true to run integration tests"
+- name: skipTests
+  desc: "Set this to true to skip integration tests"
   required: false
   default: false
 - name: selfSigned
@@ -138,6 +138,8 @@ pod:
         secretKeyRef:
           name: integration-test-user
           key: token
+    - name: self_hosted_jobs
+      value: true
     command:
       - bash
       - -c

--- a/.werft/eks-installer-tests.yaml
+++ b/.werft/eks-installer-tests.yaml
@@ -20,8 +20,8 @@ args:
   desc: "Version of gitpod to install(in the case of upgrade tests, this is the initial install version and will later get upgraded to latest"
   required: false
   default: ""
-- name: runTests
-  desc: "Set this to true to run integration tests"
+- name: skipTests
+  desc: "Set this to true to skip integration tests"
   required: false
   default: false
 - name: upgrade
@@ -89,8 +89,6 @@ pod:
       value: "/mnt/secrets/sh-playground-sa-perm/sh-sa.json"
     - name: TF_VAR_dns_sa_creds
       value: "/mnt/secrets/sh-playground-dns-perm/sh-dns-sa.json"
-    - name: TF_VAR_sa_creds
-      value: "/mnt/secrets/sh-playground-sa-perm/sh-sa.json"
     - name: NODENAME
       valueFrom:
         fieldRef:
@@ -135,6 +133,8 @@ pod:
         secretKeyRef:
           name: integration-test-user
           key: token
+    - name: self_hosted_jobs
+      value: true
     command:
       - bash
       - -c

--- a/.werft/gke-installer-tests.yaml
+++ b/.werft/gke-installer-tests.yaml
@@ -20,8 +20,8 @@ args:
   desc: "Version of gitpod to install(in the case of upgrade tests, this is the initial install version and will later get upgraded to latest"
   required: false
   default: ""
-- name: runTests
-  desc: "Set this to true to run integration tests"
+- name: skipTests
+  desc: "Set this to true to skip integration tests"
   required: false
   default: false
 - name: selfSigned
@@ -120,6 +120,8 @@ pod:
             secretKeyRef:
               name: integration-test-user
               key: token
+        - name: self_hosted_jobs
+          value: true
       command:
         - bash
         - -c

--- a/.werft/installer-tests.ts
+++ b/.werft/installer-tests.ts
@@ -18,7 +18,7 @@ const kotsApp: string = annotations.replicatedApp || "gitpod";
 const version: string = annotations.version || "-";
 const preview: string = annotations.preview || "false"; // setting to true will not destroy the setup
 const upgrade: string = annotations.upgrade || "false"; // setting to true will not KOTS upgrade to the latest version. Set the channel to beta or stable in this case.
-const runTests: string = annotations.runTests || "false"; // setting to true runs the integration tests
+const skipTests: string = annotations.skipTests || "false"; // setting to true skip the integration tests
 const selfSigned: string = annotations.selfSigned || "false";
 const deps: string = annotations.deps || ""; // options: ["external", "internal"] setting to `external` will ensure that all resource dependencies(storage, db, registry) will be external. if unset, a random selection will be used
 
@@ -155,7 +155,7 @@ const INFRA_PHASES: { [name: string]: InfraConfig } = {
     },
     GENERATE_KOTS_CONFIG: {
         phase: "generate-kots-config",
-        makeTarget: `generate-kots-config storage=${randDeps()} registry=${randDeps()} db=${randDeps()} runTests=${runTests} self_signed=${selfSigned}`,
+        makeTarget: `generate-kots-config storage=${randDeps()} registry=${randDeps()} db=${randDeps()} skipTests=${skipTests} self_signed=${selfSigned}`,
         description: `Generate KOTS Config file`,
     },
     CLUSTER_ISSUER: {
@@ -319,7 +319,7 @@ export async function installerTests(config: TestConfig) {
         }
     }
 
-    if (runTests === "false") {
+    if (skipTests === "true") {
         console.log("Skipping integration tests");
     } else {
         runIntegrationTests();

--- a/.werft/jobs/build/self-hosted-upgrade-tests.ts
+++ b/.werft/jobs/build/self-hosted-upgrade-tests.ts
@@ -81,9 +81,9 @@ export async function triggerUpgradeTests(werft: Werft, config: JobConfig, usern
 export async function triggerSelfHostedPreview(werft: Werft, config: JobConfig, username: string) {
     const replicatedChannel =  config.replicatedChannel || config.repository.branch;
     const cluster =  config.cluster || "k3s";
-    const formattedBranch = config.repository.branch.replace("/", "-").slice(0,10)
+    const formattedBranch = config.repository.branch.replace("/", "-").slice(0,11)
     const phase = phases[cluster]
-    const subdomain =  `${formattedBranch}x-${phase.cloud}`
+    const subdomain =  `${formattedBranch}-${phase.cloud}`
 
     const replicatedApp = process.env.REPLICATED_APP
 

--- a/.werft/k3s-installer-tests.yaml
+++ b/.werft/k3s-installer-tests.yaml
@@ -20,8 +20,8 @@ args:
   desc: "Version of gitpod to install(in the case of upgrade tests, this is the initial install version and will later get upgraded to latest"
   required: false
   default: ""
-- name: runTests
-  desc: "Set this to true to run integration tests"
+- name: skipTests
+  desc: "Set this to true to skip integration tests"
   required: false
   default: false
 - name: selfSigned
@@ -127,6 +127,8 @@ pod:
           secretKeyRef:
             name: replicated
             key: app
+      - name: self_hosted_jobs
+        value: true
     command:
       - bash
       - -c

--- a/install/tests/Makefile
+++ b/install/tests/Makefile
@@ -44,9 +44,9 @@ upload-gcp-cluster-creds:
 	gsutil cp gcp-creds gs://nightly-tests/tf-state/${TF_VAR_TEST_ID}-creds
 
 download-cluster-creds:
-	[[ -z $$TF_VAR_sa_creds ]] || gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS} --project=sh-automated-tests
+	[[ -z $$self_hosted_jobs ]] || gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS} --project=sh-automated-tests
 	gcloud config set project sh-automated-tests
-	[[ -n $$TF_VAR_sa_creds ]] || gsutil cp gs://nightly-tests/tf-state/${TF_VAR_TEST_ID}-creds gcs-creds
+	[[ -n $$self_hosted_jobs ]] || gsutil cp gs://nightly-tests/tf-state/${TF_VAR_TEST_ID}-creds gcs-creds
 	[[ -f gcs-creds ]]  && cat gcs-creds | tr -d '"' | base64 -d > ${TF_VAR_TEST_ID}-key.json || echo "No GCP credentials"
 	rm -f gcs-creds
 	[[ -f ${TF_VAR_TEST_ID}-key.json ]] || cp ${GOOGLE_APPLICATION_CREDENTIALS} ${TF_VAR_TEST_ID}-key.json
@@ -56,7 +56,7 @@ upload-kubeconfig-to-gcp:
 	gsutil cp ${KUBECONFIG} gs://nightly-tests/tf-state/${TF_VAR_TEST_ID}-kubeconfig
 
 sync-kubeconfig:
-	[[ -z $$TF_VAR_sa_creds ]] || gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS} --project=sh-automated-tests
+	[[ -z $$self_hosted_jobs ]] || gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS} --project=sh-automated-tests
 	gcloud config set project sh-automated-tests
 	gsutil cp gs://nightly-tests/tf-state/${TF_VAR_TEST_ID}-kubeconfig ${KUBECONFIG} || echo "No kubeconfig"
 
@@ -79,9 +79,9 @@ azure-kubeconfig:
 
 ## aws-kubeconfig: Get the kubeconfig configuration for AWS EKS
 aws-kubeconfig:
-	[[ -z $$TF_VAR_sa_creds ]] || gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS} --project=sh-automated-tests
+	[[ -z $$self_hosted_jobs ]] || gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS} --project=sh-automated-tests
 	gcloud config set project sh-automated-tests
-	[[ -n $$TF_VAR_sa_creds ]] || gsutil cp gs://nightly-tests/tf-state/${TF_VAR_TEST_ID}-creds ${TF_VAR_TEST_ID}-creds
+	[[ -n $$self_hosted_jobs ]] || gsutil cp gs://nightly-tests/tf-state/${TF_VAR_TEST_ID}-creds ${TF_VAR_TEST_ID}-creds
 	[[ -f ${TF_VAR_TEST_ID}-creds ]] || touch ${TF_VAR_TEST_ID}-creds
 	source ${TF_VAR_TEST_ID}-creds; \
 	aws eks update-kubeconfig --name ${TF_VAR_TEST_ID} --region eu-west-1 --kubeconfig ${KUBECONFIG} || echo "No cluster present"
@@ -333,7 +333,7 @@ endif
 storage ?= incluster
 registry ?= incluster
 db ?= incluster
-runTests ?= "false"
+skipTests ?= "false"
 self_signed ?= "false"
 .PHONY:
 generate-kots-config: cloud_storage = $(if $(findstring external,$(storage)),$(cloud),incluster)
@@ -341,7 +341,7 @@ generate-kots-config: cloud_registry = $(if $(findstring external,$(registry)),$
 generate-kots-config: cloud_db = $(if $(findstring external,$(db)),$(cloud),incluster)
 ## generate-kots-config: Generate the kots config based on test config
 generate-kots-config: select-workspace check-env-cloud check-env-domain check-env-sub-domain
-	if [[ $$runTests == "true" ]]; then $(MAKE) get-github-config; fi
+	if [[ $$skipTests == "false" ]]; then $(MAKE) get-github-config; fi
 	$(MAKE) get-base-config
 	$(MAKE) storage-config-${cloud_storage}
 	$(MAKE) db-config-${cloud_db}
@@ -364,7 +364,9 @@ kots-install: preflight-flag = $(if $(preflights:true=),--skip-preflights,)
 kots-install: license-file = $(if $(license_community_$(channel)),$(license_community_$(channel)),"../licenses/$(channel).yaml")
 kots-install: install-kots-cli
 	kubectl kots remove ${app} -n gitpod --force --kubeconfig=${KUBECONFIG} || echo "No kots app existing, Installing"
+	kubectl get secret -n gitpod https-certificate -o yaml > https-secret.yaml || echo "No existing certificate"
 	$(MAKE) destroy-gitpod
+	[[ -f https-secret.yaml ]] && kubectl apply -f https-secret.yaml || echo "No existing certificate"
 	export KUBECONFIG=${KUBECONFIG} && \
 	kubectl kots install ${app}/${channel} \
 	--skip-rbac-check ${version-flag} ${preflight-flag} \
@@ -452,9 +454,7 @@ destroy-kubeconfig:
 	gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS} --project=sh-automated-tests
 	gsutil rm gs://nightly-tests/tf-state/${TF_VAR_TEST_ID}-kubeconfig || echo "No kubeconfig"
 	gsutil rm gs://nightly-tests/tf-state/${TF_VAR_TEST_ID}-creds || echo "No credentials file"
-ifeq (true,$(self_signed))
 	gsutil rm gs://nightly-tests/tf-state/${TF_VAR_TEST_ID}-ca.pem || echo "No custom CA cert file"
-endif
 	rm ${KUBECONFIG} || echo "No kubeconfig"
 
 select-workspace:


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PR fixes a couple of things that are breaking with the automated tests:
- I recently changed `skipTests` to `runTests` in the intention that we can make skipping tests the default behavior. But the thing I didn't consider is, this would mean that the crons running every night doesn't run the tests. So rolled this change back to set running tests the default behavior
- In the cleanup script, currently for cleaning up certificates, it checks if variable `self_signed` is set. But during cleanup crons, no such variables are being set but we have to cleanup anyways. Hence the variable check is removed
- Currently, in `get-kubeconfig` targets (the ones used to retrieve kubeconfig file either locally or during werft jobs) I am using a secret being set to check if it is a cron or local. This is a wrong behavior since that secret is not needed in EKS or AKS. I remove this dependency and set a custom env var in case of cron jobs.
- Fixing the preview env variable name
- Backing up the certificate secret in case of re-runs

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
You can run the commands from [the internal doc](https://www.notion.so/gitpod/Self-hosted-automated-preview-and-test-pipelines-fdc5a202e67b4197aa00d93b98d57927)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
