### PR TITLE
[db] Add `applicationCluster` field to `d_b_workspace_cluster` table

### DIFF
--- a/components/gitpod-db/src/typeorm/entity/db-workspace-cluster.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-workspace-cluster.ts
@@ -84,4 +84,10 @@ export class DBWorkspaceCluster implements WorkspaceCluster {
         })(),
     })
     admissionConstraints?: AdmissionConstraint[];
+
+    @Column({
+        type: "varchar",
+        length: 255,
+    })
+    applicationCluster: string;
 }

--- a/components/gitpod-db/src/typeorm/entity/db-workspace-cluster.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-workspace-cluster.ts
@@ -87,7 +87,7 @@ export class DBWorkspaceCluster implements WorkspaceCluster {
 
     @Column({
         type: "varchar",
-        length: 255,
+        length: 60,
     })
     applicationCluster: string;
 }

--- a/components/gitpod-db/src/typeorm/migration/1665071320428-AddColumnToWorkspaceClusterTable.ts
+++ b/components/gitpod-db/src/typeorm/migration/1665071320428-AddColumnToWorkspaceClusterTable.ts
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddColumnToWorkspaceClusterTable1665071320428 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const installationShortname = process.env.GITPOD_INSTALLATION_SHORTNAME ?? "";
+
+        await queryRunner.query(
+            `ALTER TABLE d_b_workspace_cluster ADD COLUMN applicationCluster varchar(255) NOT NULL DEFAULT ''`,
+        );
+
+        await queryRunner.query(`UPDATE d_b_workspace_cluster SET applicationCluster = '${installationShortname}'`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {}
+}

--- a/components/gitpod-db/src/typeorm/migration/1665071320428-AddColumnToWorkspaceClusterTable.ts
+++ b/components/gitpod-db/src/typeorm/migration/1665071320428-AddColumnToWorkspaceClusterTable.ts
@@ -11,7 +11,7 @@ export class AddColumnToWorkspaceClusterTable1665071320428 implements MigrationI
         const installationShortname = process.env.GITPOD_INSTALLATION_SHORTNAME ?? "";
 
         await queryRunner.query(
-            `ALTER TABLE d_b_workspace_cluster ADD COLUMN applicationCluster varchar(255) NOT NULL DEFAULT ''`,
+            `ALTER TABLE d_b_workspace_cluster ADD COLUMN applicationCluster varchar(60) NOT NULL DEFAULT ''`,
         );
 
         await queryRunner.query(`UPDATE d_b_workspace_cluster SET applicationCluster = '${installationShortname}'`);

--- a/components/gitpod-db/src/typeorm/workspace-cluster-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/workspace-cluster-db-impl.ts
@@ -51,6 +51,7 @@ export class WorkspaceClusterDBImpl implements WorkspaceClusterDB {
             state: "available",
             govern: false,
             admissionConstraints: [],
+            applicationCluster: "",
         };
 
         const repo = await this.getRepo();

