### PR TITLE
Unblock Self-Hosted release by introducing UsageServiceMock

### DIFF
--- a/components/server/ee/src/billing/entitlement-service-ubp.ts
+++ b/components/server/ee/src/billing/entitlement-service-ubp.ts
@@ -26,11 +26,8 @@ import { Config } from "../../../src/config";
 import { UserService } from "../../../src/user/user-service";
 import { StripeService } from "../user/stripe-service";
 import { BillingModes } from "./billing-mode";
-import {
-    CostCenter_BillingStrategy,
-    UsageServiceClient,
-    UsageServiceDefinition,
-} from "@gitpod/usage-api/lib/usage/v1/usage.pb";
+import { CostCenter_BillingStrategy } from "@gitpod/usage-api/lib/usage/v1/usage.pb";
+import { UsageService } from "../../../src/user/usage-service";
 
 const MAX_PARALLEL_WORKSPACES_FREE = 4;
 const MAX_PARALLEL_WORKSPACES_PAID = 16;
@@ -45,7 +42,7 @@ export class EntitlementServiceUBP implements EntitlementService {
     @inject(BillingModes) protected readonly billingModes: BillingModes;
     @inject(UserService) protected readonly userService: UserService;
     @inject(StripeService) protected readonly stripeService: StripeService;
-    @inject(UsageServiceDefinition.name) protected readonly usageService: UsageServiceClient;
+    @inject(UsageService) protected readonly usageService: UsageService;
     @inject(TeamDB) protected readonly teamDB: TeamDB;
 
     async mayStartWorkspace(
@@ -136,11 +133,8 @@ export class EntitlementServiceUBP implements EntitlementService {
         // Member of paid team?
         const teams = await this.teamDB.findTeamsByUser(user.id);
         const isTeamSubscribedPromises = teams.map(async (team: Team) => {
-            const costCenter = await this.usageService.getCostCenter({
-                attributionId: AttributionId.render({ kind: "team", teamId: team.id }),
-            });
-
-            return costCenter.costCenter?.billingStrategy === CostCenter_BillingStrategy.BILLING_STRATEGY_STRIPE;
+            const billingStrategy = await this.usageService.getCurrentBillingStategy(AttributionId.create(team));
+            return billingStrategy === CostCenter_BillingStrategy.BILLING_STRATEGY_STRIPE;
         });
         // Return the first truthy promise, or false if all the promises were falsy.
         // Source: https://gist.github.com/jbreckmckye/66364021ebaa0785e426deec0410a235

--- a/components/server/ee/src/container-module.ts
+++ b/components/server/ee/src/container-module.ts
@@ -65,6 +65,7 @@ import { BillingModes, BillingModesImpl } from "./billing/billing-mode";
 import { EntitlementServiceLicense } from "./billing/entitlement-service-license";
 import { EntitlementServiceImpl } from "./billing/entitlement-service";
 import { EntitlementServiceUBP } from "./billing/entitlement-service-ubp";
+import { UsageService, UsageServiceImpl, NoOpUsageService } from "../../src/user/usage-service";
 
 export const productionEEContainerModule = new ContainerModule((bind, unbind, isBound, rebind) => {
     rebind(Server).to(ServerEE).inSingletonScope();
@@ -132,4 +133,15 @@ export const productionEEContainerModule = new ContainerModule((bind, unbind, is
     bind(EntitlementServiceImpl).toSelf().inSingletonScope();
     rebind(EntitlementService).to(EntitlementServiceImpl).inSingletonScope();
     bind(BillingModes).to(BillingModesImpl).inSingletonScope();
+
+    // TODO(gpl) Remove as part of fixing https://github.com/gitpod-io/gitpod/issues/14129
+    rebind(UsageService)
+        .toDynamicValue((ctx) => {
+            const config = ctx.container.get<Config>(Config);
+            if (config.enablePayment) {
+                return ctx.container.get<UsageServiceImpl>(UsageServiceImpl);
+            }
+            return new NoOpUsageService();
+        })
+        .inSingletonScope();
 });

--- a/components/server/src/container-module.ts
+++ b/components/server/src/container-module.ts
@@ -111,7 +111,7 @@ import { WebhookEventGarbageCollector } from "./projects/webhook-event-garbage-c
 import { LivenessController } from "./liveness/liveness-controller";
 import { IDEServiceClient, IDEServiceDefinition } from "@gitpod/ide-service-api/lib/ide.pb";
 import { prometheusClientMiddleware } from "@gitpod/gitpod-protocol/lib/util/nice-grpc";
-import { UsageService } from "./user/usage-service";
+import { UsageService, UsageServiceImpl } from "./user/usage-service";
 import { OpenPrebuildPrefixContextParser } from "./workspace/open-prebuild-prefix-context-parser";
 
 export const productionContainerModule = new ContainerModule((bind, unbind, isBound, rebind) => {
@@ -297,5 +297,6 @@ export const productionContainerModule = new ContainerModule((bind, unbind, isBo
 
     bind(WebhookEventGarbageCollector).toSelf().inSingletonScope();
 
-    bind(UsageService).toSelf().inSingletonScope();
+    bind(UsageServiceImpl).toSelf().inSingletonScope();
+    bind(UsageService).toService(UsageServiceImpl);
 });

--- a/components/server/src/user/usage-service.ts
+++ b/components/server/src/user/usage-service.ts
@@ -12,8 +12,16 @@ import {
 } from "@gitpod/usage-api/lib/usage/v1/usage.pb";
 import { inject, injectable } from "inversify";
 
+export const UsageService = Symbol("UsageService");
+
+export interface UsageService {
+    getCurrentBalance(attributionId: AttributionId): Promise<{ usedCredits: number; usageLimit: number }>;
+
+    getCurrentBillingStategy(attributionId: AttributionId): Promise<CostCenter_BillingStrategy | undefined>;
+}
+
 @injectable()
-export class UsageService {
+export class UsageServiceImpl implements UsageService {
     @inject(UsageServiceDefinition.name)
     protected readonly usageService: UsageServiceClient;
 
@@ -38,5 +46,19 @@ export class UsageService {
             attributionId: AttributionId.render(attributionId),
         });
         return response.costCenter?.billingStrategy;
+    }
+}
+
+// TODO(gpl) Remove as part of fixing https://github.com/gitpod-io/gitpod/issues/14129
+export class NoOpUsageService implements UsageService {
+    async getCurrentBalance(attributionId: AttributionId): Promise<{ usedCredits: number; usageLimit: number }> {
+        return {
+            usedCredits: 0,
+            usageLimit: 1000000000,
+        };
+    }
+
+    async getCurrentBillingStategy(attributionId: AttributionId): Promise<CostCenter_BillingStrategy | undefined> {
+        return CostCenter_BillingStrategy.BILLING_STRATEGY_OTHER;
     }
 }

--- a/components/server/src/user/user-service.ts
+++ b/components/server/src/user/user-service.ts
@@ -33,11 +33,7 @@ import { StripeService } from "../../ee/src/user/stripe-service";
 import { ResponseError } from "vscode-ws-jsonrpc";
 import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
 import { UsageService } from "./usage-service";
-import {
-    CostCenter_BillingStrategy,
-    UsageServiceClient,
-    UsageServiceDefinition,
-} from "@gitpod/usage-api/lib/usage/v1/usage.pb";
+import { CostCenter_BillingStrategy } from "@gitpod/usage-api/lib/usage/v1/usage.pb";
 
 export interface FindUserByIdentityStrResult {
     user: User;
@@ -84,8 +80,6 @@ export class UserService {
     @inject(TeamDB) protected readonly teamDB: TeamDB;
     @inject(StripeService) protected readonly stripeService: StripeService;
     @inject(UsageService) protected readonly usageService: UsageService;
-    @inject(UsageServiceDefinition.name)
-    protected readonly usageServiceClient: UsageServiceClient;
 
     /**
      * Takes strings in the form of <authHost>/<authName> and returns the matching User
@@ -327,10 +321,8 @@ export class UserService {
         if (attributionId.kind !== "team") {
             return false;
         }
-        const { costCenter } = await this.usageServiceClient.getCostCenter({
-            attributionId: AttributionId.render(attributionId),
-        });
-        return costCenter?.billingStrategy !== CostCenter_BillingStrategy.BILLING_STRATEGY_STRIPE;
+        const billingStrategy = await this.usageService.getCurrentBillingStategy(attributionId);
+        return billingStrategy !== CostCenter_BillingStrategy.BILLING_STRATEGY_STRIPE;
     }
 
     async setUsageAttribution(user: User, usageAttributionId: string): Promise<void> {


### PR DESCRIPTION
## Description
Mitigate the fact that usage is not deployed with self-hosted, yet, by mocking it away until we properly fixed it with #14129.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Context: #14129

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
