### PR TITLE
Add dev/preview:create-preview

### DIFF
--- a/dev/preview/BUILD.yaml
+++ b/dev/preview/BUILD.yaml
@@ -3,15 +3,19 @@ scripts:
     description: Build all packages needed to deploy Gitpod to preview environments
     script: ./workflow/preview/build.sh
 
+  - name: get-credentials
+    description: Provisions a new preview environment
+    script: |
+      previewctl get-credentials --kube-save-path $HOME/.kube/config
+
   - name: create-preview
     description: Provisions a new preview environment
     script: |
-      source "./util/preview-name-from-branch.sh"
       export TF_VAR_dev_kube_path="/home/gitpod/.kube/config"
       export TF_VAR_dev_kube_context="dev"
       export TF_VAR_harvester_kube_path="/home/gitpod/.kube/config"
       export TF_VAR_harvester_kube_context="harvester"
-      export TF_VAR_preview_name="$(preview-name-from-branch)"
+      export TF_VAR_preview_name="$(previewctl get-name)"
       export TF_VAR_vm_cpu=6
       export TF_VAR_vm_memory=12Gi
       export TF_VAR_vm_storage_class="longhorn-gitpod-k3s-202209251218-onereplica"
@@ -20,16 +24,9 @@ scripts:
   - name: delete-preview
     description: Delete an existing preview environment
     script: |
-      source "./util/preview-name-from-branch.sh"
       export DESTROY=true
-      export TF_VAR_dev_kube_path="/home/gitpod/.kube/config"
-      export TF_VAR_dev_kube_context="dev"
-      export TF_VAR_harvester_kube_path="/home/gitpod/.kube/config"
-      export TF_VAR_harvester_kube_context="harvester"
-      export TF_VAR_preview_name="$(preview-name-from-branch)"
-      export TF_VAR_vm_cpu=6
-      export TF_VAR_vm_memory=12Gi
-      export TF_VAR_vm_storage_class="longhorn-gitpod-k3s-202209251218-onereplica"
+      export TF_VAR_kubeconfig_path="/home/gitpod/.kube/config"
+      export TF_VAR_preview_name="$(previewctl get-name)"
       ./workflow/preview/deploy-harvester.sh
 
   - name: deploy-gitpod

--- a/dev/preview/BUILD.yaml
+++ b/dev/preview/BUILD.yaml
@@ -3,6 +3,35 @@ scripts:
     description: Build all packages needed to deploy Gitpod to preview environments
     script: ./workflow/preview/build.sh
 
+  - name: create-preview
+    description: Provisions a new preview environment
+    script: |
+      source "./util/preview-name-from-branch.sh"
+      export TF_VAR_dev_kube_path="/home/gitpod/.kube/config"
+      export TF_VAR_dev_kube_context="dev"
+      export TF_VAR_harvester_kube_path="/home/gitpod/.kube/config"
+      export TF_VAR_harvester_kube_context="harvester"
+      export TF_VAR_preview_name="$(preview-name-from-branch)"
+      export TF_VAR_vm_cpu=6
+      export TF_VAR_vm_memory=12Gi
+      export TF_VAR_vm_storage_class="longhorn-gitpod-k3s-202209251218-onereplica"
+      ./workflow/preview/deploy-harvester.sh
+
+  - name: delete-preview
+    description: Delete an existing preview environment
+    script: |
+      source "./util/preview-name-from-branch.sh"
+      export DESTROY=true
+      export TF_VAR_dev_kube_path="/home/gitpod/.kube/config"
+      export TF_VAR_dev_kube_context="dev"
+      export TF_VAR_harvester_kube_path="/home/gitpod/.kube/config"
+      export TF_VAR_harvester_kube_context="harvester"
+      export TF_VAR_preview_name="$(preview-name-from-branch)"
+      export TF_VAR_vm_cpu=6
+      export TF_VAR_vm_memory=12Gi
+      export TF_VAR_vm_storage_class="longhorn-gitpod-k3s-202209251218-onereplica"
+      ./workflow/preview/deploy-harvester.sh
+
   - name: deploy-gitpod
     description: Deploys Gitpod to an existing preview environment
     script: ./workflow/preview/deploy-gitpod.sh


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

TODO. Preview environments created in Werft works as expected, but from a workspace I get the following error:

```
leeway run dev/preview:create-preview
... a lot of output ...
/workspace/gitpod/dev/preview/infrastructure/harvester /workspace/gitpod/dev/preview
harvester_ssh_key.harvester_ssh_key: Creating...
╷
│ Error: Post "https://mads-add-l356b6c92d4.kube.gitpod-dev.com:6443/apis/harvesterhci.io/v1beta1/namespaces/preview-mads-add-l356b6c92d4/keypairs": EOF
│ 
│   with harvester_ssh_key.harvester_ssh_key,
│   on vm.tf line 59, in resource "harvester_ssh_key" "harvester_ssh_key":
│   59: resource "harvester_ssh_key" "harvester_ssh_key" {
```

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of https://github.com/gitpod-io/ops/issues/5766
Part of https://github.com/gitpod-io/ops/issues/5892

## How to test
<!-- Provide steps to test this PR -->

```sh
leeway run dev/preview:create-preview
leeway run dev/preview:delete-preview
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
