### PR TITLE
Preview vm create and delete uses the new TF flow

### DIFF
--- a/.werft/jobs/build/deploy-to-preview-environment.ts
+++ b/.werft/jobs/build/deploy-to-preview-environment.ts
@@ -133,12 +133,8 @@ export async function deployToPreviewEnvironment(werft: Werft, jobConfig: JobCon
     VM.waitForVMReadiness({ name: destname, timeoutSeconds: 60 * 10, slice: vmSlices.VM_READINESS });
     werft.done(vmSlices.VM_READINESS);
 
-    werft.log(vmSlices.START_KUBECTL_PORT_FORWARDS, "Starting SSH port forwarding");
-    VM.startSSHProxy({ name: destname, slice: vmSlices.START_KUBECTL_PORT_FORWARDS });
-    werft.done(vmSlices.START_KUBECTL_PORT_FORWARDS);
-
     werft.log(vmSlices.KUBECONFIG, "Copying k3s kubeconfig");
-    VM.copyk3sKubeconfig({ name: destname, timeoutMS: 1000 * 60 * 3, slice: vmSlices.KUBECONFIG });
+    VM.copyk3sKubeconfigShell({ name: destname, timeoutMS: 1000 * 60 * 6, slice: vmSlices.KUBECONFIG });
     werft.done(vmSlices.KUBECONFIG);
 
     werft.log(vmSlices.WAIT_K3S, "Wait for k3s");

--- a/.werft/jobs/build/prepare.ts
+++ b/.werft/jobs/build/prepare.ts
@@ -26,7 +26,7 @@ export async function prepare(werft: Werft, config: JobConfig) {
             return
         }
         var certReady = issueCertificate(werft, config);
-        decideHarvesterVMCreation(werft, config);
+        await decideHarvesterVMCreation(werft, config);
         await certReady
     } catch (err) {
         werft.fail(phaseName, err);
@@ -84,10 +84,10 @@ async function issueCertificate(werft: Werft, config: JobConfig): Promise<boolea
     return certReady
 }
 
