### PR TITLE
[server] Remove usage/stripe service from non EE user-service

### DIFF
--- a/components/server/ee/src/user/user-service.ts
+++ b/components/server/ee/src/user/user-service.ts
@@ -12,6 +12,7 @@ import {
     WORKSPACE_TIMEOUT_EXTENDED_ALT,
     WORKSPACE_TIMEOUT_DEFAULT_LONG,
     WORKSPACE_TIMEOUT_DEFAULT_SHORT,
+    Workspace,
 } from "@gitpod/gitpod-protocol";
 import { inject } from "inversify";
 import { LicenseEvaluator } from "@gitpod/licensor/lib";
@@ -20,6 +21,18 @@ import { SubscriptionService } from "@gitpod/gitpod-payment-endpoint/lib/account
 import { OssAllowListDB } from "@gitpod/gitpod-db/lib/oss-allowlist-db";
 import { HostContextProvider } from "../../../src/auth/host-context-provider";
 import { Config } from "../../../src/config";
+import { AttributionId } from "@gitpod/gitpod-protocol/lib/attribution";
+import { ResponseError } from "vscode-ws-jsonrpc";
+import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
+import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
+import { UsageServiceDefinition } from "@gitpod/usage-api/lib/usage/v1/usage.pb";
+import { UsageService } from "../../../src/user/usage-service";
+
+export interface UsageLimitReachedResult {
+    reached: boolean;
+    almostReached?: boolean;
+    attributionId: AttributionId;
+}
 
 export class UserServiceEE extends UserService {
     @inject(LicenseEvaluator) protected readonly licenseEvaluator: LicenseEvaluator;
@@ -27,7 +40,8 @@ export class UserServiceEE extends UserService {
     @inject(OssAllowListDB) protected readonly OssAllowListDb: OssAllowListDB;
     @inject(HostContextProvider) protected readonly hostContextProvider: HostContextProvider;
     @inject(Config) protected readonly config: Config;
-
+    @inject(UsageService) protected readonly usageService: UsageService;
+    @inject(UsageServiceDefinition.name)
     public workspaceTimeoutToDuration(timeout: WorkspaceTimeoutDuration): string {
         switch (timeout) {
             case WORKSPACE_TIMEOUT_DEFAULT_SHORT:
@@ -98,5 +112,132 @@ export class UserServiceEE extends UserService {
             .filter((i) => !!i) as string[];
 
         return this.OssAllowListDb.hasAny(idsWithHost);
+    }
+
+    /**
+     * Identifies the team or user to which a workspace instance's running time should be attributed to
+     * (e.g. for usage analytics or billing purposes).
+     *
+     *
+     * @param user
+     * @param projectId
+     * @returns The validated AttributionId
+     */
+    async getWorkspaceUsageAttributionId(user: User, projectId?: string): Promise<AttributionId> {
+        // if it's a workspace for a project the user has access to and the costcenter has credits use that
+        if (projectId) {
+            let attributionId: AttributionId | undefined;
+            const project = await this.projectDb.findProjectById(projectId);
+            if (project?.teamId) {
+                const teams = await this.teamDB.findTeamsByUser(user.id);
+                const team = teams.find((t) => t.id === project?.teamId);
+                if (team) {
+                    attributionId = AttributionId.create(team);
+                }
+            } else {
+                attributionId = AttributionId.create(user);
+            }
+            if (
+                !!attributionId &&
+                (await this.hasCredits(attributionId)) &&
+                !(await this.isUnbilledTeam(attributionId))
+            ) {
+                return attributionId;
+            }
+        }
+        if (user.usageAttributionId) {
+            // Return the user's explicit attribution ID.
+            return await this.validateUsageAttributionId(user, user.usageAttributionId);
+        }
+        return AttributionId.create(user);
+    }
+
+    protected async validateUsageAttributionId(user: User, usageAttributionId: string): Promise<AttributionId> {
+        const attribution = AttributionId.parse(usageAttributionId);
+        if (!attribution) {
+            throw new ResponseError(ErrorCodes.INVALID_COST_CENTER, "The billing team id configured is invalid.");
+        }
+        if (attribution.kind === "team") {
+            const team = await this.teamDB.findTeamById(attribution.teamId);
+            if (!team) {
+                throw new ResponseError(
+                    ErrorCodes.INVALID_COST_CENTER,
+                    "The billing team you've selected no longer exists.",
+                );
+            }
+            const members = await this.teamDB.findMembersByTeam(team.id);
+            if (!members.find((m) => m.userId === user.id)) {
+                throw new ResponseError(
+                    ErrorCodes.INVALID_COST_CENTER,
+                    "You're no longer a member of the selected billing team.",
+                );
+            }
+            if (await this.isUnbilledTeam(attribution)) {
+                throw new ResponseError(
+                    ErrorCodes.INVALID_COST_CENTER,
+                    "The billing team you've selected does not have billing enabled.",
+                );
+            }
+        }
+        if (attribution.kind === "user") {
+            if (user.id !== attribution.userId) {
+                throw new ResponseError(
+                    ErrorCodes.INVALID_COST_CENTER,
+                    "You can select either yourself or a team you are a member of",
+                );
+            }
+        }
+        const billedAttributionIds = await this.listAvailableUsageAttributionIds(user);
+        if (billedAttributionIds.find((id) => AttributionId.equals(id, attribution)) === undefined) {
+            throw new ResponseError(
+                ErrorCodes.INVALID_COST_CENTER,
+                "You can select either yourself or a billed team you are a member of",
+            );
+        }
+        return attribution;
+    }
+
+    /**
+     * @param user
+     * @param workspace - optional, in which case the default billing account will be checked
+     * @returns
+     */
+    async checkUsageLimitReached(user: User, workspace?: Workspace): Promise<UsageLimitReachedResult> {
+        const attributionId = await this.getWorkspaceUsageAttributionId(user, workspace?.projectId);
+        const creditBalance = await this.usageService.getCurrentBalance(attributionId);
+        const currentInvoiceCredits = creditBalance.usedCredits;
+        const usageLimit = creditBalance.usageLimit;
+        if (currentInvoiceCredits >= usageLimit) {
+            log.info({ userId: user.id }, "Usage limit reached", {
+                attributionId,
+                currentInvoiceCredits,
+                usageLimit,
+            });
+            return {
+                reached: true,
+                attributionId,
+            };
+        } else if (currentInvoiceCredits > usageLimit * 0.8) {
+            log.info({ userId: user.id }, "Usage limit almost reached", {
+                attributionId,
+                currentInvoiceCredits,
+                usageLimit,
+            });
+            return {
+                reached: false,
+                almostReached: true,
+                attributionId,
+            };
+        }
+
+        return {
+            reached: false,
+            attributionId,
+        };
+    }
+
+    protected async hasCredits(attributionId: AttributionId): Promise<boolean> {
+        const response = await this.usageService.getCurrentBalance(attributionId);
+        return response.usedCredits < response.usageLimit;
     }
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Remove all mentions of usage/stripe service from non EE user-service. Methods are shifted into the ee version instead.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
