### PR TITLE
[installer-tests] Fix the variable name corresponding domain

### DIFF
--- a/install/tests/Makefile
+++ b/install/tests/Makefile
@@ -200,11 +200,11 @@ aws-kubeconfig:
 	aws eks update-kubeconfig --name gp-${TF_VAR_TEST_ID} --region eu-west-1 --kubeconfig ${KUBECONFIG} || echo "No cluster present"
 	@echo -e "\033[0;33mAWS service account credentials fetched, run 'source $$(pwd)/$${TF_VAR_TEST_ID}-creds' to load them into your environment\033[0;m"
 
-get-github-config:
+get-github-config: check-var-DOMAIN check-var-TF_VAR_TEST_ID
 ifneq ($(GITHUB_SCM_OAUTH),)
 	@export SCM_OAUTH=./manifests/github-oauth.yaml && \
 	cat $$GITHUB_SCM_OAUTH > $$SCM_OAUTH && \
-	yq w -i $$SCM_OAUTH 'oauth.callBackUrl' https://scm.${TF_VAR_domain}/auth/github.com/callback?state=${TF_VAR_TEST_ID} && \
+	yq w -i $$SCM_OAUTH 'oauth.callBackUrl' https://scm.${DOMAIN}/auth/github.com/callback?state=${TF_VAR_TEST_ID} && \
 	kubectl --kubeconfig=${KUBECONFIG} create secret generic "github-oauth" \
 		--from-literal=provider="$$(cat $$SCM_OAUTH)" \
 		-o yaml --dry-run=client > ${github_oauth_secret}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
In a previous PR, we have changed the way variables were fed to the terraform modules(via a `terraform.tfvars` file). This changed the variable corresponding to domain name from `TF_VAR_domain` to `DOMAIN`. There was still one reference to the old variable left, which went unnoticed since it is only used when running integration tests. This PR fixes it.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
You can run a test setup like described in this [internal doc](https://www.notion.so/gitpod/Self-hosted-automated-preview-and-test-pipelines-fdc5a202e67b4197aa00d93b98d57927#7ef38c2da4714639a117d0ba61f2e8ca)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
