### PR TITLE
[ws-daemon] Ensure content-service temp directory exists

### DIFF
--- a/components/ws-daemon/pkg/content/initializer.go
+++ b/components/ws-daemon/pkg/content/initializer.go
@@ -390,6 +390,9 @@ func (rs *remoteContentStorage) Download(ctx context.Context, destination string
 
 	span.SetTag("URL", info.URL)
 
+	// ensure the temp directory exists
+	_ = os.MkdirAll(os.TempDir(), 0777)
+
 	tempFile, err := os.CreateTemp("", "remote-content-")
 	if err != nil {
 		return true, xerrors.Errorf("cannot create temporal file: %w", err)


### PR DESCRIPTION
## Description

Not all directories exist when `content-service` runs.

## How to test
- Run `TestBackup` integration test

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [x] /werft with-integration-tests=workspace
      Valid options are `all`, `workspace`, `webapp`, `ide`
