### PR TITLE
[server] Restart PVC workspace from latest valid backup

### DIFF
--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -336,14 +336,14 @@ export class WorkspaceStarter {
 
             // check if there has been an instance before, i.e. if this is a restart
             const pastInstances = await this.workspaceDb.trace({ span }).findInstances(workspace.id);
-            const hasValidBackup = pastInstances.some(
-                (i) => !!i.status && !!i.status.conditions && !i.status.conditions.failed,
-            );
             let lastValidWorkspaceInstance: WorkspaceInstance | undefined;
-            if (hasValidBackup) {
-                lastValidWorkspaceInstance = pastInstances.reduce((previousValue, currentValue) =>
-                    currentValue.creationTime > previousValue.creationTime ? currentValue : previousValue,
-                );
+            // Sorted from latest to oldest
+            for (const i of pastInstances.sort((a, b) => (a.creationTime > b.creationTime ? -1 : 1))) {
+                // We're trying to figure out whether there was a successful backup or not, and if yes for which instance
+                if (!!i.status.conditions && !i.status.conditions.failed) {
+                    lastValidWorkspaceInstance = i;
+                    break;
+                }
             }
 
             const ideConfig = await this.ideService.getIDEConfig();


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #14030

## How to test
 1. open a workspace on this PR
 1. make sure `user_pvc` is enabled for your user in ConfigCat
     1. after changing the rule, `kubectl rollout restart deployment/server`
 1. [login](https://gpl-14030-pvc.preview.gitpod-dev.com/workspaces)
 4. start a workspace
 5. check the workspace pod, and verify that the label `gitpod.io/pvcFeature: "true"` is present :heavy_check_mark: 
 6. stop the workspace
 7. start and stop that workspace another time
 8. manipulate the DB:
     1. Find the instances of your wrokspacId: `select id, creationTime, status from d_b_workspace_instance WHERE workspaceId = ' ... ';`
     2. Set the latest instance to `failed`; `UPDATE d_b_workspace_instance SET status = JSON_SET(status, "$.conditions.failed", 'test') WHERE id = ' ... ';`
 9. Start your workspace again, and see how it work :heavy_check_mark: 


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
