### PR TITLE
dev/preview:build: Clean git repository before performing build

### DIFF
--- a/dev/preview/workflow/preview/build.sh
+++ b/dev/preview/workflow/preview/build.sh
@@ -23,7 +23,44 @@ VERSION="$(preview-name-from-branch)-dev"
 # We should fix the package definitions so that they don't include these files in the hash.
 #
 # For now we're simply cleaning the repository by deleting all files that are in .gitignore.
-git clean -dfX
+# The files were produced using "git clean -ndfX"
+components_dir="$SCRIPT_PATH/../../../../components"
+install_dir="$SCRIPT_PATH/../../../../install"
+rm -rf \
+    "$components_dir/content-service-api/typescript/lib/" \
+    "$components_dir/dashboard/build/" \
+    "$components_dir/ee/db-sync/lib/" \
+    "$components_dir/ee/payment-endpoint/lib/" \
+    "$components_dir/gitpod-db/lib/" \
+    "$components_dir/gitpod-messagebus/lib/" \
+    "$components_dir/gitpod-protocol/lib/" \
+    "$components_dir/ide-metrics-api/typescript-grpc/lib/" \
+    "$components_dir/ide-metrics-api/typescript-grpcweb/lib/" \
+    "$components_dir/ide-service-api/typescript/lib/" \
+    "$components_dir/image-builder-api/typescript/lib/" \
+    "$components_dir/licensor/typescript/build/" \
+    "$components_dir/licensor/typescript/ee/lib/" \
+    "$components_dir/licensor/typescript/lib/" \
+    "$components_dir/local-app-api/typescript-grpcweb/lib/" \
+    "$components_dir/public-api/typescript/lib/" \
+    "$components_dir/server/dist/" \
+    "$components_dir/supervisor-api/typescript-grpc/lib/" \
+    "$components_dir/supervisor-api/typescript-grpcweb/lib/" \
+    "$components_dir/supervisor/frontend/dist/" \
+    "$components_dir/supervisor/frontend/lib/" \
+    "$components_dir/usage-api/typescript/lib/" \
+    "$components_dir/ws-daemon-api/typescript/lib/" \
+    "$components_dir/ws-manager-api/typescript/lib/" \
+    "$components_dir/ws-manager-bridge-api/typescript/lib/" \
+    "$components_dir/ws-manager-bridge/dist/" \
+    "$install_dir/installer/third_party/charts/docker-registry/Chart.lock" \
+    "$install_dir/installer/third_party/charts/docker-registry/charts/" \
+    "$install_dir/installer/third_party/charts/minio/Chart.lock" \
+    "$install_dir/installer/third_party/charts/minio/charts/" \
+    "$install_dir/installer/third_party/charts/mysql/Chart.lock" \
+    "$install_dir/installer/third_party/charts/mysql/charts/" \
+    "$install_dir/installer/third_party/charts/rabbitmq/Chart.lock" \
+    "$install_dir/installer/third_party/charts/rabbitmq/charts/"
 
 leeway build \
     -DSEGMENT_IO_TOKEN="$(kubectl --context=dev -n werft get secret self-hosted -o jsonpath='{.data.segmentIOToken}' | base64 -d)" \

--- a/dev/preview/workflow/preview/build.sh
+++ b/dev/preview/workflow/preview/build.sh
@@ -15,8 +15,20 @@ ensure_gcloud_auth
 
 VERSION="$(preview-name-from-branch)-dev"
 
+# We have quite a few Leeway packages whose hash includes files from .gitignore.
+# Some of these files (such as build folders) are populated as part of our prebuilds
+# which means that the hash for these components will be different from a workspace
+# then in CI.
+#
+# We should fix the package definitions so that they don't include these files in the hash.
+#
+# For now we're simply cleaning the repository by deleting all files that are in .gitignore.
+git clean -dfX
+
 leeway build \
-    -DSEGMENT_IO_TOKEN="" \
+    -DSEGMENT_IO_TOKEN="$(kubectl --context=dev -n werft get secret self-hosted -o jsonpath='{.data.segmentIOToken}' | base64 -d)" \
+    -DREPLICATED_API_TOKEN="$(kubectl --context=dev -n werft get secret replicated -o jsonpath='{.data.token}' | base64 -d)" \
+    -DREPLICATED_APP="$(kubectl --context=dev -n werft get secret replicated -o jsonpath='{.data.app}' | base64 -d)" \
     -Dversion="${VERSION}" \
     --dont-retag \
     --dont-test \


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

It turns out that the "cache miss" we were seeing from Gitpod Workspaces is due to some of our packages being sensitive to a "dirty filesystem". As a temporary solution I'm using `git clean` (see comment in code) but we should go through each component and see if we can make sure it isn't impacted by the occurrence of files that we have in .gitignore (such as build folders) - I have created an issue (https://github.com/gitpod-io/gitpod/issues/14157) and proposed it for next week.

This PR also adds a few more build arguments to align with the Leeway invocation performed by Werft to make it easier to merge the two as part of https://github.com/gitpod-io/ops/issues/5894

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/13767

## How to test
<!-- Provide steps to test this PR -->

```sh
gcloud auth login --no-launch-browser
leeway run dev/preview:build
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
