### PR TITLE
[installer-tests] Add cleanup cron for individual setups

### DIFF
--- a/.werft/cleanup-installer-tests.yaml
+++ b/.werft/cleanup-installer-tests.yaml
@@ -126,6 +126,13 @@ pod:
         (cd .werft && yarn install && mv node_modules ..) | werft log slice prep
         printf '{{ toJson . }}' > context.json
 
+        export domain="{{ .Annotations.subdomain }}"
+        if [[ "$domain" == "<no value>" ]]; then
+          echo "Cleanup all old workspaces"
+        else
+          export TF_VAR_TEST_ID="$domain"
+        fi
+
         TESTCONFIG="CLEANUP_OLD_TESTS"
 
         npx ts-node .werft/installer-tests.ts ${TESTCONFIG}

--- a/.werft/installer-tests.ts
+++ b/.werft/installer-tests.ts
@@ -21,6 +21,7 @@ const upgrade: string = annotations.upgrade || "false"; // setting to true will 
 const skipTests: string = annotations.skipTests || "false"; // setting to true skip the integration tests
 const selfSigned: string = annotations.selfSigned || "false";
 const deps: string = annotations.deps || ""; // options: ["external", "internal"] setting to `external` will ensure that all resource dependencies(storage, db, registry) will be external. if unset, a random selection will be used
+const deleteOnFail: string = annotations.deleteOnFail || "true";
 
 const baseDomain: string = annotations.domain || "tests.gitpod-self-hosted.com";
 const gcpDnsZone: string = baseDomain.replace(/\./g, '-');
@@ -265,7 +266,9 @@ if (config === undefined) {
 }
 
 installerTests(TEST_CONFIGURATIONS[testConfig]).catch((err) => {
-    cleanup();
+    if(deleteOnFail == "true") {
+        cleanup();
+    }
     console.error(err);
     process.exit(1);
 });

--- a/install/tests/cleanup.sh
+++ b/install/tests/cleanup.sh
@@ -1,12 +1,43 @@
 #!/usr/bin/env bash
 #
 #
-if [ -z "${GOOGLE_APPLICATION_CREDENTIALS}" ]; then echo "Env var GOOGLE_APPLICATION_CREDENTIALS not set"; exit 1; fi
 
+cleanup() {
+    TF_VAR_TEST_ID=$1
+    cloud=$(echo "$TF_VAR_TEST_ID" | sed 's/\(.*\)-/\1 /' | xargs | awk '{print $2}')
+
+    if [[ "$TF_VAR_TEST_ID" == gitpod-* ]] ; then echo "$TF_VAR_TEST_ID has the pattern gitpod-*, skipping"; return; fi
+    if [[ "$TF_VAR_TEST_ID" == release-* ]] ; then echo "$TF_VAR_TEST_ID has the pattern gitpod-*, skipping"; return; fi
+
+    if [ "$TF_VAR_TEST_ID" = "default" ] || [ "$TF_VAR_TEST_ID" = "" ]; then return; fi
+
+    if [ -z "$cloud" ]; then cloud=cluster; fi
+
+    echo "Cleaning up $TF_VAR_TEST_ID"
+
+    export TF_VAR_TEST_ID=$TF_VAR_TEST_ID
+
+    make cleanup cloud=$cloud
+
+    CUSTOMERID=$(replicated customer ls --app "${REPLICATED_APP}" | grep "$TF_VAR_TEST_ID" | awk '{print $1}')
+
+    [ -z "$CUSTOMERID" ] && return
+
+    echo "Trying to archive replicated license"
+
+    curl --request POST \
+    --url https://api.replicated.com/vendor/v3/customer/$CUSTOMERID/archive \
+    --header "Authorization: ${REPLICATED_API_TOKEN}" || echo "Couldn't delete replicated licese"
+}
+
+if [ -z "${GOOGLE_APPLICATION_CREDENTIALS}" ]; then echo "Env var GOOGLE_APPLICATION_CREDENTIALS not set"; exit 1; fi
 
 limit='10 hours ago'
 
 gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIALS}" --project=sh-automated-tests
+
+if [ -n "${TF_VAR_TEST_ID}" ]; then cleanup "$TF_VAR_TEST_ID"; exit 0; else echo "Cleanup all old workspaces"; fi
+
 for i in $(gsutil ls gs://nightly-tests/tf-state); do
     # we have to check if the file was created atleast 1 day ago
     datetime=$(gsutil ls -la "$i" | xargs |  awk '{print $2}')
@@ -23,28 +54,6 @@ for i in $(gsutil ls gs://nightly-tests/tf-state); do
 
     TF_VAR_TEST_ID=$(basename "$filename" .tfstate)
 
-    cloud=$(echo "$TF_VAR_TEST_ID" | sed 's/\(.*\)-/\1 /' | xargs | awk '{print $2}')
+    cleanup "$TF_VAR_TEST_ID"
 
-    if [[ "$TF_VAR_TEST_ID" == gitpod-* ]] ; then echo "$TF_VAR_TEST_ID has the pattern gitpod-*, skipping"; continue; fi
-    if [[ "$TF_VAR_TEST_ID" == release-* ]] ; then echo "$TF_VAR_TEST_ID has the pattern gitpod-*, skipping"; continue; fi
-
-    if [ "$TF_VAR_TEST_ID" = "default" ] || [ "$TF_VAR_TEST_ID" = "" ]; then continue; fi
-
-    if [ -z "$cloud" ]; then cloud=cluster; fi
-
-    echo "Cleaning up $TF_VAR_TEST_ID"
-
-    export TF_VAR_TEST_ID=$TF_VAR_TEST_ID
-
-    make cleanup cloud=$cloud
-
-    CUSTOMERID=$(replicated customer ls --app "${REPLICATED_APP}" | grep "$TF_VAR_TEST_ID" | awk '{print $1}')
-
-    [ -z "$CUSTOMERID" ] && continue
-
-    echo "Trying to archive replicated license"
-
-    curl --request POST \
-    --url https://api.replicated.com/vendor/v3/customer/$CUSTOMERID/archive \
-    --header "Authorization: ${REPLICATED_API_TOKEN}" || echo "Couldn't delete replicated licese"
 done


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PR adds a small change to the `cleanup.sh` script allowing it to delete individual test setups by providing the subdomain of the individual setup via the annotation `-a subdomain=`. We also add an annotation `deleteOnFail` which is by default "true" that saves the setup from getting destroyed upon an error. Can be used for debugging.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
One can run the command:

```
werft run github -j .werft/cleanup-installer-tests.yaml -a subdomain=inttest-k3s
```


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
