### PR TITLE
[dashboard] Fetch user BillingMode on load (or team change)

### DIFF
--- a/components/dashboard/src/App.tsx
+++ b/components/dashboard/src/App.tsx
@@ -151,7 +151,7 @@ export function getURLHash() {
 }
 
 function App() {
-    const { user, setUser } = useContext(UserContext);
+    const { user, setUser, refreshUserBillingMode } = useContext(UserContext);
     const { teams, setTeams } = useContext(TeamsContext);
     const { setIsDark } = useContext(ThemeContext);
 
@@ -273,6 +273,11 @@ function App() {
             refreshSearchData("", user);
         }
     }, [user]);
+
+    useEffect(() => {
+        // Refresh billing mode (side effect on other components per UserContext!)
+        refreshUserBillingMode();
+    }, [teams]);
 
     // redirect to website for any website slugs
     if (isGitpodIo() && isWebsiteSlug(window.location.pathname)) {


### PR DESCRIPTION
## Description
With a [recent change](https://github.com/gitpod-io/gitpod/commit/2d68f0fbec7193351d643d8c69f35eaf0572f392#diff-64248da95f399a1cfe99b03aa662caf313faf9b7016999111605da5d61f1971dL39) we stopped fetching `BillingMode`, which results in us not rendering menu entries to Personal (`/plans`) or Team (`/teams`) billing pages. This PR fixes that by fetching on load of the page.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #13618

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Fix rendering Personal/Team billing menu entries
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-payment
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
