### PR TITLE
[content-service] Fix invalid defer return

### DIFF
--- a/components/content-service/pkg/initializer/git.go
+++ b/components/content-service/pkg/initializer/git.go
@@ -166,9 +166,8 @@ func (ws *GitInitializer) realizeCloneTarget(ctx context.Context) (err error) {
 	span.SetTag("targetMode", ws.TargetMode)
 	defer tracing.FinishSpan(span, &err)
 
-	defer func() error {
+	defer func() {
 		err = checkGitStatus(err)
-		return err
 	}()
 
 	// checkout branch


### PR DESCRIPTION
## Description

Fix invalid return statement in `defer`

## Release Notes
```release-note
NONE
```
## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-integration-tests=workspace
      Valid options are `all`, `workspace`, `webapp`, `ide`
