### PR TITLE
[db-sync] Sync `d_b_pending_github_event` table

### DIFF
--- a/components/gitpod-db/src/tables.ts
+++ b/components/gitpod-db/src/tables.ts
@@ -53,6 +53,12 @@ export class GitpodTableDescriptionProvider implements TableDescriptionProvider 
             timeColumn: "_lastModified",
         },
         {
+            name: "d_b_pending_github_event",
+            primaryKeys: ["id"],
+            timeColumn: "creationDate",
+            deletionColumn: "deleted",
+        },
+        {
             name: "d_b_blocked_repository",
             primaryKeys: ["id"],
             timeColumn: "updatedAt",


### PR DESCRIPTION
## Description

With the changes to add a `deleted` column to the table (https://github.com/gitpod-io/gitpod/pull/13450) and soft-delete rows from the table (https://github.com/gitpod-io/gitpod/pull/13455), the `d_b_pending_github_event` table can now be added to `db-sync` configuration.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of #9198 
## How to test

<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
