### PR TITLE
Stream logs from TF executions

### DIFF
--- a/.werft/util/certs.ts
+++ b/.werft/util/certs.ts
@@ -1,4 +1,4 @@
-import { exec, ExecOptions } from "./shell";
+import {exec, ExecOptions, execStream} from "./shell";
 import {CORE_DEV_KUBECONFIG_PATH, GCLOUD_SERVICE_ACCOUNT_PATH, HARVESTER_KUBECONFIG_PATH} from "../jobs/build/const";
 import { Werft } from "./werft";
 import { reportCertificateError } from "../util/slack";
@@ -43,7 +43,7 @@ export async function certReady(werft: Werft, config: JobConfig, slice: string):
         }
 
         werft.log(slice, `Creating cert: Attempt ${i}`);
-        exec(`${commonVars} \
+        await execStream(`${commonVars} \
                         TF_CLI_ARGS_plan="-replace=kubernetes_manifest.cert" \
                         ./dev/preview/workflow/preview/deploy-harvester.sh`,
             {slice: slice})

--- a/.werft/vm/vm.ts
+++ b/.werft/vm/vm.ts
@@ -4,7 +4,7 @@ import {
     HARVESTER_KUBECONFIG_PATH,
     PREVIEW_K3S_KUBECONFIG_PATH
 } from "../jobs/build/const";
-import { exec } from "../util/shell";
+import {exec, execStream} from "../util/shell";
 import { getGlobalWerftInstance } from "../util/werft";
 
 import * as shell from "shelljs";
@@ -12,11 +12,11 @@ import * as shell from "shelljs";
 /**
  * Remove all VM resources - Namespace+VM+Proxy svc on Harvester, LB+SVC on DEV
  */
-export function deleteVM(options: { name: string }) {
+export async function deleteVM(options: { name: string }) {
     const werft = getGlobalWerftInstance();
 
     try {
-        exec(`DESTROY=true \
+        await execStream(`DESTROY=true \
                                     GOOGLE_APPLICATION_CREDENTIALS=${GCLOUD_SERVICE_ACCOUNT_PATH} \
                                     GOOGLE_BACKEND_CREDENTIALS=${GCLOUD_SERVICE_ACCOUNT_PATH} \
                                     TF_VAR_dev_kube_path=${CORE_DEV_KUBECONFIG_PATH} \
@@ -29,7 +29,6 @@ export function deleteVM(options: { name: string }) {
         werft.fail("Deleting VM.", new Error(`Failed creating VM: ${err}`))
         return;
     }
-
 
     werft.currentPhaseSpan.setAttribute("preview.deleted_vm", true);
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
https://github.com/gitpod-io/gitpod/pull/13627 introduced the ability to stream logs from subprocesses. This PR makes the calls to the TF scripts use that.

Verified that the streaming works in:

https://werft.gitpod-dev.com/job/gitpod-custom-aa-stream-tf.0
https://werft.gitpod-dev.com/job/gitpod-custom-aa-stream-tf.1

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
