### PR TITLE
[single-cluster/aws] Install Calico as the CNI

### DIFF
--- a/.werft/installer-tests.ts
+++ b/.werft/installer-tests.ts
@@ -99,6 +99,7 @@ const TEST_CONFIGURATIONS: { [name: string]: TestConfig } = {
         DESCRIPTION: `${op} an EKS cluster(version ${k8s_version})`,
         PHASES: [
             "STANDARD_EKS_CLUSTER",
+            "CALICO",
             "CERT_MANAGER",
             "EXTERNALDNS",
             "CLUSTER_ISSUER",
@@ -167,6 +168,11 @@ const INFRA_PHASES: { [name: string]: InfraConfig } = {
         phase: "external-dns",
         makeTarget: "external-dns",
         description: `Deploys external-dns with ${cloud} provider`,
+    },
+    CALICO: {
+        phase: "calico",
+        makeTarget: "calico",
+        description: `Deploys Calico`,
     },
     ADD_NS_RECORD: {
         phase: "add-ns-record",

--- a/install/infra/modules/eks/kubernetes.tf
+++ b/install/infra/modules/eks/kubernetes.tf
@@ -88,6 +88,10 @@ module "eks" {
     coredns = {
       resolve_conflicts = "OVERWRITE"
     }
+    vpc-cni = {
+      resolve_conflicts        = "OVERWRITE"
+      service_account_role_arn = module.vpc_cni_irsa.iam_role_arn
+    }
     kube-proxy = {}
   }
 
@@ -112,133 +116,6 @@ module "eks" {
       service containerd restart
       EOT
   }
-
-  eks_managed_node_groups = {
-    Services = {
-      enable_bootstrap_user_data = true
-      instance_types             = [var.service_machine_type]
-      name                       = "service-${var.cluster_name}"
-      iam_role_name              = format("%s-%s", substr("${var.cluster_name}-svc-ng", 0, 58), random_string.ng_role_suffix.result)
-      subnet_ids                 = module.vpc.public_subnets
-      min_size                   = 1
-      max_size                   = 4
-      desired_size               = 2
-      block_device_mappings = [{
-        device_name = "/dev/sda1"
-
-        ebs = [{
-          volume_size           = 300
-          volume_type           = "gp3"
-          throughput            = 500
-          iops                  = 6000
-          delete_on_termination = true
-        }]
-      }]
-      labels = {
-        "gitpod.io/workload_meta"               = true
-        "gitpod.io/workload_ide"                = true
-        "gitpod.io/workload_workspace_services" = true
-      }
-
-      tags = {
-        "k8s.io/cluster-autoscaler/enabled" = true
-        "k8s.io/cluster-autoscaler/gitpod"  = "owned"
-      }
-
-      pre_bootstrap_user_data = <<-EOT
-        #!/bin/bash
-        set -ex
-        cat <<-EOF > /etc/profile.d/bootstrap.sh
-        export CONTAINER_RUNTIME="containerd"
-        export USE_MAX_PODS=false
-        EOF
-        # Source extra environment variables in bootstrap script
-        sed -i '/^set -o errexit/a\\nsource /etc/profile.d/bootstrap.sh' /etc/eks/bootstrap.sh
-        EOT
-    }
-
-    RegularWorkspaces = {
-      instance_types = [var.workspace_machine_type]
-      name           = "ws-regular-${var.cluster_name}"
-      iam_role_name  = format("%s-%s", substr("${var.cluster_name}-regular-ws-ng", 0, 58), random_string.ng_role_suffix.result)
-      subnet_ids     = module.vpc.public_subnets
-      min_size       = 1
-      max_size       = 50
-      block_device_mappings = [{
-        device_name = "/dev/sda1"
-
-        ebs = [{
-          volume_size           = 512
-          volume_type           = "gp3"
-          throughput            = 500
-          iops                  = 6000
-          delete_on_termination = true
-        }]
-      }]
-      desired_size               = 2
-      enable_bootstrap_user_data = true
-      labels = {
-        "gitpod.io/workload_workspace_regular" = true
-      }
-
-      tags = {
-        "k8s.io/cluster-autoscaler/enabled" = true
-        "k8s.io/cluster-autoscaler/gitpod"  = "owned"
-      }
-
-      pre_bootstrap_user_data = <<-EOT
-        #!/bin/bash
-        set -ex
-        cat <<-EOF > /etc/profile.d/bootstrap.sh
-        export CONTAINER_RUNTIME="containerd"
-        export USE_MAX_PODS=false
-        EOF
-        # Source extra environment variables in bootstrap script
-        sed -i '/^set -o errexit/a\\nsource /etc/profile.d/bootstrap.sh' /etc/eks/bootstrap.sh
-        EOT
-    }
-
-    HeadlessWorkspaces = {
-      instance_types = [var.workspace_machine_type]
-      name           = "ws-headless-${var.cluster_name}"
-      iam_role_name  = format("%s-%s", substr("${var.cluster_name}-headless-ws-ng", 0, 58), random_string.ng_role_suffix.result)
-      subnet_ids     = module.vpc.public_subnets
-      min_size       = 1
-      max_size       = 50
-      block_device_mappings = [{
-        device_name = "/dev/sda1"
-
-        ebs = [{
-          volume_size           = 512
-          volume_type           = "gp3"
-          throughput            = 500
-          iops                  = 6000
-          delete_on_termination = true
-        }]
-      }]
-      desired_size               = 2
-      enable_bootstrap_user_data = true
-      labels = {
-        "gitpod.io/workload_workspace_headless" = true
-      }
-
-      tags = {
-        "k8s.io/cluster-autoscaler/enabled" = true
-        "k8s.io/cluster-autoscaler/gitpod"  = "owned"
-      }
-
-      pre_bootstrap_user_data = <<-EOT
-        #!/bin/bash
-        set -ex
-        cat <<-EOF > /etc/profile.d/bootstrap.sh
-        export CONTAINER_RUNTIME="containerd"
-        export USE_MAX_PODS=false
-        EOF
-        # Source extra environment variables in bootstrap script
-        sed -i '/^set -o errexit/a\\nsource /etc/profile.d/bootstrap.sh' /etc/eks/bootstrap.sh
-        EOT
-    }
-  }
 }
 
 resource "null_resource" "kubeconfig" {
@@ -249,6 +126,79 @@ resource "null_resource" "kubeconfig" {
 
   lifecycle {
     create_before_destroy = true
+  }
+}
+
+// Install Calico Here
+
+module "service-nodes" {
+  depends_on = [module.eks]
+
+  source  = "terraform-aws-modules/eks/aws//modules/eks-managed-node-group"
+  version = "18.30.0"
+
+  cluster_name        = var.cluster_name
+  cluster_version     = var.cluster_version
+  cluster_endpoint    = module.eks.cluster_endpoint
+  cluster_auth_base64 = module.eks.cluster_certificate_authority_data
+
+  enable_bootstrap_user_data = true
+  instance_types             = [var.service_machine_type]
+  name                       = "service-${var.cluster_name}"
+  create_iam_role            = false
+  iam_role_arn               = module.vpc_cni_irsa.iam_role_arn
+  iam_role_name              = format("%s-%s", substr("${var.cluster_name}-svc-ng", 0, 58), random_string.ng_role_suffix.result)
+  subnet_ids                 = module.vpc.public_subnets
+  min_size                   = 1
+  max_size                   = 4
+  desired_size               = 2
+  block_device_mappings = [{
+    device_name = "/dev/sda1"
+
+    ebs = [{
+      volume_size           = 300
+      volume_type           = "gp3"
+      throughput            = 500
+      iops                  = 6000
+      delete_on_termination = true
+    }]
+  }]
+  labels = {
+    "gitpod.io/workload_meta"               = true
+    "gitpod.io/workload_ide"                = true
+    "gitpod.io/workload_workspace_services" = true
+  }
+
+  tags = {
+    "k8s.io/cluster-autoscaler/enabled" = true
+    "k8s.io/cluster-autoscaler/gitpod"  = "owned"
+  }
+
+  pre_bootstrap_user_data = <<-EOT
+        #!/bin/bash
+        set -ex
+        cat <<-EOF > /etc/profile.d/bootstrap.sh
+        export CONTAINER_RUNTIME="containerd"
+        export USE_MAX_PODS=false
+        EOF
+        # Source extra environment variables in bootstrap script
+        sed -i '/^set -o errexit/a\\nsource /etc/profile.d/bootstrap.sh' /etc/eks/bootstrap.sh
+        EOT
+}
+
+module "vpc_cni_irsa" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  version = "~> 4.12"
+
+  role_name_prefix      = "VPC-CNI-IRSA"
+  attach_vpc_cni_policy = true
+  vpc_cni_enable_ipv4   = true
+
+  oidc_providers = {
+    main = {
+      provider_arn               = module.eks.oidc_provider_arn
+      namespace_service_accounts = ["kube-system:aws-node"]
+    }
   }
 }
 

--- a/install/infra/modules/eks/kubernetes.tf
+++ b/install/infra/modules/eks/kubernetes.tf
@@ -89,10 +89,6 @@ module "eks" {
       resolve_conflicts = "OVERWRITE"
     }
     kube-proxy = {}
-    vpc-cni = {
-      resolve_conflicts        = "OVERWRITE"
-      service_account_role_arn = module.vpc_cni_irsa.iam_role_arn
-    }
   }
 
   eks_managed_node_group_defaults = {
@@ -241,22 +237,6 @@ module "eks" {
         # Source extra environment variables in bootstrap script
         sed -i '/^set -o errexit/a\\nsource /etc/profile.d/bootstrap.sh' /etc/eks/bootstrap.sh
         EOT
-    }
-  }
-}
-
-module "vpc_cni_irsa" {
-  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "~> 4.12"
-
-  role_name_prefix      = "VPC-CNI-IRSA"
-  attach_vpc_cni_policy = true
-  vpc_cni_enable_ipv4   = true
-
-  oidc_providers = {
-    main = {
-      provider_arn               = module.eks.oidc_provider_arn
-      namespace_service_accounts = ["kube-system:aws-node"]
     }
   }
 }

