### PR TITLE
[installer]: print the installer version to the kots-install script

### DIFF
--- a/install/installer/scripts/kots-install.sh
+++ b/install/installer/scripts/kots-install.sh
@@ -86,6 +86,8 @@ version: "1.0.0"
 appVersion: "$(/app/installer version | yq e '.version' -)"
 EOF
 
+    echo "Gitpod: Installer version - $(/app/installer version | yq e '.version' -)"
+
     echo "Gitpod: Generate the base Installer config"
     /app/installer config init
 

--- a/install/kots/manifests/gitpod-installation-status.yaml
+++ b/install/kots/manifests/gitpod-installation-status.yaml
@@ -30,7 +30,7 @@ spec:
       containers:
         - name: installation-status
           # This will normally be the release tag
-          image: "eu.gcr.io/gitpod-core-dev/build/installer:sje-installer-kill-workspaces.14"
+          image: "eu.gcr.io/gitpod-core-dev/build/installer:sje-installer-version-script.2"
           envFrom:
             - configMapRef:
                 name: gitpod-kots-config

--- a/install/kots/manifests/gitpod-installer-job.yaml
+++ b/install/kots/manifests/gitpod-installer-job.yaml
@@ -39,7 +39,7 @@ spec:
       containers:
         - name: installer
           # This will normally be the release tag
-          image: "eu.gcr.io/gitpod-core-dev/build/installer:sje-installer-kill-workspaces.14"
+          image: "eu.gcr.io/gitpod-core-dev/build/installer:sje-installer-version-script.2"
           volumeMounts:
             - mountPath: /mnt/node0
               name: node-fs0


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Print the installer version to the kots-install script

## How to test
<!-- Provide steps to test this PR -->
Install via KOTS

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[installer]: print the installer version to the kots-install script
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
