### PR TITLE
feat(gateway-plugin): allow spearate builds for stable and latest

### DIFF
--- a/.github/workflows/jetbrains-update-plugin-platform.yml
+++ b/.github/workflows/jetbrains-update-plugin-platform.yml
@@ -20,6 +20,6 @@ jobs:
             pluginName: JetBrains Gateway Plugin
             pluginId: gateway-plugin
             xpath: "(/html/body/table[preceding::h2/text()='com.jetbrains.gateway'][1]/tbody/tr/td[contains(text(),'-CUSTOM-SNAPSHOT') and starts-with(text(),'MAJOR_VERSION_PLACEHOLDER') and not(contains(text(),'-NIGHTLY'))]/text())[1]"
-            gradlePropertiesPath: components/ide/jetbrains/gateway-plugin/gradle.properties
+            gradlePropertiesPath: components/ide/jetbrains/gateway-plugin/gradle-latest.properties
         secrets:
             slackWebhook: ${{ secrets.IDE_SLACK_WEBHOOK }}

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -52,7 +52,7 @@ tasks:
         read -r -p "Press enter to continue Java gradle task"
       fi
       leeway exec --package components/supervisor-api/java:lib --package components/gitpod-protocol/java:lib -- ./gradlew build
-      leeway exec --package components/ide/jetbrains/backend-plugin:plugin-latest --package components/ide/jetbrains/gateway-plugin:publish --parallel -- ./gradlew buildPlugin
+      leeway exec --package components/ide/jetbrains/backend-plugin:plugin-latest --package components/ide/jetbrains/gateway-plugin:publish-latest --parallel -- ./gradlew buildPlugin
   - name: TypeScript
     before: scripts/branch-namespace.sh
     init: yarn --network-timeout 100000 && yarn build

--- a/components/BUILD.yaml
+++ b/components/BUILD.yaml
@@ -98,7 +98,8 @@ packages:
       - components/local-app-api/typescript-grpcweb:publish
       - components/supervisor-api/typescript-grpc:publish
       - components/supervisor-api/typescript-grpcweb:publish
-      - components/ide/jetbrains/gateway-plugin:publish
+      - components/ide/jetbrains/gateway-plugin:publish-stable
+      - components/ide/jetbrains/gateway-plugin:publish-latest
       - components/public-api/typescript:publish
   - name: all-apps
     type: generic

--- a/components/ide/jetbrains/gateway-plugin/.gitignore
+++ b/components/ide/jetbrains/gateway-plugin/.gitignore
@@ -2,3 +2,4 @@
 .idea
 build
 bin
+gradle-local.properties

--- a/components/ide/jetbrains/gateway-plugin/BUILD.yaml
+++ b/components/ide/jetbrains/gateway-plugin/BUILD.yaml
@@ -1,13 +1,16 @@
 packages:
-  - name: publish
+  - name: publish-stable
     type: generic
     deps:
       - components/gitpod-protocol/java:lib
     srcs:
       - "gradle.properties"
+      - "gradle-stable.properties"
       - "gradle/wrapper/*"
       - "gradlew"
-      - "src/*"
+      - "src/main/kotlin/*"
+      - "src/main/resources/*"
+      - "src/main/resources-stable/*"
       - "*.kts"
       - "*.md"
     env:
@@ -17,4 +20,26 @@ packages:
       - jbMarketplacePublishTrigger
     config:
       commands:
-        - [ "./gradlew", "-PpluginVersion=0.0.1-${version}", "-PgitpodProtocolProjectPath=components-gitpod-protocol-java--lib/", "buildFromLeeway" ]
+        - [ "./gradlew", "-PpluginVersion=0.0.1-${version}", "-PgitpodProtocolProjectPath=components-gitpod-protocol-java--lib/", "-PenvironmentName=stable", "buildFromLeeway" ]
+  - name: publish-latest
+    type: generic
+    deps:
+      - components/gitpod-protocol/java:lib
+    srcs:
+      - "gradle.properties"
+      - "gradle-latest.properties"
+      - "gradle/wrapper/*"
+      - "gradlew"
+      - "src/main/kotlin/*"
+      - "src/main/resources/*"
+      - "src/main/resources-latest/*"
+      - "*.kts"
+      - "*.md"
+    env:
+      - JAVA_HOME=/home/gitpod/.sdkman/candidates/java/current
+      - DO_PUBLISH=${publishToJBMarketplace}
+    argdeps:
+      - jbMarketplacePublishTrigger
+    config:
+      commands:
+        - [ "./gradlew", "-PpluginVersion=0.0.1-${version}", "-PgitpodProtocolProjectPath=components-gitpod-protocol-java--lib/", "-PenvironmentName=latest", "buildFromLeeway" ]

