### PR TITLE
[usage] More useful notification

### DIFF
--- a/components/dashboard/src/AppNotifications.tsx
+++ b/components/dashboard/src/AppNotifications.tsx
@@ -6,7 +6,7 @@
 
 import { useEffect, useState } from "react";
 import Alert from "./components/Alert";
-import { getGitpodService } from "./service/service";
+import { getGitpodService, gitpodHostUrl } from "./service/service";
 
 const KEY_APP_NOTIFICATIONS = "gitpod-app-notifications";
 
@@ -36,6 +36,7 @@ export function AppNotifications() {
     };
 
     const topNotification = notifications[0];
+
     if (topNotification === undefined) {
         return null;
     }
@@ -43,6 +44,25 @@ export function AppNotifications() {
     const dismissNotification = () => {
         removeLocalStorageObject(KEY_APP_NOTIFICATIONS);
         setNotifications([]);
+    };
+
+    const getManageBilling = () => {
+        let href;
+        if (notifications.length === 1) {
+            href = `${gitpodHostUrl}billing`;
+        } else if (notifications.length === 2) {
+            href = `${gitpodHostUrl}t/${notifications[notifications.length - 1]}/billing`;
+        }
+        return (
+            <span>
+                {" "}
+                Manage
+                <a className="gp-link hover:text-gray-600" href={href}>
+                    {" "}
+                    billing.
+                </a>
+            </span>
+        );
     };
 
     return (
@@ -55,6 +75,7 @@ export function AppNotifications() {
                 className="flex rounded mb-2 w-full"
             >
                 <span>{topNotification}</span>
+                {getManageBilling()}
             </Alert>
         </div>
     );


### PR DESCRIPTION
## Description
Shows: 
1. The team/user attributed in the billing. 
2. The link to the relevant billing page.

| REACHED | 80% |
| - | - |
| <img width="300" alt="Screenshot 2022-09-29 at 20 36 00" src="https://user-images.githubusercontent.com/8015191/193114962-c0461ce5-4a50-4918-b365-4573ec85ea35.png"> | <img width="330" alt="Screenshot 2022-09-30 at 12 47 09" src="https://user-images.githubusercontent.com/8015191/193254014-50700997-aff3-46b6-add7-69357a060fa9.png"> |


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #13166

## How to test
[Preview env](https://lau-notifi6e179161fd.preview.gitpod-dev.com/)
1. Join [this team](https://lau-notifi6e179161fd.preview.gitpod-dev.com/teams/join?inviteId=85c97e27-4e1e-4b49-85c9-ec4f0c14fbe4).
2. You should see the notification already.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-payment
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
