### PR TITLE
[db-sync] Remove `d_b_email` from config

### DIFF
--- a/components/gitpod-db/src/tables.ts
+++ b/components/gitpod-db/src/tables.ts
@@ -169,11 +169,6 @@ export class GitpodTableDescriptionProvider implements TableDescriptionProvider 
             timeColumn: "_lastModified",
         },
         {
-            name: "d_b_email",
-            primaryKeys: ["uid"],
-            timeColumn: "_lastModified",
-        },
-        {
             name: "d_b_gitpod_token",
             primaryKeys: ["tokenHash"],
             deletionColumn: "deleted",


### PR DESCRIPTION
## Description

Remove the `d_b_email` table from `db-sync` config. The table was dropped in https://github.com/gitpod-io/gitpod/pull/13361.

Should have been part of https://github.com/gitpod-io/gitpod/pull/13361

## Related Issue(s)
Part of #9198 

## How to test


## Release Notes
```release-note
NONE
```

## Documentation

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
