### PR TITLE
[usage] Make function output stable to fix flaky test

### DIFF
--- a/components/usage/pkg/stripe/stripe.go
+++ b/components/usage/pkg/stripe/stripe.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 
 	"github.com/gitpod-io/gitpod/usage/pkg/db"
@@ -246,10 +247,11 @@ func GetAttributionID(ctx context.Context, customer *stripe.Customer) (db.Attrib
 // It returns multiple queries, each being a big disjunction of subclauses so that we can process multiple teamIds in one query.
 // `clausesPerQuery` is a limit enforced by the Stripe API.
 func queriesForCustomersWithAttributionIDs(creditsByAttributionID map[db.AttributionID]int64) []string {
-	attributionIDs := make([]db.AttributionID, 0, len(creditsByAttributionID))
+	attributionIDs := make([]string, 0, len(creditsByAttributionID))
 	for k := range creditsByAttributionID {
-		attributionIDs = append(attributionIDs, k)
+		attributionIDs = append(attributionIDs, string(k))
 	}
+	sort.Strings(attributionIDs)
 
 	const clausesPerQuery = 10
 	var queries []string


### PR DESCRIPTION
## Description

Ensure that the `queriesForCustomersWithAttributionIDs` is stable by sorting the the attributionIDs before mapping them to queries.

Iteration of map keys is not stable in Go.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

## How to test

```bash
cd components/usage/pkg/stripe
while true; do go test . --count=1; done 
```

The tests should pass consistently as opposed to `main` on which there will be occasional failures.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
