### PR TITLE
[kots]: put the HTTP Proxy settings behind a KOTS config bool

### DIFF
--- a/install/kots/manifests/gitpod-http-proxy-settings.yaml
+++ b/install/kots/manifests/gitpod-http-proxy-settings.yaml
@@ -8,6 +8,8 @@ metadata:
   labels:
     app: gitpod
     component: gitpod-installer
+  annotations:
+    kots.io/when: '{{repl ConfigOptionEquals "enable_proxy_settings" "1" }}'
 type: Opaque
 data:
   httpProxy: repl{{ HTTPProxy | Base64Encode | quote }}

--- a/install/kots/manifests/gitpod-kots-config.yaml
+++ b/install/kots/manifests/gitpod-kots-config.yaml
@@ -22,7 +22,7 @@ data:
   SSH_GATEWAY: repl{{ ConfigOption "ssh_gateway" | quote }}
 
   # Secret names
-  HTTP_PROXY_NAME: http-proxy-settings
+  HTTP_PROXY_NAME: '{{repl if (ConfigOptionEquals "enable_proxy_settings" "1" ) }}http-proxy-settings{{repl end }}'
   LICENSE_NAME: gitpod-license
   SSH_GATEWAY_HOST_KEY_NAME: ssh-gateway-host-key
 

--- a/install/kots/manifests/kots-config.yaml
+++ b/install/kots/manifests/kots-config.yaml
@@ -429,3 +429,14 @@ spec:
               title: Cluster IP
             - name: NodePort
               title: Node port
+
+    - name: experimental
+      title: Experimental options
+      description: Experimental options without any support
+      when: 'false'
+      items:
+        - name: enable_proxy_settings
+          title: Enable proxy settings
+          type: bool
+          default: "0"
+          help_text: Enable HTTP_PROXY support for the Gitpod application. This is currently an experimental feature.


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Add a checkbox to enable the HTTP proxy settings. The values are still taken from the KOTS CLI input variables, but will not be applied until the option is configured

![image](https://user-images.githubusercontent.com/275848/196455832-e38c9baa-495c-4df2-b30f-63b69b3fd351.png)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #13682

## How to test
<!-- Provide steps to test this PR -->
Install via KOTS. Run the command `kubectl get deployments.apps -n gitpod blobserve -o yaml | grep -i HTTP_PROXY -a2` - unless you have the checkbox enabled, this should return nothing.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[kots]: put the HTTP Proxy settings behind a KOTS config bool
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
