### PR TITLE
[metric] Add Prometheus metric for instances marked as stopped

### DIFF
--- a/components/ws-manager-bridge/src/bridge.ts
+++ b/components/ws-manager-bridge/src/bridge.ts
@@ -628,6 +628,7 @@ export class WorkspaceManagerBridge implements Disposable {
         }
         info.latestInstance.stoppedTime = nowISO;
         info.latestInstance.status.message = `Stopped by ws-manager-bridge. Previously in phase ${info.latestInstance.status.phase}`;
+        this.prometheusExporter.increaseInstanceMarkedStoppedCounter(info.latestInstance.status.phase);
         info.latestInstance.status.phase = "stopped";
         await this.workspaceDB.trace(ctx).storeInstance(info.latestInstance);
 

--- a/components/ws-manager-bridge/src/prometheus-metrics-exporter.ts
+++ b/components/ws-manager-bridge/src/prometheus-metrics-exporter.ts
@@ -20,6 +20,7 @@ export class PrometheusMetricsExporter {
     protected readonly staleStatusUpdatesTotal: prom.Counter<string>;
     protected readonly stalePrebuildEventsTotal: prom.Counter<string>;
     protected readonly prebuildsCompletedTotal: prom.Counter<string>;
+    protected readonly instanceMarkedStoppedTotal: prom.Counter<string>;
 
     protected readonly workspaceInstanceUpdateStartedTotal: prom.Counter<string>;
     protected readonly workspaceInstanceUpdateCompletedSeconds: prom.Histogram<string>;
@@ -84,6 +85,12 @@ export class PrometheusMetricsExporter {
             name: "gitpod_prebuilds_completed_total",
             help: "Counter of total prebuilds ended.",
             labelNames: ["state"],
+        });
+
+        this.instanceMarkedStoppedTotal = new prom.Counter({
+            name: "gitpod_ws_instances_marked_stopped_total",
+            help: "Counter of total instances marked stopped by the ws-manager-bridge",
+            labelNames: ["previous_phase"],
         });
     }
 
@@ -161,5 +168,9 @@ export class PrometheusMetricsExporter {
 
     increasePrebuildsCompletedCounter(state: string) {
         this.prebuildsCompletedTotal.inc({ state });
+    }
+
+    increaseInstanceMarkedStoppedCounter(previous_phase: string) {
+        this.instanceMarkedStoppedTotal.inc({ previous_phase });
     }
 }


### PR DESCRIPTION
## Description
Adds `gitpod_ws_instances_marked_stopped_total` counter for instances marked as stopped.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #12959

## How to test
Will test in prod while `in validation` to be able to gather more data compared to in a preview environment.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-observability
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
