### PR TITLE
[install/tests] Notify users to source eks credentials

### DIFF
--- a/install/tests/Makefile
+++ b/install/tests/Makefile
@@ -85,6 +85,7 @@ aws-kubeconfig:
 	[[ -f ${TF_VAR_TEST_ID}-creds ]] || touch ${TF_VAR_TEST_ID}-creds
 	source ${TF_VAR_TEST_ID}-creds; \
 	aws eks update-kubeconfig --name ${TF_VAR_TEST_ID} --region eu-west-1 --kubeconfig ${KUBECONFIG} || echo "No cluster present"
+	@echo -e "\033[0;33mAWS service account credentials fetched, run 'source $$(pwd)/$${TF_VAR_TEST_ID}-creds' to load them into your environment\033[0;m"
 
 .PHONY:
 ## gke-standard-cluster: Creates a zonal GKE cluster


### PR DESCRIPTION
## Description

Users interacting with EKS self-hosted preview environments may not realize that they need to source the AWS service account credentials file; this commit adds a nice warning indicating how users can load those credentials.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

Run the following:

```
cd install/tests
TF_VAR_TEST_ID="release-aws" make get-kubeconfig
```

The following warning should be emitted:

<img width="1160" alt="Screen Shot 2022-09-28 at 11 27 21 AM" src="https://user-images.githubusercontent.com/172194/192860340-354ac8d6-5757-4558-af5c-b8da1a351c99.png">

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
