### PR TITLE
[public-api] Refactor to use conenct handlers, route api.domain to HTTP

### DIFF
--- a/components/proxy/conf/Caddyfile
+++ b/components/proxy/conf/Caddyfile
@@ -150,14 +150,7 @@ api.{$GITPOD_DOMAIN} {
         output stdout
     }
 
-	@grpc protocol grpc
-
-	handle @grpc {
-		# gRPC traffic goes to gRPC server
-		reverse_proxy h2c://public-api-server.{$KUBE_NAMESPACE}.{$KUBE_DOMAIN}:9001
-	}
-
-	# Non-grpc traffic goes to an HTTP server
+	# All traffic goes to HTTP endpoint. We handle gRPC using connect.build
 	reverse_proxy public-api-server.{$KUBE_NAMESPACE}.{$KUBE_DOMAIN}:9002
 }
 

--- a/components/public-api-server/pkg/apiv1/prebuild.go
+++ b/components/public-api-server/pkg/apiv1/prebuild.go
@@ -6,23 +6,24 @@ package apiv1
 
 import (
 	"context"
+
+	"github.com/bufbuild/connect-go"
 	v1 "github.com/gitpod-io/gitpod/public-api/v1"
+	"github.com/gitpod-io/gitpod/public-api/v1/v1connect"
 )
 
 func NewPrebuildService() *PrebuildService {
-	return &PrebuildService{
-		UnimplementedPrebuildsServiceServer: &v1.UnimplementedPrebuildsServiceServer{},
-	}
+	return &PrebuildService{}
 }
 
 type PrebuildService struct {
-	*v1.UnimplementedPrebuildsServiceServer
+	v1connect.UnimplementedPrebuildsServiceHandler
 }
 
