### PR TITLE
Add a Prometheus alert rule for SSH Gateway

### DIFF
--- a/operations/observability/mixins/IDE/rules/ssh-gateway.yaml
+++ b/operations/observability/mixins/IDE/rules/ssh-gateway.yaml
@@ -1,0 +1,27 @@
+# Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+# Licensed under the GNU Affero General Public License (AGPL).
+# See License-AGPL.txt in the project root for license information.
+
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: k8s
+    role: alert-rules
+  name: ssh-gateway-monitoring-rules
+  namespace: monitoring-satellite
+spec:
+  groups:
+  - name: ssh-gateway
+    rules:
+    - alert: SSHGatewayFailingToConnect
+      labels:
+        severity: critical
+      for: 20m
+      annotations:
+        runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/SSHGatewayFailingToConnect.md
+        summary: SSH connectivity issues
+        description: SSH Gateway is failing to connect to SSH servers in Gitpod workspaces
+        dashboard_url: https://grafana.gitpod.io/d/3oan1Zr7k/ssh-gateway-overview?orgId=1&refresh=30s&from=now-2d&to=now
+      expr: |
+          sum by (error_type) (rate(gitpod_ws_proxy_ssh_attempt_total{error_type="CONN_FAILED",status="failed"}[5m])) / sum(rate(gitpod_ws_proxy_ssh_attempt_total{error_type!~"WS_ID_INVALID|OTHERS"}[5m])) > 0.01


### PR DESCRIPTION
## Description
Add a Prometheus alert rule for SSH Gateway - monitor for Connection issues.

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
