### PR TITLE
[registry-facade] Add more blob download metrics

### DIFF
--- a/components/registry-facade/pkg/registry/layersource.go
+++ b/components/registry-facade/pkg/registry/layersource.go
@@ -56,6 +56,10 @@ type filebackedLayer struct {
 // FileLayerSource provides the same layers independent of the workspace spec
 type FileLayerSource []filebackedLayer
 
+func (s FileLayerSource) Name() string {
+	return "filelayer"
+}
+
 // Envs returns the list of env modifiers
 func (s FileLayerSource) Envs(ctx context.Context, spec *api.ImageSpec) ([]EnvModifier, error) {
 	return nil, nil
@@ -170,6 +174,10 @@ type imagebackedLayer struct {
 type ImageLayerSource struct {
 	envs   []EnvModifier
 	layers []imagebackedLayer
+}
+
+func (s ImageLayerSource) Name() string {
+	return "imagelayer"
 }
 
 // Envs returns the list of env modifiers
@@ -316,6 +324,10 @@ func getSkipNLabelValue(cfg *ociv1.ImageConfig) (skipN int, err error) {
 // CompositeLayerSource appends layers from different sources
 type CompositeLayerSource []LayerSource
 
+func (cs CompositeLayerSource) Name() string {
+	return "composite"
+}
+
 // Envs returns the list of env modifiers
 func (cs CompositeLayerSource) Envs(ctx context.Context, spec *api.ImageSpec) ([]EnvModifier, error) {
 	var res []EnvModifier
@@ -388,6 +400,10 @@ type SpecMappedImagedSource struct {
 
 	// TODO: add ttl
 	cache *lru.Cache
+}
+
+func (src *SpecMappedImagedSource) Name() string {
+	return "specmapped"
 }
 
 // Envs returns the list of env modifiers
@@ -506,6 +522,10 @@ func NewContentLayerSource() (*ContentLayerSource, error) {
 // ContentLayerSource provides layers from other images based on the image spec
 type ContentLayerSource struct {
 	blobCache *lru.Cache
+}
+
+func (src *ContentLayerSource) Name() string {
+	return "contentlayer"
 }
 
 // Envs returns the list of env modifiers
@@ -709,6 +729,13 @@ type RevisioningLayerSource struct {
 	mu     sync.RWMutex
 	active LayerSource
 	past   []LayerSource
+}
+
+func (src *RevisioningLayerSource) Name() string {
+	src.mu.RLock()
+	defer src.mu.RUnlock()
+
+	return src.active.Name()
 }
 
 func (src *RevisioningLayerSource) Update(s LayerSource) {

--- a/components/registry-facade/pkg/registry/metrics.go
+++ b/components/registry-facade/pkg/registry/metrics.go
@@ -51,10 +51,12 @@ func (m *measuringRegistryRoundTripper) RoundTrip(req *http.Request) (*http.Resp
 
 // Metrics combine custom metrics exported by registry facade
 type metrics struct {
-	ManifestHist          prometheus.Histogram
-	ReqFailedCounter      *prometheus.CounterVec
-	BlobCounter           prometheus.Counter
-	BlobDownloadSpeedHist prometheus.Histogram
+	ManifestHist            prometheus.Histogram
+	ReqFailedCounter        *prometheus.CounterVec
+	BlobCounter             prometheus.Counter
+	BlobDownloadSizeCounter *prometheus.CounterVec
+	BlobDownloadCounter     *prometheus.CounterVec
+	BlobDownloadSpeedHist   *prometheus.HistogramVec
 }
 
 func newMetrics(reg prometheus.Registerer, upstream bool) (*metrics, error) {
@@ -88,11 +90,28 @@ func newMetrics(reg prometheus.Registerer, upstream bool) (*metrics, error) {
 		return nil, err
 	}
 
-	blobDownloadSpeedHist := prometheus.NewHistogram(prometheus.HistogramOpts{
+	blobDownloadCounter := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "blob_req_dl_total",
+		Help: "number of blob download requests",
+	}, []string{"blobSource"})
+	err = reg.Register(blobCounter)
+	if err != nil {
+		return nil, err
+	}
+	blobDownloadSizeCounter := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "blob_req_bytes_total",
+		Help: "amount of blob byytes downloaded",
+	}, []string{"blobSource"})
+	err = reg.Register(blobCounter)
+	if err != nil {
+		return nil, err
+	}
+
+	blobDownloadSpeedHist := prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "blob_req_bytes_second",
 		Help:    "blob download speed in bytes per second",
 		Buckets: prometheus.ExponentialBuckets(1024*1024, 2, 10),
-	})
+	}, []string{"blobSource"})
 	if upstream {
 		err = reg.Register(blobDownloadSpeedHist)
 		if err != nil {
@@ -101,9 +120,11 @@ func newMetrics(reg prometheus.Registerer, upstream bool) (*metrics, error) {
 	}
 
 	return &metrics{
-		ManifestHist:          manifestHist,
-		ReqFailedCounter:      reqFailedCounter,
-		BlobCounter:           blobCounter,
-		BlobDownloadSpeedHist: blobDownloadSpeedHist,
+		ManifestHist:            manifestHist,
+		ReqFailedCounter:        reqFailedCounter,
+		BlobCounter:             blobCounter,
+		BlobDownloadSpeedHist:   blobDownloadSpeedHist,
+		BlobDownloadSizeCounter: blobDownloadSizeCounter,
+		BlobDownloadCounter:     blobDownloadCounter,
 	}, nil
 }

--- a/components/registry-facade/pkg/registry/mock/layersource_mock.go
+++ b/components/registry-facade/pkg/registry/mock/layersource_mock.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
 // Licensed under the GNU Affero General Public License (AGPL).
 // See License-AGPL.txt in the project root for license information.
 
@@ -62,10 +62,10 @@ func (m *MockLayerSource) GetBlob(arg0 context.Context, arg1 *api.ImageSpec, arg
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetBlob", arg0, arg1, arg2)
 	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[0].(string)
-	ret2, _ := ret[1].(string)
-	ret3, _ := ret[2].(io.ReadCloser)
-	ret4, _ := ret[3].(error)
+	ret1, _ := ret[1].(string)
+	ret2, _ := ret[2].(string)
+	ret3, _ := ret[3].(io.ReadCloser)
+	ret4, _ := ret[4].(error)
 	return ret0, ret1, ret2, ret3, ret4
 }
 
@@ -102,4 +102,18 @@ func (m *MockLayerSource) HasBlob(arg0 context.Context, arg1 *api.ImageSpec, arg
 func (mr *MockLayerSourceMockRecorder) HasBlob(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasBlob", reflect.TypeOf((*MockLayerSource)(nil).HasBlob), arg0, arg1, arg2)
+}
+
+// Name mocks base method.
+func (m *MockLayerSource) Name() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Name")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// Name indicates an expected call of Name.
+func (mr *MockLayerSourceMockRecorder) Name() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockLayerSource)(nil).Name))
 }


### PR DESCRIPTION
to track the performance of our caching.

## Description
Adds and extends our current metrics to better track the impact our (IPFS) caching has on our performance.

## How to test
1. Start a workspace and observe the registry-facade metrics

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
