### PR TITLE
[db] Change the primary key of the `d_b_workspace_cluster` table

### DIFF
--- a/components/gitpod-db/src/typeorm/migration/1666611052662-ChangeWorkspaceClusterTablePK.ts
+++ b/components/gitpod-db/src/typeorm/migration/1666611052662-ChangeWorkspaceClusterTablePK.ts
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class ChangeWorkspaceClusterTablePK1666611052662 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE d_b_workspace_cluster DROP PRIMARY KEY`);
+        await queryRunner.query(`ALTER TABLE d_b_workspace_cluster ADD PRIMARY KEY (name, applicationCluster)`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {}
+}


### PR DESCRIPTION
## Description

Change the primary key of the `d_b_workspace_cluster` table from a key on just the `name` field to a composite key on `name` and `applicationCluster`.

<details>
<summary>Context </summary>
As part of #9198  we want to start syncing the `d_b_workspace_cluster` table with `db-sync`.

Currently, the table differs between US and EU regions because each table contains only the data relevant to that region. For example, in the EU table, the `eu70` workspace cluster is marked as `available` and the `us70` cluster is `cordoned`.  In the US cluster `eu70` is `cordoned` and `us70` is `available`.

In order to sync the table we need to get to a point where there is no difference in the data in the table between EU and US regions.

To do that we will introduce a new field in the table called `applicationCluster` which records the name of the application cluster to which the record belongs. Thus, for each workspace cluster there will be two rows in Gitpod SaaS:

| name | applicationCluster | url | tls | state | ... |
| --- | --- | --- | --- | --- | --- |
| eu70 | eu02 | url | tls info | available | ... |
| eu70 | us02 | url | tls info | cordoned | ... |

Effectively the new `applicationCluster` column gives the table an extra dimension so that we can combine both tables (EU and US) into one.

#13722  added the column to the table and made `gpctl` fill the value when `gpctl register`ing a new workspace cluster. The value is taken from the `GITPOD_INSTALLATION_SHORTNAME` environment variable in `ws-manager-bridge`.
</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of #9198 and #13800 

## How to test

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
