### PR TITLE
JetBrains: Update `launch-dev-script.sh` and contributing docs

### DIFF
--- a/components/ide/jetbrains/backend-plugin/.run/backend-plugin.run.xml
+++ b/components/ide/jetbrains/backend-plugin/.run/backend-plugin.run.xml
@@ -1,0 +1,16 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="backend-plugin" type="Remote">
+    <module name="jetbrains-backend-plugin" />
+    <option name="USE_SOCKET_TRANSPORT" value="true" />
+    <option name="SERVER_MODE" value="false" />
+    <option name="SHMEM_ADDRESS" />
+    <option name="HOST" value="localhost" />
+    <option name="PORT" value="44444" />
+    <option name="AUTO_RESTART" value="false" />
+    <RunnerSettings RunnerId="Debug">
+      <option name="DEBUG_PORT" value="44444" />
+      <option name="LOCAL" value="false" />
+    </RunnerSettings>
+    <method v="2" />
+  </configuration>
+</component>

--- a/components/ide/jetbrains/backend-plugin/README.md
+++ b/components/ide/jetbrains/backend-plugin/README.md
@@ -7,44 +7,71 @@ Provides integrations within a Gitpod workspace.
 
 ## Development
 
-Please make sure to enable IntelliJ in gitpod.io preferences: https://gitpod.io/preferences
-IntelliJ delivers better experience for development of JetBrains plugins. We should as well use it for dogfooding. If you experience any issues with JetBrains remote dev make sure to report
-issues [here](https://youtrack.jetbrains.com/issues?q=project:%20CWM)
-under remote development subsystem.
+The ideal setup to develop this plugin is using IntelliJ in Gitpod.
+
+1. Choose IntelliJ as your editor in [gitpod.io/preferences](https://gitpod.io/preferences)
+2. Start a workspace for this repository
+
+If you experience any issues with JetBrains remote dev make sure to report issues [here](https://youtrack.jetbrains.com/issues?q=project:%20CWM) under remote development subsystem.
 
 <img src="https://user-images.githubusercontent.com/3082655/187091748-c58ce156-90b6-4522-83a7-b4312e36d949.png"/>
 
-### Local
+### Testing your changes
 
-Usually you will need to create a preview environments to try your changes, but if your changes don't touch any other components beside the backend plugin then you can test against the running workspace:
+If you want to test changes in `backend-plugin`, you can use [launch-dev-server.sh](./launch-dev-server.sh). The script will build the `backend-plugin` and start another JB backend instance against a test repository.
 
-- Launch `./launch-dev-server.sh` from `components/ide/jetbrains/backend-plugin`. It builds the backend plugin, and
-  start another JB backend in the remote debug mode with it against sprint-petclinic project and services of a running
-  workspace.
+There are a set of flags available in the script:
+
 ```bash
-cd components/ide/jetbrains/backend-plugin
-./launch-dev-server.sh
-```
-- In order to open the thin client for the dev backend use a gitpod gateway link from logs:
-```
-*********************************************************
-
-Gitpod gateway link: jetbrains-gateway://connect#gitpodHost=ak-jb-backend-debug-flow.staging.gitpod-dev.com&workspaceId=gitpodio-gitpod-rvg0x7havor&backendPort=63343
-
-*********************************************************
-```
-- You should see following in the backend logs, copy the debug port:
-
-```
-Picked up JAVA_TOOL_OPTIONS:  -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:0
-Listening for transport dt_socket at address: 54963
+-s # Use the stable image of IntelliJ (by default it will use the "latest")
+-r # Specify a test repository (e.g. -r https://github.com/gitpod-io/empty)
+-p # Specify a debug port (useful if used in combination with the Remote JVM debugger in IntelliJ)
 ```
 
-- Create a new `Remote JVM Debug` launch configuration with the copied port and launch it.
-- You should be able to put breakpoint now, and it will hit. If it does not hit please also check in `Main Window`. As
-  for now each thin client is accompanied by another window (main) which directly renders UI from backend. Sometimes
-  there are bugs when a file will be opened in this window instead of the thin client. It also can be that
-  the main window is not visible then try to find it in the left top corner and resize. It looks almost like a line.
+To use the script, from your gitpod's workspace:
+
+1. Launch the script:
+  ```bash
+  cd components/ide/jetbrains/backend-plugin
+  ./launch-dev-server.sh
+  ```
+2. Connect the IDE to the test backend instance. Find the `Gitpod gateway link` in the logs and open it, e.g:
+  ```console
+  *********************************************************
+
+  Gitpod gateway link: jetbrains-gateway://connect#gitpodHost=ak-jb-backend-debug-flow.staging.gitpod-dev.com&workspaceId=gitpodio-gitpod-rvg0x7havor&backendPort=63343
+
+  *********************************************************
+  ```
+
+By default, the test-repository is [gitpod-io/spring-petclinic](https://github.com/gitpod-io/spring-petclinic). You can specify a different test repo using the `-r` argument, e.g:
+
+```bash
+./launch-dev-server.sh -r https://github.com/gitpod-io/empty
+```
+
+If you want to specify the qualifier (latest/stable) of the IntelliJ version, use the `-s` flag, by default it will use the `latest`. To use stable, run:
+
+```bash
+./launch-dev-server.sh -s
+```
+
+If you want to use breakpoints in IntelliJ, you can use the provided Run Configuration called "backend-plugin", run:
+
+1. Launch the script overriding the debug port
+```bash
+./launch-dev-server.sh -p 44444
+```
+2. Execute the run configuration "backend-plugin"
+
+Note: the port `44444` is randomly chosen and it has to match with the port specified in the [backend-plugin Run configuration](./.run/backend-plugin.run.xml).
+
+Note: You should be able to put breakpoint now, and it will hit. If it does not hit please also check in `Main Window`.
+As for now each thin client is accompanied by another window (main) which directly renders UI from backend.
+Sometimes there are bugs when a file will be opened in this window instead of the thin client.
+It also can be that the main window is not visible then try to find it in the left top corner and resize. It looks almost like a line.
+
+Note: if your changes include other components beside the `backend-plugin`, most likely you will need a preview environment.
 
 ### Hot deployment
 


### PR DESCRIPTION
## Description
1. Adds a run configuration to easily launch the debugger for `backend-plugin`
1. Update to `launch-dev-script.sh` to allow specifying a `DEBUG_PORT` and have a dynamic directory in which the test repository is cloned
2. Update contributing docs (also in view of [Hacktoberfest](https://github.com/gitpod-io/website/pull/2780))

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #13051

## How to test
<!-- Provide steps to test this PR -->
1. Choose IntelliJ as your editor in [gitpod.io/preferences](https://gitpod.io/preferences)
2. Start a workspace for this PR: https://gitpod.io/#https://github.com/gitpod-io/gitpod/pull/13454
3. Test the run configuration while running `cd components/ide/jetbrains/backend-plugin && ./launch-dev-server.sh -p 44444`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