-func (p *PrebuildService) GetPrebuild(ctx context.Context, req *v1.GetPrebuildRequest) (*v1.GetPrebuildResponse, error) {
-	return &v1.GetPrebuildResponse{
+func (p *PrebuildService) GetPrebuild(ctx context.Context, req *connect.Request[v1.GetPrebuildRequest]) (*connect.Response[v1.GetPrebuildResponse], error) {
+	return connect.NewResponse(&v1.GetPrebuildResponse{
 		Prebuild: &v1.Prebuild{
-			PrebuildId: req.GetPrebuildId(),
+			PrebuildId: req.Msg.GetPrebuildId(),
 			Spec: &v1.PrebuildSpec{
 				Context: &v1.WorkspaceContext{
 					ContextUrl: "https://github.com/gitpod-io/gitpod",
@@ -32,5 +33,5 @@ func (p *PrebuildService) GetPrebuild(ctx context.Context, req *v1.GetPrebuildRe
 			},
 			Status: nil,
 		},
-	}, nil
+	}), nil
 }

--- a/components/public-api-server/pkg/apiv1/prebuild_test.go
+++ b/components/public-api-server/pkg/apiv1/prebuild_test.go
@@ -6,18 +6,20 @@ package apiv1
 
 import (
 	"context"
+	"testing"
+
+	"github.com/bufbuild/connect-go"
 	v1 "github.com/gitpod-io/gitpod/public-api/v1"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestPrebuildService_GetPrebuild(t *testing.T) {
 	svc := NewPrebuildService()
 
 	prebuildID := "some-prebuild-id"
-	resp, err := svc.GetPrebuild(context.Background(), &v1.GetPrebuildRequest{
+	resp, err := svc.GetPrebuild(context.Background(), connect.NewRequest(&v1.GetPrebuildRequest{
 		PrebuildId: prebuildID,
-	})
+	}))
 	require.NoError(t, err)
 	require.Equal(t, &v1.GetPrebuildResponse{
 		Prebuild: &v1.Prebuild{
@@ -31,6 +33,6 @@ func TestPrebuildService_GetPrebuild(t *testing.T) {
 			},
 			Status: nil,
 		},
-	}, resp)
+	}, resp.Msg)
 
 }

--- a/components/public-api-server/pkg/apiv1/workspace.go
+++ b/components/public-api-server/pkg/apiv1/workspace.go
@@ -6,60 +6,48 @@ package apiv1
 
 import (
 	"context"
+	"fmt"
 
+	connect "github.com/bufbuild/connect-go"
 	protocol "github.com/gitpod-io/gitpod/gitpod-protocol"
+	"github.com/gitpod-io/gitpod/public-api-server/pkg/auth"
 	"github.com/gitpod-io/gitpod/public-api-server/pkg/proxy"
 	v1 "github.com/gitpod-io/gitpod/public-api/v1"
+	"github.com/gitpod-io/gitpod/public-api/v1/v1connect"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/logrus/ctxlogrus"
 	"github.com/relvacode/iso8601"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/metadata"
-	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func NewWorkspaceService(serverConnPool proxy.ServerConnectionPool) *WorkspaceService {
 	return &WorkspaceService{
-		connectionPool:                       serverConnPool,
-		UnimplementedWorkspacesServiceServer: &v1.UnimplementedWorkspacesServiceServer{},
+		connectionPool: serverConnPool,
 	}
 }
 
 type WorkspaceService struct {
 	connectionPool proxy.ServerConnectionPool
 
-	*v1.UnimplementedWorkspacesServiceServer
+	v1connect.UnimplementedWorkspacesServiceHandler
 }
 
-func (w *WorkspaceService) GetWorkspace(ctx context.Context, r *v1.GetWorkspaceRequest) (*v1.GetWorkspaceResponse, error) {
+func (s *WorkspaceService) GetWorkspace(ctx context.Context, req *connect.Request[v1.GetWorkspaceRequest]) (*connect.Response[v1.GetWorkspaceResponse], error) {
+	token := auth.TokenFromContext(ctx)
 	logger := ctxlogrus.Extract(ctx)
-	token, err := bearerTokenFromContext(ctx)
-	if err != nil {
-		return nil, err
-	}
 
-	server, err := w.connectionPool.Get(ctx, token)
+	server, err := s.connectionPool.Get(ctx, token)
 	if err != nil {
 		logger.WithError(err).Error("Failed to get connection to server.")
-		return nil, status.Error(codes.Internal, "failed to establish connection to downstream services")
+		return nil, connect.NewError(connect.CodeInternal, err)
 	}
 
-	workspace, err := server.GetWorkspace(ctx, r.GetWorkspaceId())
+	workspace, err := server.GetWorkspace(ctx, req.Msg.GetWorkspaceId())
 	if err != nil {
 		logger.WithError(err).Error("Failed to get workspace.")
-		converted := proxy.ConvertError(err)
-		switch status.Code(converted) {
-		case codes.PermissionDenied:
-			return nil, status.Error(codes.PermissionDenied, "insufficient permission to access workspace")
-		case codes.NotFound:
-			return nil, status.Error(codes.NotFound, "workspace does not exist")
-		default:
-			return nil, status.Error(codes.Internal, "unable to retrieve workspace")
-		}
+		return nil, proxy.ConvertError(err)
 	}
 
-	return &v1.GetWorkspaceResponse{
+	return connect.NewResponse(&v1.GetWorkspaceResponse{
 		Result: &v1.Workspace{
 			WorkspaceId: workspace.Workspace.ID,
 			OwnerId:     workspace.Workspace.OwnerID,
@@ -73,72 +61,40 @@ func (w *WorkspaceService) GetWorkspace(ctx context.Context, r *v1.GetWorkspaceR
 			},
 			Description: workspace.Workspace.Description,
 		},
-	}, nil
+	}), nil
 }
 
-func (w *WorkspaceService) GetOwnerToken(ctx context.Context, r *v1.GetOwnerTokenRequest) (*v1.GetOwnerTokenResponse, error) {
+func (s *WorkspaceService) GetOwnerToken(ctx context.Context, req *connect.Request[v1.GetOwnerTokenRequest]) (*connect.Response[v1.GetOwnerTokenResponse], error) {
 	logger := ctxlogrus.Extract(ctx)
-	token, err := bearerTokenFromContext(ctx)
-	if err != nil {
-		return nil, err
-	}
+	token := auth.TokenFromContext(ctx)
 
-	server, err := w.connectionPool.Get(ctx, token)
+	server, err := s.connectionPool.Get(ctx, token)
 	if err != nil {
 		logger.WithError(err).Error("Failed to get connection to server.")
-		return nil, status.Error(codes.Internal, "failed to establish connection to downstream services")
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to establish connection to downstream services"))
 	}
 
-	ownerToken, err := server.GetOwnerToken(ctx, r.GetWorkspaceId())
+	ownerToken, err := server.GetOwnerToken(ctx, req.Msg.GetWorkspaceId())
 
 	if err != nil {
 		logger.WithError(err).Error("Failed to get owner token.")
-		converted := proxy.ConvertError(err)
-		switch status.Code(converted) {
-		case codes.PermissionDenied:
-			return nil, status.Error(codes.PermissionDenied, "insufficient permission to retrieve ownertoken")
-		case codes.NotFound:
-			return nil, status.Error(codes.NotFound, "workspace does not exist")
-		default:
-			return nil, status.Error(codes.Internal, "unable to retrieve owner token")
-		}
+		return nil, proxy.ConvertError(err)
 	}
 
-	return &v1.GetOwnerTokenResponse{Token: ownerToken}, nil
+	return connect.NewResponse(&v1.GetOwnerTokenResponse{Token: ownerToken}), nil
 }
 
-func bearerTokenFromContext(ctx context.Context) (string, error) {
-	md, ok := metadata.FromIncomingContext(ctx)
-	if !ok {
-		return "", status.Error(codes.Unauthenticated, "no credentials provided")
-	}
-
-	values := md.Get("authorization")
-	if len(values) == 0 {
-		return "", status.Error(codes.Unauthenticated, "no authorization header specified")
-	}
-	if len(values) > 1 {
-		return "", status.Error(codes.Unauthenticated, "more than one authorization header specified, exactly one is required")
-	}
-
-	token := values[0]
-	return token, nil
-}
-
-func (w *WorkspaceService) ListWorkspaces(ctx context.Context, req *v1.ListWorkspacesRequest) (*v1.ListWorkspacesResponse, error) {
+func (s *WorkspaceService) ListWorkspaces(ctx context.Context, req *connect.Request[v1.ListWorkspacesRequest]) (*connect.Response[v1.ListWorkspacesResponse], error) {
 	logger := ctxlogrus.Extract(ctx)
-	token, err := bearerTokenFromContext(ctx)
-	if err != nil {
-		return nil, err
-	}
+	token := auth.TokenFromContext(ctx)
 
-	server, err := w.connectionPool.Get(ctx, token)
+	server, err := s.connectionPool.Get(ctx, token)
 	if err != nil {
 		logger.WithError(err).Error("Failed to get connection to server.")
-		return nil, status.Error(codes.Internal, "failed to establish connection to downstream services")
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to establish connection to downstream services"))
 	}
 
-	limit, err := getLimitFromPagination(req.Pagination)
+	limit, err := getLimitFromPagination(req.Msg.GetPagination())
 	if err != nil {
 		// getLimitFromPagination returns gRPC errors
 		return nil, err
@@ -161,9 +117,11 @@ func (w *WorkspaceService) ListWorkspaces(ctx context.Context, req *v1.ListWorks
 		res = append(res, workspaceAndInstance)
 	}
 
-	return &v1.ListWorkspacesResponse{
-		Result: res,
-	}, nil
+	return connect.NewResponse(
+		&v1.ListWorkspacesResponse{
+			Result: res,
+		},
+	), nil
 }
 
 func getLimitFromPagination(pagination *v1.Pagination) (int, error) {
@@ -179,7 +137,7 @@ func getLimitFromPagination(pagination *v1.Pagination) (int, error) {
 		return defaultLimit, nil
 	}
 	if pagination.PageSize < 0 || maxLimit < pagination.PageSize {
-		return 0, grpc.Errorf(codes.InvalidArgument, "invalid pagination page size (must be 0 < x < %d)", maxLimit)
+		return 0, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("invalid pagination page size (must be 0 < x < %d)", maxLimit))
 	}
 
 	return int(pagination.PageSize), nil
@@ -192,7 +150,7 @@ func convertWorkspaceInfo(input *protocol.WorkspaceInfo) (*v1.ListWorkspacesResp
 		creationTime, err := parseGitpodTimestamp(wsi.CreationTime)
 		if err != nil {
 			// TODO(cw): should this really return an error and possibly fail the entire operation?
-			return nil, grpc.Errorf(codes.FailedPrecondition, "cannot parse creation time: %v", err)
+			return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("cannot parse creation time: %v", err))
 		}
 
 		var phase v1.WorkspaceInstanceStatus_Phase
@@ -219,7 +177,7 @@ func convertWorkspaceInfo(input *protocol.WorkspaceInfo) (*v1.ListWorkspacesResp
 			phase = v1.WorkspaceInstanceStatus_PHASE_STOPPED
 		default:
 			// TODO(cw): should this really return an error and possibly fail the entire operation?
-			return nil, grpc.Errorf(codes.FailedPrecondition, "cannot convert instance phase: %s", wsi.Status.Phase)
+			return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("cannot convert instance phase: %s", wsi.Status.Phase))
 		}
 
 		var admissionLevel v1.AdmissionLevel

--- a/components/public-api-server/pkg/proxy/errors.go
+++ b/components/public-api-server/pkg/proxy/errors.go
@@ -5,9 +5,9 @@
 package proxy
 
 import (
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	"strings"
+
+	"github.com/bufbuild/connect-go"
 )
 
 func ConvertError(err error) error {
@@ -18,23 +18,23 @@ func ConvertError(err error) error {
 	s := err.Error()
 
 	if strings.Contains(s, "code 401") {
-		return status.Error(codes.PermissionDenied, s)
+		return connect.NewError(connect.CodePermissionDenied, err)
 	}
 
 	// components/gitpod-protocol/src/messaging/error.ts
 	if strings.Contains(s, "code 403") {
-		return status.Error(codes.PermissionDenied, s)
+		return connect.NewError(connect.CodePermissionDenied, err)
 	}
 
 	// components/gitpod-protocol/src/messaging/error.ts
 	if strings.Contains(s, "code 404") {
-		return status.Error(codes.NotFound, s)
+		return connect.NewError(connect.CodeNotFound, err)
 	}
 
 	// components/gitpod-messagebus/src/jsonrpc-server.ts#47
 	if strings.Contains(s, "code -32603") {
-		return status.Error(codes.Internal, s)
+		return connect.NewError(connect.CodeInternal, err)
 	}
 
-	return status.Error(codes.Internal, s)
+	return connect.NewError(connect.CodeInternal, err)
 }

--- a/components/public-api-server/pkg/proxy/errors_test.go
+++ b/components/public-api-server/pkg/proxy/errors_test.go
@@ -6,31 +6,32 @@ package proxy
 
 import (
 	"errors"
-	"github.com/stretchr/testify/require"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
+	"fmt"
 	"testing"
+
+	"github.com/bufbuild/connect-go"
+	"github.com/stretchr/testify/require"
 )
 
 func TestConvertError(t *testing.T) {
 	scenarios := []struct {
 		WebsocketError error
-		ExpectedStatus codes.Code
+		ExpectedStatus connect.Code
 	}{
 		{
 			WebsocketError: errors.New("reconnecting-ws: bad handshake: code 401 - URL: wss://main.preview.gitpod-dev.com/api/v1 - headers: map[Authorization:[Bearer foo] Origin:[http://main.preview.gitpod-dev.com/]]"),
-			ExpectedStatus: codes.PermissionDenied,
+			ExpectedStatus: connect.CodePermissionDenied,
 		},
 		{
 			WebsocketError: errors.New("jsonrpc2: code -32603 message: Request getWorkspace failed with message: No workspace with id 'some-id' found."),
-			ExpectedStatus: codes.Internal,
+			ExpectedStatus: connect.CodeInternal,
 		},
 	}
 
 	for _, s := range scenarios {
 		converted := ConvertError(s.WebsocketError)
-		require.Equal(t, s.ExpectedStatus, status.Code(converted))
+		require.Equal(t, s.ExpectedStatus, connect.CodeOf(converted))
 		// the error message should remain the same
-		require.Equal(t, s.WebsocketError.Error(), status.Convert(converted).Message())
+		require.Equal(t, fmt.Errorf("%s: %w", s.ExpectedStatus.String(), s.WebsocketError).Error(), converted.Error())
 	}
 }

--- a/dev/gpctl/cmd/public-api.go
+++ b/dev/gpctl/cmd/public-api.go
@@ -51,7 +51,7 @@ func newPublicAPIConn() (*grpc.ClientConn, error) {
 	opts := []grpc.DialOption{
 		// attach token to requests to auth
 		grpc.WithUnaryInterceptor(func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
-			withAuth := metadata.AppendToOutgoingContext(ctx, "authorization", publicApiCmdOpts.token)
+			withAuth := metadata.AppendToOutgoingContext(ctx, "authorization", "Bearer "+publicApiCmdOpts.token)
 			return invoker(withAuth, method, req, reply, cc, opts...)
 		}),
 	}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

In this PR, we 1-1 map the old implementation in gRPC to the new implementation with Connect. Changes are deliberately not made to streamline the tests and simplify to keep the PR cleaner.

In general, the changes are the following (see [docs](https://connect.build/docs/go/grpc-compatibility#migration))
1. Use the generated ServiceHandlers
2. Wrap requests and responses in `connect.NewRequest` or `connect.NewResponse`
3. Use Connects error codes
4. Use HTTP server in tests

This PR also changes default routing of `api.<domain>` requests to the HTTP server, this has the following effect:
* Connect handlers handle both gRPC and HTTP traffic - this is fine, as Connect is designed for this
* Depending on the rollout sequencing, there can be a brief period where requests would fail. This is OK, as we don't get any traffic on this yet anyway.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Depends on https://github.com/gitpod-io/gitpod/pull/13693

## How to test
<!-- Provide steps to test this PR -->
Unit tests

1. Log in to preview and run the following in the console to get an access token:
```
	await window._gp.gitpodService.server.generateNewGitpodToken({ type: 1, scopes: ["function:getGitpodTokenScopes",
	"function:getWorkspace",
	"function:getWorkspaces",
	"function:listenForWorkspaceInstanceUpdates",
	"resource:default",]})
```
To make subsequent steps readily runnable, export the token in your shell:
```
export BEARER_TOKEN="<token>"
```

Validate we can reach the new APIs over cURL:
```
curl \
    --header 'Content-Type: application/json' \
    --header 'Authorization: Bearer $BEARER_TOKEN' \
    --data '{}' \
    https://api.mp-public-ca4417e0d2.preview.gitpod-dev.com/gitpod.v1.WorkspacesService/ListWorkspaces | jq

{}
```
We're doing a list call, and we don't have workspaces so an empty list response is expected.

Validate we can reach the APIs using a gRPC client
```
gpctl api workspaces list --address api.mp-public-ca4417e0d2.preview.gitpod-dev.com:443 --token $BEARER_TOKEN 

ID        Owner        ContextURL
```
Again, we're not getting any workspaces back because we've not started any but the important part is we're not getting an error.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
