### PR TITLE
Fix the auto-port-forwarding on JetBrains EAP IDEs

### DIFF
--- a/components/ide/jetbrains/backend-plugin/gradle-latest.properties
+++ b/components/ide/jetbrains/backend-plugin/gradle-latest.properties
@@ -6,4 +6,4 @@ pluginUntilBuild=223.*
 # See https://jb.gg/intellij-platform-builds-list for available build versions.
 pluginVerifierIdeVersions=2022.3
 # Version from "com.jetbrains.intellij.idea" which can be found at https://www.jetbrains.com/intellij-repository/snapshots
-platformVersion=223.5756-EAP-CANDIDATE-SNAPSHOT
+platformVersion=223.6160-EAP-CANDIDATE-SNAPSHOT

--- a/components/ide/jetbrains/backend-plugin/launch-dev-server.sh
+++ b/components/ide/jetbrains/backend-plugin/launch-dev-server.sh
@@ -7,17 +7,19 @@ set -e
 set -o pipefail
 
 # Default Options
-DEBUG_PORT=0
+DEBUG_PORT=44444
 JB_QUALIFIER="latest"
 TEST_REPO=https://github.com/gitpod-io/spring-petclinic
+RUN_FROM="release"
 
 # Parsing Custom Options
-while getopts "p:r:s" OPTION
+while getopts "p:r:su" OPTION
 do
    case $OPTION in
        s) JB_QUALIFIER="stable" ;;
        r) TEST_REPO=$OPTARG ;;
        p) DEBUG_PORT=$OPTARG ;;
+       u) RUN_FROM="snapshot" ;;
        *) ;;
    esac
 done
@@ -25,16 +27,30 @@ done
 TEST_BACKEND_DIR="/workspace/ide-backend-$JB_QUALIFIER"
 if [ ! -d "$TEST_BACKEND_DIR" ]; then
   mkdir -p $TEST_BACKEND_DIR
-  if [[ $JB_QUALIFIER == "stable" ]]; then
-    PRODUCT_TYPE="release"
+  if [[ $RUN_FROM == "snapshot" ]]; then
+    (cd $TEST_BACKEND_DIR &&
+    SNAPSHOT_VERSION=$(grep "platformVersion=" "gradle-$JB_QUALIFIER.properties" | sed 's/platformVersion=//') &&
+    echo "Downloading the $JB_QUALIFIER version of IntelliJ IDEA ($SNAPSHOT_VERSION)..." &&
+    curl -sSLo backend.zip "https://www.jetbrains.com/intellij-repository/snapshots/com/jetbrains/intellij/idea/ideaIU/$SNAPSHOT_VERSION/ideaIU-$SNAPSHOT_VERSION.zip" &&
+    unzip backend.zip &&
+    rm backend.zip &&
+    ln -s "ideaIU-$SNAPSHOT_VERSION" . &&
+    rm -r "ideaIU-$SNAPSHOT_VERSION" &&
+    cp -r /ide-desktop/backend/jbr . &&
+    cp /ide-desktop/backend/bin/idea.properties ./bin &&
+    cp /ide-desktop/backend/bin/idea64.vmoptions ./bin)
   else
-    PRODUCT_TYPE="release,rc,eap"
+    if [[ $JB_QUALIFIER == "stable" ]]; then
+      PRODUCT_TYPE="release"
+    else
+      PRODUCT_TYPE="release,rc,eap"
+    fi
+    (cd $TEST_BACKEND_DIR &&
+    echo "Downloading the $JB_QUALIFIER version of IntelliJ IDEA..." &&
+    curl -sSLo backend.tar.gz "https://download.jetbrains.com/product?type=$PRODUCT_TYPE&distribution=linux&code=IIU" &&
+    tar -xf backend.tar.gz --strip-components=1 &&
+    rm backend.tar.gz)
   fi
-  (cd $TEST_BACKEND_DIR &&
-  echo "Downloading the $JB_QUALIFIER version of IntelliJ IDEA..." &&
-  curl -sSLo backend.tar.gz "https://download.jetbrains.com/product?type=$PRODUCT_TYPE&distribution=linux&code=IIU" &&
-  tar -xf backend.tar.gz --strip-components=1 &&
-  rm backend.tar.gz)
 fi
 
 TEST_PLUGINS_DIR="$TEST_BACKEND_DIR/plugins"

--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/latest/GitpodPortForwardingService.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/latest/GitpodPortForwardingService.kt
@@ -4,17 +4,17 @@
 
 package io.gitpod.jetbrains.remote.latest
 
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.client.ClientProjectSession
 import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.thisLogger
-import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Disposer
 import com.intellij.remoteDev.util.onTerminationOrNow
 import com.intellij.util.application
-import com.jetbrains.codeWithMe.model.RdPortType
+import com.jetbrains.rd.platform.codeWithMe.portForwarding.*
 import com.jetbrains.rd.platform.util.lifetime
 import com.jetbrains.rd.util.lifetime.LifetimeStatus
