### PR TITLE
[ws-daemon] Adjust SignedURL expiration

### DIFF
--- a/components/content-service/pkg/storage/gcloud.go
+++ b/components/content-service/pkg/storage/gcloud.go
@@ -623,7 +623,7 @@ func (p *PresignedGCPStorage) downloadInfo(ctx context.Context, client *gcpstora
 		Method:         "GET",
 		GoogleAccessID: p.accessID,
 		PrivateKey:     p.privateKey,
-		Expires:        time.Now().Add(30 * time.Minute),
+		Expires:        time.Now().Add(1 * time.Hour),
 		ContentType:    options.ContentType,
 	})
 	if err != nil {


### PR DESCRIPTION
## Description

Change default expiration from three years ago. We have up to 50GB backups now

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```


## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
