### PR TITLE
test: Show a commit hash on the nightly job

### DIFF
--- a/.werft/workspace-run-integration-tests.sh
+++ b/.werft/workspace-run-integration-tests.sh
@@ -12,6 +12,7 @@ BRANCH="wk-inte-test/"$(date +%Y%m%d%H%M%S)
 FAILURE_COUNT=0
 RUN_COUNT=0 # Prevent multiple cleanup runs
 DO_CLEANUP=0
+REVISION=""
 declare -A FAILURE_TESTS
 declare SIGNAL # used to record signal caught by trap
 
@@ -35,13 +36,13 @@ function cleanup ()
 
     if [ "${RUN_COUNT}" -eq "0" ]; then
         title=":x: *Workspace integration test fail*"
-        title=$title"\n_Repo:_ ${context_repo}\n_Build:_ ${context_name}"
+        title=$title"\n_Repo:_ ${context_repo}\n_Revision:_ ${REVISION}\n_Build:_ ${context_name}"
 
         errs="Failed at preparing the preview environment"
         BODY="{\"blocks\":[{\"type\":\"section\",\"text\":{\"type\":\"mrkdwn\",\"text\":\"${title}\"},\"accessory\":{\"type\":\"button\",\"text\":{\"type\":\"plain_text\",\"text\":\":werft: Go to Werft\",\"emoji\":true},\"value\":\"click_me_123\",\"url\":\"${werftJobUrl}\",\"action_id\":\"button-action\"}},{\"type\":\"section\",\"text\":{\"type\":\"mrkdwn\",\"text\":\"\`\`\`\\n${errs}\\n\`\`\`\"}}]}"
     elif [ "${FAILURE_COUNT}" -ne "0" ]; then
         title=":x: *Workspace integration test fail*"
-        title=$title"\n_Repo:_ ${context_repo}\n_Build:_ ${context_name}"
+        title=$title"\n_Repo:_ ${context_repo}\n_Revision:_ ${REVISION}\n_Build:_ ${context_name}"
 
         errs=""
         for TEST_NAME in ${!FAILURE_TESTS[*]}; do
@@ -53,7 +54,7 @@ function cleanup ()
     else
         title=":white_check_mark: *Workspace integration test pass*"
 
-        title=$title"\n_Repo:_ ${context_repo}\n_Build:_ ${context_name}"
+        title=$title"\n_Repo:_ ${context_repo}\n_Revision:_ ${REVISION}\n_Build:_ ${context_name}"
         BODY="{\"blocks\":[{\"type\":\"section\",\"text\":{\"type\":\"mrkdwn\",\"text\":\"${title}\"},\"accessory\":{\"type\":\"button\",\"text\":{\"type\":\"plain_text\",\"text\":\":werft: Go to Werft\",\"emoji\":true},\"value\":\"click_me_123\",\"url\":\"${werftJobUrl}\",\"action_id\":\"button-action\"}}]}"
     fi
 
@@ -102,6 +103,8 @@ git remote set-url origin https://oauth2:"${ROBOQUAT_TOKEN}"@github.com/gitpod-i
 gc_integration_branches
 
 werft log phase "build preview environment" "build preview environment"
+
+REVISION=$(git show -s --format="%h" HEAD)
 
 # Create a new branch and asks Werft to create a preview environment for it
 ( \


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

NONE

## How to test
<!-- Provide steps to test this PR -->

Run a job
```
werft run github -j ./.werft/workspace-run-integration-tests.yaml
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
