### PR TITLE
[prebuild] Support opening a specfic prebuild

### DIFF
--- a/components/dashboard/src/projects/Prebuild.tsx
+++ b/components/dashboard/src/projects/Prebuild.tsx
@@ -181,12 +181,14 @@ export default function () {
                     ) : prebuild?.status === "available" ? (
                         <a
                             className="my-auto"
-                            href={gitpodHostUrl.withContext(`${prebuild?.info.changeUrl}`).toString()}
+                            href={gitpodHostUrl
+                                .withContext(`open-prebuild/${prebuild?.info.id}/${prebuild?.info.changeUrl}`)
+                                .toString()}
                         >
-                            <button>New Workspace ({prebuild?.info.branch})</button>
+                            <button>New Workspace (with this prebuild)</button>
                         </a>
                     ) : (
-                        <button disabled={true}>New Workspace ({prebuild?.info.branch})</button>
+                        <button disabled={true}>New Workspace (with this prebuild)</button>
                     )}
                 </PrebuildLogs>
             </div>

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -1200,6 +1200,16 @@ export namespace AdditionalContentContext {
     }
 }
 
+export interface OpenPrebuildContext extends WorkspaceContext {
+    openPrebuildID: string;
+}
+
+export namespace OpenPrebuildContext {
+    export function is(ctx: any): ctx is OpenPrebuildContext {
+        return "openPrebuildID" in ctx;
+    }
+}
+
 export interface CommitContext extends WorkspaceContext, GitCheckoutInfo {
     /** @deprecated Moved to .repository.cloneUrl, left here for backwards-compatibility for old workspace contextes in the DB */
     cloneUrl?: string;

--- a/components/server/ee/src/workspace/workspace-factory.ts
+++ b/components/server/ee/src/workspace/workspace-factory.ts
@@ -21,6 +21,7 @@ import {
     PrebuiltWorkspace,
     WorkspaceConfig,
     WorkspaceImageSource,
+    OpenPrebuildContext,
 } from "@gitpod/gitpod-protocol";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 import { LicenseEvaluator } from "@gitpod/licensor/lib";
@@ -369,6 +370,18 @@ export class WorkspaceFactoryEE extends WorkspaceFactory {
                 })
             ) {
                 config._featureFlags = (config._featureFlags || []).concat(["persistent_volume_claim"]);
+            }
+
+            if (OpenPrebuildContext.is(context.originalContext)) {
+                // Because of incremental prebuilds, createForContext will take over the original context.
+                // To ensure we get the right commit when forcing a prebuild, we force the context here.
+                context.originalContext = buildWorkspace.context;
+
+                if (CommitContext.is(context.originalContext)) {
+                    // We force the checkout of the revision rather than the ref/branch.
+                    // Otherwise we'd the correct prebuild with the "wrong" Git status.
+                    delete context.originalContext.ref;
+                }
             }
 
             const id = await this.generateWorkspaceID(context);

--- a/components/server/src/container-module.ts
+++ b/components/server/src/container-module.ts
@@ -112,6 +112,7 @@ import { LivenessController } from "./liveness/liveness-controller";
 import { IDEServiceClient, IDEServiceDefinition } from "@gitpod/ide-service-api/lib/ide.pb";
 import { prometheusClientMiddleware } from "@gitpod/gitpod-protocol/lib/util/nice-grpc";
 import { UsageService } from "./user/usage-service";
+import { OpenPrebuildPrefixContextParser } from "./workspace/open-prebuild-prefix-context-parser";
 
 export const productionContainerModule = new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(Config).toConstantValue(ConfigFile.fromFile());
@@ -187,6 +188,7 @@ export const productionContainerModule = new ContainerModule((bind, unbind, isBo
     bind(IPrefixContextParser).to(ReferrerPrefixParser).inSingletonScope();
     bind(IPrefixContextParser).to(EnvvarPrefixParser).inSingletonScope();
     bind(IPrefixContextParser).to(ImageBuildPrefixContextParser).inSingletonScope();
+    bind(IPrefixContextParser).to(OpenPrebuildPrefixContextParser).inSingletonScope();
 
     bind(GitTokenScopeGuesser).toSelf().inSingletonScope();
     bind(GitTokenValidator).toSelf().inSingletonScope();

--- a/components/server/src/workspace/open-prebuild-prefix-context-parser.ts
+++ b/components/server/src/workspace/open-prebuild-prefix-context-parser.ts
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { User, WorkspaceContext } from "@gitpod/gitpod-protocol";
+import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
+import { OpenPrebuildContext } from "@gitpod/gitpod-protocol/src/protocol";
+import { inject, injectable } from "inversify";
+import { Config } from "../config";
+import { IPrefixContextParser } from "./context-parser";
+
+@injectable()
+export class OpenPrebuildPrefixContextParser implements IPrefixContextParser {
+    @inject(Config) protected readonly config: Config;
+    static PREFIX = /^\/?open-prebuild\/([^\/]*)\//;
+
+    findPrefix(user: User, context: string): string | undefined {
+        const result = OpenPrebuildPrefixContextParser.PREFIX.exec(context);
+        if (!result) {
+            return undefined;
+        }
+        return result[0];
+    }
+
+    public async handle(user: User, prefix: string, context: WorkspaceContext): Promise<WorkspaceContext> {
+        const match = OpenPrebuildPrefixContextParser.PREFIX.exec(prefix);
+        if (!match) {
+            log.error("Could not parse prefix " + prefix);
+            return context;
+        }
+
+        (context as OpenPrebuildContext).openPrebuildID = match[1];
+        return context;
+    }
+}


### PR DESCRIPTION
_(Werft was having too much trouble with https://github.com/gitpod-io/gitpod/pull/13706 hence the new PR 👇)_

## Description
This PR enables users to open a specific prebuildm, and integrates this capability on the dashboard.


## How to test
1. Make sure there's a prebuild and a newer commit on the same branch
2. Go the prebuild view
3. Open the specific prebuild and observe it's the correct state

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[prebuild] Add support for opening specific prebuilds
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`


<img src="https://front.com/assets/img/favicons/favicon-32x32.png" height="16" width="16" alt="Front logo" /> [Front conversations](https://app.frontapp.com/open/top_3rxsa)