### PR TITLE
[proxy] Enable CORS for api.<domain> from https://<domain> origin

### DIFF
--- a/components/proxy/conf/Caddyfile
+++ b/components/proxy/conf/Caddyfile
@@ -150,7 +150,10 @@ api.{$GITPOD_DOMAIN} {
         output stdout
     }
 
-	# All traffic goes to HTTP endpoint. We handle gRPC using connect.build
+	gitpod.cors_origin {
+		allowed_origins https://{$GITPOD_DOMAIN}
+	}
+
 	reverse_proxy public-api-server.{$KUBE_NAMESPACE}.{$KUBE_DOMAIN}:9002
 }
 

--- a/components/proxy/plugins/corsorigin/cors_origin.go
+++ b/components/proxy/plugins/corsorigin/cors_origin.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
@@ -27,9 +28,10 @@ func init() {
 
 // CorsOrigin implements an HTTP handler that generates a valid CORS Origin value
 type CorsOrigin struct {
-	AnyDomain  bool   `json:"any_domain,omitempty"`
-	BaseDomain string `json:"base_domain,omitempty"`
-	Debug      bool   `json:"debug,omitempty"`
+	AnyDomain      bool     `json:"any_domain,omitempty"`
+	BaseDomain     string   `json:"base_domain,omitempty"`
+	AllowedOrigins []string `json:"allowed_origins,omitempty"`
+	Debug          bool     `json:"debug,omitempty"`
 }
 
 // CaddyModule returns the Caddy module information.
@@ -54,9 +56,12 @@ func (m CorsOrigin) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddy
 	var allowedOrigins []string
 	if m.AnyDomain {
 		allowedOrigins = []string{"*"}
-	} else {
+	} else if m.BaseDomain != "" {
 		allowedOrigins = []string{"*." + m.BaseDomain}
+	} else if len(m.AllowedOrigins) != 0 {
+		allowedOrigins = m.AllowedOrigins
 	}
+
 	c := cors.New(cors.Options{
 		AllowedOrigins:   allowedOrigins,
 		AllowedMethods:   allowedMethods,
@@ -98,8 +103,15 @@ func (m *CorsOrigin) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 			}
 
 			m.AnyDomain = b
+
 		case "base_domain":
 			m.BaseDomain = value
+
+		case "allowed_origins":
+			// comma separated
+			origins := strings.Split(value, ",")
+			m.AllowedOrigins = origins
+
 		case "debug":
 			b, err := strconv.ParseBool(value)
 			if err != nil {
@@ -112,8 +124,12 @@ func (m *CorsOrigin) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 		}
 	}
 
-	if !m.AnyDomain && m.BaseDomain == "" {
-		return fmt.Errorf("Please configure the base_domain subdirective")
+	if m.BaseDomain != "" && len(m.AllowedOrigins) != 0 {
+		return fmt.Errorf("base_domain and allowed_origins subdirectives are mutually exclusive, configure only one of them")
+	}
+
+	if !m.AnyDomain && m.BaseDomain == "" && len(m.AllowedOrigins) == 0 {
+		return fmt.Errorf("Please configure the base_domain or allowed_origins subdirective")
 	}
 
 	return nil


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Extends our CORS plugin configuration to specify AllowedOrigins. This is done because the `BaseDomain` subdirective does not work (see https://github.com/gitpod-io/gitpod/pull/13740 for why), and in this case because we're enabling the cors for the sub-domain (api.<domain>) but allowing traffic from the root domain, we cannot use the `BaseDomain` directive anyway.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Part of https://github.com/gitpod-io/gitpod/issues/13574

## How to test
<!-- Provide steps to test this PR -->

Test we get the expected `Access-Control-Allow-*` headers when Origin is GITPOD_DOMAIN
```
 curl https://api.mp-proxy-c2a55ca9ff1.preview.gitpod-dev.com/ \
   -H "Origin: https://mp-proxy-c2a55ca9ff1.preview.gitpod-dev.com" \
   -H "Access-Control-Request-Method: POST" \
   -H "Access-Control-Request-Headers: X-Requested-With" \
   -X OPTIONS -i

HTTP/2 204
access-control-allow-credentials: true
access-control-allow-headers: X-Requested-With
access-control-allow-methods: POST
access-control-allow-origin: https://mp-proxy-c2a55ca9ff1.preview.gitpod-dev.com
access-control-max-age: 60
server: Caddy
vary: Origin
vary: Access-Control-Request-Method
vary: Access-Control-Request-Headers
date: Wed, 12 Oct 2022 20:53:59 GMT
```

Test that no CORS are present when Origin does not match
```
curl https://api.mp-proxy-c2a55ca9ff1.preview.gitpod-dev.com/ \
   -H "Origin: https://random.website.com" \
   -H "Access-Control-Request-Method: POST" \
   -H "Access-Control-Request-Headers: X-Requested-With" \
   -X OPTIONS -i

HTTP/2 204
server: Caddy
vary: Origin
vary: Access-Control-Request-Method
vary: Access-Control-Request-Headers
date: Wed, 12 Oct 2022 20:55:13 GMT
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
