### PR TITLE
common-go: Add code line to all emitted logs

### DIFF
--- a/components/common-go/log/log.go
+++ b/components/common-go/log/log.go
@@ -10,6 +10,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path"
+	"runtime"
+	"strings"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -111,12 +114,18 @@ func Init(service, version string, json, verbose bool) {
 	Log = log.WithFields(log.Fields{
 		"serviceContext": ServiceContext{service, version},
 	})
+	log.SetReportCaller(true)
 
 	if json {
 		Log.Logger.SetFormatter(&gcpFormatter{
 			log.JSONFormatter{
 				FieldMap: log.FieldMap{
 					log.FieldKeyMsg: "message",
+				},
+				CallerPrettyfier: func(f *runtime.Frame) (string, string) {
+					s := strings.Split(f.Function, ".")
+					funcName := s[len(s)-1]
+					return funcName, fmt.Sprintf("%s:%d", path.Base(f.File), f.Line)
 				},
 			},
 		})


### PR DESCRIPTION
Signed-off-by: ArthurSens <arthursens2005@gmail.com>

## Description
<!-- Describe your changes in detail -->
Updates common-go to emit logs that inform which code line it was emitted from.

Related discussion([ref](https://gitpod.slack.com/archives/C01KGM9AW4W/p1664387586999509))

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
* Open a workspace from this PR
* Try `kubectl logs -f ws-daemon` or any other component actually

While checking the logs, you'll notice that you'll find the code line and the function where each log was emitted from
![image](https://user-images.githubusercontent.com/24193764/192886375-bba7d189-e0b6-40d8-9510-0efc55c5cb9f.png)
![image](https://user-images.githubusercontent.com/24193764/192886840-8201e7c6-5c6b-48e5-bfb4-3f46bfb3b9fb.png)



## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
