### PR TITLE
[server] Remove createStripeCustomer, handled by usage instead

### DIFF
--- a/components/server/ee/src/user/stripe-service.ts
+++ b/components/server/ee/src/user/stripe-service.ts
@@ -16,9 +16,6 @@ import {
 } from "../../../src/prometheus-metrics";
 import { BillingServiceClient, BillingServiceDefinition } from "@gitpod/usage-api/lib/usage/v1/billing.pb";
 
-const POLL_CREATED_CUSTOMER_INTERVAL_MS = 1000;
-const POLL_CREATED_CUSTOMER_MAX_ATTEMPTS = 30;
-
 @injectable()
 export class StripeService {
     @inject(Config) protected readonly config: Config;
@@ -56,34 +53,6 @@ export class StripeService {
             log.error("Failed to get stripe customer", e, { attributionId });
             throw e;
         }
-    }
-
-    async createCustomerForAttributionId(
-        attributionId: string,
-        preferredCurrency: string,
-        billingEmail?: string,
-        billingName?: string,
-    ): Promise<string> {
-        if (await this.findCustomerByAttributionId(attributionId)) {
-            throw new Error(`A Stripe customer already exists for '${attributionId}'`);
-        }
-        // Create the customer in Stripe
-        const customer = await reportStripeOutcome("customers_create", () => {
-            return this.getStripe().customers.create({
-                email: billingEmail,
-                name: billingName,
-                metadata: { attributionId, preferredCurrency },
-            });
-        });
-        // Wait for the customer to show up in Stripe search results before proceeding
-        let attempts = 0;
-        while (!(await this.findCustomerByAttributionId(attributionId))) {
-            await new Promise((resolve) => setTimeout(resolve, POLL_CREATED_CUSTOMER_INTERVAL_MS));
-            if (++attempts > POLL_CREATED_CUSTOMER_MAX_ATTEMPTS) {
-                throw new Error(`Could not confirm Stripe customer creation for '${attributionId}'`);
-            }
-        }
-        return customer.id;
     }
 
     async setDefaultPaymentMethodForCustomer(customerId: string, setupIntentId: string): Promise<void> {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
We're removing the feature flag (by defaulting to the featureFlag true behaviour) and corresponding old implementation.

Metrics show this has worked well in production.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
