### PR TITLE
Remove Kube*Overcommit alerts

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -88,6 +88,7 @@
 /dev/loadgen @gitpod-io/engineering-workspace
 /dev/preview @gitpod-io/devx
 /operations/observability/mixins @gitpod-io/engineering-delivery-operations-experience
+/operations/observability/mixins/platform @gitpod-io/devx
 /operations/observability/mixins/IDE @gitpod-io/engineering-ide
 /operations/observability/mixins/meta @gitpod-io/engineering-webapp
 /operations/observability/mixins/workspace @gitpod-io/engineering-workspace

--- a/operations/observability/mixins/platform/rules/kubernetes/kubernetes.yaml
+++ b/operations/observability/mixins/platform/rules/kubernetes/kubernetes.yaml
@@ -49,32 +49,6 @@ spec:
       labels:
         severity: warning
         team: platform
-    - alert: KubeCPUOvercommit
-      annotations:
-        description: Cluster has overcommitted CPU resource requests for Pods by {{ $value }} CPU shares and cannot tolerate node failure.
-        summary: Cluster has overcommitted CPU resource requests.
-        dashboard_url: https://grafana.gitpod.io/d/efa86fd1d0c121a26444b636a3f509a8
-      expr: |
-        sum(namespace_cpu:kube_pod_container_resource_requests:sum{}) - (sum(kube_node_status_allocatable{resource="cpu"}) - max(kube_node_status_allocatable{resource="cpu"})) > 0
-        and
-        (sum(kube_node_status_allocatable{resource="cpu"}) - max(kube_node_status_allocatable{resource="cpu"})) > 0
-      for: 60m
-      labels:
-        severity: warning
-        team: platform
-    - alert: KubeMemoryOvercommit
-      annotations:
-        description: Cluster has overcommitted memory resource requests for Pods by {{ $value | humanize }} bytes and cannot tolerate node failure.
-        summary: Cluster has overcommitted memory resource requests.
-        dashboard_url: https://grafana.gitpod.io/d/efa86fd1d0c121a26444b636a3f509a8
-      expr: |
-        sum(namespace_memory:kube_pod_container_resource_requests:sum{}) - (sum(kube_node_status_allocatable{resource="memory"}) - max(kube_node_status_allocatable{resource="memory"})) > 0
-        and
-        (sum(kube_node_status_allocatable{resource="memory"}) - max(kube_node_status_allocatable{resource="memory"})) > 0
-      for: 60m
-      labels:
-        severity: warning
-        team: platform
     - alert: KubePersistentVolumeFillingUp
       annotations:
         description: The PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} in Namespace {{ $labels.namespace }} is only {{ $value | humanizePercentage }} free.


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
https://github.com/gitpod-io/ops/pull/6259 enables autoscaling on the only nodepool that doesn't have it still, which renders these alerts obsolete.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
