### PR TITLE
Update link to create a team

### DIFF
--- a/components/dashboard/src/Menu.tsx
+++ b/components/dashboard/src/Menu.tsx
@@ -301,7 +301,7 @@ export default function Menu() {
                 }))
                 .sort((a, b) => (a.title.toLowerCase() > b.title.toLowerCase() ? 1 : -1)),
             {
-                slug: "new",
+                slug: "teams/new",
                 title: "Create a new team",
                 customContent: (
                     <div className="w-full text-gray-400 flex items-center">


### PR DESCRIPTION
Updating the link to create a team

## Description

This will update the link to create a team in the project-deprecation-alert we currently show on personal account that are using projects.

<img width="1440" alt="Screenshot 2022-10-17 at 7 13 18 PM (2)" src="https://user-images.githubusercontent.com/120486/196229044-f50322e9-9eca-4203-9187-f6767044b79f.png">

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/13917

## How to test
<!-- Provide steps to test this PR -->

Not sure how this can be tested in a new preview environment, but the alert is visible when there's at least one project added under the personal account of the user.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [X] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
