### PR TITLE
[server] Garbage collect probe workspaces

### DIFF
--- a/components/gitpod-db/src/typeorm/workspace-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/workspace-db-impl.ts
@@ -1258,6 +1258,21 @@ export abstract class AbstractTypeORMWorkspaceDBImpl implements WorkspaceDB {
         const res = await query.getMany();
         return res.map((r) => r.info);
     }
+
+    async findProbeWorkspaceIDs(limit: number): Promise<string[]> {
+        const repo = await this.getWorkspaceRepo();
+        const results = (await repo.query(
+            `
+                SELECT ws.id AS id,
+                FROM d_b_workspace ws
+                WHERE ws.type = 'probe'
+                LIMIT ?;
+            `,
+            [limit],
+        )) as { id: string }[];
+
+        return results.map((r) => r.id);
+    }
 }
 
 @injectable()

--- a/components/gitpod-db/src/workspace-db.ts
+++ b/components/gitpod-db/src/workspace-db.ts
@@ -202,4 +202,6 @@ export interface WorkspaceDB {
 
     storePrebuildInfo(prebuildInfo: PrebuildInfo): Promise<void>;
     findPrebuildInfos(prebuildIds: string[]): Promise<PrebuildInfo[]>;
+
+    findProbeWorkspaceIDs(limit: number): Promise<string[]>;
 }

--- a/components/server/src/workspace/garbage-collector.ts
+++ b/components/server/src/workspace/garbage-collector.ts
@@ -54,6 +54,9 @@ export class WorkspaceGarbageCollector {
             this.deleteOutdatedVolumeSnapshots().catch((err) =>
                 log.error("wsgc: error during volume snapshot gc deletion", err),
             );
+            this.deleteProbeWorkspaces().catch((err) =>
+                log.error("wsgc: error during probe workspace gc deletion", err),
+            );
         }
     }
 
@@ -183,6 +186,24 @@ export class WorkspaceGarbageCollector {
                     vss.slice(1).map((vs) => this.deletionService.garbageCollectVolumeSnapshot({ span }, vs)),
                 ),
             );
+        } catch (err) {
+            TraceContext.setError({ span }, err);
+            throw err;
+        } finally {
+            span.finish();
+        }
+    }
+
+    protected async deleteProbeWorkspaces() {
+        const span = opentracing.globalTracer().startSpan("deleteProbeWorkspaces");
+        try {
+            const workspaceIDs = await this.workspaceDB.trace({ span }).findProbeWorkspaceIDs(100);
+
+            const deletes = await Promise.all(
+                workspaceIDs.map((workspaceID) => this.workspaceDB.trace({ span }).hardDeleteWorkspace(workspaceID)),
+            );
+
+            log.info(`wsgc: successfully deleted ${deletes.length} Probe workspaces`);
         } catch (err) {
             TraceContext.setError({ span }, err);
             throw err;


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Incrementally removes Probe workspaces. This was originally done in https://github.com/gitpod-io/gitpod/pull/13477 but later rolled back in https://github.com/gitpod-io/gitpod/pull/13572 because it locked the table.

The approach here limits the deletes to 100 at a time to make it incremental.

Once we stop seeing the log `wsgc: successfully deleted ${deletes.length} Probe workspaces` (or it says 0), we can remove this again. If we land this approach, I'll cut a ticket to track the removal as well.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
