### PR TITLE
[bitbucket-server] fix parsing of branch name

### DIFF
--- a/components/server/src/bitbucket-server/bitbucket-server-context-parser.spec.ts
+++ b/components/server/src/bitbucket-server/bitbucket-server-context-parser.spec.ts
@@ -19,6 +19,7 @@ import { Config } from "../config";
 import { TokenProvider } from "../user/token-provider";
 import { BitbucketServerApi } from "./bitbucket-server-api";
 import { HostContextProvider } from "../auth/host-context-provider";
+import { URL } from "url";
 
 @suite(timeout(10000), skipIfEnvVarNotSet("GITPOD_TEST_TOKEN_BITBUCKET_SERVER"))
 class TestBitbucketServerContextParser {
@@ -303,6 +304,14 @@ class TestBitbucketServerContextParser {
                 },
             },
         });
+    }
+
+    @test.only test_toSimpleBranchName() {
+        const url = new URL(
+            "https://bitbucket.gitpod-self-hosted.com/projects/FOO/repos/repo123/browse?at=refs%2Fheads%2Ffoo",
+        );
+        const branchName = this.parser.toSimpleBranchName(url.searchParams.get("at")!);
+        expect(branchName).to.equal("foo");
     }
 }
 

--- a/components/server/src/bitbucket-server/bitbucket-server-context-parser.ts
+++ b/components/server/src/bitbucket-server/bitbucket-server-context-parser.ts
@@ -32,7 +32,8 @@ export class BitbucketServerContextParser extends AbstractContextParser implemen
             );
 
             if (searchParams.has("at")) {
-                more.ref = decodeURIComponent(searchParams.get("at")!);
+                const branchName = this.toSimpleBranchName(decodeURIComponent(searchParams.get("at")!));
+                more.ref = branchName;
                 more.refType = "branch";
             }
 
@@ -56,6 +57,12 @@ export class BitbucketServerContextParser extends AbstractContextParser implemen
         } finally {
             span.finish();
         }
+    }
+
+    // Example: For a given context URL https://HOST/projects/FOO/repos/repo123/browse?at=refs%2Fheads%2Ffoo
+    // we need to parse the simple branch name `foo`.
+    public toSimpleBranchName(qualifiedBranchName: string | undefined) {
+        return qualifiedBranchName?.replace("refs/heads/", "");
     }
 
     public async parseURL(user: User, contextUrl: string): Promise<{ repoKind: "projects" | "users" } & URLParts> {


### PR DESCRIPTION
Context URLs of BitBucket Server may include a search param "at" to specify a branch fully qualified. GItpod's context parser results are expected to provide a simple "ref" name for branches.

This PR fixes parsing of branch names.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #13486

## How to test
Rerun unit test
```
cd components/server
npx mocha --opts mocha.opts /workspace/gitpod/components/server/src/bitbucket-server/bitbucket-server-context-parser.spec.ts
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Fix branch context for BitBucket Server
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
