### PR TITLE
[installer-tests] Permit successive werft runs to reuse infrastructure

### DIFF
--- a/install/tests/Makefile
+++ b/install/tests/Makefile
@@ -530,7 +530,10 @@ destroy-azure:
 
 backup-cert:
 	@echo "Backing up certificate secret to GCS"
-	@kubectl --kubeconfig=${KUBECONFIG} get secret -n gitpod https-certificates -o yaml > ${cert_secret} || { echo "No existing secret"; rm -f ${cert_secret}; }
+	@kubectl --kubeconfig=${KUBECONFIG} get secret -n gitpod https-certificates -o yaml > ${cert_secret} \
+		&& echo "---" >> ${cert_secret} \
+		&& kubectl --kubeconfig=${KUBECONFIG} get certificate -n gitpod https-certificates -o yaml >> ${cert_secret} \
+		|| { echo "No existing secret"; rm -f ${cert_secret}; }
 	@[[ -f ${cert_secret} ]] && gsutil cp ${cert_secret} gs://nightly-tests/nightly-tests-certs/${cert_secret} || echo "No certificate secret file exist"
 
 list-state:

--- a/install/tests/Makefile
+++ b/install/tests/Makefile
@@ -398,7 +398,12 @@ wait_time_azure := 300
 delete-cm-setup: sleeptime=$(if $(time_to_sleep_$(cloud)),$(time_to_sleep_$(cloud)),${time_to_sleep})
 delete-cm-setup: waittime=$(if $(wait_time_$(cloud)),$(wait_time_$(cloud)),${wait_time})
 delete-cm-setup:
-	sleep ${waittime} && kubectl --kubeconfig=${KUBECONFIG} delete pods --all -n cert-manager && sleep ${sleeptime};
+	@echo "Waiting ${waittime} for cert-manager to become ready"
+	kubectl --kubeconfig=${KUBECONFIG} --namespace cert-manager wait --for=condition=Available deployment/cert-manager --timeout=${waittime}s
+	kubectl --kubeconfig=${KUBECONFIG} delete pods --all -n cert-manager
+	@echo Waiting for up to ${sleeptime} seconds for cert-manager to become ready
+	kubectl --kubeconfig=${KUBECONFIG} --namespace gitpod wait --for=condition=Ready certificate/https-certificates --timeout ${sleeptime}s || true
+
 
 gitpod-debug-info:
 	@echo -e "\033[;31mGitpod is not ready\033[0;m"

--- a/install/tests/Makefile
+++ b/install/tests/Makefile
@@ -389,6 +389,10 @@ kots-install: install-kots-cli destroy-gitpod create-secrets restore-cert
                     --no-port-forward \
                     --config-values tmp_config.yml
 
+	sleep 30
+	$(MAKE) delete-cm-setup || { $(MAKE) gitpod-debug-info; exit 1; }
+	$(MAKE) backup-cert || true
+
 time_to_sleep_azure := 1000 # azure seem to take more time to fullfil DNS propogation
 time_to_sleep := 800
 

--- a/install/tests/Makefile
+++ b/install/tests/Makefile
@@ -379,7 +379,7 @@ version ?= -
 kots-install: version-flag = $(if $(version:-=),--app-version-label=$(version),)
 kots-install: preflight-flag = $(if $(preflights:true=),--skip-preflights,)
 kots-install: license-file = $(if $(license_community_$(channel)),$(license_community_$(channel)),"../licenses/$(channel).yaml")
-kots-install: install-kots-cli destroy-gitpod create-secrets
+kots-install: install-kots-cli destroy-gitpod create-secrets restore-cert
 	kubectl kots install ${app}/${channel} \
 	--skip-rbac-check ${version-flag} ${preflight-flag} \
 					--wait-duration "10m" \
@@ -533,8 +533,20 @@ destroy-azure:
 	ls ${KUBECONFIG} && terraform destroy -target=module.certmanager -var kubeconfig=${KUBECONFIG} --auto-approve || echo "No kubeconfig file"
 	terraform destroy -target=module.aks -var kubeconfig=${KUBECONFIG} --auto-approve
 
+restore-cert:
+	@echo "Restoring certificate for '${TF_VAR_domain}' (if present)"
+	gsutil ls gs://nightly-tests/nightly-tests-certs/${cert_secret} 1>/dev/null 2>/dev/null \
+		&& { \
+	 		gsutil cp gs://nightly-tests/nightly-tests-certs/${cert_secret} ${cert_secret} \
+			&& kubectl --kubeconfig="${KUBECONFIG}" create namespace gitpod \
+			&& kubectl --kubeconfig="${KUBECONFIG}" apply -f ${cert_secret} \
+			; \
+		} \
+		|| { echo "Certificate secrets for '${TF_VAR_domain}' not backed up, skipping restore"; } \
+
 backup-cert:
 	@echo "Backing up certificate secret to GCS"
