### PR TITLE
[server] Remove probe workspaces garbage collector

### DIFF
--- a/components/gitpod-db/src/typeorm/workspace-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/workspace-db-impl.ts
@@ -1258,21 +1258,6 @@ export abstract class AbstractTypeORMWorkspaceDBImpl implements WorkspaceDB {
         const res = await query.getMany();
         return res.map((r) => r.info);
     }
-
-    async findProbeWorkspaceIDs(limit: number): Promise<string[]> {
-        const repo = await this.getWorkspaceRepo();
-        const results = (await repo.query(
-            `
-                SELECT ws.id AS id
-                FROM d_b_workspace ws
-                WHERE ws.type = 'probe'
-                LIMIT ?;
-            `,
-            [limit],
-        )) as { id: string }[];
-
-        return results.map((r) => r.id);
-    }
 }
 
 @injectable()

--- a/components/gitpod-db/src/workspace-db.ts
+++ b/components/gitpod-db/src/workspace-db.ts
@@ -202,6 +202,4 @@ export interface WorkspaceDB {
 
     storePrebuildInfo(prebuildInfo: PrebuildInfo): Promise<void>;
     findPrebuildInfos(prebuildIds: string[]): Promise<PrebuildInfo[]>;
-
-    findProbeWorkspaceIDs(limit: number): Promise<string[]>;
 }

--- a/components/server/src/workspace/garbage-collector.ts
+++ b/components/server/src/workspace/garbage-collector.ts
@@ -54,9 +54,6 @@ export class WorkspaceGarbageCollector {
             this.deleteOutdatedVolumeSnapshots().catch((err) =>
                 log.error("wsgc: error during volume snapshot gc deletion", err),
             );
-            this.deleteProbeWorkspaces().catch((err) =>
-                log.error("wsgc: error during probe workspace gc deletion", err),
-            );
         }
     }
 
@@ -186,24 +183,6 @@ export class WorkspaceGarbageCollector {
                     vss.slice(1).map((vs) => this.deletionService.garbageCollectVolumeSnapshot({ span }, vs)),
                 ),
             );
-        } catch (err) {
-            TraceContext.setError({ span }, err);
-            throw err;
-        } finally {
-            span.finish();
-        }
-    }
-
-    protected async deleteProbeWorkspaces() {
-        const span = opentracing.globalTracer().startSpan("deleteProbeWorkspaces");
-        try {
-            const workspaceIDs = await this.workspaceDB.trace({ span }).findProbeWorkspaceIDs(100);
-
-            const deletes = await Promise.all(
-                workspaceIDs.map((workspaceID) => this.workspaceDB.trace({ span }).hardDeleteWorkspace(workspaceID)),
-            );
-
-            log.info(`wsgc: successfully deleted ${deletes.length} Probe workspaces`);
         } catch (err) {
             TraceContext.setError({ span }, err);
             throw err;


### PR DESCRIPTION
This reverts commit 0a857e5d4cb81cf59c7f3b2f93b2c40da6b95565.

## Description
<!-- Describe your changes in detail -->

We've deleted all probe workspaces, we no longer need the GC.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
