### PR TITLE
[installer/tests] upload diagnostics when installation fails

### DIFF
--- a/install/tests/Makefile
+++ b/install/tests/Makefile
@@ -401,9 +401,22 @@ delete-cm-setup:
 	sleep ${waittime} && kubectl --kubeconfig=${KUBECONFIG} delete pods --all -n cert-manager && sleep ${sleeptime};
 
 gitpod-debug-info:
-	@echo "Gitpod is not ready"
+	@echo -e "\033[;31mGitpod is not ready\033[0;m"
 	@kubectl --kubeconfig=${KUBECONFIG} get pods -n gitpod
 	@kubectl --kubeconfig=${KUBECONFIG} get certificate -n gitpod
+	@echo "Uploading diagnostics to gs://nightly-tests/nightly-tests-errors/${TF_VAR_TEST_ID}"
+
+	kubectl kots --kubeconfig=${KUBECONFIG} --namespace gitpod get app gitpod
+
+	kubectl --kubeconfig=${KUBECONFIG} --namespace gitpod get pod -ojson > pods.json \
+	&& gsutil cp pods.json gs://nightly-tests/nightly-tests-errors/${TF_VAR_TEST_ID}/pods.json
+
+	kubectl --kubeconfig=${KUBECONFIG} --namespace gitpod get event --sort-by '.metadata.creationTimestamp' > events.log \
+	&& gsutil cp events.log gs://nightly-tests/nightly-tests-errors/${TF_VAR_TEST_ID}/events.log
+
+	kubectl --kubeconfig=${KUBECONFIG} --namespace gitpod describe certificate https-certificates > cert.log \
+	&& gsutil cp cert.log gs://nightly-tests/nightly-tests-errors/${TF_VAR_TEST_ID}/cert.log
+
 
 check-kots-app:
 	kubectl kots get --kubeconfig=${KUBECONFIG} app gitpod -n gitpod | grep gitpod  | awk '{print $$2}' | grep "ready" || { $(MAKE) gitpod-debug-info; exit 1; }


### PR DESCRIPTION
## Description

This pull request enhances diagnostics collection when a Gitpod self-hosted run fails. As the infrastructure is torn down at the end of a failed test, the underlying cause of test failures cannot be diagnosed against the infrastructure directly so collecting various diagnostic information provides an option for post-hoc analysis. This collection should reduce the number of CI runs needed to locate and fix installation failures.

## Related Issue(s)

## How to test

```bash
gsutil cat gs://nightly-tests/nightly-tests-errors/24ac6-k3s/pods.json \
| jq -r '[.items[] | select(.status.conditions[] | any(. == "False")) | {metadata, status}]'
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
