### PR TITLE
Add missing Gitpod configurations for RubyMine and WebStorm

### DIFF
--- a/components/gitpod-protocol/data/gitpod-schema.json
+++ b/components/gitpod-protocol/data/gitpod-schema.json
@@ -275,6 +275,14 @@
                 "phpstorm": {
                     "$ref": "#/definitions/jetbrainsProduct",
                     "description": "Configure PhpStorm integration"
+                },
+                "rubymine": {
+                    "$ref": "#/definitions/jetbrainsProduct",
+                    "description": "Configure RubyMine integration"
+                },
+                "webstorm": {
+                    "$ref": "#/definitions/jetbrainsProduct",
+                    "description": "Configure WebStorm integration"
                 }
             }
         },

--- a/components/gitpod-protocol/go/gitpod-config-types.go
+++ b/components/gitpod-protocol/go/gitpod-config-types.go
@@ -115,6 +115,12 @@ type Jetbrains struct {
 
 	// Configure PyCharm integration
 	Pycharm *JetbrainsProduct `yaml:"pycharm,omitempty"`
+
+	// Configure RubyMine integration
+	Rubymine *JetbrainsProduct `yaml:"rubymine,omitempty"`
+
+	// Configure WebStorm integration
+	Webstorm *JetbrainsProduct `yaml:"webstorm,omitempty"`
 }
 
 // JetbrainsProduct
@@ -734,6 +740,28 @@ func (strct *Jetbrains) MarshalJSON() ([]byte, error) {
 		buf.Write(tmp)
 	}
 	comma = true
+	// Marshal the "rubymine" field
+	if comma {
+		buf.WriteString(",")
+	}
+	buf.WriteString("\"rubymine\": ")
+	if tmp, err := json.Marshal(strct.Rubymine); err != nil {
+		return nil, err
+	} else {
+		buf.Write(tmp)
+	}
+	comma = true
+	// Marshal the "webstorm" field
+	if comma {
+		buf.WriteString(",")
+	}
+	buf.WriteString("\"webstorm\": ")
+	if tmp, err := json.Marshal(strct.Webstorm); err != nil {
+		return nil, err
+	} else {
+		buf.Write(tmp)
+	}
+	comma = true
 
 	buf.WriteString("}")
 	rv := buf.Bytes()
@@ -766,6 +794,14 @@ func (strct *Jetbrains) UnmarshalJSON(b []byte) error {
 			}
 		case "pycharm":
 			if err := json.Unmarshal([]byte(v), &strct.Pycharm); err != nil {
+				return err
+			}
+		case "rubymine":
+			if err := json.Unmarshal([]byte(v), &strct.Rubymine); err != nil {
+				return err
+			}
+		case "webstorm":
+			if err := json.Unmarshal([]byte(v), &strct.Webstorm); err != nil {
 				return err
 			}
 		default:

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -795,6 +795,8 @@ export interface JetBrainsConfig {
     goland?: JetBrainsProductConfig;
     pycharm?: JetBrainsProductConfig;
     phpstorm?: JetBrainsProductConfig;
+    rubymine?: JetBrainsProductConfig;
+    webstorm?: JetBrainsProductConfig;
 }
 export interface JetBrainsProductConfig {
     prebuilds?: JetBrainsPrebuilds;

--- a/components/ide/jetbrains/backend-plugin/hot-deploy.sh
+++ b/components/ide/jetbrains/backend-plugin/hot-deploy.sh
@@ -27,12 +27,16 @@ else
     prop="pluginLatestImage"
 fi
 
-cf_patch=$(kubectl get cm server-ide-config -o=json | jq '.data."config.json"' |jq -r)
+cf_patch=$(kubectl get cm ide-config -o=json | jq '.data."config.json"' |jq -r)
 cf_patch=$(echo "$cf_patch" |jq ".ideOptions.options.intellij.$prop = \"$dev_image\"")
 cf_patch=$(echo "$cf_patch" |jq ".ideOptions.options.goland.$prop = \"$dev_image\"")
 cf_patch=$(echo "$cf_patch" |jq ".ideOptions.options.pycharm.$prop = \"$dev_image\"")
 cf_patch=$(echo "$cf_patch" |jq ".ideOptions.options.phpstorm.$prop = \"$dev_image\"")
+cf_patch=$(echo "$cf_patch" |jq ".ideOptions.options.rubymine.$prop = \"$dev_image\"")
+cf_patch=$(echo "$cf_patch" |jq ".ideOptions.options.webstorm.$prop = \"$dev_image\"")
 cf_patch=$(echo "$cf_patch" |jq tostring)
 cf_patch="{\"data\": {\"config.json\": $cf_patch}}"
 
-kubectl patch cm server-ide-config --type=merge -p "$cf_patch"
+kubectl patch cm ide-config --type=merge -p "$cf_patch"
+
+kubectl rollout restart deployment ide-service

--- a/components/server/src/ide-service.ts
+++ b/components/server/src/ide-service.ts
@@ -55,6 +55,10 @@ export class IDEService {
                     productCode = "PCP";
                 } else if (key === "phpstorm") {
                     productCode = "PS";
+                } else if (key === "rubymine") {
+                    productCode = "RM";
+                } else if (key === "webstorm") {
+                    productCode = "WS";
                 }
                 const prebuilds = productCode && ws.config.jetbrains[key as keyof JetBrainsConfig]?.prebuilds;
                 if (prebuilds) {

--- a/test/tests/ide/jetbrains/gateway_test.go
+++ b/test/tests/ide/jetbrains/gateway_test.go
@@ -52,6 +52,8 @@ func init() {
 	ideProjectMap["intellij"] = "https://github.com/gitpod-io/spring-petclinic"
 	ideProjectMap["phpstorm"] = "https://github.com/gitpod-io/template-php-laravel-mysql"
 	ideProjectMap["pycharm"] = "https://github.com/gitpod-io/template-python-django"
+	ideProjectMap["rubymine"] = "https://github.com/gitpod-io/template-ruby-on-rails-postgres"
+	ideProjectMap["webstorm"] = "https://github.com/gitpod-io/template-typescript-react"
 }
 
 func GetHttpContent(url string) ([]byte, error) {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Add missing Gitpod configurations for RubyMine and WebStorm.

## How to test
<!-- Provide steps to test this PR -->
- RubyMine
  1. Open the preview environment of this PR
  2. Create a workspace from the branch of this PR: https://github.com/gitpod-io/template-ruby-on-rails-postgres/pull/8
  3. Check if the workspace opens with the project pre-indexed.
- WebStorm
  1. Open the preview environment of this PR
  2. Create a workspace from the branch of this PR: https://github.com/gitpod-io/template-typescript-react/pull/13
  3. Check if the workspace opens with the project pre-indexed.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
