### PR TITLE
Use `previewct get-credentials` in werft job

### DIFF
--- a/.werft/jobs/build/const.ts
+++ b/.werft/jobs/build/const.ts
@@ -2,3 +2,4 @@ export const GCLOUD_SERVICE_ACCOUNT_PATH = "/mnt/secrets/gcp-sa/service-account.
 export const CORE_DEV_KUBECONFIG_PATH = "/workspace/gitpod/kubeconfigs/core-dev";
 export const HARVESTER_KUBECONFIG_PATH = "/workspace/gitpod/kubeconfigs/harvester";
 export const PREVIEW_K3S_KUBECONFIG_PATH = "/workspace/gitpod/kubeconfigs/k3s";
+export const GLOBAL_KUBECONFIG_PATH = process.env.HOME + "/.kube/config"

--- a/.werft/util/certs.ts
+++ b/.werft/util/certs.ts
@@ -1,5 +1,9 @@
 import {exec, ExecOptions, execStream} from "./shell";
-import {CORE_DEV_KUBECONFIG_PATH, GCLOUD_SERVICE_ACCOUNT_PATH, HARVESTER_KUBECONFIG_PATH} from "../jobs/build/const";
+import {
+    CORE_DEV_KUBECONFIG_PATH,
+    GCLOUD_SERVICE_ACCOUNT_PATH,
+    GLOBAL_KUBECONFIG_PATH,
+} from "../jobs/build/const";
 import { Werft } from "./werft";
 import { reportCertificateError } from "../util/slack";
 import {JobConfig} from "../jobs/build/job-config";
@@ -21,8 +25,7 @@ export async function certReady(werft: Werft, config: JobConfig, slice: string):
     // We pass the GCP credentials explicitly, otherwise for some reason TF doesn't pick them up
     const commonVars = `GOOGLE_BACKEND_CREDENTIALS=${GCLOUD_SERVICE_ACCOUNT_PATH} \
                         GOOGLE_APPLICATION_CREDENTIALS=${GCLOUD_SERVICE_ACCOUNT_PATH} \
-                        TF_VAR_dev_kube_path=${CORE_DEV_KUBECONFIG_PATH} \
-                        TF_VAR_harvester_kube_path=${HARVESTER_KUBECONFIG_PATH} \
+                        TF_VAR_kubeconfig_path=${GLOBAL_KUBECONFIG_PATH} \
                         TF_VAR_preview_name=${config.previewEnvironment.destname} \
                         TF_VAR_vm_cpu=${cpu} \
                         TF_VAR_vm_memory=${memory}Gi \

--- a/.werft/vm/vm.ts
+++ b/.werft/vm/vm.ts
@@ -1,6 +1,6 @@
 import {
-    CORE_DEV_KUBECONFIG_PATH,
     GCLOUD_SERVICE_ACCOUNT_PATH,
+    GLOBAL_KUBECONFIG_PATH,
     HARVESTER_KUBECONFIG_PATH,
     PREVIEW_K3S_KUBECONFIG_PATH
 } from "../jobs/build/const";
@@ -19,8 +19,7 @@ export async function deleteVM(options: { name: string }) {
         await execStream(`DESTROY=true \
                                     GOOGLE_APPLICATION_CREDENTIALS=${GCLOUD_SERVICE_ACCOUNT_PATH} \
                                     GOOGLE_BACKEND_CREDENTIALS=${GCLOUD_SERVICE_ACCOUNT_PATH} \
-                                    TF_VAR_dev_kube_path=${CORE_DEV_KUBECONFIG_PATH} \
-                                    TF_VAR_harvester_kube_path=${HARVESTER_KUBECONFIG_PATH} \
+                                    TF_VAR_kubeconfig_path=${GLOBAL_KUBECONFIG_PATH} \
                                     TF_VAR_preview_name=${options.name} \
                                     ./dev/preview/workflow/preview/deploy-harvester.sh`,
             {slice: "Deleting VM."})

--- a/dev/preview/infrastructure/harvester/provider.tf
+++ b/dev/preview/infrastructure/harvester/provider.tf
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     harvester = {
       source  = "harvester/harvester"
-      version = ">=0.5.1"
+      version = ">=0.5.3"
     }
     k8s = {
       source  = "hashicorp/kubernetes"
@@ -23,18 +23,21 @@ terraform {
 }
 
 provider "harvester" {
-  alias      = "harvester"
-  kubeconfig = var.harvester_kube_path
-}
-
-provider "k8s" {
-  alias       = "dev"
-  config_path = var.dev_kube_path
-}
-
-provider "k8s" {
   alias       = "harvester"
-  config_path = var.harvester_kube_path
+  kubeconfig  = var.kubeconfig_path
+  kubecontext = "harvester"
+}
+
+provider "k8s" {
+  alias          = "dev"
+  config_path    = var.kubeconfig_path
+  config_context = var.dev_kube_context
+}
+
+provider "k8s" {
+  alias          = "harvester"
+  config_path    = var.kubeconfig_path
+  config_context = var.harvester_kube_context
 }
 
 provider "google" {

--- a/dev/preview/infrastructure/harvester/variables.tf
+++ b/dev/preview/infrastructure/harvester/variables.tf
@@ -3,14 +3,22 @@ variable "preview_name" {
   description = "The preview environment's name"
 }
 
-variable "harvester_kube_path" {
+variable "kubeconfig_path" {
   type        = string
-  description = "The path to the Harvester Cluster kubeconfig"
+  default     = "/home/gitpod/.kube/config"
+  description = "The path to the kubernetes config"
 }
 
-variable "dev_kube_path" {
+variable "harvester_kube_context" {
   type        = string
-  description = "The path to the Dev Cluster kubeconfig"
+  default     = "harvester"
+  description = "The name of the harvester kube context"
+}
+
+variable "dev_kube_context" {
+  type        = string
+  default     = "dev"
+  description = "The name of the dev kube context"
 }
 
 variable "vm_memory" {
@@ -28,7 +36,6 @@ variable "vm_cpu" {
 variable "vm_storage_class" {
   type        = string
   description = "The storage class for the VM"
-  default     = "longhorn-gitpod-k3s-202209251218-onereplica"
 }
 
 variable "harvester_ingress_ip" {

--- a/dev/preview/infrastructure/harvester/variables.tf
+++ b/dev/preview/infrastructure/harvester/variables.tf
@@ -36,6 +36,7 @@ variable "vm_cpu" {
 variable "vm_storage_class" {
   type        = string
   description = "The storage class for the VM"
+  default     = "longhorn-gitpod-k3s-202209251218-onereplica"
 }
 
 variable "harvester_ingress_ip" {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Use `previewct get-credentials` to populate a single kubeconfig and target contexts explicitly in tf.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
https://werft.gitpod-dev.com/job/gitpod-custom-aa-use-previewctl-get-creds.6/results

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-preview with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