--- a/components/ide/jetbrains/gateway-plugin/build.gradle.kts
+++ b/components/ide/jetbrains/gateway-plugin/build.gradle.kts
@@ -12,19 +12,40 @@ plugins {
     // Java support
     id("java")
     // Kotlin support - check the latest version at https://plugins.gradle.org/plugin/org.jetbrains.kotlin.jvm
-    id("org.jetbrains.kotlin.jvm") version "1.7.0"
+    id("org.jetbrains.kotlin.jvm") version "1.7.20"
     // gradle-intellij-plugin - read more: https://github.com/JetBrains/gradle-intellij-plugin
-    id("org.jetbrains.intellij") version "1.7.0"
+    id("org.jetbrains.intellij") version "1.9.0"
     // gradle-changelog-plugin - read more: https://github.com/JetBrains/gradle-changelog-plugin
     id("org.jetbrains.changelog") version "1.1.2"
     // detekt linter - read more: https://detekt.github.io/detekt/gradle.html
     id("io.gitlab.arturbosch.detekt") version "1.17.1"
     // ktlint linter - read more: https://github.com/JLLeitschuh/ktlint-gradle
     id("org.jlleitschuh.gradle.ktlint") version "10.0.0"
+    // Gradle Properties Plugin - read more: https://github.com/stevesaliman/gradle-properties-plugin
+    id("net.saliman.properties") version "1.5.2"
 }
 
 group = properties("pluginGroup")
