### PR TITLE
[gpctl] Show application cluster in `gpctl clusters list` output

### DIFF
--- a/dev/gpctl/cmd/clusters-list.go
+++ b/dev/gpctl/cmd/clusters-list.go
@@ -33,9 +33,9 @@ var clustersListCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		tpl := `NAME	URL	STATIC	STATE	SCORE	GOVERNED	ADMISSION CONSTRAINTS
+		tpl := `NAME	APPCLUSTER	URL	STATIC	STATE	SCORE	GOVERNED	ADMISSION CONSTRAINTS
 {{- range .Status }}
-{{ .Name }}	{{ .Url }}	{{ .Static }}	{{ .State }}	{{ .Score }}	{{ .Governed }}	{{ .AdmissionConstraint -}}
+{{ .Name }}	{{ .ApplicationCluster }}	{{ .Url }}	{{ .Static }}	{{ .State }}	{{ .Score }}	{{ .Governed }}	{{ .AdmissionConstraint -}}
 {{ end }}
 `
 		err = getOutputFormat(tpl, "{..name}").Print(resp)


### PR DESCRIPTION
## Description

<details>
<summary>Context </summary>
As part of #9198  we want to start syncing the `d_b_workspace_cluster` table with `db-sync`.

Currently, the table differs between US and EU regions because each table contains only the data relevant to that region. For example, in the EU table, the `eu70` workspace cluster is marked as `available` and the `us70` cluster is `cordoned`.  In the US cluster `eu70` is `cordoned` and `us70` is `available`.

In order to sync the table we need to get to a point where there is no difference in the data in the table between EU and US regions.

To do that we will introduce a new field in the table called `applicationCluster` which records the name of the application cluster to which the record belongs. Thus, for each workspace cluster there will be two rows in Gitpod SaaS:

| name | applicationCluster | url | tls | state | ... |
| --- | --- | --- | --- | --- | --- |
| eu70 | eu02 | url | tls info | available | ... |
| eu70 | us02 | url | tls info | cordoned | ... |

Effectively the new `applicationCluster` column gives the table an extra dimension so that we can combine both tables (EU and US) into one.

#13722  added the column to the table and made `gpctl` fill the value when `gpctl register`ing a new workspace cluster. The value is taken from the `GITPOD_INSTALLATION_SHORTNAME` environment variable in `ws-manager-bridge`.
</details>

Add the application cluster for the workspace cluster to the output of `gpctl clusters list`:

<img width="1182" alt="image" src="https://user-images.githubusercontent.com/8225907/196400008-ba9f26f3-9a00-4090-8ad1-1897060f3fbb.png">

The `List` RPC was extended in https://github.com/gitpod-io/gitpod/pull/13940 to add the extra `application_cluster` field in the response message.

## Related Issue(s)
Part of #9198  and https://github.com/gitpod-io/gitpod/issues/13800

## How to test

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
