### PR TITLE
fix: gcloud auth for jetbrains backend-plugin gha workflow

### DIFF
--- a/.github/workflows/jetbrains-update-backend-latest.yml
+++ b/.github/workflows/jetbrains-update-backend-latest.yml
@@ -34,6 +34,10 @@ jobs:
           key: ${{ runner.os }}-leeway-cache-${{ hashFiles('backend-plugin.version') }}
           restore-keys: |
             ${{ runner.os }}-leeway-cache-
+      - name: Auth Google Cloud SDK
+        uses: google-github-actions/auth@v0
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
       - name: Set up Google Cloud SDK
         uses: google-github-actions/setup-gcloud@v0
         with:
@@ -41,4 +45,4 @@ jobs:
       - run: |
           gcloud auth configure-docker --quiet
           export LEEWAY_WORKSPACE_ROOT=$(pwd)
-          leeway build -Dversion=latest -DimageRepoBase=eu.gcr.io/gitpod-core-dev/build components/ide/jetbrains/backend-plugin:latest
+          leeway build -Dversion=latest -DimageRepoBase=eu.gcr.io/gitpod-core-dev/build components/ide/jetbrains/backend-plugin:latest --dont-retag


### PR DESCRIPTION
## Description
Update the GHA workflow fixing the gcloud auth for the job

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
We tested by triggering the workflow manually

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
