### PR TITLE
Remove node labeler waits

### DIFF
--- a/dev/ready-probe-labeler/main.go
+++ b/dev/ready-probe-labeler/main.go
@@ -77,16 +77,12 @@ func main() {
 		return
 	}
 
-	time.Sleep(1 * time.Second)
 	start := time.Now()
 
 	err = waitForURLToBeReachable(opts.ProbeURL, opts.Timeout)
 	if err != nil {
 		log.Fatalf("Unexpected error waiting for probe URL: %v", err)
 	}
-
-	// do not set the label immediately
-	time.Sleep(10 * time.Second)
 
 	err = updateLabel(opts.Label, true, nodeName, client)
 	if err != nil {


### PR DESCRIPTION
## Description

Rely on the readiness probe instead of adding artificial wait.

## How to test
- workspaces should open without issues
- Integration tests should pass

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```


## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-integration-tests=workspace
      Valid options are `all`, `workspace`, `webapp`, `ide`
