### PR TITLE
Add leeway dev/preview:build and dev/preview:deploy-gitpod

### DIFF
--- a/dev/preview/BUILD.yaml
+++ b/dev/preview/BUILD.yaml
@@ -1,0 +1,8 @@
+scripts:
+  - name: build
+    description: Build all packages needed to deploy Gitpod to preview environments
+    script: ./workflow/preview/build.sh
+
+  - name: deploy-gitpod
+    description: Deploys Gitpod to an existing preview environment
+    script: ./workflow/preview/deploy-gitpod.sh

--- a/dev/preview/workflow/lib/ensure-gcloud-auth.sh
+++ b/dev/preview/workflow/lib/ensure-gcloud-auth.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# this script is meant to be sourced
+
+function ensure_gcloud_auth() {
+    if [[ $(gcloud auth list --format=json) == '[]' ]]; then
+        echo
+        echo "Currently you need to be authenticated with gcloud to run the build"
+        echo
+        echo "This is needed to you can use the Leeway build cache that Werft also uses"
+        echo "We're working on automating this here: https://github.com/gitpod-io/gitpod/issues/13714"
+        echo
+        echo "But for now you have to run the following log in manually"
+        echo
+        gcloud auth login --no-launch-browser
+        echo
+        echo "Great, thanks!"
+        echo
+        echo "Continuing the build"
+    fi
+}

--- a/dev/preview/workflow/preview/build.sh
+++ b/dev/preview/workflow/preview/build.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_PATH=$(realpath "$(dirname "$0")")
+
+# shellcheck source=../lib/common.sh
+source "$(realpath "${SCRIPT_PATH}/../lib/common.sh")"
+# shellcheck source=../../util/preview-name-from-branch.sh
+source "$(realpath "${SCRIPT_PATH}/../../util/preview-name-from-branch.sh")"
+
+import "ensure-gcloud-auth.sh"
+
+ensure_gcloud_auth
+
+VERSION="$(preview-name-from-branch)-dev"
+
+leeway build \
+    -DSEGMENT_IO_TOKEN="" \
+    -Dversion="${VERSION}" \
+    --dont-retag \
+    --dont-test \
+    install/installer:app

--- a/dev/preview/workflow/preview/deploy-gitpod.sh
+++ b/dev/preview/workflow/preview/deploy-gitpod.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_PATH=$(realpath "$(dirname "$0")")
+
+# shellcheck source=../lib/common.sh
+source "$(realpath "${SCRIPT_PATH}/../lib/common.sh")"
+# shellcheck source=../../util/preview-name-from-branch.sh
+source "$(realpath "${SCRIPT_PATH}/../../util/preview-name-from-branch.sh")"
+
+VERSION="$(preview-name-from-branch)-dev"
+INSTALLER_HASH=$(
+    leeway describe install/installer:app \
+        -Dversion="${VERSION}" \
+        -DSEGMENT_IO_TOKEN="" \
+        --format=json \
+    | jq -r '.metadata.version'
+)
+INSTALLER_CONFIG_PATH=/tmp/$(mktemp "XXXXXX.gitpod.config.yaml")
+
+function installer {
+    "/tmp/build/install-installer--app.$INSTALLER_HASH/installer" "$@"
+}
+
+installer config init --overwrite --config "$INSTALLER_CONFIG_PATH"
+log_success "Generated config at $INSTALLER_CONFIG_PATH"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This is a step towards https://github.com/gitpod-io/ops/issues/5766. It introduces two new leeway scripts, one to build the installer and one to run it.

The build script ensures that you're logged into GCP so that Leeway can use the remote cache - there's an issue to remove this requirement in the future #13714.

It doesn't actually try to install Gitpod yet - it just generates a config file to show that we're able to invoke the installer. I will follow up with other PRs.

Things I'll do in follow-up PRs

- It doesn't use the cache for some components (e.g. dashboard) where I would expect it too. Follow up issue here https://github.com/gitpod-io/gitpod/issues/13767
- Downloading the remote cache takes more than 4 minutes. Follow up issue here https://github.com/gitpod-io/ops/issues/5814
- Creating the `launch-preview-vm` script
- Finish the implementation of `deploy-gitpod`

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

Part of https://github.com/gitpod-io/ops/issues/5766

## How to test
<!-- Provide steps to test this PR -->

**Just downloading the remote cache takes a long time, so we have optimisations we need to do.**

```sh
# To build
leeway run dev/preview:build
```

To "deploy Gitpod" (it just generates a config file for now)

```
leeway run dev/preview:deploy-gitpod
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

N/A

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
