### PR TITLE
[dashboard] Don't double-encapsulate Alert contents in <span/> or <p/>

### DIFF
--- a/components/dashboard/src/AppNotifications.tsx
+++ b/components/dashboard/src/AppNotifications.tsx
@@ -74,7 +74,7 @@ export function AppNotifications() {
                 showIcon={true}
                 className="flex rounded mb-2 w-full"
             >
-                <span>{topNotification}</span>
+                {topNotification}
                 {getManageBilling()}
             </Alert>
         </div>

--- a/components/dashboard/src/admin/BlockedRepositories.tsx
+++ b/components/dashboard/src/admin/BlockedRepositories.tsx
@@ -149,9 +149,7 @@ export function BlockedRepositoriesList(props: Props) {
             </div>
 
             <Alert type={"info"} closable={false} showIcon={true} className="flex rounded p-2 mb-2 w-full">
-                <span>
-                    Search entries by their repository URL <abbr title="regular expression">RegEx</abbr>.
-                </span>
+                Search entries by their repository URL <abbr title="regular expression">RegEx</abbr>.
             </Alert>
             <div className="flex flex-col space-y-2">
                 <div className="px-6 py-3 flex justify-between text-sm text-gray-400 border-t border-b border-gray-200 dark:border-gray-800 mb-2">
@@ -242,10 +240,10 @@ function AddBlockedRepositoryModal(p: AddBlockedRepositoryModalProps) {
             ]}
         >
             <Alert type={"warning"} closable={false} showIcon={true} className="flex rounded p-2 w-2/3 mb-2 w-full">
-                <span>Entries in this table have an immediate effect on all users. Please use it carefully.</span>
+                Entries in this table have an immediate effect on all users. Please use it carefully.
             </Alert>
             <Alert type={"message"} closable={false} showIcon={true} className="flex rounded p-2 w-2/3 mb-2 w-full">
-                <span>Repositories are blocked by matching their URL against this regular expression.</span>
+                Repositories are blocked by matching their URL against this regular expression.
             </Alert>
             <Details br={br} update={update} error={error} />
         </Modal>

--- a/components/dashboard/src/admin/WorkspacesSearch.tsx
+++ b/components/dashboard/src/admin/WorkspacesSearch.tsx
@@ -147,7 +147,7 @@ export function WorkspaceSearch(props: Props) {
                 </div>
             </div>
             <Alert type={"info"} closable={false} showIcon={true} className="flex rounded p-2 mb-2 w-full">
-                <span>Search workspaces using workspace ID.</span>
+                Search workspaces using workspace ID.
             </Alert>
             <div className="flex flex-col space-y-2">
                 <div className="px-6 py-3 flex justify-between text-sm text-gray-400 border-t border-b border-gray-200 dark:border-gray-800 mb-2">

--- a/components/dashboard/src/components/ErrorMessage.tsx
+++ b/components/dashboard/src/components/ErrorMessage.tsx
@@ -13,7 +13,7 @@ function ErrorMessage(props: { imgSrc: string; imgAlt?: string; message: string 
         <>
             <div className="mt-16 w-96">
                 <Alert closable={false} showIcon={true} type="error">
-                    <span>{props.message}</span>
+                    {props.message}
                 </Alert>
             </div>
             {isGitpodIo() && (

--- a/components/dashboard/src/projects/Projects.tsx
+++ b/components/dashboard/src/projects/Projects.tsx
@@ -133,12 +133,10 @@ export default function () {
             {!team && (
                 <div className="app-container pt-2">
                     <Alert type={"message"} closable={false} showIcon={true} className="flex rounded mb-2 w-full">
-                        <p>
-                            We'll remove projects under personal accounts in Q1'2023.{" "}
-                            <Link to="/new" className="gp-link">
-                                Create a team.
-                            </Link>
-                        </p>
+                        We'll remove projects under personal accounts in Q1'2023.{" "}
+                        <Link to="/new" className="gp-link">
+                            Create a team.
+                        </Link>
                     </Alert>
                 </div>
             )}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

`<Alert>` is already a container node. There is no need to double-encapsulate contents inside another container:

```html
<Alert>This is fine</Alert>

<Alert><span>This is unnecessary</span></Alert>

<Alert><div>This too</div></Alert>

<Alert><p>This is actually problematic in dark theme</p></Alert>
```

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes:

<img width="1437" alt="Screenshot 2022-10-06 at 09 19 52" src="https://user-images.githubusercontent.com/599268/194273773-df5ef355-678b-4e12-8ca8-0ef533a0faef.png">


## How to test
<!-- Provide steps to test this PR -->

1. Visit `/new` and create a user-owned project (i.e. under your Personal Account)
2. Create a random team (this seems to be required for the Personal Account to show up in the top-left dropdown)
3. In the dropdown, select your Personal Account
4. Observe the warning in both light and dark theme

Also:
- Check other alerts throughout the app

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-payment
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
