### PR TITLE
feat: add integration tests for ssh gateway

### DIFF
--- a/.werft/ide-integration-tests-startup.yaml
+++ b/.werft/ide-integration-tests-startup.yaml
@@ -177,7 +177,7 @@ pod:
 
           [[ "$USERNAME" != "" ]] && args+=( "-username=$USERNAME" )
 
-          IDE_TEST_LIST=(/workspace/test/tests/ide/vscode /workspace/test/tests/ide/jetbrains)
+          IDE_TEST_LIST=(/workspace/test/tests/ide/ssh /workspace/test/tests/ide/vscode /workspace/test/tests/ide/jetbrains)
           for TEST_PATH in "${IDE_TEST_LIST[@]}"
           do
               TEST_NAME=$(basename "${TEST_PATH}")

--- a/.werft/installer-tests.ts
+++ b/.werft/installer-tests.ts
@@ -227,6 +227,12 @@ const WORKSPACES_TESTS: { [name: string]: InfraConfig } = {
 };
 
 const IDE_TESTS: { [name: string]: InfraConfig } = {
+    SSH_TEST: {
+        phase: "run-ssh-tests",
+        makeTarget: "run-ssh-tests",
+        description: "SSH Gateway tests",
+        slackhook: slackHook.get("ide-jobs"),
+    },
     VSCODE_IDE_TEST: {
         phase: "run-vscode-ide-tests",
         makeTarget: "run-vscode-ide-tests",
@@ -238,7 +244,7 @@ const IDE_TESTS: { [name: string]: InfraConfig } = {
         makeTarget: "run-jb-ide-tests",
         description: "jetbrains IDE tests",
         slackhook: slackHook.get("ide-jobs"),
-    }
+    },
 }
 
 

--- a/install/tests/Makefile
+++ b/install/tests/Makefile
@@ -470,6 +470,9 @@ run-vscode-ide-tests:
 run-jb-ide-tests:
 	$(call runtests,"test/tests/ide/jetbrains/")
 
+run-ssh-tests:
+	$(call runtests,"test/tests/ide/ssh/")
+
 run-cs-component-tests:
 	$(call runtests,"test/tests/components/content-service/")
 

--- a/test/go.mod
+++ b/test/go.mod
@@ -74,6 +74,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.11.3 // indirect
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
+	github.com/helloyi/go-sshclient v1.1.1 // indirect
 	github.com/heptiolabs/healthcheck v0.0.0-20211123025425-613501dd5deb // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect

--- a/test/go.sum
+++ b/test/go.sum
@@ -360,6 +360,8 @@ github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO
 github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0mNTz8vQ=
 github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2pPBoIllUwCN7I=
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
+github.com/helloyi/go-sshclient v1.1.1 h1:yRcrc/Q1nJ2hYbtVFfBBTyneQLqr2vy/jD3/GneyirI=
+github.com/helloyi/go-sshclient v1.1.1/go.mod h1:NrhRWsYJDjoQXTDWZ4YtVk84wZ4LK3NSM9jD2TZDAm8=
 github.com/heptiolabs/healthcheck v0.0.0-20211123025425-613501dd5deb h1:tsEKRC3PU9rMw18w/uAptoijhgG4EvlA5kfJPtwrMDk=
 github.com/heptiolabs/healthcheck v0.0.0-20211123025425-613501dd5deb/go.mod h1:NtmN9h8vrTveVQRLHcX2HQ5wIPBDCsZ351TGbZWgg38=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
@@ -627,6 +629,7 @@ golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20220214200702-86341886e292 h1:f+lwQ+GtmgoY+A2YaQxlSOnDjXcQ7ZRLWOHbC6HtRqE=
 golang.org/x/crypto v0.0.0-20220214200702-86341886e292/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
@@ -839,6 +842,7 @@ golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220610221304-9f5ed59c137d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10 h1:WIoqL4EROvwiPdUtaip4VcDdpZ4kha7wBWZrbVKCIZg=
 golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 h1:JGgROgKl9N8DuW20oFS5gxc+lE67/N3FcwmBPMe7ArY=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=

--- a/test/run.sh
+++ b/test/run.sh
@@ -20,7 +20,7 @@ FAILURE_COUNT=0
 LOGS_DIR=$(mktemp -d)
 
 WEBAPP_TEST_LIST="$THIS_DIR/tests/components/database $THIS_DIR/tests/components/server"
-IDE_TEST_LIST="$THIS_DIR/tests/ide/vscode $THIS_DIR/tests/ide/jetbrains"
+IDE_TEST_LIST="$THIS_DIR/tests/ide/ssh $THIS_DIR/tests/ide/vscode $THIS_DIR/tests/ide/jetbrains"
 WORKSPACE_TEST_LIST="$THIS_DIR/tests/components/content-service $THIS_DIR/tests/components/image-builder $THIS_DIR/tests/components/ws-daemon $THIS_DIR/tests/components/ws-manager $THIS_DIR/tests/workspace"
 
 case $TEST_SUITE in

