### PR TITLE
[server] BillingMode: pass team.name

### DIFF
--- a/components/server/ee/src/billing/billing-mode.ts
+++ b/components/server/ee/src/billing/billing-mode.ts
@@ -86,6 +86,7 @@ export class BillingModesImpl implements BillingModes {
                     {
                         user,
                         teamId: team.id,
+                        teamName: team.name,
                     },
                 );
                 if (isEnabled) {
@@ -93,6 +94,7 @@ export class BillingModesImpl implements BillingModes {
                     break;
                 }
             }
+            // No need to check the user, because ConfigCat rules would have already flagged them with one of the calls above.
         } else {
             isUsageBasedBillingEnabled = await this.configCatClientFactory().getValueAsync(
                 "isUsageBasedBillingEnabled",


### PR DESCRIPTION
## Description
We're not using pattern matching on team names in prod, but do so in dev for ease of testing.
Let's keep it in until we found a better way to handle it. :+1: 


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
