### PR TITLE
[ws-daemon] Improve download options

### DIFF
--- a/components/ws-daemon/pkg/content/initializer.go
+++ b/components/ws-daemon/pkg/content/initializer.go
@@ -398,7 +398,9 @@ func (rs *remoteContentStorage) Download(ctx context.Context, destination string
 	tempFile.Close()
 
 	args := []string{
-		"-x16", "-j12",
+		"-s10", "-x16", "-j12",
+		"--retry-wait=5",
+		"--log-level=error",
 		"--allow-overwrite=true", // rewrite temporal empty file
 		info.URL,
 		"-o", tempFile.Name(),


### PR DESCRIPTION
## Description

Reduce verbosity while downloading content with aria2c and enabling retries after five seconds.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=workspace with-large-vm=true
      Valid options are `all`, `workspace`, `webapp`, `ide`
