### PR TITLE
[dashboard] Deprecate the creation of projects under individual accounts

### DIFF
--- a/components/dashboard/src/components/PillMenuItem.tsx
+++ b/components/dashboard/src/components/PillMenuItem.tsx
@@ -10,13 +10,17 @@ export default function PillMenuItem(p: {
     name: string;
     selected?: boolean;
     link?: string;
+    additionalClasses?: string;
     onClick?: (event: React.MouseEvent) => void;
 }) {
-    const classes =
+    let classes =
         "flex block font-medium dark:text-gray-400 px-3 py-1 rounded-2xl transition ease-in-out font-semibold " +
         (p.selected
             ? "text-gray-50 bg-gray-800 dark:text-gray-900 dark:bg-gray-50"
             : "hover:bg-gray-100 dark:hover:bg-gray-700");
+    if (p.additionalClasses) {
+        classes = classes + " " + p.additionalClasses;
+    }
     return !p.link || p.link.startsWith("https://") ? (
         <a className={classes} href={p.link} onClick={p.onClick} data-analytics='{"button_type":"pill_menu"}'>
             {p.name}

--- a/components/dashboard/src/projects/Projects.tsx
+++ b/components/dashboard/src/projects/Projects.tsx
@@ -19,6 +19,7 @@ import { toRemoteURL } from "./render-utils";
 import ContextMenu from "../components/ContextMenu";
 import ConfirmationModal from "../components/ConfirmationModal";
 import { prebuildStatusIcon } from "./Prebuilds";
+import Alert from "../components/Alert";
 
 export default function () {
     const location = useLocation();
@@ -128,6 +129,18 @@ export default function () {
                     onClose={() => setRemoveModalVisible(false)}
                     onConfirm={removeProjectHandler}
                 />
+            )}
+            {!team && (
+                <div className="app-container pt-2">
+                    <Alert type={"message"} closable={false} showIcon={true} className="flex rounded mb-2 w-full">
+                        <p>
+                            We'll remove projects under personal accounts in Q1'2023.{" "}
+                            <Link to="/new" className="gp-link">
+                                Create a team.
+                            </Link>
+                        </p>
+                    </Alert>
+                </div>
             )}
             <Header title="Projects" subtitle="Manage recently added projects." />
             {projects.length === 0 && (

--- a/components/dashboard/src/teams/teams-context.tsx
+++ b/components/dashboard/src/teams/teams-context.tsx
@@ -25,7 +25,7 @@ export function getCurrentTeam(location: Location<any>, teams?: Team[]): Team | 
         return;
     }
     const slug = location.pathname.startsWith("/t/") ? location.pathname.split("/")[2] : undefined;
-    if (slug === undefined && ["projects", "usage", "settings"].indexOf(location.pathname.split("/")[1]) === -1) {
+    if (slug === undefined && ["projects"].indexOf(location.pathname.split("/")[1]) === -1) {
         return undefined;
     }
     const team = teams.find((t) => t.slug === slug);


### PR DESCRIPTION
## Description
A quick prototype of how to simplify user accounts by removing the ability to create projects which belong to an individual account instead of a team, and moving the workspaces list to the left side of the nav bar.   

https://www.loom.com/share/b5d8544f7a864912a9d75ba04e921dc8

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Deprecation of the ability to create projects under an individual account for new users.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
