### PR TITLE
Provide option to enforce network connection rate limiting

### DIFF
--- a/components/ws-daemon/pkg/daemon/daemon.go
+++ b/components/ws-daemon/pkg/daemon/daemon.go
@@ -97,23 +97,27 @@ func NewDaemon(config Config, reg prometheus.Registerer) (*Daemon, error) {
 		return nil, xerrors.Errorf("cannot register cgroup plugin metrics: %w", err)
 	}
 
-	var configReloader CompositeConfigReloader
-	configReloader = append(configReloader, ConfigReloaderFunc(func(ctx context.Context, config *Config) error {
-		cgroupV1IOLimiter.Update(config.IOLimit.WriteBWPerSecond.Value(), config.IOLimit.ReadBWPerSecond.Value(), config.IOLimit.WriteIOPS, config.IOLimit.ReadIOPS)
-		cgroupV2IOLimiter.Update(config.IOLimit.WriteBWPerSecond.Value(), config.IOLimit.ReadBWPerSecond.Value(), config.IOLimit.WriteIOPS, config.IOLimit.ReadIOPS)
-		procV2Plugin.Update(config.ProcLimit)
-		return nil
-	}))
-
 	listener := []dispatch.Listener{
 		cpulimit.NewDispatchListener(&config.CPULimit, reg),
 		markUnmountFallback,
 		cgroupPlugins,
 	}
 
+	netlimiter := netlimit.NewConnLimiter(config.NetLimit, reg)
 	if config.NetLimit.Enabled {
-		listener = append(listener, netlimit.NewConnLimiter(config.NetLimit, reg))
+		listener = append(listener, netlimiter)
 	}
