### PR TITLE
[server] Use CostCenter to determine if user has paid subscription

### DIFF
--- a/components/server/ee/src/billing/entitlement-service-ubp.ts
+++ b/components/server/ee/src/billing/entitlement-service-ubp.ts
@@ -26,6 +26,11 @@ import { Config } from "../../../src/config";
 import { UserService } from "../../../src/user/user-service";
 import { StripeService } from "../user/stripe-service";
 import { BillingModes } from "./billing-mode";
+import {
+    CostCenter_BillingStrategy,
+    UsageServiceClient,
+    UsageServiceDefinition,
+} from "@gitpod/usage-api/lib/usage/v1/usage.pb";
 
 const MAX_PARALLEL_WORKSPACES_FREE = 4;
 const MAX_PARALLEL_WORKSPACES_PAID = 16;
@@ -40,6 +45,7 @@ export class EntitlementServiceUBP implements EntitlementService {
     @inject(BillingModes) protected readonly billingModes: BillingModes;
     @inject(UserService) protected readonly userService: UserService;
     @inject(StripeService) protected readonly stripeService: StripeService;
+    @inject(UsageServiceDefinition.name) protected readonly usageService: UsageServiceClient;
     @inject(TeamDB) protected readonly teamDB: TeamDB;
 
     async mayStartWorkspace(
@@ -130,10 +136,11 @@ export class EntitlementServiceUBP implements EntitlementService {
         // Member of paid team?
         const teams = await this.teamDB.findTeamsByUser(user.id);
         const isTeamSubscribedPromises = teams.map(async (team: Team) => {
-            const subscriptionId = await this.stripeService.findUncancelledSubscriptionByAttributionId(
-                AttributionId.render({ kind: "team", teamId: team.id }),
-            );
-            return !!subscriptionId;
+            const costCenter = await this.usageService.getCostCenter({
+                attributionId: AttributionId.render({ kind: "team", teamId: team.id }),
+            });
+
+            return costCenter.costCenter?.billingStrategy === CostCenter_BillingStrategy.BILLING_STRATEGY_STRIPE;
         });
         // Return the first truthy promise, or false if all the promises were falsy.
         // Source: https://gist.github.com/jbreckmckye/66364021ebaa0785e426deec0410a235


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

[See (internal) context](https://gitpod.slack.com/archives/C02EN94AEPL/p1665330076083099?thread_ts=1665177158.389409&cid=C02EN94AEPL)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
