### PR TITLE
[actions] Detect breaking Public API changes

### DIFF
--- a/.github/workflows/public-api.yml
+++ b/.github/workflows/public-api.yml
@@ -1,0 +1,17 @@
+name: public-api-compatibility
+on: pull_request
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: bufbuild/buf-setup-action@v1
+      - uses: bufbuild/buf-lint-action@v1
+        with:
+          input: "components/public-api"
+      - uses: bufbuild/buf-breaking-action@v1
+        with:
+          input: "components/public-api"
+          # We compare against the target branch of the Pull Request, normally main
+          # Note that we only apply breaking detection to the public-api component.
+          against: "https://github.com/${GITHUB_REPOSITORY}.git#branch=${GITHUB_BASE_REF},subdir=components/public-api"

--- a/components/public-api/buf.yaml
+++ b/components/public-api/buf.yaml
@@ -1,7 +1,10 @@
 version: v1
 breaking:
   use:
-    - FILE
+    - WIRE_JSON
+  ignore:
+    # Do not enforce breaking change detection for the experimental package
+    - gitpod/experimental
 lint:
   use:
     - DEFAULT

--- a/components/public-api/generate.sh
+++ b/components/public-api/generate.sh
@@ -18,6 +18,9 @@ install_dependencies
 
 lint
 
+# Run breaking change detector
+buf breaking --against "https://github.com/gitpod-io/gitpod.git#branch=main,subdir=components/public-api"
+
 protoc_buf_generate
 
 update_license


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This change introduces a new Github Action which uses [buf](https://docs.buf.build/introduction) to do the following:
* Enforce style of API definitions for the Public API (`buf lint`)
* Enforce changes are compatible - they will not break older clients (`buf breaking`)

All API definitions in `components/public-api` are subject to this rule, unless they are specified in the `components/public-api/experimental` package in which case the breaking detector does not apply.

You can see an example of how the error is reported in this [PR](https://github.com/gitpod-io/gitpod/pull/14009/files)


<img width="879" alt="Screenshot 2022-10-19 at 21 49 55" src="https://user-images.githubusercontent.com/1419286/196789798-03e6373e-615a-4270-af4f-7d884eb5a965.png">

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
Run `cd components/public-api && ./generate.sh`. The `generate.sh` command checks against main, so either you need to point it at another base branch, like (`mp/buf-breaking-demo-1` from this [demo PR](https://github.com/gitpod-io/gitpod/pull/14008)) or adjust the buf breaking configuration [based on the available command arguments](https://docs.buf.build/breaking/usage). 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
