### PR TITLE
[kots-ui] fix broken link to Customization docs

### DIFF
--- a/install/kots/manifests/kots-config.yaml
+++ b/install/kots/manifests/kots-config.yaml
@@ -399,7 +399,7 @@ spec:
           when: '{{repl ConfigOptionEquals "advanced_mode_enabled" "1" }}'
           help_text: |
             A file configured to override annotations, labels and environment variables in components. See our
-            [advanced documentation](https://www.gitpod.io/docs/self-hosted/latest/advanced/customization) for
+            [advanced documentation](https://www.gitpod.io/docs/configure/self-hosted/latest/advanced/customization) for
             more details and the format.
 
         - name: config_patch


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This is a tiny PR that fixes a broken link in KOTS UI. This link leads to the Customization doc page.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
