### PR TITLE
[installer] Support enabling protected secrets

### DIFF
--- a/install/installer/pkg/components/server/configmap.go
+++ b/install/installer/pkg/components/server/configmap.go
@@ -162,6 +162,14 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		return nil
 	})
 
+	defaultFeatureFlags := []NamedWorkspaceFeatureFlag{}
+	_ = ctx.WithExperimental(func(cfg *experimental.Config) error {
+		if cfg.Workspace != nil && cfg.Workspace.EnableProtectedSecrets {
+			defaultFeatureFlags = append(defaultFeatureFlags, NamedWorkspaceFeatureProtectedSecrets)
+		}
+		return nil
+	})
+
 	// todo(sje): all these values are configurable
 	scfg := ConfigSerialized{
 		Version:               ctx.VersionManifest.Version,
@@ -175,7 +183,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		WorkspaceDefaults: WorkspaceDefaults{
 			WorkspaceImage:      workspaceImage,
 			PreviewFeatureFlags: []NamedWorkspaceFeatureFlag{},
-			DefaultFeatureFlags: []NamedWorkspaceFeatureFlag{},
+			DefaultFeatureFlags: defaultFeatureFlags,
 			TimeoutDefault:      ctx.Config.Workspace.TimeoutDefault,
 			TimeoutExtended:     ctx.Config.Workspace.TimeoutExtended,
 		},

--- a/install/installer/pkg/components/server/types.go
+++ b/install/installer/pkg/components/server/types.go
@@ -147,6 +147,7 @@ type NamedWorkspaceFeatureFlag string
 
 const (
 	NamedWorkspaceFeatureFlagFullWorkspaceBackup NamedWorkspaceFeatureFlag = "full_workspace_backup"
+	NamedWorkspaceFeatureProtectedSecrets        NamedWorkspaceFeatureFlag = "protected_secrets"
 )
 
 type WorkspaceClassCategory string

--- a/install/installer/pkg/config/v1/experimental/experimental.go
+++ b/install/installer/pkg/config/v1/experimental/experimental.go
@@ -119,6 +119,8 @@ type WorkspaceConfig struct {
 		// Deprecated
 		UsageReportBucketName string `json:"usageReportBucketName"`
 	} `json:"contentService"`
+
+	EnableProtectedSecrets bool `json:"enableProtectedSecrets"`
 }
 
 type PersistentVolumeClaim struct {


### PR DESCRIPTION
## Description

Cherry-pick https://github.com/gitpod-io/gitpod/pull/13484 onto 2022.09.0

## Related Issue(s)


## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
