### PR TITLE
[content-service] Revert #11895

### DIFF
--- a/test/tests/components/ws-manager/additional_repositories_test.go
+++ b/test/tests/components/ws-manager/additional_repositories_test.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package wsmanager
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+
+	csapi "github.com/gitpod-io/gitpod/content-service/api"
+	"github.com/gitpod-io/gitpod/test/pkg/integration"
+	wsmanapi "github.com/gitpod-io/gitpod/ws-manager/api"
+)
+
+func TestAdditionalRepositories(t *testing.T) {
+	f := features.New("additional-repositories").
+		WithLabel("component", "ws-manager").
+		Assess("can open a workspace using the additionalRepositories property", func(_ context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			tests := []struct {
+				Name       string
+				ContextURL string
+				CloneTaget string
+			}{
+				{
+					Name:       "workspace with additionalRepositories using a branch",
+					ContextURL: "https://github.com/gitpod-io/gitpod-test-repo",
+					CloneTaget: "aledbf/test-additional-repositories",
+				},
+				{
+					Name:       "workspace with additionalRepositories also using a branch in one of the additionalRepositories",
+					ContextURL: "https://github.com/gitpod-io/gitpod-test-repo",
+					CloneTaget: "aledbf/test-additional-repositories-with-branches",
+				},
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), time.Duration(5*len(tests))*time.Minute)
+			defer cancel()
+
+			for _, test := range tests {
+				t.Run(test.Name, func(t *testing.T) {
+					api := integration.NewComponentAPI(ctx, cfg.Namespace(), kubeconfig, cfg.Client())
+					t.Cleanup(func() {
+						api.Done(t)
+					})
+
+					ws, stopWs, err := integration.LaunchWorkspaceDirectly(t, ctx, api, integration.WithRequestModifier(func(req *wsmanapi.StartWorkspaceRequest) error {
+						testRepoName := "gitpod-test-repo"
+						req.Spec.WorkspaceLocation = testRepoName
+						req.Spec.Initializer = &csapi.WorkspaceInitializer{
+							Spec: &csapi.WorkspaceInitializer_Git{
+								Git: &csapi.GitInitializer{
+									RemoteUri:  test.ContextURL,
+									CloneTaget: test.CloneTaget,
+									Config:     &csapi.GitConfig{},
+									TargetMode: csapi.CloneTargetMode_REMOTE_BRANCH,
+								},
+							},
+						}
+
+						return nil
+					}))
+					if err != nil {
+						t.Fatal(err)
+					}
+
+					defer func() {
+						// stop workspace in defer function to prevent we forget to stop the workspace
+						if err := stopWorkspace(t, cfg, stopWs); err != nil {
+							t.Errorf("cannot stop workspace: %q", err)
+						}
+					}()
+
+					rsa, closer, err := integration.Instrument(integration.ComponentWorkspace, "workspace", cfg.Namespace(), kubeconfig, cfg.Client(),
+						integration.WithInstanceID(ws.Req.Id),
+					)
+					if err != nil {
+						t.Fatal(err)
+					}
+
+					integration.DeferCloser(t, closer)
+					defer rsa.Close()
+				})
+			}
+
+			return ctx
+		}).
+		Feature()
+
+	testEnv.Test(t, f)
+}


### PR DESCRIPTION
## Description

When we open a workspace from a branch and the repository contains a .gitpod.yml file with `additionalRepositories`, we should not assume the branch exists in those repositories. Also, when we specify a branch in one of the `additionalRepositories`, we should be able to use that branch.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #13527
Fixes #13512
Reverts #11895

## How to test
- Open a workspace using
  - https://github.com/gitpod-io/gitpod-test-repo/tree/aledbf/test-additional-repositories
  - https://github.com/gitpod-io/gitpod-test-repo/tree/aledbf/test-additional-repositories-with-branches

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=workspace
      Valid options are `all`, `workspace`, `webapp`, `ide`
