### PR TITLE
Add support for JetBrains EAP IDEs (v2022.3)

### DIFF
--- a/components/ide/jetbrains/backend-plugin/build.gradle.kts
+++ b/components/ide/jetbrains/backend-plugin/build.gradle.kts
@@ -95,15 +95,15 @@ detekt {
 
 tasks {
     withType<JavaCompile> {
-        sourceCompatibility = "11"
-        targetCompatibility = "11"
+        sourceCompatibility = "17"
+        targetCompatibility = "17"
     }
     withType<KotlinCompile> {
-        kotlinOptions.jvmTarget = "11"
+        kotlinOptions.jvmTarget = "17"
     }
 
     withType<Detekt> {
-        jvmTarget = "11"
+        jvmTarget = "17"
     }
 
     buildSearchableOptions {

--- a/components/ide/jetbrains/backend-plugin/gradle-latest.properties
+++ b/components/ide/jetbrains/backend-plugin/gradle-latest.properties
@@ -1,9 +1,9 @@
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
-pluginSinceBuild=222
-pluginUntilBuild=222.*
+pluginSinceBuild=223
+pluginUntilBuild=223.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions.
-pluginVerifierIdeVersions=2022.2
+pluginVerifierIdeVersions=2022.3
 # Version from "com.jetbrains.intellij.idea" which can be found at https://www.jetbrains.com/intellij-repository/snapshots
-platformVersion=222.4167-EAP-CANDIDATE-SNAPSHOT
+platformVersion=223.4884-EAP-CANDIDATE-SNAPSHOT

--- a/components/ide/jetbrains/backend-plugin/launch-dev-server.sh
+++ b/components/ide/jetbrains/backend-plugin/launch-dev-server.sh
@@ -6,10 +6,28 @@
 set -e
 set -o pipefail
 
+JB_QUALIFIER="latest"
+while getopts "s" OPTION
+do
+   case $OPTION in
+       s) JB_QUALIFIER="stable" ;;
+       *) ;;
+   esac
+done
+
 TEST_BACKEND_DIR=/workspace/ide-backend
 if [ ! -d "$TEST_BACKEND_DIR" ]; then
   mkdir -p $TEST_BACKEND_DIR
-  cp -r /ide-desktop/backend/* $TEST_BACKEND_DIR
+  if [[ $JB_QUALIFIER == "stable" ]]; then
+    PRODUCT_TYPE="release"
+  else
+    PRODUCT_TYPE="release,rc,eap"
+  fi
+  (cd $TEST_BACKEND_DIR &&
+  echo "Downloading the ${JB_QUALIFIER} version of IntelliJ IDEA..." &&
+  curl -sSLo backend.tar.gz "https://download.jetbrains.com/product?type=${PRODUCT_TYPE}&distribution=linux&code=IIU" &&
+  tar -xf backend.tar.gz --strip-components=1 &&
+  rm backend.tar.gz)
 fi
 
 TEST_PLUGINS_DIR="$TEST_BACKEND_DIR/plugins"
@@ -17,7 +35,7 @@ TEST_PLUGIN_DIR="$TEST_PLUGINS_DIR/gitpod-remote"
 rm -rf $TEST_PLUGIN_DIR
 
 GITPOD_PLUGIN_DIR=/workspace/gitpod/components/ide/jetbrains/backend-plugin
-$GITPOD_PLUGIN_DIR/gradlew buildPlugin
+$GITPOD_PLUGIN_DIR/gradlew -PenvironmentName="$JB_QUALIFIER" buildPlugin
 
 # TODO(ak) actually should be gradle task to make use of output
 GITPOD_PLUGIN_DIST="$GITPOD_PLUGIN_DIR/build/distributions/gitpod-remote.zip"
@@ -31,7 +49,7 @@ if [ ! -d "$TEST_DIR" ]; then
      case $OPTION in
          r) TEST_REPO=$OPTARG ;;
          *) ;;
-       esac
+     esac
   done
   git clone "$TEST_REPO" $TEST_DIR
 fi
@@ -47,7 +65,7 @@ export IJ_HOST_SYSTEM_BASE_DIR=/workspace/.cache/JetBrains
 export CWM_HOST_STATUS_OVER_HTTP_TOKEN=gitpod
 
 # Build and move idea-cli, then overwrite environment variables initially defined by `components/ide/jetbrains/image/leeway.Dockerfile`
-IDEA_CLI_DEV_PATH=/ide-desktop/bin/idea-cli-dev
+IDEA_CLI_DEV_PATH=$TEST_BACKEND_DIR/bin/idea-cli-dev
 (cd ../cli && go build -o $IDEA_CLI_DEV_PATH)
 export EDITOR="$IDEA_CLI_DEV_PATH open"
 export VISUAL="$EDITOR"

--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/GitpodIgnoredPortsForNotificationService.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/GitpodIgnoredPortsForNotificationService.kt
@@ -1,0 +1,11 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package io.gitpod.jetbrains.remote
+
+interface GitpodIgnoredPortsForNotificationService {
+    fun ignorePort(portNumber: Int)
+    /** Get ports that aren't actually used by the user (e.g. ports used internally by JetBrains IDEs) */
+    fun getIgnoredPorts(): Set<Int>
+}

