### PR TITLE
Build stable image for VS Code Browser 1.72

### DIFF
--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -8,7 +8,7 @@ defaultArgs:
   jbMarketplacePublishTrigger: "false"
   publishToJBMarketplace: true
   localAppVersion: unknown
-  codeCommit: e2c3ab18a37bed1b4e43609a2c5a771ed4f07dbc
+  codeCommit: 18ef1a48293273b129feaec6c6fc1aa66e9a9b88
   codeQuality: stable
   noVerifyJBPlugin: false
   intellijDownloadUrl: "https://download.jetbrains.com/idea/ideaIU-2022.2.2.tar.gz"


### PR DESCRIPTION
## Description
Update code to `1.72.0`

## How to test

- Switch to VS Code Insiders in settings.
- Start a workspace.
- Test following:
  - [x] terminals are preserved and resized properly between window reloads
  - [x] WebViews are working
  - [x] extension host process: check language smartness and debugging 
  - [x] extension management (installing/uninstalling)
  - [x] install the [VIM extension](https://open-vsx.org/extension/vscodevim/vim) to test web extensions
  - that user data is synced across workspaces as well as on workspace restarts, especially for extensions
     - [x] extensions from `.gitpod.yml` are not installed as sync
     - [x] extensions installed as sync are actually synced to all new workspaces
  - [x] settings should not contain any mentions of MS telemetry
  - [x] WebSockets and workers are properly proxied
     - [x] diff editor should be operatable
     - [x] trigger reconnection with `window.WebSocket.disconnectWorkspace()`, check that old WebSockets are closed and new opened of the same amount
  - [x] workspace specific commands should work, i.e. F1 → type Gitpod prefix
  - [x] that a PR view is preloaded on the PR URL
  - [x] test `gp open` and `gp preview`
  - [ ] test open in VS Code Desktop, check `gp open` and `gp preview` in task/user terminals
  - [x] telemetry data is collected in [Segment](https://app.segment.com/gitpod/sources/staging_untrusted/debugger)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Release VS Code Browser `1.72`
```


## Werft options:

- [x] /werft with-preview
- [x] /werft analytics=segment|TEZnsG4QbLSxLfHfNieLYGF4cDwyFWoe