### PR TITLE
[server] Fix team deletion for non-UBP enabled teams

### DIFF
--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -1596,11 +1596,13 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
                 { teamId, chargebeeSubscriptionId },
             );
         }
-        const subscriptionId = await this.stripeService.findUncancelledSubscriptionByAttributionId(
-            AttributionId.render({ kind: "team", teamId: teamId }),
-        );
-        if (subscriptionId) {
-            await this.stripeService.cancelSubscription(subscriptionId);
+        if (this.config.enablePayment) {
+            const subscriptionId = await this.stripeService.findUncancelledSubscriptionByAttributionId(
+                AttributionId.render({ kind: "team", teamId: teamId }),
+            );
+            if (subscriptionId) {
+                await this.stripeService.cancelSubscription(subscriptionId);
+            }
         }
     }
 


### PR DESCRIPTION
## Description

Team deletion for non-UBP teams is currently broken. This PR fixes the issue by ensuring that we don't check for UBP specific details about the team (such as any currently active Stripe subscription) before ensuring that Stripe payments are enabled.

## Related Issue(s)
Fixes https://github.com/gitpod-io/gitpod/issues/13392

## How to test

Create a team in the preview environment and then delete it.

## Release Notes

```release-note
[server] Fix for the inability to delete teams that were not subscribed to usage based pricing
```

## Documentation

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
