### PR TITLE
[server] remove port 3000 from default config

### DIFF
--- a/components/server/src/workspace/config-provider.ts
+++ b/components/server/src/workspace/config-provider.ts
@@ -251,11 +251,7 @@ export class ConfigProvider {
 
     public defaultConfig(): WorkspaceConfig {
         return {
-            ports: [
-                {
-                    port: 3000,
-                },
-            ],
+            ports: [],
             tasks: [],
             image: this.config.workspaceDefaults.workspaceImage,
         };


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #
Fixes [internal chat](https://gitpod.slack.com/archives/C01KGM9BH54/p1666285436242979)

## How to test
<!-- Provide steps to test this PR -->
- Open https://github.com/gitpod-io/empty workspace in preview env
- Check if port 3000 list in `gp ports list` or PortsView

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Fixes port 3000 becomes the default config of ports if there is no `.gitpod.yml` file
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
