### PR TITLE
[server] properly parse ports of clone URLs

### DIFF
--- a/components/server/src/repohost/repo-url.spec.ts
+++ b/components/server/src/repohost/repo-url.spec.ts
@@ -72,6 +72,16 @@ export class RepoUrlTest {
             repo: "yolo",
         });
     }
+
+    @test public parseScmCloneUrl_with_port() {
+        const testUrl = RepoURL.parseRepoUrl("https://foo.bar.com:12345/scm/proj/repoName.git");
+        expect(testUrl).to.deep.include({
+            host: "foo.bar.com:12345",
+            repoKind: "projects",
+            owner: "proj",
+            repo: "repoName",
+        });
+    }
 }
 
 module.exports = new RepoUrlTest();

--- a/components/server/src/repohost/repo-url.ts
+++ b/components/server/src/repohost/repo-url.ts
@@ -10,7 +10,7 @@ export namespace RepoURL {
         repoUrl: string,
     ): { host: string; owner: string; repo: string; repoKind?: string } | undefined {
         const u = new URL(repoUrl);
-        const host = u.hostname || "";
+        const host = u.host || "";
         const path = u.pathname || "";
         const segments = path.split("/").filter((s) => !!s); // e.g. [ 'gitpod-io', 'gitpod.git' ]
         if (segments.length === 2) {


### PR DESCRIPTION
Otherwise this breaks the lookup of services mapped by host (including the port.)

This is the quite apparent aftermath of enabling ports in SCM locations.

## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Fix missing port in parsed clone URL.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
