### PR TITLE
Remove workspace class feature flag

### DIFF
--- a/components/dashboard/src/contexts/FeatureFlagContext.tsx
+++ b/components/dashboard/src/contexts/FeatureFlagContext.tsx
@@ -16,11 +16,9 @@ interface FeatureFlagConfig {
 }
 
 const FeatureFlagContext = createContext<{
-    showWorkspaceClassesUI: boolean;
     showPersistentVolumeClaimUI: boolean;
     showUsageView: boolean;
 }>({
-    showWorkspaceClassesUI: false,
     showPersistentVolumeClaimUI: false,
     showUsageView: false,
 });
@@ -31,7 +29,6 @@ const FeatureFlagContextProvider: React.FC = ({ children }) => {
     const { project } = useContext(ProjectContext);
     const location = useLocation();
     const team = getCurrentTeam(location, teams);
-    const [showWorkspaceClassesUI, setShowWorkspaceClassesUI] = useState<boolean>(false);
     const [showPersistentVolumeClaimUI, setShowPersistentVolumeClaimUI] = useState<boolean>(false);
     const [showUsageView, setShowUsageView] = useState<boolean>(false);
 
@@ -39,7 +36,6 @@ const FeatureFlagContextProvider: React.FC = ({ children }) => {
         if (!user) return;
         (async () => {
             const featureFlags: FeatureFlagConfig = {
-                workspace_classes: { defaultValue: true, setter: setShowWorkspaceClassesUI },
                 persistent_volume_claim: { defaultValue: true, setter: setShowPersistentVolumeClaimUI },
                 usage_view: { defaultValue: false, setter: setShowUsageView },
             };
@@ -57,7 +53,7 @@ const FeatureFlagContextProvider: React.FC = ({ children }) => {
     }, [user, teams, team, project]);
 
     return (
-        <FeatureFlagContext.Provider value={{ showWorkspaceClassesUI, showPersistentVolumeClaimUI, showUsageView }}>
+        <FeatureFlagContext.Provider value={{ showPersistentVolumeClaimUI, showUsageView }}>
             {children}
         </FeatureFlagContext.Provider>
     );

--- a/components/dashboard/src/settings/Preferences.tsx
+++ b/components/dashboard/src/settings/Preferences.tsx
@@ -13,7 +13,6 @@ import { trackEvent } from "../Analytics";
 import SelectIDE from "./SelectIDE";
 import SelectWorkspaceClass from "./selectClass";
 import { PageWithSettingsSubMenu } from "./PageWithSettingsSubMenu";
-import { FeatureFlagContext } from "../contexts/FeatureFlagContext";
 import { BillingMode } from "@gitpod/gitpod-protocol/lib/billing-mode";
 
 type Theme = "light" | "dark" | "system";
@@ -21,7 +20,6 @@ type Theme = "light" | "dark" | "system";
 export default function Preferences() {
     const { user, userBillingMode } = useContext(UserContext);
     const { setIsDark } = useContext(ThemeContext);
-    const { showWorkspaceClassesUI } = useContext(FeatureFlagContext);
 
     const [theme, setTheme] = useState<Theme>(localStorage.theme || "system");
     const actuallySetTheme = (theme: Theme) => {
@@ -57,9 +55,7 @@ export default function Preferences() {
                 <h3>Editor</h3>
                 <p className="text-base text-gray-500 dark:text-gray-400">Choose the editor for opening workspaces.</p>
                 <SelectIDE location="preferences" />
-                <SelectWorkspaceClass
-                    enabled={showWorkspaceClassesUI || BillingMode.canSetWorkspaceClass(userBillingMode)}
-                />
+                <SelectWorkspaceClass enabled={BillingMode.canSetWorkspaceClass(userBillingMode)} />
                 <h3 className="mt-12">Theme</h3>
                 <p className="text-base text-gray-500 dark:text-gray-400">Early bird or night owl? Choose your side.</p>
                 <div className="mt-4 space-x-3 flex">

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -879,16 +879,11 @@ export class WorkspaceStarter {
                 }
             }
 
-            let workspaceClass = "";
-            let classesEnabled = await getExperimentsClientForBackend().getValueAsync("workspace_classes", false, {
-                user,
-                teams: userTeams,
-                billingTier,
-            });
             const usageAttributionId = await this.userService.getWorkspaceUsageAttributionId(user, workspace.projectId);
             const billingMode = await this.billingModes.getBillingMode(usageAttributionId, new Date());
 
-            if (classesEnabled || BillingMode.canSetWorkspaceClass(billingMode)) {
+            let workspaceClass = "";
+            if (BillingMode.canSetWorkspaceClass(billingMode)) {
                 // this is either the first time we start the workspace or the workspace was started
                 // before workspace classes and does not have a class yet
                 workspaceClass = await getWorkspaceClassForInstance(


### PR DESCRIPTION
## Description
Workspace classes are now coupled to usage based pricing, so we should remove the feature flag. See [slack](https://gitpod.slack.com/archives/C02F19UUW6S/p1665176858966609) for additional context.

## Related Issue(s)
n.a.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
