### PR TITLE
Clean up content status request from supervisor frontend

### DIFF
--- a/components/supervisor/frontend/src/ide/supervisor-service-client.ts
+++ b/components/supervisor/frontend/src/ide/supervisor-service-client.ts
@@ -4,23 +4,15 @@
  * See License-AGPL.txt in the project root for license information.
  */
 
-import { SupervisorStatusResponse, IDEStatusResponse, ContentStatusResponse } from '@gitpod/supervisor-api-grpc/lib/status_pb'
-import { GitpodServiceClient } from './gitpod-service-client';
+import { SupervisorStatusResponse, IDEStatusResponse } from '@gitpod/supervisor-api-grpc/lib/status_pb'
 import { GitpodHostUrl } from '@gitpod/gitpod-protocol/lib/util/gitpod-host-url';
 
 export class SupervisorServiceClient {
-    readonly supervisorReady = this.checkReady('supervisor');
-    readonly ideReady = this.supervisorReady.then(() => this.checkReady('ide'))
-    readonly contentReady = Promise.all([
-        this.supervisorReady,
-        this.gitpodServiceClient.auth
-    ]).then(() => this.checkReady('content'));
+    readonly ideReady = this.checkReady('supervisor').then(() => this.checkReady('ide'))
 
-    constructor(
-        private readonly gitpodServiceClient: GitpodServiceClient
-    ) { }
+    constructor() { }
 
-    private async checkReady(kind: 'content' | 'ide' | 'supervisor', delay?: boolean): Promise<any> {
+    private async checkReady(kind: 'ide' | 'supervisor', delay?: boolean): Promise<any> {
         if (delay) {
             await new Promise((resolve) => setTimeout(resolve, 1000));
         }
@@ -50,9 +42,6 @@ export class SupervisorServiceClient {
                 if (kind === 'supervisor' && (result as SupervisorStatusResponse.AsObject).ok) {
                     return;
                 }
-                if (kind === 'content' && (result as ContentStatusResponse.AsObject).available) {
-                    return;
-                }
                 if (kind === 'ide' && (result as IDEStatusResponse.AsObject).ok) {
                     return result;
                 }
@@ -63,5 +52,4 @@ export class SupervisorServiceClient {
         }
         return this.checkReady(kind, true);
     }
-
 }

--- a/components/supervisor/frontend/src/index.ts
+++ b/components/supervisor/frontend/src/index.ts
@@ -66,6 +66,7 @@ const ideService = IDEFrontendService.create();
 const pendingGitpodServiceClient = GitpodServiceClient.create();
 const loadingIDE = new Promise(resolve => window.addEventListener('DOMContentLoaded', resolve, { once: true }));
 const toStop = new DisposableCollection();
+const supervisorServiceClient = new SupervisorServiceClient();
 
 (async () => {
     const gitpodServiceClient = await pendingGitpodServiceClient;
@@ -91,7 +92,6 @@ const toStop = new DisposableCollection();
             });
         });
     }
-    const supervisorServiceClient = new SupervisorServiceClient();
     const [ideStatus] = await Promise.all([supervisorServiceClient.ideReady, gitpodServiceClient.auth, loadingIDE]);
     if (isWorkspaceInstancePhase('stopping') || isWorkspaceInstancePhase('stopped')) {
         return;
@@ -267,7 +267,6 @@ const toStop = new DisposableCollection();
         updateCurrentFrame();
         trackIDEStatusRenderedEvent();
     });
-    const supervisorServiceClient = new SupervisorServiceClient();
     supervisorServiceClient.ideReady.then(newIdeStatus => {
         ideStatus = newIdeStatus;
         isDesktopIde = !!ideStatus && !!ideStatus.desktop && !!ideStatus.desktop.link;

--- a/components/supervisor/frontend/src/index.ts
+++ b/components/supervisor/frontend/src/index.ts
@@ -91,8 +91,8 @@ const toStop = new DisposableCollection();
             });
         });
     }
-    const supervisorServiceClient = new SupervisorServiceClient(gitpodServiceClient);
-    const [ideStatus] = await Promise.all([supervisorServiceClient.ideReady, supervisorServiceClient.contentReady, loadingIDE]);
+    const supervisorServiceClient = new SupervisorServiceClient();
+    const [ideStatus] = await Promise.all([supervisorServiceClient.ideReady, gitpodServiceClient.auth, loadingIDE]);
     if (isWorkspaceInstancePhase('stopping') || isWorkspaceInstancePhase('stopped')) {
         return;
     }
@@ -122,8 +122,6 @@ const toStop = new DisposableCollection();
     if (gitpodServiceClient.info.workspace.type !== 'regular') {
         return;
     }
-
-    const supervisorServiceClient = new SupervisorServiceClient(gitpodServiceClient);
 
     let hideDesktopIde = false;
     const serverOrigin = startUrl.url.origin;
@@ -269,6 +267,7 @@ const toStop = new DisposableCollection();
         updateCurrentFrame();
         trackIDEStatusRenderedEvent();
     });
+    const supervisorServiceClient = new SupervisorServiceClient();
     supervisorServiceClient.ideReady.then(newIdeStatus => {
         ideStatus = newIdeStatus;
         isDesktopIde = !!ideStatus && !!ideStatus.desktop && !!ideStatus.desktop.link;


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Clean up content status request from supervisor frontend, IDEs will be ready only after content is ready

## How to test
<!-- Provide steps to test this PR -->
1. Check workspaces load successfully

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
