### PR TITLE
[public-api] Add client/server metrics interceptor

### DIFF
--- a/components/public-api-server/pkg/server/metrics.go
+++ b/components/public-api-server/pkg/server/metrics.go
@@ -1,0 +1,124 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package server
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/bufbuild/connect-go"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type ConnectMetrics struct {
+	ServerRequestsStarted *prometheus.CounterVec
+	ServerRequestsHandled *prometheus.HistogramVec
+
+	ClientRequestsStarted *prometheus.CounterVec
+	ClientRequestsHandled *prometheus.HistogramVec
+}
+
+func (m *ConnectMetrics) Register(registry *prometheus.Registry) error {
+	metrics := []prometheus.Collector{
+		m.ServerRequestsStarted,
+		m.ServerRequestsHandled,
+		m.ClientRequestsStarted,
+		m.ClientRequestsHandled,
+	}
+
+	for _, metric := range metrics {
+		err := registry.Register(metric)
+		if err != nil {
+			return fmt.Errorf("failed to register metric: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func NewConnectMetrics() *ConnectMetrics {
+	return &ConnectMetrics{
+		ServerRequestsStarted: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "connect_server_started_total",
+			Help: "Counter of server connect (gRPC/HTTP) requests started",
+		}, []string{"service", "call", "call_type"}),
+		ServerRequestsHandled: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Name: "connect_server_handled_seconds",
+			Help: "Histogram of server connect (gRPC/HTTP) requests completed",
+		}, []string{"service", "call", "call_type", "code"}),
+
+		ClientRequestsStarted: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "connect_client_started_total",
+			Help: "Counter of client connect (gRPC/HTTP) requests started",
+		}, []string{"service", "call", "call_type"}),
+		ClientRequestsHandled: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Name: "connect_client_handled_seconds",
+			Help: "Histogram of client connect (gRPC/HTTP) requests completed",
+		}, []string{"service", "call", "call_type", "code"}),
+	}
+}
+
+func NewMetricsInterceptor(metrics *ConnectMetrics) connect.UnaryInterceptorFunc {
+	interceptor := func(next connect.UnaryFunc) connect.UnaryFunc {
+		return connect.UnaryFunc(func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+			now := time.Now()
+			service, call := splitServiceCall(req.Spec().Procedure)
+			callType := streamType(req.Spec().StreamType)
+			isClient := req.Spec().IsClient
+
+			if isClient {
+				metrics.ClientRequestsStarted.WithLabelValues(service, call, callType)
+			} else {
+				metrics.ServerRequestsStarted.WithLabelValues(service, call, callType)
+			}
+
+			resp, err := next(ctx, req)
+
+			code := codeOf(err)
+			if isClient {
+				metrics.ClientRequestsHandled.WithLabelValues(service, call, callType, code).Observe(time.Since(now).Seconds())
+			} else {
+				metrics.ServerRequestsHandled.WithLabelValues(service, call, callType, code).Observe(time.Since(now).Seconds())
+			}
+
+			return resp, err
+		})
+	}
+
+	return connect.UnaryInterceptorFunc(interceptor)
+}
+
+func splitServiceCall(procedure string) (string, string) {
+	procedure = strings.TrimPrefix(procedure, "/") // remove leading slash
+	if i := strings.Index(procedure, "/"); i >= 0 {
+		return procedure[:i], procedure[i+1:]
+	}
+
+	return "unknown", "unknown"
+}
+
+func streamType(st connect.StreamType) string {
+	switch st {
+	case connect.StreamTypeUnary:
+		return "unary"
+	case connect.StreamTypeClient:
+		return "client_stream"
+	case connect.StreamTypeServer:
+		return "server_stream"
+	case connect.StreamTypeBidi:
+		return "bidi"
+	default:
+		return "unknown"
+	}
+}
+
+func codeOf(err error) string {
+	if err == nil {
+		return "ok"
+	}
+	return connect.CodeOf(err).String()
+}

--- a/components/public-api-server/pkg/server/metrics_test.go
+++ b/components/public-api-server/pkg/server/metrics_test.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package server
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/bufbuild/connect-go"
+	v1 "github.com/gitpod-io/gitpod/public-api/v1"
+	"github.com/gitpod-io/gitpod/public-api/v1/v1connect"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMetricsInterceptor(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	metrics := NewConnectMetrics()
+	require.NoError(t, metrics.Register(reg))
+
+	interceptor := NewMetricsInterceptor(metrics)
+
+	_, handler := v1connect.NewPrebuildsServiceHandler(&v1connect.UnimplementedPrebuildsServiceHandler{}, connect.WithInterceptors(interceptor))
+
+	srv := httptest.NewServer(handler)
+
+	client := v1connect.NewPrebuildsServiceClient(http.DefaultClient, srv.URL, connect.WithInterceptors(interceptor))
+
+	_, _ = client.GetPrebuild(context.Background(), connect.NewRequest(&v1.GetPrebuildRequest{
+		PrebuildId: "123",
+	}))
+
+	expectedMetrics := []string{"connect_server_started_total", "connect_server_handled_seconds", "connect_client_started_total", "connect_client_handled_seconds"}
+	count, err := testutil.GatherAndCount(reg, expectedMetrics...)
+	require.NoError(t, err)
+	require.Equal(t, len(expectedMetrics), count, "must expose all expected metrics")
+}

--- a/components/public-api-server/pkg/server/server.go
+++ b/components/public-api-server/pkg/server/server.go
@@ -81,8 +81,16 @@ func Start(logger *logrus.Entry, version string, cfg *config.Configuration) erro
 func register(srv *baseserver.Server, connPool proxy.ServerConnectionPool) error {
 	proxy.RegisterMetrics(srv.MetricsRegistry())
 
+	connectMetrics := NewConnectMetrics()
+
+	err := connectMetrics.Register(srv.MetricsRegistry())
+	if err != nil {
+		return err
+	}
+
 	handlerOptions := []connect.HandlerOption{
 		connect.WithInterceptors(
+			NewMetricsInterceptor(connectMetrics),
 			auth.NewServerInterceptor(),
 		),
 	}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Reports client & server metrics on requests started and completed. Currently only applies to Unary calls, but can be extended.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
