### PR TITLE
[public-api] Authentication interceptors for connect API

### DIFF
--- a/components/public-api-server/go.sum
+++ b/components/public-api-server/go.sum
@@ -44,10 +44,10 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/cenkalti/backoff/v4 v4.1.3 h1:cFAlzYUlVYDysBEH2T5hyJZMh3+5+WCBvSnK6Q8UtC4=
-github.com/cenkalti/backoff/v4 v4.1.3/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/bufbuild/connect-go v1.0.0 h1:htSflKUT8y1jxhoPhPYTZMrsY3ipUXjjrbcZR5O2cVo=
 github.com/bufbuild/connect-go v1.0.0/go.mod h1:9iNvh/NOsfhNBUH5CtvXeVUskQO1xsrEviH7ZArwZ3I=
+github.com/cenkalti/backoff/v4 v4.1.3 h1:cFAlzYUlVYDysBEH2T5hyJZMh3+5+WCBvSnK6Q8UtC4=
+github.com/cenkalti/backoff/v4 v4.1.3/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.1.2 h1:YRXhKfTDauu4ajMg1TPgFO5jnlC2HCbmLXMcTG5cbYE=

--- a/components/public-api-server/pkg/auth/auth.go
+++ b/components/public-api-server/pkg/auth/auth.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package auth
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+var (
+	NoAccessToken      = errors.New("missing access token")
+	InvalidAccessToken = errors.New("invalid access token")
+)
+
+const bearerPrefix = "Bearer "
+const authorizationHeaderKey = "Authorization"
+
+func BearerTokenFromHeaders(h http.Header) (string, error) {
+	authorization := strings.TrimSpace(h.Get(authorizationHeaderKey))
+	if authorization == "" {
+		return "", fmt.Errorf("empty authorization header: %w", NoAccessToken)
+	}
+
+	if !strings.HasPrefix(authorization, bearerPrefix) {
+		return "", fmt.Errorf("authorization header does not have a Bearer prefix: %w", NoAccessToken)
+	}
+
+	return strings.TrimPrefix(authorization, bearerPrefix), nil
+}

--- a/components/public-api-server/pkg/auth/auth_test.go
+++ b/components/public-api-server/pkg/auth/auth_test.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package auth
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBearerTokenFromHeaders(t *testing.T) {
+	type Scenario struct {
+		Name string
+
+		// Input
+		Header http.Header
+
+		// Output
+		Token string
+		Error error
+	}
+
+	for _, s := range []Scenario{
+		{
+			Name:   "happy case",
+			Header: addToHeader(http.Header{}, "Authorization", "Bearer foo"),
+			Token:  "foo",
+		},
+		{
+			Name:   "leading and trailing spaces are trimmed",
+			Header: addToHeader(http.Header{}, "Authorization", "  Bearer foo  "),
+			Token:  "foo",
+		},
+		{
+			Name:   "anything after Bearer is extracted",
+			Header: addToHeader(http.Header{}, "Authorization", "Bearer foo bar"),
+			Token:  "foo bar",
+		},
+		{
+			Name:   "duplicate bearer",
+			Header: addToHeader(http.Header{}, "Authorization", "Bearer Bearer foo"),
+			Token:  "Bearer foo",
+		},
+		{
+			Name:   "missing Bearer prefix fails",
+			Header: addToHeader(http.Header{}, "Authorization", "foo"),
+			Error:  NoAccessToken,
+		},
+		{
+			Name:   "missing Authorization header fails",
+			Header: http.Header{},
+			Error:  NoAccessToken,
+		},
+	} {
+		t.Run(s.Name, func(t *testing.T) {
+			token, err := BearerTokenFromHeaders(s.Header)
+			require.ErrorIs(t, err, s.Error)
+			require.Equal(t, s.Token, token)
+		})
+	}
+}
+
+func addToHeader(h http.Header, key, value string) http.Header {
+	h.Add(key, value)
+	return h
+}

--- a/components/public-api-server/pkg/auth/context.go
+++ b/components/public-api-server/pkg/auth/context.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package auth
+
+import "context"
+
+type contextKey int
+
+const (
+	authContextKey contextKey = iota
+)
+
+func TokenToContext(ctx context.Context, token string) context.Context {
+	return context.WithValue(ctx, authContextKey, token)
+}
+
+func TokenFromContext(ctx context.Context) string {
+	if val, ok := ctx.Value(authContextKey).(string); ok {
+		return val
+	}
+
+	return ""
+}

--- a/components/public-api-server/pkg/auth/context_test.go
+++ b/components/public-api-server/pkg/auth/context_test.go
@@ -1,0 +1,23 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package auth
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTokenToAndFromContext(t *testing.T) {
+	token := "my_token"
+
+	extracted := TokenFromContext(TokenToContext(context.Background(), token))
+	require.Equal(t, token, extracted)
+}
+
+func TestTokenFromContext_EmptyWhenNotSet(t *testing.T) {
+	require.Equal(t, "", TokenFromContext(context.Background()))
+}