--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/latest/GitpodIgnoredPortsForNotificationServiceImpl.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/latest/GitpodIgnoredPortsForNotificationServiceImpl.kt
@@ -1,0 +1,31 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package io.gitpod.jetbrains.remote.latest
+
+import com.intellij.idea.getServerFutureAsync
+import io.gitpod.jetbrains.remote.GitpodIgnoredPortsForNotificationService
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
+import org.jetbrains.ide.BuiltInServerManager
+
+@Suppress("OPT_IN_USAGE")
+class GitpodIgnoredPortsForNotificationServiceImpl : GitpodIgnoredPortsForNotificationService {
+    private val ignoredPortsForNotification = mutableSetOf(5990)
+
+    init {
+        GlobalScope.launch {
+            BuiltInServerManager.getInstance().waitForStart().port.let { ignorePort(it) }
+            getServerFutureAsync().await()?.port?.let { ignorePort(it) }
+        }
+    }
+
+    override fun ignorePort(portNumber: Int) {
+        ignoredPortsForNotification.add(portNumber)
+    }
+
+    override fun getIgnoredPorts(): Set<Int> {
+        return ignoredPortsForNotification.toSet()
+    }
+}

--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/stable/GitpodIgnoredPortsForNotificationServiceImpl.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/stable/GitpodIgnoredPortsForNotificationServiceImpl.kt
@@ -1,0 +1,32 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package io.gitpod.jetbrains.remote.stable
+
+import com.intellij.idea.StartupUtil
+import io.gitpod.jetbrains.remote.GitpodIgnoredPortsForNotificationService
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.future.await
+import org.jetbrains.ide.BuiltInServerManager
+
+@Suppress("OPT_IN_USAGE")
+class GitpodIgnoredPortsForNotificationServiceImpl : GitpodIgnoredPortsForNotificationService {
+    private val ignoredPortsForNotification = mutableSetOf(5990)
+
+    init {
+        GlobalScope.launch {
+            BuiltInServerManager.getInstance().waitForStart().port.let { ignorePort(it) }
+            StartupUtil.getServerFuture().await().port?.let { ignorePort(it) }
+        }
+    }
+
+    override fun ignorePort(portNumber: Int) {
+        ignoredPortsForNotification.add(portNumber)
+    }
+
+    override fun getIgnoredPorts(): Set<Int> {
+        return ignoredPortsForNotification.toSet()
+    }
+}

--- a/components/ide/jetbrains/backend-plugin/src/main/resources-latest/META-INF/extensions.xml
+++ b/components/ide/jetbrains/backend-plugin/src/main/resources-latest/META-INF/extensions.xml
@@ -3,8 +3,10 @@
  Licensed under the GNU Affero General Public License (AGPL).
  See License-AGPL.txt in the project root for license information.
 -->
+<!--suppress PluginXmlValidity -->
 <idea-plugin>
     <extensions defaultExtensionNs="com.intellij">
+        <applicationService serviceInterface="io.gitpod.jetbrains.remote.GitpodIgnoredPortsForNotificationService" serviceImplementation="io.gitpod.jetbrains.remote.latest.GitpodIgnoredPortsForNotificationServiceImpl" preload="true"/>
         <projectService serviceImplementation="io.gitpod.jetbrains.remote.latest.GitpodPortForwardingService" preload="true"/>
     </extensions>
 </idea-plugin>

--- a/components/ide/jetbrains/backend-plugin/src/main/resources-stable/META-INF/extensions.xml
+++ b/components/ide/jetbrains/backend-plugin/src/main/resources-stable/META-INF/extensions.xml
@@ -3,7 +3,9 @@
  Licensed under the GNU Affero General Public License (AGPL).
  See License-AGPL.txt in the project root for license information.
 -->
+<!--suppress PluginXmlValidity -->
 <idea-plugin>
     <extensions defaultExtensionNs="com.intellij">
+        <applicationService serviceInterface="io.gitpod.jetbrains.remote.GitpodIgnoredPortsForNotificationService" serviceImplementation="io.gitpod.jetbrains.remote.stable.GitpodIgnoredPortsForNotificationServiceImpl" preload="true"/>
     </extensions>
 </idea-plugin>


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Now that IDEA/PyCharm/PhpStorm/GoLand _latest_ version is v2022.3 in Gitpod, we can add support for JetBrains IDEs v2022.3.

All code changes were done to accommodate the API differences between v2022.2 and v2022.3. There were no logic/flow changes in the plugin.

## How to test
<!-- Provide steps to test this PR -->
1. Access the Preview Environment of this PR
2. Open a workspace using the **Stable** Version of IntelliJ IDEA and check if the Control Center is being displayed correctly and that the IDE shows no errors about Gitpod Plugin.
3. Do the same as _Step 2_, but now using the **Latest** Stable Version of IntelliJ IDEA.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Gitpod Plugin was updated to work with the JetBrains IDEs v2022.3 (EAP).
```

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
