### PR TITLE
[db] Add `uid` column to `d_b_oauth_auth_code_entry` table

### DIFF
--- a/components/gitpod-db/src/typeorm/migration/1664781308555-ChangeOauthCodePrimaryKey.ts
+++ b/components/gitpod-db/src/typeorm/migration/1664781308555-ChangeOauthCodePrimaryKey.ts
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+const TABLE_NAME = "d_b_oauth_auth_code_entry";
+const COLUMN_NAME = "uid";
+
+export class ChangeOauthCodePrimaryKey1664781308555 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `ALTER TABLE ${TABLE_NAME} ADD COLUMN ${COLUMN_NAME} char(36) NOT NULL DEFAULT '', ALGORITHM=INPLACE, LOCK=NONE`,
+        );
+        await queryRunner.query(`UPDATE ${TABLE_NAME} SET ${COLUMN_NAME}=(SELECT uuid());`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {}
+}


### PR DESCRIPTION
## Description

Add a new `uid` column to the `d_b_oauth_auth_code_entry` table. 

This table should be synced by `db-sync` but currently uses an auto-incrementing PK which will cause clashes between regions. To resolve, the plan is:

1. Add a new `uid` column and populate it (this PR).
2. Switch the PK over to the `uid` column and remove the old auto-incrementing`id` column (later PR).
3. Sync the table using `db-sync` (later PR).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of #9198 

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
