### PR TITLE
[obs] Remove NetworkConnectionsTooHigh alert

### DIFF
--- a/operations/observability/mixins/workspace/rules/nodes.yaml
+++ b/operations/observability/mixins/workspace/rules/nodes.yaml
@@ -55,15 +55,3 @@ spec:
         description: Automatic scale-up failed for some reason.
       expr: |
         increase(cluster_autoscaler_failed_scale_ups_total[1m]) != 0
-
-    - alert: NetworkConnectionsTooHigh
-      labels:
-        severity: warning
-        team: workspace
-      for: 10m
-      annotations:
-        runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/NetworkConnectionsTooHigh.md
-        summary: Network connection numbers remain high for 5 minutes.
-        description: Network connection numbers remain high for 5 minutes.
-      expr: |
-        node_nf_conntrack_entries{instance=~"workspace-.*", instance!~"serv.*"} > 20000


### PR DESCRIPTION
## Description
The alert is quite noisy, so its utility is limited and we have the network limiting dashboard now.

## Related Issue(s)
See https://gitpod.slack.com/archives/C03QZ1NH517/p1665084593942539

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
