### PR TITLE
UBP: Don't block early access because of an unpaid team membership

### DIFF
--- a/components/gitpod-protocol/src/billing-mode.ts
+++ b/components/gitpod-protocol/src/billing-mode.ts
@@ -59,6 +59,10 @@ interface None {
 /** Sessions is handled with old subscription logic based on Chargebee */
 interface Chargebee {
     mode: "chargebee";
+
+    /** True iff this is a team, and is based on a paid plan. Currently only set for teams! */
+    paid?: boolean;
+
     canUpgradeToUBB?: boolean;
 }
 

--- a/components/server/ee/src/billing/billing-mode.spec.db.ts
+++ b/components/server/ee/src/billing/billing-mode.spec.db.ts
@@ -441,6 +441,7 @@ class BillingModeSpec {
                 },
                 expectation: {
                     mode: "chargebee",
+                    paid: true,
                 },
             },
             {
@@ -453,6 +454,7 @@ class BillingModeSpec {
                 },
                 expectation: {
                     mode: "chargebee",
+                    paid: true,
                 },
             },
             // team: transition chargebee -> UBB

--- a/components/server/ee/src/billing/billing-mode.ts
+++ b/components/server/ee/src/billing/billing-mode.ts
@@ -197,19 +197,19 @@ export class BillingModesImpl implements BillingModes {
             },
         );
 
-        // 1. UBB enabled?
-        if (!isUsageBasedBillingEnabled) {
-            return { mode: "chargebee" };
-        }
-
-        // 2. Any Chargbee TeamSubscription2 (old Team Subscriptions are not relevant here, as they are not associated with a team)
+        // 1. Check Chargebee: Any TeamSubscription2 (old Team Subscriptions are not relevant here, as they are not associated with a team)
         const teamSubscription = await this.teamSubscription2Db.findForTeam(team.id, now);
         if (teamSubscription && TeamSubscription2.isActive(teamSubscription, now)) {
             if (TeamSubscription2.isCancelled(teamSubscription, now)) {
                 // The team has a paid subscription, but it's already cancelled, and UBB enabled
-                return { mode: "chargebee", canUpgradeToUBB: true };
+                return { mode: "chargebee", canUpgradeToUBB: isUsageBasedBillingEnabled };
             }
 
+            return { mode: "chargebee", paid: true };
+        }
+
+        // 2. UBB enabled at all?
+        if (!isUsageBasedBillingEnabled) {
             return { mode: "chargebee" };
         }
 

--- a/components/server/ee/src/billing/billing-mode.ts
+++ b/components/server/ee/src/billing/billing-mode.ts
@@ -150,28 +150,28 @@ export class BillingModesImpl implements BillingModes {
         // 3. Check team memberships/plans
         // UBB overrides wins if there is _any_. But if there is none, use the existing Chargebee subscription.
         const teamsModes = await Promise.all(teams.map((t) => this.getBillingModeForTeam(t, now)));
-        const hasUbbPaidTeam = teamsModes.some((tm) => tm.mode === "usage-based" && !!tm.paid);
-        const hasCbTeam = teamsModes.some((tm) => tm.mode === "chargebee");
-        const hasCbTeamSeat = cbTeamSubscriptions.length > 0;
-        const hasCbTeamSubscription = cbOwnedTeamSubscriptions.length > 0;
+        const hasUbbPaidTeamMembership = teamsModes.some((tm) => tm.mode === "usage-based" && !!tm.paid);
+        const hasCbPaidTeamMembership = teamsModes.some((tm) => tm.mode === "chargebee" && !!tm.paid);
+        const hasCbPaidTeamSeat = cbTeamSubscriptions.length > 0;
+        const hasCbPaidTeamSubscription = cbOwnedTeamSubscriptions.length > 0;
 
         function usageBased() {
             const result: BillingMode = { mode: "usage-based" };
-            if (hasCbTeam) {
+            if (hasCbPaidTeamMembership) {
                 result.hasChargebeeTeamPlan = true;
             }
-            if (hasCbTeamSeat || hasCbTeamSubscription) {
+            if (hasCbPaidTeamSeat || hasCbPaidTeamSubscription) {
                 result.hasChargebeeTeamSubscription = true;
             }
             return result;
         }
 
-        if (hasUbbPaidTeam || hasUbbPersonal) {
+        if (hasUbbPaidTeamMembership || hasUbbPersonal) {
             // UBB is greedy: once a user has at least a paid team membership, they should benefit from it!
             return usageBased();
         }
-        if (hasCbTeam || hasCbTeamSeat || canUpgradeToUBB) {
-            // TODO(gpl): Q: How to test the free-tier, then? A: Make sure you have no CB seats anymore
+        if (hasCbPaidTeamMembership || hasCbPaidTeamSeat || canUpgradeToUBB) {
+            // TODO(gpl): Q: How to test the free-tier, then? A: Make sure you have no CB paid seats anymore
             // For that we could add a new field here, which lists all seats that are "blocking" you, and display them in the UI somewhere.
             return { mode: "chargebee", canUpgradeToUBB: true }; // UBB is enabled, but no seat nor subscription yet.
         }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #13999

## How to test
 - [login](https://gpl-13999-036cd0bbeb.preview.gitpod-dev.com/workspaces)       
 - create team `somethingsomething`
 - create team `Gitpod-something`
 - note how in [your personal billing settings](https://gpl-13999-036cd0bbeb.preview.gitpod-dev.com/billing) you set usage-based relevant sections (e.g. workspace-class selector)

![image](https://user-images.githubusercontent.com/32448529/196985708-8424c7bc-eb13-4d08-b1f0-5fbe161b1227.png)


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
