### PR TITLE
Re-add default value for storage class

### DIFF
--- a/dev/preview/infrastructure/harvester/variables.tf
+++ b/dev/preview/infrastructure/harvester/variables.tf
@@ -28,6 +28,7 @@ variable "vm_cpu" {
 variable "vm_storage_class" {
   type        = string
   description = "The storage class for the VM"
+  default     = "longhorn-gitpod-k3s-202209251218-onereplica"
 }
 
 variable "harvester_ingress_ip" {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Removed this, but forgot to readd it in last PR and deleting fails right now.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

https://werft.gitpod-dev.com/job/gitpod-custom-platform-artificial-job-557d32093681636f3ad2.0/logs

```tf
STDERR: ╷
│ Error: No value for required variable
│
│   on variables.tf line 28:
│   28: variable "vm_storage_class" {
│
│ The root module input variable "vm_storage_class" is not set, and has no
│ default value. Use a -var or -var-file command line argument to provide a
│ value for this variable.
╵
ERROR: Terraform plan failed
```

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
