### PR TITLE
[usage] Personal usage tab

### DIFF
--- a/components/dashboard/src/components/UsageView.tsx
+++ b/components/dashboard/src/components/UsageView.tsx
@@ -141,10 +141,12 @@ function UsageView({ attributionId }: UsageViewProps) {
 
     const currentPaginatedResults = usagePage?.usageEntriesList.filter((u) => u.kind === "workspaceinstance") ?? [];
 
+    const headerTitle = attributionId.kind === "team" ? "Team Usage" : "Personal Usage";
+
     return (
         <>
             <Header
-                title="Usage"
+                title={headerTitle}
                 subtitle={`${new Date(startDateOfBillMonth).toLocaleDateString()} - ${new Date(
                     endDateOfBillMonth,
                 ).toLocaleDateString()} (updated every 15 minutes).`}

--- a/components/dashboard/src/settings/settings-menu.ts
+++ b/components/dashboard/src/settings/settings-menu.ts
@@ -16,6 +16,7 @@ import {
     settingsPathTeams,
     settingsPathVariables,
     settingsPathSSHKeys,
+    settingsPathUsage,
 } from "./settings.routes";
 
 export default function getSettingsMenu(params: { userBillingMode?: BillingMode }) {
@@ -80,6 +81,14 @@ function renderBillingMenuEntries(billingMode?: BillingMode) {
                     title: "Billing",
                     link: [settingsPathBilling],
                 },
+                ...(BillingMode.showUsageBasedBilling(billingMode)
+                    ? [
+                          {
+                              title: "Usage",
+                              link: [settingsPathUsage],
+                          },
+                      ]
+                    : []),
                 // We need to allow access to "Team Plans" here, at least for owners.
                 ...(BillingMode.showTeamSubscriptionUI(billingMode)
                     ? [

--- a/components/dashboard/src/settings/settings.routes.ts
+++ b/components/dashboard/src/settings/settings.routes.ts
@@ -11,6 +11,7 @@ export const settingsPathAccount = "/account";
 export const settingsPathIntegrations = "/integrations";
 export const settingsPathNotifications = "/notifications";
 export const settingsPathBilling = "/billing";
+export const settingsPathUsage = "/usage";
 export const settingsPathPlans = "/plans";
 export const settingsPathPreferences = "/preferences";
 


### PR DESCRIPTION
## Description
1. Users who are flagged for UBP can now see the `Personal usage` tab under `Billing`.
2. Headers for the Usage pages are now either `Team usage` or `Personal usage`

| User settings | Team usage | Personal usage | 
| - | - | - |
| <img width="162" alt="Screenshot 2022-10-25 at 16 58 47" src="https://user-images.githubusercontent.com/8015191/197809183-a70e4292-4de4-4899-8697-d8d959962b4d.png"> | <img width="147" alt="Screenshot 2022-10-25 at 16 59 05" src="https://user-images.githubusercontent.com/8015191/197809244-cb80011e-881c-4f35-b71c-78107c038a9d.png"> | <img width="188" alt="Screenshot 2022-10-25 at 16 59 35" src="https://user-images.githubusercontent.com/8015191/197809370-bec66e0c-eeec-409a-9df2-0bb0ee5bb4f7.png"> |

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #13968

## How to test
1. Create a user
2. Add the userId to the Non-prod `isUsageBasedBillingEnabled` flag[[1](https://app.configcat.com/08da1258-64fb-4a8e-8a1e-51de773884f6/08da1258-6541-4fc7-8b61-c8b47f82f3a0/08da1258-6512-4ec0-80a3-3f6aa301f853)] 
4. User settings page should show `Personal usage` tab. (Note: change can take some minutes to take effect)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
