### PR TITLE
Fix the "Lean More" button behavior from JetBrains Gateway home screen

### DIFF
--- a/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/latest/GitpodConnector.kt
+++ b/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/latest/GitpodConnector.kt
@@ -4,55 +4,32 @@
 
 package io.gitpod.jetbrains.gateway.latest
 
-import com.intellij.ide.BrowserUtil
-import com.intellij.ui.components.ActionLink
 import com.jetbrains.gateway.api.GatewayConnector
-import com.jetbrains.gateway.api.GatewayConnectorView
-import com.jetbrains.gateway.api.GatewayRecentConnections
+import com.jetbrains.gateway.api.GatewayConnectorDocumentationPage
 import com.jetbrains.rd.util.lifetime.Lifetime
 import io.gitpod.jetbrains.gateway.GitpodRecentConnections
 import io.gitpod.jetbrains.icons.GitpodIcons
 import java.awt.Component
-import javax.swing.Icon
-import javax.swing.JComponent
 
 class GitpodConnector : GatewayConnector {
-    override val icon: Icon
-        get() = GitpodIcons.Logo
+    override val icon = GitpodIcons.Logo
 
-    override fun createView(lifetime: Lifetime): GatewayConnectorView {
-        return GitpodConnectorView(lifetime)
-    }
+    override fun createView(lifetime: Lifetime) = GitpodConnectorView(lifetime)
 
-    override fun getActionText(): String {
-        return "Connect to Gitpod"
-    }
+    override fun getActionText() = "Connect to Gitpod"
 
-    override fun getDescription(): String? {
-        return "Connect to Gitpod workspaces"
-    }
+    override fun getDescription() = "Connect to Gitpod workspaces"
 
-    override fun getDocumentationLink(): ActionLink {
-        val documentationLink = ActionLink("Documentation") {
-            BrowserUtil.browse("https://www.gitpod.io/docs/ides-and-editors/jetbrains-gateway")
-        }
-        documentationLink.setExternalLinkIcon()
-        return documentationLink
-    }
+    override fun getDocumentationAction() = GatewayConnectorDocumentationPage("https://www.gitpod.io/docs/ides-and-editors/jetbrains-gateway")
 
-    override fun getConnectorId(): String = "gitpod.connector"
+    override fun getConnectorId() = "gitpod.connector"
 
-    override fun getRecentConnections(setContentCallback: (Component) -> Unit): GatewayRecentConnections? {
-        return GitpodRecentConnections()
-    }
+    override fun getRecentConnections(setContentCallback: (Component) -> Unit) = GitpodRecentConnections()
 
-    override fun getTitle(): String {
-        return "Gitpod"
-    }
+    override fun getTitle() = "Gitpod"
 
-    override fun getTitleAdornment(): JComponent? {
-        return null
-    }
+    @Deprecated("Not used", ReplaceWith("null"))
+    override fun getTitleAdornment() = null
 
     override fun initProcedure() {}
 }

--- a/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/stable/GitpodConnector.kt
+++ b/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/stable/GitpodConnector.kt
@@ -5,54 +5,31 @@
 package io.gitpod.jetbrains.gateway.stable
 
 import com.jetbrains.gateway.api.GatewayConnector
-import com.jetbrains.gateway.api.GatewayConnectorView
-import com.jetbrains.gateway.api.GatewayRecentConnections
+import com.jetbrains.gateway.api.GatewayConnectorDocumentationPage
 import com.jetbrains.rd.util.lifetime.Lifetime
+import io.gitpod.jetbrains.gateway.GitpodRecentConnections
 import io.gitpod.jetbrains.icons.GitpodIcons
 import java.awt.Component
-import javax.swing.Icon
-import javax.swing.JComponent
-import com.intellij.ui.components.ActionLink
-import com.intellij.ide.BrowserUtil
-import io.gitpod.jetbrains.gateway.GitpodRecentConnections
 
 class GitpodConnector : GatewayConnector {
-    override val icon: Icon
-        get() = GitpodIcons.Logo
+    override val icon = GitpodIcons.Logo
 
-    override fun createView(lifetime: Lifetime): GatewayConnectorView {
-        return GitpodConnectorView(lifetime)
-    }
+    override fun createView(lifetime: Lifetime) = GitpodConnectorView(lifetime)
 
-    override fun getActionText(): String {
-        return "Connect to Gitpod"
-    }
+    override fun getActionText() = "Connect to Gitpod"
 
-    override fun getDescription(): String? {
-        return "Connect to Gitpod workspaces"
-    }
+    override fun getDescription() = "Connect to Gitpod workspaces"
 
-    override fun getDocumentationLink(): ActionLink {
-        val documentationLink = ActionLink("Documentation") {
-            BrowserUtil.browse("https://www.gitpod.io/docs/ides-and-editors/jetbrains-gateway")
-        }
-        documentationLink.setExternalLinkIcon()
-        return documentationLink
-    }
+    override fun getDocumentationAction() = GatewayConnectorDocumentationPage("https://www.gitpod.io/docs/ides-and-editors/jetbrains-gateway")
 
-    override fun getConnectorId(): String = "gitpod.connector"
+    override fun getConnectorId() = "gitpod.connector"
 
-    override fun getRecentConnections(setContentCallback: (Component) -> Unit): GatewayRecentConnections? {
-        return GitpodRecentConnections()
-    }
+    override fun getRecentConnections(setContentCallback: (Component) -> Unit) = GitpodRecentConnections()
 
-    override fun getTitle(): String {
-        return "Gitpod"
-    }
+    override fun getTitle() = "Gitpod"
 
-    override fun getTitleAdornment(): JComponent? {
-        return null
-    }
+    @Deprecated("Not used", ReplaceWith("null"))
+    override fun getTitleAdornment() = null
 
     override fun initProcedure() {}
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Update Gitpod Gateway Connector to match the latest API.

This fixes the "Learn More"/"More" button behavior, on the home screen of JetBrains Gateway, so clicking them will open https://www.gitpod.io/docs/ides-and-editors/jetbrains-gateway on browser.

|JetBrains Gatway Stable | JetBrains Gateway EAP |
| --- | --- |
| <img width="1077" alt="image" src="https://user-images.githubusercontent.com/418083/196495083-26156ee9-213a-4563-9645-0ad829edc897.png">| <img width="1077" alt="image" src="https://user-images.githubusercontent.com/418083/196494236-62c29efe-ec68-4955-bce2-8b628c083c90.png"> |


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Follow-up for #13948

## How to test
<!-- Provide steps to test this PR -->
1. Download the Stable Build of the plugin from [here](https://plugins.jetbrains.com/plugin/18438-gitpod-gateway/versions/Dev/239954), install it on Stable Gateway (2022.2) and check if the "Learn More" button works.
2. Download the EAP Build of the plugin from [here](https://plugins.jetbrains.com/plugin/18438-gitpod-gateway/versions/Dev/239953), install it on EAP Gateway (2022.3) and check if the "More" button works.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Fixed the "Lean More" button behavior from JetBrains Gateway home screen.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
