### PR TITLE
Add a lock timeout for plan/apply and general timeout on apply

### DIFF
--- a/dev/preview/workflow/lib/terraform.sh
+++ b/dev/preview/workflow/lib/terraform.sh
@@ -7,12 +7,14 @@ SCRIPT_PATH=$(dirname "${BASH_SOURCE[0]}")
 # shellcheck source=./common.sh
 source "${SCRIPT_PATH}/common.sh"
 
+TF_CLI_ARGS_plan=${TF_CLI_ARGS_plan:-""}
+TF_CLI_ARGS_apply=${TF_CLI_ARGS_apply:-""}
+
+export TF_CLI_ARGS_plan="${TF_CLI_ARGS_plan} -lock-timeout=5m"
+export TF_CLI_ARGS_apply="${TF_CLI_ARGS_apply} -lock-timeout=5m"
+
 if [ -n "${DESTROY-}" ]; then
-  if [ -n "${TF_CLI_ARGS_plan-}" ] && ! grep -q "destroy" <<<"${TF_CLI_ARGS_plan}"; then
-    TF_CLI_ARGS_plan="${TF_CLI_ARGS_plan} -destroy"
-  else
-    export TF_CLI_ARGS_plan="-destroy"
-  fi
+    export TF_CLI_ARGS_plan="${TF_CLI_ARGS_plan} -destroy"
 fi
 
 function check_workspace() {
@@ -117,7 +119,7 @@ function terraform_apply() {
     check_workspace "${WORKSPACE}"
   fi
 
-  terraform apply "${plan_location}"
+  timeout --signal=INT --foreground 10m terraform apply "${plan_location}"
 
   popd || return "${ERROR_CHANGE_DIR}"
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Adds a lock-timeout so jobs can wait a bit for the lock to get released, instead of failing immediately and a general timeout on `apply`. 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
