### PR TITLE
[jetbrains] remove unused argdeps

### DIFF
--- a/components/ide/jetbrains/backend-plugin/BUILD.yaml
+++ b/components/ide/jetbrains/backend-plugin/BUILD.yaml
@@ -1,8 +1,6 @@
 packages:
   - name: docker
     type: generic
-    argdeps:
-      - version
     deps:
       - :stable
       - :latest
@@ -12,7 +10,6 @@ packages:
       - :plugin-stable
     argdeps:
       - imageRepoBase
-      - version
     config:
       dockerfile: leeway.Dockerfile
       metadata:
@@ -27,7 +24,6 @@ packages:
       - :plugin-latest
     argdeps:
       - imageRepoBase
-      - version
     config:
       dockerfile: leeway.Dockerfile
       metadata:


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

<img width="1451" alt="image" src="https://user-images.githubusercontent.com/20944364/193073303-4d8d1b98-da94-40e1-9357-fa4ee4c02b9d.png">
At before we built backend every commit, because argdeps is include in compute leeway version, we don't actually use this `version` argument, remove it can make build easily


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
1. comment `/werft run` in this PR to re-trigger werft build, it should be not build `jb-backend-plugin`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
