### PR TITLE
Tag VS Code images with `version`

### DIFF
--- a/.github/workflows/code-nightly.yml
+++ b/.github/workflows/code-nightly.yml
@@ -33,7 +33,8 @@ jobs:
           export LEEWAY_WORKSPACE_ROOT=$(pwd)
           headCommit=$(curl -H 'Accept: application/vnd.github.VERSION.sha' https://api.github.com/repos/gitpod-io/openvscode-server/commits/gp-code/main)
           cd components/ide/code
-          leeway build -Dversion=nightly -DimageRepoBase=eu.gcr.io/gitpod-core-dev/build -DcodeCommit=$headCommit -DcodeQuality=insider .:docker
+          codeVersion=$(curl https://raw.githubusercontent.com/gitpod-io/openvscode-server/$headCommit/package.json | jq .version)
+          leeway build -Dversion=nightly -DimageRepoBase=eu.gcr.io/gitpod-core-dev/build -DcodeCommit=$headCommit -DcodeVersion=$codeVersion -DcodeQuality=insider .:docker
       - name: Get previous job's status
         id: lastrun
         uses: filiptronicek/get-last-job-status@main

--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -8,6 +8,7 @@ defaultArgs:
   publishToJBMarketplace: true
   localAppVersion: unknown
   codeCommit: 4eb2aeb56544f66b029ff76d46e2fa5f863fbb6c
+  codeVersion: 1.72.3
   codeQuality: stable
   noVerifyJBPlugin: false
   intellijDownloadUrl: "https://download.jetbrains.com/idea/ideaIU-2022.2.3.tar.gz"

--- a/components/ide/code/BUILD.yaml
+++ b/components/ide/code/BUILD.yaml
@@ -10,6 +10,7 @@ packages:
       - imageRepoBase
       - codeCommit
       - codeQuality
+      - codeVersion
     config:
       dockerfile: leeway.Dockerfile
       metadata:
@@ -17,6 +18,7 @@ packages:
       buildArgs:
         CODE_COMMIT: ${codeCommit}
         CODE_QUALITY: ${codeQuality}
+        CODE_VERSION: ${codeVersion}
       image:
         - ${imageRepoBase}/ide/code:${version}
         - ${imageRepoBase}/ide/code:commit-${__git_commit}

--- a/components/ide/code/leeway.Dockerfile
+++ b/components/ide/code/leeway.Dockerfile
@@ -20,6 +20,7 @@ FROM gitpod/openvscode-server-linux-build-agent:bionic-x64 as code_builder
 
 ARG CODE_COMMIT
 ARG CODE_QUALITY
+ARG CODE_VERSION
 
 ARG NODE_VERSION=16.16.0
 ARG NVM_DIR="/root/.nvm"
@@ -45,6 +46,10 @@ RUN yarn --frozen-lockfile --network-timeout 180000
 # copy remote dependencies build in dependencies_builder image
 RUN rm -rf remote/node_modules/
 COPY --from=dependencies_builder /gp-code/remote/node_modules/ /gp-code/remote/node_modules/
+
+# check that the provided codeVersion is the correct one for the given codeCommit
+RUN commitVersion=$(cat package.json | jq -r .version) \
+    && if [ "$commitVersion" != "$CODE_VERSION" ]; then echo "Code version mismatch: $commitVersion != $CODE_VERSION"; exit 1; fi
 
 # update product.json
 RUN nameShort=$(jq --raw-output '.nameShort' product.json) && \
@@ -98,3 +103,8 @@ ENV GITPOD_ENV_SET_GP_OPEN_EDITOR="$GITPOD_ENV_SET_EDITOR"
 ENV GITPOD_ENV_SET_GIT_EDITOR="$GITPOD_ENV_SET_EDITOR --wait"
 ENV GITPOD_ENV_SET_GP_PREVIEW_BROWSER="/ide/bin/remote-cli/gitpod-code --preview"
 ENV GITPOD_ENV_SET_GP_EXTERNAL_BROWSER="/ide/bin/remote-cli/gitpod-code --openExternal"
+
+ARG CODE_VERSION
+ARG CODE_COMMIT
+LABEL "io.gitpod.ide.version"=$CODE_VERSION
+LABEL "io.gitpod.ide.commit"=$CODE_COMMIT


### PR DESCRIPTION
## Description

Adds the `io.gitpod.ide.commit` and `io.gitpod.ide.version` labels to all images for VS Code built inside of this repository. This will allow us to add an interface on Server API through [`ide-service`](https://github.com/gitpod-io/gitpod/tree/main/components/ide-service).

## How to test
1. Go to the Werft job results [[link](https://werft.gitpod-dev.com/job/gitpod-build-ft-add-ide-versions.0/results)]
2. Copy the third docker image link
	<img width="1322" alt="image" src="https://user-images.githubusercontent.com/29888641/197021674-f22c3f2c-c293-4b0f-baac-6ca84c006ba8.png">
3. Install [OCI tool](https://github.com/csweichel/oci-tool) within a workspace (could also do locally): `go install github.com/csweichel/oci-tool@latest`
4. Execute `oci-tool fetch image IMAGE_FROM_STEP_2 | jq .config.Labels` and check whether both attributes are present

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
