### PR TITLE
feat(gitpod-cli): Create `gp info` command

### DIFF
--- a/components/gitpod-cli/cmd/info.go
+++ b/components/gitpod-cli/cmd/info.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/gitpod-io/gitpod/common-go/log"
+	supervisor_helper "github.com/gitpod-io/gitpod/gitpod-cli/pkg/supervisor-helper"
+	supervisor "github.com/gitpod-io/gitpod/supervisor/api"
+	"github.com/olekukonko/tablewriter"
+	"github.com/spf13/cobra"
+	"google.golang.org/grpc"
+	"os"
+	"time"
+)
+
+var infoCmdOpts struct {
+	// Json configures whether the command output is printed as JSON, to make it machine-readable.
+	Json bool
+}
+
+// infoCmd represents the info command.
+var infoCmd = &cobra.Command{
+	Use:   "info",
+	Short: "Display workspace info, such as its ID, class, etc.",
+	Run: func(cmd *cobra.Command, args []string) {
+		ctx, cancel := context.WithTimeout(cmd.Context(), 5*time.Second)
+		defer cancel()
+
+		conn, err := supervisor_helper.Dial(ctx)
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer conn.Close()
+
+		data, err := fetchInfo(ctx, conn)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		if infoCmdOpts.Json {
+			content, _ := json.Marshal(data)
+			fmt.Println(string(content))
+			return
+		}
+
+		outputInfo(data)
+	},
+}
+
+func fetchInfo(ctx context.Context, conn *grpc.ClientConn) (*infoData, error) {
+	wsInfo, err := supervisor.NewInfoServiceClient(conn).WorkspaceInfo(ctx, &supervisor.WorkspaceInfoRequest{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve workspace info: %w", err)
+	}
+
+	return &infoData{
+		WorkspaceId:    wsInfo.WorkspaceId,
+		InstanceId:     wsInfo.InstanceId,
+		WorkspaceClass: wsInfo.WorkspaceClass,
+		WorkspaceUrl:   wsInfo.WorkspaceUrl,
+		ClusterHost:    wsInfo.WorkspaceClusterHost,
+	}, nil
+}
+
+func outputInfo(info *infoData) {
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetColWidth(50)
+	table.SetBorder(false)
+	table.SetColumnSeparator(":")
+	table.Append([]string{"Workspace ID", info.WorkspaceId})
+	table.Append([]string{"Instance ID", info.InstanceId})
+	table.Append([]string{"Workspace class", fmt.Sprintf("%s: %s", info.WorkspaceClass.DisplayName, info.WorkspaceClass.Description)})
+	table.Append([]string{"Workspace URL", info.WorkspaceUrl})
+	table.Append([]string{"Cluster host", info.ClusterHost})
+	table.Render()
+}
+
+type infoData struct {
+	WorkspaceId    string                                           `json:"workspace_id"`
+	InstanceId     string                                           `json:"instance_id"`
+	WorkspaceClass *supervisor.WorkspaceInfoResponse_WorkspaceClass `json:"workspace_class"`
+	WorkspaceUrl   string                                           `json:"workspace_url"`
+	ClusterHost    string                                           `json:"cluster_host"`
+}
+
+func init() {
+	infoCmd.Flags().BoolVarP(&infoCmdOpts.Json, "json", "j", false, "Output in JSON format")
+	rootCmd.AddCommand(infoCmd)
+}


### PR DESCRIPTION
## Description
Adds a `gp info` command, to print workspace details. For now, this includes:
- Workspace ID
- Instance ID
- Workspace class
- Workspace URL
- Cluster host

The intention is for this to replace the use of the matching environment variables (see #10797 for more details).

Includes a `--json` flag to print as JSON, allowing e.g. for parsing the output in scripts.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #10797

## How to test

```bash
$ cd components/gitpod-cli

$ go run . info
  Workspace ID    : gitpodio-gitpod-4q1200dvfcf                            
  Instance ID     : 8a6188a3-4c7f-49fe-aa4d-db968c11e183                   
  Workspace class : Large: Up to 8 vCPU, 16GB memory, 50GB disk            
  Workspace URL   : https://gitpodio-gitpod-4q1200dvfcf.ws-eu67.gitpod.io  
  Cluster host    : ws-eu67.gitpod.io                                      

$ go run . info --json
{"workspace_id":"gitpodio-gitpod-4q1200dvfcf","instance_id":"8a6188a3-4c7f-49fe-aa4d-db968c11e183","workspace_class":{"id":"g1-large","display_name":"Large","description":"Up to 8 vCPU, 16GB memory, 50GB disk"},"workspace_url":"https://gitpodio-gitpod-4q1200dvfcf.ws-eu67.gitpod.io","cluster_host":"ws-eu67.gitpod.io"}
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Create `gp info` command
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
