### PR TITLE
[pvc] fix prestoophook.sh from failing if prebuild log does not exist

### DIFF
--- a/components/content-service/pkg/layer/provider.go
+++ b/components/content-service/pkg/layer/provider.go
@@ -522,7 +522,7 @@ git config --global --add safe.directory ${GITPOD_REPO_ROOT}
 git status --porcelain=v2 --branch -uall > /.workspace/prestophookdata/git_status.txt
 git log --pretty='%h: %s' --branches --not --remotes > /.workspace/prestophookdata/git_log_1.txt
 git log --pretty=%H -n 1 > /.workspace/prestophookdata/git_log_2.txt
-cp /workspace/.gitpod/prebuild-log* /.workspace/prestophookdata/
+cp /workspace/.gitpod/prebuild-log* /.workspace/prestophookdata/ | true
 `
 
 var pvcEnabledFile = `PVC`


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Make sure that script will not fail if prebuild log file does not exist (for workspaces that were open without prebuild).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
none
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
