### PR TITLE
[usage] Only show notification to team owners

### DIFF
--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -2256,7 +2256,8 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
             const billingMode = await this.billingModes.getBillingModeForUser(user, new Date());
             if (billingMode.mode === "usage-based") {
                 const limit = await this.billingService.checkUsageLimitReached(user);
-                let teamOrUser;
+                await this.guardCostCenterAccess(ctx, user.id, limit.attributionId, "get");
+
                 switch (limit.attributionId.kind) {
                     case "user": {
                         if (limit.reached) {
@@ -2267,7 +2268,7 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
                         break;
                     }
                     case "team": {
-                        teamOrUser = await this.teamDB.findTeamById(limit.attributionId.teamId);
+                        const teamOrUser = await this.teamDB.findTeamById(limit.attributionId.teamId);
                         if (teamOrUser) {
                             if (limit.reached) {
                                 result.push(teamOrUser?.slug);


### PR DESCRIPTION
## Description
This change only shows usage notifications to team owners.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #13187

## How to test
1. Join this team that has reached its usage limit[[1](https://lau-limit-13187.preview.gitpod-dev.com/teams/join?inviteId=db6f3336-d203-498f-94e4-d2536cf2cbd7)].
2. You should not be able to see the notifications.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-payment
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
