### PR TITLE
Use SSL Certs from ZeroSSL in Preview Envs

### DIFF
--- a/.werft/jobs/build/deploy-to-preview-environment.ts
+++ b/.werft/jobs/build/deploy-to-preview-environment.ts
@@ -57,7 +57,7 @@ const vmSlices = {
     VM_READINESS: "Waiting for VM readiness",
     START_KUBECTL_PORT_FORWARDS: "Start kubectl port forwards",
     COPY_CERT_MANAGER_RESOURCES: "Copy CertManager resources from core-dev",
-    INSTALL_LETS_ENCRYPT_ISSUER: "Install Lets Encrypt issuer",
+    INSTALL_CERT_ISSUER: "Install Certificate Issuer",
     KUBECONFIG: "Getting kubeconfig",
     WAIT_K3S: "Waiting for k3s",
     WAIT_CERTMANAGER: "Waiting for Cert-Manager",
@@ -145,18 +145,18 @@ export async function deployToPreviewEnvironment(werft: Werft, jobConfig: JobCon
 
     exec(
         `kubectl --kubeconfig ${CORE_DEV_KUBECONFIG_PATH} get secret clouddns-dns01-solver-svc-acct -n certmanager -o yaml | sed 's/namespace: certmanager/namespace: cert-manager/g' > clouddns-dns01-solver-svc-acct.yaml`,
-        { slice: vmSlices.INSTALL_LETS_ENCRYPT_ISSUER },
+        { slice: vmSlices.INSTALL_CERT_ISSUER },
     );
     exec(
         `kubectl --kubeconfig ${CORE_DEV_KUBECONFIG_PATH} get clusterissuer letsencrypt-issuer-gitpod-core-dev -o yaml | sed 's/letsencrypt-issuer-gitpod-core-dev/letsencrypt-issuer/g' > letsencrypt-issuer.yaml`,
-        { slice: vmSlices.INSTALL_LETS_ENCRYPT_ISSUER },
+        { slice: vmSlices.INSTALL_CERT_ISSUER },
     );
     exec(
         `kubectl --kubeconfig ${PREVIEW_K3S_KUBECONFIG_PATH} apply -f clouddns-dns01-solver-svc-acct.yaml -f letsencrypt-issuer.yaml`,
-        { slice: vmSlices.INSTALL_LETS_ENCRYPT_ISSUER, dontCheckRc: true },
+        { slice: vmSlices.INSTALL_CERT_ISSUER, dontCheckRc: true },
     );
     werft.rootSpan.setAttributes({ "preview.issuer_installed_successfully": true });
-    werft.done(vmSlices.INSTALL_LETS_ENCRYPT_ISSUER);
+    werft.done(vmSlices.INSTALL_CERT_ISSUER);
 
     VM.installRookCeph({ kubeconfig: PREVIEW_K3S_KUBECONFIG_PATH });
     werft.rootSpan.setAttributes({ "preview.rook_installed_successfully": true });

--- a/dev/preview/infrastructure/harvester/cert.tf
+++ b/dev/preview/infrastructure/harvester/cert.tf
@@ -20,7 +20,7 @@ resource "kubernetes_manifest" "cert" {
       ]
       issuerRef = {
         kind = "ClusterIssuer"
-        name = "letsencrypt-issuer-gitpod-core-dev"
+        name = "zerossl-issuer-gitpod-core-dev"
       }
       renewBefore = "24h0m0s"
       secretName  = "harvester-${var.preview_name}"


### PR DESCRIPTION
## Description
This PR activates the ZeroSSL certificate issuer that's introduced in https://github.com/gitpod-io/ops/pull/5970.

Letsencrypt is amazing - but ZeroSSL has no rate limit.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/ops/issues/5571

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-clean-slate-deployment
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
