### PR TITLE
chore(gitpod-cli): Update top table output format

### DIFF
--- a/components/gitpod-cli/cmd/top.go
+++ b/components/gitpod-cli/cmd/top.go
@@ -89,24 +89,22 @@ func outputWorkspaceClass(workspaceClass *supervisor.WorkspaceInfoResponse_Works
 
 func outputTable(workspaceResources *supervisor.ResourcesStatusResponse) {
 	table := tablewriter.NewWriter(os.Stdout)
-	table.SetHeader([]string{"CPU (millicores)", "Memory (bytes)"})
-	table.SetBorders(tablewriter.Border{Left: true, Top: true, Right: true, Bottom: false})
-	table.SetCenterSeparator("|")
+	table.SetBorder(false)
+	table.SetColumnSeparator(":")
 
 	cpuFraction := int64((float64(workspaceResources.Cpu.Used) / float64(workspaceResources.Cpu.Limit)) * 100)
 	memFraction := int64((float64(workspaceResources.Memory.Used) / float64(workspaceResources.Memory.Limit)) * 100)
 	cpu := fmt.Sprintf("%dm/%dm (%d%%)", workspaceResources.Cpu.Used, workspaceResources.Cpu.Limit, cpuFraction)
-	memory := fmt.Sprintf("%dMi/%dMi (%d%%)\n", workspaceResources.Memory.Used/(1024*1024), workspaceResources.Memory.Limit/(1024*1024), memFraction)
+	memory := fmt.Sprintf("%dMi/%dMi (%d%%)", workspaceResources.Memory.Used/(1024*1024), workspaceResources.Memory.Limit/(1024*1024), memFraction)
 
-	colors := []tablewriter.Colors{}
-
+	var cpuColors, memoryColors []tablewriter.Colors
 	if !noColor && utils.ColorsEnabled() {
-		cpuColor := getColor(workspaceResources.Cpu.Severity)
-		memoryColor := getColor(workspaceResources.Memory.Severity)
-		colors = []tablewriter.Colors{{cpuColor}, {memoryColor}}
+		cpuColors = []tablewriter.Colors{nil, {getColor(workspaceResources.Cpu.Severity)}}
+		memoryColors = []tablewriter.Colors{nil, {getColor(workspaceResources.Memory.Severity)}}
 	}
 
-	table.Rich([]string{cpu, memory}, colors)
+	table.Rich([]string{"CPU (millicores)", cpu}, cpuColors)
+	table.Rich([]string{"Memory (bytes)", memory}, memoryColors)
 
 	table.Render()
 }

--- a/components/gitpod-cli/cmd/top.go
+++ b/components/gitpod-cli/cmd/top.go
@@ -75,21 +75,21 @@ var topCmd = &cobra.Command{
 			fmt.Println(string(content))
 			return
 		}
-		outputWorkspaceClass(data.WorkspaceClass)
-		outputTable(data.Resources)
+		outputTable(data.Resources, data.WorkspaceClass)
 	},
 }
 
-func outputWorkspaceClass(workspaceClass *supervisor.WorkspaceInfoResponse_WorkspaceClass) {
+func formatWorkspaceClass(workspaceClass *supervisor.WorkspaceInfoResponse_WorkspaceClass) string {
 	if workspaceClass == nil || workspaceClass.DisplayName == "" {
-		return
+		return ""
 	}
-	fmt.Printf("%s: %s\n\n", workspaceClass.DisplayName, workspaceClass.Description)
+	return fmt.Sprintf("%s: %s", workspaceClass.DisplayName, workspaceClass.Description)
 }
 
-func outputTable(workspaceResources *supervisor.ResourcesStatusResponse) {
+func outputTable(workspaceResources *supervisor.ResourcesStatusResponse, workspaceClass *supervisor.WorkspaceInfoResponse_WorkspaceClass) {
 	table := tablewriter.NewWriter(os.Stdout)
 	table.SetBorder(false)
+	table.SetColWidth(50)
 	table.SetColumnSeparator(":")
 
 	cpuFraction := int64((float64(workspaceResources.Cpu.Used) / float64(workspaceResources.Cpu.Limit)) * 100)
@@ -103,6 +103,7 @@ func outputTable(workspaceResources *supervisor.ResourcesStatusResponse) {
 		memoryColors = []tablewriter.Colors{nil, {getColor(workspaceResources.Memory.Severity)}}
 	}
 
+	table.Append([]string{"Workspace class", formatWorkspaceClass(workspaceClass)})
 	table.Rich([]string{"CPU (millicores)", cpu}, cpuColors)
 	table.Rich([]string{"Memory (bytes)", memory}, memoryColors)
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Updates `gp top` table output to match `gp info`, follow up from discussion in https://github.com/gitpod-io/gitpod/pull/13537#discussion_r987641981.

Also moves the workspace class to the table. Alternatively we could remove the workspace class from the output, as it's also shown in `gp info` now. Personally I think it'd be nice to keep it in `gp top` as well as it's relevant info, and it would be a breaking change to remove it from e.g. the `--json` output.

Original:
![image](https://user-images.githubusercontent.com/9721064/194035880-2eec23b2-b7f7-4408-a58b-53cc1a6d1172.png)

New:
![image](https://user-images.githubusercontent.com/9721064/194038534-09e11c02-35fd-4d71-b57e-0e6b640bee6e.png)



## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Gitpod CLI: `gp top` table output updated to match `gp info`
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
