### PR TITLE
Add message: Prebuilds have been paused

### DIFF
--- a/components/gitpod-protocol/src/teams-projects-protocol.ts
+++ b/components/gitpod-protocol/src/teams-projects-protocol.ts
@@ -45,6 +45,7 @@ export namespace Project {
 
     export interface Overview {
         branches: BranchDetails[];
+        isConsideredInactive?: boolean;
     }
 
     export namespace Overview {

--- a/components/server/ee/src/prebuilds/prebuild-manager.ts
+++ b/components/server/ee/src/prebuilds/prebuild-manager.ts
@@ -394,14 +394,7 @@ export class PrebuildManager {
     }
 
     private async shouldSkipInactiveProject(project: Project): Promise<boolean> {
-        const usage = await this.projectService.getProjectUsage(project.id);
-        if (!usage?.lastWorkspaceStart) {
-            return false;
-        }
-        const now = Date.now();
-        const lastUse = new Date(usage.lastWorkspaceStart).getTime();
-        const inactiveProjectTime = 1000 * 60 * 60 * 24 * 7 * 1; // 1 week
-        return now - lastUse > inactiveProjectTime;
+        return await this.projectService.isProjectConsideredInactive(project.id);
     }
 
     private async shouldSkipInactiveRepository(ctx: TraceContext, cloneURL: string): Promise<boolean> {

--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -2620,6 +2620,11 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
 
         const context = (await this.contextParser.handle(ctx, user, contextURL)) as CommitContext;
 
+        // HACK: treat manual triggered prebuild as a reset for the inactivity state
+        await this.projectDB.updateProjectUsage(project.id, {
+            lastWorkspaceStart: new Date().toISOString(),
+        });
+
         const prebuild = await this.prebuildManager.startPrebuild(ctx, {
             context,
             user,

--- a/components/server/src/projects/projects-service.ts
+++ b/components/server/src/projects/projects-service.ts
@@ -279,6 +279,17 @@ export class ProjectsService {
         return this.projectDB.getProjectUsage(projectId);
     }
 
+    async isProjectConsideredInactive(projectId: string): Promise<boolean> {
+        const usage = await this.getProjectUsage(projectId);
+        if (!usage?.lastWorkspaceStart) {
+            return false;
+        }
+        const now = Date.now();
+        const lastUse = new Date(usage.lastWorkspaceStart).getTime();
+        const inactiveProjectTime = 1000 * 60 * 60 * 24 * 7 * 1; // 1 week
+        return now - lastUse > inactiveProjectTime;
+    }
+
     async getPrebuildEvents(cloneUrl: string): Promise<PrebuildEvent[]> {
         const events = await this.webhookEventDB.findByCloneUrl(cloneUrl, 100);
         return events.map((we) => ({

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -2345,7 +2345,11 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         }
         await this.guardProjectOperation(user, projectId, "get");
         try {
-            return await this.projectsService.getProjectOverviewCached(user, project);
+            const result = await this.projectsService.getProjectOverviewCached(user, project);
+            if (result) {
+                result.isConsideredInactive = await this.projectsService.isProjectConsideredInactive(project.id);
+            }
+            return result;
         } catch (error) {
             if (UnauthorizedError.is(error)) {
                 throw new ResponseError(ErrorCodes.NOT_AUTHENTICATED, "Unauthorized", error.data);


### PR DESCRIPTION
## Description
With this PR we introduce a warning message on the Project overview when it is considered inactive. A `Resume prebuilds` action allows to trigger a new prebuild on the default branch.  

<img width="1378" alt="Screen Shot 2022-10-26 at 15 17 34" src="https://user-images.githubusercontent.com/914497/198036483-0049d04e-3738-478b-a0e5-9d6a1d3ade1d.png">



## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #9232

## How to test
1. Create a project and start a workspace for it. 
2. Use this statement to set the project inactive
  `update d_b_project_usage set lastWorkspaceStart = '2021-10-21T13:02:40.674Z';`
3. Check the project page for the warning.
4. Select the resume action.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Show warning for inactive projects and allow to resume prebuilds again. 
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
