### PR TITLE
Add Namespace Selector for ArgoCD ServiceMonitors

### DIFF
--- a/operations/observability/mixins/platform/rules/argocd/servicemonitor.yaml
+++ b/operations/observability/mixins/platform/rules/argocd/servicemonitor.yaml
@@ -7,6 +7,9 @@ metadata:
     app.kubernetes.io/name: argocd
     app.kubernetes.io/part-of: kube-prometheus
 spec:
+  namespaceSelector:
+    matchNames:
+    - argocd
   selector:
     matchLabels:
       app.kubernetes.io/name: argocd-metrics
@@ -22,6 +25,9 @@ metadata:
     app.kubernetes.io/name: argocd
     app.kubernetes.io/part-of: kube-prometheus
 spec:
+  namespaceSelector:
+    matchNames:
+    - argocd
   selector:
     matchLabels:
       app.kubernetes.io/name: argocd-server-metrics
@@ -37,6 +43,9 @@ metadata:
     app.kubernetes.io/name: argocd-repo-server
     app.kubernetes.io/part-of: kube-prometheus
 spec:
+  namespaceSelector:
+    matchNames:
+    - argocd
   selector:
     matchLabels:
       app.kubernetes.io/name: argocd-repo-server
@@ -52,6 +61,9 @@ metadata:
     app.kubernetes.io/name: argocd-applicationset-controller
     app.kubernetes.io/part-of: kube-prometheus
 spec:
+  namespaceSelector:
+    matchNames:
+    - argocd
   selector:
     matchLabels:
       app.kubernetes.io/name: argocd-applicationset-controller


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
@liam-j-bennett I've taken another look at the configuration and I've noticed that we're deploying the servicemonitor in a different namespace from where ArgoCD is deployed. To fix this we can define a NamespaceSelector.

I've tried this change manually and noticed that this fixed the issue 🙂 

![image](https://user-images.githubusercontent.com/24193764/195850638-d98f0b12-c19c-41ef-83ce-b2c14c9735f5.png)


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
