### PR TITLE
Fix entrypoint

### DIFF
--- a/components/public-api/typescript/package.json
+++ b/components/public-api/typescript/package.json
@@ -8,7 +8,7 @@
     "lib"
   ],
   "scripts": {
-    "build": "mkdir -p lib; tsc && cp -fR src/* lib",
+    "build": "mkdir -p lib; tsc",
     "watch": "leeway exec --package .:lib --transitive-dependencies --filter-type yarn --components --parallel -- tsc -w --preserveWatchOutput",
     "test": "mocha --opts mocha.opts './**/*.spec.ts' --exclude './node_modules/**'",
     "test:brk": "yarn test --inspect-brk"

--- a/components/public-api/typescript/src/index.ts
+++ b/components/public-api/typescript/src/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+export * as experimental from "./gitpod/experimental/v1";


### PR DESCRIPTION
Fix entrypoint

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
