### PR TITLE
Update Platform Version from JetBrains Backend Plugin

### DIFF
--- a/components/ide/jetbrains/backend-plugin/gradle-latest.properties
+++ b/components/ide/jetbrains/backend-plugin/gradle-latest.properties
@@ -1,9 +1,9 @@
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
-pluginSinceBuild=223
+pluginSinceBuild=223.7126
 pluginUntilBuild=223.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions.
 pluginVerifierIdeVersions=2022.3
 # Version from "com.jetbrains.intellij.idea" which can be found at https://www.jetbrains.com/intellij-repository/snapshots
-platformVersion=223.6160-EAP-CANDIDATE-SNAPSHOT
+platformVersion=223.7126-EAP-CANDIDATE-SNAPSHOT

--- a/components/ide/jetbrains/backend-plugin/gradle-stable.properties
+++ b/components/ide/jetbrains/backend-plugin/gradle-stable.properties
@@ -1,9 +1,9 @@
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
-pluginSinceBuild=222
+pluginSinceBuild=222.4345
 pluginUntilBuild=222.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions.
 pluginVerifierIdeVersions=2022.2
 # Version from "com.jetbrains.intellij.idea" which can be found at https://www.jetbrains.com/intellij-repository/snapshots
-platformVersion=222.3345-EAP-CANDIDATE-SNAPSHOT
+platformVersion=222.4345-EAP-CANDIDATE-SNAPSHOT

--- a/components/ide/jetbrains/backend-plugin/launch-dev-server.sh
+++ b/components/ide/jetbrains/backend-plugin/launch-dev-server.sh
@@ -28,8 +28,8 @@ TEST_BACKEND_DIR="/workspace/ide-backend-$JB_QUALIFIER"
 if [ ! -d "$TEST_BACKEND_DIR" ]; then
   mkdir -p $TEST_BACKEND_DIR
   if [[ $RUN_FROM == "snapshot" ]]; then
+    SNAPSHOT_VERSION=$(grep "platformVersion=" "gradle-$JB_QUALIFIER.properties" | sed 's/platformVersion=//')
     (cd $TEST_BACKEND_DIR &&
-    SNAPSHOT_VERSION=$(grep "platformVersion=" "gradle-$JB_QUALIFIER.properties" | sed 's/platformVersion=//') &&
     echo "Downloading the $JB_QUALIFIER version of IntelliJ IDEA ($SNAPSHOT_VERSION)..." &&
     curl -sSLo backend.zip "https://www.jetbrains.com/intellij-repository/snapshots/com/jetbrains/intellij/idea/ideaIU/$SNAPSHOT_VERSION/ideaIU-$SNAPSHOT_VERSION.zip" &&
     unzip backend.zip &&
@@ -37,8 +37,8 @@ if [ ! -d "$TEST_BACKEND_DIR" ]; then
     ln -s "ideaIU-$SNAPSHOT_VERSION" . &&
     rm -r "ideaIU-$SNAPSHOT_VERSION" &&
     cp -r /ide-desktop/backend/jbr . &&
-    cp /ide-desktop/backend/bin/idea.properties ./bin &&
-    cp /ide-desktop/backend/bin/idea64.vmoptions ./bin)
+    cp ./bin/linux/idea.properties ./bin &&
+    cp ./bin/linux/idea64.vmoptions ./bin)
   else
     if [[ $JB_QUALIFIER == "stable" ]]; then
       PRODUCT_TYPE="release"

--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/GitpodCLIHelper.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/GitpodCLIHelper.kt
@@ -1,0 +1,11 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package io.gitpod.jetbrains.remote
+
+import java.nio.file.Path
+
+interface GitpodCLIHelper {
+    suspend fun open(file: Path, shouldWait: Boolean)
+}

--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/GitpodCLIService.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/GitpodCLIService.kt
@@ -6,7 +6,6 @@ package io.gitpod.jetbrains.remote
 
 import com.intellij.codeWithMe.ClientId
 import com.intellij.ide.BrowserUtil
-import com.intellij.ide.CommandLineProcessor
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.client.ClientSession
 import com.intellij.openapi.client.ClientSessionsManager
