### PR TITLE
Add option to add authentication to Jaeger and custom tags

### DIFF
--- a/install/installer/pkg/components/agent-smith/daemonset.go
+++ b/install/installer/pkg/components/agent-smith/daemonset.go
@@ -69,7 +69,7 @@ func daemonset(ctx *common.RenderContext) ([]runtime.Object, error) {
 						}},
 						Env: common.CustomizeEnvvar(ctx, Component, common.MergeEnv(
 							common.DefaultEnv(&ctx.Config),
-							common.WorkspaceTracingEnv(ctx),
+							common.WorkspaceTracingEnv(ctx, Component),
 							common.NodeNameEnv(ctx),
 						)),
 						SecurityContext: &corev1.SecurityContext{

--- a/install/installer/pkg/components/blobserve/deployment.go
+++ b/install/installer/pkg/components/blobserve/deployment.go
@@ -115,7 +115,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 							},
 							Env: common.CustomizeEnvvar(ctx, Component, common.MergeEnv(
 								common.DefaultEnv(&ctx.Config),
-								common.WorkspaceTracingEnv(ctx),
+								common.WorkspaceTracingEnv(ctx, Component),
 							)),
 							VolumeMounts: []corev1.VolumeMount{{
 								Name:      "config",

--- a/install/installer/pkg/components/content-service/deployment.go
+++ b/install/installer/pkg/components/content-service/deployment.go
@@ -68,7 +68,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 			},
 			Env: common.CustomizeEnvvar(ctx, Component, common.MergeEnv(
 				common.DefaultEnv(&ctx.Config),
-				common.WorkspaceTracingEnv(ctx),
+				common.WorkspaceTracingEnv(ctx, Component),
 				[]corev1.EnvVar{{
 					Name:  "GRPC_GO_RETRY",
 					Value: "on",

--- a/install/installer/pkg/components/image-builder-mk3/deployment.go
+++ b/install/installer/pkg/components/image-builder-mk3/deployment.go
@@ -154,7 +154,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 						},
 						Env: common.CustomizeEnvvar(ctx, Component, common.MergeEnv(
 							common.DefaultEnv(&ctx.Config),
-							common.WorkspaceTracingEnv(ctx),
+							common.WorkspaceTracingEnv(ctx, Component),
 						)),
 						Resources: common.ResourceRequirements(ctx, Component, Component, corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{

--- a/install/installer/pkg/components/registry-facade/daemonset.go
+++ b/install/installer/pkg/components/registry-facade/daemonset.go
@@ -235,7 +235,7 @@ func daemonset(ctx *common.RenderContext) ([]runtime.Object, error) {
 						},
 						Env: common.CustomizeEnvvar(ctx, Component, common.MergeEnv(
 							common.DefaultEnv(&ctx.Config),
-							common.WorkspaceTracingEnv(ctx),
+							common.WorkspaceTracingEnv(ctx, Component),
 							[]corev1.EnvVar{
 								{
 									Name:  "GRPC_GO_RETRY",

--- a/install/installer/pkg/components/server/deployment.go
+++ b/install/installer/pkg/components/server/deployment.go
@@ -79,7 +79,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 	env := common.MergeEnv(
 		common.DefaultEnv(&ctx.Config),
 		common.DatabaseEnv(&ctx.Config),
-		common.WebappTracingEnv(ctx),
+		common.WebappTracingEnv(ctx, Component),
 		common.AnalyticsEnv(&ctx.Config),
 		common.MessageBusEnv(&ctx.Config),
 		common.ConfigcatEnv(ctx),

--- a/install/installer/pkg/components/ws-daemon/daemonset.go
+++ b/install/installer/pkg/components/ws-daemon/daemonset.go
@@ -196,7 +196,7 @@ fi
 				}},
 				Env: common.CustomizeEnvvar(ctx, Component, common.MergeEnv(
 					common.DefaultEnv(&cfg),
-					common.WorkspaceTracingEnv(ctx),
+					common.WorkspaceTracingEnv(ctx, Component),
 					common.NodeNameEnv(ctx),
 				)),
 				Resources: common.ResourceRequirements(ctx, Component, Component, corev1.ResourceRequirements{Requests: corev1.ResourceList{

--- a/install/installer/pkg/components/ws-manager-bridge/deployment.go
+++ b/install/installer/pkg/components/ws-manager-bridge/deployment.go
@@ -127,7 +127,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 							},
 							Env: common.CustomizeEnvvar(ctx, Component, common.MergeEnv(
 								common.DefaultEnv(&ctx.Config),
-								common.WorkspaceTracingEnv(ctx),
+								common.WorkspaceTracingEnv(ctx, Component),
 								common.AnalyticsEnv(&ctx.Config),
 								common.MessageBusEnv(&ctx.Config),
 								common.DatabaseEnv(&ctx.Config),

--- a/install/installer/pkg/components/ws-manager/deployment.go
+++ b/install/installer/pkg/components/ws-manager/deployment.go
@@ -54,7 +54,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 			},
 			Env: common.CustomizeEnvvar(ctx, Component, common.MergeEnv(
 				common.DefaultEnv(&ctx.Config),
-				common.WorkspaceTracingEnv(ctx),
+				common.WorkspaceTracingEnv(ctx, Component),
 				[]corev1.EnvVar{{Name: "GRPC_GO_RETRY", Value: "on"}},
 			)),
 			VolumeMounts: []corev1.VolumeMount{

--- a/install/installer/pkg/components/ws-proxy/deployment.go
+++ b/install/installer/pkg/components/ws-proxy/deployment.go
@@ -118,7 +118,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 			},
 			Env: common.CustomizeEnvvar(ctx, Component, common.MergeEnv(
 				common.DefaultEnv(&ctx.Config),
-				common.WorkspaceTracingEnv(ctx),
+				common.WorkspaceTracingEnv(ctx, Component),
 				common.AnalyticsEnv(&ctx.Config),
 			)),
 			ReadinessProbe: &corev1.Probe{

--- a/install/installer/pkg/config/v1/config.go
+++ b/install/installer/pkg/config/v1/config.go
@@ -220,6 +220,9 @@ type Analytics struct {
 type Tracing struct {
 	Endpoint  *string `json:"endpoint,omitempty"`
 	AgentHost *string `json:"agentHost,omitempty"`
+	// Name of the kubernetes secret to use for Jaeger authentication
+	// The secret should contains two definitions: JAEGER_USER and JAEGER_PASSWORD
+	SecretName *string `json:"secretName,omitempty"`
 }
 
 type Database struct {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/13381
Fixes https://github.com/gitpod-io/gitpod/issues/13385

## How to test
- Configure the installer setting 
```
tracing:
  secretName: XXXXX
```

and verify the env variables`JAEGER_USER` and `JAEGER_PASSWORD` are configured.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Add option to add authentication to Jaeger and configure default tags with `metadata.shortName` and `metadata.region`
```

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
