### PR TITLE
[usage] Add StripeCustomer db model

### DIFF
--- a/components/usage/pkg/db/dbtest/stripe_customer.go
+++ b/components/usage/pkg/db/dbtest/stripe_customer.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package dbtest
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/gitpod-io/gitpod/usage/pkg/db"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+func NewStripeCustomer(t *testing.T, customer db.StripeCustomer) db.StripeCustomer {
+	t.Helper()
+
+	result := db.StripeCustomer{
+		StripeCustomerID: fmt.Sprintf("cus_%s", uuid.New().String()),
+		AttributionID:    db.NewUserAttributionID(uuid.New().String()),
+		CreationTime:     db.NewVarcharTime(time.Now()),
+	}
+
+	if customer.StripeCustomerID != "" {
+		result.StripeCustomerID = customer.StripeCustomerID
+	}
+
+	if customer.AttributionID != "" {
+		result.AttributionID = customer.AttributionID
+	}
+	if customer.CreationTime.IsSet() {
+		result.CreationTime = customer.CreationTime
+	}
+
+	return result
+}
+
+func CreateStripeCustomers(t *testing.T, conn *gorm.DB, customers ...db.StripeCustomer) []db.StripeCustomer {
+	t.Helper()
+
+	var records []db.StripeCustomer
+	var ids []string
+	for _, c := range customers {
+		record := NewStripeCustomer(t, c)
+		records = append(records, record)
+		ids = append(ids, record.StripeCustomerID)
+	}
+
+	require.NoError(t, conn.CreateInBatches(&records, 1000).Error)
+
+	t.Cleanup(func() {
+		require.NoError(t, conn.Where(ids).Delete(&db.StripeCustomer{}).Error)
+	})
+
+	return records
+}

--- a/components/usage/pkg/db/errors.go
+++ b/components/usage/pkg/db/errors.go
@@ -1,0 +1,11 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package db
+
+import "errors"
+
+var (
+	ErrorNotFound = errors.New("not found")
+)

--- a/components/usage/pkg/db/stripe_customer.go
+++ b/components/usage/pkg/db/stripe_customer.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package db
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+type StripeCustomer struct {
+	StripeCustomerID string        `gorm:"primary_key;column:stripeCustomerId;type:char;size:255;" json:"stripeCustomerId"`
+	AttributionID    AttributionID `gorm:"column:attributionId;type:varchar;size:255;" json:"attributionId"`
+	CreationTime     VarcharTime   `gorm:"column:creationTime;type:varchar;size:255;" json:"creationTime"`
+
+	LastModified time.Time `gorm:"->;column:_lastModified;type:timestamp;default:CURRENT_TIMESTAMP(6);" json:"_lastModified"`
+	// deleted is reserved for use by db-sync.
+	_ bool `gorm:"column:deleted;type:tinyint;default:0;" json:"deleted"`
+}
+
+// TableName sets the insert table name for this struct type
+func (d *StripeCustomer) TableName() string {
+	return "d_b_stripe_customer"
+}
+
+func CreateStripeCustomer(ctx context.Context, conn *gorm.DB, customer StripeCustomer) error {
+	if !customer.CreationTime.IsSet() {
+		customer.CreationTime = NewVarcharTime(time.Now())
+	}
+
+	tx := conn.WithContext(ctx).Create(customer)
+	if tx.Error != nil {
+		return fmt.Errorf("failed to create StripeCustomer ID %s", customer.StripeCustomerID)
+	}
+
+	return nil
+}
+
+func GetStripeCustomer(ctx context.Context, conn *gorm.DB, stripeCustomerID string) (StripeCustomer, error) {
+	var customer StripeCustomer
+	tx := conn.
+		WithContext(ctx).
+		Where("stripeCustomerId = ?", stripeCustomerID).
+		First(&customer)
+	if err := tx.Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return StripeCustomer{}, fmt.Errorf("stripe customer with ID %s does not exist: %w", stripeCustomerID, ErrorNotFound)
+		}
+
+		return StripeCustomer{}, fmt.Errorf("failed to lookup stripe customer with ID %s", stripeCustomerID)
+	}
+
+	return customer, nil
+}
+
+func GetStripeCustomerByAttributionID(ctx context.Context, conn *gorm.DB, attributionID AttributionID) (StripeCustomer, error) {
+	var customer StripeCustomer
+	tx := conn.
+		WithContext(ctx).
+		Where("attributionId = ?", string(attributionID)).
+		Order("creationTime DESC").
+		First(&customer)
+	if err := tx.Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return StripeCustomer{}, fmt.Errorf("stripe customer with attribtuon ID %s does not exist: %w", attributionID, ErrorNotFound)
+		}
+
+		return StripeCustomer{}, fmt.Errorf("failed to lookup stripe customer with attribution ID %s", attributionID)
+	}
+
+	return customer, nil
+}

