### PR TITLE
[server] bind GRPC clients in singleton scope

### DIFF
--- a/components/server/src/container-module.ts
+++ b/components/server/src/container-module.ts
@@ -260,15 +260,19 @@ export const productionContainerModule = new ContainerModule((bind, unbind, isBo
 
     bind(NewsletterSubscriptionController).toSelf().inSingletonScope();
 
-    bind<UsageServiceClient>(UsageServiceDefinition.name).toDynamicValue((ctx) => {
-        const config = ctx.container.get<Config>(Config);
-        return createClient(UsageServiceDefinition, createChannel(config.usageServiceAddr));
-    });
+    bind<UsageServiceClient>(UsageServiceDefinition.name)
+        .toDynamicValue((ctx) => {
+            const config = ctx.container.get<Config>(Config);
+            return createClient(UsageServiceDefinition, createChannel(config.usageServiceAddr));
+        })
+        .inSingletonScope();
 
-    bind<BillingServiceClient>(BillingServiceDefinition.name).toDynamicValue((ctx) => {
-        const config = ctx.container.get<Config>(Config);
-        return createClient(BillingServiceDefinition, createChannel(config.usageServiceAddr));
-    });
+    bind<BillingServiceClient>(BillingServiceDefinition.name)
+        .toDynamicValue((ctx) => {
+            const config = ctx.container.get<Config>(Config);
+            return createClient(BillingServiceDefinition, createChannel(config.usageServiceAddr));
+        })
+        .inSingletonScope();
 
     bind<IDEServiceClient>(IDEServiceDefinition.name).toDynamicValue((ctx) => {
         const config = ctx.container.get<Config>(Config);


### PR DESCRIPTION
## Description
Create only one GRPC client.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-payment
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
