### PR TITLE
[dashboard] UBP: Render relevant menu entries if users can upgrade

### DIFF
--- a/components/dashboard/src/settings/settings-menu.ts
+++ b/components/dashboard/src/settings/settings-menu.ts
@@ -65,6 +65,14 @@ function renderBillingMenuEntries(billingMode?: BillingMode) {
                     title: "Team Plans",
                     link: [settingsPathTeams],
                 },
+                ...(BillingMode.showUsageBasedBilling(billingMode)
+                    ? [
+                          {
+                              title: "Billing",
+                              link: [settingsPathBilling],
+                          },
+                      ]
+                    : []),
             ];
         case "usage-based":
             return [


### PR DESCRIPTION
## Description
Render UBP menu entries if users can upgrade.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #13886

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
