### PR TITLE
loadgen: test against a repo without .gitpod.yml

### DIFF
--- a/dev/loadgen/configs/prod-benchmark-pvc.yaml
+++ b/dev/loadgen/configs/prod-benchmark-pvc.yaml
@@ -84,7 +84,7 @@ repos:
     cloneTarget: main
     score: 20
     workspaceImage: registry.hub.docker.com/gitpod/workspace-full:latest
-  - cloneURL: https://github.com/gitpod-io/template-python-flask
+  - cloneURL: https://github.com/gitpod-io/non-gitpodified-repo
     score: 20
     cloneTarget: main
     workspaceImage: registry.hub.docker.com/gitpod/workspace-full:latest

--- a/dev/loadgen/configs/prod-benchmark-pvc.yaml
+++ b/dev/loadgen/configs/prod-benchmark-pvc.yaml
@@ -1,7 +1,7 @@
 ## start with
 ##    loadgen benchmark prod-benchmark-pvc.yaml
 
-workspaces: 1
+workspaces: 100
 ideImage: eu.gcr.io/gitpod-core-dev/build/ide/code:commit-ff263e14024f00d0ed78386b4417dfa6bcd4ae2f
 waitForRunning: "600s"
 waitForStopping: "600s"

--- a/dev/loadgen/configs/prod-benchmark.yaml
+++ b/dev/loadgen/configs/prod-benchmark.yaml
@@ -78,7 +78,7 @@ repos:
     score: 20
     workspaceImage: registry.hub.docker.com/gitpod/workspace-full:latest
     workspaceClass: "gitpodio-internal-xl"
-  - cloneURL: https://github.com/gitpod-io/template-python-flask
+  - cloneURL: https://github.com/gitpod-io/non-gitpodified-repo
     score: 20
     cloneTarget: main
     workspaceImage: registry.hub.docker.com/gitpod/workspace-full:latest

--- a/dev/loadgen/configs/workspace-preview-benchmark-pvc.yaml
+++ b/dev/loadgen/configs/workspace-preview-benchmark-pvc.yaml
@@ -76,7 +76,7 @@ repos:
     cloneTarget: main
     score: 20
     workspaceImage: registry.hub.docker.com/gitpod/workspace-full:latest
-  - cloneURL: https://github.com/gitpod-io/template-python-flask
+  - cloneURL: https://github.com/gitpod-io/non-gitpodified-repo
     score: 20
     cloneTarget: main
     workspaceImage: registry.hub.docker.com/gitpod/workspace-full:latest

--- a/dev/loadgen/configs/workspace-preview-benchmark.yaml
+++ b/dev/loadgen/configs/workspace-preview-benchmark.yaml
@@ -72,7 +72,7 @@ repos:
     cloneTarget: main
     score: 20
     workspaceImage: registry.hub.docker.com/gitpod/workspace-full:latest
-  - cloneURL: https://github.com/gitpod-io/template-python-flask
+  - cloneURL: https://github.com/gitpod-io/non-gitpodified-repo
     score: 20
     cloneTarget: main
     workspaceImage: registry.hub.docker.com/gitpod/workspace-full:latest


### PR DESCRIPTION
## Description
Test against a repo without .gitpod.yml

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://gitpod.slack.com/archives/C02F19UUW6S/p1664982541052409?thread_ts=1664974807.201539&cid=C02F19UUW6S

## How to test
<!-- Provide steps to test this PR -->
Run loadgen test

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
None

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
