### PR TITLE
Enable protected secrets by default

### DIFF
--- a/components/ws-manager/pkg/manager/create.go
+++ b/components/ws-manager/pkg/manager/create.go
@@ -643,6 +643,11 @@ func setProtectedSecrets(pod *corev1.Pod, req *api.StartWorkspaceRequest) {
 				continue
 			}
 
+			// already sourced from somewhere else
+			if env.ValueFrom != nil {
+				continue
+			}
+
 			env.Value = ""
 			env.ValueFrom = &corev1.EnvVarSource{
 				SecretKeyRef: &corev1.SecretKeySelector{

--- a/components/ws-manager/pkg/manager/testdata/cdwp_admission.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_admission.golden
@@ -136,7 +136,12 @@
                         },
                         {
                             "name": "foo",
-                            "value": "bar"
+                            "valueFrom": {
+                                "secretKeyRef": {
+                                    "name": "ws-test",
+                                    "key": "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae"
+                                }
+                            }
                         },
                         {
                             "name": "GITPOD_INTERVAL",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_class.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_class.golden
@@ -136,7 +136,12 @@
                         },
                         {
                             "name": "foo",
-                            "value": "bar"
+                            "valueFrom": {
+                                "secretKeyRef": {
+                                    "name": "ws-test",
+                                    "key": "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae"
+                                }
+                            }
                         },
                         {
                             "name": "GITPOD_INTERVAL",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_empty_resource_req.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_empty_resource_req.golden
@@ -132,7 +132,12 @@
                         },
                         {
                             "name": "foo",
-                            "value": "bar"
+                            "valueFrom": {
+                                "secretKeyRef": {
+                                    "name": "ws-test",
+                                    "key": "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae"
+                                }
+                            }
                         },
                         {
                             "name": "GITPOD_INTERVAL",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_envvars.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_envvars.golden
@@ -160,14 +160,19 @@
                         },
                         {
                             "name": "something_without_gitpod",
-                            "value": "will make it"
+                            "valueFrom": {
+                                "secretKeyRef": {
+                                    "name": "ws-test",
+                                    "key": "c1cf1305c2eb1eb4b0ce3f327b383751e785615720db2bcafc5227788067761c"
+                                }
+                            }
                         },
                         {
                             "name": "one_from_a_secret",
                             "valueFrom": {
                                 "secretKeyRef": {
-                                    "name": "some-secret",
-                                    "key": "some-key"
+                                    "name": "ws-test",
+                                    "key": "31ba5230e08a8d69893703c936aaf570c76246cac7a2f7d4cfd28b8ab180631b"
                                 }
                             }
                         },

--- a/components/ws-manager/pkg/manager/testdata/cdwp_envvars.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_envvars.golden
@@ -171,8 +171,8 @@
                             "name": "one_from_a_secret",
                             "valueFrom": {
                                 "secretKeyRef": {
-                                    "name": "ws-test",
-                                    "key": "31ba5230e08a8d69893703c936aaf570c76246cac7a2f7d4cfd28b8ab180631b"
+                                    "name": "some-secret",
+                                    "key": "some-key"
                                 }
                             }
                         },

--- a/components/ws-manager/pkg/manager/testdata/cdwp_fullworkspacebackup.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_fullworkspacebackup.golden
@@ -126,7 +126,12 @@
                         },
                         {
                             "name": "foo",
-                            "value": "bar"
+                            "valueFrom": {
+                                "secretKeyRef": {
+                                    "name": "ws-test",
+                                    "key": "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae"
+                                }
+                            }
                         },
                         {
                             "name": "GITPOD_INTERVAL",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_imagebuild.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_imagebuild.golden
@@ -144,7 +144,12 @@
                         },
                         {
                             "name": "foo",
-                            "value": "bar"
+                            "valueFrom": {
+                                "secretKeyRef": {
+                                    "name": "imagebuild-foobar",
+                                    "key": "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae"
+                                }
+                            }
                         },
                         {
                             "name": "GITPOD_INTERVAL",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_imagebuild_template.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_imagebuild_template.golden
@@ -144,7 +144,12 @@
                         },
                         {
                             "name": "foo",
-                            "value": "bar"
+                            "valueFrom": {
+                                "secretKeyRef": {
+                                    "name": "imagebuild-foobar",
+                                    "key": "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae"
+                                }
+                            }
                         },
                         {
                             "name": "GITPOD_INTERVAL",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_no_ideimage.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_no_ideimage.golden
@@ -132,7 +132,12 @@
                         },
                         {
                             "name": "foo",
-                            "value": "bar"
+                            "valueFrom": {
+                                "secretKeyRef": {
+                                    "name": "ws-test",
+                                    "key": "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae"
+                                }
+                            }
                         },
                         {
                             "name": "GITPOD_INTERVAL",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_prebuild.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_prebuild.golden
@@ -132,7 +132,12 @@
                         },
                         {
                             "name": "foo",
-                            "value": "bar"
+                            "valueFrom": {
+                                "secretKeyRef": {
+                                    "name": "prebuild-foobar",
+                                    "key": "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae"
+                                }
+                            }
                         },
                         {
                             "name": "GITPOD_INTERVAL",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_prebuild_template.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_prebuild_template.golden
@@ -132,7 +132,12 @@
                         },
                         {
                             "name": "foo",
-                            "value": "bar"
+                            "valueFrom": {
+                                "secretKeyRef": {
+                                    "name": "prebuild-foobar",
+                                    "key": "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae"
+                                }
+                            }
                         },
                         {
                             "name": "GITPOD_INTERVAL",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_prebuild_template_override_resources.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_prebuild_template_override_resources.golden
@@ -132,7 +132,12 @@
                         },
                         {
                             "name": "foo",
-                            "value": "bar"
+                            "valueFrom": {
+                                "secretKeyRef": {
+                                    "name": "prebuild-foobar",
+                                    "key": "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae"
+                                }
+                            }
                         },
                         {
                             "name": "GITPOD_INTERVAL",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_readinessprobe.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_readinessprobe.golden
@@ -132,7 +132,12 @@
                         },
                         {
                             "name": "foo",
-                            "value": "bar"
+                            "valueFrom": {
+                                "secretKeyRef": {
+                                    "name": "ws-test",
+                                    "key": "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae"
+                                }
+                            }
                         },
                         {
                             "name": "GITPOD_INTERVAL",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_sshkeys.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_sshkeys.golden
@@ -133,7 +133,12 @@
                         },
                         {
                             "name": "foo",
-                            "value": "bar"
+                            "valueFrom": {
+                                "secretKeyRef": {
+                                    "name": "ws-test",
+                                    "key": "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae"
+                                }
+                            }
                         },
                         {
                             "name": "GITPOD_INTERVAL",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_sys_envvars.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_sys_envvars.golden
@@ -175,8 +175,8 @@
                             "name": "one_from_a_secret",
                             "valueFrom": {
                                 "secretKeyRef": {
-                                    "name": "ws-test",
-                                    "key": "31ba5230e08a8d69893703c936aaf570c76246cac7a2f7d4cfd28b8ab180631b"
+                                    "name": "some-secret",
+                                    "key": "some-key"
                                 }
                             }
                         },

