### PR TITLE
Proposal: feat: Enable and autoinstall shell completions for gp CLI

### DIFF
--- a/components/gitpod-cli/cmd/completion.go
+++ b/components/gitpod-cli/cmd/completion.go
@@ -5,6 +5,8 @@
 package cmd
 
 import (
+	"fmt"
+	"log"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -12,21 +14,55 @@ import (
 
 // completionCmd represents the completion command
 var completionCmd = &cobra.Command{
-	Use:    "completion",
-	Hidden: true,
-	Short:  "Generates bash completion scripts",
-	Long: `To load completion run
+	Use:   "completion",
+	Short: "Generates shell completion",
+	Long: fmt.Sprintf(`Bash:
 
-. <(gp completion)
+	$ source <(%[1]s completion bash)
 
-To configure your bash shell to load completions for each session add to your bashrc
+	# To load completions for each session, execute once:
+	$ %[1]s completion bash | sudo tee /etc/bash_completion.d/%[1]s
 
-# ~/.bashrc or ~/.profile
-. <(gp completion)
-`,
+fish:
+
+	$ %[1]s completion fish | source
+
+	# To load completions for each session, execute once:
+	$ mkdir -p ~/.config/fish/completions && %[1]s completion fish > ~/.config/fish/completions/%[1]s.fish
+
+Zsh:
+
+	# If shell completion is not already enabled in your environment,
+	# you will need to enable it.  You can execute the following once:
+	$ echo "autoload -U compinit; compinit" >> ~/.zshrc
+
+	# To load completions for each session, execute once:
+	$ echo "%[1]s completion zsh" | sudo tee "${fpath[1]}/_%[1]s"
+
+	# You will need to start a new shell for this setup to take effect.
+`, rootCmd.Root().Name()),
+	ValidArgs: []string{"bash", "fish", "zsh"},
+	Args:      cobra.ExactValidArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		rootCmd.GenBashCompletion(os.Stdout)
+		switch args[0] {
+		case "bash":
+			if err := cmd.Root().GenBashCompletion(os.Stdout); err != nil {
+				err_log("bash")
+			}
+		case "fish":
+			if err := cmd.Root().GenFishCompletion(os.Stdout, true); err != nil {
+				err_log("fish")
+			}
+		case "zsh":
+			if err := cmd.Root().GenZshCompletion(os.Stdout); err != nil {
+				err_log("zsh")
+			}
+		}
 	},
+}
+
+func err_log(shell string) {
+	log.Fatalf("Failed to generate completion for %s", shell)
 }
 
 func init() {

--- a/components/supervisor/pkg/supervisor/supervisor.go
+++ b/components/supervisor/pkg/supervisor/supervisor.go
@@ -70,6 +70,7 @@ const (
 	gitpodGID       = 33333
 	gitpodGroupName = "gitpod"
 	desktopIDEPort  = 24000
+	gitpodCliName   = "gitpod-cli"
 )
 
 var (
@@ -178,6 +179,7 @@ func Run(options ...RunOption) {
 		log.WithError(err).Fatal("cannot ensure Gitpod user exists")
 	}
 	symlinkBinaries(cfg)
+	installGpCliCompletion()
 	configureGit(cfg, childProcEnvvars)
 
 	tokenService := NewInMemoryTokenService()
@@ -592,6 +594,76 @@ func installDotfiles(ctx context.Context, cfg *Config, tokenService *InMemoryTok
 	}
 }
 
+func installGpCliCompletion() {
+	supervisorPath, err := os.Executable()
+	if err != nil {
+		log.WithError(err).Error("supervisor bin missing")
+		return
+	}
+
+	basedir := filepath.Dir(supervisorPath)
+	gpcli := filepath.Join(basedir, gitpodCliName)
+
+	if _, err := os.Stat(gpcli); err != nil {
+		log.WithError(err).Error(gitpodCliName, "bin is missing")
+		return
+	}
+
+	write_comp := func(bin string, basedir string, shell string) {
+
+		filename := "gp"
+		if shell == "zsh" {
+			filename = "_" + filename
+		} else if shell == "fish" {
+			filename = filename + "." + shell
+		}
+		target := filepath.Join(basedir, filename)
+
+		// No need to write completion if it already exists
+		if _, err := os.Stat(target); err == nil {
+			return
+		}
+
+		if err := os.MkdirAll(basedir, 0755); err == nil {
+			if file, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644); err == nil {
+				defer file.Close()
+
+				cmd := exec.Command(bin, "completion", shell)
+				cmd.Stdout = file
+
+				if err := cmd.Run(); err != nil {
+					log.WithError(err).Error("Failed to write completion for", shell)
+				}
+			}
+		}
+	}
+
+	// bash
+	bashrc_file := filepath.FromSlash("/etc/bash.bashrc")
+	bash_comp_dir := filepath.FromSlash("/usr/share/bash-completion/completions")
+
+	if _, err := os.Stat(bash_comp_dir); err == nil {
+		write_comp(gpcli, bash_comp_dir, "bash")
+		// Unless bash-completion package is installed, do not use it's path and fallback to system bashrc
+	} else if file, err := os.OpenFile(bashrc_file, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644); err == nil {
+		defer file.Close()
+
+		if _, err := file.WriteString(`
+if test -n "${PS1:-}" && test -n "${BASH:-}" && test "${BASH:-}" != "/bin/sh" && command -v gp 1>/dev/null; then
+	source <(gp completion bash)
+fi
+		`); err != nil {
+			log.Error(err)
+		}
+	}
+
+	// fish
+	write_comp(gpcli, filepath.FromSlash("/usr/local/share/fish/vendor_completions.d"), "fish")
+
+	// zsh
+	write_comp(gpcli, filepath.FromSlash("/usr/local/share/zsh/site-functions"), "zsh")
+}
+
 func createGitpodService(cfg *Config, tknsrv api.TokenServiceServer) *gitpod.APIoverJSONRPC {
 	endpoint, host, err := cfg.GitpodAPIEndpoint()
 	if err != nil {
@@ -648,7 +720,7 @@ func symlinkBinaries(cfg *Config) {
 	base := filepath.Dir(bin)
 
 	binaries := map[string]string{
-		"gitpod-cli": "gp",
+		gitpodCliName: "gp",
 	}
 	for k, v := range binaries {
 		var (


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Glad I stumbled upon the codebase, I was literally about to write the completion scripts for use with my fish shell. It's kind of funny how this wasn't mentioned anywhere how to setup for `bash`, which was already there 😬
This updates the completion command and autoinstalls them for different shells on workspace start.

|fish|
|---|
|<img width="1176" alt="Screenshot 2022-10-16 at 12 50 17 AM" src="https://user-images.githubusercontent.com/39482679/196003229-68a55814-ada4-4b8d-b3f9-6037e06eee77.png">|

|bash|
|---|
|<img width="802" alt="Screenshot 2022-10-16 at 12 52 41 AM" src="https://user-images.githubusercontent.com/39482679/196003343-24f4b6ac-6924-45e2-a530-1ae336bc1070.png">|

|zsh|
|---|
|<img width="755" alt="Screenshot 2022-10-16 at 12 55 22 AM" src="https://user-images.githubusercontent.com/39482679/196003459-d955d12d-cdcf-4e2f-aefd-2fa16c423c54.png">|

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
1. Open a workspace in preview env
2. Type `gp` and hit `Tab` key.
- To check for other shells, switch to them by running `fish` or `zsh`
- And redo `2.`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
feat: Enable and autoinstall shell completions for gp CLI
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
