### PR TITLE
[usage] Add GetStripeCustomer to BillingService

### DIFF
--- a/components/usage-api/go/v1/billing.pb.go
+++ b/components/usage-api/go/v1/billing.pb.go
@@ -270,6 +270,189 @@ func (*CancelSubscriptionResponse) Descriptor() ([]byte, []int) {
 	return file_usage_v1_billing_proto_rawDescGZIP(), []int{5}
 }
 
+type GetStripeCustomerRequest struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	// Types that are assignable to Identifier:
+	//
+	//	*GetStripeCustomerRequest_AttributionId
+	//	*GetStripeCustomerRequest_StripeCustomerId
+	Identifier isGetStripeCustomerRequest_Identifier `protobuf_oneof:"identifier"`
+}
+
+func (x *GetStripeCustomerRequest) Reset() {
+	*x = GetStripeCustomerRequest{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_usage_v1_billing_proto_msgTypes[6]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *GetStripeCustomerRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetStripeCustomerRequest) ProtoMessage() {}
+
+func (x *GetStripeCustomerRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_usage_v1_billing_proto_msgTypes[6]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetStripeCustomerRequest.ProtoReflect.Descriptor instead.
+func (*GetStripeCustomerRequest) Descriptor() ([]byte, []int) {
+	return file_usage_v1_billing_proto_rawDescGZIP(), []int{6}
+}
+
+func (m *GetStripeCustomerRequest) GetIdentifier() isGetStripeCustomerRequest_Identifier {
+	if m != nil {
+		return m.Identifier
+	}
+	return nil
+}
+
+func (x *GetStripeCustomerRequest) GetAttributionId() string {
+	if x, ok := x.GetIdentifier().(*GetStripeCustomerRequest_AttributionId); ok {
+		return x.AttributionId
+	}
+	return ""
+}
+
+func (x *GetStripeCustomerRequest) GetStripeCustomerId() string {
+	if x, ok := x.GetIdentifier().(*GetStripeCustomerRequest_StripeCustomerId); ok {
+		return x.StripeCustomerId
+	}
+	return ""
+}
+
+type isGetStripeCustomerRequest_Identifier interface {
+	isGetStripeCustomerRequest_Identifier()
+}
+
+type GetStripeCustomerRequest_AttributionId struct {
+	AttributionId string `protobuf:"bytes,1,opt,name=attribution_id,json=attributionId,proto3,oneof"`
+}
+
+type GetStripeCustomerRequest_StripeCustomerId struct {
+	StripeCustomerId string `protobuf:"bytes,2,opt,name=stripe_customer_id,json=stripeCustomerId,proto3,oneof"`
+}
+
+func (*GetStripeCustomerRequest_AttributionId) isGetStripeCustomerRequest_Identifier() {}
+
+func (*GetStripeCustomerRequest_StripeCustomerId) isGetStripeCustomerRequest_Identifier() {}
+
+type GetStripeCustomerResponse struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	Customer      *StripeCustomer `protobuf:"bytes,1,opt,name=customer,proto3" json:"customer,omitempty"`
+	AttributionId string          `protobuf:"bytes,2,opt,name=attribution_id,json=attributionId,proto3" json:"attribution_id,omitempty"`
+}
+
+func (x *GetStripeCustomerResponse) Reset() {
+	*x = GetStripeCustomerResponse{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_usage_v1_billing_proto_msgTypes[7]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *GetStripeCustomerResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetStripeCustomerResponse) ProtoMessage() {}
+
+func (x *GetStripeCustomerResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_usage_v1_billing_proto_msgTypes[7]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetStripeCustomerResponse.ProtoReflect.Descriptor instead.
+func (*GetStripeCustomerResponse) Descriptor() ([]byte, []int) {
+	return file_usage_v1_billing_proto_rawDescGZIP(), []int{7}
+}
+
+func (x *GetStripeCustomerResponse) GetCustomer() *StripeCustomer {
+	if x != nil {
+		return x.Customer
+	}
+	return nil
+}
+
+func (x *GetStripeCustomerResponse) GetAttributionId() string {
+	if x != nil {
+		return x.AttributionId
+	}
+	return ""
+}
+
+type StripeCustomer struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+}
+
+func (x *StripeCustomer) Reset() {
+	*x = StripeCustomer{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_usage_v1_billing_proto_msgTypes[8]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *StripeCustomer) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*StripeCustomer) ProtoMessage() {}
+
+func (x *StripeCustomer) ProtoReflect() protoreflect.Message {
+	mi := &file_usage_v1_billing_proto_msgTypes[8]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use StripeCustomer.ProtoReflect.Descriptor instead.
+func (*StripeCustomer) Descriptor() ([]byte, []int) {
+	return file_usage_v1_billing_proto_rawDescGZIP(), []int{8}
+}
+
+func (x *StripeCustomer) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
 var File_usage_v1_billing_proto protoreflect.FileDescriptor
 
 var file_usage_v1_billing_proto_rawDesc = []byte{
@@ -290,7 +473,25 @@ var file_usage_v1_billing_proto_rawDesc = []byte{
 	0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x0e, 0x73, 0x75, 0x62, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74,
 	0x69, 0x6f, 0x6e, 0x49, 0x64, 0x22, 0x1c, 0x0a, 0x1a, 0x43, 0x61, 0x6e, 0x63, 0x65, 0x6c, 0x53,
 	0x75, 0x62, 0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x65, 0x73, 0x70, 0x6f,
-	0x6e, 0x73, 0x65, 0x32, 0xad, 0x02, 0x0a, 0x0e, 0x42, 0x69, 0x6c, 0x6c, 0x69, 0x6e, 0x67, 0x53,
+	0x6e, 0x73, 0x65, 0x22, 0x81, 0x01, 0x0a, 0x18, 0x47, 0x65, 0x74, 0x53, 0x74, 0x72, 0x69, 0x70,
+	0x65, 0x43, 0x75, 0x73, 0x74, 0x6f, 0x6d, 0x65, 0x72, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74,
+	0x12, 0x27, 0x0a, 0x0e, 0x61, 0x74, 0x74, 0x72, 0x69, 0x62, 0x75, 0x74, 0x69, 0x6f, 0x6e, 0x5f,
+	0x69, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x48, 0x00, 0x52, 0x0d, 0x61, 0x74, 0x74, 0x72,
+	0x69, 0x62, 0x75, 0x74, 0x69, 0x6f, 0x6e, 0x49, 0x64, 0x12, 0x2e, 0x0a, 0x12, 0x73, 0x74, 0x72,
+	0x69, 0x70, 0x65, 0x5f, 0x63, 0x75, 0x73, 0x74, 0x6f, 0x6d, 0x65, 0x72, 0x5f, 0x69, 0x64, 0x18,
+	0x02, 0x20, 0x01, 0x28, 0x09, 0x48, 0x00, 0x52, 0x10, 0x73, 0x74, 0x72, 0x69, 0x70, 0x65, 0x43,
+	0x75, 0x73, 0x74, 0x6f, 0x6d, 0x65, 0x72, 0x49, 0x64, 0x42, 0x0c, 0x0a, 0x0a, 0x69, 0x64, 0x65,
+	0x6e, 0x74, 0x69, 0x66, 0x69, 0x65, 0x72, 0x22, 0x78, 0x0a, 0x19, 0x47, 0x65, 0x74, 0x53, 0x74,
+	0x72, 0x69, 0x70, 0x65, 0x43, 0x75, 0x73, 0x74, 0x6f, 0x6d, 0x65, 0x72, 0x52, 0x65, 0x73, 0x70,
+	0x6f, 0x6e, 0x73, 0x65, 0x12, 0x34, 0x0a, 0x08, 0x63, 0x75, 0x73, 0x74, 0x6f, 0x6d, 0x65, 0x72,
+	0x18, 0x01, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x18, 0x2e, 0x75, 0x73, 0x61, 0x67, 0x65, 0x2e, 0x76,
+	0x31, 0x2e, 0x53, 0x74, 0x72, 0x69, 0x70, 0x65, 0x43, 0x75, 0x73, 0x74, 0x6f, 0x6d, 0x65, 0x72,
+	0x52, 0x08, 0x63, 0x75, 0x73, 0x74, 0x6f, 0x6d, 0x65, 0x72, 0x12, 0x25, 0x0a, 0x0e, 0x61, 0x74,
+	0x74, 0x72, 0x69, 0x62, 0x75, 0x74, 0x69, 0x6f, 0x6e, 0x5f, 0x69, 0x64, 0x18, 0x02, 0x20, 0x01,
+	0x28, 0x09, 0x52, 0x0d, 0x61, 0x74, 0x74, 0x72, 0x69, 0x62, 0x75, 0x74, 0x69, 0x6f, 0x6e, 0x49,
+	0x64, 0x22, 0x20, 0x0a, 0x0e, 0x53, 0x74, 0x72, 0x69, 0x70, 0x65, 0x43, 0x75, 0x73, 0x74, 0x6f,
+	0x6d, 0x65, 0x72, 0x12, 0x0e, 0x0a, 0x02, 0x69, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52,
+	0x02, 0x69, 0x64, 0x32, 0x8d, 0x03, 0x0a, 0x0e, 0x42, 0x69, 0x6c, 0x6c, 0x69, 0x6e, 0x67, 0x53,
 	0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x12, 0x5e, 0x0a, 0x11, 0x52, 0x65, 0x63, 0x6f, 0x6e, 0x63,
 	0x69, 0x6c, 0x65, 0x49, 0x6e, 0x76, 0x6f, 0x69, 0x63, 0x65, 0x73, 0x12, 0x22, 0x2e, 0x75, 0x73,
 	0x61, 0x67, 0x65, 0x2e, 0x76, 0x31, 0x2e, 0x52, 0x65, 0x63, 0x6f, 0x6e, 0x63, 0x69, 0x6c, 0x65,
@@ -309,6 +510,12 @@ var file_usage_v1_billing_proto_rawDesc = []byte{
 	0x74, 0x69, 0x6f, 0x6e, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x1a, 0x24, 0x2e, 0x75, 0x73,
 	0x61, 0x67, 0x65, 0x2e, 0x76, 0x31, 0x2e, 0x43, 0x61, 0x6e, 0x63, 0x65, 0x6c, 0x53, 0x75, 0x62,
 	0x73, 0x63, 0x72, 0x69, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73,
+	0x65, 0x22, 0x00, 0x12, 0x5e, 0x0a, 0x11, 0x47, 0x65, 0x74, 0x53, 0x74, 0x72, 0x69, 0x70, 0x65,
+	0x43, 0x75, 0x73, 0x74, 0x6f, 0x6d, 0x65, 0x72, 0x12, 0x22, 0x2e, 0x75, 0x73, 0x61, 0x67, 0x65,
+	0x2e, 0x76, 0x31, 0x2e, 0x47, 0x65, 0x74, 0x53, 0x74, 0x72, 0x69, 0x70, 0x65, 0x43, 0x75, 0x73,
+	0x74, 0x6f, 0x6d, 0x65, 0x72, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x1a, 0x23, 0x2e, 0x75,
+	0x73, 0x61, 0x67, 0x65, 0x2e, 0x76, 0x31, 0x2e, 0x47, 0x65, 0x74, 0x53, 0x74, 0x72, 0x69, 0x70,
+	0x65, 0x43, 0x75, 0x73, 0x74, 0x6f, 0x6d, 0x65, 0x72, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73,
 	0x65, 0x22, 0x00, 0x42, 0x2a, 0x5a, 0x28, 0x67, 0x69, 0x74, 0x68, 0x75, 0x62, 0x2e, 0x63, 0x6f,
 	0x6d, 0x2f, 0x67, 0x69, 0x74, 0x70, 0x6f, 0x64, 0x2d, 0x69, 0x6f, 0x2f, 0x67, 0x69, 0x74, 0x70,
 	0x6f, 0x64, 0x2f, 0x75, 0x73, 0x61, 0x67, 0x65, 0x2d, 0x61, 0x70, 0x69, 0x2f, 0x76, 0x31, 0x62,
@@ -327,7 +534,7 @@ func file_usage_v1_billing_proto_rawDescGZIP() []byte {
 	return file_usage_v1_billing_proto_rawDescData
 }
 
-var file_usage_v1_billing_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
+var file_usage_v1_billing_proto_msgTypes = make([]protoimpl.MessageInfo, 9)
 var file_usage_v1_billing_proto_goTypes = []interface{}{
 	(*ReconcileInvoicesRequest)(nil),   // 0: usage.v1.ReconcileInvoicesRequest
 	(*ReconcileInvoicesResponse)(nil),  // 1: usage.v1.ReconcileInvoicesResponse
@@ -335,19 +542,25 @@ var file_usage_v1_billing_proto_goTypes = []interface{}{
 	(*FinalizeInvoiceResponse)(nil),    // 3: usage.v1.FinalizeInvoiceResponse
 	(*CancelSubscriptionRequest)(nil),  // 4: usage.v1.CancelSubscriptionRequest
 	(*CancelSubscriptionResponse)(nil), // 5: usage.v1.CancelSubscriptionResponse
+	(*GetStripeCustomerRequest)(nil),   // 6: usage.v1.GetStripeCustomerRequest
+	(*GetStripeCustomerResponse)(nil),  // 7: usage.v1.GetStripeCustomerResponse
+	(*StripeCustomer)(nil),             // 8: usage.v1.StripeCustomer
 }
 var file_usage_v1_billing_proto_depIdxs = []int32{
-	0, // 0: usage.v1.BillingService.ReconcileInvoices:input_type -> usage.v1.ReconcileInvoicesRequest
-	2, // 1: usage.v1.BillingService.FinalizeInvoice:input_type -> usage.v1.FinalizeInvoiceRequest
-	4, // 2: usage.v1.BillingService.CancelSubscription:input_type -> usage.v1.CancelSubscriptionRequest
-	1, // 3: usage.v1.BillingService.ReconcileInvoices:output_type -> usage.v1.ReconcileInvoicesResponse
-	3, // 4: usage.v1.BillingService.FinalizeInvoice:output_type -> usage.v1.FinalizeInvoiceResponse
-	5, // 5: usage.v1.BillingService.CancelSubscription:output_type -> usage.v1.CancelSubscriptionResponse
-	3, // [3:6] is the sub-list for method output_type
-	0, // [0:3] is the sub-list for method input_type
-	0, // [0:0] is the sub-list for extension type_name
-	0, // [0:0] is the sub-list for extension extendee
-	0, // [0:0] is the sub-list for field type_name
+	8, // 0: usage.v1.GetStripeCustomerResponse.customer:type_name -> usage.v1.StripeCustomer
+	0, // 1: usage.v1.BillingService.ReconcileInvoices:input_type -> usage.v1.ReconcileInvoicesRequest
+	2, // 2: usage.v1.BillingService.FinalizeInvoice:input_type -> usage.v1.FinalizeInvoiceRequest
+	4, // 3: usage.v1.BillingService.CancelSubscription:input_type -> usage.v1.CancelSubscriptionRequest
+	6, // 4: usage.v1.BillingService.GetStripeCustomer:input_type -> usage.v1.GetStripeCustomerRequest
+	1, // 5: usage.v1.BillingService.ReconcileInvoices:output_type -> usage.v1.ReconcileInvoicesResponse
+	3, // 6: usage.v1.BillingService.FinalizeInvoice:output_type -> usage.v1.FinalizeInvoiceResponse
+	5, // 7: usage.v1.BillingService.CancelSubscription:output_type -> usage.v1.CancelSubscriptionResponse
+	7, // 8: usage.v1.BillingService.GetStripeCustomer:output_type -> usage.v1.GetStripeCustomerResponse
+	5, // [5:9] is the sub-list for method output_type
+	1, // [1:5] is the sub-list for method input_type
+	1, // [1:1] is the sub-list for extension type_name
+	1, // [1:1] is the sub-list for extension extendee
+	0, // [0:1] is the sub-list for field type_name
 }
 
 func init() { file_usage_v1_billing_proto_init() }
@@ -428,6 +641,46 @@ func file_usage_v1_billing_proto_init() {
 				return nil
 			}
 		}
+		file_usage_v1_billing_proto_msgTypes[6].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*GetStripeCustomerRequest); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_usage_v1_billing_proto_msgTypes[7].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*GetStripeCustomerResponse); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_usage_v1_billing_proto_msgTypes[8].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*StripeCustomer); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+	}
+	file_usage_v1_billing_proto_msgTypes[6].OneofWrappers = []interface{}{
+		(*GetStripeCustomerRequest_AttributionId)(nil),
+		(*GetStripeCustomerRequest_StripeCustomerId)(nil),
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
@@ -435,7 +688,7 @@ func file_usage_v1_billing_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: file_usage_v1_billing_proto_rawDesc,
 			NumEnums:      0,
-			NumMessages:   6,
+			NumMessages:   9,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/components/usage-api/go/v1/billing_grpc.pb.go
+++ b/components/usage-api/go/v1/billing_grpc.pb.go
@@ -35,6 +35,8 @@ type BillingServiceClient interface {
 	// CancelSubscription cancels a stripe subscription in our system
 	// Called by a stripe webhook
 	CancelSubscription(ctx context.Context, in *CancelSubscriptionRequest, opts ...grpc.CallOption) (*CancelSubscriptionResponse, error)
+	// GetStripeCustomer retrieves a Stripe Customer
+	GetStripeCustomer(ctx context.Context, in *GetStripeCustomerRequest, opts ...grpc.CallOption) (*GetStripeCustomerResponse, error)
 }
 
 type billingServiceClient struct {
@@ -72,6 +74,15 @@ func (c *billingServiceClient) CancelSubscription(ctx context.Context, in *Cance
 	return out, nil
 }
 
+func (c *billingServiceClient) GetStripeCustomer(ctx context.Context, in *GetStripeCustomerRequest, opts ...grpc.CallOption) (*GetStripeCustomerResponse, error) {
+	out := new(GetStripeCustomerResponse)
+	err := c.cc.Invoke(ctx, "/usage.v1.BillingService/GetStripeCustomer", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // BillingServiceServer is the server API for BillingService service.
 // All implementations must embed UnimplementedBillingServiceServer
 // for forward compatibility
@@ -85,6 +96,8 @@ type BillingServiceServer interface {
 	// CancelSubscription cancels a stripe subscription in our system
 	// Called by a stripe webhook
 	CancelSubscription(context.Context, *CancelSubscriptionRequest) (*CancelSubscriptionResponse, error)
+	// GetStripeCustomer retrieves a Stripe Customer
+	GetStripeCustomer(context.Context, *GetStripeCustomerRequest) (*GetStripeCustomerResponse, error)
 	mustEmbedUnimplementedBillingServiceServer()
 }
 
@@ -100,6 +113,9 @@ func (UnimplementedBillingServiceServer) FinalizeInvoice(context.Context, *Final
 }
 func (UnimplementedBillingServiceServer) CancelSubscription(context.Context, *CancelSubscriptionRequest) (*CancelSubscriptionResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method CancelSubscription not implemented")
+}
+func (UnimplementedBillingServiceServer) GetStripeCustomer(context.Context, *GetStripeCustomerRequest) (*GetStripeCustomerResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetStripeCustomer not implemented")
 }
 func (UnimplementedBillingServiceServer) mustEmbedUnimplementedBillingServiceServer() {}
 
@@ -168,6 +184,24 @@ func _BillingService_CancelSubscription_Handler(srv interface{}, ctx context.Con
 	return interceptor(ctx, in, info, handler)
 }
 
+func _BillingService_GetStripeCustomer_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetStripeCustomerRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(BillingServiceServer).GetStripeCustomer(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/usage.v1.BillingService/GetStripeCustomer",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(BillingServiceServer).GetStripeCustomer(ctx, req.(*GetStripeCustomerRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // BillingService_ServiceDesc is the grpc.ServiceDesc for BillingService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -186,6 +220,10 @@ var BillingService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "CancelSubscription",
 			Handler:    _BillingService_CancelSubscription_Handler,
+		},
+		{
+			MethodName: "GetStripeCustomer",
+			Handler:    _BillingService_GetStripeCustomer_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/components/usage-api/typescript/src/usage/v1/billing.pb.ts
+++ b/components/usage-api/typescript/src/usage/v1/billing.pb.ts
@@ -30,6 +30,20 @@ export interface CancelSubscriptionRequest {
 export interface CancelSubscriptionResponse {
 }
 
+export interface GetStripeCustomerRequest {
+  attributionId: string | undefined;
+  stripeCustomerId: string | undefined;
+}
+
+export interface GetStripeCustomerResponse {
+  customer: StripeCustomer | undefined;
+  attributionId: string;
+}
+
+export interface StripeCustomer {
+  id: string;
+}
+
 function createBaseReconcileInvoicesRequest(): ReconcileInvoicesRequest {
   return {};
 }
@@ -280,6 +294,172 @@ export const CancelSubscriptionResponse = {
   },
 };
 
+function createBaseGetStripeCustomerRequest(): GetStripeCustomerRequest {
+  return { attributionId: undefined, stripeCustomerId: undefined };
+}
+
+export const GetStripeCustomerRequest = {
+  encode(message: GetStripeCustomerRequest, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.attributionId !== undefined) {
+      writer.uint32(10).string(message.attributionId);
+    }
+    if (message.stripeCustomerId !== undefined) {
+      writer.uint32(18).string(message.stripeCustomerId);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): GetStripeCustomerRequest {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseGetStripeCustomerRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.attributionId = reader.string();
+          break;
+        case 2:
+          message.stripeCustomerId = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): GetStripeCustomerRequest {
+    return {
+      attributionId: isSet(object.attributionId) ? String(object.attributionId) : undefined,
+      stripeCustomerId: isSet(object.stripeCustomerId) ? String(object.stripeCustomerId) : undefined,
+    };
+  },
+
+  toJSON(message: GetStripeCustomerRequest): unknown {
+    const obj: any = {};
+    message.attributionId !== undefined && (obj.attributionId = message.attributionId);
+    message.stripeCustomerId !== undefined && (obj.stripeCustomerId = message.stripeCustomerId);
+    return obj;
+  },
+
+  fromPartial(object: DeepPartial<GetStripeCustomerRequest>): GetStripeCustomerRequest {
+    const message = createBaseGetStripeCustomerRequest();
+    message.attributionId = object.attributionId ?? undefined;
+    message.stripeCustomerId = object.stripeCustomerId ?? undefined;
+    return message;
+  },
+};
+
+function createBaseGetStripeCustomerResponse(): GetStripeCustomerResponse {
+  return { customer: undefined, attributionId: "" };
+}
+
+export const GetStripeCustomerResponse = {
+  encode(message: GetStripeCustomerResponse, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.customer !== undefined) {
+      StripeCustomer.encode(message.customer, writer.uint32(10).fork()).ldelim();
+    }
+    if (message.attributionId !== "") {
+      writer.uint32(18).string(message.attributionId);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): GetStripeCustomerResponse {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseGetStripeCustomerResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.customer = StripeCustomer.decode(reader, reader.uint32());
+          break;
+        case 2:
+          message.attributionId = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): GetStripeCustomerResponse {
+    return {
+      customer: isSet(object.customer) ? StripeCustomer.fromJSON(object.customer) : undefined,
+      attributionId: isSet(object.attributionId) ? String(object.attributionId) : "",
+    };
+  },
+
+  toJSON(message: GetStripeCustomerResponse): unknown {
+    const obj: any = {};
+    message.customer !== undefined &&
+      (obj.customer = message.customer ? StripeCustomer.toJSON(message.customer) : undefined);
+    message.attributionId !== undefined && (obj.attributionId = message.attributionId);
+    return obj;
+  },
+
+  fromPartial(object: DeepPartial<GetStripeCustomerResponse>): GetStripeCustomerResponse {
+    const message = createBaseGetStripeCustomerResponse();
+    message.customer = (object.customer !== undefined && object.customer !== null)
+      ? StripeCustomer.fromPartial(object.customer)
+      : undefined;
+    message.attributionId = object.attributionId ?? "";
+    return message;
+  },
+};
+
+function createBaseStripeCustomer(): StripeCustomer {
+  return { id: "" };
+}
+
+export const StripeCustomer = {
+  encode(message: StripeCustomer, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.id !== "") {
+      writer.uint32(10).string(message.id);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): StripeCustomer {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseStripeCustomer();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.id = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): StripeCustomer {
+    return { id: isSet(object.id) ? String(object.id) : "" };
+  },
+
+  toJSON(message: StripeCustomer): unknown {
+    const obj: any = {};
+    message.id !== undefined && (obj.id = message.id);
+    return obj;
+  },
+
+  fromPartial(object: DeepPartial<StripeCustomer>): StripeCustomer {
+    const message = createBaseStripeCustomer();
+    message.id = object.id ?? "";
+    return message;
+  },
+};
+
 export type BillingServiceDefinition = typeof BillingServiceDefinition;
 export const BillingServiceDefinition = {
   name: "BillingService",
@@ -321,6 +501,15 @@ export const BillingServiceDefinition = {
       responseStream: false,
       options: {},
     },
+    /** GetStripeCustomer retrieves a Stripe Customer */
+    getStripeCustomer: {
+      name: "GetStripeCustomer",
+      requestType: GetStripeCustomerRequest,
+      requestStream: false,
+      responseType: GetStripeCustomerResponse,
+      responseStream: false,
+      options: {},
+    },
   },
 } as const;
 
@@ -349,6 +538,11 @@ export interface BillingServiceServiceImplementation<CallContextExt = {}> {
     request: CancelSubscriptionRequest,
     context: CallContext & CallContextExt,
   ): Promise<DeepPartial<CancelSubscriptionResponse>>;
+  /** GetStripeCustomer retrieves a Stripe Customer */
+  getStripeCustomer(
+    request: GetStripeCustomerRequest,
+    context: CallContext & CallContextExt,
+  ): Promise<DeepPartial<GetStripeCustomerResponse>>;
 }
 
 export interface BillingServiceClient<CallOptionsExt = {}> {
@@ -376,6 +570,11 @@ export interface BillingServiceClient<CallOptionsExt = {}> {
     request: DeepPartial<CancelSubscriptionRequest>,
     options?: CallOptions & CallOptionsExt,
   ): Promise<CancelSubscriptionResponse>;
+  /** GetStripeCustomer retrieves a Stripe Customer */
+  getStripeCustomer(
+    request: DeepPartial<GetStripeCustomerRequest>,
+    options?: CallOptions & CallOptionsExt,
+  ): Promise<GetStripeCustomerResponse>;
 }
 
 export interface DataLoaderOptions {

--- a/components/usage-api/usage/v1/billing.proto
+++ b/components/usage-api/usage/v1/billing.proto
@@ -16,6 +16,10 @@ service BillingService {
   // CancelSubscription cancels a stripe subscription in our system
   // Called by a stripe webhook
   rpc CancelSubscription(CancelSubscriptionRequest) returns (CancelSubscriptionResponse) {};
+
+  // GetStripeCustomer retrieves a Stripe Customer
+  rpc GetStripeCustomer(GetStripeCustomerRequest) returns (GetStripeCustomerResponse) {};
+
 }
 
 message ReconcileInvoicesRequest {}
@@ -34,4 +38,20 @@ message CancelSubscriptionRequest {
 }
 
 message CancelSubscriptionResponse {
+}
+
+message GetStripeCustomerRequest {
+  oneof identifier {
+    string attribution_id = 1;
+    string stripe_customer_id = 2;
+  }
+}
+
+message GetStripeCustomerResponse {
+  StripeCustomer customer = 1;
+  string attribution_id = 2;
+}
+
+message StripeCustomer {
+  string id = 1;
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This will allow us to move the lookup of customers to a single place and improve our ability to respond to it consistently.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Part of https://github.com/gitpod-io/gitpod/issues/13177

## How to test
<!-- Provide steps to test this PR -->
builds

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
