### PR TITLE
Revert "[preview] Fix broken shortname assignment in preview envs"

### DIFF
--- a/.werft/jobs/build/installer/installer.ts
+++ b/.werft/jobs/build/installer/installer.ts
@@ -119,7 +119,7 @@ export class Installer {
     private configureMetadata(slice: string): void {
         exec(`cat <<EOF > shortname.yaml
 metadata:
-  shortname: "dev"
+  shortname: ""
 EOF`);
         exec(`yq m -ix ${this.options.installerConfigPath} shortname.yaml`, { slice: slice });
     }

--- a/.werft/jobs/build/installer/post-process.sh
+++ b/.werft/jobs/build/installer/post-process.sh
@@ -103,7 +103,6 @@ while [ "$documentIndex" -le "$DOCS" ]; do
       yq m --arrays=overwrite -i k8s.yaml -d "$documentIndex" /tmp/"$NAME"pool.yaml
    fi
 
-   SHORT_NAME="dev"
    # overrides for server-config
    if [[ "server-config" == "$NAME" ]] && [[ "$KIND" == "ConfigMap" ]]; then
       WORK="overrides for $NAME $KIND"
@@ -114,6 +113,12 @@ while [ "$documentIndex" -le "$DOCS" ]; do
       DEV_BRANCH_EXPR="s/\"devBranch\": \"\"/\"devBranch\": \"$DEV_BRANCH\"/"
       sed -i "$DEV_BRANCH_EXPR" /tmp/"$NAME"overrides.yaml
 
+      # InstallationShortname
+      # is expected to look like ws-dev.<branch-name-with-dashes>.staging.gitpod-dev.com
+      SHORT_NAME=$(yq r ./.werft/jobs/build/helm/values.dev.yaml installation.shortname)
+      NAMESPACE=$(kubens -c)
+      INSTALL_SHORT_NAME_EXPR="s/\"installationShortname\": \"$NAMESPACE\"/\"installationShortname\": \"$SHORT_NAME\"/"
+      sed -i "$INSTALL_SHORT_NAME_EXPR" /tmp/"$NAME"overrides.yaml
       # Stage
       STAGE=$(yq r ./.werft/jobs/build/helm/values.dev.yaml installation.stage)
       STAGE_EXPR="s/\"stage\": \"production\"/\"stage\": \"$STAGE\"/"
@@ -149,6 +154,10 @@ while [ "$documentIndex" -le "$DOCS" ]; do
       touch /tmp/"$NAME"overrides.yaml
       yq r k8s.yaml -d "$documentIndex" data | yq prefix - data > /tmp/"$NAME"overrides.yaml
 
+      # simliar to server, except the ConfigMap hierarchy, key, and value are different
+      SHORT_NAME=$(yq r ./.werft/jobs/build/helm/values.dev.yaml installation.shortname)
+      INSTALL_SHORT_NAME_EXPR="s/\"installation\": \"\"/\"installation\": \"$SHORT_NAME\"/"
+      sed -i "$INSTALL_SHORT_NAME_EXPR" /tmp/"$NAME"overrides.yaml
       yq m -x -i k8s.yaml -d "$documentIndex" /tmp/"$NAME"overrides.yaml
    fi
 
@@ -166,6 +175,7 @@ while [ "$documentIndex" -le "$DOCS" ]; do
       touch /tmp/"$NAME"overrides.yaml
       yq r k8s.yaml -d "$documentIndex" data | yq prefix - data > /tmp/"$NAME"overrides.yaml
 
+      SHORT_NAME=$(yq r ./.werft/jobs/build/helm/values.dev.yaml installation.shortname)
       STAGING_HOST_NAME=$(yq r ./.werft/jobs/build/helm/values.dev.yaml hostname)
       CURRENT_WS_HOST_NAME="ws.$DEV_BRANCH.$STAGING_HOST_NAME"
       NEW_WS_HOST_NAME="ws-$SHORT_NAME.$DEV_BRANCH.$STAGING_HOST_NAME"
@@ -212,6 +222,7 @@ while [ "$documentIndex" -le "$DOCS" ]; do
       yq r k8s.yaml -d "$documentIndex" data | yq prefix - data > /tmp/"$NAME"overrides.yaml
 
       # simliar to server, except the ConfigMap hierarchy, key, and value are different
+      SHORT_NAME=$(yq r ./.werft/jobs/build/helm/values.dev.yaml installation.shortname)
       STAGING_HOST_NAME=$(yq r ./.werft/jobs/build/helm/values.dev.yaml hostname)
       CURRENT_WS_HOST_NAME="ws.$DEV_BRANCH.$STAGING_HOST_NAME"
       NEW_WS_HOST_NAME="ws-$SHORT_NAME.$DEV_BRANCH.$STAGING_HOST_NAME"


### PR DESCRIPTION
Reverts gitpod-io/gitpod#13953

Due to a new certificate error when starting workspaces in preview environments:

<img width="1440" alt="Screenshot 2022-10-18 at 18 04 13" src="https://user-images.githubusercontent.com/599268/196485527-c3e5afe9-2a86-46e8-af2f-57b2786cfdae.png">

[More context in Slack](https://gitpod.slack.com/archives/C032A46PWR0/p1666109181630429) (internal)