### PR TITLE
[cert-manger] Rename `ca-issuer` to `gitpod`

### DIFF
--- a/install/installer/cmd/testdata/render/aws-setup/output.golden
+++ b/install/installer/cmd/testdata/render/aws-setup/output.golden
@@ -512,7 +512,7 @@ spec:
       - system-node-critical
 status: {}
 ---
-# cert-manager.io/v1/Issuer ca-issuer
+# cert-manager.io/v1/Issuer gitpod
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
@@ -520,11 +520,11 @@ metadata:
   labels:
     app: gitpod
     component: cluster
-  name: ca-issuer
+  name: gitpod
   namespace: default
 spec:
   ca:
-    secretName: ca-issuer-ca
+    secretName: gitpod-ca
 status: {}
 ---
 # cert-manager.io/v1/Issuer gitpod-selfsigned-issuer
@@ -558,7 +558,7 @@ spec:
   issuerRef:
     group: cert-manager.io
     kind: Issuer
-    name: ca-issuer
+    name: gitpod
   secretName: builtin-registry-certs
   secretTemplate:
     labels:
@@ -583,7 +583,7 @@ spec:
   issuerRef:
     group: cert-manager.io
     kind: Issuer
-    name: ca-issuer
+    name: gitpod
   secretName: builtin-registry-facade-cert
   secretTemplate:
     labels:
@@ -591,7 +591,7 @@ spec:
       component: registry-facade
 status: {}
 ---
-# cert-manager.io/v1/Certificate ca-issuer-ca
+# cert-manager.io/v1/Certificate gitpod-ca
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
@@ -599,10 +599,10 @@ metadata:
   labels:
     app: gitpod
     component: cluster
-  name: ca-issuer-ca
+  name: gitpod-ca
   namespace: default
 spec:
-  commonName: ca-issuer-ca
+  commonName: gitpod-ca
   duration: 2160h0m0s
   isCA: true
   issuerRef:
@@ -612,7 +612,7 @@ spec:
   privateKey:
     algorithm: ECDSA
     size: 256
-  secretName: ca-issuer-ca
+  secretName: gitpod-ca
   secretTemplate:
     labels:
       app: gitpod
@@ -639,7 +639,7 @@ spec:
   issuerRef:
     group: cert-manager.io
     kind: Issuer
-    name: ca-issuer
+    name: gitpod
   secretName: ws-daemon-tls
   secretTemplate:
     labels:
@@ -668,7 +668,7 @@ spec:
   issuerRef:
     group: cert-manager.io
     kind: Issuer
-    name: ca-issuer
+    name: gitpod
   secretName: ws-manager-client-tls
   secretTemplate:
     labels:
@@ -696,7 +696,7 @@ spec:
   issuerRef:
     group: cert-manager.io
     kind: Issuer
-    name: ca-issuer
+    name: gitpod
   secretName: ws-manager-tls
   secretTemplate:
     labels:
