### PR TITLE
[content-service] Make prebuild initializer more robust

### DIFF
--- a/components/content-service/pkg/git/git.go
+++ b/components/content-service/pkg/git/git.go
@@ -348,13 +348,6 @@ func (c *Client) Clone(ctx context.Context) (err error) {
 	return c.Git(ctx, "clone", args...)
 }
 
-// Fetch runs git fetch and prunes remote-tracking references as well as ALL LOCAL TAGS.
-func (c *Client) Fetch(ctx context.Context) (err error) {
-	// we need to fetch with pruning to avoid issues like github.com/gitpod-io/gitpod/issues/7561.
-	// See https://git-scm.com/docs/git-fetch#Documentation/git-fetch.txt---prune for more details.
-	return c.Git(ctx, "fetch", "-p", "-P", "--tags", "-f")
-}
-
 // UpdateRemote performs a git fetch on the upstream remote URI
 func (c *Client) UpdateRemote(ctx context.Context) (err error) {
 	//nolint:staticcheck,ineffassign

--- a/components/content-service/pkg/initializer/git.go
+++ b/components/content-service/pkg/initializer/git.go
@@ -188,7 +188,13 @@ func (ws *GitInitializer) realizeCloneTarget(ctx context.Context) (err error) {
 			ws.CloneTarget = defaultBranch
 		}
 
-		if err := ws.Git(ctx, "fetch", "--depth=1", "origin", ws.CloneTarget); err != nil {
+		// No need to prune here because we fetch the specific branch only. If we were to try and fetch everything,
+		// we might end up trying to fetch at tag/branch which has since been recreated. It's exactly the specific
+		// fetch wich prevents this situation.
+		//
+		// We don't recurse submodules because callers realizeCloneTarget() are expected to update submodules explicitly,
+		// and deal with any error appropriately (i.e. emit a warning rather than fail).
+		if err := ws.Git(ctx, "fetch", "--depth=1", "origin", "--recurse-submodules=no", ws.CloneTarget); err != nil {
 			log.WithError(err).WithField("remoteURI", ws.RemoteURI).WithField("branch", ws.CloneTarget).Error("Cannot fetch remote branch")
 			return err
 		}

--- a/components/content-service/pkg/initializer/prebuild.go
+++ b/components/content-service/pkg/initializer/prebuild.go
@@ -130,15 +130,14 @@ func runGitInit(ctx context.Context, gInit *GitInitializer) (err error) {
 		}
 		didStash := !strings.Contains(string(out), "No local changes to save")
 
-		err = gInit.Fetch(ctx)
-		err = checkGitStatus(err)
+		err = checkGitStatus(gInit.realizeCloneTarget(ctx))
 		if err != nil {
 			return xerrors.Errorf("prebuild initializer: %w", err)
 		}
 
-		err = gInit.realizeCloneTarget(ctx)
+		err = gInit.UpdateSubmodules(ctx)
 		if err != nil {
-			return xerrors.Errorf("prebuild initializer: %w", err)
+			log.WithError(err).Warn("error while updating submodules from prebuild initializer - continuing")
 		}
 
 		// If any of these cleanup operations fail that's no reason to fail ws initialization.


### PR DESCRIPTION
against submodule update problems, and awry fetch situations.

## Description
This PR 
- makes the prebuild content initializer more robust against submodule issues, by adopting the same error behaviour of the Git initializer,
- removes the "fetch all branches and tags" behaviour in the prebuild initializer which was intended to ensure that we can checkout the clone target. Instead, we make a dedicated (no submodule recursing) fetch for the clone target.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
works on #9280

## How to test
- run the workspace integration tests to make sure we didn't break anything
- deploy in production as see if the "content init failed" failures go down.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-integration-tests=workspace
      Valid options are `all`, `workspace`, `webapp`, `ide`
