### PR TITLE
[terraform] cleaning up k3s module to use for tests

### DIFF
--- a/.werft/installer-tests.ts
+++ b/.werft/installer-tests.ts
@@ -62,6 +62,7 @@ const TEST_CONFIGURATIONS: { [name: string]: TestConfig } = {
             "STANDARD_GKE_CLUSTER",
             "CERT_MANAGER",
             "GCP_MANAGED_DNS",
+            "ADD_NS_RECORD",
             "CLUSTER_ISSUER",
             "GENERATE_KOTS_CONFIG",
             "INSTALL_GITPOD",

--- a/install/infra/modules/gke/output.tf
+++ b/install/infra/modules/gke/output.tf
@@ -4,7 +4,7 @@ output "kubernetes_endpoint" {
 }
 
 output "name_servers" {
-  value = google_dns_managed_zone.gitpod-dns-zone[0].name_servers
+  value = try(google_dns_managed_zone.gitpod-dns-zone[0].name_servers, [])
 }
 
 output "client_token" {

--- a/install/infra/modules/k3s/dns.tf
+++ b/install/infra/modules/k3s/dns.tf
@@ -1,0 +1,21 @@
+resource "google_dns_managed_zone" "gitpod-dns-zone" {
+  count         = var.domain_name == null ? 0 : 1
+  name          = "zone-${var.name}"
+  dns_name      = "${var.domain_name}."
+  description   = "Terraform managed DNS zone for ${var.name}"
+  force_destroy = true
+  labels = {
+    app = "gitpod"
+  }
+}
+
+resource "google_dns_record_set" "gitpod-dns" {
+  for_each     = local.dns_list
+  name         = each.key
+  managed_zone = google_dns_managed_zone.gitpod-dns-zone[0].name
+  project      = var.gcp_project
+  type         = "A"
+  ttl          = 5
+
+  rrdatas = [google_compute_instance.k3s_master_instance.network_interface[0].access_config[0].nat_ip]
+}

--- a/install/infra/modules/k3s/local.tf
+++ b/install/infra/modules/k3s/local.tf
@@ -1,0 +1,8 @@
+locals {
+  dns_list = var.domain_name == "" ? [] : toset([
+    "${var.domain_name}.",
+    "*.${var.domain_name}.",
+    "ws.${var.domain_name}.",
+    "*.ws.${var.domain_name}."
+  ])
+}

--- a/install/infra/modules/k3s/main.tf
+++ b/install/infra/modules/k3s/main.tf
@@ -23,7 +23,7 @@ provider "google" {
 
 provider "google" {
   alias       = "dns"
-  credentials = var.dns_sa_creds
+  credentials = var.dns_sa_creds == "" ? var.credentials : var.dns_sa_creds
 }
 
 resource "google_service_account" "gcp_instance" {
@@ -124,58 +124,10 @@ resource "null_resource" "k3sup_install" {
   }
 }
 
-resource "google_dns_record_set" "gitpod-dns" {
-  provider     = google.dns
-  count        = (var.domain_name == null) || (var.managed_dns_zone == null) ? 0 : 1
-  name         = "${var.domain_name}."
-  managed_zone = var.managed_dns_zone
-  project      = var.dns_project == null ? var.gcp_project : var.dns_project
-  type         = "A"
-  ttl          = 5
-
-  rrdatas = [google_compute_instance.k3s_master_instance.network_interface[0].access_config[0].nat_ip]
-}
-
-resource "google_dns_record_set" "gitpod-dns-1" {
-  provider     = google.dns
-  count        = (var.domain_name == null) || (var.managed_dns_zone == null) ? 0 : 1
-  name         = "ws.${var.domain_name}."
-  managed_zone = var.managed_dns_zone
-  project      = var.dns_project == null ? var.gcp_project : var.dns_project
-  type         = "A"
-  ttl          = 5
-
-  rrdatas = [google_compute_instance.k3s_master_instance.network_interface[0].access_config[0].nat_ip]
-}
-
-resource "google_dns_record_set" "gitpod-dns-2" {
-  provider     = google.dns
-  count        = (var.domain_name == null) || (var.managed_dns_zone == null) ? 0 : 1
-  name         = "*.${var.domain_name}."
-  managed_zone = var.managed_dns_zone
-  project      = var.dns_project == null ? var.gcp_project : var.dns_project
-  type         = "A"
-  ttl          = 5
-
-  rrdatas = [google_compute_instance.k3s_master_instance.network_interface[0].access_config[0].nat_ip]
-}
-
-resource "google_dns_record_set" "gitpod-dns-3" {
-  provider     = google.dns
-  count        = (var.domain_name == null) || (var.managed_dns_zone == null) ? 0 : 1
-  name         = "*.ws.${var.domain_name}."
-  managed_zone = var.managed_dns_zone
-  project      = var.dns_project == null ? var.gcp_project : var.dns_project
-  type         = "A"
-  ttl          = 5
-
-  rrdatas = [google_compute_instance.k3s_master_instance.network_interface[0].access_config[0].nat_ip]
-}
-
 resource "random_string" "random" {
-  length           = 4
-  upper            = false
-  special          = false
+  length  = 4
+  upper   = false
+  special = false
 }
 
 resource "google_sql_database_instance" "gitpod" {

--- a/install/infra/modules/k3s/output.tf
+++ b/install/infra/modules/k3s/output.tf
@@ -1,9 +1,9 @@
 output "database" {
   sensitive = true
   value = try({
-    instance            = "${var.gcp_project}:${var.gcp_region}:${google_sql_database_instance.gitpod.name}"
-    username            = "${google_sql_user.users.name}"
-    password            = random_password.password.result
+    instance                 = "${var.gcp_project}:${var.gcp_region}:${google_sql_database_instance.gitpod.name}"
+    username                 = "${google_sql_user.users.name}"
+    password                 = random_password.password.result
     service_account_key_path = var.credentials
   }, "No database created")
 }
@@ -11,9 +11,9 @@ output "database" {
 output "registry" {
   sensitive = true
   value = try({
-    url      = "gcr.io/${var.gcp_project}"
-    server   = "gcr.io"
-    username = "_json_key"
+    url                = "gcr.io/${var.gcp_project}"
+    server             = "gcr.io"
+    username           = "_json_key"
     password_file_path = var.credentials
   }, "No container registry created")
 }
@@ -21,8 +21,12 @@ output "registry" {
 output "storage" {
   sensitive = true
   value = try({
-    region      = var.gcp_region
-    project     = var.gcp_project
+    region                   = var.gcp_region
+    project                  = var.gcp_project
     service_account_key_path = var.credentials
   }, "No GCS bucket created for object storage")
+}
+
+output "name_servers" {
+  value = google_dns_managed_zone.gitpod-dns-zone[0].name_servers
 }

--- a/install/infra/modules/k3s/variables.tf
+++ b/install/infra/modules/k3s/variables.tf
@@ -37,22 +37,7 @@ variable "cluster_version" {
   default     = "v1.22.12+k3s1"
 }
 
-variable "dns_sa_creds" {
-  description = "Credentials with DNS admin rights to the project with managed DNS record"
-  default     = ""
-}
-
-variable "dns_project" {
-  description = "Project associated with the dns maanged zone"
-  default     = null
-}
-
 variable "domain_name" {
   description = "Domain name to add to add DNS map to"
-  default     = null
-}
-
-variable "managed_dns_zone" {
-  description = "Name of the managed DNS record"
-  default     = null
+  default     = ""
 }

--- a/install/infra/modules/tools/cloud-dns-ns/main.tf
+++ b/install/infra/modules/tools/cloud-dns-ns/main.tf
@@ -1,14 +1,17 @@
-variable credentials {}
 variable nameservers {}
 variable domain_name {}
 variable managed_dns_zone {}
 variable dns_project {}
+variable credentials {}
 
 provider "google" {
+  alias       = "dns"
+  project     = "dns-for-playgrounds"
   credentials = var.credentials
 }
 
 resource "google_dns_record_set" "gitpod-dns-3" {
+  provider     = google.dns
   name         = "${var.domain_name}."
   managed_zone = var.managed_dns_zone
   project      =  var.dns_project

--- a/install/infra/single-cluster/k3s/cluster.tf
+++ b/install/infra/single-cluster/k3s/cluster.tf
@@ -1,16 +1,13 @@
 module "k3s" {
   source = "../../modules/k3s"
 
-  name             = var.name
-  gcp_project      = var.project
-  gcp_region       = var.region
-  gcp_zone         = var.zone
-  credentials      = var.credentials_path
-  kubeconfig       = var.kubeconfig
-  dns_sa_creds     = var.credentials_path
-  dns_project      = var.project
-  managed_dns_zone = var.managed_dns_zone
-  domain_name      = var.domain_name
-  cluster_version  = var.cluster_version
-  image_id         = var.image_id
+  name            = var.name
+  gcp_project     = var.project
+  gcp_region      = var.region
+  gcp_zone        = var.zone
+  credentials     = var.credentials_path
+  kubeconfig      = var.kubeconfig
+  domain_name     = var.domain_name
+  cluster_version = var.cluster_version
+  image_id        = var.image_id
 }

--- a/install/infra/single-cluster/k3s/local.tf
+++ b/install/infra/single-cluster/k3s/local.tf
@@ -1,3 +1,3 @@
 locals {
-  credentials = "${file(var.credentials_path)}"
+  credentials = file(var.credentials_path)
 }

--- a/install/infra/single-cluster/k3s/output.tf
+++ b/install/infra/single-cluster/k3s/output.tf
@@ -1,16 +1,16 @@
 output "database" {
-    sensitive = true
-    value = module.k3s.database
+  sensitive = true
+  value     = module.k3s.database
 }
 
 output "registry" {
-    sensitive = true
-    value = module.k3s.registry
+  sensitive = true
+  value     = module.k3s.registry
 }
 
 output "storage" {
-    sensitive = true
-    value = module.k3s.storage
+  sensitive = true
+  value     = module.k3s.storage
 }
 
 output "url" {
@@ -18,5 +18,9 @@ output "url" {
 }
 
 output "cluster_issuer" {
-  value     = module.cluster-issuer.cluster_issuer
+  value = module.cluster-issuer.cluster_issuer
+}
+
+output "name_servers" {
+  value = module.k3s.name_servers
 }

--- a/install/infra/single-cluster/k3s/tools.tf
+++ b/install/infra/single-cluster/k3s/tools.tf
@@ -1,16 +1,16 @@
 module "certmanager" {
   source = "../../modules/tools/cert-manager"
 
-  kubeconfig  = var.kubeconfig
+  kubeconfig = var.kubeconfig
 }
 
 module "cluster-issuer" {
-  source              = "../../modules/tools/issuer"
-  kubeconfig          = var.kubeconfig
-  gcp_credentials     = local.credentials
-  issuer_name         = "cloudDNS"
+  source          = "../../modules/tools/issuer"
+  kubeconfig      = var.kubeconfig
+  gcp_credentials = local.credentials
+  issuer_name     = "cloudDNS"
   cert_manager_issuer = {
-    project                 = var.project
+    project = var.project
     serviceAccountSecretRef = {
       name = "clouddns-dns01-solver"
       key  = "keys.json"

--- a/install/infra/single-cluster/k3s/variables.tf
+++ b/install/infra/single-cluster/k3s/variables.tf
@@ -4,7 +4,7 @@ variable "kubeconfig" {
 }
 
 variable "project" {
-  description = "Google cloud Region to perform operations in"
+  description = "Google cloud project to to create resources in"
 }
 
 variable "region" {
@@ -39,10 +39,5 @@ variable "cluster_version" {
 
 variable "domain_name" {
   description = "Domain name to add to add DNS map to"
-  default     = null
-}
-
-variable "managed_dns_zone" {
-  description = "The Cloud DNS managed zone where Gitpod A records will be created"
   default     = null
 }

--- a/install/tests/Makefile
+++ b/install/tests/Makefile
@@ -176,6 +176,7 @@ k3s-standard-cluster: check-env-cluster-version
 	rm -f ${KUBECONFIG} && \
 	$(MAKE) get-kubeconfig && \
 	[[ -f ${KUBECONFIG} ]] || terraform apply -target=module.k3s -var kubeconfig=${KUBECONFIG} -var k3s_node_image_id=${image_id} --auto-approve && \
+	terraform apply -target=module.k3s-add-dns-record  -var kubeconfig=${KUBECONFIG} --auto-approve
 	$(MAKE) upload-kubeconfig-to-gcp # we upload the file to GCP since we cannot retrieve the file against without SSHing to the master
 	@echo "Done creating k3s cluster"
 

--- a/install/tests/main.tf
+++ b/install/tests/main.tf
@@ -13,10 +13,13 @@ variable "project" { default = "sh-automated-tests" }
 variable "sa_creds" { default = null }
 variable "dns_sa_creds" { default = null }
 
-data local_file "dns_credentials" {
+data "local_file" "dns_credentials" {
   filename = var.dns_sa_creds
 }
 
+data "local_file" "sa_credentials" {
+  filename = var.sa_creds
+}
 
 variable "eks_node_image_id" {
   default = null
@@ -43,38 +46,35 @@ module "gke" {
   region          = "europe-west1"
   zone            = "europe-west1-d"
   cluster_version = var.cluster_version
+  domain_name     = "${var.TEST_ID}.${var.domain}"
 }
 
 module "k3s" {
   # source = "github.com/gitpod-io/gitpod//install/infra/terraform/k3s?ref=main" # we can later use tags here
   source = "../infra/modules/k3s" # we can later use tags here
 
-  name             = var.TEST_ID
-  gcp_project      = var.project
-  credentials      = var.sa_creds
-  kubeconfig       = var.kubeconfig
-  dns_sa_creds     = var.dns_sa_creds
-  dns_project      = "dns-for-playgrounds"
-  managed_dns_zone = var.gcp_zone
-  domain_name      = "${var.TEST_ID}.${var.domain}"
-  cluster_version  = var.cluster_version
-  image_id         = var.k3s_node_image_id
+  name            = var.TEST_ID
+  gcp_project     = var.project
+  credentials     = var.sa_creds
+  kubeconfig      = var.kubeconfig
+  domain_name     = "${var.TEST_ID}.${var.domain}"
+  cluster_version = var.cluster_version
+  image_id        = var.k3s_node_image_id
 }
 
 module "gcp-issuer" {
-  source      = "../infra/modules/tools/issuer"
-  kubeconfig  = var.kubeconfig
-  gcp_credentials = data.local_file.dns_credentials.content
-  issuer_name = "cloudDNS"
+  source          = "../infra/modules/tools/issuer"
+  kubeconfig      = var.kubeconfig
+  gcp_credentials = data.local_file.sa_credentials.content
+  issuer_name     = "cloudDNS"
   cert_manager_issuer = {
-    project = "dns-for-playgrounds"
+    project = var.project
     serviceAccountSecretRef = {
       name = "clouddns-dns01-solver"
       key  = "keys.json"
     }
   }
 }
-
 
 module "aks" {
   # source = "github.com/gitpod-io/gitpod//install/infra/terraform/aks?ref=main" # we can later use tags here
@@ -91,14 +91,14 @@ module "aks" {
 }
 
 module "eks" {
-  source                 = "../infra/modules/eks"
-  domain_name            = "${var.TEST_ID}.${var.domain}"
-  cluster_name           = var.TEST_ID
-  region                 = "eu-west-1"
-  vpc_availability_zones = ["eu-west-1c", "eu-west-1b"]
-  image_id               = var.eks_node_image_id
-  kubeconfig             = var.kubeconfig
-  cluster_version        = var.cluster_version
+  source                   = "../infra/modules/eks"
+  domain_name              = "${var.TEST_ID}.${var.domain}"
+  cluster_name             = var.TEST_ID
+  region                   = "eu-west-1"
+  vpc_availability_zones   = ["eu-west-1c", "eu-west-1b"]
+  image_id                 = var.eks_node_image_id
+  kubeconfig               = var.kubeconfig
+  cluster_version          = var.cluster_version
   create_external_registry = true
   create_external_database = true
   create_external_storage  = true
@@ -110,15 +110,15 @@ module "certmanager" {
   # source = "github.com/gitpod-io/gitpod//install/infra/terraform/tools/cert-manager?ref=main"
   source = "../infra/modules/tools/cert-manager"
 
-  kubeconfig  = var.kubeconfig
+  kubeconfig = var.kubeconfig
 }
 
 module "clouddns-externaldns" {
   # source = "github.com/gitpod-io/gitpod//install/infra/terraform/tools/external-dns?ref=main"
   source      = "../infra/modules/tools/cloud-dns-external-dns"
   kubeconfig  = var.kubeconfig
-  credentials = data.local_file.dns_credentials.content
-  project     = "dns-for-playgrounds"
+  credentials = data.local_file.sa_credentials.content
+  project     = var.project
 }
 
 module "azure-externaldns" {
@@ -150,6 +150,24 @@ module "aws-issuer" {
   cert_manager_issuer = module.eks.cert_manager_issuer
   secretAccessKey     = module.eks.secretAccessKey
   issuer_name         = "route53"
+}
+
+module "k3s-add-dns-record" {
+  source           = "../infra/modules/tools/cloud-dns-ns"
+  credentials      = var.dns_sa_creds
+  nameservers      = module.k3s.name_servers
+  dns_project      = "dns-for-playgrounds"
+  managed_dns_zone = var.gcp_zone
+  domain_name      = "${var.TEST_ID}.${var.domain}"
+}
+
+module "gcp-add-dns-record" {
+  source           = "../infra/modules/tools/cloud-dns-ns"
+  credentials      = var.dns_sa_creds
+  nameservers      = module.gke.name_servers
+  dns_project      = "dns-for-playgrounds"
+  managed_dns_zone = var.gcp_zone
+  domain_name      = "${var.TEST_ID}.${var.domain}"
 }
 
 module "azure-add-dns-record" {

--- a/install/tests/output.tf
+++ b/install/tests/output.tf
@@ -1,54 +1,54 @@
 output "gke_database" {
-    sensitive = true
-    value = try(module.gke.database, null)
+  sensitive = true
+  value     = try(module.gke.database, null)
 }
 
 output "gke_user_key" {
-    sensitive = true
-    value = try(module.gke.cluster-sa, null)
+  sensitive = true
+  value     = try(module.gke.cluster-sa, null)
 }
 
 output "k3s_database" {
-    sensitive = true
-    value = try(module.k3s.database, null)
+  sensitive = true
+  value     = try(module.k3s.database, null)
 }
 
 output "aws_cluster_user" {
-    sensitive = true
-    value = try(module.eks.cluster_user, null)
+  sensitive = true
+  value     = try(module.eks.cluster_user, null)
 }
 
 output "aws_storage" {
-    sensitive = true
-    value = try(module.eks.storage, null)
+  sensitive = true
+  value     = try(module.eks.storage, null)
 }
 
 output "aws_registry" {
-    sensitive = true
-    value = try(module.eks.registry, null)
+  sensitive = true
+  value     = try(module.eks.registry, null)
 }
 
 output "aws_database" {
-    sensitive = true
-    value = try(module.eks.database, null)
+  sensitive = true
+  value     = try(module.eks.database, null)
 }
 
 output "aws_s3_registry_backend" {
-    sensitive = true
-    value = try(module.eks.registry_backend, null)
+  sensitive = true
+  value     = try(module.eks.registry_backend, null)
 }
 
 output "azure_database" {
-    sensitive = true
-    value = try(module.aks.database, null)
+  sensitive = true
+  value     = try(module.aks.database, null)
 }
 
 output "azure_registry" {
-    sensitive = true
-    value = try(module.aks.registry, null)
+  sensitive = true
+  value     = try(module.aks.registry, null)
 }
 
 output "azure_storage" {
-    sensitive = true
-    value = try(module.aks.storage, null)
+  sensitive = true
+  value     = try(module.aks.storage, null)
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This is the first of a 3 part PR series that uses the terraform single-cluster setup to run the automated tests instead of a standalone `main.tf`. Since `k3s` doesn't really have a reference architecture the module we are using is quite rough and had some hacky DNS setup method. This PR cleans it up to add a proper managed DNS entry and adds the NS record to the DNS project. This still doesn't make k3s module usable for a outside user. We will be tackling that issue in the `k3s reference architecture` task.

Here are the other two PRs:
- [ ] https://github.com/gitpod-io/gitpod/pull/13561 (doesn't depend on this PR)
- [ ] https://github.com/gitpod-io/gitpod/pull/13542

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
```
werft run github -j .werft/k3s-installer-tests.yaml -a skipTests=true
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