--- a/install/infra/modules/eks/local.tf
+++ b/install/infra/modules/eks/local.tf
@@ -1,6 +1,6 @@
- locals {
-   aws_cert_manager_enabled = local.domain_name_enabled && var.use_aws_cert_manager == true
-   aws_cert_manager_count   = local.aws_cert_manager_enabled ? 1 : 0
-   domain_name_enabled      = var.domain_name != ""
-   domain_name_count        = local.domain_name_enabled ? 1 : 0
- }
+locals {
+  aws_cert_manager_enabled = local.domain_name_enabled && var.use_aws_cert_manager == true
+  aws_cert_manager_count   = local.aws_cert_manager_enabled ? 1 : 0
+  domain_name_enabled      = var.domain_name != ""
+  domain_name_count        = local.domain_name_enabled ? 1 : 0
+}

--- a/install/infra/modules/eks/providers.tf
+++ b/install/infra/modules/eks/providers.tf
@@ -1,8 +1,8 @@
 terraform {
   required_providers {
     aws = {
-        version = " ~> 3.0"
-        source = "registry.terraform.io/hashicorp/aws"
+      version = " ~> 3.0"
+      source  = "registry.terraform.io/hashicorp/aws"
     }
     helm = {
       source  = "hashicorp/helm"
@@ -12,5 +12,5 @@ terraform {
 }
 
 provider "aws" {
-  region  = var.region
+  region = var.region
 }

--- a/install/infra/modules/eks/variables.tf
+++ b/install/infra/modules/eks/variables.tf
@@ -43,7 +43,7 @@ variable "vpc_availability_zones" {
 }
 
 variable "domain_name" {
-  default = ""
+  default     = ""
   description = "Domain name to associate with the route53 zone"
 }
 

--- a/install/infra/modules/tools/aws-calico/main.tf
+++ b/install/infra/modules/tools/aws-calico/main.tf
@@ -1,0 +1,19 @@
+variable "kubeconfig" {
+  description = "Path to the KUBECONFIG file to connect to the cluster"
+  default     = "./kubeconfig"
+}
+
+provider "helm" {
+  kubernetes {
+    config_path = var.kubeconfig
+  }
+}
+
+resource "helm_release" "calico" {
+  name             = "tigera-operator"
+  repository       = "https://projectcalico.docs.tigera.io/charts"
+  chart            = "tigera-operator"
+  namespace        = "tigera-operator"
+  version          = "v3.24.1"
+  create_namespace = true
+}

--- a/install/infra/modules/tools/azure-external-dns/main.tf
+++ b/install/infra/modules/tools/azure-external-dns/main.tf
@@ -1,7 +1,7 @@
-variable settings {}
-variable domain_name { default = "test"}
-variable kubeconfig { default = "conf"}
-variable txt_owner_id { default = "nightly-test"}
+variable "settings" {}
+variable "domain_name" { default = "test" }
+variable "kubeconfig" { default = "conf" }
+variable "txt_owner_id" { default = "nightly-test" }
 
 provider "helm" {
   kubernetes {

--- a/install/infra/single-cluster/aws/Makefile
+++ b/install/infra/single-cluster/aws/Makefile
@@ -26,11 +26,15 @@ plan-cluster:
 	@terraform plan -target=module.eks
 
 .PHONY: plan-tools
-plan-tools: plan-cm-edns plan-cluster-issuer plan-cluster-autoscaler
+plan-tools: plan-calico plan-cm-edns plan-cluster-issuer plan-cluster-autoscaler
 
 .PHONY: plan-cluster-autoscaler
 plan-cluster-autoscaler:
 	@terraform plan -target=module.cluster-autoscaler
+
+.PHONY: plan-calico
+plan-calico:
+	@terraform plan -target=module.calico
 
 .PHONY: plan-cm-edns
 plan-cm-edns:
@@ -45,7 +49,11 @@ apply-cluster:
 	@terraform apply -target=module.eks --auto-approve
 
 .PHONY: apply-tools
-apply-tools: install-cm-edns install-cluster-issuer install-cluster-autoscaler
+apply-tools: install-calico install-cm-edns install-cluster-issuer install-cluster-autoscaler
+
+.PHONY: install-calico
+install-calico:
+	@terraform apply -target=module.calico --auto-approve
 
 .PHONY: install-cluster-autoscaler
 install-cluster-autoscaler:
@@ -64,7 +72,11 @@ destroy-cluster:
 	@terraform destroy -target=module.eks --auto-approve
 
 .PHONY: destroy-tools
-destroy-tools: destroy-cluster-issuer destroy-cm-edns destroy-cluster-autoscaler
+destroy-tools: destroy-calico destroy-cluster-issuer destroy-cm-edns destroy-cluster-autoscaler
+
+.PHONY: destroy-calico
+destroy-calico:
+	@terraform destroy -target=module.calico --auto-approve
 
 .PHONY: destroy-cluster-autoscaler
 destroy-cluster-autoscaler:

--- a/install/infra/single-cluster/aws/output.tf
+++ b/install/infra/single-cluster/aws/output.tf
@@ -3,7 +3,7 @@ output "url" {
 }
 
 output "cluster_name" {
-  value     = var.cluster_name
+  value = var.cluster_name
 }
 
 output "registry_backend" {

--- a/install/infra/single-cluster/aws/tools.tf
+++ b/install/infra/single-cluster/aws/tools.tf
@@ -29,3 +29,8 @@ module "cluster-autoscaler" {
   cluster_id        = module.eks.cluster_id
   oidc_provider_arn = module.eks.oidc_provider_arn
 }
+
+module "calico" {
+  source     = "../../modules/tools/aws-calico"
+  kubeconfig = var.kubeconfig
+}

--- a/install/tests/Makefile
+++ b/install/tests/Makefile
@@ -180,9 +180,15 @@ k3s-standard-cluster: check-env-cluster-version
 	@echo "Done creating k3s cluster"
 
 .PHONY:
-## cert-manager: Installs cert-manager, optionally create secret for cloud-dns access
-cert-manager:
+## calico: Installs calico
+calico:
 	$(MAKE) select-workspace && \
+	terraform apply -target=module.aws-calico -var kubeconfig=${KUBECONFIG} --auto-approve
+	@echo "Done installing Calico"
+
+.PHONY:
+## cert-manager: Installs cert-manager, optionally create secret for cloud-dns access
+cert-manager: check-env-cloud select-workspace
 	terraform apply -target=module.certmanager -var kubeconfig=${KUBECONFIG} --auto-approve
 	@echo "Done installing cert-manager"
 

--- a/install/tests/main.tf
+++ b/install/tests/main.tf
@@ -13,7 +13,7 @@ variable "project" { default = "sh-automated-tests" }
 variable "sa_creds" { default = null }
 variable "dns_sa_creds" { default = null }
 
-data local_file "dns_credentials" {
+data "local_file" "dns_credentials" {
   filename = var.dns_sa_creds
 }
 
@@ -62,10 +62,10 @@ module "k3s" {
 }
 
 module "gcp-issuer" {
-  source      = "../infra/modules/tools/issuer"
-  kubeconfig  = var.kubeconfig
+  source          = "../infra/modules/tools/issuer"
+  kubeconfig      = var.kubeconfig
   gcp_credentials = data.local_file.dns_credentials.content
-  issuer_name = "cloudDNS"
+  issuer_name     = "cloudDNS"
   cert_manager_issuer = {
     project = "dns-for-playgrounds"
     serviceAccountSecretRef = {
@@ -91,14 +91,14 @@ module "aks" {
 }
 
 module "eks" {
-  source                 = "../infra/modules/eks"
-  domain_name            = "${var.TEST_ID}.${var.domain}"
-  cluster_name           = var.TEST_ID
-  region                 = "eu-west-1"
-  vpc_availability_zones = ["eu-west-1c", "eu-west-1b"]
-  image_id               = var.eks_node_image_id
-  kubeconfig             = var.kubeconfig
-  cluster_version        = var.cluster_version
+  source                   = "../infra/modules/eks"
+  domain_name              = "${var.TEST_ID}.${var.domain}"
+  cluster_name             = var.TEST_ID
+  region                   = "eu-west-1"
+  vpc_availability_zones   = ["eu-west-1c", "eu-west-1b"]
+  image_id                 = var.eks_node_image_id
+  kubeconfig               = var.kubeconfig
+  cluster_version          = var.cluster_version
   create_external_registry = true
   create_external_database = true
   create_external_storage  = true
@@ -110,7 +110,7 @@ module "certmanager" {
   # source = "github.com/gitpod-io/gitpod//install/infra/terraform/tools/cert-manager?ref=main"
   source = "../infra/modules/tools/cert-manager"
 
-  kubeconfig  = var.kubeconfig
+  kubeconfig = var.kubeconfig
 }
 
 module "clouddns-externaldns" {
@@ -159,6 +159,11 @@ module "azure-add-dns-record" {
   dns_project      = "dns-for-playgrounds"
   managed_dns_zone = var.gcp_zone
   domain_name      = "${var.TEST_ID}.${var.domain}"
+}
+
+module "aws-calico" {
+  source     = "../infra/modules/tools/aws-calico"
+  kubeconfig = var.kubeconfig
 }
 
 module "aws-add-dns-record" {


### PR DESCRIPTION


## Description
<!-- Describe your changes in detail -->


This PR updates the EKS single cluster reference guides to install calico as the CNI. This is important for the network policies to work.

For GKE and AKS, There are already options to do the same which we use already instead of doing it manually.

Signed-off-by: Tarun Pothulapati <tarun@gitpod.io>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/12953

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[single-cluster/aws] Install Calico as the CNI
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