@@ -1385,7 +1385,7 @@ data:
   versions.json: |-
     {
       "versions": {
-        "version": "pd-ide-metrics.23",
+        "version": "main.4991",
         "components": {
           "agentSmith": {
             "version": "test"
@@ -1613,7 +1613,7 @@ data:
       labels:
         app: gitpod
         component: cluster
-      name: ca-issuer-ca
+      name: gitpod-ca
       namespace: default
     ---
     apiVersion: cert-manager.io/v1
@@ -1623,7 +1623,7 @@ data:
       labels:
         app: gitpod
         component: cluster
-      name: ca-issuer
+      name: gitpod
       namespace: default
     ---
     apiVersion: rbac.authorization.k8s.io/v1
@@ -4342,7 +4342,7 @@ apiVersion: v1
 data:
   config.json: |-
     {
-      "version": "pd-ide-metrics.23",
+      "version": "main.4991",
       "hostUrl": "https://gitpod.example.com",
       "installationShortname": "default",
       "devBranch": "",
@@ -4757,7 +4757,7 @@ data:
       "manager": {
         "namespace": "default",
         "schedulerName": "",
-        "seccompProfile": "workspace_default_pd-ide-metrics.23.json",
+        "seccompProfile": "workspace_default_main.4991.json",
         "timeouts": {
           "startup": "1h0m0s",
           "initialization": "30m0s",
@@ -7039,7 +7039,7 @@ spec:
       - command:
         - /bin/sh
         - -c
-        - cp -f /installer/workspace_default.json /mnt/dst/workspace_default_pd-ide-metrics.23.json
+        - cp -f /installer/workspace_default.json /mnt/dst/workspace_default_main.4991.json
         image: eu.gcr.io/gitpod-core-dev/build/seccomp-profile-installer:test
         name: seccomp-profile-installer
         resources: {}
@@ -8561,7 +8561,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: a4f9aa176dfae6d6939ca2759001c02d37194e89dd8c512a75e7bba7c8eb8912
+        gitpod.io/checksum_config: 5784f44a158c900bb497fb20361203be9ec9b333f363bfaf69782850d4c098a5
       creationTimestamp: null
       labels:
         app: gitpod
@@ -8836,7 +8836,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 9deca0bd07f53f6e07181614a88b15750abe54c04a0a815e9f936dfcadf97f91
+        gitpod.io/checksum_config: 124467a468ed0495814af67a2b3bc28dd416b833af308d21c6bda84319b9f1e5
       creationTimestamp: null
       labels:
         app: gitpod
@@ -9595,7 +9595,7 @@ spec:
             - send
             env:
             - name: GITPOD_INSTALLATION_VERSION
-              value: pd-ide-metrics.23
+              value: main.4991
             - name: GITPOD_INSTALLATION_PLATFORM
               value: unknown
             - name: SERVER_URL

--- a/install/installer/cmd/testdata/render/azure-setup/output.golden
+++ b/install/installer/cmd/testdata/render/azure-setup/output.golden
@@ -512,7 +512,7 @@ spec:
       - system-node-critical
 status: {}
 ---
-# cert-manager.io/v1/Issuer ca-issuer
+# cert-manager.io/v1/Issuer gitpod
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
@@ -520,11 +520,11 @@ metadata:
   labels:
     app: gitpod
     component: cluster
-  name: ca-issuer
+  name: gitpod
   namespace: default
 spec:
   ca:
-    secretName: ca-issuer-ca
+    secretName: gitpod-ca
 status: {}
 ---
 # cert-manager.io/v1/Issuer gitpod-selfsigned-issuer
@@ -558,7 +558,7 @@ spec:
   issuerRef:
     group: cert-manager.io
     kind: Issuer
-    name: ca-issuer
+    name: gitpod
   secretName: builtin-registry-facade-cert
   secretTemplate:
     labels:
@@ -566,7 +566,7 @@ spec:
       component: registry-facade
 status: {}
 ---
-# cert-manager.io/v1/Certificate ca-issuer-ca
+# cert-manager.io/v1/Certificate gitpod-ca
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
@@ -574,10 +574,10 @@ metadata:
   labels:
     app: gitpod
     component: cluster
-  name: ca-issuer-ca
+  name: gitpod-ca
   namespace: default
 spec:
-  commonName: ca-issuer-ca
+  commonName: gitpod-ca
   duration: 2160h0m0s
   isCA: true
   issuerRef:
@@ -587,7 +587,7 @@ spec:
   privateKey:
     algorithm: ECDSA
     size: 256
-  secretName: ca-issuer-ca
+  secretName: gitpod-ca
   secretTemplate:
     labels:
       app: gitpod
@@ -614,7 +614,7 @@ spec:
   issuerRef:
     group: cert-manager.io
     kind: Issuer
-    name: ca-issuer
+    name: gitpod
   secretName: ws-daemon-tls
   secretTemplate:
     labels:
@@ -643,7 +643,7 @@ spec:
   issuerRef:
     group: cert-manager.io
     kind: Issuer
-    name: ca-issuer
+    name: gitpod
   secretName: ws-manager-client-tls
   secretTemplate:
     labels:
@@ -671,7 +671,7 @@ spec:
   issuerRef:
     group: cert-manager.io
     kind: Issuer
-    name: ca-issuer
+    name: gitpod
   secretName: ws-manager-tls
   secretTemplate:
     labels:
@@ -1342,7 +1342,7 @@ data:
   versions.json: |-
     {
       "versions": {
-        "version": "pd-ide-metrics.23",
+        "version": "main.4991",
         "components": {
           "agentSmith": {
             "version": "test"
@@ -1530,7 +1530,7 @@ data:
       labels:
         app: gitpod
         component: cluster
-      name: ca-issuer-ca
+      name: gitpod-ca
       namespace: default
     ---
     apiVersion: cert-manager.io/v1
@@ -1540,7 +1540,7 @@ data:
       labels:
         app: gitpod
         component: cluster
-      name: ca-issuer
+      name: gitpod
       namespace: default
     ---
     apiVersion: rbac.authorization.k8s.io/v1
@@ -4205,7 +4205,7 @@ apiVersion: v1
 data:
   config.json: |-
     {
-      "version": "pd-ide-metrics.23",
+      "version": "main.4991",
       "hostUrl": "https://gitpod.example.com",
       "installationShortname": "default",
       "devBranch": "",
@@ -4618,7 +4618,7 @@ data:
       "manager": {
         "namespace": "default",
         "schedulerName": "",
-        "seccompProfile": "workspace_default_pd-ide-metrics.23.json",
+        "seccompProfile": "workspace_default_main.4991.json",
         "timeouts": {
           "startup": "1h0m0s",
           "initialization": "30m0s",
@@ -6881,7 +6881,7 @@ spec:
       - command:
         - /bin/sh
         - -c
-        - cp -f /installer/workspace_default.json /mnt/dst/workspace_default_pd-ide-metrics.23.json
+        - cp -f /installer/workspace_default.json /mnt/dst/workspace_default_main.4991.json
         image: eu.gcr.io/gitpod-core-dev/build/seccomp-profile-installer:test
         name: seccomp-profile-installer
         resources: {}
@@ -8412,7 +8412,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: a4f9aa176dfae6d6939ca2759001c02d37194e89dd8c512a75e7bba7c8eb8912
+        gitpod.io/checksum_config: 5784f44a158c900bb497fb20361203be9ec9b333f363bfaf69782850d4c098a5
       creationTimestamp: null
       labels:
         app: gitpod
@@ -8687,7 +8687,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 4ac62854eccd472efc91ccb1041633960da4448fe1534555abb4ac94fe22861d
+        gitpod.io/checksum_config: 4c590aaeabfa3e73d42f1e345dc62c744bc9a885a35a09da4b50ae07b60c07c4
       creationTimestamp: null
       labels:
         app: gitpod
@@ -9440,7 +9440,7 @@ spec:
             - send
             env:
             - name: GITPOD_INSTALLATION_VERSION
-              value: pd-ide-metrics.23
+              value: main.4991
             - name: GITPOD_INSTALLATION_PLATFORM
               value: unknown
             - name: SERVER_URL

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -512,7 +512,7 @@ spec:
       - system-node-critical
 status: {}
 ---
-# cert-manager.io/v1/Issuer ca-issuer
+# cert-manager.io/v1/Issuer gitpod
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
@@ -520,11 +520,11 @@ metadata:
   labels:
     app: gitpod
     component: cluster
-  name: ca-issuer
+  name: gitpod
   namespace: default
 spec:
   ca:
-    secretName: ca-issuer-ca
+    secretName: gitpod-ca
 status: {}
 ---
 # cert-manager.io/v1/Issuer gitpod-selfsigned-issuer
@@ -558,7 +558,7 @@ spec:
   issuerRef:
     group: cert-manager.io
     kind: Issuer
-    name: ca-issuer
+    name: gitpod
   secretName: builtin-registry-certs
   secretTemplate:
     labels:
@@ -583,7 +583,7 @@ spec:
   issuerRef:
     group: cert-manager.io
     kind: Issuer
-    name: ca-issuer
+    name: gitpod
   secretName: builtin-registry-facade-cert
   secretTemplate:
     labels:
@@ -591,7 +591,7 @@ spec:
       component: registry-facade
 status: {}
 ---
-# cert-manager.io/v1/Certificate ca-issuer-ca
+# cert-manager.io/v1/Certificate gitpod-ca
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
@@ -599,10 +599,10 @@ metadata:
   labels:
     app: gitpod
     component: cluster
-  name: ca-issuer-ca
+  name: gitpod-ca
   namespace: default
 spec:
-  commonName: ca-issuer-ca
+  commonName: gitpod-ca
   duration: 2160h0m0s
   isCA: true
   issuerRef:
@@ -612,7 +612,7 @@ spec:
   privateKey:
     algorithm: ECDSA
     size: 256
-  secretName: ca-issuer-ca
+  secretName: gitpod-ca
   secretTemplate:
     labels:
       app: gitpod
@@ -639,7 +639,7 @@ spec:
   issuerRef:
     group: cert-manager.io
     kind: Issuer
-    name: ca-issuer
+    name: gitpod
   secretName: ws-daemon-tls
   secretTemplate:
     labels:
@@ -668,7 +668,7 @@ spec:
   issuerRef:
     group: cert-manager.io
     kind: Issuer
-    name: ca-issuer
+    name: gitpod
   secretName: ws-manager-client-tls
   secretTemplate:
     labels:
@@ -696,7 +696,7 @@ spec:
   issuerRef:
     group: cert-manager.io
     kind: Issuer
-    name: ca-issuer
+    name: gitpod
   secretName: ws-manager-tls
   secretTemplate:
     labels:
@@ -1599,7 +1599,7 @@ data:
   versions.json: |-
     {
       "versions": {
-        "version": "pd-ide-metrics.23",
+        "version": "main.4991",
         "components": {
           "agentSmith": {
             "version": "test"
@@ -1832,7 +1832,7 @@ data:
       labels:
         app: gitpod
         component: cluster
-      name: ca-issuer-ca
+      name: gitpod-ca
       namespace: default
     ---
     apiVersion: cert-manager.io/v1
@@ -1842,7 +1842,7 @@ data:
       labels:
         app: gitpod
         component: cluster
-      name: ca-issuer
+      name: gitpod
       namespace: default
     ---
     apiVersion: rbac.authorization.k8s.io/v1
@@ -5152,7 +5152,7 @@ apiVersion: v1
 data:
   config.json: |-
     {
-      "version": "pd-ide-metrics.23",
+      "version": "main.4991",
       "hostUrl": "https://gitpod.example.com",
       "installationShortname": "default",
       "devBranch": "",
@@ -5580,7 +5580,7 @@ data:
       "manager": {
         "namespace": "default",
         "schedulerName": "",
-        "seccompProfile": "workspace_default_pd-ide-metrics.23.json",
+        "seccompProfile": "workspace_default_main.4991.json",
         "timeouts": {
           "startup": "1h0m0s",
           "initialization": "30m0s",
@@ -8117,7 +8117,7 @@ spec:
       - command:
         - /bin/sh
         - -c
-        - cp -f /installer/workspace_default.json /mnt/dst/workspace_default_pd-ide-metrics.23.json
+        - cp -f /installer/workspace_default.json /mnt/dst/workspace_default_main.4991.json
         image: eu.gcr.io/gitpod-core-dev/build/seccomp-profile-installer:test
         name: seccomp-profile-installer
         resources: {}
@@ -9980,7 +9980,7 @@ spec:
     metadata:
       annotations:
         gitpod.io: hello
-        gitpod.io/checksum_config: 129c0d1edb891b6482586f3946cb0173c86ea693948b3f99017a0bf9c7ffdf36
+        gitpod.io/checksum_config: 12b55145e2dcde9b4bf378de6e356bc2ba5b65474f7d60e49837cce688de15e8
         hello: world
       creationTimestamp: null
       labels:
@@ -10264,7 +10264,7 @@ spec:
     metadata:
       annotations:
         gitpod.io: hello
-        gitpod.io/checksum_config: 482447a616ea373c4ed547cc8cc8ab2b2c90ec1b51610d304792ec8c9f180c70
+        gitpod.io/checksum_config: 57429404c0ba3aec92e0bcd1a3504c4950cf5f1fd9f78b415d42b4ffe753f9f0
         hello: world
       creationTimestamp: null
       labels:
@@ -10936,7 +10936,7 @@ spec:
             - send
             env:
             - name: GITPOD_INSTALLATION_VERSION
-              value: pd-ide-metrics.23
+              value: main.4991
             - name: GITPOD_INSTALLATION_PLATFORM
               value: unknown
             - name: SERVER_URL

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -512,7 +512,7 @@ spec:
       - system-node-critical
 status: {}
 ---
-# cert-manager.io/v1/Issuer ca-issuer
+# cert-manager.io/v1/Issuer gitpod
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
@@ -520,11 +520,11 @@ metadata:
   labels:
     app: gitpod
     component: cluster
-  name: ca-issuer
+  name: gitpod
   namespace: default
 spec:
   ca:
-    secretName: ca-issuer-ca
+    secretName: gitpod-ca
 status: {}
 ---
 # cert-manager.io/v1/Issuer gitpod-selfsigned-issuer
@@ -558,7 +558,7 @@ spec:
   issuerRef:
     group: cert-manager.io
     kind: Issuer
-    name: ca-issuer
+    name: gitpod
   secretName: builtin-registry-facade-cert
   secretTemplate:
     labels:
@@ -566,7 +566,7 @@ spec:
       component: registry-facade
 status: {}
 ---
-# cert-manager.io/v1/Certificate ca-issuer-ca
+# cert-manager.io/v1/Certificate gitpod-ca
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
@@ -574,10 +574,10 @@ metadata:
   labels:
     app: gitpod
     component: cluster
-  name: ca-issuer-ca
+  name: gitpod-ca
   namespace: default
 spec:
-  commonName: ca-issuer-ca
+  commonName: gitpod-ca
   duration: 2160h0m0s
   isCA: true
   issuerRef:
@@ -587,7 +587,7 @@ spec:
   privateKey:
     algorithm: ECDSA
     size: 256
-  secretName: ca-issuer-ca
+  secretName: gitpod-ca
   secretTemplate:
     labels:
       app: gitpod
@@ -614,7 +614,7 @@ spec:
   issuerRef:
     group: cert-manager.io
     kind: Issuer
-    name: ca-issuer
+    name: gitpod
   secretName: ws-daemon-tls
   secretTemplate:
     labels:
@@ -643,7 +643,7 @@ spec:
   issuerRef:
     group: cert-manager.io
     kind: Issuer
-    name: ca-issuer
+    name: gitpod
   secretName: ws-manager-client-tls
   secretTemplate:
     labels:
@@ -671,7 +671,7 @@ spec:
   issuerRef:
     group: cert-manager.io
     kind: Issuer
-    name: ca-issuer
+    name: gitpod
   secretName: ws-manager-tls
   secretTemplate:
     labels:
@@ -1389,7 +1389,7 @@ data:
   versions.json: |-
     {
       "versions": {
-        "version": "pd-ide-metrics.23",
+        "version": "main.4991",
         "components": {
           "agentSmith": {
             "version": "test"
@@ -1577,7 +1577,7 @@ data:
       labels:
         app: gitpod
         component: cluster
-      name: ca-issuer-ca
+      name: gitpod-ca
       namespace: default
     ---
     apiVersion: cert-manager.io/v1
@@ -1587,7 +1587,7 @@ data:
       labels:
         app: gitpod
         component: cluster
-      name: ca-issuer
+      name: gitpod
       namespace: default
     ---
     apiVersion: rbac.authorization.k8s.io/v1
@@ -4392,7 +4392,7 @@ apiVersion: v1
 data:
   config.json: |-
     {
-      "version": "pd-ide-metrics.23",
+      "version": "main.4991",
       "hostUrl": "https://gitpod.example.com",
       "installationShortname": "default",
       "devBranch": "",
@@ -4805,7 +4805,7 @@ data:
       "manager": {
         "namespace": "default",
         "schedulerName": "",
-        "seccompProfile": "workspace_default_pd-ide-metrics.23.json",
+        "seccompProfile": "workspace_default_main.4991.json",
         "timeouts": {
           "startup": "1h0m0s",
           "initialization": "30m0s",
@@ -7163,7 +7163,7 @@ spec:
       - command:
         - /bin/sh
         - -c
-        - cp -f /installer/workspace_default.json /mnt/dst/workspace_default_pd-ide-metrics.23.json
+        - cp -f /installer/workspace_default.json /mnt/dst/workspace_default_main.4991.json
         image: eu.gcr.io/gitpod-core-dev/build/seccomp-profile-installer:test
         name: seccomp-profile-installer
         resources: {}
@@ -8838,7 +8838,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: adc398b5039ad75f724b2585a5da8a95110b918a32c0b854630fc3fa03a91722
+        gitpod.io/checksum_config: 335eefdfe860f52d0179553001668f61a018772186c32866863d80b10152b009
       creationTimestamp: null
       labels:
         app: gitpod
@@ -9113,7 +9113,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 4ac62854eccd472efc91ccb1041633960da4448fe1534555abb4ac94fe22861d
+        gitpod.io/checksum_config: 4c590aaeabfa3e73d42f1e345dc62c744bc9a885a35a09da4b50ae07b60c07c4
       creationTimestamp: null
       labels:
         app: gitpod
@@ -9754,7 +9754,7 @@ spec:
             - send
             env:
             - name: GITPOD_INSTALLATION_VERSION
-              value: pd-ide-metrics.23
+              value: main.4991
             - name: GITPOD_INSTALLATION_PLATFORM
               value: unknown
             - name: SERVER_URL

--- a/install/installer/cmd/testdata/render/gcp-setup/output.golden
+++ b/install/installer/cmd/testdata/render/gcp-setup/output.golden
@@ -512,7 +512,7 @@ spec:
       - system-node-critical
 status: {}
 ---
-# cert-manager.io/v1/Issuer ca-issuer
+# cert-manager.io/v1/Issuer gitpod
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
@@ -520,11 +520,11 @@ metadata:
   labels:
     app: gitpod
     component: cluster
-  name: ca-issuer
+  name: gitpod
   namespace: default
 spec:
   ca:
-    secretName: ca-issuer-ca
+    secretName: gitpod-ca
 status: {}
 ---
 # cert-manager.io/v1/Issuer gitpod-selfsigned-issuer
@@ -558,7 +558,7 @@ spec:
   issuerRef:
     group: cert-manager.io
     kind: Issuer
-    name: ca-issuer
+    name: gitpod
   secretName: builtin-registry-facade-cert
   secretTemplate:
     labels:
@@ -566,7 +566,7 @@ spec:
       component: registry-facade
 status: {}
 ---
-# cert-manager.io/v1/Certificate ca-issuer-ca
+# cert-manager.io/v1/Certificate gitpod-ca
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
@@ -574,10 +574,10 @@ metadata:
   labels:
     app: gitpod
     component: cluster
-  name: ca-issuer-ca
+  name: gitpod-ca
   namespace: default
 spec:
-  commonName: ca-issuer-ca
+  commonName: gitpod-ca
   duration: 2160h0m0s
   isCA: true
   issuerRef:
@@ -587,7 +587,7 @@ spec:
   privateKey:
     algorithm: ECDSA
     size: 256
-  secretName: ca-issuer-ca
+  secretName: gitpod-ca
   secretTemplate:
     labels:
       app: gitpod
@@ -614,7 +614,7 @@ spec:
   issuerRef:
     group: cert-manager.io
     kind: Issuer
-    name: ca-issuer
+    name: gitpod
   secretName: ws-daemon-tls
   secretTemplate:
     labels:
@@ -643,7 +643,7 @@ spec:
   issuerRef:
     group: cert-manager.io
     kind: Issuer
-    name: ca-issuer
+    name: gitpod
   secretName: ws-manager-client-tls
   secretTemplate:
     labels:
@@ -671,7 +671,7 @@ spec:
   issuerRef:
     group: cert-manager.io
     kind: Issuer
-    name: ca-issuer
+    name: gitpod
   secretName: ws-manager-tls
   secretTemplate:
     labels:
@@ -1320,7 +1320,7 @@ data:
   versions.json: |-
     {
       "versions": {
-        "version": "pd-ide-metrics.23",
+        "version": "main.4991",
         "components": {
           "agentSmith": {
             "version": "test"
@@ -1508,7 +1508,7 @@ data:
       labels:
         app: gitpod
         component: cluster
-      name: ca-issuer-ca
+      name: gitpod-ca
       namespace: default
     ---
     apiVersion: cert-manager.io/v1
@@ -1518,7 +1518,7 @@ data:
       labels:
         app: gitpod
         component: cluster
-      name: ca-issuer
+      name: gitpod
       namespace: default
     ---
     apiVersion: rbac.authorization.k8s.io/v1
@@ -4166,7 +4166,7 @@ apiVersion: v1
 data:
   config.json: |-
     {
-      "version": "pd-ide-metrics.23",
+      "version": "main.4991",
       "hostUrl": "https://gitpod.example.com",
       "installationShortname": "default",
       "devBranch": "",
@@ -4578,7 +4578,7 @@ data:
       "manager": {
         "namespace": "default",
         "schedulerName": "",
-        "seccompProfile": "workspace_default_pd-ide-metrics.23.json",
+        "seccompProfile": "workspace_default_main.4991.json",
         "timeouts": {
           "startup": "1h0m0s",
           "initialization": "30m0s",
@@ -6858,7 +6858,7 @@ spec:
       - command:
         - /bin/sh
         - -c
-        - cp -f /installer/workspace_default.json /mnt/dst/workspace_default_pd-ide-metrics.23.json
+        - cp -f /installer/workspace_default.json /mnt/dst/workspace_default_main.4991.json
         image: eu.gcr.io/gitpod-core-dev/build/seccomp-profile-installer:test
         name: seccomp-profile-installer
         resources: {}
@@ -8341,7 +8341,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 73fa19472813179dc8c919dc7f879256916481ff520144b6362fefaa7d5e2f15
+        gitpod.io/checksum_config: 2ac210064c7f1b173735aaa2abeee49853faf6abf6fb941963265d90b843f8d6
       creationTimestamp: null
       labels:
         app: gitpod
@@ -8604,7 +8604,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: ff12fcd029119d3d0900803abce70dd9a95d746776f14796a5bac3baf03ca8f6
+        gitpod.io/checksum_config: fcfe983925ae8c51de976f215876063c44f0b95dd8988e67828c385123993bd2
       creationTimestamp: null
       labels:
         app: gitpod
@@ -9327,7 +9327,7 @@ spec:
             - send
             env:
             - name: GITPOD_INSTALLATION_VERSION
-              value: pd-ide-metrics.23
+              value: main.4991
             - name: GITPOD_INSTALLATION_PLATFORM
               value: unknown
             - name: SERVER_URL

--- a/install/installer/cmd/testdata/render/http-proxy/output.golden
+++ b/install/installer/cmd/testdata/render/http-proxy/output.golden
@@ -512,7 +512,7 @@ spec:
       - system-node-critical
 status: {}
 ---
-# cert-manager.io/v1/Issuer ca-issuer
+# cert-manager.io/v1/Issuer gitpod
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
@@ -520,11 +520,11 @@ metadata:
   labels:
     app: gitpod
     component: cluster
-  name: ca-issuer
+  name: gitpod
   namespace: default
 spec:
   ca:
-    secretName: ca-issuer-ca
+    secretName: gitpod-ca
 status: {}
 ---
 # cert-manager.io/v1/Issuer gitpod-selfsigned-issuer
@@ -558,7 +558,7 @@ spec:
   issuerRef:
     group: cert-manager.io
     kind: Issuer
-    name: ca-issuer
+    name: gitpod
   secretName: builtin-registry-certs
   secretTemplate:
     labels:
@@ -583,7 +583,7 @@ spec:
   issuerRef:
     group: cert-manager.io
     kind: Issuer
-    name: ca-issuer
+    name: gitpod
   secretName: builtin-registry-facade-cert
   secretTemplate:
     labels:
@@ -591,7 +591,7 @@ spec:
       component: registry-facade
 status: {}
 ---
-# cert-manager.io/v1/Certificate ca-issuer-ca
+# cert-manager.io/v1/Certificate gitpod-ca
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
@@ -599,10 +599,10 @@ metadata:
   labels:
     app: gitpod
     component: cluster
-  name: ca-issuer-ca
+  name: gitpod-ca
   namespace: default
 spec:
-  commonName: ca-issuer-ca
+  commonName: gitpod-ca
   duration: 2160h0m0s
   isCA: true
   issuerRef:
@@ -612,7 +612,7 @@ spec:
   privateKey:
     algorithm: ECDSA
     size: 256
-  secretName: ca-issuer-ca
+  secretName: gitpod-ca
   secretTemplate:
     labels:
       app: gitpod
@@ -639,7 +639,7 @@ spec:
   issuerRef:
     group: cert-manager.io
     kind: Issuer
-    name: ca-issuer
+    name: gitpod
   secretName: ws-daemon-tls
   secretTemplate:
     labels:
@@ -668,7 +668,7 @@ spec:
   issuerRef:
     group: cert-manager.io
     kind: Issuer
-    name: ca-issuer
+    name: gitpod
   secretName: ws-manager-client-tls
   secretTemplate:
     labels:
@@ -696,7 +696,7 @@ spec:
   issuerRef:
     group: cert-manager.io
     kind: Issuer
-    name: ca-issuer
+    name: gitpod
   secretName: ws-manager-tls
   secretTemplate:
     labels:
@@ -1458,7 +1458,7 @@ data:
   versions.json: |-
     {
       "versions": {
-        "version": "pd-ide-metrics.23",
+        "version": "main.4991",
         "components": {
           "agentSmith": {
             "version": "test"
@@ -1686,7 +1686,7 @@ data:
       labels:
         app: gitpod
         component: cluster
-      name: ca-issuer-ca
+      name: gitpod-ca
       namespace: default
     ---
     apiVersion: cert-manager.io/v1
@@ -1696,7 +1696,7 @@ data:
       labels:
         app: gitpod
         component: cluster
-      name: ca-issuer
+      name: gitpod
       namespace: default
     ---
     apiVersion: rbac.authorization.k8s.io/v1
@@ -4615,7 +4615,7 @@ apiVersion: v1
 data:
   config.json: |-
     {
-      "version": "pd-ide-metrics.23",
+      "version": "main.4991",
       "hostUrl": "https://gitpod.example.com",
       "installationShortname": "default",
       "devBranch": "",
@@ -5028,7 +5028,7 @@ data:
       "manager": {
         "namespace": "default",
         "schedulerName": "",
-        "seccompProfile": "workspace_default_pd-ide-metrics.23.json",
+        "seccompProfile": "workspace_default_main.4991.json",
         "timeouts": {
           "startup": "1h0m0s",
           "initialization": "30m0s",
@@ -7848,7 +7848,7 @@ spec:
       - command:
         - /bin/sh
         - -c
-        - cp -f /installer/workspace_default.json /mnt/dst/workspace_default_pd-ide-metrics.23.json
+        - cp -f /installer/workspace_default.json /mnt/dst/workspace_default_main.4991.json
         image: eu.gcr.io/gitpod-core-dev/build/seccomp-profile-installer:test
         name: seccomp-profile-installer
         resources: {}
@@ -10259,7 +10259,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: adc398b5039ad75f724b2585a5da8a95110b918a32c0b854630fc3fa03a91722
+        gitpod.io/checksum_config: 335eefdfe860f52d0179553001668f61a018772186c32866863d80b10152b009
       creationTimestamp: null
       labels:
         app: gitpod
@@ -10696,7 +10696,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 4ac62854eccd472efc91ccb1041633960da4448fe1534555abb4ac94fe22861d
+        gitpod.io/checksum_config: 4c590aaeabfa3e73d42f1e345dc62c744bc9a885a35a09da4b50ae07b60c07c4
       creationTimestamp: null
       labels:
         app: gitpod
@@ -11697,7 +11697,7 @@ spec:
             - send
             env:
             - name: GITPOD_INSTALLATION_VERSION
-              value: pd-ide-metrics.23
+              value: main.4991
             - name: GITPOD_INSTALLATION_PLATFORM
               value: unknown
             - name: SERVER_URL

--- a/install/installer/cmd/testdata/render/insecure-s3-setup/output.golden
+++ b/install/installer/cmd/testdata/render/insecure-s3-setup/output.golden
@@ -512,7 +512,7 @@ spec:
       - system-node-critical
 status: {}
 ---
-# cert-manager.io/v1/Issuer ca-issuer
+# cert-manager.io/v1/Issuer gitpod
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
@@ -520,11 +520,11 @@ metadata:
   labels:
     app: gitpod
     component: cluster
-  name: ca-issuer
+  name: gitpod
   namespace: default
 spec:
   ca:
-    secretName: ca-issuer-ca
+    secretName: gitpod-ca
 status: {}
 ---
 # cert-manager.io/v1/Issuer gitpod-selfsigned-issuer
@@ -558,7 +558,7 @@ spec:
   issuerRef:
     group: cert-manager.io
     kind: Issuer
-    name: ca-issuer
+    name: gitpod
   secretName: builtin-registry-certs
   secretTemplate:
     labels:
@@ -583,7 +583,7 @@ spec:
   issuerRef:
     group: cert-manager.io
     kind: Issuer
-    name: ca-issuer
+    name: gitpod
   secretName: builtin-registry-facade-cert
   secretTemplate:
     labels:
@@ -591,7 +591,7 @@ spec:
       component: registry-facade
 status: {}
 ---
-# cert-manager.io/v1/Certificate ca-issuer-ca
+# cert-manager.io/v1/Certificate gitpod-ca
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
@@ -599,10 +599,10 @@ metadata:
   labels:
     app: gitpod
     component: cluster
-  name: ca-issuer-ca
+  name: gitpod-ca
   namespace: default
 spec:
-  commonName: ca-issuer-ca
+  commonName: gitpod-ca
   duration: 2160h0m0s
   isCA: true
   issuerRef:
@@ -612,7 +612,7 @@ spec:
   privateKey:
     algorithm: ECDSA
     size: 256
-  secretName: ca-issuer-ca
+  secretName: gitpod-ca
   secretTemplate:
     labels:
       app: gitpod
@@ -639,7 +639,7 @@ spec:
   issuerRef:
     group: cert-manager.io
     kind: Issuer
-    name: ca-issuer
+    name: gitpod
   secretName: ws-daemon-tls
   secretTemplate:
     labels:
@@ -668,7 +668,7 @@ spec:
   issuerRef:
     group: cert-manager.io
     kind: Issuer
-    name: ca-issuer
+    name: gitpod
   secretName: ws-manager-client-tls
   secretTemplate:
     labels:
@@ -696,7 +696,7 @@ spec:
   issuerRef:
     group: cert-manager.io
     kind: Issuer
-    name: ca-issuer
+    name: gitpod
   secretName: ws-manager-tls
   secretTemplate:
     labels:
@@ -1429,7 +1429,7 @@ data:
   versions.json: |-
     {
       "versions": {
-        "version": "pd-ide-metrics.23",
+        "version": "main.4991",
         "components": {
           "agentSmith": {
             "version": "test"
@@ -1657,7 +1657,7 @@ data:
       labels:
         app: gitpod
         component: cluster
-      name: ca-issuer-ca
+      name: gitpod-ca
       namespace: default
     ---
     apiVersion: cert-manager.io/v1
@@ -1667,7 +1667,7 @@ data:
       labels:
         app: gitpod
         component: cluster
-      name: ca-issuer
+      name: gitpod
       namespace: default
     ---
     apiVersion: rbac.authorization.k8s.io/v1
@@ -4526,7 +4526,7 @@ apiVersion: v1
 data:
   config.json: |-
     {
-      "version": "pd-ide-metrics.23",
+      "version": "main.4991",
       "hostUrl": "https://gitpod.example.com",
       "installationShortname": "default",
       "devBranch": "",
@@ -4940,7 +4940,7 @@ data:
       "manager": {
         "namespace": "default",
         "schedulerName": "",
-        "seccompProfile": "workspace_default_pd-ide-metrics.23.json",
+        "seccompProfile": "workspace_default_main.4991.json",
         "timeouts": {
           "startup": "1h0m0s",
           "initialization": "30m0s",
@@ -7316,7 +7316,7 @@ spec:
       - command:
         - /bin/sh
         - -c
-        - cp -f /installer/workspace_default.json /mnt/dst/workspace_default_pd-ide-metrics.23.json
+        - cp -f /installer/workspace_default.json /mnt/dst/workspace_default_main.4991.json
         image: eu.gcr.io/gitpod-core-dev/build/seccomp-profile-installer:test
         name: seccomp-profile-installer
         resources: {}
@@ -8984,7 +8984,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: adc398b5039ad75f724b2585a5da8a95110b918a32c0b854630fc3fa03a91722
+        gitpod.io/checksum_config: 335eefdfe860f52d0179553001668f61a018772186c32866863d80b10152b009
       creationTimestamp: null
       labels:
         app: gitpod
@@ -9259,7 +9259,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 059ee7fb00faa64f55167fa6467dc78d13af0d03219878e93c2e67e3606c00c0
+        gitpod.io/checksum_config: b92b2bc5e00e99fa252a5e193827aa9cc185ab8aad0b090cfbee43adf8624890
       creationTimestamp: null
       labels:
         app: gitpod
@@ -9906,7 +9906,7 @@ spec:
             - send
             env:
             - name: GITPOD_INSTALLATION_VERSION
-              value: pd-ide-metrics.23
+              value: main.4991
             - name: GITPOD_INSTALLATION_PLATFORM
               value: unknown
             - name: SERVER_URL

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -512,7 +512,7 @@ spec:
       - system-node-critical
 status: {}
 ---
-# cert-manager.io/v1/Issuer ca-issuer
+# cert-manager.io/v1/Issuer gitpod
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
@@ -520,11 +520,11 @@ metadata:
   labels:
     app: gitpod
     component: cluster
-  name: ca-issuer
+  name: gitpod
   namespace: default
 spec:
   ca:
-    secretName: ca-issuer-ca
+    secretName: gitpod-ca
 status: {}
 ---
 # cert-manager.io/v1/Issuer gitpod-selfsigned-issuer
@@ -558,7 +558,7 @@ spec:
   issuerRef:
     group: cert-manager.io
     kind: Issuer
-    name: ca-issuer
+    name: gitpod
   secretName: builtin-registry-certs
   secretTemplate:
     labels:
@@ -583,7 +583,7 @@ spec:
   issuerRef:
     group: cert-manager.io
     kind: Issuer
-    name: ca-issuer
+    name: gitpod
   secretName: builtin-registry-facade-cert
   secretTemplate:
     labels:
@@ -591,7 +591,7 @@ spec:
       component: registry-facade
 status: {}
 ---
-# cert-manager.io/v1/Certificate ca-issuer-ca
+# cert-manager.io/v1/Certificate gitpod-ca
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
@@ -599,10 +599,10 @@ metadata:
   labels:
     app: gitpod
     component: cluster
-  name: ca-issuer-ca
+  name: gitpod-ca
   namespace: default
 spec:
-  commonName: ca-issuer-ca
+  commonName: gitpod-ca
   duration: 2160h0m0s
   isCA: true
   issuerRef:
@@ -612,7 +612,7 @@ spec:
   privateKey:
     algorithm: ECDSA
     size: 256
-  secretName: ca-issuer-ca
+  secretName: gitpod-ca
   secretTemplate:
     labels:
       app: gitpod
@@ -639,7 +639,7 @@ spec:
   issuerRef:
     group: cert-manager.io
     kind: Issuer
-    name: ca-issuer
+    name: gitpod
   secretName: ws-daemon-tls
   secretTemplate:
     labels:
@@ -668,7 +668,7 @@ spec:
   issuerRef:
     group: cert-manager.io
     kind: Issuer
-    name: ca-issuer
+    name: gitpod
   secretName: ws-manager-client-tls
   secretTemplate:
     labels:
@@ -696,7 +696,7 @@ spec:
   issuerRef:
     group: cert-manager.io
     kind: Issuer
-    name: ca-issuer
+    name: gitpod
   secretName: ws-manager-tls
   secretTemplate:
     labels:
@@ -1455,7 +1455,7 @@ data:
   versions.json: |-
     {
       "versions": {
-        "version": "pd-ide-metrics.23",
+        "version": "main.4991",
         "components": {
           "agentSmith": {
             "version": "test"
@@ -1683,7 +1683,7 @@ data:
       labels:
         app: gitpod
         component: cluster
-      name: ca-issuer-ca
+      name: gitpod-ca
       namespace: default
     ---
     apiVersion: cert-manager.io/v1
@@ -1693,7 +1693,7 @@ data:
       labels:
         app: gitpod
         component: cluster
-      name: ca-issuer
+      name: gitpod
       namespace: default
     ---
     apiVersion: rbac.authorization.k8s.io/v1
@@ -4612,7 +4612,7 @@ apiVersion: v1
 data:
   config.json: |-
     {
-      "version": "pd-ide-metrics.23",
+      "version": "main.4991",
       "hostUrl": "https://gitpod.example.com",
       "installationShortname": "default",
       "devBranch": "",
@@ -5025,7 +5025,7 @@ data:
       "manager": {
         "namespace": "default",
         "schedulerName": "",
-        "seccompProfile": "workspace_default_pd-ide-metrics.23.json",
+        "seccompProfile": "workspace_default_main.4991.json",
         "timeouts": {
           "startup": "1h0m0s",
           "initialization": "30m0s",
@@ -7443,7 +7443,7 @@ spec:
       - command:
         - /bin/sh
         - -c
-        - cp -f /installer/workspace_default.json /mnt/dst/workspace_default_pd-ide-metrics.23.json
+        - cp -f /installer/workspace_default.json /mnt/dst/workspace_default_main.4991.json
         image: eu.gcr.io/gitpod-core-dev/build/seccomp-profile-installer:test
         name: seccomp-profile-installer
         resources: {}
@@ -9213,7 +9213,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: adc398b5039ad75f724b2585a5da8a95110b918a32c0b854630fc3fa03a91722
+        gitpod.io/checksum_config: 335eefdfe860f52d0179553001668f61a018772186c32866863d80b10152b009
       creationTimestamp: null
       labels:
         app: gitpod
@@ -9488,7 +9488,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 4ac62854eccd472efc91ccb1041633960da4448fe1534555abb4ac94fe22861d
+        gitpod.io/checksum_config: 4c590aaeabfa3e73d42f1e345dc62c744bc9a885a35a09da4b50ae07b60c07c4
       creationTimestamp: null
       labels:
         app: gitpod
@@ -10129,7 +10129,7 @@ spec:
             - send
             env:
             - name: GITPOD_INSTALLATION_VERSION
-              value: pd-ide-metrics.23
+              value: main.4991
             - name: GITPOD_INSTALLATION_PLATFORM
               value: unknown
             - name: SERVER_URL

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -512,7 +512,7 @@ spec:
       - system-node-critical
 status: {}
 ---
-# cert-manager.io/v1/Issuer ca-issuer
+# cert-manager.io/v1/Issuer gitpod
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
@@ -520,11 +520,11 @@ metadata:
   labels:
     app: gitpod
     component: cluster
-  name: ca-issuer
+  name: gitpod
   namespace: default
 spec:
   ca:
-    secretName: ca-issuer-ca
+    secretName: gitpod-ca
 status: {}
 ---
 # cert-manager.io/v1/Issuer gitpod-selfsigned-issuer
@@ -558,7 +558,7 @@ spec:
   issuerRef:
     group: cert-manager.io
     kind: Issuer
-    name: ca-issuer
+    name: gitpod
   secretName: builtin-registry-certs
   secretTemplate:
     labels:
@@ -583,7 +583,7 @@ spec:
   issuerRef:
     group: cert-manager.io
     kind: Issuer
-    name: ca-issuer
+    name: gitpod
   secretName: builtin-registry-facade-cert
   secretTemplate:
     labels:
@@ -591,7 +591,7 @@ spec:
       component: registry-facade
 status: {}
 ---
-# cert-manager.io/v1/Certificate ca-issuer-ca
+# cert-manager.io/v1/Certificate gitpod-ca
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
@@ -599,10 +599,10 @@ metadata:
   labels:
     app: gitpod
     component: cluster
-  name: ca-issuer-ca
+  name: gitpod-ca
   namespace: default
 spec:
-  commonName: ca-issuer-ca
+  commonName: gitpod-ca
   duration: 2160h0m0s
   isCA: true
   issuerRef:
@@ -612,7 +612,7 @@ spec:
   privateKey:
     algorithm: ECDSA
     size: 256
-  secretName: ca-issuer-ca
+  secretName: gitpod-ca
   secretTemplate:
     labels:
       app: gitpod
@@ -639,7 +639,7 @@ spec:
   issuerRef:
     group: cert-manager.io
     kind: Issuer
-    name: ca-issuer
+    name: gitpod
   secretName: ws-daemon-tls
   secretTemplate:
     labels:
@@ -668,7 +668,7 @@ spec:
   issuerRef:
     group: cert-manager.io
     kind: Issuer
-    name: ca-issuer
+    name: gitpod
   secretName: ws-manager-client-tls
   secretTemplate:
     labels:
@@ -696,7 +696,7 @@ spec:
   issuerRef:
     group: cert-manager.io
     kind: Issuer
-    name: ca-issuer
+    name: gitpod
   secretName: ws-manager-tls
   secretTemplate:
     labels:
@@ -1467,7 +1467,7 @@ data:
   versions.json: |-
     {
       "versions": {
-        "version": "pd-ide-metrics.23",
+        "version": "main.4991",
         "components": {
           "agentSmith": {
             "version": "test"
@@ -1695,7 +1695,7 @@ data:
       labels:
         app: gitpod
         component: cluster
-      name: ca-issuer-ca
+      name: gitpod-ca
       namespace: default
     ---
     apiVersion: cert-manager.io/v1
@@ -1705,7 +1705,7 @@ data:
       labels:
         app: gitpod
         component: cluster
-      name: ca-issuer
+      name: gitpod
       namespace: default
     ---
     apiVersion: rbac.authorization.k8s.io/v1
@@ -4624,7 +4624,7 @@ apiVersion: v1
 data:
   config.json: |-
     {
-      "version": "pd-ide-metrics.23",
+      "version": "main.4991",
       "hostUrl": "https://gitpod.example.com",
       "installationShortname": "default",
       "devBranch": "",
@@ -5037,7 +5037,7 @@ data:
       "manager": {
         "namespace": "default",
         "schedulerName": "",
-        "seccompProfile": "workspace_default_pd-ide-metrics.23.json",
+        "seccompProfile": "workspace_default_main.4991.json",
         "timeouts": {
           "startup": "1h0m0s",
           "initialization": "30m0s",
@@ -7455,7 +7455,7 @@ spec:
       - command:
         - /bin/sh
         - -c
-        - cp -f /installer/workspace_default.json /mnt/dst/workspace_default_pd-ide-metrics.23.json
+        - cp -f /installer/workspace_default.json /mnt/dst/workspace_default_main.4991.json
         image: eu.gcr.io/gitpod-core-dev/build/seccomp-profile-installer:test
         name: seccomp-profile-installer
         resources: {}
@@ -9225,7 +9225,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: adc398b5039ad75f724b2585a5da8a95110b918a32c0b854630fc3fa03a91722
+        gitpod.io/checksum_config: 335eefdfe860f52d0179553001668f61a018772186c32866863d80b10152b009
       creationTimestamp: null
       labels:
         app: gitpod
@@ -9500,7 +9500,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 4ac62854eccd472efc91ccb1041633960da4448fe1534555abb4ac94fe22861d
+        gitpod.io/checksum_config: 4c590aaeabfa3e73d42f1e345dc62c744bc9a885a35a09da4b50ae07b60c07c4
       creationTimestamp: null
       labels:
         app: gitpod
@@ -10141,7 +10141,7 @@ spec:
             - send
             env:
             - name: GITPOD_INSTALLATION_VERSION
-              value: pd-ide-metrics.23
+              value: main.4991
             - name: GITPOD_INSTALLATION_PLATFORM
               value: unknown
             - name: SERVER_URL

--- a/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
+++ b/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
@@ -512,7 +512,7 @@ spec:
       - system-node-critical
 status: {}
 ---
-# cert-manager.io/v1/Issuer ca-issuer
+# cert-manager.io/v1/Issuer gitpod
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
@@ -520,11 +520,11 @@ metadata:
   labels:
     app: gitpod
     component: cluster
-  name: ca-issuer
+  name: gitpod
   namespace: default
 spec:
   ca:
-    secretName: ca-issuer-ca
+    secretName: gitpod-ca
 status: {}
 ---
 # cert-manager.io/v1/Issuer gitpod-selfsigned-issuer
@@ -558,7 +558,7 @@ spec:
   issuerRef:
     group: cert-manager.io
     kind: Issuer
-    name: ca-issuer
+    name: gitpod
   secretName: builtin-registry-certs
   secretTemplate:
     labels:
@@ -583,7 +583,7 @@ spec:
   issuerRef:
     group: cert-manager.io
     kind: Issuer
-    name: ca-issuer
+    name: gitpod
   secretName: builtin-registry-facade-cert
   secretTemplate:
     labels:
@@ -591,7 +591,7 @@ spec:
       component: registry-facade
 status: {}
 ---
-# cert-manager.io/v1/Certificate ca-issuer-ca
+# cert-manager.io/v1/Certificate gitpod-ca
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
@@ -599,10 +599,10 @@ metadata:
   labels:
     app: gitpod
     component: cluster
-  name: ca-issuer-ca
+  name: gitpod-ca
   namespace: default
 spec:
-  commonName: ca-issuer-ca
+  commonName: gitpod-ca
   duration: 2160h0m0s
   isCA: true
   issuerRef:
@@ -612,7 +612,7 @@ spec:
   privateKey:
     algorithm: ECDSA
     size: 256
-  secretName: ca-issuer-ca
+  secretName: gitpod-ca
   secretTemplate:
     labels:
       app: gitpod
@@ -639,7 +639,7 @@ spec:
   issuerRef:
     group: cert-manager.io
     kind: Issuer
-    name: ca-issuer
+    name: gitpod
   secretName: ws-daemon-tls
   secretTemplate:
     labels:
@@ -668,7 +668,7 @@ spec:
   issuerRef:
     group: cert-manager.io
     kind: Issuer
-    name: ca-issuer
+    name: gitpod
   secretName: ws-manager-client-tls
   secretTemplate:
     labels:
@@ -696,7 +696,7 @@ spec:
   issuerRef:
     group: cert-manager.io
     kind: Issuer
-    name: ca-issuer
+    name: gitpod
   secretName: ws-manager-tls
   secretTemplate:
     labels:
@@ -1677,7 +1677,7 @@ data:
   versions.json: |-
     {
       "versions": {
-        "version": "pd-ide-metrics.23",
+        "version": "main.4991",
         "components": {
           "agentSmith": {
             "version": "test"
@@ -1905,7 +1905,7 @@ data:
       labels:
         app: gitpod
         component: cluster
-      name: ca-issuer-ca
+      name: gitpod-ca
       namespace: default
     ---
     apiVersion: cert-manager.io/v1
@@ -1915,7 +1915,7 @@ data:
       labels:
         app: gitpod
         component: cluster
-      name: ca-issuer
+      name: gitpod
       namespace: default
     ---
     apiVersion: rbac.authorization.k8s.io/v1
@@ -4945,7 +4945,7 @@ apiVersion: v1
 data:
   config.json: |-
     {
-      "version": "pd-ide-metrics.23",
+      "version": "main.4991",
       "hostUrl": "https://gitpod.example.com",
       "installationShortname": "default",
       "devBranch": "",
@@ -5358,7 +5358,7 @@ data:
       "manager": {
         "namespace": "default",
         "schedulerName": "",
-        "seccompProfile": "workspace_default_pd-ide-metrics.23.json",
+        "seccompProfile": "workspace_default_main.4991.json",
         "timeouts": {
           "startup": "1h0m0s",
           "initialization": "30m0s",
@@ -7887,7 +7887,7 @@ spec:
       - command:
         - /bin/sh
         - -c
-        - cp -f /installer/workspace_default.json /mnt/dst/workspace_default_pd-ide-metrics.23.json
+        - cp -f /installer/workspace_default.json /mnt/dst/workspace_default_main.4991.json
         image: eu.gcr.io/gitpod-core-dev/build/seccomp-profile-installer:test
         name: seccomp-profile-installer
         resources: {}
@@ -9657,7 +9657,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: adc398b5039ad75f724b2585a5da8a95110b918a32c0b854630fc3fa03a91722
+        gitpod.io/checksum_config: 335eefdfe860f52d0179553001668f61a018772186c32866863d80b10152b009
       creationTimestamp: null
       labels:
         app: gitpod
@@ -9932,7 +9932,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 4ac62854eccd472efc91ccb1041633960da4448fe1534555abb4ac94fe22861d
+        gitpod.io/checksum_config: 4c590aaeabfa3e73d42f1e345dc62c744bc9a885a35a09da4b50ae07b60c07c4
       creationTimestamp: null
       labels:
         app: gitpod
@@ -10573,7 +10573,7 @@ spec:
             - send
             env:
             - name: GITPOD_INSTALLATION_VERSION
-              value: pd-ide-metrics.23
+              value: main.4991
             - name: GITPOD_INSTALLATION_PLATFORM
               value: unknown
             - name: SERVER_URL

--- a/install/installer/cmd/testdata/render/versions.yaml
+++ b/install/installer/cmd/testdata/render/versions.yaml
@@ -1,8 +1,8 @@
 # Copyright (c) 2022 Gitpod GmbH. All rights reserved.
 # Licensed under the MIT License. See License-MIT.txt in the project root for license information.
 
-commit: 5c9e6394c1372f4c73031671ae786909a85d5730
-version: pd-ide-metrics.23
+commit: f4a71fa6cca9a8e774da2bca818347e1aa9d159e
+version: main.4991
 components:
   agentSmith:
     version: test
@@ -20,9 +20,9 @@ components:
     version: test
   ideMetrics:
     version: test
-  ideService:
-    version: test
   ideProxy:
+    version: test
+  ideService:
     version: test
   imageBuilderMk3:
     builderImage:
@@ -33,6 +33,8 @@ components:
   integrationTest:
     version: test
   kots-config-check:
+    certificate:
+      version: test
     database:
       version: test
     registry:
@@ -72,6 +74,10 @@ components:
         version: test
       intellijLatest:
         version: test
+      jbBackendPlugin:
+        version: test
+      jbBackendPluginLatest:
+        version: test
       phpstorm:
         version: test
       phpstormLatest:
@@ -87,10 +93,6 @@ components:
       webstorm:
         version: test
       webstormLatest:
-        version: test
-      jbBackendPlugin:
-        version: test
-      jbBackendPluginLatest:
         version: test
       version: test
     dockerUp:

--- a/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
+++ b/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
@@ -512,7 +512,7 @@ spec:
       - system-node-critical
 status: {}
 ---
-# cert-manager.io/v1/Issuer ca-issuer
+# cert-manager.io/v1/Issuer gitpod
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
@@ -520,11 +520,11 @@ metadata:
   labels:
     app: gitpod
     component: cluster
-  name: ca-issuer
+  name: gitpod
   namespace: default
 spec:
   ca:
-    secretName: ca-issuer-ca
+    secretName: gitpod-ca
 status: {}
 ---
 # cert-manager.io/v1/Issuer gitpod-selfsigned-issuer
@@ -558,7 +558,7 @@ spec:
   issuerRef:
     group: cert-manager.io
     kind: Issuer
-    name: ca-issuer
+    name: gitpod
   secretName: builtin-registry-certs
   secretTemplate:
     labels:
@@ -583,7 +583,7 @@ spec:
   issuerRef:
     group: cert-manager.io
     kind: Issuer
-    name: ca-issuer
+    name: gitpod
   secretName: builtin-registry-facade-cert
   secretTemplate:
     labels:
@@ -591,7 +591,7 @@ spec:
       component: registry-facade
 status: {}
 ---
-# cert-manager.io/v1/Certificate ca-issuer-ca
+# cert-manager.io/v1/Certificate gitpod-ca
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
@@ -599,10 +599,10 @@ metadata:
   labels:
     app: gitpod
     component: cluster
-  name: ca-issuer-ca
+  name: gitpod-ca
   namespace: default
 spec:
-  commonName: ca-issuer-ca
+  commonName: gitpod-ca
   duration: 2160h0m0s
   isCA: true
   issuerRef:
@@ -612,7 +612,7 @@ spec:
   privateKey:
     algorithm: ECDSA
     size: 256
-  secretName: ca-issuer-ca
+  secretName: gitpod-ca
   secretTemplate:
     labels:
       app: gitpod
@@ -639,7 +639,7 @@ spec:
   issuerRef:
     group: cert-manager.io
     kind: Issuer
-    name: ca-issuer
+    name: gitpod
   secretName: ws-daemon-tls
   secretTemplate:
     labels:
@@ -668,7 +668,7 @@ spec:
   issuerRef:
     group: cert-manager.io
     kind: Issuer
-    name: ca-issuer
+    name: gitpod
   secretName: ws-manager-client-tls
   secretTemplate:
     labels:
@@ -696,7 +696,7 @@ spec:
   issuerRef:
     group: cert-manager.io
     kind: Issuer
-    name: ca-issuer
+    name: gitpod
   secretName: ws-manager-tls
   secretTemplate:
     labels:
@@ -1458,7 +1458,7 @@ data:
   versions.json: |-
     {
       "versions": {
-        "version": "pd-ide-metrics.23",
+        "version": "main.4991",
         "components": {
           "agentSmith": {
             "version": "test"
@@ -1686,7 +1686,7 @@ data:
       labels:
         app: gitpod
         component: cluster
-      name: ca-issuer-ca
+      name: gitpod-ca
       namespace: default
     ---
     apiVersion: cert-manager.io/v1
@@ -1696,7 +1696,7 @@ data:
       labels:
         app: gitpod
         component: cluster
-      name: ca-issuer
+      name: gitpod
       namespace: default
     ---
     apiVersion: rbac.authorization.k8s.io/v1
@@ -4615,7 +4615,7 @@ apiVersion: v1
 data:
   config.json: |-
     {
-      "version": "pd-ide-metrics.23",
+      "version": "main.4991",
       "hostUrl": "https://gitpod.example.com",
       "installationShortname": "default",
       "devBranch": "",
@@ -5028,7 +5028,7 @@ data:
       "manager": {
         "namespace": "default",
         "schedulerName": "",
-        "seccompProfile": "workspace_default_pd-ide-metrics.23.json",
+        "seccompProfile": "workspace_default_main.4991.json",
         "timeouts": {
           "startup": "1h0m0s",
           "initialization": "30m0s",
@@ -7446,7 +7446,7 @@ spec:
       - command:
         - /bin/sh
         - -c
-        - cp -f /installer/workspace_default.json /mnt/dst/workspace_default_pd-ide-metrics.23.json
+        - cp -f /installer/workspace_default.json /mnt/dst/workspace_default_main.4991.json
         image: eu.gcr.io/gitpod-core-dev/build/seccomp-profile-installer:test
         name: seccomp-profile-installer
         resources: {}
@@ -9216,7 +9216,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: adc398b5039ad75f724b2585a5da8a95110b918a32c0b854630fc3fa03a91722
+        gitpod.io/checksum_config: 335eefdfe860f52d0179553001668f61a018772186c32866863d80b10152b009
       creationTimestamp: null
       labels:
         app: gitpod
@@ -9491,7 +9491,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 8382c106b9317df4712ae65f863b79732c33401cd56764a3c108f974a30f6583
+        gitpod.io/checksum_config: 095ccf78ca4de88cb055baa3dd30a63b36d8b4323798e7d67430fb0414d74063
       creationTimestamp: null
       labels:
         app: gitpod
@@ -10132,7 +10132,7 @@ spec:
             - send
             env:
             - name: GITPOD_INSTALLATION_VERSION
-              value: pd-ide-metrics.23
+              value: main.4991
             - name: GITPOD_INSTALLATION_PLATFORM
               value: unknown
             - name: SERVER_URL

--- a/install/installer/pkg/common/constants.go
+++ b/install/installer/pkg/common/constants.go
@@ -15,7 +15,7 @@ import (
 const (
 	AppName                     = "gitpod"
 	BlobServeServicePort        = 4000
-	CertManagerCAIssuer         = "ca-issuer"
+	CertManagerCAIssuer         = "gitpod"
 	DockerRegistryURL           = "docker.io"
 	DockerRegistryName          = "registry"
 	GitpodContainerRegistry     = "eu.gcr.io/gitpod-core-dev/build"

--- a/install/installer/pkg/config/v1/envvars.go
+++ b/install/installer/pkg/config/v1/envvars.go
@@ -348,7 +348,7 @@ func (v version) BuildFromEnvvars(in interface{}) error {
 		log.Info("Generating a self-signed certificate with the internal CA")
 		cfg.CustomCACert = &ObjectRef{
 			Kind: ObjectRefSecret,
-			Name: "ca-issuer-ca", // This comes from common/constants.go
+			Name: "gitpod-ca", // This comes from common/constants.go
 		}
 	} else if !envvars.TLSCertManagerEnabled && envvars.TLSCustomCACertEnabled {
 		log.Info("Setting the CA to be used for the certificate")

--- a/install/kots/manifests/gitpod-certificate.yaml
+++ b/install/kots/manifests/gitpod-certificate.yaml
@@ -13,7 +13,7 @@ metadata:
 spec:
   secretName: https-certificates
   issuerRef:
-    name: '{{repl if (ConfigOptionEquals "tls_self_signed_enabled" "1" ) }}ca-issuer{{repl else }}{{repl ConfigOption "cert_manager_issuer_name" }}{{repl end }}'
+    name: '{{repl if (ConfigOptionEquals "tls_self_signed_enabled" "1" ) }}gitpod{{repl else }}{{repl ConfigOption "cert_manager_issuer_name" }}{{repl end }}'
     kind: '{{repl if (ConfigOptionEquals "tls_self_signed_enabled" "1" ) }}Issuer{{repl else }}{{repl ConfigOption "cert_manager_issuer" }}{{repl end }}'
   dnsNames:
     - '{{repl ConfigOption "domain" }}'

--- a/install/kots/manifests/kots-config.yaml
+++ b/install/kots/manifests/kots-config.yaml
@@ -305,7 +305,7 @@ spec:
             certificate and install it to your browser.
 
             To download the certificate, run
-            `kubectl get secrets -n {{repl Namespace }}  ca-issuer-ca -o jsonpath='{.data.ca\.crt}' | base64 -d > ./ca.crt`
+            `kubectl get secrets -n {{repl Namespace }}  gitpod-ca -o jsonpath='{.data.ca\.crt}' | base64 -d > ./ca.crt`
 
         - name: cert_manager_enabled
           title: Use cert-manager


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Currently, `ca-issuer` is very confusing for a user whenever it is installed into the cluster due to the lack of the gitpod prefix. This PR updates it to be called `gitpod-ca` instead.

See https://github.com/gitpod-io/gitpod/issues/12836 for the full SSL certificate overview diagram.

Signed-off-by: Tarun Pothulapati <tarun@gitpod.io>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/11751

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[cert-manger] Rename `ca-issuer` to `gitpod`
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [x] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
