### PR TITLE
[terraform/gcp] Fix wrong variable name

### DIFF
--- a/install/infra/single-cluster/gcp/cluster.tf
+++ b/install/infra/single-cluster/gcp/cluster.tf
@@ -1,13 +1,13 @@
 module "gke" {
   source = "../../modules/gke"
 
-  cluster_name           = var.cluster_name
-  kubeconfig             = var.kubeconfig
-  cluster_version        = var.cluster_version
-  project                = var.project
-  region                 = var.region
-  zone                   = var.zone
-  workspace_machine_type = "n2d-standard-16"
+  cluster_name            = var.cluster_name
+  kubeconfig              = var.kubeconfig
+  cluster_version         = var.cluster_version
+  project                 = var.project
+  region                  = var.region
+  zone                    = var.zone
+  workspaces_machine_type = "n2d-standard-16"
 
   domain_name = var.domain_name
   enable_external_database = var.enable_external_database


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
In a recent PR that fixes the machine type of `GCP` and `AWS` terraform modules, we introduced a variable override in GCP reference architecture that appears to be inconsistent with what the parent module is expecting. Currently, due to this error the single-cluster terraform module is broken.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
Please follow the README of the GCP single-cluster reference architecture 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
