### PR TITLE
[dashboard] Display specific Prebuild cancellation reason in Prebuild Status again

### DIFF
--- a/components/dashboard/src/projects/Prebuilds.tsx
+++ b/components/dashboard/src/projects/Prebuilds.tsx
@@ -339,7 +339,7 @@ function getPrebuildStatusDescription(prebuild: PrebuildWithStatus): string {
         case "building":
             return `Prebuild is currently in progress.`;
         case "aborted":
-            return `Prebuild has been cancelled. Either a newer commit was pushed to the same branch, a user cancelled it manually, or the prebuild rate limit has been exceeded.`;
+            return `Prebuild has been cancelled. Either a newer commit was pushed to the same branch, a user cancelled it manually, or the prebuild rate limit has been exceeded. ${prebuild.error}`;
         case "failed":
             return `Prebuild failed for system reasons. Please contact support. ${prebuild.error}`;
         case "timeout":


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

When our system decides to cancel a prebuild automatically, it also mentions the specific cancellation reason in `prebuild.error`:

https://github.com/gitpod-io/gitpod/blob/c87781b6d2932f7f779358ef71b9923c44dfc741/components/server/ee/src/prebuilds/prebuild-manager.ts#L224-L225

https://github.com/gitpod-io/gitpod/blob/c87781b6d2932f7f779358ef71b9923c44dfc741/components/server/ee/src/prebuilds/prebuild-manager.ts#L230-L231

https://github.com/gitpod-io/gitpod/blob/c87781b6d2932f7f779358ef71b9923c44dfc741/components/server/ee/src/prebuilds/prebuild-manager.ts#L235-L236

Also, we used to display this exact message below the Prebuild Logs, so that users could be aware why exactly their prebuild got cancelled:

https://github.com/gitpod-io/gitpod/blob/31332971069a926428151aae2eacac947ed2db21/components/dashboard/src/projects/Prebuilds.tsx#L338-L344

Unfortunately, we recently stopped displaying this reason entirely:

https://github.com/gitpod-io/gitpod/blob/8200bfb7c10590875878fa2152ab17b4539702a9/components/dashboard/src/projects/Prebuilds.tsx#L341-L342

I believe this may have been accidental. This Pull Request shows the specific cancellation reason again.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

1. Get a prebuild cancelled for any reason
2. Check the cancelled prebuild for why it was cancelled (specific reason should be displayed)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
