### PR TITLE
Update balance used progress indicator height

### DIFF
--- a/components/dashboard/src/components/UsageBasedBillingConfig.tsx
+++ b/components/dashboard/src/components/UsageBasedBillingConfig.tsx
@@ -247,7 +247,7 @@ export default function UsageBasedBillingConfig({ attributionId }: Props) {
                             )}
                         </div>
                         <div className="mt-2 flex">
-                            <progress className="h-4 flex-grow rounded-xl" value={currentUsage} max={usageLimit} />
+                            <progress className="h-2 flex-grow rounded-xl" value={currentUsage} max={usageLimit} />
                         </div>
                         <div className="bg-gray-100 dark:bg-gray-800 border-t border-gray-200 dark:border-gray-700 -m-4 p-4 mt-4 rounded-b-xl flex">
                             <div className="flex-grow">


### PR DESCRIPTION
## Description

This will update the progress indicator height in the billing page. See [relevant discussion](https://gitpod.slack.com/archives/C027AUU7BC3/p1666271013855189) (internal).

### Screenshots

| BEFORE | AFTER |
|-|-|
| <img width="1440" alt="Screenshot 2022-10-20 at 7 05 19 PM" src="https://user-images.githubusercontent.com/120486/197000900-2ef14c98-bf91-498e-98df-6e350aae4782.png"> | <img width="1440" alt="Screenshot 2022-10-20 at 7 05 33 PM" src="https://user-images.githubusercontent.com/120486/197000906-793456df-2bde-45f9-bb2b-7397992eede0.png"> |

## How to test

Go to usage for a personal account or a team.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Update balance used progress indicator height
```

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [X] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
