### PR TITLE
[pvc] fix when opening repo with no .gitpod.yml

### DIFF
--- a/components/content-service/pkg/layer/provider.go
+++ b/components/content-service/pkg/layer/provider.go
@@ -346,31 +346,27 @@ func (s *Provider) GetContentLayerPVC(ctx context.Context, owner, workspaceID st
 			return
 		}
 	}
-	if gis := initializer.GetGit(); gis != nil {
-		span.LogKV("initializer", "Git")
-
-		cdesc, err := executor.Prepare(initializer, nil)
-		if err != nil {
-			return nil, nil, err
-		}
-
-		layer, err = contentDescriptorToLayerPVC(cdesc)
-		if err != nil {
-			return nil, nil, err
-		}
-		layerReady, err := workspaceReadyLayerPVC(csapi.WorkspaceInitFromOther)
-		if err != nil {
-			return nil, nil, err
-		}
-		return []Layer{*layer, *layerReady}, nil, nil
-	}
 	if initializer.GetBackup() != nil {
 		// We were asked to restore a backup and have tried above. We've failed to restore the backup,
 		// hance the backup initializer failed.
 		return nil, nil, xerrors.Errorf("no backup found")
 	}
 
-	return nil, nil, xerrors.Errorf("no backup or valid initializer present")
+	// catch all for all other initializers
+	cdesc, err := executor.Prepare(initializer, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	layer, err = contentDescriptorToLayerPVC(cdesc)
+	if err != nil {
+		return nil, nil, err
+	}
+	layerReady, err := workspaceReadyLayerPVC(csapi.WorkspaceInitFromOther)
+	if err != nil {
+		return nil, nil, err
+	}
+	return []Layer{*layer, *layerReady}, nil, nil
 }
 
 func (s *Provider) getSnapshotContentLayer(ctx context.Context, sp *csapi.SnapshotInitializer) (l []Layer, manifest *csapi.WorkspaceContentManifest, err error) {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/13531

## How to test
<!-- Provide steps to test this PR -->
Open preview env
Enable PVC flag
Open workspace that has no .gitpod.yml file in repo, eg: https://github.com/utam0k/utam0k.github.io

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
none
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-integration-tests=workspace
      Valid options are `all`, `workspace`, `webapp`, `ide`
