### PR TITLE
[certificates]: validate that certs are valid for a Gitpod install

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -28,6 +28,7 @@
 /components/image-builder-bob @gitpod-io/engineering-workspace
 /components/image-builder-mk3 @gitpod-io/engineering-workspace
 /components/installation-telemetry @gitpod-io/engineering-self-hosted
+/components/kots-config-check @gitpod-io/engineering-self-hosted
 /install @gitpod-io/engineering-self-hosted
 /install/installer @gitpod-io/engineering-self-hosted
 # For testdata a single review from anyone who is allowed to review PRs is sufficent.

--- a/components/BUILD.yaml
+++ b/components/BUILD.yaml
@@ -73,6 +73,7 @@ packages:
       - components/ide-proxy:docker
       - components/ide-metrics:docker
       - components/ide-service:docker
+      - components/kots-config-check/certificate:docker
       - components/kots-config-check/database:docker
       - components/kots-config-check/registry:docker
       - components/kots-config-check/storage:docker

--- a/components/kots-config-check/certificate/BUILD.yaml
+++ b/components/kots-config-check/certificate/BUILD.yaml
@@ -1,0 +1,14 @@
+packages:
+  - name: docker
+    type: docker
+    argdeps:
+      - imageRepoBase
+    srcs:
+      - entrypoint.sh
+    config:
+      dockerfile: leeway.Dockerfile
+      metadata:
+        helm-component: kots-config-check.certificate
+      image:
+        - ${imageRepoBase}/kots-config-check/certificate:${version}
+        - ${imageRepoBase}/kots-config-check/certificate:commit-${__git_commit}

--- a/components/kots-config-check/certificate/entrypoint.sh
+++ b/components/kots-config-check/certificate/entrypoint.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+# Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+# Licensed under the GNU Affero General Public License (AGPL).
+# See License-AGPL.txt in the project root for license information.
+
+set -euo pipefail
+
+DOMAIN="${1:-""}"
+NAMESPACE="${2:-""}"
+SECRET_NAME="${3:-""}"
+TLS_CRT_KEY="${4:-"tls.crt"}"
+TLS_KEY_KEY="${5:-"tls.key"}"
+
+cert_exists="false"
+domain="false"
+in_date="false"
+
+CRT_FILE="/tmp/tls.crt"
+CRT_CONTENTS_FILE="/tmp/tls.crt.txt"
+KEY_FILE="/tmp/tls.key"
+
+function get_cert() {
+  # Get certificate from secret
+  kubectl get secret \
+    -n "${NAMESPACE}" \
+    "${SECRET_NAME}" \
+    -o jsonpath="{.data.${TLS_CRT_KEY//./\\.}}" \
+    | base64 -d \
+    > "${CRT_FILE}" || return 1
+
+  kubectl get secret \
+    -n "${NAMESPACE}" \
+    "${SECRET_NAME}" \
+    -o jsonpath="{.data.${TLS_KEY_KEY//./\\.}}" \
+    | base64 -d \
+    > "${KEY_FILE}" || return 1
+
+  # Decode it as an x509 certificate
+  openssl x509 -in "${CRT_FILE}" -text -noout > "${CRT_CONTENTS_FILE}"
+
+  CRT_SIG="$(openssl x509 -noout -modulus -in "${CRT_FILE}" | openssl md5)"
+  KEY_SIG="$(openssl rsa -noout -modulus -in "${KEY_FILE}" | openssl md5)"
+
+  if [ "${CRT_SIG}" != "${KEY_SIG}" ]; then
+    echo "Certificate (${TLS_CRT_KEY}) does not match key (${TLS_KEY_KEY})"
+    return 1
+  fi
+}
+
+function cert_matches_domain_name() {
+  grep "${DOMAIN}" "${CRT_CONTENTS_FILE}" || return 1
+  grep "\*.${DOMAIN}" "${CRT_CONTENTS_FILE}" || return 1
+  grep "\*.ws.${DOMAIN}" "${CRT_CONTENTS_FILE}" || return 1
+}
+
+function cert_in_date() {
+  DATES="$(openssl x509 -in "${CRT_FILE}" -noout -dates)"
+
+  START_DATE="$(echo "${DATES}" | awk -F= '{a[$1]=$2} END {print(a["notBefore"])}')"
+  END_DATE="$(echo "${DATES}" | awk -F= '{a[$1]=$2} END {print(a["notAfter"])}')"
+
+  echo "Certificate start date: ${START_DATE}"
+  echo "Certificate end date: ${END_DATE}"
+
+  START_EPOCH="$(date -u -D "%b %e %H:%M:%S %Y" -d "${START_DATE}" "+%s")"
+  END_EPOCH="$(date -u -D "%b %e %H:%M:%S %Y" -d "${END_DATE}" "+%s")"
+  NOW_EPOCH="$(date -u "+%s")"
+
+  if [ "${NOW_EPOCH}" -gt "${START_EPOCH}" ] && [ "${NOW_EPOCH}" -lt "${END_EPOCH}" ]; then
+    echo "Certificate is in date"
+    return 0
+  fi
+
+  return 1
+}
+
+if get_cert; then
+  cert_exists="true"
+
+  if cert_matches_domain_name; then
+    domain="true"
+  fi
+
+  if cert_in_date; then
+    in_date="true"
+  fi
+fi
+
+if [ "${cert_exists}" = "true" ]; then
+  echo "cert_exists: ok"
+else
+  echo "cert_exists: error"
+fi
+
+if [ "${domain}" = "true" ]; then
+  echo "domain_name: ok"
+else
+  echo "domain_name: error"
+fi
+
+if [ "${in_date}" = "true" ]; then
+  echo "in_date: ok"
+else
+  echo "in_date: error"
+fi

