### PR TITLE
[dashboard] Fix off-by-one error on usage range end date

### DIFF
--- a/components/dashboard/src/components/UsageView.tsx
+++ b/components/dashboard/src/components/UsageView.tsx
@@ -112,7 +112,7 @@ function UsageView({ attributionId }: UsageViewProps) {
         for (let i = 1; i < 7; i++) {
             const endDateVar = i - 1;
             const startDate = new Date(today.getFullYear(), today.getMonth() - i);
-            const endDate = new Date(today.getFullYear(), today.getMonth() - endDateVar, 0);
+            const endDate = new Date(today.getFullYear(), today.getMonth() - endDateVar);
             const timeStampOfStartDate = startDate.getTime();
             const timeStampOfEndDate = endDate.getTime();
             rows.push(


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Fix off-by-one error on selected Usage range (end date).

Explanation:
- `new Date(year, month, 0)` results in the last day of the previous month (e.g. `2022-09-30T00:00:00.000Z`)
  - But, using this date as an "end" for a selected range omits all the data from the 24 hours between `2022-09-30T00:00:00.000Z` to `2022-10-01T00:00:00.000Z`
- A better "end" for the selected range is `new Date(year, month)`, i.e. the start of the next month, which results in `2022-10-01T00:00:00.000Z`

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/13521

## How to test
<!-- Provide steps to test this PR -->

In a Node.js or browser console, run this to verify:

```js
const today = new Date();

const startDate = new Date(today.getFullYear(), today.getMonth() - 1);
// 2022-09-01T00:00:00.000Z -- OK

const oldEndDate = new Date(today.getFullYear(), today.getMonth(), 0);
// 2022-09-30T00:00:00.000Z -- NOT OK (this is missing 24h of data)

const newEndDate = new Date(today.getFullYear(), today.getMonth());
// 2022-10-01T00:00:00.000Z -- OK
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
