### PR TITLE
Skip "MountVolume.MountDevice failed for volume"

### DIFF
--- a/components/ws-manager/pkg/manager/manager.go
+++ b/components/ws-manager/pkg/manager/manager.go
@@ -671,13 +671,6 @@ func podRunning(clientset client.Client, podName, namespace string) wait.Conditi
 					return true, nil
 				}
 			}
-			// if we failed to mount volume, we need to re-create the pod
-			// ref: https://github.com/gitpod-io/gitpod/issues/13353
-			// ref: https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/issues/608
-			if strings.Contains(pod.Status.Reason, "MountVolume.MountDevice failed for volume") {
-				return false, xerrors.Errorf("failed mounting volume, reason: %s", pod.Status.Reason)
-			}
-
 			// if pod is pending, wait for it to get scheduled
 			return false, nil
 		case corev1.PodRunning:

--- a/components/ws-manager/pkg/manager/status.go
+++ b/components/ws-manager/pkg/manager/status.go
@@ -618,8 +618,12 @@ func extractFailure(wso workspaceObjects, metrics *metrics) (string, *api.Worksp
 			continue
 		}
 
-		// ideally we do not just use evt.Message as failure reason because it contains internal paths and is not useful for the user
-		if strings.Contains(evt.Message, workspaceVolumeName) {
+		if strings.Contains(evt.Message, "MountVolume.MountDevice failed for volume") {
+			// ref: https://github.com/gitpod-io/gitpod/issues/13353
+			// ref: https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/issues/608
+			return "", nil
+		} else if strings.Contains(evt.Message, workspaceVolumeName) {
+			// ideally we do not just use evt.Message as failure reason because it contains internal paths and is not useful for the user
 			return "cannot mount workspace", nil
 		} else {
 			// if this happens we did not do a good job because that means we've introduced another volume to the pod


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Ignore the FailedMount event with the message contains `MountVolume.MountDevice failed for volume`.

The ws-manager catches the [FailedMount event](https://github.com/gitpod-io/gitpod/blob/65e99997bc3837f360b23d0dc181ef096dd3febf/components/ws-manager/pkg/manager/status.go#L615-L627) and writes the error message into the workspace [Conditions.Failed](https://github.com/gitpod-io/gitpod/blob/65e99997bc3837f360b23d0dc181ef096dd3febf/components/ws-manager/pkg/manager/status.go#L322).
Then the [workspace pod is stopped](https://github.com/gitpod-io/gitpod/blob/65e99997bc3837f360b23d0dc181ef096dd3febf/components/ws-manager/pkg/manager/monitor.go#L275-L298), and the [workspace failed message](https://github.com/gitpod-io/gitpod/blob/65e99997bc3837f360b23d0dc181ef096dd3febf/components/ws-manager/pkg/manager/manager.go#L1376-L1377) will be shown to the user.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #13353

## How to test
<!-- Provide steps to test this PR -->
Run the loadgen with PVC over 100 regular workspaces.
Watch the events `FailedMount` happens but the workspace pod turns into Running state.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
None

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-integration-tests=workspace
      Valid options are `all`, `workspace`, `webapp`, `ide`
