### PR TITLE
[db] Remove `uid` field from entity

### DIFF
--- a/components/gitpod-db/src/typeorm/entity/db-oauth-auth-code.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-oauth-auth-code.ts
@@ -7,7 +7,6 @@
 import { CodeChallengeMethod, OAuthAuthCode, OAuthClient, OAuthScope } from "@jmondi/oauth2-server";
 import { Column, Entity, JoinColumn, ManyToOne, PrimaryColumn } from "typeorm";
 import { Transformer } from "../transformer";
-import { TypeORM } from "../typeorm";
 import { DBUser } from "./db-user";
 
 @Entity({ name: "d_b_oauth_auth_code_entry" })
@@ -64,7 +63,4 @@ export class DBOAuthAuthCodeEntry implements OAuthAuthCode {
         nullable: false,
     })
     scopes: OAuthScope[];
-
-    @Column(TypeORM.UUID_COLUMN_TYPE)
-    uid: string;
 }


### PR DESCRIPTION
## Description

Remove the `uid` field from the oauth auth code entity.

This should have been done as part of https://github.com/gitpod-io/gitpod/pull/13644.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of #9198 

## How to test
<!-- Provide steps to test this PR -->

Make sure that a user can connect with VS Code Desktop and IntelliJ IDEA.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
