### PR TITLE
[public-api] Remove dependency on @gitpod/gitpod-protocol

### DIFF
--- a/components/public-api/typescript/package.json
+++ b/components/public-api/typescript/package.json
@@ -21,7 +21,6 @@
     "@testdeck/mocha": "0.1.2",
     "@types/chai": "^4.1.2",
     "@types/node": "^16.11.0",
-    "typescript": "~4.4.2",
-    "@gitpod/gitpod-protocol": "0.1.5"
+    "typescript": "~4.4.2"
   }
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Unneeded, and it actively breaks the ability for a client to do `npm install @gitpod/public-api`

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