+
+	var configReloader CompositeConfigReloader
+	configReloader = append(configReloader, ConfigReloaderFunc(func(ctx context.Context, config *Config) error {
+		cgroupV1IOLimiter.Update(config.IOLimit.WriteBWPerSecond.Value(), config.IOLimit.ReadBWPerSecond.Value(), config.IOLimit.WriteIOPS, config.IOLimit.ReadIOPS)
+		cgroupV2IOLimiter.Update(config.IOLimit.WriteBWPerSecond.Value(), config.IOLimit.ReadBWPerSecond.Value(), config.IOLimit.WriteIOPS, config.IOLimit.ReadIOPS)
+		procV2Plugin.Update(config.ProcLimit)
+		if config.NetLimit.Enabled {
+			netlimiter.Update(config.NetLimit)
+		}
+		return nil
+	}))
 
 	dsptch, err := dispatch.NewDispatch(containerRuntime, clientset, config.Runtime.KubernetesNamespace, nodename, listener...)
 	if err != nil {

--- a/components/ws-daemon/pkg/netlimit/config.go
+++ b/components/ws-daemon/pkg/netlimit/config.go
@@ -6,6 +6,7 @@ package netlimit
 
 type Config struct {
 	Enabled              bool  `json:"enabled"`
+	Enforce              bool  `json:"enforce"`
 	ConnectionsPerMinute int64 `json:"connectionsPerMinute"`
 	BucketSize           int64 `json:"bucketSize"`
 }

--- a/install/installer/cmd/testdata/render/aws-setup/output.golden
+++ b/install/installer/cmd/testdata/render/aws-setup/output.golden
@@ -4708,6 +4708,7 @@ data:
         "procLimit": 0,
         "netlimit": {
           "enabled": false,
+          "enforce": false,
           "connectionsPerMinute": 3000,
           "bucketSize": 1000
         },
@@ -6868,7 +6869,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: de8ed99a057f28c772db0287eeb93b12fe89401a2645f94d0b533eb0e5640654
+        gitpod.io/checksum_config: b16f1014837e91b50bf4b9d18e29a1c41adf08d502dee1bcc035987eb0810c5a
         seccomp.security.alpha.kubernetes.io/shiftfs-module-loader: unconfined
       creationTimestamp: null
       labels:

--- a/install/installer/cmd/testdata/render/azure-setup/output.golden
+++ b/install/installer/cmd/testdata/render/azure-setup/output.golden
@@ -4569,6 +4569,7 @@ data:
         "procLimit": 0,
         "netlimit": {
           "enabled": false,
+          "enforce": false,
           "connectionsPerMinute": 3000,
           "bucketSize": 1000
         },
@@ -6713,7 +6714,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: f39e45d788bb170ba728cfc3c69c5ca00a2b88a73a2d7288bcc1caee8e638405
+        gitpod.io/checksum_config: c6d2a80d1de7a1f91bb2bea177c784c3bc7d4cd50a3e761795fad1188e41f831
         seccomp.security.alpha.kubernetes.io/shiftfs-module-loader: unconfined
       creationTimestamp: null
       labels:

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -5526,6 +5526,7 @@ data:
         "procLimit": 0,
         "netlimit": {
           "enabled": false,
+          "enforce": false,
           "connectionsPerMinute": 3000,
           "bucketSize": 1000
         },
@@ -7946,7 +7947,7 @@ spec:
     metadata:
       annotations:
         gitpod.io: hello
-        gitpod.io/checksum_config: eed464cffbb7a8f5698bc1163b1e22cbc4593e154e2662c43dd2f643863c4548
+        gitpod.io/checksum_config: 2285dea7c1cdbfb36111baedc49012c61ac5f537bc3083118721ddf55e21ae07
         hello: world
         seccomp.security.alpha.kubernetes.io/shiftfs-module-loader: unconfined
       creationTimestamp: null

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -4756,6 +4756,7 @@ data:
         "procLimit": 0,
         "netlimit": {
           "enabled": false,
+          "enforce": false,
           "connectionsPerMinute": 3000,
           "bucketSize": 1000
         },
@@ -6995,7 +6996,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: f39e45d788bb170ba728cfc3c69c5ca00a2b88a73a2d7288bcc1caee8e638405
+        gitpod.io/checksum_config: c6d2a80d1de7a1f91bb2bea177c784c3bc7d4cd50a3e761795fad1188e41f831
         seccomp.security.alpha.kubernetes.io/shiftfs-module-loader: unconfined
       creationTimestamp: null
       labels:

--- a/install/installer/cmd/testdata/render/gcp-setup/output.golden
+++ b/install/installer/cmd/testdata/render/gcp-setup/output.golden
@@ -4529,6 +4529,7 @@ data:
         "procLimit": 0,
         "netlimit": {
           "enabled": false,
+          "enforce": false,
           "connectionsPerMinute": 3000,
           "bucketSize": 1000
         },
@@ -6687,7 +6688,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: f985a365ca2934d925e1510c4398f0cf27ba9a85413f34a1f119317ad098f028
+        gitpod.io/checksum_config: f24b5c0e027f2d12934fd5a2f5217d05b812d8dd6713d7600a9044e49346ad73
         seccomp.security.alpha.kubernetes.io/shiftfs-module-loader: unconfined
       creationTimestamp: null
       labels:

--- a/install/installer/cmd/testdata/render/http-proxy/output.golden
+++ b/install/installer/cmd/testdata/render/http-proxy/output.golden
@@ -4979,6 +4979,7 @@ data:
         "procLimit": 0,
         "netlimit": {
           "enabled": false,
+          "enforce": false,
           "connectionsPerMinute": 3000,
           "bucketSize": 1000
         },
@@ -7519,7 +7520,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: f39e45d788bb170ba728cfc3c69c5ca00a2b88a73a2d7288bcc1caee8e638405
+        gitpod.io/checksum_config: c6d2a80d1de7a1f91bb2bea177c784c3bc7d4cd50a3e761795fad1188e41f831
         seccomp.security.alpha.kubernetes.io/shiftfs-module-loader: unconfined
       creationTimestamp: null
       labels:

--- a/install/installer/cmd/testdata/render/insecure-s3-setup/output.golden
+++ b/install/installer/cmd/testdata/render/insecure-s3-setup/output.golden
@@ -4891,6 +4891,7 @@ data:
         "procLimit": 0,
         "netlimit": {
           "enabled": false,
+          "enforce": false,
           "connectionsPerMinute": 3000,
           "bucketSize": 1000
         },
@@ -7145,7 +7146,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 707e266a9ce1d118c63137dfeee9740d7577326c2c6fa509b2f79b6a2a02aa47
+        gitpod.io/checksum_config: 363bfc94ab8fd9188de7d28d665d6befe9ce521d4cc93ea6169e4b7985574108
         seccomp.security.alpha.kubernetes.io/shiftfs-module-loader: unconfined
       creationTimestamp: null
       labels:

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -4976,6 +4976,7 @@ data:
         "procLimit": 0,
         "netlimit": {
           "enabled": false,
+          "enforce": false,
           "connectionsPerMinute": 3000,
           "bucketSize": 1000
         },
@@ -7275,7 +7276,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: f39e45d788bb170ba728cfc3c69c5ca00a2b88a73a2d7288bcc1caee8e638405
+        gitpod.io/checksum_config: c6d2a80d1de7a1f91bb2bea177c784c3bc7d4cd50a3e761795fad1188e41f831
         seccomp.security.alpha.kubernetes.io/shiftfs-module-loader: unconfined
       creationTimestamp: null
       labels:

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -4988,6 +4988,7 @@ data:
         "procLimit": 0,
         "netlimit": {
           "enabled": false,
+          "enforce": false,
           "connectionsPerMinute": 3000,
           "bucketSize": 1000
         },
@@ -7287,7 +7288,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: f39e45d788bb170ba728cfc3c69c5ca00a2b88a73a2d7288bcc1caee8e638405
+        gitpod.io/checksum_config: c6d2a80d1de7a1f91bb2bea177c784c3bc7d4cd50a3e761795fad1188e41f831
         seccomp.security.alpha.kubernetes.io/shiftfs-module-loader: unconfined
       creationTimestamp: null
       labels:

--- a/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
+++ b/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
@@ -5309,6 +5309,7 @@ data:
         "procLimit": 0,
         "netlimit": {
           "enabled": false,
+          "enforce": false,
           "connectionsPerMinute": 3000,
           "bucketSize": 1000
         },
@@ -7719,7 +7720,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: f39e45d788bb170ba728cfc3c69c5ca00a2b88a73a2d7288bcc1caee8e638405
+        gitpod.io/checksum_config: c6d2a80d1de7a1f91bb2bea177c784c3bc7d4cd50a3e761795fad1188e41f831
         seccomp.security.alpha.kubernetes.io/shiftfs-module-loader: unconfined
       creationTimestamp: null
       labels:

--- a/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
+++ b/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
@@ -4979,6 +4979,7 @@ data:
         "procLimit": 0,
         "netlimit": {
           "enabled": false,
+          "enforce": false,
           "connectionsPerMinute": 3000,
           "bucketSize": 1000
         },
@@ -7278,7 +7279,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: f39e45d788bb170ba728cfc3c69c5ca00a2b88a73a2d7288bcc1caee8e638405
+        gitpod.io/checksum_config: c6d2a80d1de7a1f91bb2bea177c784c3bc7d4cd50a3e761795fad1188e41f831
         seccomp.security.alpha.kubernetes.io/shiftfs-module-loader: unconfined
       creationTimestamp: null
       labels:

--- a/install/installer/pkg/components/ws-daemon/configmap.go
+++ b/install/installer/pkg/components/ws-daemon/configmap.go
@@ -50,6 +50,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 	var procLimit int64
 	networkLimitConfig := netlimit.Config{
 		Enabled:              false,
+		Enforce:              false,
 		ConnectionsPerMinute: 3000,
 		BucketSize:           1000,
 	}
@@ -74,6 +75,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		ioLimitConfig.ReadIOPS = ucfg.Workspace.IOLimits.ReadIOPS
 
 		networkLimitConfig.Enabled = ucfg.Workspace.NetworkLimits.Enabled
+		networkLimitConfig.Enforce = ucfg.Workspace.NetworkLimits.Enforce
 		networkLimitConfig.ConnectionsPerMinute = ucfg.Workspace.NetworkLimits.ConnectionsPerMinute
 		networkLimitConfig.BucketSize = ucfg.Workspace.NetworkLimits.BucketSize
 

--- a/install/installer/pkg/config/v1/experimental/experimental.go
+++ b/install/installer/pkg/config/v1/experimental/experimental.go
@@ -77,6 +77,7 @@ type WorkspaceConfig struct {
 	} `json:"ioLimits"`
 	NetworkLimits struct {
 		Enabled              bool  `json:"enabled"`
+		Enforce              bool  `json:"enforce"`
 		ConnectionsPerMinute int64 `json:"connectionsPerMinute"`
 		BucketSize           int64 `json:"bucketSize"`
 	} `json:"networkLimits"`


### PR DESCRIPTION
## Description
Provide an option to drop traffic if network connections go over the configured limit. Also changes to the netlimit configuration can now be applied without having to restart ws-daemon.

## Related Issue(s)
n.a.

## How to test
- Ensure that ws-daemon config map looks like this
```
 "netlimit": {
          "enabled": true,
          "enforce": true,
          "connectionsPerMinute": 1000,
          "bucketSize": 1000
        },
```
- Open workspace in [preview environment](https://fo-enforce-limiting.preview.gitpod-dev.com/workspaces)
- Workspace should have label gitpod.io/netConnLimitPerMinute
- SSH into preview vm and find workspace ring 0 process
- Use the process id to enter the network namespace
- Check that nftable rules will drop traffic 
- Edit the config map of ws-daemon e.g. change connections per minute
- Wait ~1 minute for changes to propagate
- Start new workspace and check nftables rules again

## Release Notes
```release-note
Provide option to enforce network connection rate limiting
```

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
