### PR TITLE
proposal: `gp prebuild-logs` Gitpod cli command

### DIFF
--- a/components/gitpod-cli/cmd/prebuild-logs.go
+++ b/components/gitpod-cli/cmd/prebuild-logs.go
@@ -1,0 +1,60 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package cmd
+
+import (
+	"github.com/gitpod-io/gitpod/gitpod-cli/pkg/theialib"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"os"
+)
+
+// initCmd represents the init command
+var prebuildLogs = &cobra.Command{
+	Use:   "prebuild-logs",
+	Short: "Opens logs of Gitpod prebuilds",
+	Long: `
+Opens all logs of Gitpod prebuilds.
+Number of logs depends upon the init tasks you have configured.
+	`,
+	// Args:  cobra.MinimumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+
+		const prebuildFilePath = "/workspace/.gitpod/prebuild-log-*"
+		err := openPrebuildLogs(prebuildFilePath)
+
+		if err != nil {
+			log.WithError(err)
+			return
+		}
+
+		pcmd := os.Getenv("GP_OPEN_EDITOR")
+		if pcmd == "" {
+			log.Fatal("GP_OPEN_EDITOR is not set")
+			return
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(prebuildLogs)
+}
+
+func openPrebuildLogs(prebuildFilePath string) error {
+	service, err := theialib.NewServiceFromEnv()
+	if err != nil {
+		log.WithError(err)
+		return err
+	}
+
+	for {
+		_, err := service.OpenFile(theialib.OpenFileRequest{Path: prebuildFilePath})
+		if err != nil {
+			log.WithError(err).Println("Prebuild logs not found.\nMake sure you have configured prebuilds.\nLearn more about Prebuilds: https://www.gitpod.io/docs/configure/projects/prebuilds")
+			return nil
+		}
+	}
+
+}

--- a/components/gitpod-cli/cmd/prebuild-logs.go
+++ b/components/gitpod-cli/cmd/prebuild-logs.go
@@ -5,10 +5,10 @@
 package cmd
 
 import (
+	"fmt"
 	"github.com/gitpod-io/gitpod/gitpod-cli/pkg/theialib"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 // initCmd represents the init command
@@ -19,7 +19,6 @@ var prebuildLogs = &cobra.Command{
 Opens all logs of Gitpod prebuilds.
 Number of logs depends upon the init tasks you have configured.
 	`,
-	// Args:  cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 
 		const prebuildFilePath = "/workspace/.gitpod/prebuild-log-*"
@@ -27,12 +26,6 @@ Number of logs depends upon the init tasks you have configured.
 
 		if err != nil {
 			log.WithError(err)
-			return
-		}
-
-		pcmd := os.Getenv("GP_OPEN_EDITOR")
-		if pcmd == "" {
-			log.Fatal("GP_OPEN_EDITOR is not set")
 			return
 		}
 	},
@@ -52,7 +45,8 @@ func openPrebuildLogs(prebuildFilePath string) error {
 	for {
 		_, err := service.OpenFile(theialib.OpenFileRequest{Path: prebuildFilePath})
 		if err != nil {
-			log.WithError(err).Println("Prebuild logs not found.\nMake sure you have configured prebuilds.\nLearn more about Prebuilds: https://www.gitpod.io/docs/configure/projects/prebuilds")
+			log.WithError(err)
+			fmt.Println("Prebuild logs not found.\nMake sure you have configured prebuilds.\nLearn more about Prebuilds: https://www.gitpod.io/docs/configure/projects/prebuilds")
 			return nil
 		}
 	}


### PR DESCRIPTION
**Important**

> **Warning** This PR is work in progress, and a proposal. It will not be merged without prior discussions, however please treat as **low priority**. 


---

> Signed-off-by: Siddhant Khare <siddhant@gitpod.io>

## Description
This PR Introduces the new command for Gitpod CLI, `gp prebuild-logs` which will open the Prebuild Logs File (_if it exists_)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
- Open preview dev environment
- Open an empty workspace from empty repository from preview env
- Open Terminal & Run `gp preuibld-logs`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
feature: new gitpod cli command for prebuild logs - `gp prebuild-logs`
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
Yes. (will update it, after merge)

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