-import com.jetbrains.rdserver.portForwarding.ForwardedPortInfo
-import com.jetbrains.rdserver.portForwarding.PortForwardingManager
-import com.jetbrains.rdserver.portForwarding.remoteDev.PortEventsProcessor
+import io.gitpod.jetbrains.remote.GitpodIgnoredPortsForNotificationService
 import io.gitpod.jetbrains.remote.GitpodManager
 import io.gitpod.jetbrains.remote.GitpodPortsService
 import io.gitpod.supervisor.api.Status
@@ -24,14 +24,18 @@ import io.grpc.stub.ClientResponseObserver
 import io.ktor.utils.io.*
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
+import javax.swing.Icon
 
 @Suppress("UnstableApiUsage")
-class GitpodPortForwardingService(private val project: Project) {
+class GitpodPortForwardingService(private val session: ClientProjectSession) {
     companion object {
         const val FORWARDED_PORT_LABEL = "gitpod"
     }
 
     private val portsService = service<GitpodPortsService>()
+    private val perClientPortForwardingManager = service<PerClientPortForwardingManager>()
+    private val ignoredPortsForNotificationService = service<GitpodIgnoredPortsForNotificationService>()
+    private val portToDisposableMap = mutableMapOf<Int,Disposable>()
 
     init { start() }
 
@@ -42,7 +46,7 @@ class GitpodPortForwardingService(private val project: Project) {
     }
 
     private fun observePortsListWhileProjectIsOpen() = application.executeOnPooledThread {
-        while (project.lifetime.status == LifetimeStatus.Alive) {
+        while (session.project.lifetime.status == LifetimeStatus.Alive) {
             try {
                 observePortsList().get()
             } catch (throwable: Throwable) {
@@ -70,7 +74,7 @@ class GitpodPortForwardingService(private val project: Project) {
         val portsStatusResponseObserver = object :
                 ClientResponseObserver<Status.PortsStatusRequest, Status.PortsStatusResponse> {
             override fun beforeStart(request: ClientCallStreamObserver<Status.PortsStatusRequest>) {
-                project.lifetime.onTerminationOrNow { request.cancel("gitpod: Project terminated.", null) }
+                session.project.lifetime.onTerminationOrNow { request.cancel("gitpod: Project terminated.", null) }
             }
             override fun onNext(response: Status.PortsStatusResponse) {
                 application.invokeLater { updateForwardedPortsList(response) }
@@ -85,46 +89,86 @@ class GitpodPortForwardingService(private val project: Project) {
     }
 
     private fun updateForwardedPortsList(response: Status.PortsStatusResponse) {
-        val portForwardingManager = PortForwardingManager.getInstance(project)
-        val forwardedPortsList = portForwardingManager.getForwardedPortsWithLabel(FORWARDED_PORT_LABEL)
+        val ignoredPorts = ignoredPortsForNotificationService.getIgnoredPorts()
 
         for (port in response.portsList) {
+            if (ignoredPorts.contains(port.localPort)) continue
+
             val hostPort = port.localPort
             val isServed = port.served
-            val isForwarded = forwardedPortsList.find { it.hostPort == hostPort } != null
+            val isForwarded = perClientPortForwardingManager.getPorts(hostPort).isNotEmpty()
 
             if (isServed && !isForwarded) {
-                val portEventsProcessor = object : PortEventsProcessor {
-                    override fun onPortForwarded(hostPort: Int, clientPort: Int) {
-                        portsService.setForwardedPort(hostPort, clientPort)
-                        thisLogger().info("gitpod: Forwarded port $hostPort to client's port $clientPort.")
-                    }
-
-                    override fun onPortForwardingEnded(hostPort: Int) {
-                        thisLogger().info("gitpod: Finished forwarding port $hostPort.")
-                    }
-
-                    override fun onPortForwardingFailed(hostPort: Int, reason: String) {
-                        thisLogger().error("gitpod: Failed to forward port $hostPort: $reason")
-                    }
-                }
-
-                val portInfo = ForwardedPortInfo(
+                try {
+                    val forwardedPort = perClientPortForwardingManager.forwardPort(
                         hostPort,
-                        RdPortType.HTTP,
-                        port.exposed.url,
-                        port.name,
-                        port.description,
+                        PortType.TCP,
                         setOf(FORWARDED_PORT_LABEL),
-                        emptyList(),
-                        portEventsProcessor
-                )
+                        hostPort,
+                        ClientPortPickingStrategy.REASSIGN_WHEN_BUSY
+                    ) {
+                        this.name = port.name
+                        this.description = port.description
+                        this.icon = null
+                        this.tooltip = "Forwarded Port"
+                    }
 
-                portForwardingManager.forwardPort(portInfo)
+                    val portListenerDisposable = portToDisposableMap.getOrPut(hostPort, fun() = Disposer.newDisposable())
+
+                    forwardedPort.addPortListener(portListenerDisposable, object: ForwardedPortListener {
+                        override fun becameReadOnly(port: ForwardedPort, reason: String?) {
+                            thisLogger().warn("gitpod: becameReadOnly($port, $reason)")
+                        }
+
+                        override fun descriptionChanged(port: ForwardedPort, oldDescription: String?, newDescription: String?) {
+                            thisLogger().warn("gitpod: descriptionChanged($port, $oldDescription, $newDescription)")
+                        }
+
+                        override fun exposedUrlChanged(port: ForwardedPort, newUrl: String) {
+                            thisLogger().warn("gitpod: exposedUrlChanged($port, $newUrl)")
+                        }
+
+                        override fun iconChanged(port: ForwardedPort, oldIcon: Icon?, newIcon: Icon?) {
+                            thisLogger().warn("gitpod: iconChanged($port, $oldIcon, $newIcon)")
+                        }
+
+                        override fun nameChanged(port: ForwardedPort, oldName: String?, newName: String?) {
+                            thisLogger().warn("gitpod: nameChanged($port, $oldName, $newName)")
+                        }
+
+                        override fun stateChanged(port: ForwardedPort, newState: ClientPortState) {
+                            when (newState) {
+                                is ClientPortState.Assigned -> {
+                                    thisLogger().warn("gitpod: Started forwarding host port $hostPort to client port ${newState.clientPort}.")
+                                    portsService.setForwardedPort(hostPort, newState.clientPort)
+                                }
+                                is ClientPortState.FailedToAssign -> {
+                                    thisLogger().warn("gitpod: Detected that host port $hostPort failed to be assigned to a client port.")
+                                }
+                                else -> {
+                                    thisLogger().warn("gitpod: Detected that host port $hostPort is not assigned to any client port.")
+                                }
+                            }
+                        }
+
+                        override fun tooltipChanged(port: ForwardedPort, oldTooltip: String?, newTooltip: String?) {
+                            thisLogger().warn("gitpod: tooltipChanged($port, $oldTooltip, $newTooltip)")
+                        }
+                    })
+                } catch (error: Error) {
+                    thisLogger().warn("gitpod: ${error.message}")
+                }
             }
 
             if (!isServed && isForwarded) {
-                portForwardingManager.removePort(hostPort)
+                val portListenerDisposable = portToDisposableMap[hostPort]
+                if (portListenerDisposable != null) {
+                    portListenerDisposable.dispose()
+                    portToDisposableMap.remove(hostPort)
+                }
+                perClientPortForwardingManager.getPorts(hostPort).forEach { portToRemove ->
+                    perClientPortForwardingManager.removePort(portToRemove)
+                }
                 portsService.removeForwardedPort(hostPort)
                 thisLogger().info("gitpod: Stopped forwarding port $hostPort.")
             }

--- a/components/ide/jetbrains/backend-plugin/src/main/resources-latest/META-INF/extensions.xml
+++ b/components/ide/jetbrains/backend-plugin/src/main/resources-latest/META-INF/extensions.xml
@@ -7,6 +7,6 @@
 <idea-plugin>
     <extensions defaultExtensionNs="com.intellij">
         <applicationService serviceInterface="io.gitpod.jetbrains.remote.GitpodIgnoredPortsForNotificationService" serviceImplementation="io.gitpod.jetbrains.remote.latest.GitpodIgnoredPortsForNotificationServiceImpl" preload="true"/>
-        <projectService serviceImplementation="io.gitpod.jetbrains.remote.latest.GitpodPortForwardingService" preload="true"/>
+        <projectService serviceImplementation="io.gitpod.jetbrains.remote.latest.GitpodPortForwardingService" preload="true" client="guest"/>
     </extensions>
 </idea-plugin>


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Now that we have EAP IDEs build 223.6x available in gitpod.io, we need to update the back-end plugin with the support for the new Port Forwarding API.


In the current state of this PR, the plugin compiles and makes the auto-forwarding work again for EAP IDEs.

In a follow-up PR we should:
- Ensure the usage of port name/description columns is working.
- Remove the unused function overrides from `object: ForwardedPortListener`.
- Confirm there's no other way to dispose the forwarded ports listeners (currently we use a map for it).
- Confirm if ports are removed from the UI when programatically removed.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
- Fixes #13761

## How to test
<!-- Provide steps to test this PR -->
1. Open the preview environment of this PR: https://jetbrains-d939b7c0c7.preview.gitpod-dev.com/workspaces
2. In the account preferences, select the _Latest_ JetBrains IntelliJ IDEA as the editor
3. Start a workspace from https://github.com/gitpod-io/spring-petclinic and check if it there's no error triggered.
4. Open a new terminal and check if when running `python3 -m http.server 2593` it automatically forwards the server port, so you're able to access http://127.0.0.1:2593
    <img width="430" alt="image" src="https://user-images.githubusercontent.com/418083/195055757-89e3ffbd-f526-4f83-8ab6-038d78191576.png">
5. Don't worry about "Control Center >> Ports" view at this moment. We'll need to learn more about the new API before properly controlling it. It should be done in a follow-up PR.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Fixed the auto-port-forwarding on JetBrains EAP IDEs
```

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