-version = properties("pluginVersion")
+val environmentName = properties("environmentName")
+var pluginVersion = properties("pluginVersion")
+
+if (!environmentName.isNullOrBlank()) {
+    pluginVersion += "-" + environmentName
+}
+
+project(":") {
+    kotlin {
+        var excludedPackage = "stable"
+        if (environmentName == excludedPackage) excludedPackage = "latest"
+        sourceSets["main"].kotlin.exclude("io/gitpod/jetbrains/gateway/${excludedPackage}/**")
+    }
+
+    sourceSets {
+        main {
+            resources.srcDirs("src/main/resources-${environmentName}")
+        }
+    }
+}
 
 // Configure project's dependencies
 repositories {
@@ -59,7 +80,7 @@ intellij {
 // Configure gradle-changelog-plugin plugin.
 // Read more: https://github.com/JetBrains/gradle-changelog-plugin
 changelog {
-    version = properties("pluginVersion")
+    version = pluginVersion
     groups = emptyList()
 }
 
@@ -77,18 +98,23 @@ detekt {
 }
 
 tasks {
+    // JetBrains Gateway 2022.3+ requires Source Compatibility set to 17.
     // Set the compatibility versions to 1.8
     withType<JavaCompile> {
-        sourceCompatibility = "11"
-        targetCompatibility = "11"
+        sourceCompatibility = "17"
+        targetCompatibility = "17"
     }
     withType<KotlinCompile> {
-        kotlinOptions.jvmTarget = "11"
+        kotlinOptions.jvmTarget = "17"
         kotlinOptions.freeCompilerArgs = listOf("-Xjvm-default=enable")
     }
 
     withType<Detekt> {
-        jvmTarget = "11"
+        jvmTarget = "17"
+    }
+
+    buildSearchableOptions {
+        enabled = false
     }
 
     test {
@@ -96,7 +122,7 @@ tasks {
     }
 
     patchPluginXml {
-        version.set(properties("pluginVersion"))
+        version.set(pluginVersion)
         sinceBuild.set(properties("pluginSinceBuild"))
         untilBuild.set(properties("pluginUntilBuild"))
 
@@ -128,7 +154,7 @@ tasks {
         // https://plugins.jetbrains.com/docs/intellij/deployment.html#specifying-a-release-channel
         var pluginChannel: String? = System.getenv("JB_GATEWAY_GITPOD_PLUGIN_CHANNEL")
         if (pluginChannel.isNullOrBlank()) {
-            pluginChannel = if (properties("pluginVersion").matches(".+-main\\..+".toRegex())) {
+            pluginChannel = if (pluginVersion.contains("-main.")) {
                 "Nightly"
             } else {
                 "Dev"

--- a/components/ide/jetbrains/gateway-plugin/gradle-latest.properties
+++ b/components/ide/jetbrains/gateway-plugin/gradle-latest.properties
@@ -1,0 +1,10 @@
+# See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
+# for insight into build numbers and IntelliJ Platform versions.
+pluginSinceBuild=223.4884.79
+pluginUntilBuild=223.*
+# Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
+# See https://jb.gg/intellij-platform-builds-list for available build versions.
+pluginVerifierIdeVersions=2022.3
+# Version from "com.jetbrains.gateway" which can be found at https://www.jetbrains.com/intellij-repository/snapshots
+platformVersion=223.4884.79-CUSTOM-SNAPSHOT
+

--- a/components/ide/jetbrains/gateway-plugin/gradle-stable.properties
+++ b/components/ide/jetbrains/gateway-plugin/gradle-stable.properties
@@ -1,0 +1,10 @@
+# See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
+# for insight into build numbers and IntelliJ Platform versions.
+pluginSinceBuild=222.4167.26
+pluginUntilBuild=222.*
+# Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
+# See https://jb.gg/intellij-platform-builds-list for available build versions.
+pluginVerifierIdeVersions=2022.2
+# Version from "com.jetbrains.gateway" which can be found at https://www.jetbrains.com/intellij-repository/snapshots
+platformVersion=222.4345.14-CUSTOM-SNAPSHOT
+

--- a/components/ide/jetbrains/gateway-plugin/gradle.properties
+++ b/components/ide/jetbrains/gateway-plugin/gradle.properties
@@ -1,20 +1,13 @@
+# Supported environments: stable, latest (via https://github.com/stevesaliman/gradle-properties-plugin)
+environmentName=latest
 # IntelliJ Platform Artifacts Repositories
 # -> https://plugins.jetbrains.com/docs/intellij/intellij-artifacts.html
 pluginGroup=io.gitpod.jetbrains
 pluginName=gitpod-gateway
 # It is overriden by CI during the build.
 pluginVersion=0.0.1
-# See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
-# for insight into build numbers and IntelliJ Platform versions.
-pluginSinceBuild=222.4167.26
-pluginUntilBuild=222.*
-# Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
-# See https://jb.gg/intellij-platform-builds-list for available build versions.
-pluginVerifierIdeVersions=2022.2
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#intellij-extension-type
 platformType=GW
-# Version from "com.jetbrains.gateway" which can be found at https://www.jetbrains.com/intellij-repository/snapshots
-platformVersion=222.4345.14-CUSTOM-SNAPSHOT
 platformDownloadSources=true
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22

--- a/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/latest/GitpodConnector.kt
+++ b/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/latest/GitpodConnector.kt
@@ -2,18 +2,19 @@
 // Licensed under the GNU Affero General Public License (AGPL).
 // See License-AGPL.txt in the project root for license information.
 
-package io.gitpod.jetbrains.gateway
+package io.gitpod.jetbrains.gateway.latest
 
+import com.intellij.ide.BrowserUtil
+import com.intellij.ui.components.ActionLink
 import com.jetbrains.gateway.api.GatewayConnector
 import com.jetbrains.gateway.api.GatewayConnectorView
 import com.jetbrains.gateway.api.GatewayRecentConnections
 import com.jetbrains.rd.util.lifetime.Lifetime
+import io.gitpod.jetbrains.gateway.GitpodRecentConnections
 import io.gitpod.jetbrains.icons.GitpodIcons
 import java.awt.Component
 import javax.swing.Icon
 import javax.swing.JComponent
-import com.intellij.ui.components.ActionLink
-import com.intellij.ide.BrowserUtil
 
 class GitpodConnector : GatewayConnector {
     override val icon: Icon

--- a/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/latest/GitpodConnectorView.kt
+++ b/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/latest/GitpodConnectorView.kt
@@ -1,0 +1,48 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package io.gitpod.jetbrains.gateway.latest
+
+import com.intellij.openapi.wm.impl.welcomeScreen.WelcomeScreenUIManager
+import com.intellij.ui.dsl.builder.BottomGap
+import com.intellij.ui.dsl.builder.panel
+import com.intellij.ui.dsl.gridLayout.HorizontalAlign
+import com.intellij.ui.dsl.gridLayout.VerticalAlign
+import com.jetbrains.gateway.api.GatewayConnectorView
+import com.jetbrains.gateway.api.GatewayUI
+import com.jetbrains.rd.util.lifetime.Lifetime
+import io.gitpod.jetbrains.gateway.GitpodWorkspacesView
+
+class GitpodConnectorView(
+    lifetime: Lifetime
+) : GatewayConnectorView {
+
+    private val workspaces = GitpodWorkspacesView(lifetime)
+
+    override val component = panel {
+        row {
+            resizableRow()
+            cell(workspaces.component)
+                .resizableColumn()
+                .horizontalAlign(HorizontalAlign.FILL)
+                .verticalAlign(VerticalAlign.FILL)
+            cell()
+        }
+        row {
+            panel {
+                verticalAlign(VerticalAlign.BOTTOM)
+                separator(WelcomeScreenUIManager.getSeparatorColor())
+                indent {
+                    row {
+                        button("Back") {
+                            GatewayUI.getInstance().reset()
+                        }
+                    }
+                }
+            }
+        }.bottomGap(BottomGap.SMALL)
+    }.apply {
+        this.background = WelcomeScreenUIManager.getMainAssociatedComponentBackground()
+    }
+}

--- a/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/stable/GitpodConnector.kt
+++ b/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/stable/GitpodConnector.kt
@@ -1,0 +1,58 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package io.gitpod.jetbrains.gateway.stable
+
+import com.jetbrains.gateway.api.GatewayConnector
+import com.jetbrains.gateway.api.GatewayConnectorView
+import com.jetbrains.gateway.api.GatewayRecentConnections
+import com.jetbrains.rd.util.lifetime.Lifetime
+import io.gitpod.jetbrains.icons.GitpodIcons
+import java.awt.Component
+import javax.swing.Icon
+import javax.swing.JComponent
+import com.intellij.ui.components.ActionLink
+import com.intellij.ide.BrowserUtil
+import io.gitpod.jetbrains.gateway.GitpodRecentConnections
+
+class GitpodConnector : GatewayConnector {
+    override val icon: Icon
+        get() = GitpodIcons.Logo
+
+    override fun createView(lifetime: Lifetime): GatewayConnectorView {
+        return GitpodConnectorView(lifetime)
+    }
+
+    override fun getActionText(): String {
+        return "Connect to Gitpod"
+    }
+
+    override fun getDescription(): String? {
+        return "Connect to Gitpod workspaces"
+    }
+
+    override fun getDocumentationLink(): ActionLink {
+        val documentationLink = ActionLink("Documentation") {
+            BrowserUtil.browse("https://www.gitpod.io/docs/ides-and-editors/jetbrains-gateway")
+        }
+        documentationLink.setExternalLinkIcon()
+        return documentationLink
+    }
+
+    override fun getConnectorId(): String = "gitpod.connector"
+
+    override fun getRecentConnections(setContentCallback: (Component) -> Unit): GatewayRecentConnections? {
+        return GitpodRecentConnections()
+    }
+
+    override fun getTitle(): String {
+        return "Gitpod"
+    }
+
+    override fun getTitleAdornment(): JComponent? {
+        return null
+    }
+
+    override fun initProcedure() {}
+}

--- a/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/stable/GitpodConnectorView.kt
+++ b/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/stable/GitpodConnectorView.kt
@@ -2,7 +2,7 @@
 // Licensed under the GNU Affero General Public License (AGPL).
 // See License-AGPL.txt in the project root for license information.
 
-package io.gitpod.jetbrains.gateway
+package io.gitpod.jetbrains.gateway.stable
 
 import com.intellij.openapi.wm.impl.welcomeScreen.WelcomeScreenUIManager
 import com.intellij.ui.dsl.builder.BottomGap
@@ -12,6 +12,7 @@ import com.intellij.ui.dsl.gridLayout.VerticalAlign
 import com.jetbrains.gateway.api.GatewayConnectorView
 import com.jetbrains.gateway.api.GatewayUI
 import com.jetbrains.rd.util.lifetime.Lifetime
+import io.gitpod.jetbrains.gateway.GitpodWorkspacesView
 
 class GitpodConnectorView(
     lifetime: Lifetime

--- a/components/ide/jetbrains/gateway-plugin/src/main/resources-latest/META-INF/extensions.xml
+++ b/components/ide/jetbrains/gateway-plugin/src/main/resources-latest/META-INF/extensions.xml
@@ -1,0 +1,10 @@
+<!--
+ Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ Licensed under the GNU Affero General Public License (AGPL).
+ See License-AGPL.txt in the project root for license information.
+-->
+<idea-plugin>
+    <extensions defaultExtensionNs="com.jetbrains">
+        <gatewayConnector implementation="io.gitpod.jetbrains.gateway.latest.GitpodConnector"/>
+    </extensions>
+</idea-plugin>

--- a/components/ide/jetbrains/gateway-plugin/src/main/resources-stable/META-INF/extensions.xml
+++ b/components/ide/jetbrains/gateway-plugin/src/main/resources-stable/META-INF/extensions.xml
@@ -1,0 +1,10 @@
+<!--
+ Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ Licensed under the GNU Affero General Public License (AGPL).
+ See License-AGPL.txt in the project root for license information.
+-->
+<idea-plugin>
+    <extensions defaultExtensionNs="com.jetbrains">
+        <gatewayConnector implementation="io.gitpod.jetbrains.gateway.stable.GitpodConnector"/>
+    </extensions>
+</idea-plugin>

--- a/components/ide/jetbrains/gateway-plugin/src/main/resources/META-INF/plugin.xml
+++ b/components/ide/jetbrains/gateway-plugin/src/main/resources/META-INF/plugin.xml
@@ -4,7 +4,9 @@
  See License-AGPL.txt in the project root for license information.
 -->
 
-<idea-plugin require-restart="false">
+<idea-plugin require-restart="false" xmlns:xi="http://www.w3.org/2001/XInclude">
+    <xi:include href="/META-INF/extensions.xml" xpointer="xpointer(/idea-plugin/*)"/>
+
     <id>io.gitpod.jetbrains.gateway</id>
     <name>Gitpod Gateway</name>
     <vendor>Gitpod</vendor>
@@ -26,7 +28,6 @@
 
     <extensions defaultExtensionNs="com.jetbrains">
         <gatewayConnectionProvider implementation="io.gitpod.jetbrains.gateway.GitpodConnectionProvider"/>
-        <gatewayConnector implementation="io.gitpod.jetbrains.gateway.GitpodConnector"/>
     </extensions>
 
     <applicationListeners>


### PR DESCRIPTION
## Description
Allows us to build `stable` and `latest` versions of the JB Gateway Plugin simultaneously and fix our JB Gateway Integration Tests.

We used the code of these two PRs as reference: [#10595](https://github.com/gitpod-io/gitpod/pull/10595/files), [#13018](https://github.com/gitpod-io/gitpod/pull/13018/files).

Note: We are using platform version 223.4x instead of 223.6x for EAP version due to [this issue](https://github.com/JetBrains/gradle-intellij-plugin/is).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #13581

## How to test
- Download the latest build from this branch from the [marketplace](https://plugins.jetbrains.com/plugin/18438-gitpod-gateway/versions/dev)
- Install it in EAP gateway
- Observe that everything works as expected
- Download the stable version built from this branch from the [marketplace](https://plugins.jetbrains.com/plugin/18438-gitpod-gateway/versions/dev)
- Install it stable gateway
- Observe that everything works as expected

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
