### PR TITLE
fix(gitpod-cli): ports list safe access to exposed url

### DIFF
--- a/components/gitpod-cli/cmd/ports-list.go
+++ b/components/gitpod-cli/cmd/ports-list.go
@@ -48,9 +48,18 @@ var listPortsCmd = &cobra.Command{
 		table.SetCenterSeparator("|")
 
 		for _, port := range ports {
-			status := "not served"
+			status := ""
 			statusColor := tablewriter.FgHiBlackColor
-			if port.Exposed == nil && port.Tunneled == nil {
+			accessible := port.Exposed != nil || port.Tunneled != nil
+
+			exposedUrl := ""
+			if port.Exposed != nil {
+				exposedUrl = port.Exposed.Url
+			}
+
+			if !port.Served {
+				status = "not served"
+			} else if !accessible {
 				if port.AutoExposure == supervisor.PortAutoExposure_failed {
 					status = "failed to expose"
 					statusColor = tablewriter.FgRedColor
@@ -58,12 +67,23 @@ var listPortsCmd = &cobra.Command{
 					status = "detecting..."
 					statusColor = tablewriter.FgYellowColor
 				}
-			} else if port.Served {
-				status = "open (" + port.Exposed.Visibility.String() + ")"
+			} else if port.Exposed != nil {
 				if port.Exposed.Visibility == supervisor.PortVisibility_public {
+					status = "open (public)"
 					statusColor = tablewriter.FgHiGreenColor
-				} else {
+				}
+				if port.Exposed.Visibility == supervisor.PortVisibility_private {
+					status = "open (private)"
 					statusColor = tablewriter.FgHiCyanColor
+				}
+			} else if port.Tunneled != nil {
+				if port.Tunneled.Visibility == supervisor.TunnelVisiblity(supervisor.TunnelVisiblity_value["network"]) {
+					status = "open on all interfaces"
+					statusColor = tablewriter.FgHiGreenColor
+				}
+				if port.Tunneled.Visibility == supervisor.TunnelVisiblity(supervisor.TunnelVisiblity_value["host"]) {
+					status = "open on localhost"
+					statusColor = tablewriter.FgHiGreenColor
 				}
 			}
 
@@ -82,7 +102,7 @@ var listPortsCmd = &cobra.Command{
 			}
 
 			table.Rich(
-				[]string{fmt.Sprint(port.LocalPort), status, port.Exposed.Url, nameAndDescription},
+				[]string{fmt.Sprint(port.LocalPort), status, exposedUrl, nameAndDescription},
 				colors,
 			)
 		}


### PR DESCRIPTION
## Description
This PR fix safe access to `port.Exposed.*` for both `Url` and `Visibility`.

Also, I've refactored the existing logic to determine the status, to be more readable and to follow the [vscode implementation](https://github.com/gitpod-io/openvscode-server/blob/gp-code/main/extensions/gitpod-shared/src/workspacePort.ts#L116-L140)

```
 gp ports list
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x30 pc=0x97c5ae]

goroutine 1 [running]:
github.com/gitpod-io/gitpod/gitpod-cli/cmd.glob..func12(0xfb5fe0, {0xac9654, 0x0, 0x0})
        github.com/gitpod-io/gitpod/gitpod-cli/cmd/ports-list.go:86 +0x3ae
github.com/spf13/cobra.(*Command).execute(0xfb5fe0, {0xff6aa8, 0x0, 0x0})
        github.com/spf13/cobra@v1.1.3/command.go:856 +0x663
github.com/spf13/cobra.(*Command).ExecuteC(0xfb5ae0)
        github.com/spf13/cobra@v1.1.3/command.go:960 +0x39d
github.com/spf13/cobra.(*Command).Execute(...)
        github.com/spf13/cobra@v1.1.3/command.go:897
github.com/gitpod-io/gitpod/gitpod-cli/cmd.Execute()
        github.com/gitpod-io/gitpod/gitpod-cli/cmd/root.go:35 +0x325
main.main()
        github.com/gitpod-io/gitpod/gitpod-cli/main.go:12 +0x17
```

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #11990

## How to test
1. Start a workspace with https://afalz-fix-5d5a7c82e6.preview.gitpod-dev.com/#https://github.com/gitpod-io/empty
2. Run `gp ports list` and observe nothing is resulted (actually port 3000 is already displayed as non-served by default for some reason)
3. Run `curl lama.sh | sh -s — —port 3001` 
4. Run `gp ports list` and observe port 3001 being `open (private)`
5. Run `gp ports visibility 3001:public`, then run `gp ports list` and observe port 3001 being open (public)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Bugfix for gitpod CLI: avoid failure on `ports list` when port is not exposed
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
