### PR TITLE
[db] Reset primary keys in `d_b_oauth_auth_code_entry`

### DIFF
--- a/components/gitpod-db/src/typeorm/migration/1665062302891-ResetAuthCodePrimaryKeys.ts
+++ b/components/gitpod-db/src/typeorm/migration/1665062302891-ResetAuthCodePrimaryKeys.ts
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class ResetAuthCodePrimaryKeys1665062302891 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`UPDATE d_b_oauth_auth_code_entry SET id=(SELECT uuid());`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {}
+}


### PR DESCRIPTION
## Description

Reset the primary keys in the `d_b_oauth_auth_code_entry` table to random uuids.

The type of the primary key column was changed in https://github.com/gitpod-io/gitpod/pull/13616 to allow storing uids, but the field now contains a mix of integer values (for existing records) and uids (for new records). In order to be able to sync the table with `db-sync` we need to replace the integer values with uuids.

The value of the primary key for each record doesn't matter so long as it is unique across both EU and US databases, so resetting the primary key values of all rows will work fine.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of #9198 


## How to test

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
