### PR TITLE
[server]  Disallow removing all Owners from a team

### DIFF
--- a/components/gitpod-db/src/typeorm/team-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/team-db-impl.ts
@@ -203,6 +203,18 @@ export class TeamDBImpl implements TeamDB {
             throw new ResponseError(ErrorCodes.NOT_FOUND, "A team with this ID could not be found");
         }
         const membershipRepo = await this.getMembershipRepo();
+
+        if (role != "owner") {
+            const ownerCount = await membershipRepo.count({
+                teamId,
+                role: "owner",
+                deleted: false,
+            });
+            if (ownerCount <= 1) {
+                throw new ResponseError(ErrorCodes.CONFLICT, "Team must retain at least one owner");
+            }
+        }
+
         const membership = await membershipRepo.findOne({ teamId, userId, deleted: false });
         if (!membership) {
             throw new ResponseError(ErrorCodes.NOT_FOUND, "The user is not currently a member of this team");


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Block changing role on teams of size 1 (or less).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/11452

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[teams] Disallow removing all Owners from a team
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