--- a/components/gitpod-protocol/src/workspace-cluster.ts
+++ b/components/gitpod-protocol/src/workspace-cluster.ts
@@ -15,6 +15,9 @@ export interface WorkspaceCluster {
     // Must be identical to the installationShortname of the cluster it represents!
     name: string;
 
+    // The name of the application cluster to which this cluster should be registered.
+    applicationCluster: string;
+
     // URL of the cluster's ws-manager API
     url: string;
 

--- a/components/gitpod-protocol/src/workspace-cluster.ts
+++ b/components/gitpod-protocol/src/workspace-cluster.ts
@@ -16,6 +16,7 @@ export interface WorkspaceCluster {
     name: string;
 
     // The name of the application cluster to which this cluster should be registered.
+    // The name can be at most 60 characters.
     applicationCluster: string;
 
     // URL of the cluster's ws-manager API

--- a/components/ws-manager-api/typescript/src/client-provider.spec.ts
+++ b/components/ws-manager-api/typescript/src/client-provider.spec.ts
@@ -39,6 +39,7 @@ class TestClientProvider {
                         state: "cordoned",
                         url: "",
                         admissionConstraints: [],
+                        applicationCluster: "xx01",
                     },
                     {
                         name: "c2",
@@ -48,6 +49,7 @@ class TestClientProvider {
                         state: "cordoned",
                         url: "",
                         admissionConstraints: [],
+                        applicationCluster: "xx01",
                     },
                     {
                         name: "c3",
@@ -57,6 +59,7 @@ class TestClientProvider {
                         state: "cordoned",
                         url: "",
                         admissionConstraints: [],
+                        applicationCluster: "xx01",
                     },
                     {
                         name: "a1",
@@ -66,6 +69,7 @@ class TestClientProvider {
                         state: "available",
                         url: "",
                         admissionConstraints: [],
+                        applicationCluster: "xx01",
                     },
                     {
                         name: "a2",
@@ -75,6 +79,7 @@ class TestClientProvider {
                         state: "available",
                         url: "",
                         admissionConstraints: [],
+                        applicationCluster: "xx01",
                     },
                     {
                         name: "a3",
@@ -84,6 +89,7 @@ class TestClientProvider {
                         state: "available",
                         url: "",
                         admissionConstraints: [],
+                        applicationCluster: "xx01",
                     },
                     {
                         name: "con1",
@@ -93,6 +99,7 @@ class TestClientProvider {
                         state: "available",
                         url: "",
                         admissionConstraints: [{ type: "has-permission", permission: "new-workspace-cluster" }],
+                        applicationCluster: "xx01",
                     },
                     {
                         name: "con2",
@@ -104,6 +111,7 @@ class TestClientProvider {
                         admissionConstraints: [
                             { type: "has-permission", permission: "monitor" }, // This is meant to representent a permission that does not take special predence (cmp. constraints.ts)
                         ],
+                        applicationCluster: "xx01",
                     },
                 ];
                 return <WorkspaceManagerClientProviderSource>{

--- a/components/ws-manager-bridge/src/cluster-service-server.ts
+++ b/components/ws-manager-bridge/src/cluster-service-server.ts
@@ -107,6 +107,14 @@ export class ClusterService implements IClusterServiceServer {
                     }
                 }
 
+                const applicationCluster = process.env.GITPOD_INSTALLATION_SHORTNAME;
+                if (applicationCluster === undefined) {
+                    throw new GRPCError(
+                        grpc.status.INTERNAL,
+                        "no GITPOD_INSTALLATION_SHORTNAME environment variable is set on the server",
+                    );
+                }
+
                 // store the ws-manager into the database
                 let perfereability = Preferability.NONE;
                 let govern = false;
@@ -141,6 +149,7 @@ export class ClusterService implements IClusterServiceServer {
                 const newCluster: WorkspaceCluster = {
                     name: req.name,
                     url: req.url,
+                    applicationCluster,
                     state,
                     score,
                     maxScore: 100,


### PR DESCRIPTION
## Description

As part of #9198  we want to start syncing the `d_b_workspace_cluster` table with `db-sync`.

Currently, the table differs between US and EU regions because each table contains only the data relevant to that region. For example, in the EU table, the `eu70` workspace cluster is marked as `available` and the `us70` cluster is `cordoned`.  In the US cluster `eu70` is `cordoned` and `us70` is `available`.

In order to sync the table we need to get to a point where there is no difference in the data in the table between EU and US regions.

To do that we will introduce a new field in the table called `applicationCluster` which records the name of the application cluster to which the record belongs. Thus, for each workspace cluster there will be two rows in Gitpod SaaS:

| name | applicationCluster | url | tls | state | ... |
| --- | --- | --- | --- | --- | --- |
| eu70 | eu02 | url | tls info | available | ... |
| eu70 | us02 | url | tls info | cordoned | ... |

Effectively the new `applicationCluster` column gives the table an extra dimension so that we can combine both tables (EU and US) into one.

As a first step towards this, this PR adds the column to the table and makes `gpctl` fill the value when `gpctl register`ing a new workspace cluster. The value is taken from the `GITPOD_INSTALLATION_SHORTNAME` environment variable in `ws-manager-bridge`.

⚠️ Needs https://github.com/gitpod-io/ops/pull/5758 merged first ⚠️ 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of #9198 

## How to test

I'd like to be able to register a workspace cluster from a preview environment to check that the value of `applicationCluster` is correctly populated.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
