### PR TITLE
[server] Log unspecific sendHeartBeat errors

### DIFF
--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -946,6 +946,10 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
                 // This is an old tab with open workspace: drop silently
                 return;
             } else {
+                if (!(e instanceof ResponseError)) {
+                    log.error({ instanceId, userId: user.id }, "Failed to send heartbeat", e);
+                }
+
                 throw e;
             }
         }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Log cause of sendHeartBeat errors when they are not specific Response Errors. This is needed to isolate cases where `sendHeartBeat` returns 500 to the caller.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Relates to https://github.com/gitpod-io/gitpod/issues/13128

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
