### PR TITLE
supervisor: Ignore the terminated signal

### DIFF
--- a/components/supervisor/pkg/supervisor/supervisor.go
+++ b/components/supervisor/pkg/supervisor/supervisor.go
@@ -821,10 +821,8 @@ func launchIDE(cfg *Config, ideConfig *IDEConfig, cmd *exec.Cmd, ideStopped chan
 		}()
 
 		err = cmd.Wait()
-		if err != nil {
-			if errSignalTerminated.Error() != err.Error() {
-				log.WithField("ide", ide.String()).WithError(err).Warn("IDE was stopped")
-			}
+		if err != nil && err.Error() != errSignalTerminated.Error() {
+			log.WithField("ide", ide.String()).WithError(err).Warn("IDE was stopped")
 
 			ideWasReady, _ := ideReady.Get()
 			if !ideWasReady {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Until now, the start-up time of a workspace is slower than the start-up of an IDE but reserved. Therefore, if you requested to exit immediately after starting the workspace such as [the integration test](https://gitpod.slack.com/archives/C03E52788SU/p1665448602379589), the IDE was sometimes not ready!

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
None

## How to test
<!-- Provide steps to test this PR -->

Pass the integration test

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Ignore a noisy error in the supervisor
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
