### PR TITLE
[stripe] Report metrics from client calls in Go

### DIFF
--- a/components/usage/go.mod
+++ b/components/usage/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.4.0
 	github.com/stretchr/testify v1.7.0
+	github.com/stripe/stripe-go v70.15.0+incompatible
 	github.com/stripe/stripe-go/v72 v72.114.0
 	google.golang.org/grpc v1.49.0
 	google.golang.org/protobuf v1.28.1

--- a/components/usage/go.sum
+++ b/components/usage/go.sum
@@ -328,6 +328,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stripe/stripe-go v70.15.0+incompatible h1:hNML7M1zx8RgtepEMlxyu/FpVPrP7KZm1gPFQquJQvM=
+github.com/stripe/stripe-go v70.15.0+incompatible/go.mod h1:A1dQZmO/QypXmsL0T8axYZkSN/uA/T/A64pfKdBAMiY=
 github.com/stripe/stripe-go/v72 v72.114.0 h1:fF4EEF9p+e8UzRsUYV1woTr8CC8f/51wXJr1MAnnP2M=
 github.com/stripe/stripe-go/v72 v72.114.0/go.mod h1:QwqJQtduHubZht9mek5sds9CtQcKFdsykV9ZepRWwo0=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/components/usage/pkg/stripe/reporter.go
+++ b/components/usage/pkg/stripe/reporter.go
@@ -6,6 +6,10 @@ package stripe
 
 import (
 	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -16,11 +20,27 @@ var (
 		Name:      "usage_records_updated_total",
 		Help:      "Counter of usage records updated",
 	}, []string{"outcome"})
+
+	stripeClientRequestsStarted = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "gitpod",
+		Subsystem: "stripe",
+		Name:      "requests_started_total",
+		Help:      "Counter of requests started by stripe clients",
+	}, []string{"method", "path"})
+
+	stripeClientRequestsCompletedSeconds = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: "gitpod",
+		Subsystem: "stripe",
+		Name:      "requests_completed_seconds",
+		Help:      "Histogram of requests completed by stripe clients",
+	}, []string{"method", "path", "code"})
 )
 
 func RegisterMetrics(reg *prometheus.Registry) error {
 	metrics := []prometheus.Collector{
 		stripeUsageUpdateTotal,
+		stripeClientRequestsStarted,
+		stripeClientRequestsCompletedSeconds,
 	}
 	for _, metric := range metrics {
 		err := reg.Register(metric)
@@ -38,4 +58,29 @@ func reportStripeUsageUpdate(err error) {
 		outcome = "fail"
 	}
 	stripeUsageUpdateTotal.WithLabelValues(outcome).Inc()
+}
+
+type stripeRoundTripper struct {
+	next http.RoundTripper
+}
+
+func (rt *stripeRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
+	now := time.Now()
+	path := r.URL.Path
+	method := r.Method
+	stripeClientRequestsStarted.WithLabelValues(method, path).Inc()
+
+	resp, err := rt.next.RoundTrip(r)
+	took := time.Since(now)
+	code := 0
+	if err == nil && resp != nil {
+		code = resp.StatusCode
+	}
+
+	stripeClientRequestsCompletedSeconds.WithLabelValues(method, path, strconv.Itoa(code)).Observe(took.Seconds())
+	return resp, err
+}
+
+func StripeClientMetricsRoundTripper(next http.RoundTripper) http.RoundTripper {
+	return &stripeRoundTripper{next: next}
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Report metrics when stripe client makes calls

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Relates to https://github.com/gitpod-io/gitpod/issues/13157

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
