### PR TITLE
Fix prebuild open

### DIFF
--- a/components/dashboard/src/projects/Project.tsx
+++ b/components/dashboard/src/projects/Project.tsx
@@ -333,7 +333,17 @@ export default function () {
                                                     )}
                                                 </a>
                                                 <span className="flex-grow" />
-                                                <a href={gitpodHostUrl.withContext(`${branch.url}`).toString()}>
+                                                <a
+                                                    href={
+                                                        prebuild
+                                                            ? gitpodHostUrl
+                                                                  .withContext(
+                                                                      `open-prebuild/${prebuild.info.id}/${prebuild.info.changeUrl}`,
+                                                                  )
+                                                                  .toString()
+                                                            : gitpodHostUrl.withContext(`${branch.url}`).toString()
+                                                    }
+                                                >
                                                     <button
                                                         className={`primary mr-2 py-2 opacity-0 group-hover:opacity-100`}
                                                     >

--- a/components/server/ee/src/workspace/workspace-factory.ts
+++ b/components/server/ee/src/workspace/workspace-factory.ts
@@ -373,15 +373,22 @@ export class WorkspaceFactoryEE extends WorkspaceFactory {
             }
 
             if (OpenPrebuildContext.is(context.originalContext)) {
+                if (CommitContext.is(buildWorkspace.context)) {
+                    if (
+                        CommitContext.is(context.originalContext) &&
+                        CommitContext.computeHash(context.originalContext) !==
+                            CommitContext.computeHash(buildWorkspace.context)
+                    ) {
+                        // If the current context has a newer/different commit hash than the prebuild
+                        // we force the checkout of the revision rather than the ref/branch.
+                        // Otherwise we'd get the correct prebuild with the "wrong" Git ref.
+                        delete buildWorkspace.context.ref;
+                    }
+                }
+
                 // Because of incremental prebuilds, createForContext will take over the original context.
                 // To ensure we get the right commit when forcing a prebuild, we force the context here.
                 context.originalContext = buildWorkspace.context;
-
-                if (CommitContext.is(context.originalContext)) {
-                    // We force the checkout of the revision rather than the ref/branch.
-                    // Otherwise we'd the correct prebuild with the "wrong" Git status.
-                    delete context.originalContext.ref;
-                }
             }
 
             const id = await this.generateWorkspaceID(context);


### PR DESCRIPTION
## Description
Made this PR in an effort to address some issues I ran into with prebuilds.
I don't know how to test the changes I made in `workspace-factory.ts`. The original pull request that had changes to that block of code (#13768) didn't have any unit tests, so I wasn't sure where to add some.


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #14017

## How to test
<!-- Provide steps to test this PR -->
- Create new prebuild
- Open workspace from either the branches tab or the specific prebuild page
- Prebuild should load correctly and the branch should be checked out in git

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
