### PR TITLE
Implement soft deletion of pending github events

### DIFF
--- a/components/ee/payment-endpoint/src/github/subscription-reconciler.ts
+++ b/components/ee/payment-endpoint/src/github/subscription-reconciler.ts
@@ -45,7 +45,8 @@ export class GithubSubscriptionReconciler {
                 event: JSON.stringify(evt),
                 githubUserId: evt.payload.marketplace_purchase.account.id.toString(),
                 id: evt.id,
-                type: `marketplace_purchase.${evt.payload.action}`
+                type: `marketplace_purchase.${evt.payload.action}`,
+                deleted: false
             });
         }
     }

--- a/components/gitpod-db/src/typeorm/entity/db-pending-github-event.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-pending-github-event.ts
@@ -24,4 +24,8 @@ export class DBPendingGithubEvent implements PendingGithubEvent {
 
     @Column()
     event: string;
+
+    // This column triggers the db-sync deletion mechanism. It's not intended for public consumption.
+    @Column()
+    deleted: boolean;
 }

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -639,6 +639,7 @@ export interface PendingGithubEvent {
     creationDate: Date;
     type: string;
     event: string;
+    deleted: boolean;
 }
 
 export interface Snapshot {


### PR DESCRIPTION
## Description

Implement soft deletion of rows from the `d_b_pending_github_event` table.

The migration to add the `deleted` column was done in https://github.com/gitpod-io/gitpod/pull/13450.

With soft deletion in place, the table can be synced between regions in a followup PR.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of #9198 

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-payment
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
