### PR TITLE
Specify a restartPolicy so job pods are never restarted

### DIFF
--- a/.werft/aks-installer-tests.yaml
+++ b/.werft/aks-installer-tests.yaml
@@ -41,6 +41,7 @@ args:
   required: false
 pod:
   serviceAccount: werft
+  restartPolicy: Never
   affinity:
   nodeAffinity:
     requiredDuringSchedulingIgnoredDuringExecution:

--- a/.werft/build.yaml
+++ b/.werft/build.yaml
@@ -1,6 +1,7 @@
 # debug using `werft run github -f -s .werft/build.js -j .werft/build.yaml -a debug=true`
 pod:
   serviceAccount: werft
+  restartPolicy: Never
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/.werft/cleanup-installer-tests.yaml
+++ b/.werft/cleanup-installer-tests.yaml
@@ -1,6 +1,7 @@
 # debug using `werft run github -f -s .werft/installer-tests.ts -j .werft/self-hosted-installer-tests.yaml -a debug=true`
 pod:
   serviceAccount: werft
+  restartPolicy: Never
   affinity:
   nodeAffinity:
     requiredDuringSchedulingIgnoredDuringExecution:

--- a/.werft/debug.yaml
+++ b/.werft/debug.yaml
@@ -1,6 +1,7 @@
 # debug using `werft run github -f -s .werft/build.js -j .werft/build.yaml -a debug=true`
 pod:
   serviceAccount: werft
+  restartPolicy: Never
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/.werft/eks-installer-tests.yaml
+++ b/.werft/eks-installer-tests.yaml
@@ -41,6 +41,7 @@ args:
   required: false
 pod:
   serviceAccount: werft
+  restartPolicy: Never
   affinity:
   nodeAffinity:
     requiredDuringSchedulingIgnoredDuringExecution:

--- a/.werft/gke-installer-tests.yaml
+++ b/.werft/gke-installer-tests.yaml
@@ -41,6 +41,7 @@ args:
   required: false
 pod:
   serviceAccount: werft
+  restartPolicy: Never
   affinity:
   nodeAffinity:
     requiredDuringSchedulingIgnoredDuringExecution:

--- a/.werft/ide-integration-tests-startup.yaml
+++ b/.werft/ide-integration-tests-startup.yaml
@@ -1,5 +1,6 @@
 pod:
   serviceAccount: werft
+  restartPolicy: Never
   nodeSelector:
     dev/workload: builds
   imagePullSecrets:

--- a/.werft/k3s-installer-tests.yaml
+++ b/.werft/k3s-installer-tests.yaml
@@ -41,6 +41,7 @@ args:
   required: false
 pod:
   serviceAccount: werft
+  restartPolicy: Never
   affinity:
   nodeAffinity:
     requiredDuringSchedulingIgnoredDuringExecution:

--- a/.werft/platform-delete-preview-environment.yaml
+++ b/.werft/platform-delete-preview-environment.yaml
@@ -1,5 +1,6 @@
 pod:
   serviceAccount: werft
+  restartPolicy: Never
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/.werft/platform-delete-preview-environments-cron.yaml
+++ b/.werft/platform-delete-preview-environments-cron.yaml
@@ -1,5 +1,6 @@
 pod:
   serviceAccount: werft
+  restartPolicy: Never
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/.werft/platform-trigger-artificial-job.yaml
+++ b/.werft/platform-trigger-artificial-job.yaml
@@ -7,6 +7,7 @@
 #
 pod:
   serviceAccount: werft
+  restartPolicy: Never
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/.werft/platform-trigger-werft-cleanup.yaml
+++ b/.werft/platform-trigger-werft-cleanup.yaml
@@ -5,6 +5,7 @@
 #
 pod:
   serviceAccount: werft
+  restartPolicy: Never
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/.werft/workspace-run-integration-tests.yaml
+++ b/.werft/workspace-run-integration-tests.yaml
@@ -5,6 +5,7 @@
 #
 pod:
   serviceAccount: werft
+  restartPolicy: Never
   nodeSelector:
     dev/workload: builds
   imagePullSecrets:


### PR DESCRIPTION
## Description

This sets the PodSpec `restartPolicy` to `Never` for all Werft jobs.  See [this investigation](https://github.com/gitpod-io/ops/issues/5720#issuecomment-1269949085) for details, but the tl;dr is that Werft uses `OnFailure` by default and is supposed to handle pod restarts but there might be edge cases with bugs in it - rather than dive into Werft to fix the issues I'm using `restartPolicy` `Never` explicitly - that's the quickest way to see if our issues disappear ☺️

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

If this is indeed the cause, then this:

Fixes #12795 
Fixes https://github.com/gitpod-io/ops/issues/5720

## How to test
<!-- Provide steps to test this PR -->

I won't test every single job - so I'm just triggering the build job to see that I didn't have a typo or indentation issue with the policy

```sh
werft job run github
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
