### PR TITLE
[db] Set `uid` column when writing to the `d_b_oauth_auth_code_entry` table

### DIFF
--- a/components/gitpod-db/src/typeorm/auth-code-repository-db.ts
+++ b/components/gitpod-db/src/typeorm/auth-code-repository-db.ts
@@ -13,6 +13,7 @@ import {
     OAuthUser,
 } from "@jmondi/oauth2-server";
 import * as crypto from "crypto";
+import { v4 as uuidv4 } from "uuid";
 import { inject, injectable } from "inversify";
 import { EntityManager, Repository } from "typeorm";
 import { DBOAuthAuthCodeEntry } from "./entity/db-oauth-auth-code";
@@ -56,6 +57,7 @@ export class AuthCodeRepositoryDB implements OAuthAuthCodeRepository {
     }
     public async persist(authCode: DBOAuthAuthCodeEntry): Promise<void> {
         const authCodeRepo = await this.getOauthAuthCodeRepo();
+        authCode.uid = uuidv4();
         authCodeRepo.save(authCode);
     }
     public async isRevoked(authCodeCode: string): Promise<boolean> {

--- a/components/gitpod-db/src/typeorm/entity/db-oauth-auth-code.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-oauth-auth-code.ts
@@ -7,6 +7,7 @@
 import { CodeChallengeMethod, OAuthAuthCode, OAuthClient, OAuthScope } from "@jmondi/oauth2-server";
 import { Column, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn } from "typeorm";
 import { Transformer } from "../transformer";
+import { TypeORM } from "../typeorm";
 import { DBUser } from "./db-user";
 
 @Entity({ name: "d_b_oauth_auth_code_entry" })
@@ -38,7 +39,7 @@ export class DBOAuthAuthCodeEntry implements OAuthAuthCode {
         type: "varchar",
         length: 10,
     })
-    codeChallengeMethod: CodeChallengeMethod
+    codeChallengeMethod: CodeChallengeMethod;
 
     @Column({
         type: "timestamp",
@@ -61,4 +62,7 @@ export class DBOAuthAuthCodeEntry implements OAuthAuthCode {
         nullable: false,
     })
     scopes: OAuthScope[];
+
+    @Column(TypeORM.UUID_COLUMN_TYPE)
+    uid: string;
 }


### PR DESCRIPTION
## Description

https://github.com/gitpod-io/gitpod/pull/13524 added a new `uid` column to the `d_b_oauth_auth_code_entry` table.

This PR ensures that all new records written to the table set this new field.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of #9198 

Follow up to #13524 

## How to test

1. Run the local-companion app `local-app` against the preview environment:
```bash
GITPOD_HOST=https://af-set-uid-column.preview.gitpod-dev.com ./local-app test
```
2. Run through the auth flow.
3. See that the new rows in the `d_b_oauth_auth_code_entry` table have their `uid` column set.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
