### PR TITLE
[supervisor] on shutdown send SIGINT to direct child processes of terminals

### DIFF
--- a/components/supervisor/pkg/supervisor/supervisor.go
+++ b/components/supervisor/pkg/supervisor/supervisor.go
@@ -36,10 +36,8 @@ import (
 	grpcruntime "github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/improbable-eng/grpc-web/go/grpcweb"
 	"github.com/prometheus/common/route"
-	"github.com/prometheus/procfs"
 	"github.com/soheilhy/cmux"
 	"golang.org/x/crypto/ssh"
-	"golang.org/x/sys/unix"
 	"golang.org/x/xerrors"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
@@ -50,7 +48,6 @@ import (
 	csapi "github.com/gitpod-io/gitpod/content-service/api"
 	"github.com/gitpod-io/gitpod/content-service/pkg/executor"
 	"github.com/gitpod-io/gitpod/content-service/pkg/git"
-	"github.com/gitpod-io/gitpod/content-service/pkg/initializer"
 	gitpod "github.com/gitpod-io/gitpod/gitpod-protocol"
 	"github.com/gitpod-io/gitpod/supervisor/api"
 	"github.com/gitpod-io/gitpod/supervisor/pkg/activation"
@@ -395,10 +392,7 @@ func Run(options ...RunOption) {
 		log.WithError(err).Error("terminal closure failed")
 	}
 
-	// terminate all child processes once the IDE is gone
 	ideWG.Wait()
-	terminateChildProcesses()
-
 	wg.Wait()
 }
 
@@ -1414,77 +1408,6 @@ func startContentInit(ctx context.Context, cfg *Config, wg *sync.WaitGroup, cst 
 
 	log.WithField("source", src).Info("supervisor: workspace content init finished")
 	cst.MarkContentReady(src)
-}
-
-func terminateChildProcesses() {
-	parent := os.Getpid()
-
-	children, err := processesWithParent(parent)
-	if err != nil {
-		log.WithError(err).WithField("pid", parent).Warn("cannot find children processes")
-		return
-	}
-
-	for pid, uid := range children {
-		privileged := false
-		if initializer.GitpodUID != uid {
-			privileged = true
-		}
-
-		terminateProcess(pid, privileged)
-	}
-}
-
-func terminateProcess(pid int, privileged bool) {
-	var err error
-	if privileged {
-		cmd := exec.Command("kill", "-SIGTERM", fmt.Sprintf("%v", pid))
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-		err = cmd.Run()
-	} else {
-		err = syscall.Kill(pid, unix.SIGTERM)
-	}
-
-	if err != nil {
-		log.WithError(err).WithField("pid", pid).Debug("child process is already terminated")
-		return
-	}
-
-	log.WithField("pid", pid).Debug("SIGTERM'ed child process")
-}
-
-func processesWithParent(ppid int) (map[int]int, error) {
-	procs, err := procfs.AllProcs()
-	if err != nil {
-		return nil, err
-	}
-
-	children := make(map[int]int)
-	for _, proc := range procs {
-		stat, err := proc.Stat()
-		if err != nil {
-			continue
-		}
-
-		if stat.PPID != ppid {
-			continue
-		}
-
-		status, err := proc.NewStatus()
-		if err != nil {
-			continue
-		}
-
-		uid, err := strconv.Atoi(status.UIDs[0])
-		if err != nil {
-			continue
-		}
-
-		children[proc.PID] = uid
-	}
-
-	return children, nil
 }
 
 func socketActivationForDocker(ctx context.Context, wg *sync.WaitGroup, term *terminal.Mux) {

--- a/components/supervisor/pkg/terminal/service.go
+++ b/components/supervisor/pkg/terminal/service.go
@@ -25,12 +25,6 @@ import (
 	"github.com/gitpod-io/gitpod/supervisor/api"
 )
 
-const (
-	// closeTerminaldefaultGracePeriod is the time terminal
-	// processes get between SIGTERM and SIGKILL.
-	closeTerminaldefaultGracePeriod = 10 * time.Second
-)
-
 // NewMuxTerminalService creates a new terminal service.
 func NewMuxTerminalService(m *Mux) *MuxTerminalService {
 	shell := os.Getenv("SHELL")
@@ -139,7 +133,7 @@ func (srv *MuxTerminalService) OpenWithOptions(ctx context.Context, req *api.Ope
 
 // Close closes a terminal for the given alias.
 func (srv *MuxTerminalService) Shutdown(ctx context.Context, req *api.ShutdownTerminalRequest) (*api.ShutdownTerminalResponse, error) {
-	err := srv.Mux.CloseTerminal(req.Alias, closeTerminaldefaultGracePeriod)
+	err := srv.Mux.CloseTerminal(req.Alias)
 	if err == ErrNotFound {
 		return nil, status.Error(codes.NotFound, err.Error())
 	}


### PR DESCRIPTION
## Description
We currently send sigint to the terminal process directly, but bash doesn't propagate it to its child processes. 
With this change we first send a SIGINT to the direct children of the main terminal process and waiting for them to exit, before sending SIGINT to the main process itself. 
Also, we are waiting indefinitely for those processes to stop, relying on the graceperiod of Kubernetes.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #13365

## How to test
Start a workspace https://se-sighup.preview.gitpod-dev.com/#https://github.com/svenefftinge/termination-test

Run 
```
./ignoresigterm > out_disown.txt &
disown $1
./ignoresigterm > out_bg.txt &
./ignoresigterm > out.txt
```
and stop the workspace.
With this preview environment you should see log output like below in all three files
```
awaiting signal

Received signal
terminated

Ignored for 0 seconds.
Ignored for 1 seconds.
Ignored for 2 seconds.
Ignored for 3 seconds.
Ignored for 4 seconds.
Ignored for 5 seconds.
Ignored for 6 seconds.
Ignored for 7 seconds.
Ignored for 8 seconds.
Ignored for 9 seconds.
Ignored for 10 seconds.
Ignored for 11 seconds.
Ignored for 12 seconds.
Ignored for 13 seconds.
Ignored for 14 seconds.
Ignored for 15 seconds.
...
```

With gitpod.io you will see only (i.e. the processes never received SIGINT):
```
awaiting signal
```



## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
