### PR TITLE
fix network connections alert to fire only for workspace pods

### DIFF
--- a/operations/observability/mixins/workspace/rules/nodes.yaml
+++ b/operations/observability/mixins/workspace/rules/nodes.yaml
@@ -66,4 +66,4 @@ spec:
         summary: Network connection numbers remain high for 5 minutes.
         description: Network connection numbers remain high for 5 minutes.
       expr: |
-        node_nf_conntrack_entries{instance=~"workspace-.*", instance!~"serv.*"} > 20000
+        node_nf_conntrack_entries{instance=~"workspace-.*", instance!~"serv.*", pod=~"ws-.*"} > 20000


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This alert is specifically made to monitor workspaces that might be abusing conntrack table.
So update it to make sure it fires only for workspace pods, and not for any other pods.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
none
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
