### PR TITLE
Pin harvester tf provider version

### DIFF
--- a/dev/preview/infrastructure/harvester/provider.tf
+++ b/dev/preview/infrastructure/harvester/provider.tf
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     harvester = {
       source  = "harvester/harvester"
-      version = ">=0.5.3"
+      version = "=0.5.3"
     }
     k8s = {
       source  = "hashicorp/kubernetes"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Harvester released a new version of the provider, which is not compatible with the version of harvester we run: https://github.com/harvester/terraform-provider-harvester/releases/tag/v0.6.0

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://gitpod.slack.com/archives/C032A46PWR0/p1666691304322049

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
