### PR TITLE
[stripe] Recreate d_b_stripe_customer table

### DIFF
--- a/components/gitpod-db/src/typeorm/migration/1666162573134-RecreateStripeCustomersTable.ts
+++ b/components/gitpod-db/src/typeorm/migration/1666162573134-RecreateStripeCustomersTable.ts
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { tableExists } from "./helper/helper";
+
+export class RecreateStripeCustomersTable1666162573134 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const exists = await tableExists(queryRunner, "d_b_stripe_customer");
+
+        if (exists) {
+            // Drop because previous table accidentally used underscore case for the Primary Key
+            await queryRunner.query(`DROP TABLE \`d_b_stripe_customer\``);
+
+            // Recrate the table
+            await queryRunner.query(
+                `CREATE TABLE IF NOT EXISTS \`d_b_stripe_customer\` (
+                    \`stripeCustomerId\` char(255) NOT NULL,
+                    \`attributionId\` char(255) NOT NULL,
+                    \`creationTime\` varchar(255) NOT NULL,
+                    \`deleted\` tinyint(4) NOT NULL DEFAULT '0',
+                    \`_lastModified\` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+
+                    INDEX \`ind_attribution_id\` (\`attributionId\`),
+                    INDEX \`ind_dbsync\` (\`_lastModified\`),
+                    PRIMARY KEY (\`stripeCustomerId\`)
+                ) ENGINE=InnoDB`,
+            );
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {}
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Recreates it, because I've accidentally named the PK with underscore case.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
