### PR TITLE
[terraform] prepare terraform modules to use for tests

### DIFF
--- a/install/infra/modules/aks/local.tf
+++ b/install/infra/modules/aks/local.tf
@@ -14,9 +14,9 @@ locals {
   ])
 
   workspace_name = replace(terraform.workspace, "/[\\W\\-]/", "") # alphanumeric workspace name
-  db       = "GP_Gen5_2"
-  location = substr(var.location, 0, 3) # Short code for location
-  machine  = "Standard_D4_v3"
+  db             = "GP_Gen5_2"
+  location       = substr(var.location, 0, 3) # Short code for location
+  machine        = "Standard_D4_v3"
   network_security_rules = var.enable_airgapped ? [
     {
       name                       = "AllowContainerRegistry"
@@ -78,7 +78,7 @@ locals {
   nodes = [
     {
       name = "services"
-       labels = {
+      labels = {
         lookup(local.labels, "workload_meta")      = true
         lookup(local.labels, "workload_ide")       = true
         lookup(local.labels, "workspace_services") = true

--- a/install/infra/modules/aks/output.tf
+++ b/install/infra/modules/aks/output.tf
@@ -1,11 +1,11 @@
 output "cert_manager_issuer" {
   value = try({
-        subscriptionID    = data.azurerm_client_config.current.subscription_id
-        resourceGroupName = azurerm_resource_group.gitpod.name
-        hostedZoneName    = azurerm_dns_zone.dns.0.name
-        managedIdentity = {
-          clientID = azurerm_kubernetes_cluster.k8s.kubelet_identity.0.client_id
-        }
+    subscriptionID    = data.azurerm_client_config.current.subscription_id
+    resourceGroupName = azurerm_resource_group.gitpod.name
+    hostedZoneName    = azurerm_dns_zone.dns.0.name
+    managedIdentity = {
+      clientID = azurerm_kubernetes_cluster.k8s.kubelet_identity.0.client_id
+    }
   }, {})
 }
 
@@ -27,7 +27,7 @@ output "database" {
   }, {})
 }
 
-output "domain_nameservers" {
+output "name_servers" {
   value = try(azurerm_dns_zone.dns.0.name_servers, null)
 }
 
@@ -38,28 +38,28 @@ output "external_dns_secrets" {
 output "external_dns_settings" {
   value = [
     {
-      "name": "provider",
-      "value": "azure"
+      "name" : "provider",
+      "value" : "azure"
     },
     {
-      "name": "azure.resourceGroup",
-      "value": azurerm_resource_group.gitpod.name,
+      "name" : "azure.resourceGroup",
+      "value" : azurerm_resource_group.gitpod.name,
     },
     {
-      "name": "azure.subscriptionId",
-      "value": data.azurerm_client_config.current.subscription_id,
+      "name" : "azure.subscriptionId",
+      "value" : data.azurerm_client_config.current.subscription_id,
     },
     {
-      "name": "azure.tenantId",
-      "value": data.azurerm_client_config.current.tenant_id,
+      "name" : "azure.tenantId",
+      "value" : data.azurerm_client_config.current.tenant_id,
     },
     {
-      "name": "azure.useManagedIdentityExtension",
-      "value": true
+      "name" : "azure.useManagedIdentityExtension",
+      "value" : true
     },
     {
-      "name": "azure.userAssignedIdentityID",
-      "value": azurerm_kubernetes_cluster.k8s.kubelet_identity.0.client_id
+      "name" : "azure.userAssignedIdentityID",
+      "value" : azurerm_kubernetes_cluster.k8s.kubelet_identity.0.client_id
     },
   ]
 }

--- a/install/infra/modules/eks/local.tf
+++ b/install/infra/modules/eks/local.tf
@@ -1,6 +1,6 @@
- locals {
-   aws_cert_manager_enabled = local.domain_name_enabled && var.use_aws_cert_manager == true
-   aws_cert_manager_count   = local.aws_cert_manager_enabled ? 1 : 0
-   domain_name_enabled      = var.domain_name != ""
-   domain_name_count        = local.domain_name_enabled ? 1 : 0
- }
+locals {
+  aws_cert_manager_enabled = local.domain_name_enabled && var.use_aws_cert_manager == true
+  aws_cert_manager_count   = local.aws_cert_manager_enabled ? 1 : 0
+  domain_name_enabled      = var.domain_name != ""
+  domain_name_count        = local.domain_name_enabled ? 1 : 0
+}

--- a/install/infra/modules/eks/output.tf
+++ b/install/infra/modules/eks/output.tf
@@ -47,7 +47,7 @@ output "cert_manager_issuer" {
   }, {})
 }
 
-output "domain_nameservers" {
+output "name_servers" {
   value = formatlist("%s.", resource.aws_route53_zone.gitpod[0].name_servers)
 }
 

--- a/install/infra/modules/eks/providers.tf
+++ b/install/infra/modules/eks/providers.tf
@@ -1,8 +1,8 @@
 terraform {
   required_providers {
     aws = {
-        version = " ~> 3.0"
-        source = "registry.terraform.io/hashicorp/aws"
+      version = " ~> 3.0"
+      source  = "registry.terraform.io/hashicorp/aws"
     }
     helm = {
       source  = "hashicorp/helm"
@@ -12,5 +12,5 @@ terraform {
 }
 
 provider "aws" {
-  region  = var.region
+  region = var.region
 }

--- a/install/infra/modules/eks/variables.tf
+++ b/install/infra/modules/eks/variables.tf
@@ -43,7 +43,7 @@ variable "vpc_availability_zones" {
 }
 
 variable "domain_name" {
-  default = ""
+  default     = ""
   description = "Domain name to associate with the route53 zone"
 }
 

--- a/install/infra/modules/tools/cloud-dns-ns/main.tf
+++ b/install/infra/modules/tools/cloud-dns-ns/main.tf
@@ -1,8 +1,8 @@
-variable nameservers {}
-variable domain_name {}
-variable managed_dns_zone {}
-variable dns_project {}
-variable credentials {}
+variable "nameservers" {}
+variable "domain_name" {}
+variable "managed_dns_zone" {}
+variable "dns_project" {}
+variable "credentials" {}
 
 provider "google" {
   alias       = "dns"
@@ -14,7 +14,7 @@ resource "google_dns_record_set" "gitpod-dns-3" {
   provider     = google.dns
   name         = "${var.domain_name}."
   managed_zone = var.managed_dns_zone
-  project      =  var.dns_project
+  project      = var.dns_project
   type         = "NS"
   ttl          = 5
 

--- a/install/infra/single-cluster/aws/output.tf
+++ b/install/infra/single-cluster/aws/output.tf
@@ -3,7 +3,7 @@ output "url" {
 }
 
 output "cluster_name" {
-  value     = var.cluster_name
+  value = var.cluster_name
 }
 
 output "registry_backend" {
@@ -16,6 +16,11 @@ output "storage" {
   value     = module.eks.storage
 }
 
+output "registry" {
+  sensitive = true
+  value     = module.eks.registry
+}
+
 output "database" {
   sensitive = true
   value     = module.eks.database
@@ -23,10 +28,15 @@ output "database" {
 
 output "nameservers" {
   sensitive = false
-  value     = module.eks.domain_nameservers
+  value     = module.eks.name_servers
 }
 
 output "cluster_issuer" {
   sensitive = false
   value     = module.cluster-issuer.cluster_issuer
+}
+
+output "aws_cluster_user" {
+  sensitive = true
+  value     = module.eks.cluster_user
 }

--- a/install/infra/single-cluster/azure/cluster.tf
+++ b/install/infra/single-cluster/azure/cluster.tf
@@ -1,5 +1,5 @@
 module "aks" {
-#   source = "github.com/gitpod-io/gitpod//install/infra/modules/aks?ref=main"
+  #   source = "github.com/gitpod-io/gitpod//install/infra/modules/aks?ref=main"
   source = "../../modules/aks"
 
   domain_name              = var.domain_name

--- a/install/infra/single-cluster/azure/output.tf
+++ b/install/infra/single-cluster/azure/output.tf
@@ -23,7 +23,7 @@ output "database" {
 
 output "nameservers" {
   sensitive = false
-  value     = module.aks.domain_nameservers
+  value     = module.aks.name_servers
 }
 
 output "cluster_issuer" {

--- a/install/infra/single-cluster/gcp/cluster.tf
+++ b/install/infra/single-cluster/gcp/cluster.tf
@@ -9,7 +9,7 @@ module "gke" {
   zone                    = var.zone
   workspaces_machine_type = "n2d-standard-16"
 
-  domain_name = var.domain_name
+  domain_name              = var.domain_name
   enable_external_database = var.enable_external_database
   enable_external_storage  = var.enable_external_storage
   enable_external_registry = var.enable_external_registry

--- a/install/infra/single-cluster/gcp/output.tf
+++ b/install/infra/single-cluster/gcp/output.tf
@@ -34,3 +34,8 @@ output "storage" {
   sensitive = true
   value     = module.gke.storage
 }
+
+output "gke_user_key" {
+  sensitive = true
+  value     = try(module.gke.cluster-sa, null)
+}

--- a/install/infra/single-cluster/gcp/terraform.tfvars
+++ b/install/infra/single-cluster/gcp/terraform.tfvars
@@ -4,9 +4,9 @@ cluster_name = "gitpod"
 # a cloudDNS zone and certificate request will be created for this domain; surround the domain name within double quotes
 domain_name = "your_domain_name.com"
 
-region      = "europe-west1"
-zone        = "europe-west1-d"
-project     = "my-gcp-project"
+region  = "europe-west1"
+zone    = "europe-west1-d"
+project = "my-gcp-project"
 
 cluster_version = "1.22"
 

--- a/install/infra/single-cluster/gcp/tools.tf
+++ b/install/infra/single-cluster/gcp/tools.tf
@@ -1,7 +1,7 @@
 module "certmanager" {
   source = "../../modules/tools/cert-manager"
 
-  kubeconfig  = var.kubeconfig
+  kubeconfig = var.kubeconfig
 }
 
 module "externaldns" {
@@ -12,12 +12,12 @@ module "externaldns" {
 }
 
 module "cluster-issuer" {
-  source              = "../../modules/tools/issuer"
-  kubeconfig          = var.kubeconfig
-  gcp_credentials     = module.gke.dns_credentials
-  issuer_name         = "cloudDNS"
+  source          = "../../modules/tools/issuer"
+  kubeconfig      = var.kubeconfig
+  gcp_credentials = module.gke.dns_credentials
+  issuer_name     = "cloudDNS"
   cert_manager_issuer = {
-    project                 = var.project
+    project = var.project
     serviceAccountSecretRef = {
       name = "clouddns-dns01-solver"
       key  = "keys.json"

--- a/install/tests/main.tf
+++ b/install/tests/main.tf
@@ -173,7 +173,7 @@ module "gcp-add-dns-record" {
 module "azure-add-dns-record" {
   source           = "../infra/modules/tools/cloud-dns-ns"
   credentials      = var.dns_sa_creds
-  nameservers      = module.aks.domain_nameservers
+  nameservers      = module.aks.name_servers
   dns_project      = "dns-for-playgrounds"
   managed_dns_zone = var.gcp_zone
   domain_name      = "${var.TEST_ID}.${var.domain}"
@@ -182,7 +182,7 @@ module "azure-add-dns-record" {
 module "aws-add-dns-record" {
   source           = "../infra/modules/tools/cloud-dns-ns"
   credentials      = var.dns_sa_creds
-  nameservers      = module.eks.domain_nameservers
+  nameservers      = module.eks.name_servers
   dns_project      = "dns-for-playgrounds"
   managed_dns_zone = var.gcp_zone
   domain_name      = "${var.TEST_ID}.${var.domain}"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PR is the second of the 3 part PR that uses terraform reference architecture to run tests. The main goal of this PR is to align all the reference architecture modules so these can be invoked in a standard manner using the `make` targets. Other than a bunch of linting fixing, the `name_servers` output had a standardization fix.

Here are the other two PRs:
- [ ] https://github.com/gitpod-io/gitpod/pull/13540 (doesn't depend on this PR)
- [ ] https://github.com/gitpod-io/gitpod/pull/13542

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
