### PR TITLE
[jetbrains]: force initialize maven project

### DIFF
--- a/components/ide/jetbrains/backend-plugin/gradle.properties
+++ b/components/ide/jetbrains/backend-plugin/gradle.properties
@@ -10,7 +10,7 @@ platformType=IU
 platformDownloadSources=true
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
-platformPlugins=Git4Idea, org.jetbrains.plugins.terminal, com.jetbrains.codeWithMe
+platformPlugins=Git4Idea, org.jetbrains.plugins.terminal, com.jetbrains.codeWithMe, org.jetbrains.idea.maven
 # Opt-out flag for bundling Kotlin standard library.
 # See https://plugins.jetbrains.com/docs/intellij/kotlin.html#kotlin-standard-library for details.
 kotlin.stdlib.default.dependency=false

--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/maven/GitpodMavenProjectManager.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/maven/GitpodMavenProjectManager.kt
@@ -1,0 +1,19 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package io.gitpod.jetbrains.remote.maven
+
+import com.intellij.openapi.project.Project
+import org.jetbrains.idea.maven.project.MavenProjectsManager
+
+class GitpodMavenProjectManager(
+        private val project: Project
+) {
+
+    init {
+        // force initialize maven project
+        MavenProjectsManager.getInstance(project)
+    }
+
+}

--- a/components/ide/jetbrains/backend-plugin/src/main/resources/META-INF/maven.xml
+++ b/components/ide/jetbrains/backend-plugin/src/main/resources/META-INF/maven.xml
@@ -1,0 +1,11 @@
+<!--
+ Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ Licensed under the GNU Affero General Public License (AGPL).
+ See License-AGPL.txt in the project root for license information.
+-->
+<!--suppress PluginXmlValidity -->
+<idea-plugin>
+    <extensions defaultExtensionNs="com.intellij">
+        <projectService serviceImplementation="io.gitpod.jetbrains.remote.maven.GitpodMavenProjectManager" preload="true"/>
+    </extensions>
+</idea-plugin>

--- a/components/ide/jetbrains/backend-plugin/src/main/resources/META-INF/plugin.xml
+++ b/components/ide/jetbrains/backend-plugin/src/main/resources/META-INF/plugin.xml
@@ -15,6 +15,7 @@
     <!-- Product and plugin compatibility requirements -->
     <!-- https://plugins.jetbrains.com/docs/intellij/plugin-compatibility.html -->
     <depends>com.intellij.modules.platform</depends>
+    <depends optional="true" config-file="maven.xml">org.jetbrains.idea.maven</depends>
     <dependencies>
         <plugin id="Git4Idea"/>
         <plugin id="org.jetbrains.plugins.terminal"/>


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

to work around initialization after warmup in prebuilds

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
