### PR TITLE
Change also "pluginSinceBuild" property when updating JetBrains Plugins via GitHub Action

### DIFF
--- a/.github/workflows/jetbrains-update-plugin-platform-template.yml
+++ b/.github/workflows/jetbrains-update-plugin-platform-template.yml
@@ -62,6 +62,8 @@ jobs:
             - name: Update ${{ inputs.gradlePropertiesPath }}
               if: ${{ steps.latest-version.outputs.result != steps.current-version.outputs.result }}
               run: |
+                  PLUGIN_SINCE_BUILD=$(echo "${{ steps.latest-version.outputs.result }}" | sed 's/-EAP-CANDIDATE-SNAPSHOT//' | sed 's/-CUSTOM-SNAPSHOT//')
+                  sed -i "s/pluginSinceBuild=.*/pluginSinceBuild=$PLUGIN_SINCE_BUILD/" ${{ inputs.gradlePropertiesPath }}
                   sed -i 's/platformVersion=${{ steps.current-version.outputs.result }}/platformVersion=${{ steps.latest-version.outputs.result }}/' ${{ inputs.gradlePropertiesPath }}
                   git diff
             - name: Create Pull Request for Gateway Plugin
@@ -90,7 +92,8 @@ jobs:
                   commit-message: "Update Platform Version of ${{ inputs.pluginName }} to ${{ steps.latest-version.outputs.result }}"
                   branch: "jetbrains/${{ inputs.pluginId }}-platform"
                   labels: "team: IDE,editor: jetbrains"
-                  team-reviewers: "engineering-ide"
+                  # We can't use `team-reviewers` until we resolve https://github.com/gitpod-io/gitpod/issues/12194
+                  # team-reviewers: "engineering-ide"
             - name: Create Pull Request for Backend Plugin
               if: ${{ inputs.pluginId == 'backend-plugin' && steps.latest-version.outputs.result != steps.current-version.outputs.result }}
               uses: peter-evans/create-pull-request@v4
@@ -119,7 +122,8 @@ jobs:
                   commit-message: "Update Platform Version of ${{ inputs.pluginName }} to ${{ steps.latest-version.outputs.result }}"
                   branch: "jetbrains/${{ inputs.pluginId }}-platform"
                   labels: "team: IDE"
-                  team-reviewers: "engineering-ide"
+                  # We can't use `team-reviewers` until we resolve https://github.com/gitpod-io/gitpod/issues/12194
+                  # team-reviewers: "engineering-ide"
             - name: Get previous job's status
               id: lastrun
               uses: filiptronicek/get-last-job-status@main
@@ -127,6 +131,6 @@ jobs:
               if: ${{ (success() && steps.lastrun.outputs.status == 'failed') || failure() }}
               uses: rtCamp/action-slack-notify@v2
               env:
-                SLACK_WEBHOOK: ${{ secrets.slackWebhook }}
-                SLACK_COLOR: ${{ job.status }}
-                SLACK_TITLE: ${{ inputs.productName }}
+                  SLACK_WEBHOOK: ${{ secrets.slackWebhook }}
+                  SLACK_COLOR: ${{ job.status }}
+                  SLACK_TITLE: ${{ inputs.productName }}

--- a/.github/workflows/jetbrains-updates-template.yml
+++ b/.github/workflows/jetbrains-updates-template.yml
@@ -90,7 +90,8 @@ jobs:
           commit-message: "[${{ inputs.productId }}] Update IDE image to build version ${{ steps.latest-release.outputs.version }}"
           branch: "jetbrains/${{ inputs.productId }}-${{ steps.latest-release.outputs.version2 }}"
           labels: "team: IDE,editor: jetbrains"
-          team-reviewers: "engineering-ide"
+          # We can't use `team-reviewers` until we resolve https://github.com/gitpod-io/gitpod/issues/12194
+          # team-reviewers: "engineering-ide"
       - name: Get previous job's status
         id: lastrun
         uses: filiptronicek/get-last-job-status@main


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PR brings two changes:
- Change also the `pluginSinceBuild` Gradle property when updating JetBrains Plugins via GitHub Action. Previously, we were updating only the `platformVersion` which could cause incompatibilities with old JetBrains Gateway versions.
- Comment out the line `team-reviewers: "engineering-ide"`, to avoid the action failing (when it's actually creating the Pull Request properly). (See https://github.com/gitpod-io/gitpod/issues/12194)
    | Screenshot from the error on slack when `team-reviewers: "engineering-ide"` is set |
    | --- |
    | <img width="439" alt="image" src="https://user-images.githubusercontent.com/418083/196166436-bdd82f50-d96d-4a18-89b3-9d13df220a02.png"> |

## How to test
<!-- Provide steps to test this PR -->
Optional: Click "Run Workflow" (targeting the `jetbrains/update-also-plugin-since-build-property` branch) on [JB Plugins Platform Update action page](https://github.com/gitpod-io/gitpod/actions/workflows/jetbrains-update-plugin-platform.yml) to create PRs.
    <img width="349" alt="image" src="https://user-images.githubusercontent.com/418083/196171379-bd2dced4-5c58-4f1c-88a1-ea96ac546b2b.png">

I've already run it, and you can see the Diff result [here](https://github.com/gitpod-io/gitpod/actions/runs/3264921977).
<img width="1134" alt="image" src="https://user-images.githubusercontent.com/418083/196149099-6a91af27-142d-404e-bfdc-7a8af89c665b.png">
So when it creates the PR, this is what the reviewer will see:
<img width="2185" alt="image" src="https://user-images.githubusercontent.com/418083/196148248-76aec8f3-a1cd-4eb9-afc5-0a2db2d00c75.png">

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```