### PR TITLE
Revert "ws-manager: remove PVC object if the workspace pod fails to up"

### DIFF
--- a/components/ws-manager/pkg/manager/monitor.go
+++ b/components/ws-manager/pkg/manager/monitor.go
@@ -300,18 +300,6 @@ func actOnPodEvent(ctx context.Context, m actingManager, manager *Manager, statu
 			return xerrors.Errorf("cannot stop workspace: %w", err)
 		}
 
-		// Delete PVC if it exists
-		// Note that: the PVC removal is postponed until the PVC is no longer actively used by its workspace pod.
-		//            Therefore, the PVC is removed after the workspace pod finalizer is removed.
-		//            No data loss unless we remove the workspace pod finalizer incorrectly.
-		_, createPVC := pod.Labels[pvcWorkspaceFeatureLabel]
-		if !createPVC {
-			return nil
-		}
-		err = manager.deleteWorkspacePVC(ctx, pod.Name)
-		if err != nil {
-			return xerrors.Errorf("cannot remove PVC: %w", err)
-		}
 		return nil
 	} else if status.Conditions.StoppedByRequest == api.WorkspaceConditionBool_TRUE {
 		span.LogKV("event", "stopped by request")


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This reverts commit 28fae90078c351207f3f0f48ab7fc6154cc4e5ce.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related #13282

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
None

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
