### PR TITLE
ws-manager: remove PVC object if the workspace pod fails to up

### DIFF
--- a/components/ws-manager/pkg/manager/monitor.go
+++ b/components/ws-manager/pkg/manager/monitor.go
@@ -300,6 +300,18 @@ func actOnPodEvent(ctx context.Context, m actingManager, manager *Manager, statu
 			return xerrors.Errorf("cannot stop workspace: %w", err)
 		}
 
+		// Delete PVC if it exists
+		// Note that: the PVC removal is postponed until the PVC is no longer actively used by its workspace pod.
+		//            Therefore, the PVC is removed after the workspace pod finalizer is removed.
+		//            No data loss unless we remove the workspace pod finalizer incorrectly.
+		_, createPVC := pod.Labels[pvcWorkspaceFeatureLabel]
+		if !createPVC {
+			return nil
+		}
+		err = manager.deleteWorkspacePVC(ctx, pod.Name)
+		if err != nil {
+			return xerrors.Errorf("cannot remove PVC: %w", err)
+		}
 		return nil
 	} else if status.Conditions.StoppedByRequest == api.WorkspaceConditionBool_TRUE {
 		span.LogKV("event", "stopped by request")


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Remove the PVC object if the workspace pod could not create or the workspace pod never reached a running state.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #13282

## How to test
<!-- Provide steps to test this PR -->
- Create 110 pods to reach the per-node max pod limit
  ```console
  for i in {1..110}; do kubectl run test-${i} --image ubuntu -- sleep 3600; done
  ```
- Enable PVC feature flag.
- Create a workspace, and make sure the workspace pod failed to up.
- Waits for 30 minutes, and the workspace pod is terminated and done.
- The PVC object is gone as well.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[experimental] remove PVC object if the workspace pod fails to up
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
None

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-integration-tests=workspace
      Valid options are `all`, `workspace`, `webapp`, `ide`
