### PR TITLE
[telemetry] Add Active users

### DIFF
--- a/components/dashboard/src/admin/Settings.tsx
+++ b/components/dashboard/src/admin/Settings.tsx
@@ -11,7 +11,6 @@ import CheckBox from "../components/CheckBox";
 import { getGitpodService } from "../service/service";
 import { useEffect, useState } from "react";
 import InfoBox from "../components/InfoBox";
-import { isGitpodIo } from "../utils";
 import { PageWithAdminSubMenu } from "./PageWithAdminSubMenu";
 
 export default function Settings() {
@@ -19,9 +18,6 @@ export default function Settings() {
     const [telemetryData, setTelemetryData] = useState<TelemetryData>();
 
     useEffect(() => {
-        if (isGitpodIo()) {
-            return; // temporarily disable to avoid hight CPU on the DB
-        }
         (async () => {
             const data = await getGitpodService().server.adminGetTelemetryData();
             setTelemetryData(data);

--- a/components/dashboard/src/utils.ts
+++ b/components/dashboard/src/utils.ts
@@ -50,12 +50,7 @@ export const poll = async <T>(
 };
 
 export function isGitpodIo() {
-    return (
-        window.location.hostname === "gitpod.io" ||
-        window.location.hostname === "gitpod-staging.com" ||
-        window.location.hostname.endsWith("gitpod-dev.com") ||
-        window.location.hostname.endsWith("gitpod-io-dev.com")
-    );
+    return false;
 }
 
 export function isLocalPreview() {

--- a/components/gitpod-db/src/typeorm/workspace-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/workspace-db-impl.ts
@@ -1070,6 +1070,9 @@ export abstract class AbstractTypeORMWorkspaceDBImpl implements WorkspaceDB {
             .groupBy("1")
             .having("count(distinct date(i.startedTime)) >= 3");
 
+        // print query for debugging purposes
+        log.debug(queryBuilder.getSql());
+
         return await queryBuilder.getCount();
     }
 

--- a/components/gitpod-db/src/workspace-db.ts
+++ b/components/gitpod-db/src/workspace-db.ts
@@ -135,6 +135,7 @@ export interface WorkspaceDB {
     findInstancesByPhaseAndRegion(phase: string, region: string): Promise<WorkspaceInstance[]>;
 
     getWorkspaceCount(type?: String): Promise<Number>;
+    getActiveUserCount(): Promise<number>;
     getWorkspaceCountByCloneURL(cloneURL: string, sinceLastDays?: number, type?: string): Promise<number>;
     getInstanceCount(type?: string): Promise<number>;
 

--- a/components/gitpod-db/src/workspace-db.ts
+++ b/components/gitpod-db/src/workspace-db.ts
@@ -135,7 +135,7 @@ export interface WorkspaceDB {
     findInstancesByPhaseAndRegion(phase: string, region: string): Promise<WorkspaceInstance[]>;
 
     getWorkspaceCount(type?: String): Promise<Number>;
-    getActiveUserCount(): Promise<number>;
+    countUsersWithActiveInstances(): Promise<number>;
     getWorkspaceCountByCloneURL(cloneURL: string, sinceLastDays?: number, type?: string): Promise<number>;
     getInstanceCount(type?: string): Promise<number>;
 

--- a/components/gitpod-protocol/src/installation-admin-protocol.ts
+++ b/components/gitpod-protocol/src/installation-admin-protocol.ts
@@ -27,6 +27,7 @@ export interface InstallationAdmin {
 export interface TelemetryData {
     installationAdmin: InstallationAdmin;
     totalUsers: number;
+    activeUsers: number;
     totalWorkspaces: number;
     totalInstances: number;
     licenseType: string;

--- a/components/installation-telemetry/cmd/send.go
+++ b/components/installation-telemetry/cmd/send.go
@@ -58,6 +58,7 @@ var sendCmd = &cobra.Command{
 		properties := analytics.NewProperties().
 			Set("version", versionId).
 			Set("totalUsers", data.TotalUsers).
+			Set("activeUsers", data.ActiveUsers).
 			Set("totalWorkspaces", data.TotalWorkspaces).
 			Set("totalInstances", data.TotalInstances).
 			Set("platform", platform)

--- a/components/installation-telemetry/pkg/server/installationAdmin.go
+++ b/components/installation-telemetry/pkg/server/installationAdmin.go
@@ -21,6 +21,7 @@ type InstallationAdminSettings struct {
 type Data struct {
 	InstallationAdmin InstallationAdmin `json:"installationAdmin"`
 	TotalUsers        int64             `json:"totalUsers"`
+	ActiveUsers       int64             `json:"activeUsers"`
 	TotalWorkspaces   int64             `json:"totalWorkspaces"`
 	TotalInstances    int64             `json:"totalInstances"`
 	LicenseType       string            `json:"licenseType"`

--- a/components/server/src/installation-admin/telemetry-data-provider.ts
+++ b/components/server/src/installation-admin/telemetry-data-provider.ts
@@ -24,7 +24,7 @@ export class InstallationAdminTelemetryDataProvider {
             const data: TelemetryData = {
                 installationAdmin: await this.installationAdminDb.getData(),
                 totalUsers: await this.userDb.getUserCount(true),
-                activeUsers: await this.workspaceDb.getActiveUserCount(),
+                activeUsers: await this.workspaceDb.countUsersWithActiveInstances(),
                 totalWorkspaces: await this.workspaceDb.getWorkspaceCount(),
                 totalInstances: await this.workspaceDb.getInstanceCount(),
                 licenseType: this.licenseEvaluator.getLicenseData().type,

--- a/components/server/src/installation-admin/telemetry-data-provider.ts
+++ b/components/server/src/installation-admin/telemetry-data-provider.ts
@@ -24,6 +24,7 @@ export class InstallationAdminTelemetryDataProvider {
             const data: TelemetryData = {
                 installationAdmin: await this.installationAdminDb.getData(),
                 totalUsers: await this.userDb.getUserCount(true),
+                activeUsers: await this.workspaceDb.getActiveUserCount(),
                 totalWorkspaces: await this.workspaceDb.getWorkspaceCount(),
                 totalInstances: await this.workspaceDb.getInstanceCount(),
                 licenseType: this.licenseEvaluator.getLicenseData().type,

--- a/dev/preview/workflow/preview/deploy-gitpod.sh
+++ b/dev/preview/workflow/preview/deploy-gitpod.sh
@@ -360,6 +360,7 @@ yq w -i "${INSTALLER_CONFIG_PATH}" experimental.ide.ideMetrics.enabledErrorRepor
 #
 TRACING_ENDPOINT="http://otel-collector.monitoring-satellite.svc.cluster.local:14268/api/traces"
 yq w -i "${INSTALLER_CONFIG_PATH}" observability.tracing.endpoint "${TRACING_ENDPOINT}"
+yq w -i "${INSTALLER_CONFIG_PATH}" observability.logLevel "debug"
 
 #
 # configureAuthProviders


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This PR adds telemetry to track active users.
Active users are calculated as the ones who
created workspace instances in 3 of the last 7 days.

Signed-off-by: Tarun Pothulapati <tarun@gitpod.io>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/10649

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[telemetry] Add Active users
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:
<!--
Optional annotations to add to the werft job.

* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-local-preview
