### PR TITLE
[dev] Add latest version of `fish` shell to image

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
-image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:af-dev-update-image.8
+image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:af-add-fish-to-dev-image.0
 workspaceLocation: gitpod/gitpod-ws.code-workspace
 checkoutLocation: gitpod
 ports:

--- a/.werft/aks-installer-tests.yaml
+++ b/.werft/aks-installer-tests.yaml
@@ -65,7 +65,7 @@ pod:
       secretName: self-hosted-github-oauth
   containers:
   - name: nightly-test
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:af-dev-update-image.8
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:af-add-fish-to-dev-image.0
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/build.yaml
+++ b/.werft/build.yaml
@@ -76,7 +76,7 @@ pod:
     - name: MYSQL_TCP_PORT
       value: 23306
   - name: build
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:af-dev-update-image.8
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:af-add-fish-to-dev-image.0
     workingDir: /workspace
     imagePullPolicy: IfNotPresent
     resources:

--- a/.werft/cleanup-installer-tests.yaml
+++ b/.werft/cleanup-installer-tests.yaml
@@ -25,7 +25,7 @@ pod:
       secretName: aks-credentials
   containers:
   - name: nightly-test
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:af-dev-update-image.8
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:af-add-fish-to-dev-image.0
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/debug.yaml
+++ b/.werft/debug.yaml
@@ -54,7 +54,7 @@ pod:
     - name: MYSQL_TCP_PORT
       value: 23306
   - name: build
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:af-dev-update-image.8
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:af-add-fish-to-dev-image.0
     workingDir: /workspace
     imagePullPolicy: IfNotPresent
     volumeMounts:

--- a/.werft/eks-installer-tests.yaml
+++ b/.werft/eks-installer-tests.yaml
@@ -65,7 +65,7 @@ pod:
       secretName: self-hosted-github-oauth
   containers:
   - name: nightly-test
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:af-dev-update-image.8
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:af-add-fish-to-dev-image.0
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/gke-installer-tests.yaml
+++ b/.werft/gke-installer-tests.yaml
@@ -65,7 +65,7 @@ pod:
         secretName: self-hosted-github-oauth
   containers:
     - name: nightly-test
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:af-dev-update-image.8
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:af-add-fish-to-dev-image.0
       workingDir: /workspace
       imagePullPolicy: Always
       volumeMounts:

--- a/.werft/ide-integration-tests-startup.yaml
+++ b/.werft/ide-integration-tests-startup.yaml
@@ -17,7 +17,7 @@ pod:
         secretName: github-token-gitpod-bot
   containers:
     - name: gcloud
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:af-dev-update-image.8
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:af-add-fish-to-dev-image.0
       workingDir: /workspace
       imagePullPolicy: IfNotPresent
       env:

--- a/.werft/k3s-installer-tests.yaml
+++ b/.werft/k3s-installer-tests.yaml
@@ -65,7 +65,7 @@ pod:
       secretName: self-hosted-github-oauth
   containers:
   - name: nightly-test
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:af-dev-update-image.8
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:af-add-fish-to-dev-image.0
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/platform-delete-preview-environment.yaml
+++ b/.werft/platform-delete-preview-environment.yaml
@@ -25,7 +25,7 @@ pod:
         secretName: harvester-vm-ssh-keys
   containers:
     - name: build
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:af-dev-update-image.8
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:af-add-fish-to-dev-image.0
       workingDir: /workspace
       imagePullPolicy: IfNotPresent
       volumeMounts:

--- a/.werft/platform-delete-preview-environments-cron.yaml
+++ b/.werft/platform-delete-preview-environments-cron.yaml
@@ -29,7 +29,7 @@ pod:
         secretName: github-token-gitpod-bot
   containers:
     - name: build
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:af-dev-update-image.8
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:af-add-fish-to-dev-image.0
       workingDir: /workspace
       imagePullPolicy: IfNotPresent
       volumeMounts:

--- a/.werft/platform-trigger-werft-cleanup.yaml
+++ b/.werft/platform-trigger-werft-cleanup.yaml
@@ -22,7 +22,7 @@ pod:
         secretName: gcp-sa-gitpod-dev-deployer
   containers:
     - name: build
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:af-dev-update-image.8
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:af-add-fish-to-dev-image.0
       workingDir: /workspace
       imagePullPolicy: IfNotPresent
       volumeMounts:

--- a/.werft/workspace-run-integration-tests.yaml
+++ b/.werft/workspace-run-integration-tests.yaml
@@ -22,7 +22,7 @@ pod:
         secretName: github-token-gitpod-bot
   containers:
     - name: gcloud
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:af-dev-update-image.8
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:af-add-fish-to-dev-image.0
       workingDir: /workspace
       imagePullPolicy: IfNotPresent
       env:

--- a/dev/image/Dockerfile
+++ b/dev/image/Dockerfile
@@ -247,6 +247,11 @@ RUN curl https://raw.githubusercontent.com/replicatedhq/replicated/$(curl -s htt
     curl https://kots.io/install | sudo bash && \
     bash -c "echo . \<\(kubectl kots completion bash\) >> ~/.bashrc"
 
+# Install fish shell
+RUN sudo apt-add-repository -y ppa:fish-shell/release-3 && \
+    sudo apt update && \
+    sudo apt install -y fish
+
 # Copy our own tools
 ENV NEW_KUBECDL=1
 COPY dev-kubecdl--app/kubecdl dev-gpctl--app/gpctl dev-preview-previewctl--cli/previewctl /usr/bin/


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Add the latest version of the [`fish` shell](https://fishshell.com/) to the Gitpod dev image.

`fish` is installed as part of the [base image](https://github.com/gitpod-io/workspace-images/blob/99de871d7ff8b7d914f34fff166398673202d63d/base/Dockerfile#L30), but that version is now 4 minor versions out of date and missing several features.

## Related Issue(s)
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