--- a/components/usage/pkg/db/stripe_customer_test.go
+++ b/components/usage/pkg/db/stripe_customer_test.go
@@ -1,0 +1,85 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package db_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/gitpod-io/gitpod/usage/pkg/db"
+	"github.com/gitpod-io/gitpod/usage/pkg/db/dbtest"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateStripeCustomer(t *testing.T) {
+	conn := dbtest.ConnectForTests(t)
+
+	customer := db.StripeCustomer{
+		StripeCustomerID: "cus_1234",
+		AttributionID:    db.NewUserAttributionID(uuid.New().String()),
+		CreationTime:     db.NewVarcharTime(time.Now()),
+	}
+	t.Cleanup(func() {
+		require.NoError(t, conn.Delete(&customer).Error)
+	})
+
+	require.NoError(t, db.CreateStripeCustomer(context.Background(), conn, customer))
+
+	// second create should fail due to PK contstraint
+	require.Error(t, db.CreateStripeCustomer(context.Background(), conn, customer))
+}
+
+func TestGetStripeCustomer(t *testing.T) {
+	conn := dbtest.ConnectForTests(t)
+
+	customers := dbtest.CreateStripeCustomers(t, conn, dbtest.NewStripeCustomer(t, db.StripeCustomer{}))
+	customer := customers[0]
+
+	retrieved, err := db.GetStripeCustomer(context.Background(), conn, customer.StripeCustomerID)
+	require.NoError(t, err)
+	require.Equal(t, customer.StripeCustomerID, retrieved.StripeCustomerID)
+	require.Equal(t, customer.AttributionID, retrieved.AttributionID)
+}
+
+func TestGetStripeCustomer_NotFound_WhenNotExists(t *testing.T) {
+	conn := dbtest.ConnectForTests(t)
+
+	_, err := db.GetStripeCustomer(context.Background(), conn, "cus_12314141")
+	require.Error(t, err)
+	require.ErrorIs(t, err, db.ErrorNotFound)
+}
+
+func TestGetStripeCustomerByAttributionID_ReturnsLatestRecord(t *testing.T) {
+	conn := dbtest.ConnectForTests(t)
+	now := time.Now()
+
+	attributionID := db.NewTeamAttributionID(uuid.New().String())
+	first := dbtest.NewStripeCustomer(t, db.StripeCustomer{
+		AttributionID: attributionID,
+		CreationTime:  db.NewVarcharTime(now.Add(-1 * time.Hour)),
+	})
+	second := dbtest.NewStripeCustomer(t, db.StripeCustomer{
+		AttributionID: attributionID,
+		CreationTime:  db.NewVarcharTime(now),
+	})
+	dbtest.CreateStripeCustomers(t, conn, first, second)
+
+	retrieved, err := db.GetStripeCustomerByAttributionID(context.Background(), conn, attributionID)
+	require.NoError(t, err)
+	require.Equal(t, second.StripeCustomerID, retrieved.StripeCustomerID)
+	require.Equal(t, second.AttributionID, retrieved.AttributionID)
+}
+
+func TestGetStripeCustomerByAttributionID_NotFound_WhenNotExists(t *testing.T) {
+	conn := dbtest.ConnectForTests(t)
+
+	attributionID := db.NewTeamAttributionID(uuid.New().String())
+
+	_, err := db.GetStripeCustomerByAttributionID(context.Background(), conn, attributionID)
+	require.Error(t, err)
+	require.ErrorIs(t, err, db.ErrorNotFound)
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Adds golang model for StripeCustomer and implements Creation and lookup by Stripe Customer ID and AttributionID

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Part of https://github.com/gitpod-io/gitpod/issues/13935

## How to test
<!-- Provide steps to test this PR -->
unit tests

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
