### PR TITLE
[supervisor] localify struct of ports sort

### DIFF
--- a/components/gitpod-protocol/go/gitpod-service.go
+++ b/components/gitpod-protocol/go/gitpod-service.go
@@ -1756,7 +1756,6 @@ type PortConfig struct {
 	Visibility  string  `json:"visibility,omitempty"`
 	Description string  `json:"description,omitempty"`
 	Name        string  `json:"name,omitempty"`
-	Sort        uint32  `json:"sort,omitempty"`
 }
 
 // TaskConfig is the TaskConfig message type

--- a/components/supervisor/pkg/ports/ports-config.go
+++ b/components/supervisor/pkg/ports/ports-config.go
@@ -16,6 +16,8 @@ import (
 	"github.com/gitpod-io/gitpod/supervisor/pkg/config"
 )
 
+const NON_CONFIGED_BASIC_SCORE = 100000
+
 // RangeConfig is a port range config.
 type RangeConfig struct {
 	gitpod.PortsItems
@@ -190,7 +192,7 @@ func parseWorkspaceConfigs(ports []*gitpod.PortConfig) (portConfigs map[uint32]*
 			portConfigs[port] = &SortConfig{
 				PortConfig: *config,
 				// We don't care about workspace configs but instance config
-				Sort: 0,
+				Sort: NON_CONFIGED_BASIC_SCORE - 1,
 			}
 		}
 	}

--- a/components/supervisor/pkg/ports/ports-config_test.go
+++ b/components/supervisor/pkg/ports/ports-config_test.go
@@ -89,7 +89,7 @@ func TestPortsConfig(t *testing.T) {
 			Expectation: &PortConfigTestExpectations{
 				InstanceRangeConfigs: []*RangeConfig{
 					{
-						PortsItems: &gitpod.PortsItems{
+						PortsItems: gitpod.PortsItems{
 							Port:        "9229-9339",
 							OnOpen:      "ignore",
 							Visibility:  "public",
@@ -136,7 +136,7 @@ func TestPortsConfig(t *testing.T) {
 				t.Fatal(err)
 			case change := <-updates:
 				for _, config := range change.workspaceConfigs {
-					actual.WorkspaceConfigs = append(actual.WorkspaceConfigs, config)
+					actual.WorkspaceConfigs = append(actual.WorkspaceConfigs, &config.PortConfig)
 				}
 			}
 
@@ -150,7 +150,7 @@ func TestPortsConfig(t *testing.T) {
 				case change := <-updates:
 					actual.InstanceRangeConfigs = change.instanceRangeConfigs
 					for _, config := range change.instancePortConfigs {
-						actual.InstancePortConfigs = append(actual.InstancePortConfigs, config)
+						actual.InstancePortConfigs = append(actual.InstancePortConfigs, &config.PortConfig)
 					}
 				}
 			}

--- a/components/supervisor/pkg/ports/ports.go
+++ b/components/supervisor/pkg/ports/ports.go
@@ -291,7 +291,7 @@ func (pm *Manager) updateState(ctx context.Context, exposed []ExposedPort, serve
 	stateChanged := !reflect.DeepEqual(newState, pm.state)
 	pm.state = newState
 
-	if !stateChanged {
+	if !stateChanged && configured == nil {
 		return
 	}
 

--- a/components/supervisor/pkg/ports/ports.go
+++ b/components/supervisor/pkg/ports/ports.go
@@ -748,8 +748,8 @@ func (pm *Manager) getStatus() []*api.PortsStatus {
 	}
 	sort.SliceStable(res, func(i, j int) bool {
 		// Max number of port 65536
-		score1 := 100000 + res[i].LocalPort
-		score2 := 100000 + res[j].LocalPort
+		score1 := NON_CONFIGED_BASIC_SCORE + res[i].LocalPort
+		score2 := NON_CONFIGED_BASIC_SCORE + res[j].LocalPort
 		if c, _, ok := pm.configs.Get(res[i].LocalPort); ok {
 			score1 = c.Sort
 		}

--- a/components/supervisor/pkg/ports/ports_test.go
+++ b/components/supervisor/pkg/ports/ports_test.go
@@ -63,8 +63,8 @@ func TestPortsUpdateState(t *testing.T) {
 				[]*api.PortsStatus{{LocalPort: 8080, Served: true, OnOpen: api.PortsStatus_notify_private}},
 				[]*api.PortsStatus{{LocalPort: 8080, Served: true, OnOpen: api.PortsStatus_notify_private, Exposed: &api.ExposedPortInfo{OnExposed: api.OnPortExposedAction_notify_private, Visibility: api.PortVisibility_private, Url: "foobar"}}},
 				[]*api.PortsStatus{{LocalPort: 8080, Served: true, OnOpen: api.PortsStatus_notify_private, Exposed: &api.ExposedPortInfo{OnExposed: api.OnPortExposedAction_notify_private, Visibility: api.PortVisibility_private, Url: "foobar"}}, {LocalPort: 60000, Served: true}},
-				[]*api.PortsStatus{{LocalPort: 60000, Served: true}},
-				{},
+				[]*api.PortsStatus{{LocalPort: 8080, Served: false, OnOpen: api.PortsStatus_notify_private, Exposed: &api.ExposedPortInfo{OnExposed: api.OnPortExposedAction_notify_private, Visibility: api.PortVisibility_private, Url: "foobar"}}, {LocalPort: 60000, Served: true}},
+				[]*api.PortsStatus{{LocalPort: 8080, Served: false, OnOpen: api.PortsStatus_notify_private, Exposed: &api.ExposedPortInfo{OnExposed: api.OnPortExposedAction_notify_private, Visibility: api.PortVisibility_private, Url: "foobar"}}},
 			},
 		},
 		{


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
- Move sort property exists in supervisor only to address https://github.com/gitpod-io/gitpod/pull/13788#discussion_r1001082758
- Don't filter not served ports

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

- Follow PR https://github.com/gitpod-io/gitpod/pull/13788
- And check if functions of ports working

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
