### PR TITLE
Two rows of 4 option on onboarding IDE selector

### DIFF
--- a/components/dashboard/src/settings/SelectIDEModal.tsx
+++ b/components/dashboard/src/settings/SelectIDEModal.tsx
@@ -44,7 +44,7 @@ export default function (props: SelectIDEModalProps) {
             visible={visible}
             onClose={handleContinue}
             closeable={true}
-            className="_max-w-xl"
+            className="max-w-2xl"
             buttons={<button onClick={handleContinue}>Continue</button>}
         >
             <p className="text-gray-500 dark:text-gray-400 text-base pb-3">


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PR solves the issue #13497 as suggested over there : 2 rows, 4 column style on-boarding IDE selector window

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #13497

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
   NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
