### PR TITLE
[Usage-based] Adjust Stripe usage limits to spec

### DIFF
--- a/components/dashboard/src/components/UsageBasedBillingConfig.tsx
+++ b/components/dashboard/src/components/UsageBasedBillingConfig.tsx
@@ -102,9 +102,10 @@ export default function UsageBasedBillingConfig({ attributionId }: Props) {
                     const members = await getGitpodService().server.getTeamMembers(attrId.teamId);
                     limit = BASE_USAGE_LIMIT_FOR_STRIPE_USERS * members.length;
                 }
-                await getGitpodService().server.subscribeToStripe(attributionId, setupIntentId, limit);
-                const newLimit = await getGitpodService().server.getUsageLimit(attributionId);
-                setUsageLimit(newLimit);
+                const newLimit = await getGitpodService().server.subscribeToStripe(attributionId, setupIntentId, limit);
+                if (newLimit) {
+                    setUsageLimit(newLimit);
+                }
             } catch (error) {
                 console.error("Could not subscribe to Stripe", error);
                 window.localStorage.removeItem(localStorageKey);

--- a/components/dashboard/src/components/UsageBasedBillingConfig.tsx
+++ b/components/dashboard/src/components/UsageBasedBillingConfig.tsx
@@ -407,6 +407,7 @@ export default function UsageBasedBillingConfig({ attributionId }: Props) {
             )}
             {showUpdateLimitModal && (
                 <UpdateLimitModal
+                    minValue={AttributionId.parse(attributionId || "")?.kind === "user" ? 1000 : 0}
                     currentValue={usageLimit}
                     onClose={() => setShowUpdateLimitModal(false)}
                     onUpdate={(newLimit) => updateUsageLimit(newLimit)}
@@ -537,12 +538,13 @@ function CreditCardInputForm(props: { attributionId: string }) {
 }
 
 function UpdateLimitModal(props: {
+    minValue?: number;
     currentValue: number | undefined;
     onClose: () => void;
     onUpdate: (newLimit: number) => {};
 }) {
     const [newLimit, setNewLimit] = useState<string | undefined>(
-        props.currentValue ? String(props.currentValue) : undefined,
+        typeof props.currentValue === "number" ? String(props.currentValue) : undefined,
     );
 
     return (
@@ -556,7 +558,7 @@ function UpdateLimitModal(props: {
                     <div className="w-full">
                         <input
                             type="number"
-                            min={0}
+                            min={props.minValue || 0}
                             value={newLimit}
                             className="rounded-md w-full truncate overflow-x-scroll pr-8"
                             onChange={(e) => setNewLimit(e.target.value)}

--- a/components/dashboard/src/components/UsageBasedBillingConfig.tsx
+++ b/components/dashboard/src/components/UsageBasedBillingConfig.tsx
@@ -101,6 +101,8 @@ export default function UsageBasedBillingConfig({ attributionId }: Props) {
                     limit = 1000 * members.length;
                 }
                 await getGitpodService().server.subscribeToStripe(attributionId, setupIntentId, limit);
+                const newLimit = await getGitpodService().server.getUsageLimit(attributionId);
+                setUsageLimit(newLimit);
             } catch (error) {
                 console.error("Could not subscribe to Stripe", error);
                 window.localStorage.removeItem(localStorageKey);

--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -278,7 +278,7 @@ export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, 
     getStripeSetupIntentClientSecret(): Promise<string>;
     findStripeSubscriptionId(attributionId: string): Promise<string | undefined>;
     createStripeCustomerIfNeeded(attributionId: string, currency: string): Promise<void>;
-    subscribeToStripe(attributionId: string, setupIntentId: string): Promise<void>;
+    subscribeToStripe(attributionId: string, setupIntentId: string, usageLimit: number): Promise<void>;
     getStripePortalUrl(attributionId: string): Promise<string>;
     getUsageLimit(attributionId: string): Promise<number | undefined>;
     setUsageLimit(attributionId: string, usageLimit: number): Promise<void>;

--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -278,7 +278,7 @@ export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, 
     getStripeSetupIntentClientSecret(): Promise<string>;
     findStripeSubscriptionId(attributionId: string): Promise<string | undefined>;
     createStripeCustomerIfNeeded(attributionId: string, currency: string): Promise<void>;
-    subscribeToStripe(attributionId: string, setupIntentId: string, usageLimit: number): Promise<void>;
+    subscribeToStripe(attributionId: string, setupIntentId: string, usageLimit: number): Promise<number | undefined>;
     getStripePortalUrl(attributionId: string): Promise<string>;
     getUsageLimit(attributionId: string): Promise<number | undefined>;
     setUsageLimit(attributionId: string, usageLimit: number): Promise<void>;

--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -2113,8 +2113,12 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
         }
     }
 
-    protected defaultSpendingLimit = 100;
-    async subscribeToStripe(ctx: TraceContext, attributionId: string, setupIntentId: string): Promise<void> {
+    async subscribeToStripe(
+        ctx: TraceContext,
+        attributionId: string,
+        setupIntentId: string,
+        usageLimit: number,
+    ): Promise<void> {
         const attrId = AttributionId.parse(attributionId);
         if (attrId === undefined) {
             log.error(`Invalid attribution id: ${attributionId}`);
@@ -2142,7 +2146,7 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
             await this.usageService.setCostCenter({
                 costCenter: {
                     attributionId: attributionId,
-                    spendingLimit: this.defaultSpendingLimit,
+                    spendingLimit: usageLimit,
                     billingStrategy: CostCenter_BillingStrategy.BILLING_STRATEGY_STRIPE,
                 },
             });

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -3101,7 +3101,12 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
     async createStripeCustomerIfNeeded(ctx: TraceContext, attributionId: string, currency: string): Promise<void> {
         throw new ResponseError(ErrorCodes.SAAS_FEATURE, `Not implemented in this version`);
     }
-    async subscribeToStripe(ctx: TraceContext, attributionId: string, setupIntentId: string): Promise<void> {
+    async subscribeToStripe(
+        ctx: TraceContext,
+        attributionId: string,
+        setupIntentId: string,
+        usageLimit: number,
+    ): Promise<void> {
         throw new ResponseError(ErrorCodes.SAAS_FEATURE, `Not implemented in this version`);
     }
     async getStripePortalUrl(ctx: TraceContext, attributionId: string): Promise<string> {

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -3106,7 +3106,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         attributionId: string,
         setupIntentId: string,
         usageLimit: number,
-    ): Promise<void> {
+    ): Promise<number | undefined> {
         throw new ResponseError(ErrorCodes.SAAS_FEATURE, `Not implemented in this version`);
     }
     async getStripePortalUrl(ctx: TraceContext, attributionId: string): Promise<string> {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Adjust Stripe usage limits to spec

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of https://github.com/gitpod-io/gitpod/issues/13389
~~Depends on https://github.com/gitpod-io/gitpod/pull/13798~~

## How to test
<!-- Provide steps to test this PR -->

1. Create a team called "Gitpod [Something]"
2. Go to team billing
3. There shouldn't be a visible usage limit
4. Upgrade the team by adding a payment method
5. The default usage limit should be `1000 * team_size` (but you can set it to any value)
6. Go to your individual billing settings
7. The usage limit should be `500` (not editable)
8. Upgrade by adding a payment method
9. The usage limit should now be `1000`, and you should be able to set any value >= 1000 (but not < )
10. Cancel your individual user subscription
11. The limit should be back to `500` (not editable)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-payment
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
