### PR TITLE
New Default `.gitpod.yml` Template while using `gp init`

### DIFF
--- a/components/gitpod-cli/cmd/init.go
+++ b/components/gitpod-cli/cmd/init.go
@@ -52,15 +52,139 @@ Create a Gitpod configuration for this project.
 			log.Fatal(err)
 		}
 		if !interactive {
-			d = []byte(`# List the start up tasks. Learn more https://www.gitpod.io/docs/config-start-tasks/
-tasks:
-  - init: echo 'init script' # runs during prebuild
-    command: echo 'start script'
+			d = []byte(`## Learn more about this file at 'https://www.gitpod.io/docs/references/gitpod-yml'
 
-# List the ports to expose. Learn more https://www.gitpod.io/docs/config-ports/
-ports:
-  - port: 3000
-    onOpen: open-preview
+## This '.gitpod.yml' file when placed at the root of a project instructs
+## Gitpod how to prepare & build the project, start development environments
+## and configure continuous prebuilds. Prebuilds when enabled builds a project
+## like a CI server so you can start coding right away - no more waiting for
+## dependencies to download and builds to finish when reviewing pull-requests
+## or hacking on something new.
+
+## With Gitpod you can develop software from any device (even iPads) via
+## desktop or browser based versions of VS Code or any JetBrains IDE and
+## customise it to your individual needs - from themes to extensions, you
+## have full control.
+
+## The easiest way to try out Gitpod is install the browser extenion:
+## 'https://www.gitpod.io/docs/configure/user-settings/browser-extension' or by prefixing
+## 'https://gitpod.io#' to the source control URL of any project.
+##
+## For example: 'https://gitpod.io#https://github.com/gitpod-io/gitpod'
+
+## The 'image' section defines which Docker image Gitpod should use.
+## By default, Gitpod uses a standard Docker Image called 'workspace-full'
+## which can be found at 'https://github.com/gitpod-io/workspace-images'
+
+## Workspaces started based on this default image come pre-installed with
+## Docker, Go, Java, Node.js, C/C++, Python, Ruby, Rust, PHP as well as
+## tools such as Homebrew, Tailscale, Nginx and several more.
+
+## If this image does not include the tools needed for your project then
+## a public Docker image or your own Docker file can be configured.
+##
+## Learn more about images at 'https://www.gitpod.io/docs/configure/workspaces/workspace-image'
+
+#image: node:buster                        # use 'https://hub.docker.com/_/node'
+#
+#image:                                    # leave image undefined if using a Dockerfile
+#  file: .gitpod.Dockerfile                # relative path to the Dockerfile from the
+#                                          # root of the project
+
+## The 'tasks' section defines how Gitpod prepares and builds this project
+## or how Gitpod can start development servers. With Gitpod, there are three
+## types of tasks:
+
+## - before: Use this for tasks that need to run before init and before command.
+## - init: Use this to configure prebuilds of heavy-lifting tasks such as
+##         downloading dependencies or compiling source code.
+## - command: Use this to start your database or application when the workspace starts.
+
+## Learn more about these tasks at 'https://www.gitpod.io/docs/configure/workspaces/tasks'
+
+#tasks:
+#  - before: |
+#      # commands to execute...
+#
+#  - init: |
+#      # sudo apt-get install python3     # can be used to install operating system
+#                                         # dependencies but these are not kept after the
+#                                         # prebuild completes thus Gitpod recommends moving
+#                                         # operating system dependency installation steps
+#                                         # to a custom Dockerfile to make prebuilds faster
+#                                         # and to keep your codebase DRY.
+#                                         # 'https://www.gitpod.io/docs/configure/workspaces/workspace-image'
+#
+#      # pip install -r requirements.txt  # install codebase dependencies
+#      # cmake                            # precompile codebase
+#
+#  - name: Web Server
+#    openMode: split-left
+#    env:
+#      WEBSERVER_PORT: 8080
+#    command: |
+#     python3 -m http.server $WEBSERVER_PORT
+#
+#  - name: Web Browser
+#    openMode: split-right
+#    env:
+#      WEBSERVER_PORT: 8080
+#    command: |
+#     gp await-port $WEBSERVER_PORT
+
+## The 'ports' section defines various ports your may listen on are
+## configured in Gitpod on an authenticated URL. By default, all ports
+## are in private visibility state.
+
+## Learn more about ports at 'https://www.gitpod.io/docs/configure/workspaces/ports'
+
+#ports:
+#  - port: 8080 # alternatively configure entire ranges via '8080-8090'
+#    visibility: private # either 'public' or 'private' (default)
+#    onOpen: open-browser # either 'open-browser', 'open-preview' or 'ignore'
+
+## The 'vscode' section defines a list of Visual Studio Code extensions from
+## the OpenVSX.org registry to be installed upon workspace startup. OpenVSX
+## is an open alternative to the proprietary Visual Studio Code Marketplace
+## and extensions can be added by sending a pull-request with the extension
+## identifier to https://github.com/open-vsx/publish-extensions
+
+## The identifier of an extension is always ${publisher}.${name}.
+
+## For example: 'vscodevim.vim'
+
+## Learn more at 'https://www.gitpod.io/docs/references/ides-and-editors/vscode'
+
+#vscode:
+#  extensions:
+#    - vscodevim.vim
+#    - esbenp.prettier-vscode@9.5.0
+#    - https://example.com/abc/releases/extension-0.26.0.vsix
+
+## The 'github' section defines configuration of continuous prebuilds
+## for GitHub repositories when the GitHub application
+## 'https://github.com/apps/gitpod-io' is installed in GitHub and granted
+## permissions to access the repository.
+
+## Learn more at 'https://www.gitpod.io/docs/configure/projects/prebuilds'
+
+github:
+prebuilds:
+# enable for the default branch
+master: true
+# enable for all branches in this repo
+branches: true
+# enable for pull requests coming from this repo
+pullRequests: true
+# enable for pull requests coming from forks
+pullRequestsFromForks: true
+# add a check to pull requests
+addCheck: true
+# add a "Review in Gitpod" button as a comment to pull requests
+addComment: false
+# add a "Review in Gitpod" button to the pull request's description
+addBadge: true
+
 `)
 		} else {
 			fmt.Printf("\n\n---\n%s", d)
@@ -96,7 +220,7 @@ USER gitpod
 #     sudo apt-get install -yq bastet && \
 #     sudo rm -rf /var/lib/apt/lists/*
 #
-# More information: https://www.gitpod.io/docs/config-docker/
+# More information: https://www.gitpod.io/docs/configure/workspaces/workspace-image
 `), 0644); err != nil {
 					log.Fatal(err)
 				}

