### PR TITLE
[self-hosted-preview] Support version specification in preview

### DIFF
--- a/.werft/jobs/build/job-config.ts
+++ b/.werft/jobs/build/job-config.ts
@@ -34,6 +34,7 @@ export interface JobConfig {
     workspaceFeatureFlags: string[];
     previewEnvironment: PreviewEnvironmentConfig;
     repository: Repository;
+    replicatedVersion: string;
     observability: Observability;
     withLargeVM: boolean;
 }
@@ -85,6 +86,7 @@ export function jobConfig(werft: Werft, context: any): JobConfig {
     const replicatedChannel = buildConfig["channel"];
     const cluster = buildConfig["cluster"];
     const withSelfHostedPreview = "with-sh-preview" in buildConfig;
+    const replicatedVersion = withSelfHostedPreview ? buildConfig["version"] : "";
     const publishToNpm = "publish-to-npm" in buildConfig || mainBuild;
     const publishToJBMarketplace = "publish-to-jb-marketplace" in buildConfig || mainBuild;
     const publishToKots = "publish-to-kots" in buildConfig || withSelfHostedPreview || mainBuild;
@@ -142,6 +144,7 @@ export function jobConfig(werft: Werft, context: any): JobConfig {
         publishToNpm,
         publishToKots,
         replicatedChannel,
+        replicatedVersion,
         repository,
         retag,
         storage,

--- a/install/tests/Makefile
+++ b/install/tests/Makefile
@@ -226,7 +226,7 @@ endif
 
 KOTS_KONFIG := "./manifests/kots-config.yaml"
 
-get-base-config: get-github-config
+get-base-config:
 	export DOMAIN=${TF_VAR_domain} && \
 	export PATCH=$$(cat ${config_patch}) || export PATCH="" && \
 	envsubst < ${KOTS_KONFIG} > tmp_config.yml


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PR adds an extra flag `version` to the werft command to spin up self-hosted preview environments. Considering different teams might want to test specific versions of Gitpod self-hosted, this would be an improvement in experience. This PR also fixes a small bug that ran integration tests when running preview.
Once the PR is merged, if the user wants to create a GKE cluster with Gitpod 2022.8.0 installed, they can simply do:
```
# as a PR comment
/werft run with-sh-preview version=2022.8.0 channel=stable
# from a gitpod workspace
werft run github -j .werft/build.yaml -a with-sh-preview=true -a channel=stable -a version=2022.8.0
```
Considering that the users were having issues finding the werft job that gets spun up from the first job, I have also added a URL to the new werft job in the results tab of the first.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
You can try the following command:
```
werft run github -j .werft/build.yaml -a with-sh-preview=true -a channel=stable -a version=2022.8.0
```
(You cannot test it as PR comment yet since this change is not in main yet)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
