### PR TITLE
[werft] only publish jetbrains gateway plugin when relevant file changes

### DIFF
--- a/.werft/jobs/build/build-and-publish.ts
+++ b/.werft/jobs/build/build-and-publish.ts
@@ -19,7 +19,6 @@ export async function buildAndPublish(werft: Werft, jobConfig: JobConfig) {
         retag,
         version,
         localAppVersion,
-        publishToJBMarketplace,
         publishToNpm,
         coverageOutput,
     } = jobConfig;
@@ -55,7 +54,6 @@ export async function buildAndPublish(werft: Werft, jobConfig: JobConfig) {
         REPLICATED_API_TOKEN: process.env.REPLICATED_API_TOKEN,
         REPLICATED_APP: process.env.REPLICATED_APP,
         npmPublishTrigger: publishToNpm ? Date.now().toString() : "false",
-        jbMarketplacePublishTrigger: publishToJBMarketplace ? Date.now().toString() : "false",
     }).map(([key, value]) => `-D${key}=${value}`).join(" ");
 
     const buildFlags = [

--- a/.werft/jobs/build/job-config.ts
+++ b/.werft/jobs/build/job-config.ts
@@ -17,7 +17,7 @@ export interface JobConfig {
     mainBuild: boolean;
     withPreview: boolean;
     publishRelease: boolean;
-    publishToJBMarketplace: string;
+    publishToJBMarketplace: boolean;
     publishToNpm: string;
     publishToKots: boolean;
     retag: string;

--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -5,7 +5,6 @@ defaultArgs:
   coreYarnLockBase: ../..
   npmPublishTrigger: "false"
   publishToNPM: true
-  jbMarketplacePublishTrigger: "false"
   publishToJBMarketplace: true
   localAppVersion: unknown
   codeCommit: 239fa626a44652cebf293a994a3330e90e873daa

--- a/components/ide/jetbrains/gateway-plugin/BUILD.yaml
+++ b/components/ide/jetbrains/gateway-plugin/BUILD.yaml
@@ -16,8 +16,6 @@ packages:
     env:
       - JAVA_HOME=/home/gitpod/.sdkman/candidates/java/current
       - DO_PUBLISH=${publishToJBMarketplace}
-    argdeps:
-      - jbMarketplacePublishTrigger
     config:
       commands:
         - [ "./gradlew", "-PpluginVersion=0.0.1-${version}", "-PgitpodProtocolProjectPath=components-gitpod-protocol-java--lib/", "-PenvironmentName=stable", "buildFromLeeway" ]
@@ -38,8 +36,6 @@ packages:
     env:
       - JAVA_HOME=/home/gitpod/.sdkman/candidates/java/current
       - DO_PUBLISH=${publishToJBMarketplace}
-    argdeps:
-      - jbMarketplacePublishTrigger
     config:
       commands:
         - [ "./gradlew", "-PpluginVersion=0.0.1-${version}", "-PgitpodProtocolProjectPath=components-gitpod-protocol-java--lib/", "-PenvironmentName=latest", "buildFromLeeway" ]


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PR remove `jbMarketplacePublishTrigger` to avoid publishing builds which have no relevant changes in the gw

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Relate #13654

## How to test
<!-- Provide steps to test this PR -->
It need merge to main, and see what is effect

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
