### PR TITLE
[usage] Validate spending limits in UpdateCostCenter

### DIFF
--- a/.werft/jobs/build/installer/installer.ts
+++ b/.werft/jobs/build/installer/installer.ts
@@ -277,6 +277,7 @@ EOF`);
         exec(`yq w -i ${this.options.installerConfigPath} experimental.webapp.usage.billInstancesAfter "2022-08-11T08:05:32.499Z"`, { slice: slice })
         exec(`yq w -i ${this.options.installerConfigPath} experimental.webapp.usage.defaultSpendingLimit.forUsers 500`, { slice: slice })
         exec(`yq w -i ${this.options.installerConfigPath} experimental.webapp.usage.defaultSpendingLimit.forTeams 0`, { slice: slice })
+        exec(`yq w -i ${this.options.installerConfigPath} experimental.webapp.usage.defaultSpendingLimit.minForUsersOnStripe 1000`, { slice: slice })
         exec(`yq w -i ${this.options.installerConfigPath} experimental.webapp.usage.creditsPerMinuteByWorkspaceClass['default'] 0.1666666667`, { slice: slice })
         exec(`yq w -i ${this.options.installerConfigPath} experimental.webapp.usage.creditsPerMinuteByWorkspaceClass['gitpodio-internal-xl'] 0.3333333333`, { slice: slice })
     }

--- a/components/usage/pkg/apiv1/usage_test.go
+++ b/components/usage/pkg/apiv1/usage_test.go
@@ -80,8 +80,9 @@ func newUsageService(t *testing.T, dbconn *gorm.DB) v1.UsageServiceClient {
 	)
 
 	costCenterManager := db.NewCostCenterManager(dbconn, db.DefaultSpendingLimit{
-		ForTeams: 0,
-		ForUsers: 500,
+		ForTeams:            0,
+		ForUsers:            500,
+		MinForUsersOnStripe: 1000,
 	})
 
 	v1.RegisterUsageServiceServer(srv.GRPC(), NewUsageService(dbconn, DefaultWorkspacePricer, costCenterManager))
@@ -227,13 +228,13 @@ func TestGetAndSetCostCenter(t *testing.T) {
 	conn := dbtest.ConnectForTests(t)
 	costCenterUpdates := []*v1.CostCenter{
 		{
-			AttributionId:   string(db.NewTeamAttributionID(uuid.New().String())),
-			SpendingLimit:   5000,
-			BillingStrategy: v1.CostCenter_BILLING_STRATEGY_OTHER,
+			AttributionId:   string(db.NewUserAttributionID(uuid.New().String())),
+			SpendingLimit:   8000,
+			BillingStrategy: v1.CostCenter_BILLING_STRATEGY_STRIPE,
 		},
 		{
-			AttributionId:   string(db.NewTeamAttributionID(uuid.New().String())),
-			SpendingLimit:   8000,
+			AttributionId:   string(db.NewUserAttributionID(uuid.New().String())),
+			SpendingLimit:   500,
 			BillingStrategy: v1.CostCenter_BILLING_STRATEGY_OTHER,
 		},
 		{
@@ -243,7 +244,7 @@ func TestGetAndSetCostCenter(t *testing.T) {
 		},
 		{
 			AttributionId:   string(db.NewTeamAttributionID(uuid.New().String())),
-			SpendingLimit:   5000,
+			SpendingLimit:   0,
 			BillingStrategy: v1.CostCenter_BILLING_STRATEGY_OTHER,
 		},
 	}

--- a/components/usage/pkg/db/cost_center_test.go
+++ b/components/usage/pkg/db/cost_center_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/gitpod-io/gitpod/usage/pkg/db/dbtest"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"gorm.io/gorm"
 )
 
@@ -58,26 +60,143 @@ func TestCostCenterManager_GetOrCreateCostCenter(t *testing.T) {
 
 func TestCostCenterManager_UpdateCostCenter(t *testing.T) {
 	conn := dbtest.ConnectForTests(t)
-	mnr := db.NewCostCenterManager(conn, db.DefaultSpendingLimit{
-		ForTeams: 0,
-		ForUsers: 500,
-	})
-	team := db.NewTeamAttributionID(uuid.New().String())
-	cleanUp(t, conn, team)
-	teamCC, err := mnr.GetOrCreateCostCenter(context.Background(), team)
-	t.Cleanup(func() {
-		conn.Model(&db.CostCenter{}).Delete(teamCC)
-	})
-	require.NoError(t, err)
-	require.Equal(t, int32(0), teamCC.SpendingLimit)
+	limits := db.DefaultSpendingLimit{
+		ForTeams:            0,
+		ForUsers:            500,
+		MinForUsersOnStripe: 1000,
+	}
 
-	teamCC.SpendingLimit = 2000
-	teamCC, err = mnr.UpdateCostCenter(context.Background(), teamCC)
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		conn.Model(&db.CostCenter{}).Delete(teamCC)
+	t.Run("prevents updates to negative spending limit", func(t *testing.T) {
+		mnr := db.NewCostCenterManager(conn, limits)
+		userAttributionID := db.NewUserAttributionID(uuid.New().String())
+		teamAttributionID := db.NewTeamAttributionID(uuid.New().String())
+		cleanUp(t, conn, userAttributionID, teamAttributionID)
+
+		_, err := mnr.UpdateCostCenter(context.Background(), db.CostCenter{
+			ID:              userAttributionID,
+			BillingStrategy: db.CostCenter_Other,
+			SpendingLimit:   -1,
+		})
+		require.Error(t, err)
+		require.Equal(t, codes.InvalidArgument, status.Code(err))
+
+		_, err = mnr.UpdateCostCenter(context.Background(), db.CostCenter{
+			ID:              teamAttributionID,
+			BillingStrategy: db.CostCenter_Stripe,
+			SpendingLimit:   -1,
+		})
+		require.Error(t, err)
+		require.Equal(t, codes.InvalidArgument, status.Code(err))
 	})
-	require.Equal(t, int32(2000), teamCC.SpendingLimit)
+
+	t.Run("individual user on Other billing strategy cannot change spending limit of 500", func(t *testing.T) {
+		mnr := db.NewCostCenterManager(conn, limits)
+		userAttributionID := db.NewUserAttributionID(uuid.New().String())
+		cleanUp(t, conn, userAttributionID)
+
+		_, err := mnr.UpdateCostCenter(context.Background(), db.CostCenter{
+			ID:              userAttributionID,
+			BillingStrategy: db.CostCenter_Other,
+			SpendingLimit:   501,
+		})
+		require.Error(t, err)
+		require.Equal(t, codes.FailedPrecondition, status.Code(err))
+
+	})
+
+	t.Run("individual user upgrading to stripe can set a limit of 1000 or more, but not less than 1000", func(t *testing.T) {
+		mnr := db.NewCostCenterManager(conn, limits)
+		userAttributionID := db.NewUserAttributionID(uuid.New().String())
+		cleanUp(t, conn, userAttributionID)
+
+		// Upgrading to Stripe requires spending limit
+		res, err := mnr.UpdateCostCenter(context.Background(), db.CostCenter{
+			ID:              userAttributionID,
+			BillingStrategy: db.CostCenter_Stripe,
+			SpendingLimit:   1000,
+		})
+		require.NoError(t, err)
+		requireCostCenterEqual(t, db.CostCenter{
+			ID:              userAttributionID,
+			SpendingLimit:   1000,
+			BillingStrategy: db.CostCenter_Stripe,
+		}, res)
+
+		// Try to lower the spending limit below configured limit
+		_, err = mnr.UpdateCostCenter(context.Background(), db.CostCenter{
+			ID:              userAttributionID,
+			BillingStrategy: db.CostCenter_Stripe,
+			SpendingLimit:   999,
+		})
+		require.Error(t, err, "lowering spending limit  below configured value is not allowed for user subscriptions")
+
+		// Try to update the cost center to higher usage limit
+		res, err = mnr.UpdateCostCenter(context.Background(), db.CostCenter{
+			ID:              userAttributionID,
+			BillingStrategy: db.CostCenter_Stripe,
+			SpendingLimit:   1001,
+		})
+		require.NoError(t, err)
+		requireCostCenterEqual(t, db.CostCenter{
+			ID:              userAttributionID,
+			SpendingLimit:   1001,
+			BillingStrategy: db.CostCenter_Stripe,
+		}, res)
+	})
+
+	t.Run("team on Other billing strategy get a spending limit of 0, and cannot change it", func(t *testing.T) {
+		mnr := db.NewCostCenterManager(conn, limits)
+		teamAttributionID := db.NewTeamAttributionID(uuid.New().String())
+		cleanUp(t, conn, teamAttributionID)
+
+		// Allows udpating cost center as long as spending limit remains as configured
+		res, err := mnr.UpdateCostCenter(context.Background(), db.CostCenter{
+			ID:              teamAttributionID,
+			BillingStrategy: db.CostCenter_Other,
+			SpendingLimit:   limits.ForTeams,
+		})
+		require.NoError(t, err)
+		requireCostCenterEqual(t, db.CostCenter{
+			ID:              teamAttributionID,
+			SpendingLimit:   limits.ForTeams,
+			BillingStrategy: db.CostCenter_Other,
+		}, res)
+
+		// Prevents updating when spending limit changes
+		_, err = mnr.UpdateCostCenter(context.Background(), db.CostCenter{
+			ID:              teamAttributionID,
+			BillingStrategy: db.CostCenter_Other,
+			SpendingLimit:   1,
+		})
+		require.Error(t, err)
+	})
+
+	t.Run("team on Stripe billing strategy can set arbitrary positive spending limit", func(t *testing.T) {
+		mnr := db.NewCostCenterManager(conn, limits)
+		teamAttributionID := db.NewTeamAttributionID(uuid.New().String())
+		cleanUp(t, conn, teamAttributionID)
+
+		// Allows udpating cost center as long as spending limit remains as configured
+		res, err := mnr.UpdateCostCenter(context.Background(), db.CostCenter{
+			ID:              teamAttributionID,
+			BillingStrategy: db.CostCenter_Stripe,
+			SpendingLimit:   limits.ForTeams,
+		})
+		require.NoError(t, err)
+		requireCostCenterEqual(t, db.CostCenter{
+			ID:              teamAttributionID,
+			BillingStrategy: db.CostCenter_Stripe,
+			SpendingLimit:   limits.ForTeams,
+		}, res)
+
+		// Allows updating cost center to any positive value
+		_, err = mnr.UpdateCostCenter(context.Background(), db.CostCenter{
+			ID:              teamAttributionID,
+			BillingStrategy: db.CostCenter_Stripe,
+			SpendingLimit:   10,
+		})
+		require.NoError(t, err)
+	})
 }
 
 func TestSaveCostCenterMovedToStripe(t *testing.T) {
@@ -115,4 +234,13 @@ func cleanUp(t *testing.T, conn *gorm.DB, attributionIds ...db.AttributionID) {
 			conn.Where("attributionId = ?", string(attributionId)).Delete(&db.Usage{})
 		}
 	})
+}
+
+func requireCostCenterEqual(t *testing.T, expected, actual db.CostCenter) {
+	t.Helper()
+
+	// ignore timestamps in comparsion
+	require.Equal(t, expected.ID, actual.ID)
+	require.EqualValues(t, expected.SpendingLimit, actual.SpendingLimit)
+	require.Equal(t, expected.BillingStrategy, actual.BillingStrategy)
 }

--- a/install/installer/pkg/components/usage/configmap.go
+++ b/install/installer/pkg/components/usage/configmap.go
@@ -29,8 +29,9 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		},
 		DefaultSpendingLimit: db.DefaultSpendingLimit{
 			// because we only want spending limits in SaaS, if not configured we go with a very high (i.e. no) spending limit
-			ForTeams: 1_000_000_000,
-			ForUsers: 1_000_000_000,
+			ForTeams:            1_000_000_000,
+			ForUsers:            1_000_000_000,
+			MinForUsersOnStripe: 0,
 		},
 	}
 	expConfig := getExperimentalConfig(ctx)

--- a/install/installer/pkg/components/usage/configmap_test.go
+++ b/install/installer/pkg/components/usage/configmap_test.go
@@ -26,7 +26,8 @@ func TestConfigMap_ContainsSchedule(t *testing.T) {
        "stripeCredentialsFile": "stripe-secret/apikeys",
 	   "defaultSpendingLimit": {
 		"forUsers": 1000000000,
-		"forTeams": 1000000000
+		"forTeams": 1000000000,
+		"minForUsersOnStripe": 0
 	   },
        "server": {
          "services": {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Enforces usage limit values for users & teams.

Adds a new piece of config for the default value of UsersOnStripe. When this rolls out, it will be 0 (due to missing config) but because we set it on the `server` side, this is okay and the check here will simply check if new limit is > 0. We'll add the config to ensure it does not prevent setting lower in subsequent PR.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-payment
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
