### PR TITLE
Delete cordoned node once it's empty during werft cleanup p2

### DIFF
--- a/.werft/platform-trigger-werft-cleanup.sh
+++ b/.werft/platform-trigger-werft-cleanup.sh
@@ -59,7 +59,7 @@ function cordon-node-if-almost-full {
 
 function is_node_empty {
   local node=$1
-  pods=$(kubectl -n werft get pods -o wide --field-selector spec.nodeName="${node}")
+  pods=$(kubectl -n werft get pods -o wide --field-selector spec.nodeName="${node}" 2>&1)
   if [[ "${pods}" == "No resources found in werft namespace." ]]; then
     return 0
   fi


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Fix for capturing the correct output from: https://github.com/gitpod-io/gitpod/pull/13709

The output we want to capture is in stderr, so redirect it to stdout.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
