### PR TITLE
[pvc] run git commands as gitpod user when using pvc

### DIFF
--- a/components/content-service/pkg/git/git.go
+++ b/components/content-service/pkg/git/git.go
@@ -92,6 +92,9 @@ type Client struct {
 
 	// UpstreamCloneURI is the fork upstream of a repository
 	UpstreamRemoteURI string
+
+	// if true will run git command as gitpod user (should be executed as root that has access to sudo in this case)
+	RunAsGitpodUser bool
 }
 
 // Status describes the status of a Git repo/working copy akin to "git status"
@@ -197,7 +200,12 @@ func (c *Client) GitWithOutput(ctx context.Context, ignoreErr *string, subcomman
 
 	span.LogKV("args", fullArgs)
 
-	cmd := exec.Command("git", fullArgs...)
+	cmdName := "git"
+	if c.RunAsGitpodUser {
+		cmdName = "sudo"
+		fullArgs = append([]string{"-u", "gitpod", "git"}, fullArgs...)
+	}
+	cmd := exec.Command(cmdName, fullArgs...)
 	cmd.Dir = c.Location
 	cmd.Env = env
 

--- a/components/content-service/pkg/initializer/initializer.go
+++ b/components/content-service/pkg/initializer/initializer.go
@@ -261,10 +261,11 @@ func newGitInitializer(ctx context.Context, loc string, req *csapi.GitInitialize
 			Config:            req.Config.CustomConfig,
 			AuthMethod:        authMethod,
 			AuthProvider:      authProvider,
+			RunAsGitpodUser:   forceGitpodUser,
 		},
 		TargetMode:  targetMode,
 		CloneTarget: req.CloneTaget,
-		Chown:       forceGitpodUser,
+		Chown:       false,
 	}, nil
 }
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
When using PVC, we run content-init from inside the supervisor, which runs as root user.
This causes git clone to run as root, causing cloned repo to be owned by root. 
Workaround was to do chown as the end of clone, but on big repos it is slow.

This allows to run git op as gitpod user instead, thus not needing to do chown at the end.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #12892

## How to test
<!-- Provide steps to test this PR -->
Open and close all kind of various ways of opening a workspace.
This code should only affect PVC code path, so to properly test you need to enable PVC feature flag on your account first.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
none
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview with-large-vm=true
- [x] /werft with-integration-tests=workspace
      Valid options are `all`, `workspace`, `webapp`, `ide`
