### PR TITLE
[usage] Use buf for ts_proto plugin codegen

### DIFF
--- a/components/usage-api/buf.gen.yaml
+++ b/components/usage-api/buf.gen.yaml
@@ -8,3 +8,13 @@ plugins:
     out: go
     opt:
       - module=github.com/gitpod-io/gitpod/usage-api
+
+  - name: ts_proto
+    out: typescript/src
+    path: typescript/node_modules/.bin/protoc-gen-ts_proto
+    opt:
+     - context=true
+     - lowerCaseServiceMethods=true
+     - stringEnums=true
+     - fileSuffix=.pb
+     - outputServices=nice-grpc,outputServices=generic-definitions,useExactTypes=false

--- a/components/usage-api/generate.sh
+++ b/components/usage-api/generate.sh
@@ -9,18 +9,12 @@ set -o nounset
 set -o pipefail
 
 ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)/../../
-COMPONENTS_DIR="$ROOT_DIR"/components
 
 # include protoc bash functions
 # shellcheck disable=SC1090,SC1091
 source "$ROOT_DIR"/scripts/protoc-generator.sh
 
-
-
 install_dependencies
 lint
 protoc_buf_generate
-
-typescript_ts_protoc "$COMPONENTS_DIR" "usage/v1"
-
 update_license


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Results in exactly the same generated output, but it's more readable and can be grouped together with other codegen.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
```
cd components/usage-api
./generate.sh
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
