### PR TITLE
[supervisor] fix environment replace rule

### DIFF
--- a/components/supervisor/pkg/supervisor/ssh.go
+++ b/components/supervisor/pkg/supervisor/ssh.go
@@ -109,7 +109,7 @@ func (s *sshServer) handleConn(ctx context.Context, conn net.Conn) {
 		if len(s) != 2 {
 			continue
 		}
-		envs = append(envs, fmt.Sprintf("%s=%s", s[0], fmt.Sprintf("\"%s\"", strings.ReplaceAll(s[1], "\"", "\\\""))))
+		envs = append(envs, fmt.Sprintf("%s=%s", s[0], fmt.Sprintf("\"%s\"", strings.ReplaceAll(strings.ReplaceAll(s[1], `\`, `\\`), `"`, `\"`))))
 	}
 	if len(envs) > 0 {
 		args = append(args, fmt.Sprintf("-oSetEnv %s", strings.Join(envs, " ")))


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PR fixes a minor issue for ssh environment
it should support `TEST=\"test test\"` now

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
1. set a env `TEST=\"test test\"` in the preview environment, and start a workspace
2. run `export` in vscode browser to see `TEST` env
3. connect workspace via ssh gateway, it should connect successfully
4. run `export` in ssh, see `TEST` env, it should be the same as vscode
5. open this workspace in vscode desktop
6. open `gitpod` repo in preview environment, do test again.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
