### PR TITLE
Delete cordoned node once it's empty during werft cleanup

### DIFF
--- a/.werft/platform-trigger-werft-cleanup.sh
+++ b/.werft/platform-trigger-werft-cleanup.sh
@@ -40,11 +40,31 @@ function cordon-node-if-almost-full {
     if [ "$disk_used_pct" -gt "$DISK_USED_THRESHOLD" ]; then
         echo "${disk_used_pct} is greater than ${DISK_USED_THRESHOLD}. Cordining node" | werft log slice "$slice_id"
         kubectl cordon "$node" | werft log slice "$slice_id"
+
+        if [[ "${node}" =~ "builds-static" ]]; then
+          echo "Cleaning up static node [${node}]"
+          while ! is_node_empty "${node}";do
+            echo "Node is not empty yet. Sleeping for 15 seconds."
+            sleep 15
+          done
+
+          gcloud compute instances delete "${node}" --zone="${zone}" -q
+        fi
     else
         echo "${disk_used_pct} is less than the trehold of ${DISK_USED_THRESHOLD}. Skipping node" | werft log slice "$slice_id"
     fi
 
     werft log slice "$slice_id" --done
+}
+
+function is_node_empty {
+  local node=$1
+  pods=$(kubectl -n werft get pods -o wide --field-selector spec.nodeName="${node}")
+  if [[ "${pods}" == "No resources found in werft namespace." ]]; then
+    return 0
+  fi
+
+  return 1
 }
 
 # Activate service account and install core-dev context


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
We introduced a static build nodepool in https://github.com/gitpod-io/ops/pull/5281 but it stays cordoned off and the instance never gets terminated, since it cannot scale down. 

This PR waits until there are no more pods with werft jobs on the node (after it's cordoned) and deletes the GCE instance. This will force its recreation with a fresh local volume.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
