### PR TITLE
[installer-tests] disable npm version update notice

### DIFF
--- a/.werft/aks-installer-tests.yaml
+++ b/.werft/aks-installer-tests.yaml
@@ -169,6 +169,7 @@ pod:
           (cd .werft && yarn install && mv node_modules ..) | werft log slice prep
           printf '{{ toJson . }}' > context.json
 
+          npm config set update-notifier false
           npx ts-node .werft/installer-tests.ts "STANDARD_AKS_TEST"
 
 # The bit below makes this a cron job

--- a/.werft/eks-installer-tests.yaml
+++ b/.werft/eks-installer-tests.yaml
@@ -168,6 +168,7 @@ pod:
           (cd .werft && yarn install && mv node_modules ..) | werft log slice prep
           printf '{{ toJson . }}' > context.json
 
+          npm config set update-notifier false
           npx ts-node .werft/installer-tests.ts "STANDARD_EKS_TEST"
 
 # The bit below makes this a cron job

--- a/.werft/gke-installer-tests.yaml
+++ b/.werft/gke-installer-tests.yaml
@@ -154,6 +154,7 @@ pod:
           (cd .werft && yarn install && mv node_modules ..) | werft log slice prep
           printf '{{ toJson . }}' > context.json
 
+          npm config set update-notifier false
           npx ts-node .werft/installer-tests.ts "STANDARD_GKE_TEST"
 # The bit below makes this a cron job
 plugins:

--- a/.werft/k3s-installer-tests.yaml
+++ b/.werft/k3s-installer-tests.yaml
@@ -157,6 +157,7 @@ pod:
         (cd .werft && yarn install && mv node_modules ..) | werft log slice prep
         printf '{{ toJson . }}' > context.json
 
+        npm config set update-notifier false
         npx ts-node .werft/installer-tests.ts "STANDARD_K3S_TEST"
 # The bit below makes this a cron job
 plugins:


### PR DESCRIPTION
## Description

This is a small quality of life improvement for the self hosted terraform tests.

Unnecessary log chatter is a source of distraction while debugging failed CI jobs. While looking at werft failures npx emits the following message:

[gitpod-custom-alt-stream-exec-logs.2](https://werft.gitpod-dev.com/job/gitpod-custom-alt-stream-exec-logs.2)

```
Could not find license, skipping replicated license cleanup
FailedSliceError: create-gcp-infra
    at new FailedSliceError (/workspace/.werft/util/werft.ts:8:9)
    at Werft.fail (/workspace/.werft/util/werft.ts:117:15)
    at /workspace/.werft/installer-tests.ts:291:19
    at step (/workspace/.werft/installer-tests.ts:33:23)
    at Object.next (/workspace/.werft/installer-tests.ts:14:53)
    at fulfilled (/workspace/.werft/installer-tests.ts:5:58)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
npm notice
npm notice New minor version of npm available! 8.11.0 -> 8.19.2
npm notice Changelog: <https://github.com/npm/cli/releases/tag/v8.19.2>
npm notice Run `npm install -g npm@8.19.2` to update!
npm notice
```

There will almost certainly never be a time where we'll upgrade npm solely because of a message sent to stderr in a CI job; it doesn't provide any value for us and will chew up more mental cycles than necessary. This commit disables npm update notifications within our CI jobs.

<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test

```
werft run github -j .werft/k3s-installer-tests.yaml -a domain=tests.doptig.com
```
[Example job with npm update notifications disabled](https://werft.gitpod-dev.com/job/gitpod-custom-alt-terraform-error-fixups.1)

<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
