### PR TITLE
Add missing entrypoint

### DIFF
--- a/components/public-api/typescript/package.json
+++ b/components/public-api/typescript/package.json
@@ -2,6 +2,8 @@
   "name": "@gitpod/public-api",
   "version": "0.1.5",
   "license": "UNLICENSED",
+  "main": "./lib/index.js",
+  "types": "./lib/index.d.ts",
   "files": [
     "lib"
   ],

--- a/components/public-api/typescript/src/gitpod/experimental/v1/index.ts
+++ b/components/public-api/typescript/src/gitpod/experimental/v1/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+export * from "./pagination_pb";
+export * from "./workspaces_pb";
+export * from "./workspaces_connectweb";


### PR DESCRIPTION
Adds missing entry point

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
