### PR TITLE
[proxy] Remove ineffectual cors on /api/* and /headless-log-download*

### DIFF
--- a/components/proxy/conf/Caddyfile
+++ b/components/proxy/conf/Caddyfile
@@ -225,10 +225,6 @@ https://{$GITPOD_DOMAIN} {
 
 	@backend path /api/* /headless-logs/*
 	handle @backend {
-		gitpod.cors_origin {
-			base_domain {$GITPOD_DOMAIN}
-		}
-
 		# note: no compression, as that breaks streaming for headless logs
 
 		uri strip_prefix /api


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

[See context](https://gitpod.slack.com/archives/C01KGM9AW4W/p1665470818969739)

Because the configuration results in `AllowedOrigins = ["*.<domain>"]`, it doesn't actually match anything because the AllowedOrigins must contain a URL (ie. `https://*.gitpod.io`), rather than just the host.

To prove the existing configuration does not work as intended, do the following requests:
```
curl https://gitpod.io/api/foo-bar \
   -H "Origin: https://api.gitpod.io/" \
   -H "Access-Control-Request-Method: POST" \
   -H "Access-Control-Request-Headers: X-Requested-With" \
   -X OPTIONS \
   -v

 HTTP/2 204
< access-control-allow-credentials: true
< access-control-allow-headers: X-Requested-With
< access-control-allow-methods: POST
< access-control-allow-origin: https://api.gitpod.io/
< access-control-max-age: 60
< content-security-policy: frame-ancestors 'self' https://*.gitpod.io https://gitpod.io/
< referrer-policy: no-referrer-when-downgrade
< strict-transport-security: max-age=31536000
< vary: Origin
< vary: Access-Control-Request-Method
< vary: Access-Control-Request-Headers
< x-content-type-options: nosniff
< x-xss-protection: 1; mode=block
< date: Tue, 11 Oct 2022 06:53:14 GMT
< via: 1.1 google
< alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000


curl https://gitpod.io/api/foo-bar \
   -H "Origin: https://gitpod.io/" \
   -H "Access-Control-Request-Method: POST" \
   -H "Access-Control-Request-Headers: X-Requested-With" \
   -X OPTIONS -v

 HTTP/2 204
< content-security-policy: frame-ancestors 'self' https://*.gitpod.io https://gitpod.io/
< referrer-policy: no-referrer-when-downgrade
< strict-transport-security: max-age=31536000
< vary: Origin
< vary: Access-Control-Request-Method
< vary: Access-Control-Request-Headers
< x-content-type-options: nosniff
< x-xss-protection: 1; mode=block
< date: Tue, 11 Oct 2022 06:54:42 GMT
< via: 1.1 google
< alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
```

Neither of these contain the required `Access-Control-Allow-*` headers on the responses.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
