### PR TITLE
[installer-tests] Splitting the integration tests

### DIFF
--- a/.werft/installer-tests.ts
+++ b/.werft/installer-tests.ts
@@ -19,6 +19,8 @@ const version: string = annotations.version || "-";
 const preview: string = annotations.preview || "false"; // setting to true will not destroy the setup
 const upgrade: string = annotations.upgrade || "false"; // setting to true will not KOTS upgrade to the latest version. Set the channel to beta or stable in this case.
 const skipTests: string = annotations.skipTests || "false"; // setting to true skip the integration tests
+// we can explicitly specify which tests is it that we want to run or the cron will randomly pick a suite
+const testSuite: string = annotations.testSuite || randomize(["workspaces", "ide", "webapp"])
 const selfSigned: string = annotations.selfSigned || "false";
 const deps: string = annotations.deps || ""; // options: ["external", "internal"] setting to `external` will ensure that all resource dependencies(storage, db, registry) will be external. if unset, a random selection will be used
 const deleteOnFail: string = annotations.deleteOnFail || "true";
@@ -208,13 +210,28 @@ const INFRA_PHASES: { [name: string]: InfraConfig } = {
     },
 };
 
-const TESTS: { [name: string]: InfraConfig } = {
+const WORKSPACES_TESTS: { [name: string]: InfraConfig } = {
     WORKSPACE_TEST: {
         phase: "run-workspace-tests",
         makeTarget: "run-workspace-tests",
         description: "Workspace integration tests",
         slackhook: slackHook.get("workspace-jobs"),
     },
+    WS_DAEMON_TEST: {
+        phase: "run-ws-daemon-component-tests",
+        makeTarget: "run-wsd-component-tests",
+        description: "ws-daemon integration tests",
+        slackhook: slackHook.get("workspace-jobs"),
+    },
+    WS_MNGR_TEST: {
+        phase: "run-ws-manager-component-tests",
+        makeTarget: "run-wsm-component-tests",
+        description: "ws-manager integration tests",
+        slackhook: slackHook.get("workspace-jobs"),
+    },
+};
+
+const IDE_TESTS: { [name: string]: InfraConfig } = {
     VSCODE_IDE_TEST: {
         phase: "run-vscode-ide-tests",
         makeTarget: "run-vscode-ide-tests",
@@ -226,40 +243,38 @@ const TESTS: { [name: string]: InfraConfig } = {
         makeTarget: "run-jb-ide-tests",
         description: "jetbrains IDE tests",
         slackhook: slackHook.get("ide-jobs"),
-    },
+    }
+}
+
+
+const WEBAPP_TESTS: { [name: string]: InfraConfig } = {
     CONTENTSERVICE_TEST: {
-        phase: "run-cs-component-tests",
+        phase: "run-content-service-tests",
         makeTarget: "run-cs-component-tests",
         description: "content-service tests",
     },
     DB_TEST: {
-        phase: "run-db-component-tests",
+        phase: "run-database-tests",
         makeTarget: "run-db-component-tests",
         description: "database integration tests",
     },
     IMAGEBUILDER_TEST: {
-        phase: "run-ib-component-tests",
+        phase: "run-image-builder-tests",
         makeTarget: "run-ib-component-tests",
         description: "image-builder tests",
     },
     SERVER_TEST: {
-        phase: "run-server-component-tests",
+        phase: "run-server-tests",
         makeTarget: "run-server-component-tests",
         description: "server integration tests",
     },
-    WS_DAEMON_TEST: {
-        phase: "run-wsd-component-tests",
-        makeTarget: "run-wsd-component-tests",
-        description: "ws-daemon integration tests",
-        slackhook: slackHook.get("workspace-jobs"),
-    },
-    WS_MNGR_TEST: {
-        phase: "run-wsm-component-tests",
-        makeTarget: "run-wsm-component-tests",
-        description: "ws-manager integration tests",
-        slackhook: slackHook.get("workspace-jobs"),
-    },
-};
+}
+
+const TestMap = {
+    "workspaces": WORKSPACES_TESTS,
+    "ide": IDE_TESTS,
+    "webapp": WEBAPP_TESTS,
+}
 
 if (config === undefined) {
     console.log(`Unknown configuration specified: "${testConfig}", Exiting...`);
@@ -369,10 +384,19 @@ export async function installerTests(config: TestConfig) {
 }
 
 function runIntegrationTests() {
-    werft.phase("run-integration-tests", "Run all existing integration tests");
+    werft.phase(`run-${testSuite}-integration-tests`, `Run all ${testSuite} integration tests`);
+
+    const componentTests = TestMap[testSuite.toLowerCase()]
+    if(componentTests === undefined) {
+        console.log("'%s' is not a valid testSuite name, options are: 'workspaces', 'ide', 'webapp'", testSuite)
+        werft.fail(`run-${testSuite}-integration-tests`, "Error finding the testSuite")
+        return
+    }
+
     const slackAlerts = new Map<string, string>([]);
-    for (let test in TESTS) {
-        const testPhase = TESTS[test];
+    console.log(`Running ${testSuite} tests`)
+    for (let test in componentTests) {
+        const testPhase = componentTests[test];
         const ret = callMakeTargets(testPhase.phase, testPhase.description, testPhase.makeTarget);
         if (ret) {
             exec(

--- a/install/tests/tests.sh
+++ b/install/tests/tests.sh
@@ -12,7 +12,7 @@ echo "Starting test on ${DATE} for ${TESTPATH}"
 
 cd "${TESTPATH}" ||  echo "Path invalid ${TESTPATH}"
 
-go test -v ./... "-kubeconfig=$1" -namespace=gitpod -username=gitpod-integration-test 2>&0 -coverprofile=coverage.out
+go test -timeout 30m -v ./... "-kubeconfig=$1" -namespace=gitpod -username=gitpod-integration-test 2>&0 -coverprofile=coverage.out
 
 TEST_STATUS=$?
 echo ${TEST_STATUS}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
So far we have been trying to run all the integration tests every night and this caused several timeout issues and we noticed some tests affecting the setup in a way that other tests ended up failing. So this is the first step towards making the tests pass. This PR splits up the tests team wise (IDE, workspaces, and webapp). Every night, against each of the architecture one of the tests run and send slack alert to the corresponding team channel. If one wants to explicitly specify a test suite they can use the annotation `testSuite` with one of these values: `ide`, `workspaces`, `webapp`.

Alongside the PR also increases the timeout of each test to the maximum value. This ensure each test gets as much time as possible and if it get stuck, the process will be killed by the hard timeout of `werft`(2 hours)


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
You can try running:

```
werft run github -j .werft/gke-installer-tests.yaml
# OR
werft run github -j .werft/gke-installer-tests.yaml -a testSuite=ide
```

See [gitpod-custom-nvn-fix-int-test.10](https://werft.gitpod-dev.com/job/gitpod-custom-nvn-fix-int-test.10)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
