### PR TITLE
Add dashboard URL to GitpodOpenVSXRegistryDown alert

### DIFF
--- a/operations/observability/mixins/IDE/rules/opensvx.yaml
+++ b/operations/observability/mixins/IDE/rules/opensvx.yaml
@@ -22,6 +22,7 @@ spec:
         runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodOpenVsxRegistryDown.md
         summary: Open-VSX registry is possibly down
         description: Open-VSX registry is possibly down. We cannot pull VSCode extensions we don't have in our caches
+        dashboard_url: https://grafana.gitpod.io/d/HNOvmGpxgd/openvsx-proxy
       expr: |
           sum(rate(gitpod_vscode_extension_gallery_query_total{status="failure",errorCode!="canceled"}[5m])) / sum(rate(gitpod_vscode_extension_gallery_query_total[5m])) > 0.01
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Just to make navigation easier, this PR will improve our navigation from alert notification to grafana.

In pagerduty a new link will be added at the button:
![image](https://user-images.githubusercontent.com/24193764/192852310-da7a00ab-6990-414f-9e69-6ebb28d49325.png)

If going straight to slack, it will appear as an extra button:
![image](https://user-images.githubusercontent.com/24193764/192852462-d0a622ba-6b39-48ea-8062-8eb615147239.png)



## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
