### PR TITLE
Respond PortsStatus with sorted ports

### DIFF
--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -7,7 +7,7 @@ defaultArgs:
   publishToNPM: true
   publishToJBMarketplace: true
   localAppVersion: unknown
-  codeCommit: 239fa626a44652cebf293a994a3330e90e873daa
+  codeCommit: f604b771695de9ac3744a1aec9d32112c8873843
   codeQuality: stable
   noVerifyJBPlugin: false
   intellijDownloadUrl: "https://download.jetbrains.com/idea/ideaIU-2022.2.3.tar.gz"

--- a/components/gitpod-cli/cmd/ports-list.go
+++ b/components/gitpod-cli/cmd/ports-list.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"sort"
 	"time"
 
 	supervisor_helper "github.com/gitpod-io/gitpod/gitpod-cli/pkg/supervisor-helper"
@@ -37,10 +36,6 @@ var listPortsCmd = &cobra.Command{
 			fmt.Println("No ports detected.")
 			return
 		}
-
-		sort.Slice(ports, func(i, j int) bool {
-			return int(ports[i].LocalPort) < int(ports[j].LocalPort)
-		})
 
 		table := tablewriter.NewWriter(os.Stdout)
 		table.SetHeader([]string{"Port", "Status", "URL", "Name & Description"})

--- a/components/gitpod-protocol/go/gitpod-service.go
+++ b/components/gitpod-protocol/go/gitpod-service.go
@@ -1756,6 +1756,7 @@ type PortConfig struct {
 	Visibility  string  `json:"visibility,omitempty"`
 	Description string  `json:"description,omitempty"`
 	Name        string  `json:"name,omitempty"`
+	Sort        uint32  `json:"sort,omitempty"`
 }
 
 // TaskConfig is the TaskConfig message type

--- a/components/supervisor/pkg/ports/ports-config.go
+++ b/components/supervisor/pkg/ports/ports-config.go
@@ -21,6 +21,7 @@ type RangeConfig struct {
 	*gitpod.PortsItems
 	Start uint32
 	End   uint32
+	Sort  uint32
 }
 
 // Configs provides access to port configurations.
@@ -79,6 +80,7 @@ func (configs *Configs) Get(port uint32) (*gitpod.PortConfig, ConfigKind, bool) 
 				Visibility:  rangeConfig.Visibility,
 				Description: rangeConfig.Description,
 				Name:        rangeConfig.Name,
+				Sort:        rangeConfig.Sort,
 			}, RangeConfigKind, true
 		}
 	}
@@ -184,7 +186,7 @@ func parseWorkspaceConfigs(ports []*gitpod.PortConfig) (portConfigs map[uint32]*
 }
 
 func parseInstanceConfigs(ports []*gitpod.PortsItems) (portConfigs map[uint32]*gitpod.PortConfig, rangeConfigs []*RangeConfig) {
-	for _, config := range ports {
+	for index, config := range ports {
 		if config == nil {
 			continue
 		}
@@ -204,6 +206,7 @@ func parseInstanceConfigs(ports []*gitpod.PortsItems) (portConfigs map[uint32]*g
 					Visibility:  config.Visibility,
 					Description: config.Description,
 					Name:        config.Name,
+					Sort:        uint32(index),
 				}
 			}
 			continue
@@ -224,6 +227,7 @@ func parseInstanceConfigs(ports []*gitpod.PortsItems) (portConfigs map[uint32]*g
 			PortsItems: config,
 			Start:      uint32(start),
 			End:        uint32(end),
+			Sort:       uint32(index),
 		})
 	}
 	return portConfigs, rangeConfigs


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Related PR https://github.com/gitpod-io/openvscode-server/pull/444

<img width="1922" alt="image" src="https://user-images.githubusercontent.com/20944364/196697642-aaf16083-ba34-42b8-b843-db83b075b9d5.png">

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
- Fixes https://github.com/gitpod-io/gitpod/issues/7764

## How to test
<!-- Provide steps to test this PR -->
- Open workspace in preview env with ports opened. Example repo https://github.com/mustard-mh/test/tree/hw/logs-ports
- Check if ports are sorted in PortsView
- Check if ports are sorted in `gp-cli`
- Update `.gitpod.yml` ports order should change order in portsView too (if file change is detect, you can change name after order change to see if it is detect or not)

### Rules of order

- First respect to `.gitpod.yml` 's ports define
- Others' are sorted by port number ASC
- Filter with ports that are not served and defined in `gitpod.yml`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Display sorted ports with both `gp-cli` and VSCode Browser `PortsView`
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
