### PR TITLE
[server] Fix network connections not limited

### DIFF
--- a/components/server/ee/src/billing/entitlement-service-chargebee.ts
+++ b/components/server/ee/src/billing/entitlement-service-chargebee.ts
@@ -189,7 +189,7 @@ export class EntitlementServiceChargebee implements EntitlementService {
      * @param user
      */
     async limitNetworkConnections(user: User, date: Date = new Date()): Promise<boolean> {
-        const hasPaidPlan = this.hasPaidSubscription(user, date);
+        const hasPaidPlan = await this.hasPaidSubscription(user, date);
         return !hasPaidPlan;
     }
 


### PR DESCRIPTION
## Description
The result is not awaited and so the check if the user is on the  free tier is performed against the promise and not against the boolean which makes the returned result always false.

## Related Issue(s)
n.a.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
