### PR TITLE
[stripe] Populate Stripe Customers from searches, use as lookup

### DIFF
--- a/components/usage/pkg/apiv1/billing.go
+++ b/components/usage/pkg/apiv1/billing.go
@@ -6,6 +6,7 @@ package apiv1
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"math"
@@ -39,6 +40,25 @@ type BillingService struct {
 }
 
 func (s *BillingService) GetStripeCustomer(ctx context.Context, req *v1.GetStripeCustomerRequest) (*v1.GetStripeCustomerResponse, error) {
+
+	storeStripeCustomerAndRespond := func(ctx context.Context, cus *stripe_api.Customer, attributionID db.AttributionID) (*v1.GetStripeCustomerResponse, error) {
+		logger := log.WithField("stripe_customer_id", cus.ID).WithField("attribution_id", attributionID)
+		// Store it in the DB such that subsequent lookups don't need to go to Stripe
+		result, err := s.storeStripeCustomer(ctx, cus, attributionID)
+		if err != nil {
+			logger.WithError(err).Error("Failed to store stripe customer in the database.")
+
+			// Storing failed, but we don't want to block the caller since we do have the data, return it as a success
+			return &v1.GetStripeCustomerResponse{
+				Customer: convertStripeCustomer(cus),
+			}, nil
+		}
+
+		return &v1.GetStripeCustomerResponse{
+			Customer: result,
+		}, nil
+	}
+
 	switch identifier := req.GetIdentifier().(type) {
 	case *v1.GetStripeCustomerRequest_AttributionId:
 		attributionID, err := db.ParseAttributionID(identifier.AttributionId)
@@ -46,30 +66,58 @@ func (s *BillingService) GetStripeCustomer(ctx context.Context, req *v1.GetStrip
 			return nil, status.Errorf(codes.InvalidArgument, "Invalid attribution ID %s", attributionID)
 		}
 
-		customer, err := s.stripeClient.GetCustomerByAttributionID(ctx, string(attributionID))
+		logger := log.WithField("attribution_id", attributionID)
+
+		customer, err := db.GetStripeCustomerByAttributionID(ctx, s.conn, attributionID)
 		if err != nil {
-			return nil, err
+			// We don't yet have it in the DB
+			if errors.Is(err, db.ErrorNotFound) {
+				stripeCustomer, err := s.stripeClient.GetCustomerByAttributionID(ctx, string(attributionID))
+				if err != nil {
+					return nil, err
+				}
+
+				return storeStripeCustomerAndRespond(ctx, stripeCustomer, attributionID)
+			}
+
+			logger.WithError(err).Error("Failed to lookup stripe customer from DB")
 		}
 
 		return &v1.GetStripeCustomerResponse{
-			AttributionId: string(attributionID),
-			Customer:      convertStripeCustomer(customer),
+			Customer: convertDBStripeCustomerToResponse(customer),
 		}, nil
+
 	case *v1.GetStripeCustomerRequest_StripeCustomerId:
-		customer, err := s.stripeClient.GetCustomer(ctx, identifier.StripeCustomerId)
-		if err != nil {
-			return nil, err
+		if identifier.StripeCustomerId == "" {
+			return nil, status.Errorf(codes.InvalidArgument, "empty stripe customer ID supplied")
 		}
 
-		attributionID, err := stripe.GetAttributionID(ctx, customer)
+		logger := log.WithField("stripe_customer_id", identifier.StripeCustomerId)
+
+		customer, err := db.GetStripeCustomer(ctx, s.conn, identifier.StripeCustomerId)
 		if err != nil {
-			return nil, status.Errorf(codes.Internal, "Failed to parse attribution ID from Stripe customer %s", customer.ID)
+			// We don't yet have it in the DB
+			if errors.Is(err, db.ErrorNotFound) {
+				stripeCustomer, err := s.stripeClient.GetCustomer(ctx, identifier.StripeCustomerId)
+				if err != nil {
+					return nil, err
+				}
+
+				attributionID, err := stripe.GetAttributionID(ctx, stripeCustomer)
+				if err != nil {
+					return nil, status.Errorf(codes.Internal, "Failed to parse attribution ID from Stripe customer %s", stripeCustomer.ID)
+				}
+
+				return storeStripeCustomerAndRespond(ctx, stripeCustomer, attributionID)
+			}
+
+			logger.WithError(err).Error("Failed to lookup stripe customer from DB")
 		}
 
 		return &v1.GetStripeCustomerResponse{
-			AttributionId: string(attributionID),
-			Customer:      convertStripeCustomer(customer),
+			Customer: convertDBStripeCustomerToResponse(customer),
 		}, nil
+
 	default:
 		return nil, status.Errorf(codes.InvalidArgument, "Unknown identifier")
 	}
@@ -221,6 +269,22 @@ func (s *BillingService) CancelSubscription(ctx context.Context, in *v1.CancelSu
 	return &v1.CancelSubscriptionResponse{}, nil
 }
 
+func (s *BillingService) storeStripeCustomer(ctx context.Context, cus *stripe_api.Customer, attributionID db.AttributionID) (*v1.StripeCustomer, error) {
+	err := db.CreateStripeCustomer(ctx, s.conn, db.StripeCustomer{
+		StripeCustomerID: cus.ID,
+		AttributionID:    attributionID,
+		// We use the original Stripe supplied creation timestamp, this ensures that we stay true to our ordering of customer creation records.
+		CreationTime: db.NewVarcharTime(time.Unix(cus.Created, 0)),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &v1.StripeCustomer{
+		Id: cus.ID,
+	}, nil
+}
+
 func balancesForStripeCostCenters(ctx context.Context, cm *db.CostCenterManager, balances []db.Balance) ([]db.Balance, error) {
 	var result []db.Balance
 	for _, balance := range balances {
@@ -244,5 +308,11 @@ func balancesForStripeCostCenters(ctx context.Context, cm *db.CostCenterManager,
 func convertStripeCustomer(customer *stripe_api.Customer) *v1.StripeCustomer {
 	return &v1.StripeCustomer{
 		Id: customer.ID,
+	}
+}
+
+func convertDBStripeCustomerToResponse(cus db.StripeCustomer) *v1.StripeCustomer {
+	return &v1.StripeCustomer{
+		Id: cus.StripeCustomerID,
 	}
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Starts to use the StripeCustomers table to answer lookup queries, but also populates the DB when it's not yet available in the DB.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
