### PR TITLE
[supervisor] shutdown processes gracefully

### DIFF
--- a/components/common-go/process/process.go
+++ b/components/common-go/process/process.go
@@ -4,6 +4,14 @@
 
 package process
 
+import (
+	"context"
+	"errors"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
 // IsNotChildProcess checks if an error returned by a command
 // execution is an error related to no child processes running
 // This can be seen, for instance, in short lived commands.
@@ -13,4 +21,37 @@ func IsNotChildProcess(err error) bool {
 	}
 
 	return (err.Error() == "wait: no child processes" || err.Error() == "waitid: no child processes")
+}
+
+var ErrForceKilled = errors.New("Process didn't terminate, so we sent SIGKILL")
+
+// TerminateSync sends a SIGTERM to the given process and returns when the process has terminated or when the context was cancelled.
+// When the context is cancelled this function sends a SIGKILL to the process and return immediately with ErrForceKilled.
+func TerminateSync(ctx context.Context, pid int) error {
+	process, err := os.FindProcess(pid)
+	if err != nil { // never happens on UNIX
+		return err
+	}
+	err = process.Signal(unix.SIGTERM)
+	if err != nil {
+		if err == os.ErrProcessDone {
+			return nil
+		}
+		return err
+	}
+	terminated := make(chan error, 1)
+	go func() {
+		_, err := process.Wait()
+		terminated <- err
+	}()
+	select {
+	case err := <-terminated:
+		return err
+	case <-ctx.Done():
+		err = process.Kill()
+		if err != nil {
+			return err
+		}
+		return ErrForceKilled
+	}
 }

--- a/components/common-go/process/process_test.go
+++ b/components/common-go/process/process_test.go
@@ -1,0 +1,91 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package process
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+)
+
+func TestTerminateSync(t *testing.T) {
+	cmd := exec.Command("/bin/sleep", "20")
+	require.NoError(t, cmd.Start())
+	require.NotNil(t, cmd.Process)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+	err := TerminateSync(ctx, cmd.Process.Pid)
+	require.NoError(t, err)
+	require.Equal(t, os.ErrProcessDone, cmd.Process.Signal(unix.SIGHUP))
+}
+
+func TestTerminateSync_ignoring_process(t *testing.T) {
+
+	tests := []struct {
+		processTimeSeconds int
+		gracePeriod        time.Duration
+		fileExists         bool
+	}{
+		{
+			processTimeSeconds: 1,
+			gracePeriod:        7 * time.Second,
+			fileExists:         true,
+		},
+		{
+			processTimeSeconds: 7,
+			gracePeriod:        time.Second,
+			fileExists:         false,
+		},
+		{
+			processTimeSeconds: 0,
+			gracePeriod:        5 * time.Second,
+			fileExists:         true,
+		},
+	}
+	for _, test := range tests {
+		dir, err := ioutil.TempDir("", "terminal_test_close")
+		require.NoError(t, err)
+		expectedFile := dir + "/done.txt"
+		script := dir + "/script.sh"
+		err = ioutil.WriteFile(script, []byte(fmt.Sprintf(`#!/bin/bash
+		trap 'echo \"Be patient\"' SIGTERM SIGINT SIGHUP
+		for ((n= %d ; n; n--))
+		do
+		   sleep 1
+		done
+		echo touching
+		touch %s
+		echo touched
+		`, test.processTimeSeconds, expectedFile)), 0644)
+		require.NoError(t, err)
+
+		cmd := exec.Command("/bin/bash", script)
+
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		require.NoError(t, cmd.Start())
+		require.NotNil(t, cmd.Process)
+		time.Sleep(100 * time.Millisecond)
+		require.NotEqual(t, os.ErrProcessDone, cmd.Process.Signal(syscall.Signal(0)))
+		ctx, cancel := context.WithTimeout(context.Background(), test.gracePeriod)
+		defer cancel()
+		err = TerminateSync(ctx, cmd.Process.Pid)
+		if test.fileExists {
+			require.NoError(t, err)
+			require.FileExists(t, expectedFile)
+		} else {
+			require.Equal(t, ErrForceKilled, err)
+			require.NoFileExists(t, expectedFile)
+		}
+	}
+}

--- a/components/supervisor/go.mod
+++ b/components/supervisor/go.mod
@@ -82,6 +82,7 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/ramr/go-reaper v0.2.1 // indirect
 	github.com/rs/cors v1.8.2 // indirect
 	github.com/rs/xid v1.2.1 // indirect
 	github.com/segmentio/backo-go v0.0.0-20200129164019-23eae7c10bd3 // indirect

--- a/components/supervisor/go.sum
+++ b/components/supervisor/go.sum
@@ -382,6 +382,8 @@ github.com/prometheus/procfs v0.8.0 h1:ODq8ZFEaYeCaZOJlZZdJA2AbQR98dSHSM1KW/You5
 github.com/prometheus/procfs v0.8.0/go.mod h1:z7EfXMXOkbkqb9IINtpCn86r/to3BnA0uaxHdg830/4=
 github.com/prometheus/pushgateway v1.4.3 h1:8CpqPzTERYPSp29cUUvqp35MH7LX5EJ+S+k1Tqq/aP0=
 github.com/prometheus/pushgateway v1.4.3/go.mod h1:7Pl8nVWIfsjU81qLIWrmqFzHO22ZJyA77ZOD5K33390=
