### PR TITLE
Bump leeway to v0.3.1 for Github Action

### DIFF
--- a/.github/workflows/code-nightly.yaml
+++ b/.github/workflows/code-nightly.yaml
@@ -15,7 +15,7 @@ jobs:
         with:
           go-version: '1.19'
       - name: Download leeway
-        run: cd /usr/bin && curl -fsSL https://github.com/gitpod-io/leeway/releases/download/v0.2.21/leeway_0.2.21_Linux_x86_64.tar.gz | sudo tar xz
+        run: cd /usr/bin && curl -fsSL https://github.com/gitpod-io/leeway/releases/download/v0.3.1/leeway_0.3.1_Linux_x86_64.tar.gz | sudo tar xz
       - name: Download golangci-lint
         run: cd /usr/local && curl -fsSL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.49.0
       - name: Download GoKart

--- a/.github/workflows/jetbrains-auto-update-template.yml
+++ b/.github/workflows/jetbrains-auto-update-template.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           go-version: '1.19'
       - name: Download leeway
-        run: cd /usr/local/bin && curl -fsSL https://github.com/gitpod-io/leeway/releases/download/v0.2.21/leeway_0.2.21_Linux_x86_64.tar.gz | tar xz
+        run: cd /usr/local/bin && curl -fsSL https://github.com/gitpod-io/leeway/releases/download/v0.3.1/leeway_0.3.1_Linux_x86_64.tar.gz | tar xz
       - name: Download golangci-lint
         run: cd /usr/local && curl -fsSL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.49.0
       - name: Download GoKart


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

To fix GH Action with JetBrains Nightly and Code Nightly

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

See action results

- https://github.com/gitpod-io/gitpod/actions/runs/3144246029
- https://github.com/gitpod-io/gitpod/actions/runs/3144243938

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