@@ -40,6 +39,7 @@ class GitpodCLIService : RestService() {
 
     private val manager = service<GitpodManager>()
     private val portsService = service<GitpodPortsService>()
+    private val cliHelperService = service<GitpodCLIHelper>()
 
     override fun getServiceName() = SERVICE_NAME
 
@@ -71,7 +71,7 @@ class GitpodCLIService : RestService() {
             return withClient(request, context) {
                 GlobalScope.launch {
                     withContext(Dispatchers.IO) {
-                        CommandLineProcessor.doOpenFileOrProject(file, shouldWait).future.get()
+                        cliHelperService.open(file, shouldWait)
                     }
                 }
             }

--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/GitpodGlobalPortForwardingService.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/GitpodGlobalPortForwardingService.kt
@@ -1,0 +1,11 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package io.gitpod.jetbrains.remote
+
+import com.intellij.openapi.Disposable
+
+interface GitpodGlobalPortForwardingService {
+    fun monitorPortsOfPid(disposable: Disposable, pid: Long)
+}

--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/latest/GitpodCLIHelperImpl.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/latest/GitpodCLIHelperImpl.kt
@@ -1,0 +1,16 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package io.gitpod.jetbrains.remote.latest
+
+import com.intellij.ide.CommandLineProcessor
+import io.gitpod.jetbrains.remote.GitpodCLIHelper
+import java.nio.file.Path
+
+@Suppress("UnstableApiUsage")
+class GitpodCLIHelperImpl : GitpodCLIHelper  {
+    override suspend fun open(file :Path, shouldWait: Boolean) {
+        CommandLineProcessor.doOpenFileOrProject(file, shouldWait).future.await()
+    }
+}

--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/latest/GitpodGlobalPortForwardingServiceImpl.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/latest/GitpodGlobalPortForwardingServiceImpl.kt
@@ -1,0 +1,48 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package io.gitpod.jetbrains.remote.latest
+
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.components.service
+import com.intellij.openapi.diagnostic.thisLogger
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Disposer
+import com.intellij.remoteDev.util.onTerminationOrNow
+import com.intellij.ui.RowIcon
+import com.intellij.util.application
+import com.jetbrains.rd.platform.codeWithMe.portForwarding.*
+import com.jetbrains.rd.platform.util.lifetime
+import com.jetbrains.rd.util.lifetime.LifetimeStatus
+import io.gitpod.jetbrains.remote.GitpodIgnoredPortsForNotificationService
+import io.gitpod.jetbrains.remote.GitpodManager
+import io.gitpod.jetbrains.remote.GitpodGlobalPortForwardingService
+import io.gitpod.jetbrains.remote.GitpodPortsService
+import io.gitpod.jetbrains.remote.icons.GitpodIcons
+import io.gitpod.supervisor.api.Status
+import io.gitpod.supervisor.api.StatusServiceGrpc
+import io.grpc.stub.ClientCallStreamObserver
+import io.grpc.stub.ClientResponseObserver
+import io.ktor.utils.io.*
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.TimeUnit
+import javax.swing.Icon
+
+@Suppress("UnstableApiUsage")
+class GitpodGlobalPortForwardingServiceImpl: GitpodGlobalPortForwardingService {
+    private val globalPortForwardingManager = service<GlobalPortForwardingManager>()
+
+    override fun monitorPortsOfPid(disposable: Disposable, pid: Long) {
+        globalPortForwardingManager.monitorPortsOfPid(
+                disposable,
+                pid,
+                object : ListeningPortHandler {
+                    override fun onPortListeningStarted(port: ListeningPort) {
+                        thisLogger().warn("gitpod: onPortListeningStarted ${port.portType} ${port.pid} ${port.socketAddress}")
+                    }
+                },
+                PortListeningOptions.INCLUDE_SELF_AND_CHILDREN
+        )
+    }
+}

--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/latest/GitpodPortsActionCopyUrl.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/latest/GitpodPortsActionCopyUrl.kt
@@ -1,0 +1,25 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package io.gitpod.jetbrains.remote.latest
+
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.diagnostic.thisLogger
+import com.intellij.openapi.ide.CopyPasteManager
+import com.jetbrains.rd.platform.codeWithMe.portForwarding.PortForwardingDataKeys
+import java.awt.datatransfer.StringSelection
+
+@Suppress("ComponentNotRegistered", "UnstableApiUsage")
+class GitpodPortsActionCopyUrl : AnAction() {
+    override fun actionPerformed(e: AnActionEvent) {
+        val port = e.dataContext.getData(PortForwardingDataKeys.PORT)
+        if (port != null) {
+            thisLogger().warn("gitpod: Exec GitpodPortsActionCopyUrl: ${port.hostPortNumber}")
+            CopyPasteManager.getInstance().setContents(StringSelection(port.hostPortNumber.toString()))
+        } else {
+            thisLogger().warn("gitpod: Exec: GitpodPortsActionCopyUrl: error unknown port")
+        }
+    }
+}

--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/stable/GitpodCLIHelperImpl.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/stable/GitpodCLIHelperImpl.kt
@@ -1,0 +1,16 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package io.gitpod.jetbrains.remote.stable
+
+import com.intellij.ide.CommandLineProcessor
+import io.gitpod.jetbrains.remote.GitpodCLIHelper
+import java.nio.file.Path
+
+@Suppress("UnstableApiUsage")
+class GitpodCLIHelperImpl : GitpodCLIHelper  {
+    override suspend fun open(file :Path, shouldWait: Boolean) {
+        CommandLineProcessor.doOpenFileOrProject(file, shouldWait).future.get()
+    }
+}

--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/stable/GitpodClientProjectGuestSessionTracker.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/stable/GitpodClientProjectGuestSessionTracker.kt
@@ -1,0 +1,13 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package io.gitpod.jetbrains.remote.stable
+
+import com.intellij.openapi.client.ClientProjectSession
+import io.gitpod.jetbrains.remote.GitpodClientProjectSessionTracker
+
+@Suppress("UnstableApiUsage")
+class GitpodClientProjectGuestSessionTracker(session: ClientProjectSession) {
+    init { GitpodClientProjectSessionTracker(session.project) }
+}

--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/stable/GitpodGlobalPortForwardingServiceImpl.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/stable/GitpodGlobalPortForwardingServiceImpl.kt
@@ -1,0 +1,12 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package io.gitpod.jetbrains.remote.stable
+
+import com.intellij.openapi.Disposable
+import io.gitpod.jetbrains.remote.GitpodGlobalPortForwardingService
+
+class GitpodGlobalPortForwardingServiceImpl : GitpodGlobalPortForwardingService {
+    override fun monitorPortsOfPid(disposable: Disposable, pid: Long) = Unit
+}

--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/stable/GitpodTerminalGuestService.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/stable/GitpodTerminalGuestService.kt
@@ -1,0 +1,12 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package io.gitpod.jetbrains.remote.stable
+import com.intellij.openapi.client.ClientProjectSession
+import io.gitpod.jetbrains.remote.GitpodTerminalService
+
+@Suppress("UnstableApiUsage")
+class GitpodTerminalGuestService(session: ClientProjectSession) {
+    init { GitpodTerminalService(session.project) }
+}

--- a/components/ide/jetbrains/backend-plugin/src/main/resources-latest/META-INF/extensions.xml
+++ b/components/ide/jetbrains/backend-plugin/src/main/resources-latest/META-INF/extensions.xml
@@ -7,6 +7,18 @@
 <idea-plugin>
     <extensions defaultExtensionNs="com.intellij">
         <applicationService serviceInterface="io.gitpod.jetbrains.remote.GitpodIgnoredPortsForNotificationService" serviceImplementation="io.gitpod.jetbrains.remote.latest.GitpodIgnoredPortsForNotificationServiceImpl" preload="true"/>
-        <projectService serviceImplementation="io.gitpod.jetbrains.remote.latest.GitpodPortForwardingService" preload="true" client="guest"/>
+        <applicationService serviceInterface="io.gitpod.jetbrains.remote.GitpodCLIHelper" serviceImplementation="io.gitpod.jetbrains.remote.latest.GitpodCLIHelperImpl"/>
+        <applicationService serviceInterface="io.gitpod.jetbrains.remote.GitpodGlobalPortForwardingService" serviceImplementation="io.gitpod.jetbrains.remote.latest.GitpodGlobalPortForwardingServiceImpl"/>
+        <projectService serviceImplementation="io.gitpod.jetbrains.remote.GitpodClientProjectSessionTracker" client="controller" preload="true"/>
+        <projectService serviceImplementation="io.gitpod.jetbrains.remote.GitpodTerminalService" client="controller" preload="true"/>
+        <projectService serviceImplementation="io.gitpod.jetbrains.remote.latest.GitpodPortForwardingService" client="controller" preload="true"/>
     </extensions>
+<!--    <actions>-->
+<!--        <action id="io.gitpod.jetbrains.remote.latest.GitpodPortsActionCopyUrl"-->
+<!--                class="io.gitpod.jetbrains.remote.latest.GitpodPortsActionCopyUrl"-->
+<!--                text="Gitpod: Copy Port URL"-->
+<!--                icon="AllIcons.Actions.Copy">-->
+<!--            <add-to-group group-id="PortForwardingPortGroup" anchor="last"/>-->
+<!--        </action>-->
+<!--    </actions>-->
 </idea-plugin>

--- a/components/ide/jetbrains/backend-plugin/src/main/resources-stable/META-INF/extensions.xml
+++ b/components/ide/jetbrains/backend-plugin/src/main/resources-stable/META-INF/extensions.xml
@@ -7,5 +7,9 @@
 <idea-plugin>
     <extensions defaultExtensionNs="com.intellij">
         <applicationService serviceInterface="io.gitpod.jetbrains.remote.GitpodIgnoredPortsForNotificationService" serviceImplementation="io.gitpod.jetbrains.remote.stable.GitpodIgnoredPortsForNotificationServiceImpl" preload="true"/>
+        <applicationService serviceInterface="io.gitpod.jetbrains.remote.GitpodCLIHelper" serviceImplementation="io.gitpod.jetbrains.remote.stable.GitpodCLIHelperImpl"/>
+        <applicationService serviceInterface="io.gitpod.jetbrains.remote.GitpodGlobalPortForwardingService" serviceImplementation="io.gitpod.jetbrains.remote.latest.GitpodGlobalPortForwardingServiceImpl"/>
+        <projectService serviceImplementation="io.gitpod.jetbrains.remote.stable.GitpodClientProjectGuestSessionTracker" client="guest" preload="true"/>
+        <projectService serviceImplementation="io.gitpod.jetbrains.remote.stable.GitpodTerminalGuestService" client="guest" preload="true"/>
     </extensions>
 </idea-plugin>

--- a/components/ide/jetbrains/backend-plugin/src/main/resources/META-INF/plugin.xml
+++ b/components/ide/jetbrains/backend-plugin/src/main/resources/META-INF/plugin.xml
@@ -3,6 +3,7 @@
  Licensed under the GNU Affero General Public License (AGPL).
  See License-AGPL.txt in the project root for license information.
 -->
+<!--suppress PluginXmlValidity -->
 <idea-plugin xmlns:xi="http://www.w3.org/2001/XInclude">
     <xi:include href="/META-INF/extensions.xml" xpointer="xpointer(/idea-plugin/*)"/>
 
@@ -28,11 +29,7 @@
         <applicationService serviceImplementation="io.gitpod.jetbrains.remote.GitpodPortsService" preload="true"/>
         <notificationGroup id="Gitpod Notifications" displayType="BALLOON" isLogByDefault="false"/>
         <httpRequestHandler implementation="io.gitpod.jetbrains.remote.GitpodCLIService"/>
-        <projectService serviceImplementation="io.gitpod.jetbrains.remote.GitpodClientProjectSessionTracker"
-                        client="guest" preload="true"/>
         <projectService serviceImplementation="io.gitpod.jetbrains.remote.GitpodProjectManager" preload="true"/>
-        <projectService serviceImplementation="io.gitpod.jetbrains.remote.GitpodTerminalService" client="guest"
-                        preload="true"/>
         <gateway.customization.name
                 implementation="io.gitpod.jetbrains.remote.GitpodGatewayClientCustomizationProvider"/>
         <gateway.customization.performance id="gitpodMetricsControl" order="before cpuControl"


### PR DESCRIPTION
## Description
This PR updates the Platform Version from JetBrains Backend Plugin to the latest version.

Note: This should only be merged after all 6 EAP JB IDEs available on Gitpod become v223.7x.

## How to test
1. Open the preview environment generated for this branch
2. Choose the _Latest Release (Unstable)_ version of IntelliJ IDEA as your preferred editor
3. Start a workspace using this repository: https://github.com/gitpod-io/spring-petclinic
4. Verify that the workspace starts successfully
5. Verify that the IDE opens successfully

## Release Notes
```release-note
NONE
```

## Werft options:
- [x] /werft with-preview
- [x] /werft with-large-vm