### PR TITLE
Fix previewctl SA, rebuild and update docker image

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
-image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:af-add-fish-to-dev-image.0
+image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aa-previewctl-fix-rebuild.6
 workspaceLocation: gitpod/gitpod-ws.code-workspace
 checkoutLocation: gitpod
 ports:

--- a/.werft/aks-installer-tests.yaml
+++ b/.werft/aks-installer-tests.yaml
@@ -65,7 +65,7 @@ pod:
       secretName: self-hosted-github-oauth
   containers:
   - name: nightly-test
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:af-add-fish-to-dev-image.0
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aa-previewctl-fix-rebuild.6
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/build.yaml
+++ b/.werft/build.yaml
@@ -76,7 +76,7 @@ pod:
     - name: MYSQL_TCP_PORT
       value: 23306
   - name: build
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:af-add-fish-to-dev-image.0
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aa-previewctl-fix-rebuild.6
     workingDir: /workspace
     imagePullPolicy: IfNotPresent
     resources:

--- a/.werft/cleanup-installer-tests.yaml
+++ b/.werft/cleanup-installer-tests.yaml
@@ -25,7 +25,7 @@ pod:
       secretName: aks-credentials
   containers:
   - name: nightly-test
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:af-add-fish-to-dev-image.0
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aa-previewctl-fix-rebuild.6
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/debug.yaml
+++ b/.werft/debug.yaml
@@ -54,7 +54,7 @@ pod:
     - name: MYSQL_TCP_PORT
       value: 23306
   - name: build
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:af-add-fish-to-dev-image.0
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aa-previewctl-fix-rebuild.6
     workingDir: /workspace
     imagePullPolicy: IfNotPresent
     volumeMounts:

--- a/.werft/eks-installer-tests.yaml
+++ b/.werft/eks-installer-tests.yaml
@@ -65,7 +65,7 @@ pod:
       secretName: self-hosted-github-oauth
   containers:
   - name: nightly-test
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:af-add-fish-to-dev-image.0
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aa-previewctl-fix-rebuild.6
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/gke-installer-tests.yaml
+++ b/.werft/gke-installer-tests.yaml
@@ -65,7 +65,7 @@ pod:
         secretName: self-hosted-github-oauth
   containers:
     - name: nightly-test
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:af-add-fish-to-dev-image.0
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aa-previewctl-fix-rebuild.6
       workingDir: /workspace
       imagePullPolicy: Always
       volumeMounts:

--- a/.werft/ide-integration-tests-startup.yaml
+++ b/.werft/ide-integration-tests-startup.yaml
@@ -17,7 +17,7 @@ pod:
         secretName: github-token-gitpod-bot
   containers:
     - name: gcloud
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:af-add-fish-to-dev-image.0
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aa-previewctl-fix-rebuild.6
       workingDir: /workspace
       imagePullPolicy: IfNotPresent
       env:

--- a/.werft/k3s-installer-tests.yaml
+++ b/.werft/k3s-installer-tests.yaml
@@ -65,7 +65,7 @@ pod:
       secretName: self-hosted-github-oauth
   containers:
   - name: nightly-test
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:af-add-fish-to-dev-image.0
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aa-previewctl-fix-rebuild.6
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/platform-delete-preview-environment.yaml
+++ b/.werft/platform-delete-preview-environment.yaml
@@ -25,7 +25,7 @@ pod:
         secretName: harvester-vm-ssh-keys
   containers:
     - name: build
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:af-add-fish-to-dev-image.0
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aa-previewctl-fix-rebuild.6
       workingDir: /workspace
       imagePullPolicy: IfNotPresent
       volumeMounts:

--- a/.werft/platform-delete-preview-environments-cron.yaml
+++ b/.werft/platform-delete-preview-environments-cron.yaml
@@ -29,7 +29,7 @@ pod:
         secretName: github-token-gitpod-bot
   containers:
     - name: build
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:af-add-fish-to-dev-image.0
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aa-previewctl-fix-rebuild.6
       workingDir: /workspace
       imagePullPolicy: IfNotPresent
       volumeMounts:

--- a/.werft/platform-trigger-artificial-job.yaml
+++ b/.werft/platform-trigger-artificial-job.yaml
@@ -24,7 +24,7 @@ pod:
         secretName: github-token-gitpod-bot
   containers:
     - name: build
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-dl.1
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aa-previewctl-fix-rebuild.6
       workingDir: /workspace
       imagePullPolicy: IfNotPresent
       volumeMounts:

--- a/.werft/platform-trigger-werft-cleanup.yaml
+++ b/.werft/platform-trigger-werft-cleanup.yaml
@@ -22,7 +22,7 @@ pod:
         secretName: gcp-sa-gitpod-dev-deployer
   containers:
     - name: build
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:af-add-fish-to-dev-image.0
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aa-previewctl-fix-rebuild.6
       workingDir: /workspace
       imagePullPolicy: IfNotPresent
       volumeMounts:

--- a/.werft/workspace-run-integration-tests.yaml
+++ b/.werft/workspace-run-integration-tests.yaml
@@ -22,7 +22,7 @@ pod:
         secretName: github-token-gitpod-bot
   containers:
     - name: gcloud
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:af-add-fish-to-dev-image.0
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aa-previewctl-fix-rebuild.6
       workingDir: /workspace
       imagePullPolicy: IfNotPresent
       env:

--- a/dev/image/Dockerfile
+++ b/dev/image/Dockerfile
@@ -4,7 +4,7 @@
 
 FROM gitpod/workspace-full:2022-10-15-02-50-27
 
-ENV TRIGGER_REBUILD 22
+ENV TRIGGER_REBUILD 23
 
 USER root
 

--- a/dev/preview/previewctl/cmd/credentials.go
+++ b/dev/preview/previewctl/cmd/credentials.go
@@ -34,9 +34,6 @@ type getCredentialsOpts struct {
 	gcpClient *gcloud.Config
 	logger    *logrus.Logger
 
-	serviceAccountPath string
-	kubeConfigSavePath string
-
 	getCredentialsMap map[string]func(ctx context.Context) (*api.Config, error)
 	configMap         map[string]*api.Config
 }
@@ -46,10 +43,8 @@ func newGetCredentialsCommand(logger *logrus.Logger) *cobra.Command {
 	var client *gcloud.Config
 	ctx := context.Background()
 	opts := &getCredentialsOpts{
-		logger:             logger,
-		kubeConfigSavePath: kubeConfigSavePath,
-		serviceAccountPath: serviceAccountPath,
-		configMap:          map[string]*api.Config{},
+		logger:    logger,
+		configMap: map[string]*api.Config{},
 	}
 
 	cmd := &cobra.Command{
@@ -57,7 +52,7 @@ func newGetCredentialsCommand(logger *logrus.Logger) *cobra.Command {
 		Long: `previewctl get-credentials retrieves the kubernetes configs for core-dev and harvester clusters,
 merges them with the default config, and outputs them either to stdout or to a file.`,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			client, err = gcloud.New(ctx, opts.serviceAccountPath)
+			client, err = gcloud.New(ctx, serviceAccountPath)
 			if err != nil {
 				return err
 			}
@@ -118,7 +113,7 @@ func (o *getCredentialsOpts) mergeContexts() error {
 		return err
 	}
 
-	if o.kubeConfigSavePath != "" {
+	if kubeConfigSavePath != "" {
 		return clientcmd.WriteToFile(*finalConfig, kubeConfigSavePath)
 	}
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Fix an issue with passing a variable + trigger rebuild of the image so it's available in werft.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-preview with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
