### PR TITLE
[db] Change the type of the primary key in the `d_b_oauth_auth_code_entry` table

### DIFF
--- a/components/gitpod-db/src/typeorm/auth-code-repository-db.ts
+++ b/components/gitpod-db/src/typeorm/auth-code-repository-db.ts
@@ -57,6 +57,7 @@ export class AuthCodeRepositoryDB implements OAuthAuthCodeRepository {
     }
     public async persist(authCode: DBOAuthAuthCodeEntry): Promise<void> {
         const authCodeRepo = await this.getOauthAuthCodeRepo();
+        authCode.id = uuidv4();
         authCode.uid = uuidv4();
         authCodeRepo.save(authCode);
     }

--- a/components/gitpod-db/src/typeorm/entity/db-oauth-auth-code.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-oauth-auth-code.ts
@@ -5,15 +5,17 @@
  */
 
 import { CodeChallengeMethod, OAuthAuthCode, OAuthClient, OAuthScope } from "@jmondi/oauth2-server";
-import { Column, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn } from "typeorm";
+import { Column, Entity, JoinColumn, ManyToOne, PrimaryColumn } from "typeorm";
 import { Transformer } from "../transformer";
 import { TypeORM } from "../typeorm";
 import { DBUser } from "./db-user";
 
 @Entity({ name: "d_b_oauth_auth_code_entry" })
 export class DBOAuthAuthCodeEntry implements OAuthAuthCode {
-    @PrimaryGeneratedColumn()
-    id: number;
+    // The type of the primary key used to be `int`.
+    // Some (old) rows in the table have integer keys; new values use uids.
+    @PrimaryColumn()
+    id: string;
 
     @Column({
         type: "varchar",

--- a/components/gitpod-db/src/typeorm/migration/1664974727836-ChangeOauthCodePKType.ts
+++ b/components/gitpod-db/src/typeorm/migration/1664974727836-ChangeOauthCodePKType.ts
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class ChangeOauthCodePKType1664974727836 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        // Change the type of the primary key field.
+        // Some (old) rows in the table have integer keys; new values will have uids.
+        await queryRunner.query(`ALTER TABLE d_b_oauth_auth_code_entry CHANGE id id char(36);`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {}
+}


### PR DESCRIPTION
## Description

In order to de-risk the process of swapping the primary key in the `d_b_oauth_auth_code_entry` table, this PR stops the primary key from auto-incrementing and instead sets its value manually when persisting new rows.

We want to switch the primary key to one that is suitable for `db-sync` to be able to sync the table between regions.

See [this comment](https://github.com/gitpod-io/gitpod/pull/13583#issuecomment-1268320895) for more context.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of #9198 

## How to test

1. Run the local-companion app `local-app` against the preview environment:
```bash
GITPOD_HOST=<preview url> ./local-app test
```
2. Run through the auth flow.
3. See that the new rows in the `d_b_oauth_auth_code_entry` table have their `id` column set and that the type of the column is now a `char(36)` and no longer auto-increments.


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
