### PR TITLE
Refactor previewctl get-name

### DIFF
--- a/dev/preview/previewctl/cmd/get_name.go
+++ b/dev/preview/previewctl/cmd/get_name.go
@@ -12,12 +12,19 @@ import (
 	"github.com/gitpod-io/gitpod/previewctl/pkg/preview"
 )
 
-func getNameCmd() *cobra.Command {
+func newGetNameCmd(branch string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "get-name",
 		Short: "Returns the name of the preview for the corresponding branch.",
-		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Println(preview.GetName(branch))
+		RunE: func(cmd *cobra.Command, args []string) error {
+			branch, err := preview.GetName(branch)
+			if err != nil {
+				return err
+			}
+
+			fmt.Println(branch)
+
+			return nil
 		},
 	}
 

--- a/dev/preview/previewctl/cmd/root.go
+++ b/dev/preview/previewctl/cmd/root.go
@@ -24,7 +24,7 @@ func RootCmd(logger *logrus.Logger) *cobra.Command {
 
 	cmd.AddCommand(
 		installContextCmd(logger),
-		getNameCmd(),
+		newGetNameCmd(branch),
 		listPreviewsCmd(logger),
 		SSHPreviewCmd(logger),
 		newGetCredentialsCommand(logger),

--- a/dev/preview/previewctl/pkg/preview/preview.go
+++ b/dev/preview/previewctl/pkg/preview/preview.go
@@ -22,6 +22,10 @@ import (
 	"github.com/gitpod-io/gitpod/previewctl/pkg/k8s"
 )
 
+var (
+	ErrBranchNotExist = errors.New("branch doesn't exist")
+)
+
 const harvesterContextName = "harvester"
 
 type Preview struct {
@@ -37,20 +41,13 @@ type Preview struct {
 }
 
 func New(branch string, logger *logrus.Logger) (*Preview, error) {
-	if branch == "" {
-		out, err := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD").Output()
-		if err != nil {
-			logger.WithFields(logrus.Fields{"err": err}).Fatal("Could not retrieve branch name.")
-		}
-		branch = string(out)
-	} else {
-		_, err := exec.Command("git", "rev-parse", "--verify", branch).Output()
-		if err != nil {
-			logger.WithFields(logrus.Fields{"branch": branch, "err": err}).Fatal("Branch does not exist.")
-		}
+	branch, err := GetName(branch)
+	if err != nil {
+		return nil, err
 	}
 
 	branch = strings.TrimRight(branch, "\n")
+
 	logEntry := logger.WithFields(logrus.Fields{"branch": branch})
 
 	harvesterConfig, err := k8s.NewFromDefaultConfigWithContext(logEntry.Logger, harvesterContextName)
@@ -60,8 +57,8 @@ func New(branch string, logger *logrus.Logger) (*Preview, error) {
 
 	return &Preview{
 		branch:          branch,
-		namespace:       fmt.Sprintf("preview-%s", GetName(branch)),
-		name:            GetName(branch),
+		namespace:       fmt.Sprintf("preview-%s", branch),
+		name:            branch,
 		kubeClient:      harvesterConfig,
 		logger:          logEntry,
 		vmiCreationTime: nil,
@@ -167,7 +164,33 @@ func SSHPreview(branch string) error {
 	return sshCommand.Run()
 }
 
-func GetName(branch string) string {
+func branchFromGit(branch string) (string, error) {
+	if branch == "" {
+		out, err := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD").Output()
+		if err != nil {
+			return "", errors.Wrap(err, "Could not retrieve branch name.")
+		}
+
+		branch = string(out)
+	} else {
+		_, err := exec.Command("git", "rev-parse", "--verify", branch).Output()
+		if err != nil {
+			return "", errors.CombineErrors(err, ErrBranchNotExist)
+		}
+	}
+
+	return branch, nil
+}
+
+func GetName(branch string) (string, error) {
+	var err error
+	if branch == "" {
+		branch, err = branchFromGit(branch)
+		if err != nil {
+			return "", err
+		}
+	}
+
 	withoutRefsHead := strings.Replace(branch, "/refs/heads/", "", 1)
 	lowerCased := strings.ToLower(withoutRefsHead)
 
@@ -182,7 +205,7 @@ func GetName(branch string) string {
 		sanitizedBranch = sanitizedBranch[0:10] + hashedBranch[0:10]
 	}
 
-	return sanitizedBranch
+	return sanitizedBranch, nil
 }
 
 func (p *Preview) ListAllPreviews() error {

--- a/dev/preview/previewctl/pkg/preview/preview_test.go
+++ b/dev/preview/previewctl/pkg/preview/preview_test.go
@@ -45,7 +45,10 @@ func TestGetPreviewName(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		previewName := preview.GetName(tc.branch)
+		previewName, err := preview.GetName(tc.branch)
+		if err != nil {
+			t.Fatal(err)
+		}
 
 		if tc.expectedResult != previewName {
 			log.Fatalf("Test '%s' failed. Expected '%s' but got '%s'", tc.testName, tc.expectedResult, previewName)


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Refactor a bit `previewctl get-name`

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
