### PR TITLE
Set timeout to 30 minutes for JetBrains integration tests

### DIFF
--- a/install/tests/Makefile
+++ b/install/tests/Makefile
@@ -418,7 +418,7 @@ endif
 	curl -i -X GET https://${TF_VAR_TEST_ID}.${TF_VAR_domain}/api/version || { echo "Curling Gitpod endpoint failed"; exit 1; }
 
 define runtests
-	./tests.sh ${KUBECONFIG} $(1)
+	./tests.sh ${KUBECONFIG} $(1) $(2)
 endef
 
 run-workspace-tests:
@@ -428,7 +428,7 @@ run-vscode-ide-tests:
 	$(call runtests,"test/tests/ide/vscode/")
 
 run-jb-ide-tests:
-	$(call runtests,"test/tests/ide/jetbrains/")
+	$(call runtests,"test/tests/ide/jetbrains/", 30)
 
 run-cs-component-tests:
 	$(call runtests,"test/tests/components/content-service/")

--- a/install/tests/tests.sh
+++ b/install/tests/tests.sh
@@ -3,6 +3,7 @@
 # Licensed under the GNU Affero General Public License (AGPL).
 # See License-AGPL.txt in the project root for license information.
 
+TIMEOUT=${3:-10}
 CURRENT=$(pwd)
 TESTPATH="../../$2"
 DATE_BIN=$(command -v date)
@@ -12,7 +13,7 @@ echo "Starting test on ${DATE} for ${TESTPATH}"
 
 cd "${TESTPATH}" ||  echo "Path invalid ${TESTPATH}"
 
-go test -v ./... "-kubeconfig=$1" -namespace=gitpod -username=gitpod-integration-test 2>&0 -coverprofile=coverage.out
+go test -v ./... "-timeout=${TIMEOUT}m" "-kubeconfig=$1" -namespace=gitpod -username=gitpod-integration-test 2>&0 -coverprofile=coverage.out
 
 TEST_STATUS=$?
 echo ${TEST_STATUS}


### PR DESCRIPTION
## Description
Set timeout to 30 minutes for JetBrains integration tests, to avoid failure due to long-runs like [this one](https://github.com/gitpod-io/gitpod/actions/runs/3224409693).

<img width="700" alt="image" src="https://user-images.githubusercontent.com/418083/195113578-4670ecf9-4154-4699-8c06-cdbe6f0b4033.png">

## How to test
<!-- Provide steps to test this PR -->
You can confirm the changed script is working fine by doing the following: 
1. Open this PR on Gitpod, with any IDE.
2. Open a terminal and run `werft run github -j .werft/gke-installer-tests.yaml` and confirm it completes successfully.

Note: We've run it already, if you want to see the result of werft job: https://werft.gitpod-dev.com/job/gitpod-custom-jetbrains-fix-timeout-for-jetbrains-integrat.0

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
