### PR TITLE
[ws-manager] Make cluster selection filter by application cluster

### DIFF
--- a/components/gitpod-db/src/typeorm/workspace-cluster-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/workspace-cluster-db-impl.ts
@@ -37,9 +37,9 @@ export class WorkspaceClusterDBImpl implements WorkspaceClusterDB {
         await repo.delete(name);
     }
 
-    async findByName(name: string): Promise<WorkspaceCluster | undefined> {
+    async findByName(name: string, applicationCluster: string): Promise<WorkspaceCluster | undefined> {
         const repo = await this.getRepo();
-        return repo.findOne(name);
+        return repo.findOne({ name, applicationCluster });
     }
 
     async findFiltered(predicate: WorkspaceClusterFilter): Promise<WorkspaceClusterWoTLS[]> {

--- a/components/gitpod-db/src/typeorm/workspace-cluster-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/workspace-cluster-db-impl.ts
@@ -32,9 +32,9 @@ export class WorkspaceClusterDBImpl implements WorkspaceClusterDB {
         await repo.save(cluster);
     }
 
-    async deleteByName(name: string): Promise<void> {
+    async deleteByName(name: string, applicationCluster: string): Promise<void> {
         const repo = await this.getRepo();
-        await repo.delete(name);
+        await repo.delete({ name, applicationCluster });
     }
 
     async findByName(name: string, applicationCluster: string): Promise<WorkspaceCluster | undefined> {

--- a/components/gitpod-db/src/typeorm/workspace-cluster-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/workspace-cluster-db-impl.ts
@@ -59,6 +59,12 @@ export class WorkspaceClusterDBImpl implements WorkspaceClusterDB {
             .createQueryBuilder("wsc")
             .select(Object.keys(prototype).map((k) => `wsc.${k}`))
             .where("TRUE = TRUE"); // make sure andWhere works
+        if (predicate.name !== undefined) {
+            qb = qb.andWhere("wsc.name = :name", predicate);
+        }
+        if (predicate.applicationCluster !== undefined) {
+            qb = qb.andWhere("wsc.applicationCluster = :applicationCluster", predicate);
+        }
         if (predicate.state !== undefined) {
             qb = qb.andWhere("wsc.state = :state", predicate);
         }

--- a/components/gitpod-db/src/typeorm/workspace-cluster-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/workspace-cluster-db-impl.ts
@@ -4,7 +4,7 @@
  * See License-AGPL.txt in the project root for license information.
  */
 
-import { Repository, EntityManager, DeepPartial } from "typeorm";
+import { Repository, EntityManager } from "typeorm";
 import { injectable, inject } from "inversify";
 import { TypeORM } from "./typeorm";
 import { WorkspaceClusterDB } from "../workspace-cluster-db";
@@ -42,7 +42,7 @@ export class WorkspaceClusterDBImpl implements WorkspaceClusterDB {
         return repo.findOne(name);
     }
 
-    async findFiltered(predicate: DeepPartial<WorkspaceClusterFilter>): Promise<WorkspaceClusterWoTLS[]> {
+    async findFiltered(predicate: WorkspaceClusterFilter): Promise<WorkspaceClusterWoTLS[]> {
         const prototype: WorkspaceClusterWoTLS = {
             name: "",
             url: "",

--- a/components/gitpod-db/src/workspace-cluster-db.spec.db.ts
+++ b/components/gitpod-db/src/workspace-cluster-db.spec.db.ts
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import * as chai from "chai";
+import { suite, test, timeout } from "mocha-typescript";
+import { testContainer } from "./test-container";
+import { TypeORM } from "./typeorm/typeorm";
+import { WorkspaceClusterDB } from "@gitpod/gitpod-protocol/lib/workspace-cluster";
+import { DBWorkspaceCluster } from "./typeorm/entity/db-workspace-cluster";
+const expect = chai.expect;
+
+@suite
+@timeout(5000)
+export class WorkspaceClusterDBSpec {
+    typeORM = testContainer.get<TypeORM>(TypeORM);
+    db = testContainer.get<WorkspaceClusterDB>(WorkspaceClusterDB);
+
+    async before() {
+        await this.clear();
+    }
+
+    async after() {
+        await this.clear();
+    }
+
+    protected async clear() {
+        const connection = await this.typeORM.getConnection();
+        const manager = connection.manager;
+        await manager.clear(DBWorkspaceCluster);
+    }
+
+    @test public async testFindFilteredByName() {
+        const wsc1: DBWorkspaceCluster = {
+            name: "eu71",
+            applicationCluster: "eu02",
+            url: "some-url",
+            state: "available",
+            score: 100,
+            maxScore: 100,
+            govern: true,
+        };
+        const wsc2: DBWorkspaceCluster = {
+            name: "us71",
+            applicationCluster: "eu02",
+            url: "some-url",
+            state: "cordoned",
+            score: 0,
+            maxScore: 0,
+            govern: false,
+        };
+
+        await this.db.save(wsc1);
+        await this.db.save(wsc2);
+
+        const wscs = await this.db.findFiltered({ name: "eu71" });
+        expect(wscs.length).to.equal(1);
+        expect(wscs[0].name).to.equal("eu71");
+    }
+
+    @test public async testFindFilteredByApplicationCluster() {
+        const wsc1: DBWorkspaceCluster = {
+            name: "eu71",
+            applicationCluster: "eu02",
+            url: "some-url",
+            state: "available",
+            score: 100,
+            maxScore: 100,
+            govern: true,
+        };
+        const wsc2: DBWorkspaceCluster = {
+            name: "us71",
+            applicationCluster: "us02",
+            url: "some-url",
+            state: "available",
+            score: 100,
+            maxScore: 100,
+            govern: true,
+        };
+
+        await this.db.save(wsc1);
+        await this.db.save(wsc2);
+
+        const wscs = await this.db.findFiltered({ applicationCluster: "eu02" });
+        expect(wscs.length).to.equal(1);
+        expect(wscs[0].name).to.equal("eu71");
+    }
+}
+
+module.exports = WorkspaceClusterDBSpec;

--- a/components/gitpod-db/src/workspace-cluster-db.spec.db.ts
+++ b/components/gitpod-db/src/workspace-cluster-db.spec.db.ts
@@ -8,7 +8,7 @@ import * as chai from "chai";
 import { suite, test, timeout } from "mocha-typescript";
 import { testContainer } from "./test-container";
 import { TypeORM } from "./typeorm/typeorm";
-import { WorkspaceClusterDB } from "@gitpod/gitpod-protocol/lib/workspace-cluster";
+import { WorkspaceCluster, WorkspaceClusterDB } from "@gitpod/gitpod-protocol/lib/workspace-cluster";
 import { DBWorkspaceCluster } from "./typeorm/entity/db-workspace-cluster";
 const expect = chai.expect;
 
@@ -30,6 +30,34 @@ export class WorkspaceClusterDBSpec {
         const connection = await this.typeORM.getConnection();
         const manager = connection.manager;
         await manager.clear(DBWorkspaceCluster);
+    }
+
+    @test public async findByName() {
+        const wsc1: DBWorkspaceCluster = {
+            name: "eu71",
+            applicationCluster: "eu02",
+            url: "some-url",
+            state: "available",
+            score: 100,
+            maxScore: 100,
+            govern: true,
+        };
+        const wsc2: DBWorkspaceCluster = {
+            name: "us71",
+            applicationCluster: "eu02",
+            url: "some-url",
+            state: "cordoned",
+            score: 0,
+            maxScore: 0,
+            govern: false,
+        };
+
+        await this.db.save(wsc1);
+        await this.db.save(wsc2);
+
+        const wsc = await this.db.findByName("eu71", "eu02");
+        expect(wsc).not.to.be.undefined;
+        expect((wsc as WorkspaceCluster).name).to.equal("eu71");
     }
 
     @test public async testFindFilteredByName() {

--- a/components/gitpod-db/src/workspace-cluster-db.spec.db.ts
+++ b/components/gitpod-db/src/workspace-cluster-db.spec.db.ts
@@ -55,7 +55,7 @@ export class WorkspaceClusterDBSpec {
         await this.db.save(wsc1);
         await this.db.save(wsc2);
 
-        const wscs = await this.db.findFiltered({ name: "eu71" });
+        const wscs = await this.db.findFiltered({ name: "eu71", applicationCluster: "eu02" });
         expect(wscs.length).to.equal(1);
         expect(wscs[0].name).to.equal("eu71");
     }

--- a/components/gitpod-db/src/workspace-cluster-db.spec.db.ts
+++ b/components/gitpod-db/src/workspace-cluster-db.spec.db.ts
@@ -55,9 +55,49 @@ export class WorkspaceClusterDBSpec {
         await this.db.save(wsc1);
         await this.db.save(wsc2);
 
-        const wsc = await this.db.findByName("eu71", "eu02");
-        expect(wsc).not.to.be.undefined;
-        expect((wsc as WorkspaceCluster).name).to.equal("eu71");
+        // Can find the eu71 cluster as seen by the eu02 application cluster.
+        const result = await this.db.findByName("eu71", "eu02");
+        expect(result).not.to.be.undefined;
+        expect((result as WorkspaceCluster).name).to.equal("eu71");
+
+        // Can't find the eu71 cluster as seen by the us02 application cluster.
+        // (no record in the db for that (ws-cluster, app-cluster) combination).
+        const result2 = await this.db.findByName("eu71", "us02");
+        expect(result2).to.be.undefined;
+
+        // Can find the us71 cluster as seen by the eu02 application cluster.
+        const result3 = await this.db.findByName("us71", "eu02");
+        expect(result3).not.to.be.undefined;
+        expect((result3 as WorkspaceCluster).name).to.equal("us71");
+    }
+
+    @test public async deleteByName() {
+        const wsc1: DBWorkspaceCluster = {
+            name: "eu71",
+            applicationCluster: "eu02",
+            url: "some-url",
+            state: "available",
+            score: 100,
+            maxScore: 100,
+            govern: true,
+        };
+        const wsc2: DBWorkspaceCluster = {
+            name: "us71",
+            applicationCluster: "eu02",
+            url: "some-url",
+            state: "cordoned",
+            score: 0,
+            maxScore: 0,
+            govern: false,
+        };
+
+        await this.db.save(wsc1);
+        await this.db.save(wsc2);
+
+        // Can delete the eu71 cluster as seen by the eu02 application cluster.
+        await this.db.deleteByName("eu71", "eu02");
+        expect(await this.db.findByName("eu71", "eu02")).to.be.undefined;
+        expect(await this.db.findByName("us71", "eu02")).not.to.be.undefined;
     }
 
     @test public async testFindFilteredByName() {

--- a/components/gitpod-protocol/src/workspace-cluster.ts
+++ b/components/gitpod-protocol/src/workspace-cluster.ts
@@ -104,6 +104,7 @@ export interface WorkspaceClusterDB {
      */
     findFiltered(predicate: DeepPartial<WorkspaceClusterFilter>): Promise<WorkspaceClusterWoTLS[]>;
 }
-export interface WorkspaceClusterFilter extends Pick<WorkspaceCluster, "state" | "govern" | "url"> {
+export interface WorkspaceClusterFilter
+    extends Pick<WorkspaceCluster, "name" | "state" | "govern" | "url" | "applicationCluster"> {
     minScore: number;
 }

--- a/components/gitpod-protocol/src/workspace-cluster.ts
+++ b/components/gitpod-protocol/src/workspace-cluster.ts
@@ -96,7 +96,7 @@ export interface WorkspaceClusterDB {
      * Finds a WorkspaceCluster with the given name. If there is none, `undefined` is returned.
      * @param name
      */
-    findByName(name: string): Promise<WorkspaceCluster | undefined>;
+    findByName(name: string, applicationCluster: string): Promise<WorkspaceCluster | undefined>;
 
     /**
      * Lists all WorkspaceClusterWoTls for which the given predicate is true (does not return TLS for size/speed concerns)

--- a/components/gitpod-protocol/src/workspace-cluster.ts
+++ b/components/gitpod-protocol/src/workspace-cluster.ts
@@ -90,7 +90,7 @@ export interface WorkspaceClusterDB {
      * Deletes the cluster identified by this name, if any.
      * @param name
      */
-    deleteByName(name: string): Promise<void>;
+    deleteByName(name: string, applicationCluster: string): Promise<void>;
 
     /**
      * Finds a WorkspaceCluster with the given name. If there is none, `undefined` is returned.

--- a/components/gitpod-protocol/src/workspace-cluster.ts
+++ b/components/gitpod-protocol/src/workspace-cluster.ts
@@ -102,9 +102,9 @@ export interface WorkspaceClusterDB {
      * Lists all WorkspaceClusterWoTls for which the given predicate is true (does not return TLS for size/speed concerns)
      * @param predicate
      */
-    findFiltered(predicate: DeepPartial<WorkspaceClusterFilter>): Promise<WorkspaceClusterWoTLS[]>;
+    findFiltered(predicate: WorkspaceClusterFilter): Promise<WorkspaceClusterWoTLS[]>;
 }
-export interface WorkspaceClusterFilter
-    extends Pick<WorkspaceCluster, "name" | "state" | "govern" | "url" | "applicationCluster"> {
-    minScore: number;
-}
+
+export type WorkspaceClusterFilter = Pick<WorkspaceCluster, "applicationCluster"> &
+    DeepPartial<Pick<WorkspaceCluster, "name" | "state" | "govern" | "url">> &
+    Partial<{ minScore: number }>;

--- a/components/image-builder-api/typescript/src/sugar.ts
+++ b/components/image-builder-api/typescript/src/sugar.ts
@@ -31,7 +31,12 @@ export const ImageBuilderClientProvider = Symbol("ImageBuilderClientProvider");
 
 // ImageBuilderClientProvider caches image builder connections
 export interface ImageBuilderClientProvider {
-    getClient(user: User, workspace: Workspace, instance?: WorkspaceInstance): Promise<PromisifiedImageBuilderClient>;
+    getClient(
+        applicationCluster: string,
+        user: User,
+        workspace: Workspace,
+        instance?: WorkspaceInstance,
+    ): Promise<PromisifiedImageBuilderClient>;
 }
 
 function withTracing(ctx: TraceContext) {
@@ -91,7 +96,7 @@ export class CachingImageBuilderClientProvider implements ImageBuilderClientProv
         return connection;
     }
 
-    async getClient(user: User, workspace: Workspace, instance?: WorkspaceInstance) {
+    async getClient(applicationCluster: string, user: User, workspace: Workspace, instance?: WorkspaceInstance) {
         return this.getDefault();
     }
 

--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -387,7 +387,10 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
         await this.guardAccess({ kind: "workspaceInstance", subject: runningInstance, workspace: workspace }, "update");
 
         // if any other running instance has a custom timeout other than the user's default, we'll reset that timeout
-        const client = await this.workspaceManagerClientProvider.get(runningInstance.region);
+        const client = await this.workspaceManagerClientProvider.get(
+            runningInstance.region,
+            this.config.installationShortname,
+        );
         const defaultTimeout = await this.entitlementService.getDefaultWorkspaceTimeout(user, new Date());
         const instancesWithReset = runningInstances.filter(
             (i) => i.workspaceId !== workspaceId && i.status.timeout !== defaultTimeout && i.status.phase === "running",
@@ -398,7 +401,10 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
                 req.setId(i.id);
                 req.setDuration(this.userService.workspaceTimeoutToDuration(defaultTimeout));
 
-                const client = await this.workspaceManagerClientProvider.get(i.region);
+                const client = await this.workspaceManagerClientProvider.get(
+                    i.region,
+                    this.config.installationShortname,
+                );
                 return client.setTimeout(ctx, req);
             }),
         );
@@ -436,7 +442,10 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
         const req = new DescribeWorkspaceRequest();
         req.setId(runningInstance.id);
 
-        const client = await this.workspaceManagerClientProvider.get(runningInstance.region);
+        const client = await this.workspaceManagerClientProvider.get(
+            runningInstance.region,
+            this.config.installationShortname,
+        );
         const desc = await client.describeWorkspace(ctx, req);
         const duration = this.userService.durationToWorkspaceTimeout(desc.getStatus()!.getSpec()!.getTimeout());
         const durationRaw = this.userService.workspaceTimeoutToDuration(duration);
@@ -491,7 +500,10 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
             req.setId(instance.id);
             req.setLevel(lvlmap.get(level)!);
 
-            const client = await this.workspaceManagerClientProvider.get(instance.region);
+            const client = await this.workspaceManagerClientProvider.get(
+                instance.region,
+                this.config.installationShortname,
+            );
             await client.controlAdmission(ctx, req);
         }
 
@@ -517,7 +529,10 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
         }
         await this.guardAccess({ kind: "workspaceInstance", subject: instance, workspace }, "get");
 
-        const client = await this.workspaceManagerClientProvider.get(instance.region);
+        const client = await this.workspaceManagerClientProvider.get(
+            instance.region,
+            this.config.installationShortname,
+        );
         const request = new TakeSnapshotRequest();
         request.setId(instance.id);
         request.setReturnImmediately(true);

--- a/components/server/src/user/user-deletion-service.ts
+++ b/components/server/src/user/user-deletion-service.ts
@@ -122,7 +122,10 @@ export class UserDeletionService {
                 req.setPolicy(StopWorkspacePolicy.NORMALLY);
 
                 try {
-                    const manager = await this.workspaceManagerClientProvider.get(wsi.region);
+                    const manager = await this.workspaceManagerClientProvider.get(
+                        wsi.region,
+                        this.config.installationShortname,
+                    );
                     await manager.stopWorkspace({}, req);
                 } catch (err) {
                     log.debug(

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -931,7 +931,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
             req.setId(instanceId);
             req.setClosed(wasClosed);
 
-            const client = await this.workspaceManagerClientProvider.get(wsi.region);
+            const client = await this.workspaceManagerClientProvider.get(wsi.region, this.config.installationShortname);
             await client.markActive(ctx, req);
 
             if (options && options.roundTripTime && Number.isFinite(options.roundTripTime)) {
@@ -1473,7 +1473,10 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
 
         const req = new DescribeWorkspaceRequest();
         req.setId(instance.id);
-        const client = await this.workspaceManagerClientProvider.get(instance.region);
+        const client = await this.workspaceManagerClientProvider.get(
+            instance.region,
+            this.config.installationShortname,
+        );
         const desc = await client.describeWorkspace(ctx, req);
 
         if (!desc.hasStatus()) {
@@ -1526,7 +1529,10 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         req.setExpose(true);
 
         try {
-            const client = await this.workspaceManagerClientProvider.get(runningInstance.region);
+            const client = await this.workspaceManagerClientProvider.get(
+                runningInstance.region,
+                this.config.installationShortname,
+            );
             await client.controlPort(ctx, req);
         } catch (e) {
             throw this.mapGrpcError(e);
@@ -1578,7 +1584,10 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         req.setSpec(spec);
         req.setExpose(false);
 
-        const client = await this.workspaceManagerClientProvider.get(instance.region);
+        const client = await this.workspaceManagerClientProvider.get(
+            instance.region,
+            this.config.installationShortname,
+        );
         await client.controlPort(ctx, req);
     }
 
@@ -1985,7 +1994,10 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
                 const req = new UpdateSSHKeyRequest();
                 req.setId(instance.id);
                 req.setKeysList(keys);
-                const cli = await this.workspaceManagerClientProvider.get(instance.region);
+                const cli = await this.workspaceManagerClientProvider.get(
+                    instance.region,
+                    this.config.installationShortname,
+                );
                 await cli.updateSSHPublicKey(ctx, req);
             } catch (err) {
                 const logCtx = { userId, instanceId: instance.id };
@@ -3184,9 +3196,19 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
             },
         );
         if (isMovedImageBuilder) {
-            return this.wsClusterImageBuilderClientProvider.getClient(user, workspace, instance);
+            return this.wsClusterImageBuilderClientProvider.getClient(
+                this.config.installationShortname,
+                user,
+                workspace,
+                instance,
+            );
         } else {
-            return this.imagebuilderClientProvider.getClient(user, workspace, instance);
+            return this.imagebuilderClientProvider.getClient(
+                this.config.installationShortname,
+                user,
+                workspace,
+                instance,
+            );
         }
     }
 

--- a/components/server/src/workspace/workspace-cluster-imagebuilder-client-provider.ts
+++ b/components/server/src/workspace/workspace-cluster-imagebuilder-client-provider.ts
@@ -32,13 +32,14 @@ export class WorkspaceClusterImagebuilderClientProvider implements ImageBuilderC
     protected readonly connectionCache = new Map<string, ImageBuilderClient>();
 
     async getClient(
+        applicationCluster: string,
         user: ExtendedUser,
         workspace: Workspace,
         instance: WorkspaceInstance,
     ): Promise<PromisifiedImageBuilderClient> {
-        const clusters = await this.clientProvider.getStartClusterSets(user, workspace, instance);
+        const clusters = await this.clientProvider.getStartClusterSets(applicationCluster, user, workspace, instance);
         for await (let cluster of clusters) {
-            const info = await this.source.getWorkspaceCluster(cluster.installation);
+            const info = await this.source.getWorkspaceCluster(cluster.installation, applicationCluster);
             if (!info) {
                 continue;
             }

--- a/components/server/src/workspace/workspace-deletion-service.ts
+++ b/components/server/src/workspace/workspace-deletion-service.ts
@@ -145,7 +145,9 @@ export class WorkspaceDeletionService {
         const span = TraceContext.startSpan("garbageCollectVolumeSnapshot", ctx);
 
         try {
-            const allClusters = await this.workspaceManagerClientProvider.getAllWorkspaceClusters();
+            const allClusters = await this.workspaceManagerClientProvider.getAllWorkspaceClusters(
+                this.config.installationShortname,
+            );
             // we need to do two things here:
             // 1. we want to delete volume snapshot object from all workspace clusters
             // 2. we want to delete cloud provider source snapshot
@@ -154,7 +156,10 @@ export class WorkspaceDeletionService {
 
             let availableClusters = allClusters.filter((c) => c.state === "available");
             for (let cluster of availableClusters) {
-                const client = await this.workspaceManagerClientProvider.get(cluster.name);
+                const client = await this.workspaceManagerClientProvider.get(
+                    cluster.name,
+                    this.config.installationShortname,
+                );
                 const req = new DeleteVolumeSnapshotRequest();
                 req.setId(vs.id);
                 req.setVolumeHandle(vs.volumeHandle);

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -441,7 +441,7 @@ export class WorkspaceStarter {
         req.setId(instanceId);
         req.setPolicy(policy || StopWorkspacePolicy.NORMALLY);
 
-        const client = await this.clientProvider.get(instanceRegion);
+        const client = await this.clientProvider.get(instanceRegion, this.config.installationShortname);
         await client.stopWorkspace(ctx, req);
     }
 
@@ -617,7 +617,12 @@ export class WorkspaceStarter {
         instance: WorkspaceInstance,
     ): Promise<StartWorkspaceResponse.AsObject | undefined> {
         let lastInstallation = "";
-        const clusters = await this.clientProvider.getStartClusterSets(euser, workspace, instance);
+        const clusters = await this.clientProvider.getStartClusterSets(
+            this.config.installationShortname,
+            euser,
+            workspace,
+            instance,
+        );
         for await (let cluster of clusters) {
             try {
                 // getStartManager will throw an exception if there's no cluster available and hence exit the loop
@@ -1974,9 +1979,19 @@ export class WorkspaceStarter {
             },
         );
         if (isMovedImageBuilder) {
-            return this.wsClusterImageBuilderClientProvider.getClient(user, workspace, instance);
+            return this.wsClusterImageBuilderClientProvider.getClient(
+                this.config.installationShortname,
+                user,
+                workspace,
+                instance,
+            );
         } else {
-            return this.imagebuilderClientProvider.getClient(user, workspace, instance);
+            return this.imagebuilderClientProvider.getClient(
+                this.config.installationShortname,
+                user,
+                workspace,
+                instance,
+            );
         }
     }
 }

--- a/components/ws-manager-api/typescript/src/client-provider.spec.ts
+++ b/components/ws-manager-api/typescript/src/client-provider.spec.ts
@@ -127,7 +127,11 @@ class TestClientProvider {
         this.provider = c.get(WorkspaceManagerClientProvider);
 
         // we don't actually want to try and connect here
-        this.provider.get = async (name: string, grpcOptions?: object): Promise<PromisifiedWorkspaceManagerClient> => {
+        this.provider.get = async (
+            name: string,
+            applicationCluster: string,
+            grpcOptions?: object,
+        ): Promise<PromisifiedWorkspaceManagerClient> => {
             return {} as PromisifiedWorkspaceManagerClient;
         };
     }
@@ -136,12 +140,13 @@ class TestClientProvider {
     public async getStartClusterSets() {
         await this.expectInstallations(
             [["a2", "a3"]],
-            await this.provider.getStartClusterSets({} as User, {} as Workspace, {} as WorkspaceInstance),
+            await this.provider.getStartClusterSets("xx01", {} as User, {} as Workspace, {} as WorkspaceInstance),
             "default case",
         );
         await this.expectInstallations(
             [["con1"], ["a2", "a3", "con1"]],
             await this.provider.getStartClusterSets(
+                "xx01",
                 { rolesOrPermissions: ["new-workspace-cluster"] } as User,
                 {} as Workspace,
                 {} as WorkspaceInstance,
@@ -151,6 +156,7 @@ class TestClientProvider {
         await this.expectInstallations(
             [["a2", "a3", "con2"]],
             await this.provider.getStartClusterSets(
+                "xx01",
                 { rolesOrPermissions: ["monitor"] } as User,
                 {} as Workspace,
                 {} as WorkspaceInstance,
@@ -159,7 +165,7 @@ class TestClientProvider {
         );
         await this.expectInstallations(
             [["a2", "a3"]],
-            await this.provider.getStartClusterSets({} as User, {} as Workspace, {} as WorkspaceInstance),
+            await this.provider.getStartClusterSets("xx01", {} as User, {} as Workspace, {} as WorkspaceInstance),
             "cluster has permission w/o precedence, user NOT",
         );
     }

--- a/components/ws-manager-bridge/src/bridge-controller.ts
+++ b/components/ws-manager-bridge/src/bridge-controller.ts
@@ -100,14 +100,14 @@ export class BridgeController {
             ...defaultGRPCOptions,
         };
         const clientProvider = async () => {
-            return this.clientProvider.get(cluster.name, grpcOptions);
+            return this.clientProvider.get(cluster.name, this.config.installation, grpcOptions);
         };
         bridge.start(cluster, clientProvider);
         return bridge;
     }
 
     protected async getAllWorkspaceClusters(): Promise<Map<string, WorkspaceClusterWoTLS>> {
-        const allInfos = await this.clientProvider.getAllWorkspaceClusters();
+        const allInfos = await this.clientProvider.getAllWorkspaceClusters(this.config.installation);
         const result: Map<string, WorkspaceClusterWoTLS> = new Map();
         for (const cluster of allInfos) {
             result.set(cluster.name, cluster);

--- a/components/ws-manager-bridge/src/cluster-service-server.ts
+++ b/components/ws-manager-bridge/src/cluster-service-server.ts
@@ -87,7 +87,7 @@ export class ClusterService implements IClusterServiceServer {
                 // check if the name or URL are already registered/in use
                 const req = call.request.toObject();
 
-                const clusterByNamePromise = this.clusterDB.findByName(req.name);
+                const clusterByNamePromise = this.clusterDB.findByName(req.name, this.config.installation);
                 const clusterByUrlPromise = this.clusterDB.findFiltered({
                     url: req.url,
                     applicationCluster: this.config.installation,
@@ -211,7 +211,7 @@ export class ClusterService implements IClusterServiceServer {
         this.queue.enqueue(async () => {
             try {
                 const req = call.request.toObject();
-                const cluster = await this.clusterDB.findByName(req.name);
+                const cluster = await this.clusterDB.findByName(req.name, this.config.installation);
                 if (!cluster) {
                     throw new GRPCError(
                         grpc.status.NOT_FOUND,

--- a/components/ws-manager-bridge/src/cluster-service-server.ts
+++ b/components/ws-manager-bridge/src/cluster-service-server.ts
@@ -88,7 +88,10 @@ export class ClusterService implements IClusterServiceServer {
                 const req = call.request.toObject();
 
                 const clusterByNamePromise = this.clusterDB.findByName(req.name);
-                const clusterByUrlPromise = this.clusterDB.findFiltered({ url: req.url });
+                const clusterByUrlPromise = this.clusterDB.findFiltered({
+                    url: req.url,
+                    applicationCluster: this.config.installation,
+                });
 
                 const [clusterByName, clusterByUrl] = await Promise.all([clusterByNamePromise, clusterByUrlPromise]);
 
@@ -303,7 +306,9 @@ export class ClusterService implements IClusterServiceServer {
                 const response = new ListResponse();
 
                 const dbClusterIdx = new Map<string, boolean>();
-                const allDBClusters = await this.clusterDB.findFiltered({});
+                const allDBClusters = await this.clusterDB.findFiltered({
+                    applicationCluster: this.config.installation,
+                });
                 for (const cluster of allDBClusters) {
                     const clusterStatus = convertToGRPC(cluster);
                     response.addStatus(clusterStatus);

--- a/components/ws-manager-bridge/src/cluster-service-server.ts
+++ b/components/ws-manager-bridge/src/cluster-service-server.ts
@@ -163,7 +163,12 @@ export class ClusterService implements IClusterServiceServer {
                     {},
                 );
                 if (enabled) {
-                    let classConstraints = await getSupportedWorkspaceClasses(this.clientProvider, newCluster, false);
+                    let classConstraints = await getSupportedWorkspaceClasses(
+                        this.clientProvider,
+                        newCluster,
+                        this.config.installation,
+                        false,
+                    );
                     newCluster.admissionConstraints = admissionConstraints.concat(classConstraints);
                 } else {
                     // try to connect to validate the config. Throws an exception if it fails.
@@ -305,7 +310,7 @@ export class ClusterService implements IClusterServiceServer {
                     dbClusterIdx.set(cluster.name, true);
                 }
 
-                const allCluster = await this.allClientProvider.getAllWorkspaceClusters();
+                const allCluster = await this.allClientProvider.getAllWorkspaceClusters(this.config.installation);
                 for (const cluster of allCluster) {
                     if (dbClusterIdx.get(cluster.name)) {
                         continue;

--- a/components/ws-manager-bridge/src/cluster-service-server.ts
+++ b/components/ws-manager-bridge/src/cluster-service-server.ts
@@ -288,7 +288,7 @@ export class ClusterService implements IClusterServiceServer {
                     );
                 }
 
-                await this.clusterDB.deleteByName(req.name);
+                await this.clusterDB.deleteByName(req.name, this.config.installation);
                 log.info({}, "cluster deregistered", { cluster: req.name });
                 this.triggerReconcile("deregister", req.name);
 

--- a/components/ws-manager-bridge/src/cluster-sync-service.ts
+++ b/components/ws-manager-bridge/src/cluster-sync-service.ts
@@ -51,7 +51,12 @@ export class ClusterSyncService {
         let allClusters = await this.clusterDB.findFiltered({});
         for (const cluster of allClusters) {
             try {
-                let supportedClasses = await getSupportedWorkspaceClasses(this.clientProvider, cluster, true);
+                let supportedClasses = await getSupportedWorkspaceClasses(
+                    this.clientProvider,
+                    cluster,
+                    this.config.installation,
+                    true,
+                );
                 let existingOtherConstraints = cluster.admissionConstraints?.filter((c) => c.type !== "has-class");
                 cluster.admissionConstraints = existingOtherConstraints?.concat(supportedClasses);
                 await this.clusterDB.save(cluster);
@@ -70,6 +75,7 @@ export class ClusterSyncService {
 export async function getSupportedWorkspaceClasses(
     clientProvider: WorkspaceManagerClientProvider,
     cluster: WorkspaceCluster,
+    applicationCluster: string,
     useCache: boolean,
 ) {
     let constraints = await new Promise<AdmissionConstraintHasClass[]>(async (resolve, reject) => {
@@ -78,7 +84,7 @@ export async function getSupportedWorkspaceClasses(
         };
         let client = useCache
             ? await (
-                  await clientProvider.get(cluster.name, grpcOptions)
+                  await clientProvider.get(cluster.name, applicationCluster, grpcOptions)
               ).client
             : clientProvider.createConnection(WorkspaceManagerClient, cluster, grpcOptions);
 

--- a/components/ws-manager-bridge/src/cluster-sync-service.ts
+++ b/components/ws-manager-bridge/src/cluster-sync-service.ts
@@ -48,7 +48,7 @@ export class ClusterSyncService {
         }
 
         log.debug("reconciling workspace classes...");
-        let allClusters = await this.clusterDB.findFiltered({});
+        let allClusters = await this.clusterDB.findFiltered({ applicationCluster: this.config.installation });
         for (const cluster of allClusters) {
             try {
                 let supportedClasses = await getSupportedWorkspaceClasses(


### PR DESCRIPTION
## Description

Redo of #14000 (reverted in https://github.com/gitpod-io/gitpod/pull/14029). The original lacked the changes to `components/gitpod-db/src/typeorm/workspace-cluster-db-impl.ts`. This PR adds that filtering and adds tests for it.

<details>
<summary>Context </summary>
As part of #9198  we want to start syncing the `d_b_workspace_cluster` table with `db-sync`.

Currently, the table differs between US and EU regions because each table contains only the data relevant to that region. For example, in the EU table, the `eu70` workspace cluster is marked as `available` and the `us70` cluster is `cordoned`.  In the US cluster `eu70` is `cordoned` and `us70` is `available`.

In order to sync the table we need to get to a point where there is no difference in the data in the table between EU and US regions.

To do that we will introduce a new field in the table called `applicationCluster` which records the name of the application cluster to which the record belongs. Thus, for each workspace cluster there will be two rows in Gitpod SaaS:

| name | applicationCluster | url | tls | state | ... |
| --- | --- | --- | --- | --- | --- |
| eu70 | eu02 | url | tls info | available | ... |
| eu70 | us02 | url | tls info | cordoned | ... |

Effectively the new `applicationCluster` column gives the table an extra dimension so that we can combine both tables (EU and US) into one.

#13722  added the column to the table and made `gpctl` fill the value when `gpctl register`ing a new workspace cluster. The value is taken from the `GITPOD_INSTALLATION_SHORTNAME` environment variable in `ws-manager-bridge`.
</details>

Make the cluster selection mechanism in `ws-manager-api` aware of the application cluster to which each workspace cluster is registered. Previously, the selection was by workspace cluster name only. Soon, as described in the **context** section, each region in gitpod will store records in the database for *all* workspace clusters - not just the ones in its region. This PR ensures that workspace clusters not in the same region as the application cluster will not be considered.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of https://github.com/gitpod-io/gitpod/issues/9198 and https://github.com/gitpod-io/gitpod/issues/13800

## How to test

Edit the `server` deployment and change the `WSMAN_CFG_MANAGERS` environment variable to change the `applicationCluster` to which the default workspace cluster in the preview environment is registered:

```json
[
  {
    "name": "",
    "url": "dns:///ws-manager:8080",
    "tls": {
      "ca": "/ws-manager-client-tls-certs/ca.crt",
      "crt": "/ws-manager-client-tls-certs/tls.crt",
      "key": "/ws-manager-client-tls-certs/tls.key"
    },
    "state": "available",
    "maxScore": 100,
    "score": 50,
    "govern": true,
    "admissionConstraints": null,
    "applicationCluster": "dev" // <- change this from "dev" to anything else
  }
]
```
The `WSMAN_CFG_MANAGERS` environment variable is base64 encoded.

Once the `server` deployment is edited it should no longer be possible to start a workspace as the only workspace cluster is now associated with a different (non-existent) application cluster:

<img width="743" alt="image" src="https://user-images.githubusercontent.com/8225907/197509275-61ebccb0-dace-44d0-9b54-72fbe3cb4629.png">

Edit the `WSMAN_CFG_MANAGERS` environment variable once more and set the `applicationCluster` field back to `"dev"`. Starting a workspace should now proceed as normal.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`