### PR TITLE
Always prorate when cancelling Stripe subscriptions

### DIFF
--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -279,6 +279,7 @@ export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, 
     findStripeSubscriptionId(attributionId: string): Promise<string | undefined>;
     createStripeCustomerIfNeeded(attributionId: string, currency: string): Promise<void>;
     subscribeToStripe(attributionId: string, setupIntentId: string, usageLimit: number): Promise<number | undefined>;
+    cancelStripeSubscription(attributionId: string): Promise<void>;
     getStripePortalUrl(attributionId: string): Promise<string>;
     getUsageLimit(attributionId: string): Promise<number | undefined>;
     setUsageLimit(attributionId: string, usageLimit: number): Promise<void>;

--- a/components/server/ee/src/user/stripe-service.ts
+++ b/components/server/ee/src/user/stripe-service.ts
@@ -117,7 +117,7 @@ export class StripeService {
 
     async cancelSubscription(subscriptionId: string): Promise<void> {
         await reportStripeOutcome("subscriptions_cancel", () => {
-            return this.getStripe().subscriptions.del(subscriptionId);
+            return this.getStripe().subscriptions.del(subscriptionId, { prorate: true, invoice_now: true });
         });
     }
 

--- a/components/server/ee/src/user/user-deletion-service.ts
+++ b/components/server/ee/src/user/user-deletion-service.ts
@@ -8,13 +8,16 @@ import { injectable, inject } from "inversify";
 import { UserDeletionService } from "../../../src/user/user-deletion-service";
 import { SubscriptionService } from "@gitpod/gitpod-payment-endpoint/lib/accounting/subscription-service";
 import { Plans } from "@gitpod/gitpod-protocol/lib/plans";
+import { AttributionId } from "@gitpod/gitpod-protocol/lib/attribution";
 import { ChargebeeService } from "./chargebee-service";
+import { StripeService } from "./stripe-service";
 import { TeamSubscriptionService } from "@gitpod/gitpod-payment-endpoint/lib/accounting";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 
 @injectable()
 export class UserDeletionServiceEE extends UserDeletionService {
     @inject(ChargebeeService) protected readonly chargebeeService: ChargebeeService;
+    @inject(StripeService) protected readonly stripeService: StripeService;
     @inject(SubscriptionService) protected readonly subscriptionService: SubscriptionService;
     @inject(TeamSubscriptionService) protected readonly teamSubscriptionService: TeamSubscriptionService;
 
@@ -27,14 +30,14 @@ export class UserDeletionServiceEE extends UserDeletionService {
         const errors = [];
         if (this.config.enablePayment) {
             const now = new Date();
-            const subscriptions = await this.subscriptionService.getNotYetCancelledSubscriptions(
+            const chargebeeSubscriptions = await this.subscriptionService.getNotYetCancelledSubscriptions(
                 user,
                 now.toISOString(),
             );
-            for (const subscription of subscriptions) {
+            for (const chargebeeSubscription of chargebeeSubscriptions) {
                 try {
-                    const planId = subscription.planId!;
-                    const paymentReference = subscription.paymentReference;
+                    const planId = chargebeeSubscription.planId!;
+                    const paymentReference = chargebeeSubscription.paymentReference;
                     if (Plans.isFreeNonTransientPlan(planId)) {
                         // only delete those plans that are persisted in the DB
                         await this.subscriptionService.unsubscribe(user.id, now.toISOString(), planId);
@@ -58,8 +61,8 @@ export class UserDeletionServiceEE extends UserDeletionService {
                             throw new Error("Cannot delete user subscription from GitHub");
                         } else {
                             // cancel Chargebee subscriptions
-                            const subscriptionId = subscription.uid;
-                            const chargebeeSubscriptionId = subscription.paymentReference!;
+                            const subscriptionId = chargebeeSubscription.uid;
+                            const chargebeeSubscriptionId = chargebeeSubscription.paymentReference!;
                             await this.chargebeeService.cancelSubscription(
                                 chargebeeSubscriptionId,
                                 { userId: user.id },
@@ -69,8 +72,22 @@ export class UserDeletionServiceEE extends UserDeletionService {
                     }
                 } catch (error) {
                     errors.push(error);
-                    log.error("Error cancelling subscription", error, { subscription });
+                    log.error("Error cancelling Chargebee user subscription", error, {
+                        subscription: chargebeeSubscription,
+                    });
                 }
+            }
+            // Also cancel any usage-based (Stripe) subscription
+            const subscriptionId = await this.stripeService.findUncancelledSubscriptionByAttributionId(
+                AttributionId.render({ kind: "user", userId: user.id }),
+            );
+            try {
+                if (subscriptionId) {
+                    await this.stripeService.cancelSubscription(subscriptionId);
+                }
+            } catch (error) {
+                errors.push(error);
+                log.error("Error cancelling Stripe user subscription", error, { subscriptionId });
             }
         }
 

--- a/components/server/src/auth/rate-limiter.ts
+++ b/components/server/src/auth/rate-limiter.ts
@@ -201,6 +201,7 @@ const defaultFunctions: FunctionsConfig = {
     findStripeSubscriptionId: { group: "default", points: 1 },
     createStripeCustomerIfNeeded: { group: "default", points: 1 },
     subscribeToStripe: { group: "default", points: 1 },
+    cancelStripeSubscription: { group: "default", points: 1 },
     getStripePortalUrl: { group: "default", points: 1 },
     listUsage: { group: "default", points: 1 },
     getBillingModeForTeam: { group: "default", points: 1 },

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -3121,6 +3121,9 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
     ): Promise<number | undefined> {
         throw new ResponseError(ErrorCodes.SAAS_FEATURE, `Not implemented in this version`);
     }
+    async cancelStripeSubscription(ctx: TraceContext, attributionId: string): Promise<void> {
+        throw new ResponseError(ErrorCodes.SAAS_FEATURE, `Not implemented in this version`);
+    }
     async getStripePortalUrl(ctx: TraceContext, attributionId: string): Promise<string> {
         throw new ResponseError(ErrorCodes.SAAS_FEATURE, `Not implemented in this version`);
     }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Always prorate when cancelling Stripe subscriptions

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/13804

## How to test
<!-- Provide steps to test this PR -->

1. Create a team called "Gitpod [Something]" to enable usage-based for your user
2. Go to `/billing` and upgrade your personal account to usage-based billing by adding a credit card
3. Click on 'Manage Plan' -- there should no longer be a 'Cancel' option in the Stripe Customer Portal
4. Back in your billing page, click on 'Cancel Plan' and confirm
5. This should bill you for a pro-rated amount (e.g. not the full 9€, but something smaller or no charge) -- you can check the issued invoiced in the Stripe dashboard
6. Try upgrading again, then delete your user
7. This should also bill you for a pro-rated amount

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