--- a/components/ws-manager/pkg/manager/testdata/cdwp_sys_envvars.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_sys_envvars.golden
@@ -164,14 +164,19 @@
                         },
                         {
                             "name": "something_without_gitpod",
-                            "value": "will make it"
+                            "valueFrom": {
+                                "secretKeyRef": {
+                                    "name": "ws-test",
+                                    "key": "c1cf1305c2eb1eb4b0ce3f327b383751e785615720db2bcafc5227788067761c"
+                                }
+                            }
                         },
                         {
                             "name": "one_from_a_secret",
                             "valueFrom": {
                                 "secretKeyRef": {
-                                    "name": "some-secret",
-                                    "key": "some-key"
+                                    "name": "ws-test",
+                                    "key": "31ba5230e08a8d69893703c936aaf570c76246cac7a2f7d4cfd28b8ab180631b"
                                 }
                             }
                         },

--- a/components/ws-manager/pkg/manager/testdata/cdwp_tasks.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_tasks.golden
@@ -136,7 +136,12 @@
                         },
                         {
                             "name": "foo",
-                            "value": "bar"
+                            "valueFrom": {
+                                "secretKeyRef": {
+                                    "name": "ws-test",
+                                    "key": "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae"
+                                }
+                            }
                         },
                         {
                             "name": "GITPOD_INTERVAL",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_template.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_template.golden
@@ -132,7 +132,12 @@
                         },
                         {
                             "name": "foo",
-                            "value": "bar"
+                            "valueFrom": {
+                                "secretKeyRef": {
+                                    "name": "ws-test",
+                                    "key": "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae"
+                                }
+                            }
                         },
                         {
                             "name": "GITPOD_INTERVAL",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_timeout.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_timeout.golden
@@ -137,7 +137,12 @@
                         },
                         {
                             "name": "foo",
-                            "value": "bar"
+                            "valueFrom": {
+                                "secretKeyRef": {
+                                    "name": "ws-test",
+                                    "key": "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae"
+                                }
+                            }
                         },
                         {
                             "name": "GITPOD_INTERVAL",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_userns.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_userns.golden
@@ -132,7 +132,12 @@
                         },
                         {
                             "name": "foo",
-                            "value": "bar"
+                            "valueFrom": {
+                                "secretKeyRef": {
+                                    "name": "ws-test",
+                                    "key": "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae"
+                                }
+                            }
                         },
                         {
                             "name": "GITPOD_INTERVAL",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_with_ephemeral_storage.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_with_ephemeral_storage.golden
@@ -144,7 +144,12 @@
                         },
                         {
                             "name": "foo",
-                            "value": "bar"
+                            "valueFrom": {
+                                "secretKeyRef": {
+                                    "name": "imagebuild-foobar",
+                                    "key": "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae"
+                                }
+                            }
                         },
                         {
                             "name": "GITPOD_INTERVAL",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_withaffinity_regular.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_withaffinity_regular.golden
@@ -132,7 +132,12 @@
                         },
                         {
                             "name": "foo",
-                            "value": "bar"
+                            "valueFrom": {
+                                "secretKeyRef": {
+                                    "name": "ws-test",
+                                    "key": "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae"
+                                }
+                            }
                         },
                         {
                             "name": "GITPOD_INTERVAL",

--- a/components/ws-manager/pkg/manager/testdata/cdwp_withaffinityheadless.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_withaffinityheadless.golden
@@ -144,7 +144,12 @@
                         },
                         {
                             "name": "foo",
-                            "value": "bar"
+                            "valueFrom": {
+                                "secretKeyRef": {
+                                    "name": "imagebuild-foobar",
+                                    "key": "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae"
+                                }
+                            }
                         },
                         {
                             "name": "GITPOD_INTERVAL",


### PR DESCRIPTION
## Description
Enable protected secrets by default. This is the part for the workspace side. Once this change is deployed we can also change it on web app side.

## Related Issue(s)
Related to https://github.com/gitpod-io/gitpod/issues/13634

## How to test
- Open workspace in preview environment and check that protected secrets are still used

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-integration-tests=workspace
      Valid options are `all`, `workspace`, `webapp`, `ide`
