### PR TITLE
Change getDocumentationLink() in GitpodConnector

### DIFF
--- a/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodConnector.kt
+++ b/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodConnector.kt
@@ -31,13 +31,7 @@ class GitpodConnector : GatewayConnector {
         return "Connect to Gitpod workspaces"
     }
 
-    override fun getDocumentationLink(): ActionLink {
-        val documentationLink = ActionLink("Documentation") {
-            BrowserUtil.browse("https://www.gitpod.io/docs/ides-and-editors/jetbrains-gateway")
-        }
-        documentationLink.setExternalLinkIcon()
-        return documentationLink
-    }
+    override fun getDocumentationLink() = GatewayConnectorDocumentationPage("https://www.gitpod.io/docs/ides-and-editors/jetbrains-gateway")
 
     override fun getConnectorId(): String = "gitpod.connector"
 


### PR DESCRIPTION
## Description
This PR removes deprecated API

## Related Issue(s)
Should fix https://youtrack.jetbrains.com/issue/GTW-1976

## How to test
1. Open Gateway
2. Click on More button

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
