### PR TITLE
Show feedback form for more errors

### DIFF
--- a/components/dashboard/src/feedback-form/FeedbackComponent.tsx
+++ b/components/dashboard/src/feedback-form/FeedbackComponent.tsx
@@ -81,7 +81,7 @@ function FeedbackComponent(props: {
                 <div
                     className={
                         "flex flex-col justify-center px-6 py-4 border-gray-200 dark:border-gray-800 " +
-                        (props.isError ? "mt-20 bg-gray-100 dark:bg-gray-800 rounded-xl" : "border-t")
+                        (props.isError ? "mt-14 bg-gray-100 dark:bg-gray-800 rounded-xl" : "border-t")
                     }
                 >
                     <p

--- a/components/dashboard/src/start/CreateWorkspace.tsx
+++ b/components/dashboard/src/start/CreateWorkspace.tsx
@@ -127,6 +127,7 @@ export default class CreateWorkspace extends React.Component<CreateWorkspaceProp
         );
 
         let error = this.state?.error;
+        let errorMessage = this.state?.error?.message || "";
         if (error) {
             switch (error.code) {
                 case ErrorCodes.CONTEXT_PARSE_ERROR:
@@ -290,7 +291,7 @@ export default class CreateWorkspace extends React.Component<CreateWorkspaceProp
                         isError={true}
                         initialSize={24}
                         errorObject={error}
-                        errorMessage={error?.message}
+                        errorMessage={errorMessage}
                     />
                 )}
                 {error && (

--- a/components/dashboard/src/start/CreateWorkspace.tsx
+++ b/components/dashboard/src/start/CreateWorkspace.tsx
@@ -283,6 +283,16 @@ export default class CreateWorkspace extends React.Component<CreateWorkspaceProp
         return (
             <StartPage phase={phase} error={error}>
                 {statusMessage}
+                {error && isGitpodIo() && (
+                    <FeedbackComponent
+                        isModal={false}
+                        message={"Was this error message helpful?"}
+                        isError={true}
+                        initialSize={24}
+                        errorObject={error}
+                        errorMessage={error?.message}
+                    />
+                )}
                 {error && (
                     <div>
                         <a href={gitpodHostUrl.asDashboard().toString()}>

--- a/components/dashboard/src/start/CreateWorkspace.tsx
+++ b/components/dashboard/src/start/CreateWorkspace.tsx
@@ -284,21 +284,21 @@ export default class CreateWorkspace extends React.Component<CreateWorkspaceProp
         return (
             <StartPage phase={phase} error={error}>
                 {statusMessage}
-                {error && isGitpodIo() && (
-                    <FeedbackComponent
-                        isModal={false}
-                        message={"Was this error message helpful?"}
-                        isError={true}
-                        initialSize={24}
-                        errorObject={error}
-                        errorMessage={errorMessage}
-                    />
-                )}
                 {error && (
                     <div>
                         <a href={gitpodHostUrl.asDashboard().toString()}>
                             <button className="mt-8 secondary">Go to Dashboard</button>
                         </a>
+                        {isGitpodIo() && (
+                            <FeedbackComponent
+                                isModal={false}
+                                message={"Was this error message helpful?"}
+                                isError={true}
+                                initialSize={24}
+                                errorObject={error}
+                                errorMessage={errorMessage}
+                            />
+                        )}
                         <p className="mt-14 text-base text-gray-400 flex space-x-2">
                             <a
                                 className="hover:text-blue-600 dark:hover:text-blue-400"

--- a/components/dashboard/src/start/CreateWorkspace.tsx
+++ b/components/dashboard/src/start/CreateWorkspace.tsx
@@ -141,6 +141,8 @@ export default class CreateWorkspace extends React.Component<CreateWorkspaceProp
                             </p>
                         </div>
                     );
+                    errorMessage +=
+                        "\nAre you trying to open a Git repository from a self-hosted instance? [Add integration]";
                     break;
                 case ErrorCodes.INVALID_GITPOD_YML:
                     statusMessage = (
@@ -155,6 +157,7 @@ export default class CreateWorkspace extends React.Component<CreateWorkspaceProp
                             </button>
                         </div>
                     );
+                    errorMessage += "\n[Continue with default configuration]";
                     break;
                 case ErrorCodes.NOT_AUTHENTICATED:
                     statusMessage = (
@@ -169,9 +172,11 @@ export default class CreateWorkspace extends React.Component<CreateWorkspaceProp
                             </button>
                         </div>
                     );
+                    errorMessage += "\n[Authorize with {host}]";
                     break;
                 case ErrorCodes.PERMISSION_DENIED:
                     statusMessage = <p className="text-base text-gitpod-red w-96">Access is not allowed</p>;
+                    errorMessage += "\n[Access is not allowed]";
                     break;
                 case ErrorCodes.USER_BLOCKED:
                     window.location.href = "/blocked";
@@ -214,6 +219,7 @@ export default class CreateWorkspace extends React.Component<CreateWorkspaceProp
                             Unknown Error: {JSON.stringify(this.state?.error, null, 2)}
                         </p>
                     );
+                    errorMessage += "\nUnknown Error";
                     break;
             }
         }
@@ -289,16 +295,6 @@ export default class CreateWorkspace extends React.Component<CreateWorkspaceProp
                         <a href={gitpodHostUrl.asDashboard().toString()}>
                             <button className="mt-8 secondary">Go to Dashboard</button>
                         </a>
-                        {isGitpodIo() && (
-                            <FeedbackComponent
-                                isModal={false}
-                                message={"Was this error message helpful?"}
-                                isError={true}
-                                initialSize={24}
-                                errorObject={error}
-                                errorMessage={errorMessage}
-                            />
-                        )}
                         <p className="mt-14 text-base text-gray-400 flex space-x-2">
                             <a
                                 className="hover:text-blue-600 dark:hover:text-blue-400"
@@ -322,6 +318,16 @@ export default class CreateWorkspace extends React.Component<CreateWorkspaceProp
                             </a>
                         </p>
                     </div>
+                )}
+                {error && isGitpodIo() && (
+                    <FeedbackComponent
+                        isModal={false}
+                        message={"Was this error message helpful?"}
+                        isError={true}
+                        initialSize={24}
+                        errorObject={error}
+                        errorMessage={errorMessage}
+                    />
                 )}
             </StartPage>
         );


### PR DESCRIPTION
Currently only NOT_FOUND errors include a feedback form.
This PR adds the feedback form for other workspace start errors

### Related Issue(s)
Fixes #13485

### How to test

### Release Notes
```release-note
Offer feedback form on more workspace start errors. 
```

### Werft options:
- [x] /werft with-preview
- [x] /werft with-payment
- [x] /werft analytics=segment|TEZnsG4QbLSxLfHfNieLYGF4cDwyFWoe