### PR TITLE
[dashboard] Fix display of billing period boundaries by using only UTC times

### DIFF
--- a/components/dashboard/src/components/UsageBasedBillingConfig.tsx
+++ b/components/dashboard/src/components/UsageBasedBillingConfig.tsx
@@ -21,6 +21,20 @@ import Modal from "../components/Modal";
 import Alert from "./Alert";
 
 const BASE_USAGE_LIMIT_FOR_STRIPE_USERS = 1000;
+const MONTH_NAMES = [
+    "January",
+    "February",
+    "March",
+    "April",
+    "May",
+    "June",
+    "July",
+    "August",
+    "September",
+    "October",
+    "November",
+    "December",
+];
 
 type PendingStripeSubscription = { pendingSince: number };
 
@@ -44,8 +58,11 @@ export default function UsageBasedBillingConfig({ attributionId }: Props) {
 
     const localStorageKey = `pendingStripeSubscriptionFor${attributionId}`;
     const billingPeriodFrom = new Date(new Date().toISOString().slice(0, 7) + "-01"); // First day of this month: YYYY-MM-01T00:00:00.000Z
-    const billingPeriodTo = new Date(billingPeriodFrom.getUTCFullYear(), billingPeriodFrom.getMonth() + 1); // First day of next month
-    billingPeriodTo.setMilliseconds(billingPeriodTo.getMilliseconds() - 1); // Last millisecond of this month
+    const billingPeriodTo = new Date(billingPeriodFrom.getTime());
+    billingPeriodTo.setUTCMonth(billingPeriodTo.getUTCMonth() + 1); // First day of next month
+    billingPeriodTo.setUTCMilliseconds(billingPeriodTo.getUTCMilliseconds() - 1); // Last millisecond of this month
+    const billingPeriodMonthName = MONTH_NAMES[billingPeriodFrom.getUTCMonth()];
+    const billingPeriodMonthShortname = billingPeriodMonthName.slice(0, 3);
 
     useEffect(() => {
         if (!attributionId) {
@@ -254,11 +271,10 @@ export default function UsageBasedBillingConfig({ attributionId }: Props) {
                                 <div className="uppercase text-sm text-gray-400 dark:text-gray-500">Current Period</div>
                                 <div className="text-sm font-medium text-gray-500 dark:text-gray-400">
                                     <span className="font-semibold">
-                                        {billingPeriodFrom.toLocaleString("default", { month: "long" })}{" "}
-                                        {billingPeriodFrom.getFullYear()}
+                                        {`${billingPeriodMonthName} ${billingPeriodFrom.getUTCFullYear()}`}
                                     </span>{" "}
-                                    ({billingPeriodFrom.toLocaleString("default", { month: "short", day: "numeric" })} -{" "}
-                                    {billingPeriodTo.toLocaleString("default", { month: "short", day: "numeric" })})
+                                    {`(${billingPeriodMonthShortname} ${billingPeriodFrom.getUTCDate()}` +
+                                        ` - ${billingPeriodMonthShortname} ${billingPeriodTo.getUTCDate()})`}
                                 </div>
                             </div>
                             <div>
@@ -279,7 +295,8 @@ export default function UsageBasedBillingConfig({ attributionId }: Props) {
                             <Check className="m-0.5 w-5 h-5" />
                             <div className="flex flex-col">
                                 <span>
-                                    {currency === "EUR" ? "€" : "$"}0.36 for 10 credits or 1 hour of Standard workspace usage.{" "}
+                                    {currency === "EUR" ? "€" : "$"}0.36 for 10 credits or 1 hour of Standard workspace
+                                    usage.{" "}
                                     <a
                                         className="gp-link"
                                         href="https://www.gitpod.io/docs/configure/billing/usage-based-billing"
@@ -330,7 +347,10 @@ export default function UsageBasedBillingConfig({ attributionId }: Props) {
                                 <Check className="m-0.5 w-5 h-5" />
                                 <div className="flex flex-col">
                                     <span className="font-bold">Pay-as-you-go after 1,000 credits</span>
-                                    <span>{currency === "EUR" ? "€" : "$"}0.36 for 10 credits or 1 hour of Standard workspace usage.</span>
+                                    <span>
+                                        {currency === "EUR" ? "€" : "$"}0.36 for 10 credits or 1 hour of Standard
+                                        workspace usage.
+                                    </span>
                                 </div>
                             </div>
                             <div className="mt-5 flex flex-col">
@@ -373,7 +393,10 @@ export default function UsageBasedBillingConfig({ attributionId }: Props) {
                                             <span className="font-bold text-gray-500 dark:text-gray-400">
                                                 Pay-as-you-go after 1,000 credits
                                             </span>
-                                            <span>{currency === "EUR" ? "€" : "$"}0.36 for 10 credits or 1 hour of Standard workspace usage.</span>
+                                            <span>
+                                                {currency === "EUR" ? "€" : "$"}0.36 for 10 credits or 1 hour of
+                                                Standard workspace usage.
+                                            </span>
                                         </div>
                                     </div>
                                 </>
@@ -386,7 +409,8 @@ export default function UsageBasedBillingConfig({ attributionId }: Props) {
                                         <Check className="m-0.5 w-5 h-5 text-orange-500" />
                                         <div className="flex flex-col">
                                             <span>
-                                                {currency === "EUR" ? "€" : "$"}0.36 for 10 credits or 1 hour of Standard workspace usage.{" "}
+                                                {currency === "EUR" ? "€" : "$"}0.36 for 10 credits or 1 hour of
+                                                Standard workspace usage.{" "}
                                                 <a
                                                     className="gp-link"
                                                     href="https://www.gitpod.io/docs/configure/billing/usage-based-billing"

--- a/components/dashboard/src/index.tsx
+++ b/components/dashboard/src/index.tsx
@@ -19,10 +19,12 @@ import { StartWorkspaceModalContextProvider } from "./workspaces/start-workspace
 import { BrowserRouter } from "react-router-dom";
 import dayjs from "dayjs";
 import relativeTime from "dayjs/plugin/relativeTime";
+import utc from "dayjs/plugin/utc";
 
 import "./index.css";
 
 dayjs.extend(relativeTime);
+dayjs.extend(utc);
 
 ReactDOM.render(
     <React.StrictMode>


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Fix display of billing period boundaries in the dashboard by using only UTC times.

(Note: I did try to use `dayjs` for this, but couldn't figure out how to "force" everything to be UTC, so I fell back on the native Date type. Happy to switch to `dayjs` if you know how to achieve exactly the same result. 👍)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

1. Upgrade to usage-based billing
2. Billing period boundaries shown in your billing UI should be correct

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-payment
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