--- a/components/public-api-server/pkg/auth/middleware.go
+++ b/components/public-api-server/pkg/auth/middleware.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package auth
+
+import (
+	"context"
+
+	"github.com/bufbuild/connect-go"
+)
+
+// NewServerInterceptor creates a server-side interceptor which validates that an incoming request contains a Bearer Authorization header
+func NewServerInterceptor() connect.UnaryInterceptorFunc {
+	interceptor := func(next connect.UnaryFunc) connect.UnaryFunc {
+		return connect.UnaryFunc(func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+
+			if req.Spec().IsClient {
+				return next(ctx, req)
+			}
+
+			headers := req.Header()
+
+			token, err := BearerTokenFromHeaders(headers)
+			if err != nil {
+				return nil, connect.NewError(connect.CodeUnauthenticated, err)
+
+			}
+			return next(TokenToContext(ctx, token), req)
+		})
+	}
+
+	return connect.UnaryInterceptorFunc(interceptor)
+}
+
+// NewClientInterceptor creates a client-side interceptor which injects token as a Bearer Authorization header
+func NewClientInterceptor(token string) connect.UnaryInterceptorFunc {
+	interceptor := func(next connect.UnaryFunc) connect.UnaryFunc {
+		return connect.UnaryFunc(func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+
+			if !req.Spec().IsClient {
+				return next(ctx, req)
+			}
+
+			req.Header().Add(authorizationHeaderKey, bearerPrefix+token)
+			return next(ctx, req)
+		})
+	}
+
+	return connect.UnaryInterceptorFunc(interceptor)
+}

--- a/components/public-api-server/pkg/auth/middleware_test.go
+++ b/components/public-api-server/pkg/auth/middleware_test.go
@@ -1,0 +1,97 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package auth
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/bufbuild/connect-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewServerInterceptor(t *testing.T) {
+	requestPayload := "request"
+	type TokenResponse struct {
+		Token string `json:"token"`
+	}
+
+	type Header struct {
+		Key   string
+		Value string
+	}
+
+	handler := connect.UnaryFunc(func(ctx context.Context, ar connect.AnyRequest) (connect.AnyResponse, error) {
+		token := TokenFromContext(ctx)
+		return connect.NewResponse(&TokenResponse{Token: token}), nil
+	})
+
+	scenarios := []struct {
+		Name string
+
+		Headers []Header
+
+		ExpectedError error
+		ExpectedToken string
+	}{
+		{
+			Name:          "no headers return Unathenticated",
+			Headers:       nil,
+			ExpectedError: connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("empty authorization header: %w", NoAccessToken)),
+		},
+		{
+			Name:          "authorization header with bearer token returns ok",
+			Headers:       []Header{{Key: "Authorization", Value: "Bearer foo"}},
+			ExpectedToken: "foo",
+		},
+	}
+
+	for _, s := range scenarios {
+		t.Run(s.Name, func(t *testing.T) {
+			ctx := context.Background()
+			request := connect.NewRequest(&requestPayload)
+
+			for _, header := range s.Headers {
+				request.Header().Add(header.Key, header.Value)
+			}
+
+			resp, err := NewServerInterceptor()(handler)(ctx, request)
+
+			require.Equal(t, s.ExpectedError, err)
+			if err == nil {
+				require.Equal(t, &TokenResponse{
+					Token: s.ExpectedToken,
+				}, resp.Any())
+			}
+
+		})
+	}
+}
+
+func TestNewClientInterceptor(t *testing.T) {
+	expectedToken := "my_token"
+
+	tokenOnRequest := ""
+	// Setup a test server where we capture the token supplied, we don't actually care for the response.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Println(r.Header)
+		token, err := BearerTokenFromHeaders(r.Header)
+		require.NoError(t, err)
+
+		// Capture the token supplied in the request so we can test for it
+		tokenOnRequest = token
+		w.WriteHeader(http.StatusNotFound)
+	}))
+
+	client := connect.NewClient[any, any](http.DefaultClient, srv.URL, connect.WithInterceptors(
+		NewClientInterceptor(expectedToken),
+	))
+
+	_, _ = client.CallUnary(context.Background(), connect.NewRequest[any](nil))
+	require.Equal(t, expectedToken, tokenOnRequest)
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Adds authentication interceptors for [connect](https://connect.build/) API on public-api.

This is a pre-cursor to refactoring existing handlers to use connect.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Part of https://github.com/gitpod-io/gitpod/issues/13574

## How to test
<!-- Provide steps to test this PR -->
* Unit tests

```bash
➜ curl \
    --header 'Content-Type: application/json' \
    --data '{"workspaceId": "123"}' \
    https://api.mp-public-8c1701f31b.preview.gitpod-dev.com/gitpod.v1.WorkspacesService/GetWorkspace | jq

{
  "code": "unauthenticated",
  "message": "empty authorization header: missing access token"
}

➜ curl \
    --header 'Content-Type: application/json' \
    --header 'Authorization: Bearer foo' \
    --data '{"workspaceId": "123"}' \
    https://api.mp-public-8c1701f31b.preview.gitpod-dev.com/gitpod.v1.WorkspacesService/GetWorkspace | jq

{
  "code": "unimplemented",
  "message": "gitpod.v1.WorkspacesService.GetWorkspace is not implemented"
}
```


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
