### PR TITLE
obs: fix new workspace does not shown workspace success rate

### DIFF
--- a/operations/observability/mixins/workspace/dashboards/success-criteria.json
+++ b/operations/observability/mixins/workspace/dashboards/success-criteria.json
@@ -87,7 +87,7 @@
             "uid": "${datasource}"
           },
           "exemplar": false,
-          "expr": "1-((\n  (\n    (sum(rate(gitpod_ws_manager_workspace_stops_total{reason=\"failed\",cluster!~\"prod-meta-.*|ephemeral.*\"}[1d])) OR on() vector(0))\n    /\n    sum(rate(gitpod_ws_manager_workspace_stops_total{cluster!~\"prod-meta-.*|ephemeral.*\"}[1d]))\n  )\n) + (\n  (\n    (sum(rate(grpc_server_handled_total{grpc_method=\"StartWorkspace\",grpc_code!~\"OK|ResourceExhausted\",cluster!~\"prod-meta-.*|ephemeral.*\"}[1d])) OR on() vector(0))\n    /\n    sum(rate(grpc_server_handled_total{grpc_method=\"StartWorkspace\",cluster!~\"prod-meta-.*|ephemeral.*\"}[1d]))\n  )\n))",
+          "expr": "1-((\n  (\n    (sum(rate(gitpod_ws_manager_workspace_stops_total{reason=\"failed\",cluster!~\"prod-meta-.*|ephemeral.*\"}[1d])) OR on() vector(0))\n    /\n    sum(rate(gitpod_ws_manager_workspace_stops_total{cluster!~\"prod-meta-.*|ephemeral.*\"}[1d]))\n  )\n) OR on() vector(0) + (\n  (\n    (sum(rate(grpc_server_handled_total{grpc_method=\"StartWorkspace\",grpc_code!~\"OK|ResourceExhausted\",cluster!~\"prod-meta-.*|ephemeral.*\"}[1d])) OR on() vector(0))\n    /\n    sum(rate(grpc_server_handled_total{grpc_method=\"StartWorkspace\",cluster!~\"prod-meta-.*|ephemeral.*\"}[1d]))\n  )\n))",
           "instant": false,
           "interval": "",
           "legendFormat": "Success Rate",


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Fix new workspace does not show workspace success rate because no workspace failed in metric `gitpod_ws_manager_workspace_stops_total`.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Partially #12364

## How to test
<!-- Provide steps to test this PR -->
was:
![image](https://user-images.githubusercontent.com/49380831/195491713-0e14fadc-28e0-4222-becc-231011b3a82e.png)

is:
![image](https://user-images.githubusercontent.com/49380831/195491746-9701e64d-6c08-4232-afaf-23e2277ff35d.png)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
None

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
