### PR TITLE
[db] Drop `d_b_layout_data` table

### DIFF
--- a/components/gitpod-db/src/typeorm/entity/db-snapshot.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-snapshot.ts
@@ -37,9 +37,6 @@ export class DBSnapshot implements Snapshot {
     @Column()
     bucketId: string;
 
-    @Column({ nullable: true })
-    layoutData?: string;
-
     @Column({
         // because we introduced this as an afterthought the default is 'available'
         default: <SnapshotState>"available",

--- a/components/gitpod-db/src/typeorm/migration/1664460477008-DropLayoutDataTable.ts
+++ b/components/gitpod-db/src/typeorm/migration/1664460477008-DropLayoutDataTable.ts
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class DropLayoutDataTable1664460477008 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP TABLE \`d_b_layout_data\``);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {}
+}

--- a/components/gitpod-db/src/typeorm/migration/1664531268399-RemoveSnapshotLayoutDataColumn.ts
+++ b/components/gitpod-db/src/typeorm/migration/1664531268399-RemoveSnapshotLayoutDataColumn.ts
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class RemoveSnapshotLayoutDataColumn1664531268399 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE d_b_snapshot DROP COLUMN layoutData`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {}
+}


### PR DESCRIPTION
## Description

Remove the `d_b_layout_data` table and  the `layoutData` column from the `d_b_snapshot` table.

See ([Slack thread](https://gitpod.slack.com/archives/C01KGM9BH54/p1664290138597739)) for additional context.

⚠️ Merge and deploy https://github.com/gitpod-io/gitpod/pull/13519 first. ⚠️ 

## Related Issue(s)
Part of #9198 

Follow up to https://github.com/gitpod-io/gitpod/pull/13519

## How to test

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
