### PR TITLE
[public-api] Reuse metrics registry from baseserver

### DIFF
--- a/components/public-api-server/pkg/server/server.go
+++ b/components/public-api-server/pkg/server/server.go
@@ -6,11 +6,12 @@ package server
 
 import (
 	"fmt"
-	"github.com/gitpod-io/gitpod/common-go/log"
 	"net/http"
 	"net/url"
 	"os"
 	"strings"
+
+	"github.com/gitpod-io/gitpod/common-go/log"
 
 	"github.com/gitpod-io/gitpod/public-api/config"
 	"github.com/gorilla/handlers"
@@ -33,12 +34,9 @@ func Start(logger *logrus.Entry, version string, cfg *config.Configuration) erro
 		return fmt.Errorf("failed to parse Gitpod API URL: %w", err)
 	}
 
-	registry := prometheus.NewRegistry()
-
 	srv, err := baseserver.New("public_api_server",
 		baseserver.WithLogger(logger),
 		baseserver.WithConfig(cfg.Server),
-		baseserver.WithMetricsRegistry(registry),
 		baseserver.WithVersion(version),
 	)
 	if err != nil {
@@ -66,7 +64,7 @@ func Start(logger *logrus.Entry, version string, cfg *config.Configuration) erro
 
 	srv.HTTPMux().Handle("/stripe/invoices/webhook", handlers.ContentTypeHandler(stripeWebhookHandler, "application/json"))
 
-	if registerErr := register(srv, gitpodAPI, registry); registerErr != nil {
+	if registerErr := register(srv, gitpodAPI, srv.MetricsRegistry()); registerErr != nil {
 		return fmt.Errorf("failed to register services: %w", registerErr)
 	}
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

With baseserver already providing a metrics registry, we don't have to construct it ourselves.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
