### PR TITLE
[installer-tests] dump config at start of test

### DIFF
--- a/.werft/installer-tests.ts
+++ b/.werft/installer-tests.ts
@@ -274,8 +274,33 @@ installerTests(TEST_CONFIGURATIONS[testConfig]).catch((err) => {
     process.exit(1);
 });
 
+function logJobConfig(): void {
+    werft.phase("Job configuration");
+    const sliceId = "Parsing job configuration";
+
+    const jobConfig = {
+        config,
+        k8s_version,
+        os_version,
+        deps,
+        version,
+        preview,
+        upgrade,
+        skipTests,
+        selfSigned,
+        deleteOnFail,
+        baseDomain,
+        gcpDnsZone,
+    };
+
+    werft.logOutput(sliceId, JSON.stringify(jobConfig, null, 2));
+
+    werft.log(sliceId, "Expand to see the job configuration");
+    werft.done(sliceId);
+}
+
 export async function installerTests(config: TestConfig) {
-    console.log(config.DESCRIPTION);
+    logJobConfig();
 
     // these phases sets up or clean up the infrastructure
     let majorPhase: string;


### PR DESCRIPTION
## Description

This commit dumps the installer tests configuration at the beginning of the job. If unforeseen errors arise it will be simpler to determine if the tests are aborting early.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test

```
werft run github -j .werft/k3s-installer-tests.yaml  -a domain=tests.doptig.com 
```

[gitpod-custom-alt-installer-tests-log-job-config.0](https://werft.gitpod-dev.com/job/gitpod-custom-alt-installer-tests-log-job-config.0)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