+	kubectl --kubeconfig="${KUBECONFIG}" wait --namespace gitpod --for=condition=Ready certificate/https-certificates --timeout=120s
 	@kubectl --kubeconfig=${KUBECONFIG} get secret -n gitpod https-certificates -o yaml > ${cert_secret} \
 		&& echo "---" >> ${cert_secret} \
 		&& kubectl --kubeconfig=${KUBECONFIG} get certificate -n gitpod https-certificates -o yaml >> ${cert_secret} \

--- a/install/tests/Makefile
+++ b/install/tests/Makefile
@@ -428,6 +428,8 @@ gitpod-debug-info:
 
 
 check-kots-app:
+	@echo "Waiting for up to 5 minutes for gitpod to become available"
+	kubectl --kubeconfig=${KUBECONFIG} --namespace gitpod wait --for=condition=Available deployment/installation-status --timeout 5m || true
 	kubectl kots get --kubeconfig=${KUBECONFIG} app gitpod -n gitpod | grep gitpod  | awk '{print $$2}' | grep "ready" || { $(MAKE) gitpod-debug-info; exit 1; }
 
 self_signed ?= false

--- a/install/tests/Makefile
+++ b/install/tests/Makefile
@@ -550,12 +550,16 @@ restore-cert:
 
 backup-cert:
 	@echo "Backing up certificate secret to GCS"
-	kubectl --kubeconfig="${KUBECONFIG}" wait --namespace gitpod --for=condition=Ready certificate/https-certificates --timeout=120s
-	@kubectl --kubeconfig=${KUBECONFIG} get secret -n gitpod https-certificates -o yaml > ${cert_secret} \
+	kubectl --kubeconfig="${KUBECONFIG}" get --namespace gitpod certificate/https-certificates \
+	&& { \
+		kubectl --kubeconfig="${KUBECONFIG}" wait --namespace gitpod --for=condition=Ready certificate/https-certificates --timeout=120s \
+		&& kubectl --kubeconfig=${KUBECONFIG} get secret -n gitpod https-certificates -o yaml > ${cert_secret} \
 		&& echo "---" >> ${cert_secret} \
 		&& kubectl --kubeconfig=${KUBECONFIG} get certificate -n gitpod https-certificates -o yaml >> ${cert_secret} \
-		|| { echo "No existing secret"; rm -f ${cert_secret}; }
-	@[[ -f ${cert_secret} ]] && gsutil cp ${cert_secret} gs://nightly-tests/nightly-tests-certs/${cert_secret} || echo "No certificate secret file exist"
+		&& gsutil cp ${cert_secret} gs://nightly-tests/nightly-tests-certs/${cert_secret} \
+		; \
+	} \
+	|| { echo "No existing secret"; rm -f ${cert_secret}; }
 
 list-state:
 	terraform state list


### PR DESCRIPTION
## Description

This pull request improves the experience of re-running werft/terraform jobs against the same infrastructure. When developing a feature against the installer or Terraform a significant amount of time is spent waiting on CI runs to complete; having the ability to re-run the same tests quickly by reusing infrastructure can save a lot of time.

This pull request improves the installation experience in the following ways:
1. Backup and restore Gitpod's certificates upon environment reuse; we've run into Let's Encrypt rate limits and being able to deploy a given environment repeatedly without bumping into rate limits will improve the experience quite a bit.
2. Use `kubectl wait` to delay for cluster operations to complete; we have a few cases where long delays may be necessary to wait for certificates to issue but static timeouts set an absolute minimum for how long the installation may take. By waiting for resources to become ready rather than using static sleeps we can shave off time from the development cycle process.
3. Shuffle around werft slice and phase names; emitting werft logs with the same name as a werft phase appears to mask them from the UI. Our cleanup steps were running but were not directly visible; this is resolved by choosing a unique name for the cleanup logs.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

Run against `subdomain=2f928-k3s` to test the certificate reuse behavior.

```bash
werft run github -j .werft/k3s-installer-tests.yaml  -a domain=tests.doptig.com -a subdomain=2f928-k3s -a preview=true -a deleteOnFail=false -a skipTests=true
```

[gitpod-custom-alt-installer-tests-certificate-backup-resto.0](https://werft.gitpod-dev.com/job/gitpod-custom-alt-installer-tests-certificate-backup-resto.0)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
