### PR TITLE
[db] Add stripeCustomerId to d_b_cost_center table + index

### DIFF
--- a/components/gitpod-db/src/typeorm/migration/1665058581369-CostCenterAddColumnStripeCustomer.ts
+++ b/components/gitpod-db/src/typeorm/migration/1665058581369-CostCenterAddColumnStripeCustomer.ts
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { columnExists } from "./helper/helper";
+import { indexExists } from "./helper/helper";
+
+const D_B_COST_CENTER = "d_b_cost_center";
+const COL_STRIPE_CUSTOMER_ID = "stripeCustomerId";
+
+export class CostCenterAddColumnStripeCustomer1665058581369 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        if (!(await columnExists(queryRunner, D_B_COST_CENTER, COL_STRIPE_CUSTOMER_ID))) {
+            await queryRunner.query(
+                `ALTER TABLE ${D_B_COST_CENTER} ADD COLUMN ${COL_STRIPE_CUSTOMER_ID} varchar(60), ALGORITHM=INPLACE, LOCK=NONE `,
+            );
+
+            const INDEX_NAME = "IDX_stripe_customer_id";
+            if (!(await indexExists(queryRunner, D_B_COST_CENTER, INDEX_NAME))) {
+                await queryRunner.query(`CREATE INDEX ${INDEX_NAME} ON ${D_B_COST_CENTER} (${COL_STRIPE_CUSTOMER_ID})`);
+            }
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {}
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Adds optional stripeCustomerId to CostCenter DB

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Part of https://github.com/gitpod-io/gitpod/issues/13177

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
