### PR TITLE
[prebuild] Support opening a specfic prebuild

### DIFF
--- a/components/dashboard/src/projects/Prebuild.tsx
+++ b/components/dashboard/src/projects/Prebuild.tsx
@@ -181,7 +181,9 @@ export default function () {
                     ) : prebuild?.status === "available" ? (
                         <a
                             className="my-auto"
-                            href={gitpodHostUrl.withContext(`${prebuild?.info.changeUrl}`).toString()}
+                            href={gitpodHostUrl
+                                .withContext(`open-prebuild/${prebuild?.info.id}/${prebuild?.info.changeUrl}`)
+                                .toString()}
                         >
                             <button>New Workspace ({prebuild?.info.branch})</button>
                         </a>

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -1200,6 +1200,16 @@ export namespace AdditionalContentContext {
     }
 }
 
+export interface OpenPrebuildContext extends WorkspaceContext {
+    openPrebuilID: string;
+}
+
+export namespace OpenPrebuildContext {
+    export function is(ctx: any): ctx is OpenPrebuildContext {
+        return "openPrebuildID" in ctx;
+    }
+}
+
 export interface CommitContext extends WorkspaceContext, GitCheckoutInfo {
     /** @deprecated Moved to .repository.cloneUrl, left here for backwards-compatibility for old workspace contextes in the DB */
     cloneUrl?: string;

--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -47,6 +47,7 @@ import {
     TeamMemberRole,
     WORKSPACE_TIMEOUT_DEFAULT_SHORT,
     PrebuildEvent,
+    OpenPrebuildContext,
 } from "@gitpod/gitpod-protocol";
 import { ResponseError } from "vscode-jsonrpc";
 import {
@@ -963,9 +964,19 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
 
             const logCtx: LogContext = { userId: user.id };
             const cloneUrl = context.repository.cloneUrl;
-            const prebuiltWorkspace = await this.workspaceDb
-                .trace(ctx)
-                .findPrebuiltWorkspaceByCommit(cloneUrl, commitSHAs);
+            let prebuiltWorkspace: PrebuiltWorkspace | undefined;
+            if (OpenPrebuildContext.is(context)) {
+                prebuiltWorkspace = await this.workspaceDb.trace(ctx).findPrebuildByID(context.openPrebuilID);
+                if (prebuiltWorkspace?.cloneURL !== cloneUrl) {
+                    // prevent users from opening arbitrary prebuilds this way - they must match the clone URL so that the resource guards are correct.
+                    return;
+                }
+            } else {
+                prebuiltWorkspace = await this.workspaceDb
+                    .trace(ctx)
+                    .findPrebuiltWorkspaceByCommit(cloneUrl, commitSHAs);
+            }
+
             const logPayload = { mode, cloneUrl, commit: commitSHAs, prebuiltWorkspace };
             log.debug(logCtx, "Looking for prebuilt workspace: ", logPayload);
             if (!prebuiltWorkspace) {
@@ -994,7 +1005,7 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
                 const makeResult = (instanceID: string): WorkspaceCreationResult => {
                     return <WorkspaceCreationResult>{
                         runningWorkspacePrebuild: {
-                            prebuildID: prebuiltWorkspace.id,
+                            prebuildID: prebuiltWorkspace!.id,
                             workspaceID,
                             instanceID,
                             starting: "queued",

--- a/components/server/src/container-module.ts
+++ b/components/server/src/container-module.ts
@@ -113,6 +113,7 @@ import { LivenessController } from "./liveness/liveness-controller";
 import { IDEServiceClient, IDEServiceDefinition } from "@gitpod/ide-service-api/lib/ide.pb";
 import { prometheusClientMiddleware } from "@gitpod/gitpod-protocol/lib/util/nice-grpc";
 import { UsageService } from "./user/usage-service";
+import { OpenPrebuildPrefixContextParser } from "./workspace/open-prebuild-prefix-context-parser";
 
 export const productionContainerModule = new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(Config).toConstantValue(ConfigFile.fromFile());
@@ -189,6 +190,7 @@ export const productionContainerModule = new ContainerModule((bind, unbind, isBo
     bind(IPrefixContextParser).to(EnvvarPrefixParser).inSingletonScope();
     bind(IPrefixContextParser).to(ImageBuildPrefixContextParser).inSingletonScope();
     bind(IPrefixContextParser).to(AdditionalContentPrefixContextParser).inSingletonScope();
+    bind(IPrefixContextParser).to(OpenPrebuildPrefixContextParser).inSingletonScope();
 
     bind(GitTokenScopeGuesser).toSelf().inSingletonScope();
     bind(GitTokenValidator).toSelf().inSingletonScope();

--- a/components/server/src/workspace/open-prebuild-prefix-context-parser.ts
+++ b/components/server/src/workspace/open-prebuild-prefix-context-parser.ts
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { User, WorkspaceContext } from "@gitpod/gitpod-protocol";
+import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
+import { OpenPrebuildContext } from "@gitpod/gitpod-protocol/src/protocol";
+import { inject, injectable } from "inversify";
+import { Config } from "../config";
+import { IPrefixContextParser } from "./context-parser";
+
+@injectable()
+export class OpenPrebuildPrefixContextParser implements IPrefixContextParser {
+    @inject(Config) protected readonly config: Config;
+    static PREFIX = /^\/?open-prebuild\/([^\/]*)\//;
+
+    findPrefix(user: User, context: string): string | undefined {
+        const result = OpenPrebuildPrefixContextParser.PREFIX.exec(context);
+        if (!result) {
+            return undefined;
+        }
+        return result[0];
+    }
+
+    public async handle(user: User, prefix: string, context: WorkspaceContext): Promise<WorkspaceContext> {
+        const match = OpenPrebuildPrefixContextParser.PREFIX.exec(prefix);
+        if (!match) {
+            log.error("Could not parse prefix " + prefix);
+            return context;
+        }
+
+        (context as OpenPrebuildContext).openPrebuilID = match[1];
+        return context;
+    }
+}


### PR DESCRIPTION
## Description
This PR enables users to open a specific prebuildm, and integrates this capability on the dashboard.


## How to test
1. Make sure there's a prebuild and a newer commit on the same branch
2. Go the prebuild view
3. Open the specific prebuild and observe it's the correct state

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[prebuild] Add support for opening specific prebuilds
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
