### PR TITLE
[db-sync] Update config with `d_b_volume_snapshot` table

### DIFF
--- a/components/gitpod-db/src/tables.ts
+++ b/components/gitpod-db/src/tables.ts
@@ -59,6 +59,12 @@ export class GitpodTableDescriptionProvider implements TableDescriptionProvider 
             deletionColumn: "deleted",
         },
         {
+            name: "d_b_volume_snapshot",
+            primaryKeys: ["id"],
+            timeColumn: "_lastModified",
+            deletionColumn: "deleted",
+        },
+        {
             name: "d_b_blocked_repository",
             primaryKeys: ["id"],
             timeColumn: "updatedAt",


### PR DESCRIPTION
## Description

Add the `d_b_volume_snapshot` table to the list of tables to be synced by `db-sync`.

* The migration to add the `_lastModfied` and `deleted` columns was added in https://github.com/gitpod-io/gitpod/pull/13348
* Soft deletion of volume snapshot records was added in https://github.com/gitpod-io/gitpod/pull/13391

With these two in place we can switch on sync for this table.

## Related Issue(s)
Part of #9198 

## How to test

## Release Notes

```release-note
NONE
```

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
