### PR TITLE
Use dev/preview:create-preview in Werft

### DIFF
--- a/dev/preview/BUILD.yaml
+++ b/dev/preview/BUILD.yaml
@@ -11,22 +11,22 @@ scripts:
   - name: create-preview
     description: Provisions a new preview environment
     script: |
-      export TF_VAR_dev_kube_path="/home/gitpod/.kube/config"
-      export TF_VAR_dev_kube_context="dev"
-      export TF_VAR_harvester_kube_path="/home/gitpod/.kube/config"
-      export TF_VAR_harvester_kube_context="harvester"
-      export TF_VAR_preview_name="$(previewctl get-name)"
-      export TF_VAR_vm_cpu=6
-      export TF_VAR_vm_memory=12Gi
-      export TF_VAR_vm_storage_class="longhorn-gitpod-k3s-202209251218-onereplica"
+      export TF_VAR_dev_kube_path="${TF_VAR_dev_kube_path:-/home/gitpod/.kube/config}"
+      export TF_VAR_dev_kube_context="${TF_VAR_dev_kube_context:-dev}"
+      export TF_VAR_harvester_kube_path="${TF_VAR_harvester_kube_path:-/home/gitpod/.kube/config}"
+      export TF_VAR_harvester_kube_context="${TF_VAR_harvester_kube_context:-harvester}"
+      export TF_VAR_preview_name="${TF_VAR_preview_name:-$(previewctl get-name)}"
+      export TF_VAR_vm_cpu="${TF_VAR_vm_cpu:-6}"
+      export TF_VAR_vm_memory="${TF_VAR_vm_memory:-12Gi}"
+      export TF_VAR_vm_storage_class="${TF_VAR_vm_storage_class:-longhorn-gitpod-k3s-202209251218-onereplica}"
       ./workflow/preview/deploy-harvester.sh
 
   - name: delete-preview
     description: Delete an existing preview environment
     script: |
       export DESTROY=true
-      export TF_VAR_kubeconfig_path="/home/gitpod/.kube/config"
-      export TF_VAR_preview_name="$(previewctl get-name)"
+      export TF_VAR_kubeconfig_path="${TF_VAR_kubeconfig_path:-/home/gitpod/.kube/config}"
+      export TF_VAR_preview_name="${TF_VAR_preview_name:-$(previewctl get-name)}"
       ./workflow/preview/deploy-harvester.sh
 
   - name: deploy-gitpod


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Use `leeway run dev/preview:create-preview` in our Werft job.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/ops/issues/5893

## How to test
<!-- Provide steps to test this PR -->

That it works in Werft ([job](https://werft.gitpod-dev.com/job/gitpod-build-mads-use-create-preview-in-werft.10), [preview environment](https://mads-use-cc85c4e71e3.preview.gitpod-dev.com/workspaces))

```
werft job run github
```

That it works in workspaces

```sh
leeway run dev/preview:create-preview
leeway run dev/preview:delete-preview
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