--- a/components/gitpod-cli/cmd/init.go
+++ b/components/gitpod-cli/cmd/init.go
@@ -169,22 +169,21 @@ Create a Gitpod configuration for this project.
 ## Learn more at 'https://www.gitpod.io/docs/configure/projects/prebuilds'
 
 github:
-prebuilds:
-# enable for the default branch
-master: true
-# enable for all branches in this repo
-branches: true
-# enable for pull requests coming from this repo
-pullRequests: true
-# enable for pull requests coming from forks
-pullRequestsFromForks: true
-# add a check to pull requests
-addCheck: true
-# add a "Review in Gitpod" button as a comment to pull requests
-addComment: false
-# add a "Review in Gitpod" button to the pull request's description
-addBadge: true
-
+    prebuilds:
+        # enable for the default branch
+        master: true
+        # enable for all branches in this repo
+        branches: true
+        # enable for pull requests coming from this repo
+        pullRequests: true
+        # enable for pull requests coming from forks
+        pullRequestsFromForks: true
+        # add a check to pull requests
+        addCheck: true
+        # add a "Review in Gitpod" button as a comment to pull requests
+        addComment: false
+        # add a "Review in Gitpod" button to the pull request's description
+        addBadge: true
 `)
 		} else {
 			fmt.Printf("\n\n---\n%s", d)

--- a/components/gitpod-cli/cmd/init.go
+++ b/components/gitpod-cli/cmd/init.go
@@ -56,17 +56,17 @@ Create a Gitpod configuration for this project.
 
 ## This '.gitpod.yml' file when placed at the root of a project instructs
 ## Gitpod how to prepare & build the project, start development environments
-## and configure continuous prebuilds. Prebuilds when enabled builds a project
+## and configure continuous prebuilds. Prebuilds (when enabled) builds a project
 ## like a CI server so you can start coding right away - no more waiting for
-## dependencies to download and builds to finish when reviewing pull-requests
+## dependencies to download and builds to finish when reviewing pull requests
 ## or hacking on something new.
 
 ## With Gitpod you can develop software from any device (even iPads) via
 ## desktop or browser based versions of VS Code or any JetBrains IDE and
-## customise it to your individual needs - from themes to extensions, you
+## customize it to your individual needs - from themes to extensions, you
 ## have full control.
 
-## The easiest way to try out Gitpod is install the browser extenion:
+## The easiest way to try out Gitpod is to install the browser extension:
 ## 'https://www.gitpod.io/docs/configure/user-settings/browser-extension' or by prefixing
 ## 'https://gitpod.io#' to the source control URL of any project.
 ##
@@ -147,7 +147,7 @@ Create a Gitpod configuration for this project.
 ## the OpenVSX.org registry to be installed upon workspace startup. OpenVSX
 ## is an open alternative to the proprietary Visual Studio Code Marketplace
 ## and extensions can be added by sending a pull-request with the extension
-## identifier to https://github.com/open-vsx/publish-extensions
+## identifier to https://www.gitpod.io/docs/references/gitpod-yml/#vscodeextensions
 
 ## The identifier of an extension is always ${publisher}.${name}.
 


### PR DESCRIPTION
> Educate More about Gitpod through `gp init`
Signed-off-by: Siddhant Khare <siddhant@gitpod.io>

## Description
This PR Change introduces the new `.gitpod.yml` template. Which Describes all the possible syntax/ features we support in `.gitpod.yml`. The old template only suggests the tasks & ports. And Misses the crucial things like educating more about Prebuilds, Extensions, Gitpod GitHub App badges, etc. & respective Docs. References will help users to learn about Gitpod, "How X Works"...

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes [Internal Discussion](https://www.notion.so/gitpod/Speed-up-the-Inner-Loop-for-Configuration-Changes-f1fa5e7ce80c4b0b8a044c1fa9046465#2205fcb3160d4fc39dfc0017f6893e80)

## How to test
<!-- Provide steps to test this PR -->
- Open [preview dev environment](https://gitpod-cli559a93a73a.preview.gitpod-dev.com/workspaces)
- Open an empty workspace from [empty repository from preview env](https://gitpod-cli559a93a73a.preview.gitpod-dev.com/#https://github.com/gitpod-io/empty)
- Open Terminal & Run `gp init`

It will look something like this:

![image](https://user-images.githubusercontent.com/55068936/193394220-54026aca-e37e-4fcd-a794-b9d5a9a10fb4.png)


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
chore: New `.gitpod.yml` template while using `gp init`
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-integration-tests=ide
