### PR TITLE
[db] Add `_lastModified` column to `d_b_workspace_cluster` table

### DIFF
--- a/components/gitpod-db/src/typeorm/entity/db-workspace-cluster.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-workspace-cluster.ts
@@ -14,6 +14,7 @@ import {
 import { ValueTransformer } from "typeorm/decorator/options/ValueTransformer";
 
 @Entity()
+// on DB but not Typeorm: @Index("ind_lastModified", ["_lastModified"])   // DBSync
 export class DBWorkspaceCluster implements WorkspaceCluster {
     @PrimaryColumn()
     name: string;

--- a/components/gitpod-db/src/typeorm/migration/1666616345054-AddLastModifiedToWorkspaceClusterTable.ts
+++ b/components/gitpod-db/src/typeorm/migration/1666616345054-AddLastModifiedToWorkspaceClusterTable.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+const TABLE_NAME = "d_b_workspace_cluster";
+const COLUMN_NAME = "_lastModified";
+const INDEX_NAME = "ind_lastModified";
+
+export class AddLastModifiedToWorkspaceClusterTable1666616345054 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `ALTER TABLE ${TABLE_NAME} ADD COLUMN ${COLUMN_NAME} timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6), ALGORITHM=INPLACE, LOCK=NONE `,
+        );
+        queryRunner.query(`CREATE INDEX ${INDEX_NAME} ON ${TABLE_NAME} (${COLUMN_NAME})`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {}
+}


### PR DESCRIPTION
## Description

Add a `_lastModified` column to `d_b_workspace_cluster` table so that it can be synced with `db-sync` in a later PR.
 
## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of #9198 and https://github.com/gitpod-io/gitpod/issues/13800
## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
