### PR TITLE
[installer] Don't keep random trailing spaces when creating .golden files

### DIFF
--- a/install/installer/cmd/render_test.go
+++ b/install/installer/cmd/render_test.go
@@ -7,6 +7,7 @@ import (
 	"flag"
 	"io/ioutil"
 	"os"
+	"os/exec"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -75,6 +76,8 @@ func TestRender(t *testing.T) {
 			f, err := os.OpenFile(goldenPath, os.O_RDWR, 0644)
 			defer f.Close()
 			require.NoError(t, err)
+			cmd := exec.Command("sed", "-i", "-e", "\"s/[[:space:]]*$//\"", goldenPath)
+                        defer cmd.Run()
 
 			content, err := ioutil.ReadAll(f)
 			if err != nil {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Always output clean `.golden` files without random trailing spaces in them, by simply running a one-line post-processing script after the main generator.

Based on [this attempt](https://github.com/gitpod-io/gitpod/pull/11981#issuecomment-1210317909).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes random trailing spaces in `.golden` files.

## How to test
<!-- Provide steps to test this PR -->

1. Regenerate `.golden` files
2. They shouldn't contain random trailing spaces

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
