### PR TITLE
[ws-daemon] Stop logging cpu limit error

### DIFF
--- a/components/ws-daemon/pkg/cpulimit/cfs.go
+++ b/components/ws-daemon/pkg/cpulimit/cfs.go
@@ -35,7 +35,7 @@ func (basePath CgroupV1CFSController) Usage() (usage CPUTime, err error) {
 func (basePath CgroupV1CFSController) SetLimit(limit Bandwidth) (changed bool, err error) {
 	period, err := basePath.readCfsPeriod()
 	if err != nil {
-		err = xerrors.Errorf("cannot parse CFS period: %w", err)
+		err = xerrors.Errorf("failed to read CFS period: %w", err)
 		return
 	}
 

--- a/components/ws-daemon/pkg/cpulimit/dispatch.go
+++ b/components/ws-daemon/pkg/cpulimit/dispatch.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -161,7 +162,7 @@ func (d *DispatchListener) sink(id string, limit Bandwidth, burst bool) {
 	d.workspacesBurstCounterVec.WithLabelValues("none").Inc()
 
 	changed, err := ws.CFS.SetLimit(limit)
-	if err != nil {
+	if err != nil && !strings.HasPrefix(err.Error(), "failed to read") {
 		log.WithError(err).WithFields(ws.OWI).Warn("cannot set CPU limit")
 	}
 	if changed {


### PR DESCRIPTION
## Description
Stop logging cpu limit error when the cgroup cannot be found. This pis caused by a delay between the pod disappearing and the dispatch being informed about it. It just pollutes the log and does not help us identifying errors.

## Related Issue(s)
n.a.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
