### PR TITLE
Minor cleanup for blobserver response headers

### DIFF
--- a/components/ide-proxy/conf/Caddyfile
+++ b/components/ide-proxy/conf/Caddyfile
@@ -34,13 +34,13 @@
 		header {
 			Access-Control-Allow-Origin *
 			Access-Control-Allow-Methods "GET, OPTIONS"
+			Cross-Origin-Resource-Policy cross-origin
+			Vary Origin
 		}
 
 		reverse_proxy blobserve.{$KUBE_NAMESPACE}.{$KUBE_DOMAIN}:4000 {
 			import upstream_headers
 			import upstream_connection
-
-			flush_interval -1
 		}
 	}
 

--- a/components/ws-proxy/pkg/proxy/routes.go
+++ b/components/ws-proxy/pkg/proxy/routes.go
@@ -323,13 +323,7 @@ const imagePathSeparator = "/__files__"
 // installBlobserveRoutes  implements long-lived caching with versioned URLs, see https://web.dev/http-cache/#versioned-urls
 func installBlobserveRoutes(r *mux.Router, config *RouteHandlerConfig, infoProvider WorkspaceInfoProvider) {
 	r.Use(logHandler)
-	r.Use(handlers.CompressHandler)
 	r.Use(logRouteHandlerHandler("BlobserveRootHandler"))
-	r.Use(handlers.CORS(
-		// CORS headers are stored in the browser cache, we cannot be specific here to allow reuse between workspaces
-		handlers.AllowedOrigins([]string{"*"}),
-		handlers.AllowedMethods([]string{"GET", "OPTIONS"}),
-	))
 
 	targetResolver := func(cfg *Config, infoProvider WorkspaceInfoProvider, req *http.Request) (tgt *url.URL, err error) {
 		segments := strings.SplitN(req.URL.Path, imagePathSeparator, 2)

--- a/components/ws-proxy/pkg/proxy/routes_test.go
+++ b/components/ws-proxy/pkg/proxy/routes_test.go
@@ -347,7 +347,6 @@ func TestRoutes(t *testing.T) {
 					"Cache-Control":  {"public, max-age=31536000"},
 					"Content-Length": {"54"},
 					"Content-Type":   {"text/plain; charset=utf-8"},
-					"Vary":           {"Accept-Encoding"},
 				},
 				Body: "blobserve hit: /image/test.html\nhost: localhost:20003\n",
 			},


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Minor cleanup for blobserver response headers

## How to test
1. Open a workspace and check vscode webview work, e.g. vscode ports view

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
