### PR TITLE
Fix ArgoCD dashboard name

### DIFF
--- a/operations/observability/mixins/self-hosted/dashboards.libsonnet
+++ b/operations/observability/mixins/self-hosted/dashboards.libsonnet
@@ -6,6 +6,6 @@
 {
   grafanaDashboards+:: {
     'gitpod-sh-example-overview.json': (import 'dashboards/examples/overview.json'),
-    'gitpod-sh-example-overview.json': (import 'dashboards/argocd/argocd.json'),
+    'argocd.json': (import 'dashboards/argocd/argocd.json'),
   },
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
After https://github.com/gitpod-io/gitpod/pull/13879, it was strange to me that we didn't see that dashboard in production. After some investigation I found this mistake 😅 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