--- a/components/kots-config-check/certificate/leeway.Dockerfile
+++ b/components/kots-config-check/certificate/leeway.Dockerfile
@@ -1,0 +1,9 @@
+# Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+# Licensed under the GNU Affero General Public License (AGPL).
+# See License-AGPL.txt in the project root for license information.
+
+FROM alpine/openssl
+COPY --from=bitnami/kubectl /opt/bitnami/kubectl/bin/kubectl /usr/local/bin/kubectl
+COPY entrypoint.sh /entrypoint.sh
+RUN apk add --no-cache bash
+ENTRYPOINT [ "/entrypoint.sh" ]

--- a/install/kots/manifests/kots-support-bundle.yaml
+++ b/install/kots/manifests/kots-support-bundle.yaml
@@ -7,6 +7,20 @@ metadata:
   name: gitpod
 spec:
   collectors:
+    - runPod:
+        name: certificate
+        namespace: '{{repl Namespace }}'
+        podSpec:
+          serviceAccountName: kotsadm
+          containers:
+            - name: certificate
+              image: eu.gcr.io/gitpod-core-dev/build/kots-config-check/certificate:mrsimonemms-add-kots-support-bundle-11865.7
+              args:
+                - '{{repl ConfigOption "domain" }}' # DOMAIN
+                - '{{repl Namespace }}' # NAMESPACE
+                - https-certificates # SECRET_NAME
+                - tls.crt # TLS_CRT_KEY
+                - tls.key # TLS_KEY_KEY
     - run:
         collectorName: database
         image: eu.gcr.io/gitpod-core-dev/build/kots-config-check/database:sje-kots-config-check.9
@@ -125,3 +139,34 @@ spec:
           - '{{repl LicenseFieldValue "appSlug" }}'
           - --namespace
           - '{{repl Namespace }}'
+  analyzers:
+    - textAnalyze:
+        checkName: TLS certificate exists
+        fileName: certificate/certificate.log
+        regexGroups: 'cert_exists: (?P<Valid>\w+)'
+        outcomes:
+          - pass:
+              when: "Valid == ok"
+              message: TLS certificate exists
+          - fail:
+              message: TLS certificate does not exist. If using cert-manager, please check your settings and that your domain name is pointing to the correct name server. If you are supplying your own certificate, this will need to be re-uploaded.
+    - textAnalyze:
+        checkName: TLS certificate domain name
+        fileName: certificate/certificate.log
+        regexGroups: 'domain_name: (?P<Valid>\w+)'
+        outcomes:
+          - pass:
+              when: "Valid == ok"
+              message: TLS certificate has the correct domain names
+          - fail:
+              message: TLS certificate does not have the correct domain names. It requires the DNS names `{{repl ConfigOption "domain" }}`, `*.{{repl ConfigOption "domain" }}` and `*.ws.{{repl ConfigOption "domain" }}` on the certificate.
+    - textAnalyze:
+        checkName: TLS certificate in date
+        fileName: certificate/certificate.log
+        regexGroups: 'in_date: (?P<Valid>\w+)'
+        outcomes:
+          - pass:
+              when: "Valid == ok"
+              message: TLS certificate is in date
+          - fail:
+              message: TLS certificate is not date and will need to be reissued. If using cert-manager, please check your settings and that your domain name is pointing to the correct name server. If you are supplying your own certificate, this will need to be re-uploaded.


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Add some rudimentary checks for the certificate - importantly, these are the skateboard not the finished article. These download and decode the certificate secret and perform the following checks:
1. that the secret exists and is able to be decoded as an OpenSSL x509 certificate
2. that `$DOMAIN`, `*.$DOMAIN` and `*.ws.$DOMAIN` exist in the secret (the subject alternate names seems to be non-standard, so this is a simple `grep`)
3. that the current timestamp is between the `notBefore` and `notAfter` timestamps

**NB** it does **NOT** validate that the certificate's CA is known and installed in the cluster. That's important but it's beyond the 🛹 

As with the other KOTS checks, these are perhaps a little rudimentary but they give an indication of whether the provided state is Gitpod-compatible. As there's a time-based test, it is plausible (however unlikely) that this could fail 5 minutes later if the cert expiry then occurs - again, this can be tweaked as a 🚲 

**IMPORTANT** this is not provided as a pre-flight check. As the majority of our users will be using LetsEncrypt and cert-manager to generate their certs, these are not triggered until _AFTER_ the first deployment. This would mean that the pre-flight checks are likely to fail. Instead, this is part of the troubleshooting to provide answers if the installation is not working.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #11865

## How to test
<!-- Provide steps to test this PR -->
> Example support bundle - [file](https://vendor.replicated.com/troubleshoot/analyze/2022-09-30@11:18/contents/support-bundle-2022-09-30T11_15_35/certificate/certificate.log) and [analyzer](https://vendor.replicated.com/troubleshoot/analyze/2022-09-30@11:18)
 
Install via KOTS and go to "troubleshoot" to build a support bundle. This has been checked with both a LetsEncrypt and a self-signed cert built in-cluster. I do not have a valid, publicly-signed cert that's not provided by LetsEncrypt.

To check the edge-cases that KOTS smooths away for us, you can run the script in the image directly

```bash
docker run -it --rm \
  -v "${HOME}/.kube:/root/.kube" \
  eu.gcr.io/gitpod-core-dev/build/kots-config-check/certificate:mrsimonemms-add-kots-support-bundle-11865.1 \
  <domain> \
  gitpod \
  https-certificates
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[certificates]: validate that certs are valid for a Gitpod install
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
