### PR TITLE
[installer-tests] Use reference architecture to run integration tests

### DIFF
--- a/.werft/installer-tests.ts
+++ b/.werft/installer-tests.ts
@@ -62,23 +62,26 @@ const TEST_CONFIGURATIONS: { [name: string]: TestConfig } = {
         CLOUD: "gcp",
         DESCRIPTION: `${op} Gitpod on GKE managed cluster(version ${k8s_version})`,
         PHASES: [
-            "STANDARD_GKE_CLUSTER",
+            "STANDARD_CLUSTER",
+            "EXTERNALDNS",
             "CERT_MANAGER",
-            "GCP_MANAGED_DNS",
             "ADD_NS_RECORD",
             "CLUSTER_ISSUER",
+            "UPLOAD_CREDENTIALS",
             "GENERATE_KOTS_CONFIG",
             "INSTALL_GITPOD",
             "CHECK_INSTALLATION",
         ],
     },
     STANDARD_K3S_TEST: {
-        CLOUD: "gcp", // the cloud provider is still GCP
+        CLOUD: "k3s",
         DESCRIPTION: `${op} Gitpod on a K3s cluster(version ${k8s_version}) on a GCP instance with ubuntu ${os_version}`,
         PHASES: [
-            "STANDARD_K3S_CLUSTER_ON_GCP",
+            "STANDARD_CLUSTER",
+            "ADD_NS_RECORD",
             "CERT_MANAGER",
             "CLUSTER_ISSUER",
+            "UPLOAD_CREDENTIALS",
             "GENERATE_KOTS_CONFIG",
             "INSTALL_GITPOD",
             "CHECK_INSTALLATION",
@@ -88,11 +91,12 @@ const TEST_CONFIGURATIONS: { [name: string]: TestConfig } = {
         CLOUD: "azure",
         DESCRIPTION: `${op} Gitpod on AKS(version ${k8s_version})`,
         PHASES: [
-            "STANDARD_AKS_CLUSTER",
+            "STANDARD_CLUSTER",
             "CERT_MANAGER",
             "CLUSTER_ISSUER",
             "EXTERNALDNS",
             "ADD_NS_RECORD",
+            "UPLOAD_CREDENTIALS",
             "GENERATE_KOTS_CONFIG",
             "INSTALL_GITPOD",
             "CHECK_INSTALLATION",
@@ -102,11 +106,12 @@ const TEST_CONFIGURATIONS: { [name: string]: TestConfig } = {
         CLOUD: "aws",
         DESCRIPTION: `${op} an EKS cluster(version ${k8s_version})`,
         PHASES: [
-            "STANDARD_EKS_CLUSTER",
+            "STANDARD_CLUSTER",
             "CERT_MANAGER",
             "EXTERNALDNS",
             "CLUSTER_ISSUER",
             "ADD_NS_RECORD",
+            "UPLOAD_CREDENTIALS",
             "GENERATE_KOTS_CONFIG",
             "INSTALL_GITPOD",
             "CHECK_INSTALLATION",
@@ -127,25 +132,15 @@ const cloud: string = config.CLOUD;
 // Each phase should contain a `makeTarget` which
 // corresponds to a target in the Makefile in ../install/tests/Makefile
 const INFRA_PHASES: { [name: string]: InfraConfig } = {
-    STANDARD_GKE_CLUSTER: {
-        phase: "create-std-gke-cluster",
-        makeTarget: `gke-standard-cluster`,
-        description: `Creating a GCP GKE cluster(version: ${k8s_version}) with 1 nodepool each for workspace and server`,
+    STANDARD_CLUSTER: {
+        phase: `create-${cloud}-ref-arch-single-cluster`,
+        makeTarget: `standard-cluster`,
+        description: `Create a ${cloud} kubernetes cluster(version: ${k8s_version}) using single-cluster ref-arch`
     },
-    STANDARD_K3S_CLUSTER_ON_GCP: {
-        phase: "create-std-k3s-cluster",
-        makeTarget: `k3s-standard-cluster os_version=${os_version}`,
-        description: `Creating a k3s(version: ${k8s_version}) cluster on GCP with 1 node`,
-    },
-    STANDARD_AKS_CLUSTER: {
-        phase: "create-std-aks-cluster",
-        makeTarget: `aks-standard-cluster`,
-        description: `Creating an Azure AKS cluster(version: ${k8s_version})`,
-    },
-    STANDARD_EKS_CLUSTER: {
-        phase: "create-std-eks-cluster",
-        makeTarget: `eks-standard-cluster`,
-        description: `Creating a AWS EKS cluster(version: ${k8s_version}) with 1 nodepool each for workspace and server`,
+    UPLOAD_CREDENTIALS: {
+        phase: "upload-credentials",
+        makeTarget: `upload-creds`,
+        description: `Upload ${cloud} kubernetes credentials to GCS`,
     },
     CERT_MANAGER: {
         phase: "setup-cert-manager",
@@ -452,7 +447,7 @@ function runIntegrationTests() {
 function callMakeTargets(phase: string, description: string, makeTarget: string, failable: boolean = false) {
     werft.log(phase, `Calling ${makeTarget}`);
     // exporting cloud env var is important for the make targets
-    const env = `export TF_VAR_cluster_version=${k8s_version} cloud=${cloud} TF_VAR_domain=${baseDomain} TF_VAR_gcp_zone=${gcpDnsZone}`;
+    const env = `export CLUSTER_VERSION=${k8s_version} cloud=${cloud} DOMAIN=${baseDomain} GCP_ZONE=${gcpDnsZone} os_version=${os_version}`;
 
     const response = exec(
         `${env} && make -C ${makefilePath} ${makeTarget}`,

--- a/install/infra/modules/k3s/main.tf
+++ b/install/infra/modules/k3s/main.tf
@@ -21,11 +21,6 @@ provider "google" {
   zone        = var.gcp_zone
 }
 
-provider "google" {
-  alias       = "dns"
-  credentials = var.dns_sa_creds == "" ? var.credentials : var.dns_sa_creds
-}
-
 resource "google_service_account" "gcp_instance" {
   account_id   = "sa-${var.name}"
   display_name = "Service Account"

--- a/install/infra/modules/k3s/output.tf
+++ b/install/infra/modules/k3s/output.tf
@@ -28,5 +28,5 @@ output "storage" {
 }
 
 output "name_servers" {
-  value = google_dns_managed_zone.gitpod-dns-zone[0].name_servers
+  value = try(google_dns_managed_zone.gitpod-dns-zone[0].name_servers, [])
 }

--- a/install/tests/Makefile
+++ b/install/tests/Makefile
@@ -11,26 +11,10 @@ cert_secret := ${TF_VAR_TEST_ID}-cert-secret.yaml
 github_oauth_secret := ${TF_VAR_TEST_ID}-github-secret.yaml
 config_patch := ./manifests/config_patch.yaml
 
-check-env-sub-domain:
-ifndef TF_VAR_TEST_ID
-	$(error TF_VAR_TEST_ID is not defined)
-endif
+TF_MOD := ../infra/single-cluster/$(cloud)
 
-check-env-domain:
-ifndef TF_VAR_domain
-	$(error TF_VAR_domain is not defined)
-endif
-
-
-check-env-cloud:
-ifndef cloud
-	$(error cloud is not defined)
-endif
-
-check-env-cluster-version:
-ifndef TF_VAR_cluster_version
-	$(error TF_VAR_cluster_version is not defined)
-endif
+check-var-%:
+	@[[ "${${*}}" ]] || (echo '*** Please define variable `${*}` ***' && exit 1)
 
 .PHONY: help
 all: help
@@ -41,23 +25,135 @@ help: Makefile
 	@sed -n 's/^##//p' $< | column -t -s ':' |  sed -e 's/^/ /'
 	@echo
 
-upload-gcp-cluster-creds:
-	export GKE_CREDS=$$(terraform output -json gke_user_key) && \
-	echo $$GKE_CREDS > gcp-creds
-	gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS} --project=sh-automated-tests
-	gsutil cp gcp-creds gs://nightly-tests/tf-state/${TF_VAR_TEST_ID}-creds
+tf-init: check-var-cloud
+	@terraform -chdir=${TF_MOD} init --upgrade
 
-download-cluster-creds:
-	[[ -z $$self_hosted_jobs ]] || gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS} --project=sh-automated-tests
-	gcloud config set project sh-automated-tests
-	[[ -n $$self_hosted_jobs ]] || gsutil cp gs://nightly-tests/tf-state/${TF_VAR_TEST_ID}-creds gcs-creds
-	[[ -f gcs-creds ]]  && cat gcs-creds | tr -d '"' | base64 -d > ${TF_VAR_TEST_ID}-key.json || echo "No GCP credentials"
-	rm -f gcs-creds
-	[[ -f ${TF_VAR_TEST_ID}-key.json ]] || cp ${GOOGLE_APPLICATION_CREDENTIALS} ${TF_VAR_TEST_ID}-key.json
+tf-ws: check-var-cloud
+	@terraform -chdir=${TF_MOD} workspace new ${TF_VAR_TEST_ID} || terraform -chdir=${TF_MOD} workspace select ${TF_VAR_TEST_ID}
+
+tf-plan: check-var-cloud tf-ws
+	$(MAKE) -C ${TF_MOD} plan
+
+tf-apply: check-var-cloud tf-ws
+	@echo "Get kubeconfig of existing cluster(if any)..."
+	$(MAKE) get-kubeconfig || echo "No pre-existing cluster"
+	@echo "Run terraform apply"
+	$(MAKE) -C ${TF_MOD} apply-cluster
+
+tf-destroy: check-var-cloud
+	[[ -f ${KUBECONFIG} ]] && $(MAKE) -C ${TF_MOD} destroy-tools || echo "**Warning**: Could not cleanup helm resources"
+	$(MAKE) -C ${TF_MOD} destroy-cluster
+
+tf-refresh: check-var-cloud
+	$(MAKE) -C ${TF_MOD} refresh
+
+tf-output: tf-ws check-var-cloud tf-refresh
+	@terraform -chdir=${TF_MOD} output -json > ${TOPDIR}/${TF_VAR_TEST_ID}-output.json
+	@echo "Output written to ${TF_VAR_TEST_ID}-output.json"
+
+create-eks-user:
+ifeq ($(cloud), aws)
+	@export USERARN=$$(cat ${TF_VAR_TEST_ID}-output.json | yq r - 'aws_cluster_user.value.userarn') && \
+	export NAME=$$(cat ${TF_VAR_TEST_ID}-output.json | yq r - 'aws_cluster_user.value.name') && \
+	envsubst < ./manifests/aws-auth.yaml > tmp-aws-auth.yaml
+	@kubectl --kubeconfig=${KUBECONFIG} get configmap -n kube-system aws-auth -o yaml | grep -v "creationTimestamp\|resourceVersion\|selfLink\|uid" | sed '/^  annotations:/,+2 d' > /tmp/aws-auth.yaml
+	@yq m --inplace /tmp/aws-auth.yaml tmp-aws-auth.yaml
+	@kubectl --kubeconfig=${KUBECONFIG} replace -f /tmp/aws-auth.yaml
+else
+	@echo "Nothing to do"
+endif
+
+upload-creds: tf-output create-eks-user
+	@echo "Trying to upload the JSON output to GCS"
+	@gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS} --project=sh-automated-tests
+	@gsutil cp $(TF_VAR_TEST_ID)-output.json gs://nightly-tests/tf-state/${TF_VAR_TEST_ID}-creds.json || echo "Could not upload credentials"
+	@[[ $(cloud) = k3s ]] && $(MAKE) upload-kubeconfig-to-gcp || echo "Skipping upload of kubeconfig since cluster is not k3s"
 
 upload-kubeconfig-to-gcp:
-	gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS} --project=sh-automated-tests
-	gsutil cp ${KUBECONFIG} gs://nightly-tests/tf-state/${TF_VAR_TEST_ID}-kubeconfig
+	@echo "Upload k3s kubeconfig to GCS"
+	@gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS} --project=sh-automated-tests
+	@gsutil cp ${KUBECONFIG} gs://nightly-tests/tf-state/${TF_VAR_TEST_ID}-kubeconfig
+
+download-creds:
+	@echo "Download terraform output from GCS"
+	@[[ -z $$self_hosted_jobs ]] || gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS} --project=sh-automated-tests
+	@gsutil cp gs://nightly-tests/tf-state/${TF_VAR_TEST_ID}-creds.json $(TF_VAR_TEST_ID)-output.json || echo "Could not upload credentials"
+
+ami_id_121 := "ami-060637af2651bc8bb"
+ami_id_122 := "ami-0733d755ed2c97a4d"
+ami_id_123 := "ami-05ec8881b9c2740d4"
+
+# K3S ubuntu image ID
+image_id_1804 := "ubuntu-1804-bionic-v20220712"
+image_id_2004 := "ubuntu-2004-focal-v20220712"
+image_id_2204 := "ubuntu-2204-jammy-v20220712a"
+
+os_version ?= "2004"
+
+.PHONY:
+prepare-terraform: ami_id = $(if $(ami_id_${CLUSTER_VERSION//.}),$(ami_id_${CLUSTER_VERSION//.}),$(ami_id_122))
+prepare-terraform: ubuntu_image_id = $(if $(image_id_$(os_version)),$(image_id_$(os_version)),$(image_id_2004))
+prepare-terraform: check-var-cloud check-var-CLUSTER_VERSION check-var-DOMAIN check-var-GCP_ZONE
+	@export KUBECONFIG=${KUBECONFIG} IMAGE_ID=${ami_id} UBUNTU_IMAGE=${ubuntu_image_id} && \
+	envsubst < ./manifests/$(cloud)-terraform.tfvars > $(TF_MOD)/terraform.tfvars && \
+	cp ./manifests/tf-backend.tf $(TF_MOD)/main.tf  # we set the backend to be gcs based
+	@$(MAKE) copy-dns-tf
+	@echo "Done setting up tf backend and terraform.tfvars file"
+
+
+cluster_gcp := gke
+cluster_k3s := k3s
+cluster_aws := eks
+cluster_azure := aks
+
+copy-dns-tf: cluster_mod = $(cluster_$(cloud))
+copy-dns-tf:
+	@export cluster=$(cluster_mod) && \
+	envsubst < ./manifests/managed-dns.tf > $(TF_MOD)/managed-dns.tf
+	@echo "Copied managed-dns.tf to create NS record entries"
+
+.PHONY:
+standard-cluster: check-var-cloud check-var-TF_VAR_TEST_ID prepare-terraform tf-init
+	$(MAKE) get-kubeconfig
+	[[ -f ${KUBECONFIG} ]] || { echo "No pre-existing clusters, creating..."; $(MAKE) tf-apply; }
+
+.PHONY:
+## add-ns-record: Adds NS record for subdomain under gitpod-selfhosted.com
+add-ns-record: check-var-cloud prepare-terraform tf-init tf-ws
+	@terraform -chdir=$(TF_MOD) apply -target=module.add-dns-record --auto-approve
+	@echo "Done adding NS record"
+
+.PHONY:
+## cert-manager: Installs cert-manager, optionally create secret for cloud-dns access
+cert-manager: check-var-cloud prepare-terraform tf-init tf-ws
+	@terraform -chdir=$(TF_MOD) apply -target=module.certmanager --auto-approve
+	@echo "Done installing cert-manager"
+
+.PHONY:
+## external-dns: Installs external-dns
+external-dns: check-var-cloud prepare-terraform tf-init tf-ws
+	@terraform -chdir=$(TF_MOD) apply -target=module.externaldns --auto-approve
+	@echo "Done creating externaldns for $(cloud)"
+
+self_signed ?= false
+.PHONY:
+## cluster-issuer: Creates a cluster issuer for the correspondign provider
+cluster-issuer: check-var-cloud tf-init tf-ws
+ifeq (true,$(self_signed))
+	@echo "Skipped creating cluster issuer"
+else
+	$(MAKE) -C $(TF_MOD) install-cluster-issuer
+	@echo "Done creating cluster issuer"
+endif
+
+
+## TODO: (nvn) cleanup all the `get-kubeconfig` targets
+.PHONY:
+## get-kubeconfig: Returns KUBECONFIG of a just created cluster
+get-kubeconfig:
+	@echo "Getting kubeconfig for $$TF_VAR_TEST_ID terraform state" && \
+    export provider=$$(echo "$$TF_VAR_TEST_ID" | sed 's/\(.*\)-/\1 /' | xargs | awk '{print $$2}') && \
+	$(MAKE) $$provider-kubeconfig && echo "kubeconfig written to ${KUBECONFIG}"
 
 sync-kubeconfig:
 	[[ -z $$self_hosted_jobs ]] || gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS} --project=sh-automated-tests
@@ -69,150 +165,44 @@ k3s-kubeconfig: sync-kubeconfig
 
 ## gcp-kubeconfig: Get the kubeconfig configuration for GCP GKE
 gcp-kubeconfig:
-	$(MAKE) download-cluster-creds
-	gcloud auth activate-service-account --key-file=${TF_VAR_TEST_ID}-key.json --project=sh-automated-tests || { echo "Count not authenicate the service account"; exit 1; }
-	export KUBECONFIG=${KUBECONFIG} && \
+	@echo "Getting GKE kubeconfig"
+	@[[ -n $$self_hosted_jobs ]] || $(MAKE) download-creds
+	@[[ -n $$self_hosted_jobs ]] || cat $(TF_VAR_TEST_ID)-output.json | yq r - 'gke_user_key.value' | base64 -d > ${TF_VAR_TEST_ID}-key.json
+	@[[ -f ${TF_VAR_TEST_ID}-key.json ]] || cat ${GOOGLE_APPLICATION_CREDENTIALS} > ${TF_VAR_TEST_ID}-key.json
+	@gcloud auth activate-service-account --key-file=${TF_VAR_TEST_ID}-key.json --project=sh-automated-tests || { echo "Count not authenicate the service account"; exit 1; }
+	@export KUBECONFIG=${KUBECONFIG} && \
 	gcloud container clusters get-credentials gp-${TF_VAR_TEST_ID} --zone europe-west1-d --project sh-automated-tests || echo "No cluster present"
-	rm -f ${TF_VAR_TEST_ID}-key.json
+	@rm -f ${TF_VAR_TEST_ID}-key.json
+	@echo "Kubeconfig written to ${KUBECONFIG}"
 
 ## azure-kubeconfig: Get the kubeconfig configuration for Azure AKS
 azure-kubeconfig:
-	[[ -z "$$self_hosted_jobs" ]] || az login --service-principal -u $$ARM_CLIENT_ID -p $$ARM_CLIENT_SECRET  --tenant $$ARM_TENANT_ID
-	export KUBECONFIG=${KUBECONFIG} && \
-	az aks get-credentials --name p$$TF_VAR_TEST_ID-cluster --resource-group p$$TF_VAR_TEST_ID --file ${KUBECONFIG} || echo "No cluster present"
+	@echo "Getting GKE kubeconfig"
+	@[[ -z "$$self_hosted_jobs" ]] || az login --service-principal -u $$ARM_CLIENT_ID -p $$ARM_CLIENT_SECRET  --tenant $$ARM_TENANT_ID
+	@export KUBECONFIG=${KUBECONFIG} && \
+	az aks get-credentials --name gp-$$TF_VAR_TEST_ID-cluster --resource-group gp-$$TF_VAR_TEST_ID --file ${KUBECONFIG} || echo "No cluster present"
+
+get-aws-secret:
+	@echo "Getting AWS terraform output"
+	@[[ -z $$self_hosted_jobs ]] || gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS} --project=sh-automated-tests
+	@gcloud config set project sh-automated-tests
+	@gsutil cp gs://nightly-tests/tf-state/${TF_VAR_TEST_ID}-creds.json ${TF_VAR_TEST_ID}-output.json
+	@echo "export AWS_SECRET_ACCESS_KEY=$$(cat ${TF_VAR_TEST_ID}-output.json | yq r - 'aws_cluster_user.value.secret_access_key')" > ${TF_VAR_TEST_ID}-creds
+	@echo "export AWS_ACCESS_KEY_ID=$$(cat ${TF_VAR_TEST_ID}-output.json | yq r - 'aws_cluster_user.value.access_key_id')" >>  ${TF_VAR_TEST_ID}-creds
+	@echo -e "\033[0;33mAWS service account credentials fetched, run 'source $$(pwd)/$${TF_VAR_TEST_ID}-creds' to load them into your environment\033[0;m"
 
 ## aws-kubeconfig: Get the kubeconfig configuration for AWS EKS
 aws-kubeconfig:
-	[[ -z $$self_hosted_jobs ]] || gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS} --project=sh-automated-tests
-	gcloud config set project sh-automated-tests
-	[[ -n $$self_hosted_jobs ]] || gsutil cp gs://nightly-tests/tf-state/${TF_VAR_TEST_ID}-creds ${TF_VAR_TEST_ID}-creds
-	[[ -f ${TF_VAR_TEST_ID}-creds ]] || touch ${TF_VAR_TEST_ID}-creds
-	source ${TF_VAR_TEST_ID}-creds; \
-	aws eks update-kubeconfig --name ${TF_VAR_TEST_ID} --region eu-west-1 --kubeconfig ${KUBECONFIG} || echo "No cluster present"
+	@echo "Getting kubeconfig"
+	@[[ -n $$self_hosted_jobs ]] || $(MAKE) get-aws-secret
+	@[[ -f ${TF_VAR_TEST_ID}-creds ]] || touch ${TF_VAR_TEST_ID}-creds
+	@source ${TF_VAR_TEST_ID}-creds; \
+	aws eks update-kubeconfig --name gp-${TF_VAR_TEST_ID} --region eu-west-1 --kubeconfig ${KUBECONFIG} || echo "No cluster present"
 	@echo -e "\033[0;33mAWS service account credentials fetched, run 'source $$(pwd)/$${TF_VAR_TEST_ID}-creds' to load them into your environment\033[0;m"
-
-.PHONY:
-## gke-standard-cluster: Creates a zonal GKE cluster
-gke-standard-cluster: check-env-cluster-version
-	terraform init --upgrade && \
-	terraform workspace new $(TF_VAR_TEST_ID) || $(MAKE) select-workspace && \
-	rm -f ${KUBECONFIG} && \
-	$(MAKE) get-kubeconfig && \
-	[[ -f ${KUBECONFIG} ]] || terraform apply -target=module.gke -var kubeconfig=${KUBECONFIG} --auto-approve
-	$(MAKE) upload-gcp-cluster-creds
-	@echo "Done creating GKE cluster"
-
-upload-eks-user:
-	export AWS_CLUSTER_USER=$$(terraform output -json aws_cluster_user) && \
-	export USERARN=$$(echo $$AWS_CLUSTER_USER | yq r - 'userarn') && \
-	export NAME=$$(echo $$AWS_CLUSTER_USER | yq r - 'name') && \
-	envsubst < ./manifests/aws-auth.yaml > tmp-aws-auth.yaml && \
-	echo "export AWS_SECRET_ACCESS_KEY=$$(echo $$AWS_CLUSTER_USER | yq r - 'secret_access_key')" > ${TF_VAR_TEST_ID}-creds && \
-	echo "export AWS_ACCESS_KEY_ID=$$(echo $$AWS_CLUSTER_USER | yq r - 'access_key_id')" >> ${TF_VAR_TEST_ID}-creds && \
-	kubectl --kubeconfig=${KUBECONFIG} get configmap -n kube-system aws-auth -o yaml | grep -v "creationTimestamp\|resourceVersion\|selfLink\|uid" | sed '/^  annotations:/,+2 d' > /tmp/aws-auth.yaml
-	yq m --inplace /tmp/aws-auth.yaml tmp-aws-auth.yaml
-	gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS} --project=sh-automated-tests
-	gsutil cp ${TF_VAR_TEST_ID}-creds gs://nightly-tests/tf-state/${TF_VAR_TEST_ID}-creds
-	kubectl --kubeconfig=${KUBECONFIG} replace -f /tmp/aws-auth.yaml
-
-ami_id_121 := "ami-060637af2651bc8bb"
-
-ami_id_122 := "ami-0733d755ed2c97a4d"
-
-ami_id_123 := "ami-05ec8881b9c2740d4"
-
-.PHONY:
-## eks-standard-cluster: Creates an EKS cluster
-eks-standard-cluster: ami_id = $(if $(ami_id_${TF_VAR_cluster_version//.}),$(ami_id_${TF_VAR_cluster_version//.}),$(ami_id_122))
-eks-standard-cluster: check-env-cluster-version
-	terraform init --upgrade && \
-	terraform workspace new $(TF_VAR_TEST_ID) || $(MAKE) select-workspace && \
-	rm -f ${KUBECONFIG} && \
-	$(MAKE) get-kubeconfig && \
-	[[ -f ${KUBECONFIG} ]] || terraform apply -target=module.eks -var kubeconfig=${KUBECONFIG} -var eks_node_image_id=${ami_id} --auto-approve
-	$(MAKE) upload-eks-user
-	@echo "Done creating EKS cluster"
-
-.PHONY:
-## aks-standard-cluster: Creates an AKS cluster
-aks-standard-cluster: check-env-cluster-version
-	terraform init --upgrade && \
-	terraform workspace new $(TF_VAR_TEST_ID) || $(MAKE) select-workspace && \
-	rm -f ${KUBECONFIG} && \
-	$(MAKE) get-kubeconfig && \
-	[[ -f ${KUBECONFIG} ]] || terraform apply -target=module.aks -var kubeconfig=${KUBECONFIG} --auto-approve
-	@echo "Done creating AKS cluster"
-
-.PHONY:
-## add-ns-record: Adds NS record for subdomain under gitpod-selfhosted.com
-add-ns-record: check-env-cloud
-	terraform init --upgrade && \
-	terraform workspace new $(TF_VAR_TEST_ID) || terraform workspace select $(TF_VAR_TEST_ID) && \
-	terraform apply -target=module.$(cloud)-add-dns-record  -var kubeconfig=${KUBECONFIG} --auto-approve
-	@echo "Done adding NS record"
-
-self_signed ?= false
-.PHONY:
-## cluster-issuer: Creates a cluster issuer for the correspondign provider
-cluster-issuer: check-env-cloud
-ifeq (true,$(self_signed))
-	@echo "Skipped creating cluster issuer"
-else
-	terraform init --upgrade && \
-	terraform workspace new $(TF_VAR_TEST_ID) || terraform workspace select $(TF_VAR_TEST_ID) && \
-	terraform apply -target=module.$(cloud)-issuer  -var kubeconfig=${KUBECONFIG} --auto-approve
-	@echo "Done creating cluster issuer"
-endif
-
-image_id_1804 := "ubuntu-1804-bionic-v20220712"
-
-image_id_2004 := "ubuntu-2004-focal-v20220712"
-
-image_id_2204 := "ubuntu-2204-jammy-v20220712a"
-
-os_version ?= "2004"
-.PHONY:
-## k3s-standard-cluster: Creates a K3S cluster on GCP with one master and 1 worker node
-k3s-standard-cluster: image_id = $(if $(image_id_$(os_version)),$(image_id_$(os_version)),$(image_id_2004))
-k3s-standard-cluster: check-env-cluster-version
-	terraform init --upgrade && \
-	terraform workspace new $(TF_VAR_TEST_ID) || $(MAKE) select-workspace && \
-	rm -f ${KUBECONFIG} && \
-	$(MAKE) get-kubeconfig && \
-	[[ -f ${KUBECONFIG} ]] || terraform apply -target=module.k3s -var kubeconfig=${KUBECONFIG} -var k3s_node_image_id=${image_id} --auto-approve && \
-	terraform apply -target=module.k3s-add-dns-record  -var kubeconfig=${KUBECONFIG} --auto-approve
-	$(MAKE) upload-kubeconfig-to-gcp # we upload the file to GCP since we cannot retrieve the file against without SSHing to the master
-	@echo "Done creating k3s cluster"
-
-.PHONY:
-## cert-manager: Installs cert-manager, optionally create secret for cloud-dns access
-cert-manager:
-	$(MAKE) select-workspace && \
-	terraform apply -target=module.certmanager -var kubeconfig=${KUBECONFIG} --auto-approve
-	@echo "Done installing cert-manager"
-
-.PHONY:
-## managed-dns: Installs external-dns, and setup up CloudDNS access
-managed-dns: check-env-sub-domain select-workspace
-	terraform apply -target=module.clouddns-externaldns -var kubeconfig=${KUBECONFIG} --auto-approve
-	@echo "Done created GCP managed DNS"
-
-.PHONY:
-## external-dns: Installs external-dns
-external-dns: check-env-cloud select-workspace
-	terraform apply -target=module.$(cloud)-externaldns -var kubeconfig=${KUBECONFIG} --auto-approve
-	@echo "Done creating externaldns for $(cloud)"
-
-.PHONY:
-## get-kubeconfig: Returns KUBECONFIG of a just created cluster
-get-kubeconfig:
-	echo "Getting kubeconfig for $$TF_VAR_TEST_ID terraform state" && \
-    export provider=$$(echo "$$TF_VAR_TEST_ID" | sed 's/\(.*\)-/\1 /' | xargs | awk '{print $$2}') && \
-	$(MAKE) $$provider-kubeconfig && echo "kubeconfig written to ${KUBECONFIG}"
 
 get-github-config:
 ifneq ($(GITHUB_SCM_OAUTH),)
-	export SCM_OAUTH=./manifests/github-oauth.yaml && \
+	@export SCM_OAUTH=./manifests/github-oauth.yaml && \
 	cat $$GITHUB_SCM_OAUTH > $$SCM_OAUTH && \
 	yq w -i $$SCM_OAUTH 'oauth.callBackUrl' https://scm.${TF_VAR_domain}/auth/github.com/callback?state=${TF_VAR_TEST_ID} && \
 	kubectl --kubeconfig=${KUBECONFIG} create secret generic "github-oauth" \
@@ -220,108 +210,145 @@ ifneq ($(GITHUB_SCM_OAUTH),)
 		-o yaml --dry-run=client > ${github_oauth_secret}
 	echo -en  "authProviders:\n  - kind: secret\n    name: github-oauth\n" | base64 -w 0 > ${config_patch}
 else
-	echo "Skipping github setup since var GITHUB_SCM_OAUTH is not set"
+	@echo "Skipping github setup since var GITHUB_SCM_OAUTH is not set"
 endif
 
 
 KOTS_KONFIG := "./manifests/kots-config.yaml"
 
 get-base-config:
-	export DOMAIN=${TF_VAR_domain} && \
+	@echo "Creating base configuration"
+	@export CONFIG_PATCH=./manifests/config-patch.yaml && \
 	export PATCH=$$(cat ${config_patch}) || export PATCH="" && \
 	envsubst < ${KOTS_KONFIG} > tmp_config.yml
 
-storage-config-gcp:
-	export BASE64_GCP_KEY=$$(cat $$TF_VAR_sa_creds | tr -d '\n' | base64 -w 0) && \
+storage-config-k3s:
+	@export k3s_storage_credentials=$$(cat ${TF_VAR_TEST_ID}-output.json | yq r - 'storage.value.service_account_key_path') && \
+	[[ $$k3s_storage_credentials = /* ]] || export k3s_storage_credentials=$$(realpath $(TF_MOD)/$$k3s_storage_credentials) && \
+	export BASE64_GCP_KEY=$$(cat $$k3s_storage_credentials | tr -d '\n' | base64 -w 0) && \
 	envsubst < ./manifests/kots-config-gcp-storage.yaml > tmp_2_config.yml
 	yq m -i tmp_config.yml tmp_2_config.yml
 
-registry-config-gcp:
-	export GCP_KEY=$$(cat $$TF_VAR_sa_creds | tr -d '\n' | jq -Rsa .) && \
+registry-config-k3s:
+	@export k3s_registry_credentials=$$(cat ${TF_VAR_TEST_ID}-output.json | yq r - 'registry.value.password_file_path') && \
+	[[ $$k3s_registry_credentials = /* ]] || export k3s_registry_credentials=$$(realpath $(TF_MOD)/$$k3s_registry_credentials) && \
+	export GCP_KEY=$$(cat $$k3s_registry_credentials | tr -d '\n' | jq -Rsa .) && \
 	envsubst < ./manifests/kots-config-gcp-registry.yaml > tmp_4_config.yml
 	yq m -i tmp_config.yml tmp_4_config.yml
 
-db-config-gcp:
-	export BASE64_GCP_KEY=$$(cat $$TF_VAR_sa_creds | tr -d '\n' | base64 -w 0) && \
-	export DB_OUTPUT=$$(terraform output -json k3s_database || terraform output -json gke_database) && \
-	export DB_INSTANCE=$$(echo $$DB_OUTPUT | yq r - 'instance') && \
-	export DB_PASSWORD=$$(echo $$DB_OUTPUT | yq r - 'password') && \
-	export DB_USER=$$(echo $$DB_OUTPUT | yq r - 'username') && \
+db-config-k3s:
+	@export k3s_db_credentials=$$(cat ${TF_VAR_TEST_ID}-output.json | yq r - 'database.value.service_account_key_path') && \
+	[[ $$k3s_db_credentials = /* ]] || export k3s_db_credentials=$$(realpath $(TF_MOD)/$$k3s_db_credentials) && \
+	export BASE64_GCP_KEY=$$(cat $$k3s_db_credentials | tr -d '\n' | base64 -w 0) && \
+	export DB_INSTANCE=$$(cat ${TF_VAR_TEST_ID}-output.json | yq r - 'database.value.instance') && \
+	export DB_PASSWORD=$$(cat ${TF_VAR_TEST_ID}-output.json | yq r - 'database.value.password') && \
+	export DB_USER=$$(cat ${TF_VAR_TEST_ID}-output.json | yq r - 'database.value.username') && \
 	envsubst < ./manifests/kots-config-gcp-db.yaml > tmp_4_config.yml
 	envsubst < tmp_4_config.yml > tmp_5_config.yml
 	yq m -i tmp_config.yml tmp_5_config.yml
 
+storage-config-gcp:
+	@echo "Creating GCP storage configuration"
+	@export BASE64_GCP_KEY=$$(cat ${TF_VAR_TEST_ID}-output.json | yq r - 'storage.value.service_account_key' | tr -d '\n' | base64 -w 0) && \
+	envsubst < ./manifests/kots-config-gcp-storage.yaml > tmp_2_config.yml
+	@yq m -i tmp_config.yml tmp_2_config.yml
+
+registry-config-gcp:
+	@echo "Creating GCP registry configuration"
+	@export GCP_KEY=$$(cat ${TF_VAR_TEST_ID}-output.json | yq r - 'registry.value.password' | tr -d '\n' | jq -Rsa .) && \
+	envsubst < ./manifests/kots-config-gcp-registry.yaml > tmp_4_config.yml
+	@yq m -i tmp_config.yml tmp_4_config.yml
+
+db-config-gcp:
+	@echo "Creating GCP database configuration"
+	@export BASE64_GCP_KEY=$$(cat ${TF_VAR_TEST_ID}-output.json | yq r - 'database.value.service_account_key' | tr -d '\n' | base64 -w 0) && \
+	export DB_INSTANCE=$$(cat ${TF_VAR_TEST_ID}-output.json | yq r - 'database.value.instance') && \
+	export DB_PASSWORD=$$(cat ${TF_VAR_TEST_ID}-output.json | yq r - 'database.value.password') && \
+	export DB_USER=$$(cat ${TF_VAR_TEST_ID}-output.json | yq r - 'database.value.username') && \
+	envsubst < ./manifests/kots-config-gcp-db.yaml > tmp_4_config.yml
+	@envsubst < tmp_4_config.yml > tmp_5_config.yml
+
 registry-config-azure:
-	export SERVER=$$(terraform output -json azure_registry | yq r - 'server') && \
-	export URL=$$(terraform output -json azure_registry | yq r - 'url') && \
-	export PASSWORD=$$(terraform output -json azure_registry | yq r - 'password') && \
-	export USERNAME=$$(terraform output -json azure_registry | yq r - 'username') && \
+	@echo "Creating Azure registry configuration"
+	@export SERVER=$$(cat ${TF_VAR_TEST_ID}-output.json | yq r - 'registry.value.server') && \
+	export URL=$$(cat ${TF_VAR_TEST_ID}-output.json | yq r - 'registry.value.url') && \
+	export PASSWORD=$$(cat ${TF_VAR_TEST_ID}-output.json | yq r - 'registry.value.password') && \
+	export USERNAME=$$(cat ${TF_VAR_TEST_ID}-output.json | yq r - 'registry.value.username') && \
 	envsubst < ./manifests/kots-config-azure-registry.yaml > tmp_2_config.yml
-	yq m -i tmp_config.yml tmp_2_config.yml
+	@yq m -i tmp_config.yml tmp_2_config.yml
 
 storage-config-azure:
-	export USERNAME=$$(terraform output -json azure_storage | yq r - 'account_name') && \
-	export PASSWORD=$$(terraform output -json azure_storage | yq r - 'account_key') && \
-	export REGION=$$(terraform output -json azure_storage | yq r - 'storage_region') && \
+	@echo "Creating Azure storage configuration"
+	@export USERNAME=$$(cat ${TF_VAR_TEST_ID}-output.json | yq r - 'storage.value.account_name') && \
+	export PASSWORD=$$(cat ${TF_VAR_TEST_ID}-output.json| yq r - 'storage.value.account_key') && \
+	export REGION=$$(cat ${TF_VAR_TEST_ID}-output.json | yq r - 'storage.value.storage_region') && \
 	envsubst < ./manifests/kots-config-azure-storage.yaml > tmp_2_config.yml
-	yq m -i tmp_config.yml tmp_2_config.yml
+	@yq m -i tmp_config.yml tmp_2_config.yml
 
 db-config-azure:
-	export DBHOST=$$(terraform output -json azure_database | yq r - 'host') && \
-	export DBPASS=$$(terraform output -json azure_database | yq r - 'password') && \
-	export DBUSER=$$(terraform output -json azure_database | yq r - 'username') && \
+	@echo "Creating Azure database configuration"
+	@export DBHOST=$$(cat ${TF_VAR_TEST_ID}-output.json | yq r - 'database.value.host') && \
+	export DBPASS=$$(cat ${TF_VAR_TEST_ID}-output.json | yq r - 'database.value.password') && \
+	export DBUSER=$$(cat ${TF_VAR_TEST_ID}-output.json | yq r - 'database.value.username') && \
 	envsubst < ./manifests/kots-config-azure-db.yaml > tmp_2_config.yml
-	yq m -i tmp_config.yml tmp_2_config.yml
+	@yq m -i tmp_config.yml tmp_2_config.yml
 
 db-config-aws:
-	export DBHOST=$$(terraform output -json aws_database | yq r - 'host') && \
-	export DBPASS=$$(terraform output -json aws_database | yq r - 'password') && \
-	export DBUSER=$$(terraform output -json aws_database | yq r - 'username') && \
+	@echo "Creating AWS database configuration"
+	@export DBHOST=$$(cat ${TF_VAR_TEST_ID}-output.json | yq r - 'database.value.host') && \
+	export DBPASS=$$(cat ${TF_VAR_TEST_ID}-output.json  | yq r - 'database.value.password') && \
+	export DBUSER=$$(cat ${TF_VAR_TEST_ID}-output.json  | yq r - 'database.value.username') && \
 	envsubst < ./manifests/kots-config-aws-db.yaml > tmp_2_config.yml
-	yq m -i tmp_config.yml tmp_2_config.yml
+	@yq m -i tmp_config.yml tmp_2_config.yml
 
 storage-config-aws:
-	export REGION=$$(terraform output -json aws_storage | yq r - 'region') && \
-	export ENDPOINT=$$(terraform output -json aws_storage | yq r - 'endpoint') && \
-	export BUCKET=$$(terraform output -json aws_storage | yq r - 'bucket_name') && \
-	export S3_ACCESS_KEY_ID=$$(terraform output -json aws_storage | yq r - 'access_key_id') && \
-	export S3_SECRET_ACCESS_KEY=$$(terraform output -json aws_storage | yq r - 'secret_access_key') && \
+	@echo "Creating AWS storage configuration"
+	@export REGION=$$(cat ${TF_VAR_TEST_ID}-output.json | yq r - 'storage.value.region') && \
+	export ENDPOINT=$$(cat ${TF_VAR_TEST_ID}-output.json | yq r - 'storage.value.endpoint') && \
+	export BUCKET=$$(cat ${TF_VAR_TEST_ID}-output.json | yq r - 'storage.value.bucket_name') && \
+	export S3_ACCESS_KEY_ID=$$(cat ${TF_VAR_TEST_ID}-output.json | yq r - 'storage.value.access_key_id') && \
+	export S3_SECRET_ACCESS_KEY=$$(cat ${TF_VAR_TEST_ID}-output.json | yq r - 'storage.value.secret_access_key') && \
 	envsubst < ./manifests/kots-config-aws-storage.yaml > tmp_2_config.yml
-	yq m -i tmp_config.yml tmp_2_config.yml
+	@yq m -i tmp_config.yml tmp_2_config.yml
 
 s3-registry-backend-config-aws: # this registry config involves using s3 backend for incluster registry
-	export REGION=$$(terraform output -json aws_s3_registry_backend | yq r - 'region') && \
-	export ENDPOINT=$$(terraform output -json aws_s3_registry_backend | yq r - 'endpoint') && \
-	export BUCKET=$$(terraform output -json aws_s3_registry_backend | yq r - 'bucket_name') && \
-	export S3_ACCESS_KEY_ID=$$(terraform output -json aws_s3_registry_backend | yq r - 'access_key_id') && \
-	export S3_SECRET_ACCESS_KEY=$$(terraform output -json aws_s3_registry_backend | yq r - 'secret_access_key') && \
+	@echo "Creating AWS registry backend configuration"
+	@export REGION=$$(cat ${TF_VAR_TEST_ID}-output.json | yq r - 'storage.value.region') && \
+	export ENDPOINT=$$(cat ${TF_VAR_TEST_ID}-output.json | yq r - 'storage.value.endpoint') && \
+	export BUCKET=$$(cat ${TF_VAR_TEST_ID}-output.json | yq r - 'storage.value.bucket_name') && \
+	export S3_ACCESS_KEY_ID=$$(cat ${TF_VAR_TEST_ID}-output.json | yq r - 'storage.value.access_key_id') && \
+	export S3_SECRET_ACCESS_KEY=$$(cat ${TF_VAR_TEST_ID}-output.json | yq r - 'storage.value.secret_access_key') && \
 	envsubst < ./manifests/kots-config-aws-s3-backend.yaml > tmp_2_config.yml
-	yq m -i tmp_config.yml tmp_2_config.yml
+	@yq m -i tmp_config.yml tmp_2_config.yml
 
 registry-config-aws:
-	export SERVER=$$(terraform output -json aws_registry | yq r - 'server' | cut -d / -f 1) && \
-	export PASSWORD=$$(terraform output -json aws_registry | yq r - 'password') && \
-	export USERNAME=$$(terraform output -json aws_registry | yq r - 'username') && \
-	envsubst < ./manifests/kots-config-aws-registry.yaml > tmp_2_config.yml
-	yq m -i tmp_config.yml tmp_2_config.yml
+	@echo "External registry is not supported yet for AWS"
+
+# @echo "Creating AWS registry configuration"
+# @export SERVER=$$(cat ${TF_VAR_TEST_ID}-output.json | yq r - 'registry.value.server' | cut -d / -f 1) && \
+# export PASSWORD=$$(cat ${TF_VAR_TEST_ID}-output.json | yq r - 'registry.value.password') && \
+# export USERNAME=$$(cat ${TF_VAR_TEST_ID}-output.json | yq r - 'registry.value.username') && \
+# envsubst < ./manifests/kots-config-aws-registry.yaml > tmp_2_config.yml
+# @yq m -i tmp_config.yml tmp_2_config.yml
 
 self-signed-config:
 	# install in local store
-	mkcert -install
+	@echo "Creating self-signed certificate"
+	@mkcert -install
 
-	cat "${HOME}"/.local/share/mkcert/rootCA.pem > ./ca.pem
-	mkcert -cert-file "./ssl.crt" \
+	@cat "${HOME}"/.local/share/mkcert/rootCA.pem > ./ca.pem
+	@mkcert -cert-file "./ssl.crt" \
 	  -key-file "./ssl.key" \
-	  "*.ws.${TF_VAR_TEST_ID}.${TF_VAR_domain}" "*.${TF_VAR_TEST_ID}.${TF_VAR_domain}" "${TF_VAR_TEST_ID}.${TF_VAR_domain}"
+	  "*.ws.${TF_VAR_TEST_ID}.${DOMAIN}" "*.${TF_VAR_TEST_ID}.${DOMAIN}" "${TF_VAR_TEST_ID}.${DOMAIN}"
 
-	export CA_CERT=$$(cat ./ca.pem | base64 -w 0) && \
+	@export CA_CERT=$$(cat ./ca.pem | base64 -w 0) && \
 	export SSL_CERT=$$(cat ./ssl.crt | base64 -w 0) && \
 	export SSL_KEY=$$(cat ./ssl.key | base64 -w 0) && \
 	envsubst < ./manifests/kots-config-self-signed.yaml > tmp_2_config.yml
-	yq m -i tmp_config.yml tmp_2_config.yml
+	@yq m -i tmp_config.yml tmp_2_config.yml
 
 	# upload the Custom CA Cert into tf-state
-	gsutil cp ./ca.pem gs://nightly-tests/tf-state/${TF_VAR_TEST_ID}-ca.pem
+	@gsutil cp ./ca.pem gs://nightly-tests/tf-state/${TF_VAR_TEST_ID}-ca.pem
 
 storage-config-incluster:
 	@echo "Nothing to do"
@@ -331,7 +358,7 @@ db-config-incluster:
 
 registry-config-incluster:
 ifeq ($(cloud), aws)
-	$(MAKE) s3-registry-backend-config-aws
+	@$(MAKE) s3-registry-backend-config-aws
 else
 	@echo "Nothing to do"
 endif
@@ -346,13 +373,14 @@ generate-kots-config: cloud_storage = $(if $(findstring external,$(storage)),$(c
 generate-kots-config: cloud_registry = $(if $(findstring external,$(registry)),$(cloud),incluster)
 generate-kots-config: cloud_db = $(if $(findstring external,$(db)),$(cloud),incluster)
 ## generate-kots-config: Generate the kots config based on test config
-generate-kots-config: select-workspace check-env-cloud check-env-domain check-env-sub-domain
-	if [[ $$skipTests == "false" ]]; then $(MAKE) get-github-config; fi
+generate-kots-config: tf-init tf-output check-var-cloud check-var-DOMAIN check-var-TF_VAR_TEST_ID
+	@if [[ $$skipTests == "false" ]]; then $(MAKE) get-github-config; fi
 	$(MAKE) get-base-config
 	$(MAKE) storage-config-${cloud_storage}
 	$(MAKE) db-config-${cloud_db}
 	$(MAKE) registry-config-${cloud_registry}
-	if [[ $$self_signed == "true" ]]; then $(MAKE) self-signed-config; fi
+	@if [[ $$self_signed == "true" ]]; then $(MAKE) self-signed-config; fi
+	@echo -e "\033[0;33mGitpod config is created in 'tmp_config.yml'\033[0;m"
 
 download-certs:
 	@echo "Trying to download pre-existing secrets for certificate from GCS"
@@ -370,7 +398,7 @@ license_community_stable := "../licenses/Community.yaml"
 license_community_unstable := "../licenses/Community (Unstable).yaml"
 
 install-kots-cli:
-	curl https://kots.io/install | bash
+	@curl https://kots.io/install | bash
 
 preflights ?= true
 channel ?= unstable
@@ -389,8 +417,8 @@ kots-install: install-kots-cli destroy-gitpod create-secrets
                     --no-port-forward \
                     --config-values tmp_config.yml
 
-time_to_sleep_azure := 1000 # azure seem to take more time to fullfil DNS propogation
-time_to_sleep := 800
+time_to_sleep_azure := 800 # azure seem to take more time to fullfil DNS propogation
+time_to_sleep := 500
 
 wait_time := 180
 wait_time_azure := 300
@@ -398,7 +426,8 @@ wait_time_azure := 300
 delete-cm-setup: sleeptime=$(if $(time_to_sleep_$(cloud)),$(time_to_sleep_$(cloud)),${time_to_sleep})
 delete-cm-setup: waittime=$(if $(wait_time_$(cloud)),$(wait_time_$(cloud)),${wait_time})
 delete-cm-setup:
-	sleep ${waittime} && kubectl --kubeconfig=${KUBECONFIG} delete pods --all -n cert-manager && sleep ${sleeptime};
+	@echo "restarting cert-manager"
+	@sleep ${waittime} && kubectl --kubeconfig=${KUBECONFIG} delete pods --all -n cert-manager && sleep ${sleeptime};
 
 gitpod-debug-info:
 	@echo -e "\033[;31mGitpod is not ready\033[0;m"
@@ -419,16 +448,17 @@ gitpod-debug-info:
 
 
 check-kots-app:
-	kubectl kots get --kubeconfig=${KUBECONFIG} app gitpod -n gitpod | grep gitpod  | awk '{print $$2}' | grep "ready" || { $(MAKE) gitpod-debug-info; exit 1; }
+	@echo "Check if Gitpod kots app is ready"
+	@kubectl kots get --kubeconfig=${KUBECONFIG} app gitpod -n gitpod | grep gitpod  | awk '{print $$2}' | grep "ready" || { $(MAKE) gitpod-debug-info; exit 1; }
 
 self_signed ?= false
 
-check-gitpod-installation: delete-cm-setup check-kots-app check-env-sub-domain
-	@echo "Curling https://${TF_VAR_TEST_ID}.${TF_VAR_domain}/api/version"
+check-gitpod-installation: delete-cm-setup check-kots-app check-var-TF_VAR_TEST_ID
+	@echo "Curling https://${TF_VAR_TEST_ID}.${DOMAIN}/api/version"
 ifeq (true,$(self_signed))
 	export SSL_CERT_FILE=./ca.pem
 endif
-	curl -i -X GET https://${TF_VAR_TEST_ID}.${TF_VAR_domain}/api/version || { echo "Curling Gitpod endpoint failed"; exit 1; }
+	@curl -i -X GET https://${TF_VAR_TEST_ID}.${DOMAIN}/api/version || { echo "**Error**: Curling Gitpod endpoint failed"; exit 1; }
 
 define runtests
 	./tests.sh ${KUBECONFIG} $(1)
@@ -463,45 +493,22 @@ run-wsm-component-tests:
 
 kots-upgrade:
 	@echo "Upgrade gitpod KOTS app to latest"
-	kubectl kots upstream upgrade --kubeconfig=${KUBECONFIG} gitpod -n gitpod --deploy
+	@kubectl kots upstream upgrade --kubeconfig=${KUBECONFIG} gitpod -n gitpod --deploy
 
-cloud ?= cluster
-cleanup: get-kubeconfig destroy-gitpod tf-init destroy-$(cloud) destroy-workspace destroy-kubeconfig
-
-cluster-kubeconfig: azure-kubeconfig aws-kubeconfig k3s-kubeconfig gcp-kubeconfig
-
-tf-init:
-	@terraform init
-
-destroy-cluster: destroy-gcp destroy-aws destroy-azure
+cleanup: get-kubeconfig destroy-gitpod prepare-terraform tf-init tf-ws tf-destroy destroy-workspace destroy-kubeconfig
 
 destroy-kubeconfig:
-	gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS} --project=sh-automated-tests
-	gsutil rm gs://nightly-tests/tf-state/${TF_VAR_TEST_ID}-kubeconfig || echo "No kubeconfig"
-	gsutil rm gs://nightly-tests/tf-state/${TF_VAR_TEST_ID}-creds || echo "No credentials file"
-	gsutil rm gs://nightly-tests/tf-state/${TF_VAR_TEST_ID}-ca.pem || echo "No custom CA cert file"
-	rm ${KUBECONFIG} || echo "No kubeconfig"
-
-select-workspace:
-	terraform workspace select $(TF_VAR_TEST_ID)
+	@gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS} --project=sh-automated-tests
+	@gsutil rm gs://nightly-tests/tf-state/${TF_VAR_TEST_ID}-kubeconfig || echo "No kubeconfig"
+	@gsutil rm gs://nightly-tests/tf-state/${TF_VAR_TEST_ID}-creds || echo "No credentials file"
+	@gsutil rm gs://nightly-tests/tf-state/${TF_VAR_TEST_ID}-creds.json || echo "No credentials file"
+	@gsutil rm gs://nightly-tests/tf-state/${TF_VAR_TEST_ID}-ca.pem || echo "No custom CA cert file"
+	@rm ${KUBECONFIG} || echo "No kubeconfig"
 
 destroy-workspace:
-	terraform workspace select default
-	terraform workspace delete $(TF_VAR_TEST_ID) || echo "Couldn't delete workspace, please cleanup manually"
-
-destroy-gcp: destroy-k3s destroy-gke
-
-destroy-k3s: select-workspace
-	[[ -f ${KUBECONFIG} ]] && terraform destroy -target=module.gcp-issuer -var kubeconfig=${KUBECONFIG} --auto-approve || echo "No kubeconfig file"
-	[[ -f ${KUBECONFIG} ]] && terraform destroy -target=module.clouddns-externaldns -var kubeconfig=${KUBECONFIG} --auto-approve || echo "No kubeconfig file"
-	[[ -f ${KUBECONFIG} ]] && terraform destroy -target=module.certmanager -var kubeconfig=${KUBECONFIG} --auto-approve || echo "No kubeconfig file"
-	terraform destroy -target=module.k3s -var kubeconfig=${KUBECONFIG} --auto-approve
-
-destroy-gke: select-workspace
-	[[ -f ${KUBECONFIG} ]] && terraform destroy -target=module.gcp-issuer -var kubeconfig=${KUBECONFIG} --auto-approve || echo "No kubeconfig file"
-	[[ -f ${KUBECONFIG} ]] && terraform destroy -target=module.clouddns-externaldns -var kubeconfig=${KUBECONFIG} --auto-approve || echo "No kubeconfig file"
-	[[ -f ${KUBECONFIG} ]] && terraform destroy -target=module.certmanager -var kubeconfig=${KUBECONFIG} --auto-approve || echo "No kubeconfig file"
-	terraform destroy -target=module.gke -var kubeconfig=${KUBECONFIG} --auto-approve
+	@echo "Destroying the workspace $$TF_VAR_TEST_ID"
+	@terraform -chdir=${TF_MOD} workspace select default
+	@terraform -chdir=${TF_MOD} workspace delete $(TF_VAR_TEST_ID) || { echo "**Error**: Couldn't delete workspace, please cleanup manually"; $(MAKE) list-state; }
 
 # Delete the Gitpod namespace and all associated resources.
 #
@@ -512,29 +519,13 @@ destroy-gitpod: backup-cert
 		&& kubectl --kubeconfig=${KUBECONFIG} delete namespace/gitpod --now --timeout 180s \
 		|| true
 
-destroy-aws:
-	$(MAKE) select-workspace
-	terraform destroy -target=module.aws-add-dns-record -var kubeconfig=${KUBECONFIG} --auto-approve
-	ls ${KUBECONFIG} && terraform destroy -target=module.aws-issuer -var kubeconfig=${KUBECONFIG} --auto-approve || echo "No kubeconfig file"
-	ls ${KUBECONFIG} && terraform destroy -target=module.aws-externaldns -var kubeconfig=${KUBECONFIG} --auto-approve || echo "No kubeconfig file"
-	ls ${KUBECONFIG} && terraform destroy -target=module.certmanager -var kubeconfig=${KUBECONFIG} --auto-approve || echo "No kubeconfig file"
-	terraform destroy -target=module.eks -var kubeconfig=${KUBECONFIG} --auto-approve
-
-destroy-azure:
-	$(MAKE) select-workspace
-	ls ${KUBECONFIG} && terraform destroy -target=module.azure-issuer -var kubeconfig=${KUBECONFIG} --auto-approve || echo "No kubeconfig file"
-	terraform destroy -target=module.azure-add-dns-record -var kubeconfig=${KUBECONFIG} --auto-approve
-	ls ${KUBECONFIG} && terraform destroy -target=module.azure-externaldns -var kubeconfig=${KUBECONFIG} --auto-approve || echo "No kubeconfig file"
-	ls ${KUBECONFIG} && terraform destroy -target=module.certmanager -var kubeconfig=${KUBECONFIG} --auto-approve || echo "No kubeconfig file"
-	terraform destroy -target=module.aks -var kubeconfig=${KUBECONFIG} --auto-approve
-
 backup-cert:
 	@echo "Backing up certificate secret to GCS"
 	@kubectl --kubeconfig=${KUBECONFIG} get secret -n gitpod https-certificates -o yaml > ${cert_secret} || { echo "No existing secret"; rm -f ${cert_secret}; }
 	@[[ -f ${cert_secret} ]] && gsutil cp ${cert_secret} gs://nightly-tests/nightly-tests-certs/${cert_secret} || echo "No certificate secret file exist"
 
-list-state:
-	terraform state list
+list-state: tf-ws
+	@terraform -chdir=${TF_MOD} state list
 
 cleanup-old-tests:
 	./cleanup.sh

--- a/install/tests/manifests/aws-terraform.tfvars
+++ b/install/tests/manifests/aws-terraform.tfvars
@@ -1,0 +1,30 @@
+# the cluster_name should be of length less than 15 characters and surrounded by double quotes
+cluster_name = "gp-${TF_VAR_TEST_ID}"
+
+# a route53 zone and certificate request will be created for this domain; surround the domain name within double quotes
+domain_name = "${TF_VAR_TEST_ID}.${DOMAIN}"
+
+region = "eu-west-1"
+
+# make sure the cidr do not have any conflicts and will have IP ranges enough to split into 5 subnets
+vpc_cidr = "10.100.0.0/16"
+
+# should be atleast 2 zones
+vpc_availability_zones = ["eu-west-1c", "eu-west-1b"]
+
+# !important!: You need to make sure the image_id below matches your region.
+# You can find the list of UBUNTU AMIs here corresponding to the k8s version and your region via
+# https://cloud-images.ubuntu.com/docs/aws/eks/
+cluster_version = "${CLUSTER_VERSION}"
+
+image_id = "${IMAGE_ID}"
+
+create_external_database = true
+create_external_storage  = true
+create_external_registry = true
+
+# if you want to create a separate s3 bucket to use as registry backend,
+# set the following to true. You can re-use the above bucket or incluster registry otherwise.
+create_external_storage_for_registry_backend = false
+
+kubeconfig = "${KUBECONFIG}"

--- a/install/tests/manifests/azure-terraform.tfvars
+++ b/install/tests/manifests/azure-terraform.tfvars
@@ -1,0 +1,17 @@
+# The resource should be of length less than 12 characters and surrounded by double quotes
+# Make sure no such resource group exists
+resource_group_name = "gp-${TF_VAR_TEST_ID}"
+
+# a Azure cloud dns zone and certificate request will be created for this domain; surround the domain name within double quotes
+domain_name = "${TF_VAR_TEST_ID}.${DOMAIN}"
+
+
+location = "northeurope"
+
+cluster_version = "1.22"
+
+create_external_database = true
+create_external_storage  = true
+create_external_registry = true
+
+kubeconfig = "${KUBECONFIG}"

--- a/install/tests/manifests/gcp-terraform.tfvars
+++ b/install/tests/manifests/gcp-terraform.tfvars
@@ -1,0 +1,17 @@
+# the cluster_name should be of length less than 15 characters and surrounded by double quotes
+cluster_name = "gp-${TF_VAR_TEST_ID}"
+
+# a cloudDNS zone and certificate request will be created for this domain; surround the domain name within double quotes
+domain_name = "${TF_VAR_TEST_ID}.${DOMAIN}"
+
+region  = "europe-west1"
+zone    = "europe-west1-d"
+project = "sh-automated-tests"
+
+cluster_version = "${CLUSTER_VERSION}"
+
+enable_external_database = true
+enable_external_storage  = true
+enable_external_registry = true
+
+kubeconfig = "${KUBECONFIG}"

--- a/install/tests/manifests/k3s-terraform.tfvars
+++ b/install/tests/manifests/k3s-terraform.tfvars
@@ -1,0 +1,17 @@
+# the cluster_name should be of length less than 15 characters and surrounded by double quotes
+name = "gp-${TF_VAR_TEST_ID}"
+
+# a cloudDNS zone and certificate request will be created for this domain; surround the domain name within double quotes
+domain_name = "${TF_VAR_TEST_ID}.${DOMAIN}"
+
+region  = "europe-west1"
+zone    = "europe-west1-b"
+project = "sh-automated-tests"
+
+credentials_path = "${GOOGLE_APPLICATION_CREDENTIALS}"
+
+cluster_version = "${CLUSTER_VERSION}"
+
+image_id = "${UBUNTU_IMAGE}"
+
+kubeconfig = "${KUBECONFIG}"

--- a/install/tests/manifests/managed-dns.tf
+++ b/install/tests/manifests/managed-dns.tf
@@ -1,0 +1,13 @@
+variable "gcp_zone" { default = "${GCP_ZONE}" }
+variable "dns_sa_creds" { }
+
+
+module "add-dns-record" {
+  source = "../../modules/tools/cloud-dns-ns"
+
+  nameservers      = module.${cluster}.name_servers
+  dns_project      = "dns-for-playgrounds"
+  managed_dns_zone = var.gcp_zone
+  domain_name      = var.domain_name
+  credentials      = var.dns_sa_creds
+}

--- a/install/tests/manifests/tf-backend.tf
+++ b/install/tests/manifests/tf-backend.tf
@@ -1,0 +1,20 @@
+terraform {
+  backend "gcs" {
+    bucket = "nightly-tests"
+    prefix = "tf-state"
+  }
+
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+
+    helm = {
+      source = "hashicorp/helm"
+    }
+  }
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PR changes the `installer-tests.ts` and the `Makefile` being called from it, to use the single-cluster reference architecture to run the integration tests. This is the third of a 3 part PR series. This PR requires the other two PRs to be gone in first and that would reduce the file changes in this file to very few in number.

The two preceding PRs are: **TO BE REVIEWED BEFORE REVIEWING THIS PR**
- [ ] https://github.com/gitpod-io/gitpod/pull/13540
- [ ] https://github.com/gitpod-io/gitpod/pull/13561

The following are the test runs:
k3s: https://werft.gitpod-dev.com/job/gitpod-custom-nvn-add-tf-tests.31 :heavy_check_mark:
gke: https://werft.gitpod-dev.com/job/gitpod-custom-nvn-add-tf-tests.32 :heavy_check_mark:
aks: https://werft.gitpod-dev.com/job/gitpod-custom-nvn-add-tf-tests.33 :heavy_check_mark:
eks: https://werft.gitpod-dev.com/job/gitpod-custom-nvn-add-tf-tests.34 :heavy_check_mark:

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #12865

## How to test
<!-- Provide steps to test this PR -->
You can follow this [internal](https://www.notion.so/gitpod/WIP-Self-hosted-automated-nightly-pipelines-fdc5a202e67b4197aa00d93b98d57927) doc to trigger self-hosted setups.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
