### PR TITLE
[image-builder-bob] Enable wait if error in debug mode

### DIFF
--- a/components/image-builder-bob/cmd/root.go
+++ b/components/image-builder-bob/cmd/root.go
@@ -7,8 +7,10 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"time"
 
 	log "github.com/gitpod-io/gitpod/common-go/log"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -23,6 +25,11 @@ func Execute() {
 	log.Init("bob", "", true, false)
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)
+
+		if log.Log.Logger.IsLevelEnabled(logrus.DebugLevel) {
+			time.Sleep(1 * time.Minute)
+		}
+
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
## Description

This is useful for debugging issues with the build. By default, `image-builder-bob` pod disappears almost instantly, making hard to find the reason. 

## How to test
- Enable LOG_LEVEL=debug in `image-builder-mk3`.
- Trigger a build that fails
- Check `image-builder-bob` pod stays alive for 1m. Inspect the log of the pod.
 
## Release Notes
```release-note
NONE
```

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
