### PR TITLE
Adjust IDE alerts to work with centralized alerting

### DIFF
--- a/operations/observability/mixins/IDE/rules/opensvx.yaml
+++ b/operations/observability/mixins/IDE/rules/opensvx.yaml
@@ -22,9 +22,9 @@ spec:
         runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodOpenVsxRegistryDown.md
         summary: Open-VSX registry is possibly down
         description: Open-VSX registry is possibly down. We cannot pull VSCode extensions we don't have in our caches
-        dashboard_url: https://grafana.gitpod.io/d/HNOvmGpxgd/openvsx-proxy
+        dashboard_url: https://grafana.gitpod.io/d/HNOvmGpxgd/openvsx-proxy?var-cluster={{ $labels.cluster }}
       expr: |
-          sum(rate(gitpod_vscode_extension_gallery_query_total{status="failure",errorCode!="canceled"}[5m])) / sum(rate(gitpod_vscode_extension_gallery_query_total[5m])) > 0.01
+          sum(rate(gitpod_vscode_extension_gallery_query_total{status="failure",errorCode!="canceled"}[5m])) by(cluster) / sum(rate(gitpod_vscode_extension_gallery_query_total[5m])) by(cluster) > 0.01
 
     - alert: GitpodOpenVSXUnavailable
       labels:
@@ -33,5 +33,5 @@ spec:
       for: 10m
       annotations:
         summary: Prometheus is failing to scrape OpenVSX-proxy
-        description: OpenVSX-proxy is possibly down, or prometheus is failing to scrape it.
+        description: OpenVSX-proxy(Pod {{ $labels.pod }}, cluster {{ $labels.cluster }}) is possibly down, or prometheus is failing to scrape it.
       expr: up{job="openvsx-proxy"} == 0


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Inspired by https://github.com/gitpod-io/gitpod/pull/13766, this PR updates PrometheusRules from the IDE team to make sure they work as expected with the new Centralized alerting infrastructure.

Work done while pairing with @felladrin  🙂 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/ops/issues/5599

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
