### PR TITLE
[ide-proxy] add HSTS header

### DIFF
--- a/components/ide-proxy/conf/Caddyfile
+++ b/components/ide-proxy/conf/Caddyfile
@@ -9,6 +9,24 @@
 	}
 }
 
+# configure headers to force HTTPS and enable more strict rules for the browser
+(security_headers) {
+	header {
+		# enable HSTS
+		Strict-Transport-Security  max-age=31536000
+		# disable clients from sniffing the media type
+		X-Content-Type-Options     nosniff
+		# Define valid parents that may embed a page
+		Content-Security-Policy    "frame-ancestors 'self' https://*.{$GITPOD_DOMAIN} https://{$GITPOD_DOMAIN}"
+		# keep referrer data off of HTTP connections
+		Referrer-Policy            no-referrer-when-downgrade
+		# Enable cross-site filter (XSS) and tell browser to block detected attacks
+		X-XSS-Protection           "1; mode=block"
+
+		defer # delay changes
+	}
+}
+
 (compression) {
 	encode zstd gzip
 }
@@ -22,6 +40,7 @@
 }
 
 :80 {
+	import security_headers
 	header -Server
 
 	@blobserve path /blobserve/*


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
[ide-proxy] add HSTS header

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #https://github.com/gitpod-io/security/issues/38

## How to test
<!-- Provide steps to test this PR -->
1. open a workspace in preview environment, it should work as usually (special to check simple browser extension)
2. using `curl -v https://ide.pd-ide-hsts.preview.gitpod-dev.com/metrics-api/metrics/` to ensure there is HSTS header in there

<img width="548" alt="image" src="https://user-images.githubusercontent.com/8299500/193088455-5643450c-b9e7-4ff8-8896-3fa1b44f978b.png">
<img width="640" alt="image" src="https://user-images.githubusercontent.com/8299500/193088782-750b0d77-0e15-4370-a5f5-98c45c561547.png">



## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
