### PR TITLE
loadgen: support custom workspace timeout

### DIFF
--- a/dev/loadgen/README.md
+++ b/dev/loadgen/README.md
@@ -41,6 +41,7 @@ In order to configure the benchmark, you can use the configuration file
 | successRate | Percentage of started workspaces that should enter running state to count as a successful run |
 | environment | Global environment variables that will be set for all repositories |
 | workspaceClass | The workspace class to use for workspaces. This setting can be overriden for individual repositories |
+| workspaceTimeout | The workspace timeout value |
 | repoAuth | The authentication for a repository. This setting can be overriden for individual repositories |
 | repoAuth.authUser | The user that should be used for authentication |
 | repoAuth.authPassword | The password that should be used for authentication |

--- a/dev/loadgen/cmd/benchmark.go
+++ b/dev/loadgen/cmd/benchmark.go
@@ -75,7 +75,7 @@ var benchmarkCommand = &cobra.Command{
 					Username: "foobar",
 				},
 				FeatureFlags:   scenario.FeatureFlags,
-				Timeout:        "5m",
+				Timeout:        scenario.WorkspaceTimeout,
 				WorkspaceImage: "will-be-overriden",
 				Envvars:        scenario.Environment,
 				Class:          scenario.WorkspaceClass,
@@ -191,16 +191,17 @@ func init() {
 }
 
 type BenchmarkScenario struct {
-	Workspaces      int                        `json:"workspaces"`
-	IDEImage        string                     `json:"ideImage"`
-	Repos           []loadgen.WorkspaceCfg     `json:"repos"`
-	Environment     []*api.EnvironmentVariable `json:"environment"`
-	RunningTimeout  string                     `json:"waitForRunning"`
-	StoppingTimeout string                     `json:"waitForStopping"`
-	SuccessRate     float32                    `json:"successRate"`
-	WorkspaceClass  string                     `json:"workspaceClass"`
-	FeatureFlags    []api.WorkspaceFeatureFlag `json:"featureFlags"`
-	RepositoryAuth  *loadgen.RepositoryAuth    `json:"repoAuth,omitempty"`
+	Workspaces       int                        `json:"workspaces"`
+	IDEImage         string                     `json:"ideImage"`
+	Repos            []loadgen.WorkspaceCfg     `json:"repos"`
+	Environment      []*api.EnvironmentVariable `json:"environment"`
+	RunningTimeout   string                     `json:"waitForRunning"`
+	StoppingTimeout  string                     `json:"waitForStopping"`
+	SuccessRate      float32                    `json:"successRate"`
+	WorkspaceClass   string                     `json:"workspaceClass"`
+	FeatureFlags     []api.WorkspaceFeatureFlag `json:"featureFlags"`
+	RepositoryAuth   *loadgen.RepositoryAuth    `json:"repoAuth,omitempty"`
+	WorkspaceTimeout string                     `json:"workspaceTimeout,omitempty"`
 }
 
 func handleWorkspaceDeletion(timeout string, executor loadgen.Executor, canceled bool) error {

--- a/dev/loadgen/configs/prod-benchmark-pvc.yaml
+++ b/dev/loadgen/configs/prod-benchmark-pvc.yaml
@@ -10,6 +10,7 @@ environment:
   - name: "THEIA_SUPERVISOR_TOKENS"
     value: '[{"token":"foobar","host":"gitpod-staging.com","scope":["function:getWorkspace","function:getLoggedInUser","function:getPortAuthenticationToken","function:getWorkspaceOwner","function:getWorkspaceUsers","function:isWorkspaceOwner","function:controlAdmission","function:setWorkspaceTimeout","function:getWorkspaceTimeout","function:sendHeartBeat","function:getOpenPorts","function:openPort","function:closePort","function:generateNewGitpodToken","function:takeSnapshot","function:stopWorkspace","resource:workspace::fa498dcc-0a84-448f-9666-79f297ad821a::get/update","resource:workspaceInstance::e0a17083-6a78-441a-9b97-ef90d6aff463::get/update/delete","resource:snapshot::*::create/get","resource:gitpodToken::*::create","resource:userStorage::*::create/get/update"],"expiryDate":"2020-12-01T07:55:12.501Z","reuse":2}]'
 workspaceClass: "g1-standard-pvc"
+workspaceTimeout: 1h
 featureFlags:
 # https://github.com/gitpod-io/gitpod/blob/e437e1868072dfad1d195031a4709a254bd60dc8/components/ws-manager-api/core.proto#L596
 # from core.proto: PERSISTENT_VOLUME_CLAIM = 7;

--- a/dev/loadgen/configs/prod-benchmark.yaml
+++ b/dev/loadgen/configs/prod-benchmark.yaml
@@ -10,6 +10,7 @@ environment:
   - name: "THEIA_SUPERVISOR_TOKENS"
     value: '[{"token":"foobar","host":"gitpod-staging.com","scope":["function:getWorkspace","function:getLoggedInUser","function:getPortAuthenticationToken","function:getWorkspaceOwner","function:getWorkspaceUsers","function:isWorkspaceOwner","function:controlAdmission","function:setWorkspaceTimeout","function:getWorkspaceTimeout","function:sendHeartBeat","function:getOpenPorts","function:openPort","function:closePort","function:generateNewGitpodToken","function:takeSnapshot","function:stopWorkspace","resource:workspace::fa498dcc-0a84-448f-9666-79f297ad821a::get/update","resource:workspaceInstance::e0a17083-6a78-441a-9b97-ef90d6aff463::get/update/delete","resource:snapshot::*::create/get","resource:gitpodToken::*::create","resource:userStorage::*::create/get/update"],"expiryDate":"2020-12-01T07:55:12.501Z","reuse":2}]'
 workspaceClass: "g1-standard"
+workspaceTimeout: 1h
 repos:
   - cloneURL: https://github.com/Furisto/workspace-stress
     cloneTarget: main

--- a/dev/loadgen/configs/workspace-preview-benchmark-pvc.yaml
+++ b/dev/loadgen/configs/workspace-preview-benchmark-pvc.yaml
@@ -7,6 +7,7 @@ environment:
   - name: "THEIA_SUPERVISOR_TOKENS"
     value: '[{"token":"foobar","host":"gitpod-staging.com","scope":["function:getWorkspace","function:getLoggedInUser","function:getPortAuthenticationToken","function:getWorkspaceOwner","function:getWorkspaceUsers","function:isWorkspaceOwner","function:controlAdmission","function:setWorkspaceTimeout","function:getWorkspaceTimeout","function:sendHeartBeat","function:getOpenPorts","function:openPort","function:closePort","function:generateNewGitpodToken","function:takeSnapshot","function:stopWorkspace","resource:workspace::fa498dcc-0a84-448f-9666-79f297ad821a::get/update","resource:workspaceInstance::e0a17083-6a78-441a-9b97-ef90d6aff463::get/update/delete","resource:snapshot::*::create/get","resource:gitpodToken::*::create","resource:userStorage::*::create/get/update"],"expiryDate":"2020-12-01T07:55:12.501Z","reuse":2}]'
 workspaceClass: ""
+workspaceTimeout: 1h
 featureFlags:
 # https://github.com/gitpod-io/gitpod/blob/e437e1868072dfad1d195031a4709a254bd60dc8/components/ws-manager-api/core.proto#L596
 # from core.proto: PERSISTENT_VOLUME_CLAIM = 7;

--- a/dev/loadgen/configs/workspace-preview-benchmark.yaml
+++ b/dev/loadgen/configs/workspace-preview-benchmark.yaml
@@ -7,6 +7,7 @@ environment:
   - name: "THEIA_SUPERVISOR_TOKENS"
     value: '[{"token":"foobar","host":"gitpod-staging.com","scope":["function:getWorkspace","function:getLoggedInUser","function:getPortAuthenticationToken","function:getWorkspaceOwner","function:getWorkspaceUsers","function:isWorkspaceOwner","function:controlAdmission","function:setWorkspaceTimeout","function:getWorkspaceTimeout","function:sendHeartBeat","function:getOpenPorts","function:openPort","function:closePort","function:generateNewGitpodToken","function:takeSnapshot","function:stopWorkspace","resource:workspace::fa498dcc-0a84-448f-9666-79f297ad821a::get/update","resource:workspaceInstance::e0a17083-6a78-441a-9b97-ef90d6aff463::get/update/delete","resource:snapshot::*::create/get","resource:gitpodToken::*::create","resource:userStorage::*::create/get/update"],"expiryDate":"2020-12-01T07:55:12.501Z","reuse":2}]'
 workspaceClass: ""
+workspaceTimeout: 1h
 repos:
   - cloneURL: https://github.com/Furisto/workspace-stress
     cloneTarget: main


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Support custom workspace timeout.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related to #12747

## How to test
<!-- Provide steps to test this PR -->
Run loadgen and check the workspace pod annotation `gitpod/customTimeout` matches to the config setting.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
None

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
