### PR TITLE
[ws-manager] Make cluster selection filter by application cluster

### DIFF
--- a/components/gitpod-protocol/src/workspace-cluster.ts
+++ b/components/gitpod-protocol/src/workspace-cluster.ts
@@ -104,6 +104,7 @@ export interface WorkspaceClusterDB {
      */
     findFiltered(predicate: DeepPartial<WorkspaceClusterFilter>): Promise<WorkspaceClusterWoTLS[]>;
 }
-export interface WorkspaceClusterFilter extends Pick<WorkspaceCluster, "state" | "govern" | "url"> {
+export interface WorkspaceClusterFilter
+    extends Pick<WorkspaceCluster, "name" | "state" | "govern" | "url" | "applicationCluster"> {
     minScore: number;
 }


### PR DESCRIPTION
## Description

<details>
<summary>Context </summary>
As part of #9198  we want to start syncing the `d_b_workspace_cluster` table with `db-sync`.

Currently, the table differs between US and EU regions because each table contains only the data relevant to that region. For example, in the EU table, the `eu70` workspace cluster is marked as `available` and the `us70` cluster is `cordoned`.  In the US cluster `eu70` is `cordoned` and `us70` is `available`.

In order to sync the table we need to get to a point where there is no difference in the data in the table between EU and US regions.

To do that we will introduce a new field in the table called `applicationCluster` which records the name of the application cluster to which the record belongs. Thus, for each workspace cluster there will be two rows in Gitpod SaaS:

| name | applicationCluster | url | tls | state | ... |
| --- | --- | --- | --- | --- | --- |
| eu70 | eu02 | url | tls info | available | ... |
| eu70 | us02 | url | tls info | cordoned | ... |

Effectively the new `applicationCluster` column gives the table an extra dimension so that we can combine both tables (EU and US) into one.

#13722  added the column to the table and made `gpctl` fill the value when `gpctl register`ing a new workspace cluster. The value is taken from the `GITPOD_INSTALLATION_SHORTNAME` environment variable in `ws-manager-bridge`.
</details>

Make the cluster selection mechanism in `ws-manager-api` aware of the application cluster to which each workspace cluster is registered. Previously, the selection was by workspace cluster name only. Soon, as described in the **context** section, each region in gitpod will store records in the database for *all* workspace clusters - not just the ones in its region. This PR ensures that workspace clusters not in the same regions as the application cluster will not be considered.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of https://github.com/gitpod-io/gitpod/issues/9198 and https://github.com/gitpod-io/gitpod/issues/13800

## How to test

Edit the `server` deployment and change the `WSMAN_CFG_MANAGERS` environment variable to change the `applicationCluster` to which the default workspace cluster in the preview environment is registered:

```json
[
  {
    "name": "",
    "url": "dns:///ws-manager:8080",
    "tls": {
      "ca": "/ws-manager-client-tls-certs/ca.crt",
      "crt": "/ws-manager-client-tls-certs/tls.crt",
      "key": "/ws-manager-client-tls-certs/tls.key"
    },
    "state": "available",
    "maxScore": 100,
    "score": 50,
    "govern": true,
    "admissionConstraints": null,
    "applicationCluster": "" // <- change this from "" to anything else
  }
]
```
The `WSMAN_CFG_MANAGERS` environment variable is base64 encoded.

Once the `server` deployment is edited it should no longer be possible to start a workspace as the only workspace cluster is now associated with a different (non-existent) application cluster. 

Edit the `WSMAN_CFG_MANAGERS` environment variable once more and set the `applicationCluster` field back to `""`. Starting a workspace should now proceed as normal (the application cluster in preview environments is currently called `""`).

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
