### PR TITLE
[proxy] Handle both gRPC and HTTP requests against public-api

### DIFF
--- a/components/proxy/conf/Caddyfile
+++ b/components/proxy/conf/Caddyfile
@@ -150,7 +150,15 @@ api.{$GITPOD_DOMAIN} {
         output stdout
     }
 
-    reverse_proxy h2c://public-api-server.{$KUBE_NAMESPACE}.{$KUBE_DOMAIN}:9001
+	@grpc protocol grpc
+
+	handle @grpc {
+		# gRPC traffic goes to gRPC server
+		reverse_proxy h2c://public-api-server.{$KUBE_NAMESPACE}.{$KUBE_DOMAIN}:9001
+	}
+
+	# Non-grpc traffic goes to an HTTP server
+	reverse_proxy public-api-server.{$KUBE_NAMESPACE}.{$KUBE_DOMAIN}:9002
 }
 
 

--- a/components/public-api-server/pkg/server/server.go
+++ b/components/public-api-server/pkg/server/server.go
@@ -62,6 +62,9 @@ func Start(logger *logrus.Entry, version string, cfg *config.Configuration) erro
 		log.Info("No stripe webhook secret is configured, endpoints will return NotImplemented")
 	}
 
+	srv.HTTPMux().Handle("/test", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`test`))
+	}))
 	srv.HTTPMux().Handle("/stripe/invoices/webhook", handlers.ContentTypeHandler(stripeWebhookHandler, "application/json"))
 
 	if registerErr := register(srv, gitpodAPI, srv.MetricsRegistry()); registerErr != nil {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Part of https://github.com/gitpod-io/gitpod/issues/13574

## How to test
<!-- Provide steps to test this PR -->

Ensure that gRPC traffic is still routed to the gRPC server
```
gpctl api workspaces get 123 --address api.mp-caddy-r9ed2436f9c.preview.gitpod-dev.com:443 --token foo
FATA[0000] failed to retrieve workspace (ID: 123)        error="rpc error: code = PermissionDenied desc = insufficient permission to access workspace"
```
Permission denied is expected, we're supplying a dummy token. But we got an application level response - this means it works.

Test that HTTP routing works to the HTTP server
```
curl https://api.mp-caddy-r9ed2436f9c.preview.gitpod-dev.com/test
test
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
