### PR TITLE
[ws-manager] Do not follow redirect when ready probe

### DIFF
--- a/components/ws-manager/pkg/manager/probe.go
+++ b/components/ws-manager/pkg/manager/probe.go
@@ -70,6 +70,9 @@ func (p *WorkspaceReadyProbe) Run(ctx context.Context) WorkspaceProbeResult {
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 		},
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
 	}
 
 	for {

--- a/components/ws-manager/pkg/manager/probe.go
+++ b/components/ws-manager/pkg/manager/probe.go
@@ -7,12 +7,14 @@ package manager
 import (
 	"context"
 	"crypto/tls"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 	"time"
 
 	"github.com/gitpod-io/gitpod/common-go/log"
 	"github.com/gitpod-io/gitpod/common-go/tracing"
+	"k8s.io/apimachinery/pkg/util/json"
 )
 
 // WorkspaceProbeResult marks the result of a workspace probe
@@ -38,7 +40,7 @@ type WorkspaceReadyProbe struct {
 
 // NewWorkspaceReadyProbe creates a new workspace probe
 func NewWorkspaceReadyProbe(workspaceID string, workspaceURL url.URL) WorkspaceReadyProbe {
-	workspaceURL.Path += "/_supervisor/v1/status/ide"
+	workspaceURL.Path += "/_supervisor/v1/status/ide/wait/true"
 	readyURL := workspaceURL.String()
 
 	return WorkspaceReadyProbe{
@@ -92,14 +94,31 @@ func (p *WorkspaceReadyProbe) Run(ctx context.Context) WorkspaceProbeResult {
 			// we've timed out - do not log this as it would spam the logs for no good reason
 			continue
 		}
-		resp.Body.Close()
 
-		if resp.StatusCode == http.StatusOK {
-			break
+		if resp.StatusCode != http.StatusOK {
+			resp.Body.Close()
+			log.WithField("url", p.readyURL).WithField("status", resp.StatusCode).Debug("workspace did not respond to ready probe with OK status")
+			time.Sleep(p.RetryDelay)
+			continue
 		}
 
-		log.WithField("url", p.readyURL).WithField("status", resp.StatusCode).Debug("workspace did not respond to ready probe with OK status")
-		time.Sleep(p.RetryDelay)
+		rawBody, err := ioutil.ReadAll(resp.Body)
+		resp.Body.Close()
+		if err != nil {
+			log.WithField("url", p.readyURL).WithField("status", resp.StatusCode).WithError(err).Debug("ready probe failed: cannot read body")
+			continue
+		}
+		var probeResult struct {
+			Ok bool `json:"ok"`
+		}
+		err = json.Unmarshal(rawBody, &probeResult)
+		if err != nil {
+			log.WithField("url", p.readyURL).WithField("status", resp.StatusCode).WithError(err).Debug("ready probe failed: unable to unmarshal json")
+			continue
+		}
+		if probeResult.Ok {
+			break
+		}
 	}
 
 	// workspace is actually ready

--- a/test/pkg/integration/workspace.go
+++ b/test/pkg/integration/workspace.go
@@ -155,7 +155,7 @@ func LaunchWorkspaceDirectly(t *testing.T, ctx context.Context, api *ComponentAP
 
 	req := &wsmanapi.StartWorkspaceRequest{
 		Id:            instanceID.String(),
-		ServicePrefix: instanceID.String(),
+		ServicePrefix: workspaceID,
 		Metadata: &wsmanapi.WorkspaceMetadata{
 			Owner:  gitpodBuiltinUserID,
 			MetaId: workspaceID,


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PR fixes some issue from `ws-manager`
1. `ws-manager` do not follow redirect when it run ide ready probe
2. `ws-manager` will check ide ready response, it include `ok` status
3. using `/_supervisor/v1/status/ide/wait/true` API in order to reduce request


And do some minor change for integration test
1. using workspaceId as `servicePrefix`, because `ws-proxy` will check the hostname regex
2. refactor some workspace integration-test, to make it pass


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
integration test should pass
1. start a workspace in preview environment, it should work as before

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-integration-tests=workspace
      Valid options are `all`, `workspace`, `webapp`, `ide`
