### PR TITLE
[server] Don't fetch the repository config a second time when starting incremental prebuilds

### DIFF
--- a/components/server/ee/src/prebuilds/incremental-prebuilds-service.ts
+++ b/components/server/ee/src/prebuilds/incremental-prebuilds-service.ts
@@ -66,6 +66,7 @@ export class IncrementalPrebuildsService {
 
     public async findGoodBaseForIncrementalBuild(
         context: CommitContext,
+        config: WorkspaceConfig,
         history: WithCommitHistory,
         user: User,
     ): Promise<PrebuiltWorkspace | undefined> {
@@ -73,7 +74,6 @@ export class IncrementalPrebuildsService {
             return;
         }
 
-        const { config } = await this.configProvider.fetchConfig({}, user, context);
         const imageSource = await this.imageSourceProvider.getImageSource({}, user, context, config);
 
         // Note: This query returns only not-garbage-collected prebuilds in order to reduce cardinality

--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -117,11 +117,13 @@ import { BillingMode } from "@gitpod/gitpod-protocol/lib/billing-mode";
 import { BillingModes } from "../billing/billing-mode";
 import { UsageServiceDefinition } from "@gitpod/usage-api/lib/usage/v1/usage.pb";
 import { IncrementalPrebuildsService } from "../prebuilds/incremental-prebuilds-service";
+import { ConfigProvider } from "../../../src/workspace/config-provider";
 
 @injectable()
 export class GitpodServerEEImpl extends GitpodServerImpl {
     @inject(PrebuildManager) protected readonly prebuildManager: PrebuildManager;
     @inject(IncrementalPrebuildsService) protected readonly incrementalPrebuildsService: IncrementalPrebuildsService;
+    @inject(ConfigProvider) protected readonly configProvider: ConfigProvider;
     @inject(LicenseDB) protected readonly licenseDB: LicenseDB;
     @inject(LicenseKeySource) protected readonly licenseKeySource: LicenseKeySource;
 
@@ -982,9 +984,11 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
             const logPayload = { mode, cloneUrl, commit: commitSHAs, prebuiltWorkspace };
             log.debug(logCtx, "Looking for prebuilt workspace: ", logPayload);
             if (prebuiltWorkspace?.state !== "available" && mode === CreateWorkspaceMode.UseLastSuccessfulPrebuild) {
+                const { config } = await this.configProvider.fetchConfig({}, user, context);
                 const history = await this.incrementalPrebuildsService.getCommitHistoryForContext(context, user);
                 prebuiltWorkspace = await this.incrementalPrebuildsService.findGoodBaseForIncrementalBuild(
                     context,
+                    config,
                     history,
                     user,
                 );

--- a/components/server/ee/src/workspace/workspace-factory.ts
+++ b/components/server/ee/src/workspace/workspace-factory.ts
@@ -121,6 +121,7 @@ export class WorkspaceFactoryEE extends WorkspaceFactory {
             let ws;
             const recentPrebuild = await this.incrementalPrebuildsService.findGoodBaseForIncrementalBuild(
                 commitContext,
+                config,
                 context,
                 user,
             );


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Follow-up to https://github.com/gitpod-io/gitpod/pull/13801: Don't fetch the repository config a second time when starting incremental prebuilds

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/pull/13801#discussion_r998170168

> And this has the unfortunate consequence of calling `fetchConfig` twice now [[1](https://github.com/gitpod-io/gitpod/blob/9dffa5d337eb4ed1787084d1aa90f6cee2a7560d/components/server/ee/src/workspace/workspace-factory.ts#L118), [2](https://github.com/gitpod-io/gitpod/blob/9dffa5d337eb4ed1787084d1aa90f6cee2a7560d/components/server/ee/src/prebuilds/incremental-prebuilds-service.ts#L76)]. This could be resolved by allowing to pass an optional `config` to `findGoodBaseForIncrementalBuild`.

## How to test
<!-- Provide steps to test this PR -->

1. Incremental prebuilds should still work

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
