### PR TITLE
[usage] Remove 'Get or create CostCenter' log

### DIFF
--- a/components/usage/pkg/db/cost_center.go
+++ b/components/usage/pkg/db/cost_center.go
@@ -59,7 +59,6 @@ type CostCenterManager struct {
 // This method creates a codt center and stores it in the DB if there is no preexisting one.
 func (c *CostCenterManager) GetOrCreateCostCenter(ctx context.Context, attributionID AttributionID) (CostCenter, error) {
 	logger := log.WithField("attributionId", attributionID)
-	logger.Info("Get or create CostCenter")
 
 	result, err := getCostCenter(ctx, c.conn, attributionID)
 	if err != nil {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Produces about [120k log messages an hour](https://console.cloud.google.com/logs/query;query=resource.labels.pod_name%20:%20%2528%22usage%22%2529%0AjsonPayload.message%3D%22Get%20or%20create%20CostCenter%22;timeRange=PT1H;cursorTimestamp=2022-09-29T07:14:00.000Z?authuser=0&project=gitpod-191109)

We still continue to log it when a new one is created.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
