### PR TITLE
[db] Change the primary key of the `d_b_oauth_auth_code_entry` table

### DIFF
--- a/components/gitpod-db/src/typeorm/auth-code-repository-db.ts
+++ b/components/gitpod-db/src/typeorm/auth-code-repository-db.ts
@@ -57,7 +57,7 @@ export class AuthCodeRepositoryDB implements OAuthAuthCodeRepository {
     }
     public async persist(authCode: DBOAuthAuthCodeEntry): Promise<void> {
         const authCodeRepo = await this.getOauthAuthCodeRepo();
-        authCode.uid = uuidv4();
+        authCode.id = uuidv4();
         authCodeRepo.save(authCode);
     }
     public async isRevoked(authCodeCode: string): Promise<boolean> {

--- a/components/gitpod-db/src/typeorm/entity/db-oauth-auth-code.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-oauth-auth-code.ts
@@ -5,15 +5,15 @@
  */
 
 import { CodeChallengeMethod, OAuthAuthCode, OAuthClient, OAuthScope } from "@jmondi/oauth2-server";
-import { Column, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn } from "typeorm";
-import { Transformer } from "../transformer";
+import { Column, Entity, JoinColumn, ManyToOne, PrimaryColumn } from "typeorm";
 import { TypeORM } from "../typeorm";
+import { Transformer } from "../transformer";
 import { DBUser } from "./db-user";
 
 @Entity({ name: "d_b_oauth_auth_code_entry" })
 export class DBOAuthAuthCodeEntry implements OAuthAuthCode {
-    @PrimaryGeneratedColumn()
-    id: number;
+    @PrimaryColumn(TypeORM.UUID_COLUMN_TYPE)
+    id: string;
 
     @Column({
         type: "varchar",

--- a/components/gitpod-db/src/typeorm/entity/db-oauth-auth-code.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-oauth-auth-code.ts
@@ -62,7 +62,4 @@ export class DBOAuthAuthCodeEntry implements OAuthAuthCode {
         nullable: false,
     })
     scopes: OAuthScope[];
-
-    @Column(TypeORM.UUID_COLUMN_TYPE)
-    uid: string;
 }

--- a/components/gitpod-db/src/typeorm/migration/1664799675276-MakeUidColumnPrimaryKeyInAuthCodeTable.ts
+++ b/components/gitpod-db/src/typeorm/migration/1664799675276-MakeUidColumnPrimaryKeyInAuthCodeTable.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+const TABLE_NAME = "d_b_oauth_auth_code_entry";
+const PK_COLUMN = "id";
+const UID_COLUMN = "uid";
+
+export class MakeUidColumnPrimaryKeyInAuthCodeTable1664799675276 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`UPDATE d_b_oauth_auth_code_entry SET uid=(SELECT uuid()) where uid='';`);
+
+        await queryRunner.query(`ALTER TABLE ${TABLE_NAME} DROP COLUMN ${PK_COLUMN}`);
+        await queryRunner.query(
+            `ALTER TABLE ${TABLE_NAME} CHANGE ${UID_COLUMN} ${PK_COLUMN} char(36) NOT NULL DEFAULT '';`,
+        );
+        await queryRunner.query(`ALTER TABLE ${TABLE_NAME} ADD PRIMARY KEY (${PK_COLUMN});`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {}
+}


### PR DESCRIPTION
## Description

Following on from https://github.com/gitpod-io/gitpod/pull/13524 which added the `uid` column to the `d_b_oauth_auth_code_entry` table and https://github.com/gitpod-io/gitpod/pull/13577 which ensured that all new records set the `uid` field, this PR changes to the primary key to the `uid` column (and renames it to `id`).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of #9198 


## How to test

1. Run the local-companion app `local-app` against the preview environment:
```bash
GITPOD_HOST=https://af-make-uib1daf36a03.preview.gitpod-dev.com ./local-app test
```
2. Run through the auth flow.
3. See that the new rows in the `d_b_oauth_auth_code_entry` table have their `id` column set.


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
