### PR TITLE
ws-manager: `NODE_EXTRA_CA_CERTS` is the value of the gitpod internals

### DIFF
--- a/components/ws-manager/pkg/manager/create.go
+++ b/components/ws-manager/pkg/manager/create.go
@@ -873,7 +873,8 @@ func isGitpodInternalEnvVar(name string) bool {
 	return strings.HasPrefix(name, "GITPOD_") ||
 		strings.HasPrefix(name, "SUPERVISOR_") ||
 		strings.HasPrefix(name, "BOB_") ||
-		strings.HasPrefix(name, "THEIA_")
+		strings.HasPrefix(name, "THEIA_") ||
+		name == "NODE_EXTRA_CA_CERTS"
 }
 
 func isProtectedEnvVar(name string, sysEnvvars []*api.EnvironmentVariable) bool {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

`NODE_EXTRA_CA_CERTS` is a variable used inside gitpod, but it was encrypted.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #13735

## How to test
<!-- Provide steps to test this PR -->

- Open a workspace on https://c16f5-aws.tests.gitpod-self-hosted.com/workspaces

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Fix an issue with a workspace not starting with a self-signed cluster
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
