### PR TITLE
[dashboard] Keep showing 'Personal Account' menu entry if you have personal projects but no team yet

### DIFF
--- a/components/dashboard/src/Menu.tsx
+++ b/components/dashboard/src/Menu.tsx
@@ -249,7 +249,7 @@ export default function Menu() {
     };
     const isTeamLevelActive = !projectSlug && !isWorkspacesUI && !isPersonalSettingsUI && !isAdminUI && teamOrUserSlug;
     const renderTeamMenu = () => {
-        if (!teams || teams.length === 0) {
+        if (!hasIndividualProjects && (!teams || teams.length === 0)) {
             return (
                 <div className="p-1 text-base text-gray-500 dark:text-gray-400 border-gray-800">
                     <PillMenuItem


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

When you have Projects under your 'Personal Account' (now being deprecated), but you have no Teams yet, we currently show only a "New Team →" button, with no way to access the projects under your 'Personal Account'. 🐞 

This PR makes Gitpod show your 'Personal Account' menu entry again when you're in that specific case (but not if you don't have any Projects there).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/14002

## How to test
<!-- Provide steps to test this PR -->

1. Log in to the preview environment
2. Visit `/new` to create a Project under your 'Personal Account' manually
3. Your 'Personal Account' should be accessible from the top menu's "account selector" (without you having to create a team first)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
