### PR TITLE
[code] fix portsView address open twice #13778

### DIFF
--- a/install/installer/cmd/testdata/render/aws-setup/output.golden
+++ b/install/installer/cmd/testdata/render/aws-setup/output.golden
@@ -3279,7 +3279,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-8a4dc22ae336edbbf521396b7d45b1be6756911b",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-46e9df494af98d87fc4fb65d9c251f0d9bcc1cd2",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {
@@ -4487,7 +4487,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-8a4dc22ae336edbbf521396b7d45b1be6756911b",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-46e9df494af98d87fc4fb65d9c251f0d9bcc1cd2",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/azure-setup/output.golden
+++ b/install/installer/cmd/testdata/render/azure-setup/output.golden
@@ -3196,7 +3196,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-8a4dc22ae336edbbf521396b7d45b1be6756911b",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-46e9df494af98d87fc4fb65d9c251f0d9bcc1cd2",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {
@@ -4350,7 +4350,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-8a4dc22ae336edbbf521396b7d45b1be6756911b",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-46e9df494af98d87fc4fb65d9c251f0d9bcc1cd2",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -4008,7 +4008,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-8a4dc22ae336edbbf521396b7d45b1be6756911b",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-46e9df494af98d87fc4fb65d9c251f0d9bcc1cd2",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {
@@ -5302,7 +5302,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-8a4dc22ae336edbbf521396b7d45b1be6756911b",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-46e9df494af98d87fc4fb65d9c251f0d9bcc1cd2",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -3337,7 +3337,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-8a4dc22ae336edbbf521396b7d45b1be6756911b",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-46e9df494af98d87fc4fb65d9c251f0d9bcc1cd2",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {
@@ -4537,7 +4537,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-8a4dc22ae336edbbf521396b7d45b1be6756911b",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-46e9df494af98d87fc4fb65d9c251f0d9bcc1cd2",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/gcp-setup/output.golden
+++ b/install/installer/cmd/testdata/render/gcp-setup/output.golden
@@ -3167,7 +3167,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-8a4dc22ae336edbbf521396b7d45b1be6756911b",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-46e9df494af98d87fc4fb65d9c251f0d9bcc1cd2",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {
@@ -4311,7 +4311,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-8a4dc22ae336edbbf521396b7d45b1be6756911b",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-46e9df494af98d87fc4fb65d9c251f0d9bcc1cd2",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/http-proxy/output.golden
+++ b/install/installer/cmd/testdata/render/http-proxy/output.golden
@@ -3506,7 +3506,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-8a4dc22ae336edbbf521396b7d45b1be6756911b",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-46e9df494af98d87fc4fb65d9c251f0d9bcc1cd2",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {
@@ -4760,7 +4760,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-8a4dc22ae336edbbf521396b7d45b1be6756911b",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-46e9df494af98d87fc4fb65d9c251f0d9bcc1cd2",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/insecure-s3-setup/output.golden
+++ b/install/installer/cmd/testdata/render/insecure-s3-setup/output.golden
@@ -3417,7 +3417,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-8a4dc22ae336edbbf521396b7d45b1be6756911b",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-46e9df494af98d87fc4fb65d9c251f0d9bcc1cd2",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {
@@ -4671,7 +4671,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-8a4dc22ae336edbbf521396b7d45b1be6756911b",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-46e9df494af98d87fc4fb65d9c251f0d9bcc1cd2",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -3503,7 +3503,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-8a4dc22ae336edbbf521396b7d45b1be6756911b",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-46e9df494af98d87fc4fb65d9c251f0d9bcc1cd2",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {
@@ -4757,7 +4757,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-8a4dc22ae336edbbf521396b7d45b1be6756911b",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-46e9df494af98d87fc4fb65d9c251f0d9bcc1cd2",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -3515,7 +3515,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-8a4dc22ae336edbbf521396b7d45b1be6756911b",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-46e9df494af98d87fc4fb65d9c251f0d9bcc1cd2",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {
@@ -4769,7 +4769,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-8a4dc22ae336edbbf521396b7d45b1be6756911b",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-46e9df494af98d87fc4fb65d9c251f0d9bcc1cd2",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
+++ b/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
@@ -3836,7 +3836,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-8a4dc22ae336edbbf521396b7d45b1be6756911b",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-46e9df494af98d87fc4fb65d9c251f0d9bcc1cd2",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {
@@ -5090,7 +5090,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-8a4dc22ae336edbbf521396b7d45b1be6756911b",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-46e9df494af98d87fc4fb65d9c251f0d9bcc1cd2",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
+++ b/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
@@ -3506,7 +3506,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-8a4dc22ae336edbbf521396b7d45b1be6756911b",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-46e9df494af98d87fc4fb65d9c251f0d9bcc1cd2",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {
@@ -4760,7 +4760,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-8a4dc22ae336edbbf521396b7d45b1be6756911b",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-46e9df494af98d87fc4fb65d9c251f0d9bcc1cd2",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/pkg/components/workspace/ide/constants.go
+++ b/install/installer/pkg/components/workspace/ide/constants.go
@@ -6,7 +6,7 @@ package ide
 
 const (
 	CodeIDEImage                = "ide/code"
-	CodeIDEImageStableVersion   = "commit-8a4dc22ae336edbbf521396b7d45b1be6756911b" // stable version that will be updated manually on demand
+	CodeIDEImageStableVersion   = "commit-46e9df494af98d87fc4fb65d9c251f0d9bcc1cd2" // stable version that will be updated manually on demand
 	CodeDesktopIDEImage         = "ide/code-desktop"
 	CodeDesktopInsidersIDEImage = "ide/code-desktop-insiders"
 	IntelliJDesktopIDEImage     = "ide/intellij"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #13778

## How to test
<!-- Provide steps to test this PR -->
- Open workspace with **Stable Code** in Firefox / Arc Browser in preview env
- Check if portsView address will NOT open twice

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
VSCode: Fix portsView address open twice in some browsers
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
