### PR TITLE
Adjust JetBrains Backend Plugin to work with the new Port Forwarding API

### DIFF
--- a/components/ide/jetbrains/backend-plugin/gradle-latest.properties
+++ b/components/ide/jetbrains/backend-plugin/gradle-latest.properties
@@ -6,4 +6,4 @@ pluginUntilBuild=223.*
 # See https://jb.gg/intellij-platform-builds-list for available build versions.
 pluginVerifierIdeVersions=2022.3
 # Version from "com.jetbrains.intellij.idea" which can be found at https://www.jetbrains.com/intellij-repository/snapshots
-platformVersion=223.5756-EAP-CANDIDATE-SNAPSHOT
+platformVersion=223.6160-EAP-CANDIDATE-SNAPSHOT

--- a/components/ide/jetbrains/backend-plugin/launch-dev-server.sh
+++ b/components/ide/jetbrains/backend-plugin/launch-dev-server.sh
@@ -7,17 +7,19 @@ set -e
 set -o pipefail
 
 # Default Options
-DEBUG_PORT=0
+DEBUG_PORT=44444
 JB_QUALIFIER="latest"
 TEST_REPO=https://github.com/gitpod-io/spring-petclinic
+RUN_FROM="release"
 
 # Parsing Custom Options
-while getopts "p:r:s" OPTION
+while getopts "p:r:su" OPTION
 do
    case $OPTION in
        s) JB_QUALIFIER="stable" ;;
        r) TEST_REPO=$OPTARG ;;
        p) DEBUG_PORT=$OPTARG ;;
+       u) RUN_FROM="snapshot" ;;
        *) ;;
    esac
 done
@@ -25,16 +27,30 @@ done
 TEST_BACKEND_DIR="/workspace/ide-backend-$JB_QUALIFIER"
 if [ ! -d "$TEST_BACKEND_DIR" ]; then
   mkdir -p $TEST_BACKEND_DIR
-  if [[ $JB_QUALIFIER == "stable" ]]; then
-    PRODUCT_TYPE="release"
+  if [[ $RUN_FROM == "snapshot" ]]; then
+    (cd $TEST_BACKEND_DIR &&
+    SNAPSHOT_VERSION=$(grep "platformVersion=" "gradle-$JB_QUALIFIER.properties" | sed 's/platformVersion=//') &&
+    echo "Downloading the $JB_QUALIFIER version of IntelliJ IDEA ($SNAPSHOT_VERSION)..." &&
+    curl -sSLo backend.zip "https://www.jetbrains.com/intellij-repository/snapshots/com/jetbrains/intellij/idea/ideaIU/$SNAPSHOT_VERSION/ideaIU-$SNAPSHOT_VERSION.zip" &&
+    unzip backend.zip &&
+    rm backend.zip &&
+    ln -s "ideaIU-$SNAPSHOT_VERSION" . &&
+    rm -r "ideaIU-$SNAPSHOT_VERSION" &&
+    cp -r /ide-desktop/backend/jbr . &&
+    cp /ide-desktop/backend/bin/idea.properties ./bin &&
+    cp /ide-desktop/backend/bin/idea64.vmoptions ./bin)
   else
-    PRODUCT_TYPE="release,rc,eap"
+    if [[ $JB_QUALIFIER == "stable" ]]; then
+      PRODUCT_TYPE="release"
+    else
+      PRODUCT_TYPE="release,rc,eap"
+    fi
+    (cd $TEST_BACKEND_DIR &&
+    echo "Downloading the $JB_QUALIFIER version of IntelliJ IDEA..." &&
+    curl -sSLo backend.tar.gz "https://download.jetbrains.com/product?type=$PRODUCT_TYPE&distribution=linux&code=IIU" &&
+    tar -xf backend.tar.gz --strip-components=1 &&
+    rm backend.tar.gz)
   fi
-  (cd $TEST_BACKEND_DIR &&
-  echo "Downloading the $JB_QUALIFIER version of IntelliJ IDEA..." &&
-  curl -sSLo backend.tar.gz "https://download.jetbrains.com/product?type=$PRODUCT_TYPE&distribution=linux&code=IIU" &&
-  tar -xf backend.tar.gz --strip-components=1 &&
-  rm backend.tar.gz)
 fi
 
 TEST_PLUGINS_DIR="$TEST_BACKEND_DIR/plugins"

--- a/components/ide/jetbrains/backend-plugin/src/main/resources-latest/META-INF/extensions.xml
+++ b/components/ide/jetbrains/backend-plugin/src/main/resources-latest/META-INF/extensions.xml
@@ -7,6 +7,6 @@
 <idea-plugin>
     <extensions defaultExtensionNs="com.intellij">
         <applicationService serviceInterface="io.gitpod.jetbrains.remote.GitpodIgnoredPortsForNotificationService" serviceImplementation="io.gitpod.jetbrains.remote.latest.GitpodIgnoredPortsForNotificationServiceImpl" preload="true"/>
-        <projectService serviceImplementation="io.gitpod.jetbrains.remote.latest.GitpodPortForwardingService" preload="true"/>
+        <projectService serviceImplementation="io.gitpod.jetbrains.remote.latest.GitpodPortForwardingService" preload="true" client="guest"/>
     </extensions>
 </idea-plugin>


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Now that we have EAP IDEs build 223.6x available in gitpod.io, we need to update the back-end plugin with the support for the new Port Forwarding API.

In the current state of this PR, the plugin compiles and doesn't throw errors, but before setting it as Ready for Review, here's what we need to accomplish:
- [ ] Ensure the usage of port name/description columns is working.
- [ ] Remove the unused function overrides from `object: ForwardedPortListener`
- [ ] Confirm there's no other way to dispose the forwarded ports listeners (currently we use a map for it).
- [ ] Confirm if ports are removed from the UI when programatically removed.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
- https://github.com/gitpod-io/gitpod/issues/10581

## How to test
<!-- Provide steps to test this PR -->
1. Open the preview environment of this PR: https://felladrin-a8c1911845.preview.gitpod-dev.com/
2. In the account preferences, select the _Latest_ JetBrains IntelliJ IDEA as the editor
3. (...)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
