### PR TITLE
Revert "fix network connections alert to fire only for workspace pods"

### DIFF
--- a/operations/observability/mixins/workspace/rules/nodes.yaml
+++ b/operations/observability/mixins/workspace/rules/nodes.yaml
@@ -66,4 +66,4 @@ spec:
         summary: Network connection numbers remain high for 5 minutes.
         description: Network connection numbers remain high for 5 minutes.
       expr: |
-        node_nf_conntrack_entries{instance=~"workspace-.*", instance!~"serv.*", pod=~"ws-.*"} > 20000
+        node_nf_conntrack_entries{instance=~"workspace-.*", instance!~"serv.*"} > 20000


### PR DESCRIPTION
## Description
Reverts https://github.com/gitpod-io/gitpod/pull/13427. The pod refers to the pod that is exporting the metric which would be the node-exporter, so the alert will not fire as it will find no matching entries. This can be checked by using 'Explore' in Grafana and using this query: `node_nf_conntrack_entries{instance=~"workspace-.*", instance!~"serv.*"}`. When you check the values for pod in the output you will see that there are no workspace pods, only node exporter.

## Related Issue(s)
n.a.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
