### PR TITLE
[sever] Delegate stripe customer create to usage (behind feature flag)

### DIFF
--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -116,6 +116,8 @@ import { EntitlementService, MayStartWorkspaceResult } from "../../../src/billin
 import { BillingMode } from "@gitpod/gitpod-protocol/lib/billing-mode";
 import { BillingModes } from "../billing/billing-mode";
 import { UsageServiceDefinition } from "@gitpod/usage-api/lib/usage/v1/usage.pb";
+import { getExperimentsClientForBackend } from "@gitpod/gitpod-protocol/lib/experiments/configcat-server";
+import { BillingServiceClient, BillingServiceDefinition } from "@gitpod/usage-api/lib/usage/v1/billing.pb";
 import { IncrementalPrebuildsService } from "../prebuilds/incremental-prebuilds-service";
 
 @injectable()
@@ -163,6 +165,9 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
     @inject(EntitlementService) protected readonly entitlementService: EntitlementService;
 
     @inject(BillingModes) protected readonly billingModes: BillingModes;
+
+    @inject(BillingServiceDefinition.name)
+    protected readonly billingService: BillingServiceClient;
 
     initialize(
         client: GitpodClient | undefined,
@@ -2114,10 +2119,44 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
             }
             await this.ensureStripeApiIsAllowed({ user });
         }
+
+        const billingEmail = User.getPrimaryEmail(user);
+        const billingName = attrId.kind === "team" ? team!.name : User.getName(user);
+
+        const isCreateStripeCustomerOnUsageEnabled = await getExperimentsClientForBackend().getValueAsync(
+            "createStripeCustomersOnUsage",
+            false,
+            {
+                user: user,
+                teamId: team ? team.id : undefined,
+            },
+        );
+        if (isCreateStripeCustomerOnUsageEnabled) {
+            try {
+                try {
+                    // customer already exists, we don't need to create a new one.
+                    await this.billingService.getStripeCustomer({ attributionId });
+                    return;
+                } catch (e) {}
+
+                await this.billingService.createStripeCustomer({
+                    attributionId,
+                    currency,
+                    email: billingEmail,
+                    name: billingName,
+                });
+                return;
+            } catch (error) {
+                log.error(`Failed to create Stripe customer profile for '${attributionId}'`, error);
+                throw new ResponseError(
+                    ErrorCodes.INTERNAL_SERVER_ERROR,
+                    `Failed to create Stripe customer profile for '${attributionId}'`,
+                );
+            }
+        }
+
         try {
             if (!(await this.stripeService.findCustomerByAttributionId(attributionId))) {
-                const billingEmail = User.getPrimaryEmail(user);
-                const billingName = attrId.kind === "team" ? team!.name : User.getName(user);
                 await this.stripeService.createCustomerForAttributionId(
                     attributionId,
                     currency,


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

When feature flag is enabled, calls to create stripe customer are delegated to the BillingService.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
Feature flag
Preview env

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
