### PR TITLE
Fixes "Open in Integrated Terminal" won't work in VS Code

### DIFF
--- a/components/supervisor/pkg/supervisor/ssh.go
+++ b/components/supervisor/pkg/supervisor/ssh.go
@@ -219,13 +219,13 @@ func configureSSHDefaultDir(cfg *Config) {
 		log.Error("cannot configure ssh default dir with empty repo root")
 		return
 	}
-	file, err := os.OpenFile("/home/gitpod/.bashrc", os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0o644)
+	file, err := os.OpenFile("/home/gitpod/.bash_profile", os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0o644)
 	if err != nil {
-		log.WithError(err).Error("cannot write .bashrc")
+		log.WithError(err).Error("cannot write .bash_profile")
 	}
 	defer file.Close()
 	if _, err := file.WriteString(fmt.Sprintf("\nif [[ -n $SSH_CONNECTION ]]; then cd \"%s\"; fi\n", cfg.RepoRoot)); err != nil {
-		log.WithError(err).Error("write .bashrc failed")
+		log.WithError(err).Error("write .bash_profile failed")
 	}
 }
 


### PR DESCRIPTION
## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/13793

## How to test
<!-- Provide steps to test this PR -->
1. Connect to vscode desktop and  run `Open in Integrated Terminal` from context menu in explorer on some folder
2. Check terminal opens in the specified folder
3. Check connecting using ssh opens the workspace folder by defaul

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
