### PR TITLE
[pvc] add a test for non gitpodified repo

### DIFF
--- a/test/tests/components/ws-manager/content_test.go
+++ b/test/tests/components/ws-manager/content_test.go
@@ -46,6 +46,13 @@ func TestBackup(t *testing.T) {
 					CheckoutLocation: "empty",
 					FF:               []wsmanapi.WorkspaceFeatureFlag{wsmanapi.WorkspaceFeatureFlag_PERSISTENT_VOLUME_CLAIM},
 				},
+				{
+					Name:             "pvc-non-gitpodified",
+					ContextURL:       "https://github.com/gitpod-io/non-gitpodified-repo",
+					WorkspaceRoot:    "/workspace/non-gitpodified-repo",
+					CheckoutLocation: "non-gitpodified-repo",
+					FF:               []wsmanapi.WorkspaceFeatureFlag{wsmanapi.WorkspaceFeatureFlag_PERSISTENT_VOLUME_CLAIM},
+				},
 			}
 			ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
 			defer cancel()


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Add integration test that tests PVC against non gitpodified repo.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #13591

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
none
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-integration-tests=workspace
      Valid options are `all`, `workspace`, `webapp`, `ide`
