### PR TITLE
[usage] Check UBP even without any teams

### DIFF
--- a/components/server/ee/src/billing/billing-mode.ts
+++ b/components/server/ee/src/billing/billing-mode.ts
@@ -77,15 +77,30 @@ export class BillingModesImpl implements BillingModes {
         // Is Usage Based Billing enabled for this user or not?
         const teams = await this.teamDB.findTeamsByUser(user.id);
         let isUsageBasedBillingEnabled = false;
-        for (const team of teams) {
-            const isEnabled = await this.configCatClientFactory().getValueAsync("isUsageBasedBillingEnabled", false, {
-                user,
-                teamId: team.id,
-            });
-            if (isEnabled) {
-                isUsageBasedBillingEnabled = true;
-                break;
+        if (teams.length > 0) {
+            for (const team of teams) {
+                // Checking here doesn't actually block on every team as the flags are fetched once and catched, subsequent calls are non-blocking.
+                const isEnabled = await this.configCatClientFactory().getValueAsync(
+                    "isUsageBasedBillingEnabled",
+                    false,
+                    {
+                        user,
+                        teamId: team.id,
+                    },
+                );
+                if (isEnabled) {
+                    isUsageBasedBillingEnabled = true;
+                    break;
+                }
             }
+        } else {
+            isUsageBasedBillingEnabled = await this.configCatClientFactory().getValueAsync(
+                "isUsageBasedBillingEnabled",
+                false,
+                {
+                    user,
+                },
+            );
         }
 
         // 1. UBB enabled?


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
We wouldn't ask ConfigCat for the feature flag value if there were no teams associated. This fixes that.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #13886 

## How to test
<!-- Provide steps to test this PR -->
1. Onboard your preview user to the feature
2. See the UI offers switching to UBP
3. Check that once you create a team on no plan, you can still upgrade to UBP

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
