### PR TITLE
Add gitleaks pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,4 +58,9 @@ repos:
         args:
           - --args=-diff
 
+  - repo: https://github.com/zricethezav/gitleaks
+    rev: v8.15.0
+    hooks:
+      - id: gitleaks
+
 exclude: ^install/installer/.*/.*\.golden$


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
We have [GitGuardian check running](https://github.com/gitpod-io/gitpod/pull/13994/checks?check_run_id=8980721379), but this is on push and only notifies if sensitive data has already been committed.

This PR adds [`gitleaks`](https://github.com/zricethezav/gitleaks) pre-commit hook, which would prevent committing most sensitive data and leaking it through a commit. It's been in use for months in the [`observability`](https://github.com/gitpod-io/observability/blob/main/.pre-commit-config.yaml) repo

```bash
pre-commit run gitleaks --all-files

[INFO] Initializing environment for https://github.com/zricethezav/gitleaks.
[INFO] Installing environment for https://github.com/zricethezav/gitleaks.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
Detect hardcoded secrets.................................................Passed

```

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
