### PR TITLE
[server] Observe request duration even for failures, report statusCode

### DIFF
--- a/components/server/src/prometheus-metrics.ts
+++ b/components/server/src/prometheus-metrics.ts
@@ -66,12 +66,12 @@ export function increaseApiCallCounter(method: string, statusCode: number) {
 export const apiCallDurationHistogram = new prometheusClient.Histogram({
     name: "gitpod_server_api_calls_duration_seconds",
     help: "Duration of API calls in seconds",
-    labelNames: ["method"],
+    labelNames: ["method", "statusCode"],
     buckets: [0.1, 0.5, 1, 5, 10, 15, 30],
 });
 
-export function observeAPICallsDuration(method: string, duration: number) {
-    apiCallDurationHistogram.observe({ method }, duration);
+export function observeAPICallsDuration(method: string, statusCode: number, duration: number) {
+    apiCallDurationHistogram.observe({ method, statusCode }, duration);
 }
 
 const apiCallUserCounter = new prometheusClient.Counter({


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

We wouldn't track duration for failures, so when a request timed out our otherwise failed, we'd not record it in metrics.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