-function decideHarvesterVMCreation(werft: Werft, config: JobConfig) {
+async function decideHarvesterVMCreation(werft: Werft, config: JobConfig) {
     // always try to create - usually it will be no-op, but if tf changed for any reason we would reconcile
     if (config.withPreview) {
-        createVM(werft, config);
+        await createVM(werft, config);
     }
     werft.done(prepareSlices.BOOT_VM);
 }

--- a/.werft/jobs/build/prepare.ts
+++ b/.werft/jobs/build/prepare.ts
@@ -1,11 +1,9 @@
 import { previewNameFromBranchName } from "../../util/preview";
 import { exec } from "../../util/shell";
 import { Werft } from "../../util/werft";
-import * as VM from "../../vm/vm";
 import { CORE_DEV_KUBECONFIG_PATH, GCLOUD_SERVICE_ACCOUNT_PATH, HARVESTER_KUBECONFIG_PATH } from "./const";
 import { issueMetaCerts } from "./deploy-to-preview-environment";
 import { JobConfig } from "./job-config";
-import * as Manifests from "../../vm/manifests";
 
 const phaseName = "prepare";
 const prepareSlices = {
@@ -87,43 +85,51 @@ async function issueCertificate(werft: Werft, config: JobConfig): Promise<boolea
 }
 
 function decideHarvesterVMCreation(werft: Werft, config: JobConfig) {
-    if (shouldCreateVM(config)) {
+    // always try to create - usually it will be no-op, but if tf changed for any reason we would reconcile
+    if (config.withPreview) {
         createVM(werft, config);
     }
-    applyLoadBalancer({ name: config.previewEnvironment.destname });
     werft.done(prepareSlices.BOOT_VM);
-}
-
-function shouldCreateVM(config: JobConfig) {
-    return (
-        config.withPreview &&
-        (!VM.vmExists({ name: config.previewEnvironment.destname }) || config.cleanSlateDeployment)
-    );
 }
 
 // createVM only triggers the VM creation.
 // Readiness is not guaranted.
 function createVM(werft: Werft, config: JobConfig) {
+    const cpu = config.withLargeVM ? 12 : 6;
+    const memory = config.withLargeVM ? 24 : 12;
+
+    // set some common vars for TF
+    // We pass the GCP credentials explicitly, otherwise for some reason TF doesn't pick them up
+    const commonVars = `GOOGLE_BACKEND_CREDENTIALS=${GCLOUD_SERVICE_ACCOUNT_PATH} \
+                        TF_VAR_dev_kube_path=${CORE_DEV_KUBECONFIG_PATH} \
+                        TF_VAR_harvester_kube_path=${HARVESTER_KUBECONFIG_PATH} \
+                        TF_VAR_preview_name=${config.previewEnvironment.destname} \
+                        TF_VAR_vm_cpu=${cpu} \
+                        TF_VAR_vm_memory=${memory}Gi \
+                        TF_VAR_vm_storage_class="longhorn-gitpod-k3s-202209251218-onereplica"`
+
     if (config.cleanSlateDeployment) {
         werft.log(prepareSlices.BOOT_VM, "Cleaning previously created VM");
-        VM.deleteVM({ name: config.previewEnvironment.destname });
+        // -replace=... forces recreation of the resource
+        exec(`${commonVars} \
+                        TF_CLI_ARGS_plan="-replace=harvester_virtualmachine.harvester" \
+                        ./dev/preview/workflow/preview/deploy-harvester.sh`,
+            {slice: prepareSlices.BOOT_VM}
+        );
     }
 
     werft.log(prepareSlices.BOOT_VM, "Creating  VM");
-    const cpu = config.withLargeVM ? 12 : 6;
-    const memory = config.withLargeVM ? 24 : 12;
-    VM.startVM({ name: config.previewEnvironment.destname, cpu, memory });
-    werft.currentPhaseSpan.setAttribute("preview.created_vm", true);
-}
 
-function applyLoadBalancer(option: { name: string }) {
-    function kubectlApplyManifest(manifest: string, options?: { validate?: boolean }) {
-        exec(`
-            cat <<EOF | kubectl --kubeconfig ${CORE_DEV_KUBECONFIG_PATH} apply --validate=${!!options?.validate} -f -
-${manifest}
-EOF
-        `);
+    try {
+        exec(`${commonVars} \
+                        ./dev/preview/workflow/preview/deploy-harvester.sh`,
+            {slice: prepareSlices.BOOT_VM}
+        );
+    } catch (err) {
+        werft.currentPhaseSpan.setAttribute("preview.created_vm", false);
+        werft.fail(prepareSlices.BOOT_VM, new Error(`Failed creating VM: ${err}`))
+        return;
     }
-    kubectlApplyManifest(Manifests.LBDeployManifest({ name: option.name }));
-    kubectlApplyManifest(Manifests.LBServiceManifest({ name: option.name }));
+
+    werft.currentPhaseSpan.setAttribute("preview.created_vm", true);
 }

--- a/.werft/util/certs.ts
+++ b/.werft/util/certs.ts
@@ -69,12 +69,12 @@ function waitCertReady(certName: string): boolean {
 }
 
 function isCertReady(certName: string): boolean {
-    const rc = exec(
+    const output = exec(
         `kubectl --kubeconfig ${CORE_DEV_KUBECONFIG_PATH} -n certs get certificate ${certName} -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}'`,
         { dontCheckRc: true }
     ).stdout.trim();
 
-    return rc == "True";
+    return output == "True";
 }
 
 function retrieveFailedCertDebug(certName: string, slice: string) {

--- a/.werft/util/preview.ts
+++ b/.werft/util/preview.ts
@@ -151,11 +151,7 @@ export class HarvesterPreviewEnvironment {
                 return true;
             }
 
-            // The preview env is its own k3s cluster, so we need to get the kubeconfig for it
-            VM.startSSHProxy({ name: this.name, slice: sliceID });
-            exec("sleep 5", { silent: true, slice: sliceID });
-
-            VM.copyk3sKubeconfig({ name: this.name, timeoutMS: 1000 * 60 * 3, slice: sliceID });
+            VM.copyk3sKubeconfigShell({ name: this.name, timeoutMS: 1000 * 60 * 3, slice: sliceID });
             const kubectclCmd = `KUBECONFIG=${PREVIEW_K3S_KUBECONFIG_PATH} kubectl --insecure-skip-tls-verify`;
 
             this.werft.log(sliceID, `${this.name} (${this.k3sNamespace}) - Checking status of the MySQL pod`);

--- a/dev/preview/infrastructure/harvester/provider.tf
+++ b/dev/preview/infrastructure/harvester/provider.tf
@@ -20,7 +20,7 @@ terraform {
 
 provider "harvester" {
   alias      = "harvester"
-  kubeconfig = file(var.harvester_kube_path)
+  kubeconfig = var.harvester_kube_path
 }
 
 provider "k8s" {
@@ -32,3 +32,4 @@ provider "k8s" {
   alias       = "harvester"
   config_path = var.harvester_kube_path
 }
+

--- a/dev/preview/infrastructure/harvester/svc.tf
+++ b/dev/preview/infrastructure/harvester/svc.tf
@@ -56,7 +56,7 @@ resource "kubernetes_service" "harvester-svc" {
       name        = "https"
       protocol    = "TCP"
       port        = 443
-      target_port = 4430
+      target_port = 443
     }
     port {
       name        = "kube-api"

--- a/dev/preview/infrastructure/harvester/variables.tf
+++ b/dev/preview/infrastructure/harvester/variables.tf
@@ -6,13 +6,11 @@ variable "preview_name" {
 variable "harvester_kube_path" {
   type        = string
   description = "The path to the Harvester Cluster kubeconfig"
-  default     = "~/.kube/harvester"
 }
 
 variable "dev_kube_path" {
   type        = string
   description = "The path to the Dev Cluster kubeconfig"
-  default     = "~/.kube/dev"
 }
 
 variable "vm_memory" {
@@ -25,22 +23,6 @@ variable "vm_cpu" {
   type        = number
   default     = 2
   description = "CPU for the VM"
-}
-
-variable "vm_image" {
-  type        = string
-  default     = "default/gitpod-k3s-202209251218"
-  description = "The image name"
-}
-
-variable "dockerhub_user" {
-  type        = string
-  description = "The dockerhub user used to pull images in k3s"
-}
-
-variable "dockerhub_password" {
-  type        = string
-  description = "The password for the dockerhub user used to pull images in k3s"
 }
 
 variable "vm_storage_class" {

--- a/dev/preview/install-k3s-kubeconfig.sh
+++ b/dev/preview/install-k3s-kubeconfig.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 
+# shellcheck disable=SC2069
+
 set -euo pipefail
+
 
 THIS_DIR="$(dirname "$0")"
 
@@ -10,10 +13,11 @@ PRIVATE_KEY=$HOME/.ssh/vm_id_rsa
 PUBLIC_KEY=$HOME/.ssh/vm_id_rsa.pub
 USER="ubuntu"
 BRANCH=""
+GCLOUD_SERVICE_ACCOUNT_PATH=${GCLOUD_SERVICE_ACCOUNT_PATH:-}
 
 KUBECONFIG_PATH="/home/gitpod/.kube/config"
-K3S_KUBECONFIG_PATH="$(mktemp)"
-MERGED_KUBECONFIG_PATH="$(mktemp)"
+K3S_KUBECONFIG_PATH=${K3S_KUBECONFIG_PATH:-$(mktemp)}
+MERGED_KUBECONFIG_PATH=${MERGED_KUBECONFIG_PATH:-$(mktemp)}
 
 while getopts n:p:u:b: flag
 do
@@ -24,16 +28,32 @@ do
     esac
 done
 
-if [[ "${BRANCH}" == "" ]]; then
-    VM_NAME="$(preview-name-from-branch)"
-else
-    VM_NAME="$(preview-name-from-branch "$BRANCH")"
+if [ -z "${VM_NAME:-}" ]; then
+  if [[ "${BRANCH}" == "" ]]; then
+      VM_NAME="$(preview-name-from-branch)"
+  else
+      VM_NAME="$(preview-name-from-branch "$BRANCH")"
+  fi
+fi
+
+K3S_CONTEXT="${VM_NAME}"
+K3S_ENDPOINT="${VM_NAME}.kube.gitpod-dev.com"
+
+# If we can access the k3s cluster, there's nothing to do
+if kubectl --context="${K3S_CONTEXT}" auth can-i get secrets 2>&1 1>/dev/null ;then
+  exit 0
 fi
 
 echo "Installing context from VM: $VM_NAME"
 
-K3S_CONTEXT="${VM_NAME}"
-K3S_ENDPOINT="${VM_NAME}.kube.gitpod-dev.com"
+# Run this part only in automation and if we don't have access to dev/harvester
+if [ -n "${WERFT_SERVICE_HOST-}" ];then
+  for ctx in dev harvester;do
+    if ! kubectl --context="${ctx}" auth can-i get secrets 2>&1 1>/dev/null; then
+      "$THIS_DIR"/util/setup-access.sh
+    fi
+  done
+fi
 
 function log {
     echo "[$(date)] $*"
@@ -60,8 +80,5 @@ KUBECONFIG="${K3S_KUBECONFIG_PATH}:${KUBECONFIG_PATH}" \
 
 log "Overwriting ${KUBECONFIG_PATH}"
 mv "${MERGED_KUBECONFIG_PATH}" "${KUBECONFIG_PATH}"
-
-log "Cleaning up temporary K3S kubeconfig"
-rm "${K3S_KUBECONFIG_PATH}"
 
 log "Done"

--- a/dev/preview/ssh-vm.sh
+++ b/dev/preview/ssh-vm.sh
@@ -28,13 +28,15 @@ do
     esac
 done
 
-if [[ "${BRANCH}" == "" ]]; then
-    VM_NAME="$(preview-name-from-branch)"
-else
-    VM_NAME="$(preview-name-from-branch "$BRANCH")"
+if [ -z "${VM_NAME:-}" ]; then
+  if [[ "${BRANCH}" == "" ]]; then
+      VM_NAME="$(preview-name-from-branch)"
+  else
+      VM_NAME="$(preview-name-from-branch "$BRANCH")"
+  fi
 fi
-NAMESPACE="preview-${VM_NAME}"
 
+NAMESPACE="preview-${VM_NAME}"
 
 function log {
     echo "[$(date)] $*"

--- a/dev/preview/util/download-and-merge-harvester-kubeconfig.sh
+++ b/dev/preview/util/download-and-merge-harvester-kubeconfig.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 KUBE_CONTEXT="dev"
-KUBECONFIG_PATH="/home/gitpod/.kube/config"
+KUBECONFIG_PATH=${KUBECONFIG_PATH:-"/home/gitpod/.kube/config"}
 HARVESTER_KUBECONFIG_PATH="$(mktemp)"
 MERGED_KUBECONFIG_PATH="$(mktemp)"
 
@@ -12,7 +12,8 @@ function log {
 }
 
 function has-dev-access {
-    kubectl --context=$KUBE_CONTEXT auth can-i get secrets > /dev/null 2>&1 || false
+    # shellcheck disable=SC2069
+    kubectl --context=$KUBE_CONTEXT auth can-i get secrets 2>&1 1> /dev/null  || false
 }
 
 if ! has-dev-access; then

--- a/dev/preview/util/install-vm-ssh-keys.sh
+++ b/dev/preview/util/install-vm-ssh-keys.sh
@@ -6,6 +6,8 @@ THIS_DIR="$(dirname "$0")"
 PRIVATE_KEY_PATH="$HOME/.ssh/vm_id_rsa"
 PUBLIC_KEY_PATH="$HOME/.ssh/vm_id_rsa.pub"
 
+mkdir -p "$HOME/.ssh"
+
 function log {
     echo "[$(date)] $*"
 }

--- a/dev/preview/util/setup-access.sh
+++ b/dev/preview/util/setup-access.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+function log {
+  echo "[$(date)] $*"
+}
+
+KUBECONFIG_PATH="$HOME/.kube/config"
+
+if test -f "${KUBECONFIG_PATH}"; then
+  log "Backing up kubeconfig to ${KUBECONFIG_PATH}.bak"
+  mv "${KUBECONFIG_PATH}" "${KUBECONFIG_PATH}.bak"
+fi
+
+# shellcheck disable=SC2139
+alias kubectl="KUBECONFIG=${KUBECONFIG_PATH} kubectl"
+
+if [ -n "${GCLOUD_SERVICE_ACCOUNT_PATH-}" ]; then
+  auth=$(gcloud config get-value account)
+  if [[ "${auth}" = "(unset)" ]] || [ -z "${auth:-}" ]; then
+    gcloud auth activate-service-account --key-file "${GCLOUD_SERVICE_ACCOUNT_PATH}"
+  fi
+fi
+
+KUBECONFIG="${KUBECONFIG_PATH}" gcloud container clusters get-credentials core-dev --zone europe-west1-b --project gitpod-core-dev
+kubectl config rename-context "$(kubectl config current-context)" dev
+
+HARVESTER_KUBECONFIG_PATH=$(mktemp)
+MERGED_KUBECONFIG_PATH=$(mktemp)
+
+kubectl --context=dev -n werft get secret harvester-kubeconfig -o jsonpath='{.data}' |
+  jq -r '.["harvester-kubeconfig.yml"]' |
+  base64 -d |
+  sed 's/default/harvester/g' \
+    >"${HARVESTER_KUBECONFIG_PATH}"
+
+KUBECONFIG="${KUBECONFIG_PATH}:${HARVESTER_KUBECONFIG_PATH}" \
+  kubectl --context=dev config view --flatten --merge >"${MERGED_KUBECONFIG_PATH}"
+
+log "Overwriting ${KUBECONFIG_PATH}"
+mv "${MERGED_KUBECONFIG_PATH}" "${KUBECONFIG_PATH}"
+
+log "Cleaning up temporary Harvester kubeconfig"
+rm "${HARVESTER_KUBECONFIG_PATH}"
+
+log "Done"

--- a/dev/preview/workflow/lib/common.sh
+++ b/dev/preview/workflow/lib/common.sh
@@ -10,6 +10,7 @@ export ERROR_CHANGE_DIR=31
 export ERROR_NO_WORKSPACE=32
 export ERROR_NO_DIR=33
 export ERROR_NO_PLAN=34
+export ERROR_PLAN_FAIL=35
 
 function import() {
   local file="${SCRIPT_PATH}/${1}"
@@ -42,15 +43,6 @@ function log_success() {
 function log_info() {
   local text=$1
   echo -e "${BLUE}INFO: ${NC}${text}"
-}
-
-# Checks if we have the correct context or exits with an error
-function check_kubectx() {
-  local expected=$1
-  if [[ $(kubectl config current-context) != "${expected}" ]]; then
-    log_error "Wrong context. Wanted [${expected}], got [$(kubectl config current-context)]"
-    exit "${ERROR_WRONG_KUBECTX}"
-  fi
 }
 
 function ask() {

--- a/dev/preview/workflow/lib/terraform.sh
+++ b/dev/preview/workflow/lib/terraform.sh
@@ -8,7 +8,11 @@ SCRIPT_PATH=$(dirname "${BASH_SOURCE[0]}")
 source "${SCRIPT_PATH}/common.sh"
 
 if [ -n "${DESTROY-}" ]; then
-  export TF_CLI_ARGS_plan="-destroy"
+  if [ -n "${TF_CLI_ARGS_plan-}" ] && ! grep -q "destroy" <<<"${TF_CLI_ARGS_plan}"; then
+    TF_CLI_ARGS_plan="${TF_CLI_ARGS_plan} -destroy"
+  else
+    export TF_CLI_ARGS_plan="-destroy"
+  fi
 fi
 
 function check_workspace() {
@@ -79,10 +83,6 @@ function terraform_plan() {
   # therefore we capture the output so our function doesn't cause a script to terminate if the caller has `set -e`
   EXIT_CODE=0
   terraform plan -detailed-exitcode -out="${plan_location}" || EXIT_CODE=$?
-
-  if [[ ${EXIT_CODE} = 2 ]]; then
-    terraform show "${plan_location}"
-  fi
 
   popd || exit "${ERROR_CHANGE_DIR}"
 

--- a/dev/preview/workflow/preview/deploy-harvester.sh
+++ b/dev/preview/workflow/preview/deploy-harvester.sh
@@ -14,12 +14,12 @@ import "terraform.sh"
 
 PROJECT_ROOT=$(realpath "${SCRIPT_PATH}/../../../../")
 
-if [[ -n ${WERFT_HOST+x} ]]; then
-  TF_CLI_ARGS="-input=false"
+if [[ -n ${WERFT_SERVICE_HOST+x} ]]; then
+  export TF_INPUT=0
   TF_IN_AUTOMATION=true
 fi
 
-WORKSPACE="${TF_VAR_preview_name:-}"
+WORKSPACE="${TF_VAR_preview_name:-$WORKSPACE}"
 TARGET_DIR="${PROJECT_ROOT}/dev/preview/infrastructure/harvester"
 # Setting the TF_DATA_DIR is advisable if we set the PLAN_LOCATION in a different place than the dir with the tf
 TF_DATA_DIR="${TARGET_DIR}"
@@ -36,14 +36,23 @@ terraform_init
 PLAN_EXIT_CODE=0
 terraform_plan || PLAN_EXIT_CODE=$?
 
-# If there are changes
-if [[ ${PLAN_EXIT_CODE} == 2 ]]; then
+case ${PLAN_EXIT_CODE} in
+0)
+  log_success "No changes to the plan"
+  exit 0
+  ;;
+1)
+  log_error "Terraform plan failed"
+  exit "${ERROR_PLAN_FAIL}"
+  ;;
+2)
   # If we're NOT in werft, ask if we want to apply the plan
-  if [ -z ${WERFT_HOST+x} ]; then
+  if [ -z ${WERFT_SERVICE_HOST+x} ]; then
     ask "Do you want to apply the plan?"
   fi
   terraform_apply
-fi
+  ;;
+esac
 
 if [ -n "${DESTROY-}" ] && [ -n "${WORKSPACE}" ]; then
   pushd "${TARGET_DIR}"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This PR executes the TF workflow introduced in https://github.com/gitpod-io/gitpod/pull/12981 and https://github.com/gitpod-io/gitpod/pull/13319 in the context of werft.

Create job: https://werft.gitpod-dev.com/job/gitpod-custom-aa-preview-tf-werft-2.35
Delete job: https://werft.gitpod-dev.com/job/gitpod-custom-aa-preview-tf-werft-2.36

Will remove the manifests at a following PR.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/ops/issues/5224

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
