### PR TITLE
Inject new `IApplicationCluster` dependency into `server` and `wsman-bridge`

### DIFF
--- a/components/server/src/container-module.ts
+++ b/components/server/src/container-module.ts
@@ -37,6 +37,7 @@ import { EnvvarPrefixParser } from "./workspace/envvar-prefix-context-parser";
 import {
     IWorkspaceManagerClientCallMetrics,
     WorkspaceManagerClientProvider,
+    IApplicationClusterProvider,
 } from "@gitpod/ws-manager/lib/client-provider";
 import {
     WorkspaceManagerClientProviderCompositeSource,
@@ -208,6 +209,7 @@ export const productionContainerModule = new ContainerModule((bind, unbind, isBo
 
     bind(TracingManager).toSelf().inSingletonScope();
 
+    bind(IApplicationClusterProvider).toDynamicValue(newApplicationClusterProvider).inSingletonScope();
     bind(WorkspaceManagerClientProvider).toSelf().inSingletonScope();
     bind(WorkspaceManagerClientProviderCompositeSource).toSelf().inSingletonScope();
     bind(WorkspaceManagerClientProviderSource).to(WorkspaceManagerClientProviderEnvSource).inSingletonScope();
@@ -299,3 +301,9 @@ export const productionContainerModule = new ContainerModule((bind, unbind, isBo
 
     bind(UsageService).toSelf().inSingletonScope();
 });
+
+function newApplicationClusterProvider(): IApplicationClusterProvider {
+    return {
+        getApplicationCluster: () => process.env.GITPOD_INSTALLATION_SHORTNAME ?? "",
+    };
+}

--- a/components/server/src/workspace/workspace-cluster-imagebuilder-client-provider.ts
+++ b/components/server/src/workspace/workspace-cluster-imagebuilder-client-provider.ts
@@ -12,7 +12,7 @@ import {
     ImageBuilderClientProvider,
     PromisifiedImageBuilderClient,
 } from "@gitpod/image-builder/lib";
-import { WorkspaceManagerClientProvider } from "@gitpod/ws-manager/lib/client-provider";
+import { IApplicationClusterProvider, WorkspaceManagerClientProvider } from "@gitpod/ws-manager/lib/client-provider";
 import {
     WorkspaceManagerClientProviderCompositeSource,
     WorkspaceManagerClientProviderSource,
@@ -26,6 +26,9 @@ export class WorkspaceClusterImagebuilderClientProvider implements ImageBuilderC
     protected readonly source: WorkspaceManagerClientProviderSource;
     @inject(WorkspaceManagerClientProvider) protected readonly clientProvider: WorkspaceManagerClientProvider;
     @inject(ImageBuilderClientCallMetrics) @optional() protected readonly clientCallMetrics: IClientCallMetrics;
+
+    @inject(IApplicationClusterProvider)
+    protected readonly _applicationClusterProvider: IApplicationClusterProvider;
 
     // gRPC connections can be used concurrently, even across services.
     // Thus it makes sense to cache them rather than create a new connection for each request.

--- a/components/ws-manager-api/typescript/src/client-provider.spec.ts
+++ b/components/ws-manager-api/typescript/src/client-provider.spec.ts
@@ -9,7 +9,11 @@ import "reflect-metadata";
 import { Container } from "inversify";
 import { suite, test } from "@testdeck/mocha";
 import * as chai from "chai";
-import { IWorkspaceClusterStartSet, WorkspaceManagerClientProvider } from "./client-provider";
+import {
+    IApplicationClusterProvider,
+    IWorkspaceClusterStartSet,
+    WorkspaceManagerClientProvider,
+} from "./client-provider";
 import {
     WorkspaceManagerClientProviderCompositeSource,
     WorkspaceManagerClientProviderSource,
@@ -26,6 +30,10 @@ class TestClientProvider {
 
     public before() {
         const c = new Container();
+        c
+            .bind(IApplicationClusterProvider)
+            .toDynamicValue((): IApplicationClusterProvider => ({ getApplicationCluster: () => "xx01" }))
+            .inSingletonScope;
         c.bind(WorkspaceManagerClientProvider).toSelf().inSingletonScope();
         c.bind(WorkspaceManagerClientProviderCompositeSource).toSelf().inSingletonScope();
         c.bind(WorkspaceManagerClientProviderSource)

--- a/components/ws-manager-api/typescript/src/client-provider.ts
+++ b/components/ws-manager-api/typescript/src/client-provider.ts
@@ -21,6 +21,11 @@ import { linearBackoffStrategy, PromisifiedWorkspaceManagerClient } from "./prom
 
 export const IWorkspaceManagerClientCallMetrics = Symbol("IWorkspaceManagerClientCallMetrics");
 
+export const IApplicationClusterProvider = Symbol("IApplicationClusterProvider");
+export interface IApplicationClusterProvider {
+    getApplicationCluster: () => string;
+}
+
 @injectable()
 export class WorkspaceManagerClientProvider implements Disposable {
     @inject(WorkspaceManagerClientProviderCompositeSource)
@@ -29,6 +34,9 @@ export class WorkspaceManagerClientProvider implements Disposable {
     @inject(IWorkspaceManagerClientCallMetrics)
     @optional()
     protected readonly clientCallMetrics: IClientCallMetrics;
+
+    @inject(IApplicationClusterProvider)
+    protected readonly _applicationClusterProvider: IApplicationClusterProvider;
 
     // gRPC connections maintain their connectivity themselves, i.e. they reconnect when neccesary.
     // They can also be used concurrently, even across services.

--- a/components/ws-manager-bridge/src/container-module.ts
+++ b/components/ws-manager-bridge/src/container-module.ts
@@ -20,6 +20,7 @@ import { filePathTelepresenceAware } from "@gitpod/gitpod-protocol/lib/env";
 import {
     WorkspaceManagerClientProvider,
     IWorkspaceManagerClientCallMetrics,
+    IApplicationClusterProvider,
 } from "@gitpod/ws-manager/lib/client-provider";
 import {
     WorkspaceManagerClientProviderCompositeSource,
@@ -51,6 +52,7 @@ export const containerModule = new ContainerModule((bind) => {
     bind(IClientCallMetrics).to(PrometheusClientCallMetrics).inSingletonScope();
     bind(IWorkspaceManagerClientCallMetrics).toService(IClientCallMetrics);
 
+    bind(IApplicationClusterProvider).toDynamicValue(newApplicationClusterProvider).inSingletonScope();
     bind(WorkspaceManagerClientProvider).toSelf().inSingletonScope();
     bind(WorkspaceManagerClientProviderCompositeSource).toSelf().inSingletonScope();
     bind(WorkspaceManagerClientProviderSource).to(WorkspaceManagerClientProviderConfigSource).inSingletonScope();
@@ -96,3 +98,9 @@ export const containerModule = new ContainerModule((bind) => {
     // transient to make sure we're creating a separate instance every time we ask for it
     bind(WorkspaceInstanceController).to(WorkspaceInstanceControllerImpl).inTransientScope();
 });
+
+function newApplicationClusterProvider(): IApplicationClusterProvider {
+    return {
+        getApplicationCluster: () => process.env.GITPOD_INSTALLATION_SHORTNAME ?? "",
+    };
+}


### PR DESCRIPTION
## Description

Create a new `IApplicationClusterProvider` interface and inject implementations into `WorkspaceManagerClientProvider`.

The injected implemenations will be used to let the `WorkspaceManagerClientProvider` know in which application cluster it runs.

By injecting a new dependency, we can do the environment variable check once at the top of the object composition graph rather than having to read the environment in multiple places lower down the object graph.

## Related Issue(s)
Part of #9198  and https://github.com/gitpod-io/gitpod/issues/13800

## How to test

No behaviour change - all tests pass and workspaces start as before.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
