### PR TITLE
[usage] Configure Stripe Price IDs through installer

### DIFF
--- a/.werft/jobs/build/installer/installer.ts
+++ b/.werft/jobs/build/installer/installer.ts
@@ -277,6 +277,12 @@ EOF`);
         exec(`yq w -i ${this.options.installerConfigPath} experimental.webapp.usage.defaultSpendingLimit.minForUsersOnStripe 1000`, { slice: slice })
         exec(`yq w -i ${this.options.installerConfigPath} experimental.webapp.usage.creditsPerMinuteByWorkspaceClass['default'] 0.1666666667`, { slice: slice })
         exec(`yq w -i ${this.options.installerConfigPath} experimental.webapp.usage.creditsPerMinuteByWorkspaceClass['gitpodio-internal-xl'] 0.3333333333`, { slice: slice })
+
+        // Configure Price IDs
+        exec(`yq w -i ${this.options.installerConfigPath} experimental.webapp.stripe.individualUsagePriceIds['EUR'] price_1LmYVxGadRXm50o3AiLq0Qmo`, { slice: slice })
+        exec(`yq w -i ${this.options.installerConfigPath} experimental.webapp.stripe.individualUsagePriceIds['USD'] price_1LmYWRGadRXm50o3Ym8PLqnG`, { slice: slice })
+        exec(`yq w -i ${this.options.installerConfigPath} experimental.webapp.stripe.teamUsagePriceIds['EUR'] price_1LiId7GadRXm50o3OayAS2y4`, { slice: slice })
+        exec(`yq w -i ${this.options.installerConfigPath} experimental.webapp.stripe.teamUsagePriceIds['USD'] price_1LiIdbGadRXm50o3ylg5S44r`, { slice: slice })
     }
 
     private configureConfigCat(slice: string) {

--- a/components/usage/pkg/server/server.go
+++ b/components/usage/pkg/server/server.go
@@ -38,6 +38,19 @@ type Config struct {
 	Server *baseserver.Configuration `json:"server,omitempty"`
 
 	DefaultSpendingLimit db.DefaultSpendingLimit `json:"defaultSpendingLimit"`
+
+	// StripePrices configure which Stripe Price IDs should be used
+	StripePrices StripePrices `json:"stripePrices"`
+}
+
+type PriceConfig struct {
+	EUR string `json:"eur"`
+	USD string `json:"usd"`
+}
+
+type StripePrices struct {
+	IndividualUsagePriceIDs PriceConfig `json:"individualUsagePriceIds"`
+	TeamUsagePriceIDs       PriceConfig `json:"teamUsagePriceIds"`
 }
 
 func Start(cfg Config, version string) error {

--- a/install/installer/pkg/components/usage/configmap.go
+++ b/install/installer/pkg/components/usage/configmap.go
@@ -34,16 +34,31 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 			MinForUsersOnStripe: 0,
 		},
 	}
-	expConfig := getExperimentalConfig(ctx)
 
-	if expConfig != nil {
-		if expConfig.Schedule != "" {
-			cfg.ControllerSchedule = expConfig.Schedule
+	expWebAppConfig := getExperimentalWebAppConfig(ctx)
+	if expWebAppConfig != nil && expWebAppConfig.Stripe != nil {
+		cfg.StripePrices = server.StripePrices{
+			IndividualUsagePriceIDs: server.PriceConfig{
+				EUR: expWebAppConfig.Stripe.IndividualUsagePriceIDs.EUR,
+				USD: expWebAppConfig.Stripe.IndividualUsagePriceIDs.USD,
+			},
+			TeamUsagePriceIDs: server.PriceConfig{
+				EUR: expWebAppConfig.Stripe.TeamUsagePriceIDs.EUR,
+				USD: expWebAppConfig.Stripe.TeamUsagePriceIDs.USD,
+			},
 		}
-		if expConfig.DefaultSpendingLimit != nil {
-			cfg.DefaultSpendingLimit = *expConfig.DefaultSpendingLimit
+	}
+
+	expUsageConfig := getExperimentalUsageConfig(ctx)
+
+	if expUsageConfig != nil {
+		if expUsageConfig.Schedule != "" {
+			cfg.ControllerSchedule = expUsageConfig.Schedule
 		}
-		cfg.CreditsPerMinuteByWorkspaceClass = expConfig.CreditsPerMinuteByWorkspaceClass
+		if expUsageConfig.DefaultSpendingLimit != nil {
+			cfg.DefaultSpendingLimit = *expUsageConfig.DefaultSpendingLimit
+		}
+		cfg.CreditsPerMinuteByWorkspaceClass = expUsageConfig.CreditsPerMinuteByWorkspaceClass
 	}
 
 	_ = ctx.WithExperimental(func(ucfg *experimental.Config) error {

--- a/install/installer/pkg/components/usage/configmap_test.go
+++ b/install/installer/pkg/components/usage/configmap_test.go
@@ -29,6 +29,16 @@ func TestConfigMap_ContainsSchedule(t *testing.T) {
 		"forTeams": 1000000000,
 		"minForUsersOnStripe": 0
 	   },
+	   "stripePrices": {
+		"individualUsagePriceIds": {
+		  "eur": "",
+		  "usd": ""
+		},
+		"teamUsagePriceIds": {
+		  "eur": "",
+		  "usd": ""
+		}
+	   },
        "server": {
          "services": {
            "grpc": {

--- a/install/installer/pkg/components/usage/objects.go
+++ b/install/installer/pkg/components/usage/objects.go
@@ -11,7 +11,7 @@ import (
 )
 
 func Objects(ctx *common.RenderContext) ([]runtime.Object, error) {
-	cfg := getExperimentalConfig(ctx)
+	cfg := getExperimentalUsageConfig(ctx)
 	if cfg == nil {
 		return nil, nil
 	}
@@ -27,7 +27,7 @@ func Objects(ctx *common.RenderContext) ([]runtime.Object, error) {
 	)(ctx)
 }
 
-func getExperimentalConfig(ctx *common.RenderContext) *experimental.UsageConfig {
+func getExperimentalWebAppConfig(ctx *common.RenderContext) *experimental.WebAppConfig {
 	var experimentalCfg *experimental.Config
 
 	_ = ctx.WithExperimental(func(ucfg *experimental.Config) error {
@@ -35,9 +35,19 @@ func getExperimentalConfig(ctx *common.RenderContext) *experimental.UsageConfig 
 		return nil
 	})
 
-	if experimentalCfg == nil || experimentalCfg.WebApp == nil || experimentalCfg.WebApp.Usage == nil {
+	if experimentalCfg == nil || experimentalCfg.WebApp == nil {
 		return nil
 	}
 
-	return experimentalCfg.WebApp.Usage
+	return experimentalCfg.WebApp
+}
+
+func getExperimentalUsageConfig(ctx *common.RenderContext) *experimental.UsageConfig {
+	experimentalWebAppCfg := getExperimentalWebAppConfig(ctx)
+	if experimentalWebAppCfg == nil || experimentalWebAppCfg.Usage == nil {
+
+		return nil
+	}
+
+	return experimentalWebAppCfg.Usage
 }

--- a/install/installer/pkg/config/v1/experimental/experimental.go
+++ b/install/installer/pkg/config/v1/experimental/experimental.go
@@ -167,6 +167,16 @@ type WorkspaceTemplates struct {
 	Regular    *corev1.Pod `json:"regular"`
 }
 
+type StripePriceIDs struct {
+	EUR string `json:"eur"`
+	USD string `json:"usd"`
+}
+
+type StripeConfig struct {
+	IndividualUsagePriceIDs StripePriceIDs `json:"individualUsagePriceIds"`
+	TeamUsagePriceIDs       StripePriceIDs `json:"teamUsagePriceIds"`
+}
+
 type WebAppConfig struct {
 	PublicAPI              *PublicAPIConfig       `json:"publicApi,omitempty"`
 	Server                 *ServerConfig          `json:"server,omitempty"`
@@ -178,6 +188,7 @@ type WebAppConfig struct {
 	Usage                  *UsageConfig           `json:"usage,omitempty"`
 	ConfigcatKey           string                 `json:"configcatKey"`
 	WorkspaceClasses       []WebAppWorkspaceClass `json:"workspaceClasses"`
+	Stripe                 *StripeConfig          `json:"stripe,omitempty"`
 }
 
 type WorkspaceDefaults struct {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Loads Stripe Price ID configuration from installer config. These fields are already defined in https://github.com/gitpod-io/ops/commit/a5855e723fe7b703d81b5f09a4869fef186b5581

The prices IDs are only loaded into the deployment, but do not get used. This allows us to validate it before we make code changes to start using them.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #14115 

## How to test
<!-- Provide steps to test this PR -->
1. Preview configmap for usage contains the price IDs

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
