### PR TITLE
[supervisor] local exposed

### DIFF
--- a/components/supervisor/pkg/ports/exposed-ports.go
+++ b/components/supervisor/pkg/ports/exposed-ports.go
@@ -6,6 +6,8 @@ package ports
 
 import (
 	"context"
+	"fmt"
+	"net/url"
 	"time"
 
 	backoff "github.com/cenkalti/backoff/v4"
@@ -57,9 +59,14 @@ func (*NoopExposedPorts) Expose(ctx context.Context, local uint32, public bool) 
 // GitpodExposedPorts uses a connection to the Gitpod server to implement
 // the ExposedPortsInterface.
 type GitpodExposedPorts struct {
-	WorkspaceID string
-	InstanceID  string
-	C           gitpod.APIInterface
+	WorkspaceID  string
+	InstanceID   string
+	WorkspaceUrl string
+	C            gitpod.APIInterface
+
+	localExposedPort   []uint32
+	localExposedNotice chan struct{}
+	lastServerExposed  []*gitpod.WorkspaceInstancePort
 
 	requests chan *exposePortRequest
 }
@@ -71,15 +78,35 @@ type exposePortRequest struct {
 }
 
 // NewGitpodExposedPorts creates a new instance of GitpodExposedPorts
-func NewGitpodExposedPorts(workspaceID string, instanceID string, gitpodService gitpod.APIInterface) *GitpodExposedPorts {
+func NewGitpodExposedPorts(workspaceID string, instanceID string, workspaceUrl string, gitpodService gitpod.APIInterface) *GitpodExposedPorts {
 	return &GitpodExposedPorts{
-		WorkspaceID: workspaceID,
-		InstanceID:  instanceID,
-		C:           gitpodService,
+		WorkspaceID:  workspaceID,
+		InstanceID:   instanceID,
+		WorkspaceUrl: workspaceUrl,
+		C:            gitpodService,
 
 		// allow clients to submit 30 expose requests without blocking
-		requests: make(chan *exposePortRequest, 30),
+		requests:           make(chan *exposePortRequest, 30),
+		localExposedNotice: make(chan struct{}, 30),
 	}
+}
+
+func (g *GitpodExposedPorts) getPortUrl(port uint32) string {
+	u, err := url.Parse(g.WorkspaceUrl)
+	if err != nil {
+		return ""
+	}
+	u.Host = fmt.Sprintf("%d-%s", port, u.Host)
+	return u.String()
+}
+
+func (g *GitpodExposedPorts) existInLocalExposed(port uint32) bool {
+	for _, p := range g.localExposedPort {
+		if p == port {
+			return true
+		}
+	}
+	return false
 }
 
 // Observe starts observing the exposed ports until the context is canceled.
@@ -98,22 +125,41 @@ func (g *GitpodExposedPorts) Observe(ctx context.Context) (<-chan []ExposedPort,
 			errchan <- err
 			return
 		}
+		mixin := func(localExposedPort []uint32, serverExposePort []*gitpod.WorkspaceInstancePort) []ExposedPort {
+			res := make(map[uint32]ExposedPort)
+			for _, port := range g.localExposedPort {
+				res[port] = ExposedPort{
+					LocalPort: port,
+					Public:    false,
+					URL:       g.getPortUrl(port),
+				}
+			}
+
+			for _, p := range serverExposePort {
+				res[uint32(p.Port)] = ExposedPort{
+					LocalPort: uint32(p.Port),
+					Public:    p.Visibility == "public",
+					URL:       p.URL,
+				}
+			}
+			exposedPort := make([]ExposedPort, 0, len(res))
+			for _, p := range res {
+				exposedPort = append(exposedPort, p)
+			}
+			return exposedPort
+		}
 		for {
 			select {
 			case u := <-updates:
 				if u == nil {
 					return
 				}
+				g.lastServerExposed = u.Status.ExposedPorts
 
-				res := make([]ExposedPort, len(u.Status.ExposedPorts))
-				for i, p := range u.Status.ExposedPorts {
-					res[i] = ExposedPort{
-						LocalPort: uint32(p.Port),
-						Public:    p.Visibility == "public",
-						URL:       p.URL,
-					}
-				}
-
+				res := mixin(g.localExposedPort, g.lastServerExposed)
+				reschan <- res
+			case <-g.localExposedNotice:
+				res := mixin(g.localExposedPort, g.lastServerExposed)
 				reschan <- res
 			case <-ctx.Done():
 				return
@@ -180,14 +226,19 @@ func (g *GitpodExposedPorts) doExpose(req *exposePortRequest) {
 
 // Expose exposes a port to the internet. Upon successful execution any Observer will be updated.
 func (g *GitpodExposedPorts) Expose(ctx context.Context, local uint32, public bool) <-chan error {
-	v := "private"
-	if public {
-		v = "public"
+	if !public {
+		if !g.existInLocalExposed(local) {
+			g.localExposedPort = append(g.localExposedPort, local)
+			g.localExposedNotice <- struct{}{}
+		}
+		c := make(chan error)
+		close(c)
+		return c
 	}
 	req := &exposePortRequest{
 		port: &gitpod.WorkspaceInstancePort{
 			Port:       float64(local),
-			Visibility: v,
+			Visibility: "public",
 		},
 		ctx:  ctx,
 		done: make(chan error),

--- a/components/supervisor/pkg/supervisor/supervisor.go
+++ b/components/supervisor/pkg/supervisor/supervisor.go
@@ -634,7 +634,7 @@ func createExposedPortsImpl(cfg *Config, gitpodService *gitpod.APIoverJSONRPC) p
 		log.Error("auto-port exposure won't work")
 		return &ports.NoopExposedPorts{}
 	}
-	return ports.NewGitpodExposedPorts(cfg.WorkspaceID, cfg.WorkspaceInstanceID, gitpodService)
+	return ports.NewGitpodExposedPorts(cfg.WorkspaceID, cfg.WorkspaceInstanceID, cfg.WorkspaceUrl, gitpodService)
 }
 
 // supervisor ships some binaries we want in the PATH. We could just add some directory to the path, but


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Expose ports locally in supervisor (private is default available in ws-proxy)

**Context**

`ws-proxy` served every port in private, the user can access them or not is depending on if the ports are served.

This means auto `openPort` with private (call server API) in supervisor makes no sense (they are already in `private` state). So we can do it in supervisor locally

**Result**

With this PR, we can reduce 99% of useless requests, 99% comes from **Affect** section below

**Affect**

> _(Ignore `.gitpod.yml` ports defined with public)_

From Grafana, we can see today's `openPorts` calling total is around 60k, but users only change ports visibility (via vscode) 314 times today.

|Grafana|
|-|
|<img width="1920" alt="image" src="https://user-images.githubusercontent.com/20944364/193014963-a6091507-3a03-4d80-9b81-d4e21d965f84.png">|

|VSCode|
|-|
|<img width="1845" alt="image" src="https://user-images.githubusercontent.com/20944364/193015080-2b909ad6-0b0e-4bbb-882c-b3a1f0b4fc02.png">|

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
- Related https://github.com/gitpod-io/gitpod/issues/13239

## How to test
<!-- Provide steps to test this PR -->

Example repo https://github.com/mustard-mh/test/tree/hw/logs-ports will open 100+ ports and mark port `8080` as public only

### Will not break default behavior
- Open workspace with a repo that provides both private and public ports in preview env and check if they work
- Change ports visibility by `gp-cli` or `PortsView` in VSCode (Do we provide more ways to do it?) and check if they work
- Check if ports status in `gp-cli` and `PortsView` are correct

### Will reduce the number of requests
- Open workspace with lots of ports defined/served with private and only one with public in `.gitpod.yml` on starting
- Check metrics of the num of `ControlPort` gRPC method called only one time

### How to check metrics of gRPC
Open Gitpod with this PR, exec command below
```
kubectl port-forward svc/prometheus-k8s -n monitoring-satellite 9090:9090
```
Search `grpc_client_handled_total{grpc_method='ControlPort'}` in graph tab

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
