### PR TITLE
[installer] Support enabling protected secrets

### DIFF
--- a/install/installer/pkg/components/server/configmap.go
+++ b/install/installer/pkg/components/server/configmap.go
@@ -163,6 +163,14 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		return nil
 	})
 
+	defaultFeatureFlags := []NamedWorkspaceFeatureFlag{}
+	_ = ctx.WithExperimental(func(cfg *experimental.Config) error {
+		if cfg.Workspace != nil && cfg.Workspace.EnableProtectedSecrets {
+			defaultFeatureFlags = append(defaultFeatureFlags, NamedWorkspaceFeatureProtectedSecrets)
+		}
+		return nil
+	})
+
 	// todo(sje): all these values are configurable
 	scfg := ConfigSerialized{
 		Version:               ctx.VersionManifest.Version,
@@ -176,7 +184,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		WorkspaceDefaults: WorkspaceDefaults{
 			WorkspaceImage:      workspaceImage,
 			PreviewFeatureFlags: []NamedWorkspaceFeatureFlag{},
-			DefaultFeatureFlags: []NamedWorkspaceFeatureFlag{},
+			DefaultFeatureFlags: defaultFeatureFlags,
 			TimeoutDefault:      ctx.Config.Workspace.TimeoutDefault,
 			TimeoutExtended:     ctx.Config.Workspace.TimeoutExtended,
 		},

--- a/install/installer/pkg/components/server/types.go
+++ b/install/installer/pkg/components/server/types.go
@@ -148,6 +148,7 @@ type NamedWorkspaceFeatureFlag string
 
 const (
 	NamedWorkspaceFeatureFlagFullWorkspaceBackup NamedWorkspaceFeatureFlag = "full_workspace_backup"
+	NamedWorkspaceFeatureProtectedSecrets        NamedWorkspaceFeatureFlag = "protected_secrets"
 )
 
 type WorkspaceClassCategory string

--- a/install/installer/pkg/config/v1/experimental/experimental.go
+++ b/install/installer/pkg/config/v1/experimental/experimental.go
@@ -119,6 +119,8 @@ type WorkspaceConfig struct {
 		// Deprecated
 		UsageReportBucketName string `json:"usageReportBucketName"`
 	} `json:"contentService"`
+
+	EnableProtectedSecrets bool `json:"enableProtectedSecrets"`
 }
 
 type PersistentVolumeClaim struct {


### PR DESCRIPTION
## Description
Adds support for enabling protected secrets in the installer.


## How to test
Run the installer with the following config:
```YAML
experimental:
  workspace:
    enableProtectedSecrets: true
```

and observe how the server configmap now contains a new default feature flag.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Add experimental support for protected secrets
```
