### PR TITLE
[db-sync] Add `d_b_oauth_auth_code_entry` to db-sync

### DIFF
--- a/components/gitpod-db/src/tables.ts
+++ b/components/gitpod-db/src/tables.ts
@@ -48,6 +48,11 @@ export class GitpodTableDescriptionProvider implements TableDescriptionProvider 
     readonly name = "gitpod";
     protected readonly tables: TableDescription[] = [
         {
+            name: "d_b_oauth_auth_code_entry",
+            primaryKeys: ["id"],
+            timeColumn: "_lastModified",
+        },
+        {
             name: "d_b_installation_admin",
             primaryKeys: ["id"],
             timeColumn: "_lastModified",


### PR DESCRIPTION
## Description

Add the `d_b_oauth_auth_code_entry` table to `db-sync` config.

Follows up on PRs to prepare the table to be synced:
* https://github.com/gitpod-io/gitpod/pull/13616
* https://github.com/gitpod-io/gitpod/pull/13584

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of #9198 

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
