### PR TITLE
[content-service] Check git default branch name

### DIFF
--- a/components/content-service/pkg/initializer/git.go
+++ b/components/content-service/pkg/initializer/git.go
@@ -174,11 +174,29 @@ func (ws *GitInitializer) realizeCloneTarget(ctx context.Context) (err error) {
 	// checkout branch
 	switch ws.TargetMode {
 	case RemoteBranch:
-		// check remote branch exists before git checkout
-		gitout, err := ws.GitWithOutput(ctx, nil, "ls-remote", "--exit-code", "origin", ws.CloneTarget)
-		if err != nil || len(gitout) == 0 {
-			log.WithError(err).WithField("remoteURI", ws.RemoteURI).WithField("branch", ws.CloneTarget).Error("Remote branch doesn't exist.")
-			return err
+		// we already cloned the git repository but we need to check CloneTarget exists,
+		// except when the name is main or master because either value could be wrong
+		// and we are going to use the incorrect value (default is main).
+		if ws.CloneTarget == "main" || ws.CloneTarget == "master" {
+			// confirm the value of the default branch name using rev-parse
+			gitout, _ := ws.GitWithOutput(ctx, nil, "rev-parse", "--abbrev-ref", "origin/HEAD")
+			defaultBranch := strings.TrimSpace(strings.Replace(string(gitout), "origin/", "", -1))
+			if defaultBranch != ws.CloneTarget {
+				// the default branch name we cloned is not the one specified by the user
+				// check if the branch exits in the repository
+				gitout, err := ws.GitWithOutput(ctx, nil, "ls-remote", "--exit-code", "origin", ws.CloneTarget)
+				if err != nil || len(gitout) == 0 {
+					log.WithField("remoteURI", ws.RemoteURI).WithField("branch", ws.CloneTarget).Warnf("Invalid default branch name. Changing to %v", defaultBranch)
+					ws.CloneTarget = defaultBranch
+				}
+			}
+		} else {
+			// check remote branch exists before git checkout when the branch is not the default
+			gitout, err := ws.GitWithOutput(ctx, nil, "ls-remote", "--exit-code", "origin", ws.CloneTarget)
+			if err != nil || len(gitout) == 0 {
+				log.WithError(err).WithField("remoteURI", ws.RemoteURI).WithField("branch", ws.CloneTarget).Error("Remote branch doesn't exist.")
+				return xerrors.Errorf("Remote branch %v does not exist in %v", ws.CloneTarget, ws.RemoteURI)
+			}
 		}
 
 		if err := ws.Git(ctx, "fetch", "--depth=1", "origin", ws.CloneTarget); err != nil {

--- a/test/tests/components/ws-manager/multi_repo_test.go
+++ b/test/tests/components/ws-manager/multi_repo_test.go
@@ -25,31 +25,43 @@ import (
 var repos = []struct {
 	RemoteUri        string
 	CloneTarget      string
+	ExpectedBranch   string
 	CheckoutLocation string
 }{
 	{
 		RemoteUri:        "https://github.com/gitpod-io/gitpod",
 		CloneTarget:      "main",
+		ExpectedBranch:   "main",
+		CheckoutLocation: "gitpod",
+	},
+	{
+		RemoteUri:        "https://github.com/gitpod-io/gitpod",
+		CloneTarget:      "master",
+		ExpectedBranch:   "main",
 		CheckoutLocation: "gitpod",
 	},
 	{
 		RemoteUri:        "https://github.com/gitpod-io/website",
 		CloneTarget:      "main",
+		ExpectedBranch:   "main",
 		CheckoutLocation: "website",
 	},
 	{
 		RemoteUri:        "https://github.com/gitpod-io/dazzle",
 		CloneTarget:      "main",
+		ExpectedBranch:   "main",
 		CheckoutLocation: "dazzle",
 	},
 	{
 		RemoteUri:        "https://github.com/gitpod-io/leeway",
 		CloneTarget:      "main",
+		ExpectedBranch:   "main",
 		CheckoutLocation: "leeway",
 	},
 	{
 		RemoteUri:        "https://github.com/gitpod-io/ws-manager-integration-test",
-		CloneTarget:      "master",
+		CloneTarget:      "master", // default branch is main
+		ExpectedBranch:   "master",
 		CheckoutLocation: "ws-manager-integration-test",
 	},
 }
@@ -154,7 +166,7 @@ func assertRepositories(t *testing.T, rsa *rpc.Client) {
 			Branch string
 		}{
 			Cloned: false,
-			Branch: r.CloneTarget,
+			Branch: r.ExpectedBranch,
 		}
 	}
 


### PR DESCRIPTION
## Description

Check `CloneTarget` branch name when using `main` or `master`. 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/13479

## How to test
- Open a workspace using a repository with `master` as the default branch name and no `main`.

## Release Notes
```release-note
NONE
```

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
