### PR TITLE
[werft] Use awscliv2 from dev-environment and skip install in cleanup preview job

### DIFF
--- a/.werft/cleanup-installer-tests.yaml
+++ b/.werft/cleanup-installer-tests.yaml
@@ -122,9 +122,6 @@ pod:
 
         curl -sLS https://get.k3sup.dev | sh
         curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
-        curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-        unzip awscliv2.zip
-        sudo ./aws/install
 
         (cd .werft && yarn install && mv node_modules ..) | werft log slice prep
         printf '{{ toJson . }}' > context.json


### PR DESCRIPTION
## Description

This commit depends on awscliv2 being available in the dev environment and skips the installation step in the cleanup-installer-tests job.

## Related Issue(s)

Depends on https://github.com/gitpod-io/gitpod/pull/12278

## How to test

```bash
werft run github -j .werft/cleanup-installer-tests.yaml
```

Should result in something like the following:

```
cleanup-infra        Manage the infrastructure in
[cleanup-old-tests] Calling cleanup-old-tests
[cleanup-old-tests] STDOUT: make: Entering directory '/workspace/install/tests'
[cleanup-old-tests] ./cleanup.sh
[cleanup-old-tests] release-2-aws has the pattern gitpod-*, skipping
[cleanup-old-tests] release-azure has the pattern gitpod-*, skipping
[cleanup-old-tests] release-gcp has the pattern gitpod-*, skipping
[cleanup-old-tests] gs://nightly-tests/tf-state/release-k3s-kubeconfig was not created atleast '10 hours ago', skipping
[cleanup-old-tests] gs://nightly-tests/tf-state/release-k3s.tfstate was not created atleast '10 hours ago', skipping
[cleanup-old-tests] make: Leaving directory '/workspace/install/tests'
[cleanup-old-tests] 
[cleanup-old-tests] STDERR: Activated service account credentials for: [sh-automated-tests@sh-automated-tests.iam.gserviceaccount.com]
[cleanup-old-tests] 
[cleanup-old-tests] '' succeeded
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
