### PR TITLE
[public-api] Export metrics with package label instead of service

### DIFF
--- a/components/public-api-server/pkg/server/metrics.go
+++ b/components/public-api-server/pkg/server/metrics.go
@@ -45,20 +45,20 @@ func NewConnectMetrics() *ConnectMetrics {
 		ServerRequestsStarted: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "connect_server_started_total",
 			Help: "Counter of server connect (gRPC/HTTP) requests started",
-		}, []string{"service", "call", "call_type"}),
+		}, []string{"package", "call", "call_type"}),
 		ServerRequestsHandled: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Name: "connect_server_handled_seconds",
 			Help: "Histogram of server connect (gRPC/HTTP) requests completed",
-		}, []string{"service", "call", "call_type", "code"}),
+		}, []string{"package", "call", "call_type", "code"}),
 
 		ClientRequestsStarted: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "connect_client_started_total",
 			Help: "Counter of client connect (gRPC/HTTP) requests started",
-		}, []string{"service", "call", "call_type"}),
+		}, []string{"package", "call", "call_type"}),
 		ClientRequestsHandled: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Name: "connect_client_handled_seconds",
 			Help: "Histogram of client connect (gRPC/HTTP) requests completed",
-		}, []string{"service", "call", "call_type", "code"}),
+		}, []string{"package", "call", "call_type", "code"}),
 	}
 }
 
@@ -66,23 +66,23 @@ func NewMetricsInterceptor(metrics *ConnectMetrics) connect.UnaryInterceptorFunc
 	interceptor := func(next connect.UnaryFunc) connect.UnaryFunc {
 		return connect.UnaryFunc(func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
 			now := time.Now()
-			service, call := splitServiceCall(req.Spec().Procedure)
+			callPackage, callName := splitServiceCall(req.Spec().Procedure)
 			callType := streamType(req.Spec().StreamType)
 			isClient := req.Spec().IsClient
 
 			if isClient {
-				metrics.ClientRequestsStarted.WithLabelValues(service, call, callType)
+				metrics.ClientRequestsStarted.WithLabelValues(callPackage, callName, callType)
 			} else {
-				metrics.ServerRequestsStarted.WithLabelValues(service, call, callType)
+				metrics.ServerRequestsStarted.WithLabelValues(callPackage, callName, callType)
 			}
 
 			resp, err := next(ctx, req)
 
 			code := codeOf(err)
 			if isClient {
-				metrics.ClientRequestsHandled.WithLabelValues(service, call, callType, code).Observe(time.Since(now).Seconds())
+				metrics.ClientRequestsHandled.WithLabelValues(callPackage, callName, callType, code).Observe(time.Since(now).Seconds())
 			} else {
-				metrics.ServerRequestsHandled.WithLabelValues(service, call, callType, code).Observe(time.Since(now).Seconds())
+				metrics.ServerRequestsHandled.WithLabelValues(callPackage, callName, callType, code).Observe(time.Since(now).Seconds())
 			}
 
 			return resp, err


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

The label `service` is used by k8s prometheus exporter. This results in our `service` label being re-exported as `exported_service` which is not ideal. Renaming to `package` avoids this collision.

[See here](https://grafana.gitpod.io/explore?orgId=1&left=%7B%22datasource%22:%22P4169E866C3094E38%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22editorMode%22:%22code%22,%22expr%22:%22connect_server_handled_seconds_count%22,%22legendFormat%22:%22__auto%22,%22range%22:true,%22instant%22:true%7D%5D,%22range%22:%7B%22from%22:%22now-24h%22,%22to%22:%22now%22%7D%7D)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
