### PR TITLE
[db-sync] Optionally read DB credentials from env vars

### DIFF
--- a/components/ee/db-sync/src/config.ts
+++ b/components/ee/db-sync/src/config.ts
@@ -11,9 +11,9 @@ export type NamedConnectionConfig = ConnectionConfig & { name?: string };
 export interface ReplicationConfig {
     syncPeriod: number;
     roundRobin: boolean;
-    source: NamedConnectionConfig,
-    targets: NamedConnectionConfig[],
-    tableSet: "gitpod" | "gitpod-sessions",
-    disableTransactions: boolean,
-    replicationLogDir: string | undefined
+    source?: NamedConnectionConfig;
+    targets: NamedConnectionConfig[];
+    tableSet: "gitpod" | "gitpod-sessions";
+    disableTransactions: boolean;
+    replicationLogDir: string | undefined;
 }


### PR DESCRIPTION
## Description
Optionally read DB credentials from env vars ([commit without formatting](https://github.com/gitpod-io/gitpod/pull/13573/commits/15bb1f3857868132557550d326369bd1e889292a)).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
