### PR TITLE
[usage] Implement CreateStripeSubscription

### DIFF
--- a/components/usage/pkg/server/server.go
+++ b/components/usage/pkg/server/server.go
@@ -44,17 +44,7 @@ type Config struct {
 	DefaultSpendingLimit db.DefaultSpendingLimit `json:"defaultSpendingLimit"`
 
 	// StripePrices configure which Stripe Price IDs should be used
-	StripePrices StripePrices `json:"stripePrices"`
-}
-
-type PriceConfig struct {
-	EUR string `json:"eur"`
-	USD string `json:"usd"`
-}
-
-type StripePrices struct {
-	IndividualUsagePriceIDs PriceConfig `json:"individualUsagePriceIds"`
-	TeamUsagePriceIDs       PriceConfig `json:"teamUsagePriceIds"`
+	StripePrices stripe.StripePrices `json:"stripePrices"`
 }
 
 func Start(cfg Config, version string) error {
@@ -188,7 +178,7 @@ func registerGRPCServices(srv *baseserver.Server, conn *gorm.DB, stripeClient *s
 	if stripeClient == nil {
 		v1.RegisterBillingServiceServer(srv.GRPC(), &apiv1.BillingServiceNoop{})
 	} else {
-		v1.RegisterBillingServiceServer(srv.GRPC(), apiv1.NewBillingService(stripeClient, conn, ccManager))
+		v1.RegisterBillingServiceServer(srv.GRPC(), apiv1.NewBillingService(stripeClient, conn, ccManager, cfg.StripePrices))
 	}
 	return nil
 }

--- a/components/usage/pkg/stripe/stripe_test.go
+++ b/components/usage/pkg/stripe/stripe_test.go
@@ -6,8 +6,10 @@ package stripe
 
 import (
 	"fmt"
-	"github.com/gitpod-io/gitpod/usage/pkg/db"
 	"testing"
+	"time"
+
+	"github.com/gitpod-io/gitpod/usage/pkg/db"
 
 	"github.com/stretchr/testify/require"
 )
@@ -88,4 +90,10 @@ func TestCustomerQueriesForTeamIds_MultipleQueries(t *testing.T) {
 			require.Equal(t, tc.ExpectedNumberOfQueries, len(actualQueries))
 		})
 	}
+}
+
+func TestStartOfNextMonth(t *testing.T) {
+	ts := time.Date(2022, 10, 1, 0, 0, 0, 0, time.UTC)
+
+	require.Equal(t, time.Date(2022, 11, 1, 0, 0, 0, 0, time.UTC), getStartOfNextMonth(ts))
 }

--- a/install/installer/pkg/components/usage/configmap.go
+++ b/install/installer/pkg/components/usage/configmap.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gitpod-io/gitpod/common-go/baseserver"
 	"github.com/gitpod-io/gitpod/usage/pkg/db"
 	"github.com/gitpod-io/gitpod/usage/pkg/server"
+	"github.com/gitpod-io/gitpod/usage/pkg/stripe"
 
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 	"github.com/gitpod-io/gitpod/installer/pkg/config/v1/experimental"
@@ -39,12 +40,12 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 
 	expWebAppConfig := getExperimentalWebAppConfig(ctx)
 	if expWebAppConfig != nil && expWebAppConfig.Stripe != nil {
-		cfg.StripePrices = server.StripePrices{
-			IndividualUsagePriceIDs: server.PriceConfig{
+		cfg.StripePrices = stripe.StripePrices{
+			IndividualUsagePriceIDs: stripe.PriceConfig{
 				EUR: expWebAppConfig.Stripe.IndividualUsagePriceIDs.EUR,
 				USD: expWebAppConfig.Stripe.IndividualUsagePriceIDs.USD,
 			},
-			TeamUsagePriceIDs: server.PriceConfig{
+			TeamUsagePriceIDs: stripe.PriceConfig{
 				EUR: expWebAppConfig.Stripe.TeamUsagePriceIDs.EUR,
 				USD: expWebAppConfig.Stripe.TeamUsagePriceIDs.USD,
 			},


### PR DESCRIPTION
## Description
Implements CreateStripeSubscription.
Follow-up: Plug it into server with a feature flag.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Depends on #14124
Fixes #13198

## How to test
1. Go to the [preview env](https://lau-create12ffe4ff15.preview.gitpod-dev.com/).
2. Create a team with the name `Gitpod` in it (make sure to use the capital 'G').
3. Go to the team's Billing page.
4. Upgrade plan. 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
