### PR TITLE
Add .tar extension to downloaded workspace

### DIFF
--- a/components/dashboard/src/components/ContextMenu.tsx
+++ b/components/dashboard/src/components/ContextMenu.tsx
@@ -27,6 +27,7 @@ export interface ContextMenuEntry {
     href?: string;
     link?: string;
     target?: HTMLAttributeAnchorTarget;
+    download?: string;
 }
 
 function ContextMenu(props: ContextMenuProps) {
@@ -138,7 +139,13 @@ function ContextMenu(props: ContextMenuProps) {
                                 );
                             } else if (e.href) {
                                 return (
-                                    <a key={key} href={e.href} onClick={e.onClick} target={e.target}>
+                                    <a
+                                        key={key}
+                                        download={e.download}
+                                        href={e.href}
+                                        onClick={e.onClick}
+                                        target={e.target}
+                                    >
                                         {entry}
                                     </a>
                                 );

--- a/components/dashboard/src/workspaces/WorkspaceEntry.tsx
+++ b/components/dashboard/src/workspaces/WorkspaceEntry.tsx
@@ -92,6 +92,7 @@ export function WorkspaceEntry({ desc, model, isAdmin, stopWorkspace }: Props) {
     menuEntries.push({
         title: "Download",
         href: downloadURL,
+        download: `${ws.id}.tar`,
     });
     if (!isAdmin) {
         menuEntries.push(


### PR DESCRIPTION
## Description
Currently when downloading a workspace it misses the `.tar` file extension. This uses the html native `download` property to add the `.tar` extension

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #7955

## How to test
(taken from #7955)
- Go to https://gitpod.io/workspaces
- Toggle the right options menu of a workspace in the list
- Select `Download Workspace`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Fixed missing .tar file extension from a downloaded workspace
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