--- a/test/tests/ide/ssh/main_test.go
+++ b/test/tests/ide/ssh/main_test.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package ide
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/gitpod-io/gitpod/test/pkg/integration"
+	"sigs.k8s.io/e2e-framework/pkg/env"
+)
+
+var (
+	testEnv    env.Environment
+	username   string
+	namespace  string
+	kubeconfig string
+)
+
+func TestMain(m *testing.M) {
+	username, namespace, testEnv, _, kubeconfig, _ = integration.Setup(context.Background())
+	os.Exit(testEnv.Run(m))
+}

--- a/test/tests/ide/ssh/ssh_gateway_test.go
+++ b/test/tests/ide/ssh/ssh_gateway_test.go
@@ -1,0 +1,116 @@
+// Copyright (c) 2020 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package ide
+
+import (
+	"context"
+	"io"
+	"log"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/helloyi/go-sshclient"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+
+	gitpod "github.com/gitpod-io/gitpod/gitpod-protocol"
+	"github.com/gitpod-io/gitpod/test/pkg/integration"
+)
+
+func TestSSHGatewayConnection(t *testing.T) {
+	userToken, _ := os.LookupEnv("USER_TOKEN")
+	integration.SkipWithoutUsername(t, username)
+	integration.SkipWithoutUserToken(t, userToken)
+
+	f := features.New("TestSSHGatewayConnection").
+		WithLabel("component", "server").
+		Assess("it can connect to a workspace via SSH gateway", func(_ context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+			defer cancel()
+
+			api := integration.NewComponentAPI(ctx, cfg.Namespace(), kubeconfig, cfg.Client())
+			t.Cleanup(func() {
+				api.Done(t)
+			})
+
+			_, err := api.CreateUser(username, userToken)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			serverOpts := []integration.GitpodServerOpt{integration.WithGitpodUser(username)}
+			server, err := api.GitpodServer(serverOpts...)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// This env var caused an incident https://www.gitpodstatus.com/incidents/26gwnhcpvqqx before
+			// Which was introduced by PR https://github.com/gitpod-io/gitpod/pull/13822
+			// And fixed by PR https://github.com/gitpod-io/gitpod/pull/13858
+			_ = server.SetEnvVar(ctx, &gitpod.UserEnvVarValue{
+				Name:              "TEST",
+				RepositoryPattern: "*/*",
+				Value:             "\\\"test space\\\"",
+			})
+
+			_ = server.SetEnvVar(ctx, &gitpod.UserEnvVarValue{
+				Name:              "TEST_MULTIPLE_LINES",
+				RepositoryPattern: "*/*",
+				Value: `Hello
+World`,
+			})
+
+			nfo, stopWs, err := integration.LaunchWorkspaceFromContextURL(t, ctx, "github.com/gitpod-io/empty", username, api)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() {
+				sctx, scancel := context.WithTimeout(context.Background(), 5*time.Minute)
+				defer scancel()
+
+				sapi := integration.NewComponentAPI(sctx, cfg.Namespace(), kubeconfig, cfg.Client())
+				defer sapi.Done(t)
+
+				stopWs(true, sapi)
+			}()
+
+			wsUrl, err := url.Parse(nfo.LatestInstance.IdeURL)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			wId := nfo.Workspace.ID
+			ownerToken, err := server.GetOwnerToken(ctx, wId)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			urlComponents := strings.Split(wsUrl.Host, ".")
+			connUrl := []string{urlComponents[0], "ssh"}
+			connUrl = append(connUrl, urlComponents[1:]...)
+			connUrlStr := strings.Join(connUrl, ".")
+
+			cli, err := sshclient.DialWithPasswd(connUrlStr+":22", wId, ownerToken)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			output, err := cli.Cmd("gp info").Output()
+			if err != nil && err != io.EOF {
+				log.Println("[error]", err)
+				time.Sleep(1 * time.Second)
+			}
+
+			t.Log(string(output))
+
+			return ctx
+		}).
+		Feature()
+
+	testEnv.Test(t, f)
+}


### PR DESCRIPTION
## Description
This PR introduces SSH gateway integration tests.

Created during an IDE mob programming session 🎉

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
- Open this PR with Gitpod
- Exec `werft run github -j .werft/ide-integration-tests-startup.yaml`
- See werft result of ssh test

(Already tested [here](https://werft.gitpod-dev.com/job/gitpod-build-afalz-ssh-gateway-integration-tests.13), but you can test it again 👍 )

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```


## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-preview with-large-vm
- [ ] /werft with-integration-tests=ide
      Valid options are `all`, `workspace`, `webapp`, `ide`