+github.com/ramr/go-reaper v0.2.1 h1:zww+wlQOvTjBZuk1920R/e0GFEb6O7+B0WQLV6dM924=
+github.com/ramr/go-reaper v0.2.1/go.mod h1:AVypdzrcCXjSc/JYnlXl8TsB+z84WyFzxWE8Jh0MOJc=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rs/cors v1.8.2 h1:KCooALfAYGs415Cwu5ABvv9n9509fSiG5SQJn/AQo4U=

--- a/components/supervisor/pkg/supervisor/config.go
+++ b/components/supervisor/pkg/supervisor/config.go
@@ -279,6 +279,9 @@ type WorkspaceConfig struct {
 	//
 	// The format of the content downloaded from this URL is expected to be JSON in the form of [{"name":"name", "value":"value"}]
 	EnvvarOTS string `env:"SUPERVISOR_ENVVAR_OTS"`
+
+	// TerminationGracePeriodSeconds is the max number of seconds the workspace can take to shut down all its processes after SIGTERM was sent.
+	TerminationGracePeriodSeconds *int `env:"GITPOD_TERMINATION_GRACE_PERIOD_SECONDS"`
 }
 
 // WorkspaceGitpodToken is a list of tokens that should be added to supervisor's token service.
@@ -408,6 +411,14 @@ func (c WorkspaceConfig) getCommit() (commit *gitpod.Commit, err error) {
 		return nil, xerrors.Errorf("cannot parse workspace context as a commit: %w", err)
 	}
 	return
+}
+
+func (c WorkspaceConfig) GetTerminationGracePeriod() time.Duration {
+	defaultGracePeriod := 15 * time.Second
+	if c.TerminationGracePeriodSeconds == nil || *c.TerminationGracePeriodSeconds <= 0 {
+		return defaultGracePeriod
+	}
+	return time.Duration(*c.TerminationGracePeriodSeconds) * time.Second
 }
 
 // GetConfig loads the supervisor configuration.

--- a/components/supervisor/pkg/terminal/service.go
+++ b/components/supervisor/pkg/terminal/service.go
@@ -25,12 +25,6 @@ import (
 	"github.com/gitpod-io/gitpod/supervisor/api"
 )
 
-const (
-	// closeTerminaldefaultGracePeriod is the time terminal
-	// processes get between SIGTERM and SIGKILL.
-	closeTerminaldefaultGracePeriod = 10 * time.Second
-)
-
 // NewMuxTerminalService creates a new terminal service.
 func NewMuxTerminalService(m *Mux) *MuxTerminalService {
 	shell := os.Getenv("SHELL")
@@ -139,7 +133,7 @@ func (srv *MuxTerminalService) OpenWithOptions(ctx context.Context, req *api.Ope
 
 // Close closes a terminal for the given alias.
 func (srv *MuxTerminalService) Shutdown(ctx context.Context, req *api.ShutdownTerminalRequest) (*api.ShutdownTerminalResponse, error) {
-	err := srv.Mux.CloseTerminal(req.Alias, closeTerminaldefaultGracePeriod)
+	err := srv.Mux.CloseTerminal(ctx, req.Alias)
 	if err == ErrNotFound {
 		return nil, status.Error(codes.NotFound, err.Error())
 	}

--- a/components/supervisor/pkg/terminal/terminal_test.go
+++ b/components/supervisor/pkg/terminal/terminal_test.go
@@ -48,7 +48,7 @@ func TestTitle(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.Desc, func(t *testing.T) {
 			mux := NewMux()
-			defer mux.Close()
+			defer mux.Close(context.Background())
 
 			tmpWorkdir, err := os.MkdirTemp("", "workdirectory")
 			if err != nil {
@@ -187,7 +187,7 @@ func TestAnnotations(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.Desc, func(t *testing.T) {
 			mux := NewMux()
-			defer mux.Close()
+			defer mux.Close(context.Background())
 
 			terminalService := NewMuxTerminalService(mux)
 			var err error
@@ -315,7 +315,7 @@ func TestConcurrent(t *testing.T) {
 
 func TestWorkDirProvider(t *testing.T) {
 	mux := NewMux()
-	defer mux.Close()
+	defer mux.Close(context.Background())
 
 	terminalService := NewMuxTerminalService(mux)
 


### PR DESCRIPTION
## Description
Changes the shutdown logic so that on SIGTERM or SIGINT on the `supervisor init` process we are sending SIGTERM to `supervisor` which in turn sends SIGTERM on all its terminal processes.
When supervisor finished we iterate over all of `init`'s child processes until the grace period is up.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #13365

## How to test
## How to test
Start a workspace https://se-supervi88c18dbe3b.preview.gitpod-dev.com/#https://github.com/svenefftinge/termination-test

Run 
```
./ignoresigterm > out_disown.txt &
disown $1
./ignoresigterm > out_bg.txt &
./ignoresigterm > out.txt
```
and stop the workspace.
With this preview environment you should see log output like below in all three files
```
awaiting signal

Received signal
terminated

Ignored for 0 seconds.
Ignored for 1 seconds.
Ignored for 2 seconds.
Ignored for 3 seconds.
Ignored for 4 seconds.
Ignored for 5 seconds.
Ignored for 6 seconds.
Ignored for 7 seconds.
Ignored for 8 seconds.
Ignored for 9 seconds.
Ignored for 10 seconds.
Ignored for 11 seconds.
Ignored for 12 seconds.
Ignored for 13 seconds.
Ignored for 14 seconds.
Ignored for 15 seconds.
...
```

With gitpod.io you will see only (i.e. the processes never received SIGINT):
```
awaiting signal
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
All running processes receive a SIGTERM when a workspace shuts down.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
