### PR TITLE
[migrations] Delete Probe workspaces from DB

### DIFF
--- a/components/gitpod-db/src/typeorm/migration/1664524890935-DeleteProbeWorkspacesAndInstances.ts
+++ b/components/gitpod-db/src/typeorm/migration/1664524890935-DeleteProbeWorkspacesAndInstances.ts
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class DeleteProbeWorkspacesAndInstances1664524890935 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        // first we delete workspace instances
+        await queryRunner.query(
+            `DELETE FROM d_b_workspace_instance WHERE workspaceId IN (SELECT id AS workspaceId FROM d_b_workspace WHERE type = 'probe')`,
+        );
+
+        // second we delete workspaces
+        await queryRunner.query(`DELETE FROM d_b_workspace WHERE type = 'probe'`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {}
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Delete Probe workspaces from the DB

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Part of https://github.com/gitpod-io/gitpod/issues/11315

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
