### PR TITLE
content-service: Ignore git hooks when checkout 

### DIFF
--- a/components/content-service/pkg/initializer/git.go
+++ b/components/content-service/pkg/initializer/git.go
@@ -198,13 +198,13 @@ func (ws *GitInitializer) realizeCloneTarget(ctx context.Context) (err error) {
 			return err
 		}
 
-		if err := ws.Git(ctx, "checkout", "-B", branchName, "origin/"+ws.CloneTarget); err != nil {
+		if err := ws.Git(ctx, "-c", "core.hooksPath=/dev/null", "checkout", "-B", branchName, "origin/"+ws.CloneTarget); err != nil {
 			log.WithError(err).WithField("remoteURI", ws.RemoteURI).WithField("branch", branchName).Error("Cannot fetch remote branch")
 			return err
 		}
 	case LocalBranch:
 		// checkout local branch based on remote HEAD
-		if err := ws.Git(ctx, "checkout", "-B", ws.CloneTarget, "origin/HEAD", "--no-track"); err != nil {
+		if err := ws.Git(ctx, "-c", "core.hooksPath=/dev/null", "checkout", "-B", ws.CloneTarget, "origin/HEAD", "--no-track"); err != nil {
 			return err
 		}
 	case RemoteCommit:
@@ -216,7 +216,7 @@ func (ws *GitInitializer) realizeCloneTarget(ctx context.Context) (err error) {
 		}
 
 		// checkout specific commit
-		if err := ws.Git(ctx, "checkout", ws.CloneTarget); err != nil {
+		if err := ws.Git(ctx, "-c", "core.hooksPath=/dev/null", "checkout", ws.CloneTarget); err != nil {
 			return err
 		}
 	default:

--- a/test/tests/workspace/git_hooks_test.go
+++ b/test/tests/workspace/git_hooks_test.go
@@ -1,0 +1,117 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package workspace
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+
+	"github.com/gitpod-io/gitpod/test/pkg/integration"
+)
+
+type GitHooksTest struct {
+	Name          string
+	ContextURL    string
+	WorkspaceRoot string
+}
+
+func GithuHooksTest(t *testing.T) {
+	userToken, _ := os.LookupEnv("USER_TOKEN")
+	integration.SkipWithoutUsername(t, username)
+	integration.SkipWithoutUserToken(t, userToken)
+
+	parallelLimiter := make(chan struct{}, 2)
+
+	tests := []GitHooksTest{
+		{
+			Name:          "husky",
+			ContextURL:    "https://github.com/gitpod-io/gitpod-test-repo/tree/husky",
+			WorkspaceRoot: "/workspace/template-golang-cli",
+		},
+	}
+
+	f := features.New("git hooks").
+		WithLabel("component", "server").
+		Assess("should run git hooks tests", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			ffs := []struct {
+				Name string
+				FF   string
+			}{
+				{Name: "classic"},
+				{Name: "pvc", FF: "persistent_volume_claim"},
+			}
+
+			for _, ff := range ffs {
+				func() {
+					ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+					defer cancel()
+
+					api := integration.NewComponentAPI(ctx, cfg.Namespace(), kubeconfig, cfg.Client())
+					defer api.Done(t)
+
+					username := username + ff.Name
+					userId, err := api.CreateUser(username, userToken)
+					if err != nil {
+						t.Fatal(err)
+					}
+
+					if err := api.UpdateUserFeatureFlag(userId, ff.FF); err != nil {
+						t.Fatal(err)
+					}
+				}()
+			}
+
+			for _, ff := range ffs {
+				for _, test := range tests {
+					t.Run(test.ContextURL+"_"+ff.Name, func(t *testing.T) {
+						t.Parallel()
+
+						t.Logf("Waiting %s", test.ContextURL+"_"+ff.Name)
+
+						parallelLimiter <- struct{}{}
+						defer func() {
+							<-parallelLimiter
+						}()
+
+						t.Logf("Running %s", test.ContextURL+"_"+ff.Name)
+
+						username := username + ff.Name
+
+						ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+						defer cancel()
+
+						api := integration.NewComponentAPI(ctx, cfg.Namespace(), kubeconfig, cfg.Client())
+						defer api.Done(t)
+
+						_, stopWs, err := integration.LaunchWorkspaceFromContextURL(t, ctx, test.ContextURL, username, api)
+						if err != nil {
+							t.Fatal(err)
+						}
+
+						defer func() {
+							sctx, scancel := context.WithTimeout(context.Background(), 10*time.Minute)
+							defer scancel()
+
+							sapi := integration.NewComponentAPI(sctx, cfg.Namespace(), kubeconfig, cfg.Client())
+							defer sapi.Done(t)
+
+							if _, err := stopWs(true, sapi); err != nil {
+								t.Fatal(err)
+							}
+						}()
+					})
+				}
+			}
+			return ctx
+		}).
+		Feature()
+
+	testEnv.Test(t, f)
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

It is not expected that hooks will be executed at checkout, i.e. prebuild, etc.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/ops/issues/5740

## How to test
<!-- Provide steps to test this PR -->

There are two way to check this PR
1. Open https://github.com/gitpod-io/gitpod-test-repo/tree/husky and check if not exist `output.txt`
    - https://to-git-hooks.preview.gitpod-dev.com/#https://github.com/gitpod-io/gitpod-test-repo/tree/husky
2. Run the integration test

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Fix a bug that a workspace is not started when there was a checkout hook
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
No

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-integration-tests=workspace
      Valid options are `all`, `workspace`, `webapp`, `ide`
