### PR TITLE
[gitpod-protocol] Add createTeam, joinTeam, getTeamMembers to Go lib

### DIFF
--- a/components/gitpod-protocol/go/gitpod-service.go
+++ b/components/gitpod-protocol/go/gitpod-service.go
@@ -84,6 +84,10 @@ type APIInterface interface {
 	TrackEvent(ctx context.Context, event *RemoteTrackMessage) (err error)
 	GetSupportedWorkspaceClasses(ctx context.Context) (res []*SupportedWorkspaceClass, err error)
 
+	CreateTeam(ctx context.Context, params string) (*Team, error)
+	GetTeamMembers(ctx context.Context, params string) ([]*TeamMemberInfo, error)
+	JoinTeam(ctx context.Context, params string) (*Team, error)
+
 	InstanceUpdates(ctx context.Context, instanceID string) (<-chan *WorkspaceInstance, error)
 }
 
@@ -1382,6 +1386,36 @@ func (gp *APIoverJSONRPC) GetSupportedWorkspaceClasses(ctx context.Context) (res
 	return
 }
 
+func (gp *APIoverJSONRPC) CreateTeam(ctx context.Context, teamName string) (res *Team, err error) {
+	if gp == nil {
+		err = errNotConnected
+		return
+	}
+	_params := []interface{}{teamName}
+	err = gp.C.Call(ctx, "createTeam", _params, &res)
+	return
+}
+
+func (gp *APIoverJSONRPC) GetTeamMembers(ctx context.Context, teamID string) (res []*TeamMemberInfo, err error) {
+	if gp == nil {
+		err = errNotConnected
+		return
+	}
+	_params := []interface{}{teamID}
+	err = gp.C.Call(ctx, "getTeamMembers", _params, &res)
+	return
+}
+
+func (gp *APIoverJSONRPC) JoinTeam(ctx context.Context, inviteID string) (res *Team, err error) {
+	if gp == nil {
+		err = errNotConnected
+		return
+	}
+	_params := []interface{}{inviteID}
+	err = gp.C.Call(ctx, "joinTeam", _params, &res)
+	return
+}
+
 // PermissionName is the name of a permission
 type PermissionName string
 
@@ -2073,4 +2107,27 @@ type UserMessage struct {
 	ID    string `json:"id,omitempty"`
 	Title string `json:"title,omitempty"`
 	URL   string `json:"url,omitempty"`
+}
+
+type Team struct {
+	ID           string `json:"id,omitempty"`
+	Name         string `json:"name,omitempty"`
+	Slug         string `json:"slug,omitempty"`
+	CreationTime string `json:"creationTime,omitempty"`
+}
+
+type TeamMemberRole string
+
+const (
+	TeamMember_Owner  TeamMemberRole = "owner"
+	TeamMember_Member TeamMemberRole = "member"
+)
+
+type TeamMemberInfo struct {
+	UserId       string         `json:"userId,omitempty"`
+	FullName     string         `json:"fullName,omitempty"`
+	PrimaryEmail string         `json:"primaryEmail,omitempty"`
+	AvatarUrl    string         `json:"avatarUrl,omitempty"`
+	Role         TeamMemberRole `json:"role,omitempty"`
+	MemberSince  string         `json:"memberSince,omitempty"`
 }

--- a/components/gitpod-protocol/go/mock.go
+++ b/components/gitpod-protocol/go/mock.go
@@ -109,6 +109,21 @@ func (mr *MockAPIInterfaceMockRecorder) ControlAdmission(ctx, id, level interfac
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ControlAdmission", reflect.TypeOf((*MockAPIInterface)(nil).ControlAdmission), ctx, id, level)
 }
 
+// CreateTeam mocks base method.
+func (m *MockAPIInterface) CreateTeam(ctx context.Context, params string) (*Team, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateTeam", ctx, params)
+	ret0, _ := ret[0].(*Team)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateTeam indicates an expected call of CreateTeam.
+func (mr *MockAPIInterfaceMockRecorder) CreateTeam(ctx, params interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTeam", reflect.TypeOf((*MockAPIInterface)(nil).CreateTeam), ctx, params)
+}
+
 // CreateWorkspace mocks base method.
 func (m *MockAPIInterface) CreateWorkspace(ctx context.Context, options *CreateWorkspaceOptions) (*WorkspaceCreationResult, error) {
 	m.ctrl.T.Helper()
@@ -478,6 +493,21 @@ func (mr *MockAPIInterfaceMockRecorder) GetSupportedWorkspaceClasses(ctx interfa
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSupportedWorkspaceClasses", reflect.TypeOf((*MockAPIInterface)(nil).GetSupportedWorkspaceClasses), ctx)
 }
 
+// GetTeamMembers mocks base method.
+func (m *MockAPIInterface) GetTeamMembers(ctx context.Context, params string) ([]*TeamMemberInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTeamMembers", ctx, params)
+	ret0, _ := ret[0].([]*TeamMemberInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetTeamMembers indicates an expected call of GetTeamMembers.
+func (mr *MockAPIInterfaceMockRecorder) GetTeamMembers(ctx, params interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTeamMembers", reflect.TypeOf((*MockAPIInterface)(nil).GetTeamMembers), ctx, params)
+}
+
 // GetToken mocks base method.
 func (m *MockAPIInterface) GetToken(ctx context.Context, query *GetTokenSearchOptions) (*Token, error) {
 	m.ctrl.T.Helper()
@@ -671,6 +701,21 @@ func (m *MockAPIInterface) IsWorkspaceOwner(ctx context.Context, workspaceID str
 func (mr *MockAPIInterfaceMockRecorder) IsWorkspaceOwner(ctx, workspaceID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsWorkspaceOwner", reflect.TypeOf((*MockAPIInterface)(nil).IsWorkspaceOwner), ctx, workspaceID)
+}
+
+// JoinTeam mocks base method.
+func (m *MockAPIInterface) JoinTeam(ctx context.Context, params string) (*Team, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "JoinTeam", ctx, params)
+	ret0, _ := ret[0].(*Team)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// JoinTeam indicates an expected call of JoinTeam.
+func (mr *MockAPIInterfaceMockRecorder) JoinTeam(ctx, params interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "JoinTeam", reflect.TypeOf((*MockAPIInterface)(nil).JoinTeam), ctx, params)
 }
 
 // OpenPort mocks base method.


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Adds Team RPCs to Go gitpod protocol library

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
