### PR TITLE
[db-sync] Add `d_b_installation_admin` table to db-sync

### DIFF
--- a/components/gitpod-db/src/tables.ts
+++ b/components/gitpod-db/src/tables.ts
@@ -48,6 +48,11 @@ export class GitpodTableDescriptionProvider implements TableDescriptionProvider 
     readonly name = "gitpod";
     protected readonly tables: TableDescription[] = [
         {
+            name: "d_b_installation_admin",
+            primaryKeys: ["id"],
+            timeColumn: "_lastModified",
+        },
+        {
             name: "d_b_blocked_repository",
             primaryKeys: ["id"],
             timeColumn: "updatedAt",


### PR DESCRIPTION
## Description

Add the `d_b_installation_admin` table to the list of tables to be synced by `db_sync`.

## Related Issue(s)
Part of #9198 

## How to test

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
