### PR TITLE
[configcat] Do not supply lists to configcat evaluations

### DIFF
--- a/components/dashboard/src/contexts/FeatureFlagContext.tsx
+++ b/components/dashboard/src/contexts/FeatureFlagContext.tsx
@@ -40,12 +40,28 @@ const FeatureFlagContextProvider: React.FC = ({ children }) => {
                 usage_view: { defaultValue: false, setter: setShowUsageView },
             };
             for (const [flagName, config] of Object.entries(featureFlags)) {
+                if (teams) {
+                    for (const team of teams) {
+                        const flagValue = await getExperimentsClient().getValueAsync(flagName, config.defaultValue, {
+                            user,
+                            projectId: project?.id,
+                            teamId: team.id,
+                            teamName: team?.name,
+                        });
+
+                        // We got an explicit override value from ConfigCat
+                        if (flagValue !== config.defaultValue) {
+                            config.setter(flagValue);
+                            return;
+                        }
+                    }
+                }
+
                 const flagValue = await getExperimentsClient().getValueAsync(flagName, config.defaultValue, {
                     user,
                     projectId: project?.id,
                     teamId: team?.id,
                     teamName: team?.name,
-                    teams,
                 });
                 config.setter(flagValue);
             }

--- a/components/gitpod-protocol/src/experiments/configcat.ts
+++ b/components/gitpod-protocol/src/experiments/configcat.ts
@@ -12,7 +12,6 @@ import { User } from "../protocol";
 export const USER_ID_ATTRIBUTE = "user_id";
 export const PROJECT_ID_ATTRIBUTE = "project_id";
 export const TEAM_ID_ATTRIBUTE = "team_id";
-export const TEAM_IDS_ATTRIBUTE = "team_ids";
 export const TEAM_NAME_ATTRIBUTE = "team_name";
 export const TEAM_NAMES_ATTRIBUTE = "team_names";
 export const BILLING_TIER_ATTRIBUTE = "billing_tier";
@@ -49,10 +48,6 @@ export function attributesToUser(attributes: Attributes): ConfigCatUser {
     }
     if (attributes.teamName) {
         custom[TEAM_NAME_ATTRIBUTE] = attributes.teamName;
-    }
-    if (attributes.teams) {
-        custom[TEAM_NAMES_ATTRIBUTE] = attributes.teams.map((t) => t.name).join(",");
-        custom[TEAM_IDS_ATTRIBUTE] = attributes.teams.map((t) => t.id).join(",");
     }
     if (attributes.billingTier) {
         custom[BILLING_TIER_ATTRIBUTE] = attributes.billingTier;

--- a/components/gitpod-protocol/src/experiments/types.ts
+++ b/components/gitpod-protocol/src/experiments/types.ts
@@ -5,7 +5,6 @@
  */
 
 import { BillingTier, User } from "../protocol";
-import { Team } from "../teams-projects-protocol";
 
 export const Client = Symbol("Client");
 
@@ -25,9 +24,6 @@ export interface Attributes {
     teamId?: string;
     // Currently selected Gitpod Team Name (mapped to "custom.team_name")
     teamName?: string;
-
-    // All the Gitpod Teams that the user is a member (or owner) of (mapped to "custom.team_names" and "custom.team_ids")
-    teams?: Team[];
 }
 
 export interface Client {

--- a/components/server/ee/src/billing/billing-mode.ts
+++ b/components/server/ee/src/billing/billing-mode.ts
@@ -76,14 +76,17 @@ export class BillingModesImpl implements BillingModes {
 
         // Is Usage Based Billing enabled for this user or not?
         const teams = await this.teamDB.findTeamsByUser(user.id);
-        const isUsageBasedBillingEnabled = await this.configCatClientFactory().getValueAsync(
-            "isUsageBasedBillingEnabled",
-            false,
-            {
+        let isUsageBasedBillingEnabled = false;
+        for (const team of teams) {
+            const isEnabled = await this.configCatClientFactory().getValueAsync("isUsageBasedBillingEnabled", false, {
                 user,
-                teams,
-            },
-        );
+                teamId: team.id,
+            });
+            if (isEnabled) {
+                isUsageBasedBillingEnabled = true;
+                break;
+            }
+        }
 
         // 1. UBB enabled?
         if (!isUsageBasedBillingEnabled) {

--- a/components/server/ee/src/workspace/workspace-factory.ts
+++ b/components/server/ee/src/workspace/workspace-factory.ts
@@ -361,12 +361,10 @@ export class WorkspaceFactoryEE extends WorkspaceFactory {
                 config._featureFlags = (config._featureFlags || []).concat(["persistent_volume_claim"]);
             }
             const billingTier = await this.entitlementService.getBillingTier(user);
-            const userTeams = await this.teamDB.findTeamsByUser(user.id);
             // this allows to control user`s PVC feature flag via ConfigCat
             if (
                 await getExperimentsClientForBackend().getValueAsync("user_pvc", false, {
                     user,
-                    teams: userTeams,
                     billingTier,
                 })
             ) {

--- a/components/server/src/workspace/config-provider.ts
+++ b/components/server/src/workspace/config-provider.ts
@@ -135,15 +135,12 @@ export class ConfigProvider {
                 );
             }
             const billingTier = await this.entitlementService.getBillingTier(user);
-            const userTeams = await this.teamDB.findTeamsByUser(user.id);
             // this allows to control user`s PVC feature flag via ConfigCat
-            if (
-                await getExperimentsClientForBackend().getValueAsync("user_pvc", false, {
-                    user,
-                    teams: userTeams,
-                    billingTier,
-                })
-            ) {
+            const isPVCEnabled = await getExperimentsClientForBackend().getValueAsync("user_pvc", false, {
+                user,
+                billingTier,
+            });
+            if (isPVCEnabled) {
                 config._featureFlags = (config._featureFlags || []).concat(["persistent_volume_claim"]);
             }
 

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -3162,12 +3162,11 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
      * @returns
      */
     protected async getImageBuilderClient(user: User, workspace: Workspace, instance?: WorkspaceInstance) {
-        const teams = await this.teamDB.findTeamsByUser(user.id);
         const isMovedImageBuilder = await getExperimentsClientForBackend().getValueAsync("movedImageBuilder", false, {
             user,
             projectId: workspace.projectId,
-            teams,
         });
+
         log.info(
             { userId: user.id, workspaceId: workspace.id, instanceId: instance?.id },
             "image-builder in workspace cluster?",


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Before we land this, we need to adjust our existing feature flag configuration to use `team_id CONTAINS <list of IDs>` such that it continues to work 

In this change, we entirely remove the ability to supply a list of teams to configcat. We're doing this because it creates confusion on how the flag actually behaves. In the cases where we need to evaluate against multiple teams, we loop over them. This doesn't actually incur any extra network overhead as the flags are cached by the client so while the firs call may require a fetch (which it did before also), the subsequent calls will be resolved using a local cache.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
* On preview, create a team and add it to Configcat's UBP config for non-prod as `user_id ONE OF <your team ID>.
* Wait for the flag to propagate (around 3 minutes)
* You should see UBP


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
