### PR TITLE
[installer] Actually add 'inactivityPeriodForReposInDays' to server configmap

### DIFF
--- a/components/server/ee/src/prebuilds/prebuild-manager.ts
+++ b/components/server/ee/src/prebuilds/prebuild-manager.ts
@@ -406,9 +406,9 @@ export class PrebuildManager {
 
     private async shouldSkipInactiveRepository(ctx: TraceContext, cloneURL: string): Promise<boolean> {
         const span = TraceContext.startSpan("shouldSkipInactiveRepository", ctx);
-        const { inactivityPeriodForRepos } = this.config;
-        if (!inactivityPeriodForRepos) {
-            // skipping is disabled if `inactivityPeriodForRepos` is not set
+        const { inactivityPeriodForReposInDays } = this.config;
+        if (!inactivityPeriodForReposInDays) {
+            // skipping is disabled if `inactivityPeriodForReposInDays` is not set
             span.finish();
             return false;
         }
@@ -416,7 +416,8 @@ export class PrebuildManager {
             return (
                 (await this.workspaceDB
                     .trace({ span })
-                    .getWorkspaceCountByCloneURL(cloneURL, inactivityPeriodForRepos /* in days */, "regular")) === 0
+                    .getWorkspaceCountByCloneURL(cloneURL, inactivityPeriodForReposInDays /* in days */, "regular")) ===
+                0
             );
         } catch (error) {
             log.error("cannot compute activity for repository", { cloneURL }, error);

--- a/components/server/src/config.ts
+++ b/components/server/src/config.ts
@@ -29,7 +29,7 @@ export type Config = Omit<
     stripeSecrets?: { publishableKey: string; secretKey: string };
     stripeConfig?: StripeConfig;
     builtinAuthProvidersConfigured: boolean;
-    inactivityPeriodForRepos?: number;
+    inactivityPeriodForReposInDays?: number;
 };
 
 export interface WorkspaceDefaults {
@@ -203,7 +203,7 @@ export interface ConfigSerialized {
      * If a numeric value interpreted as days is set, repositories not beeing opened with Gitpod are
      * considered inactive.
      */
-    inactivityPeriodForRepos?: number;
+    inactivityPeriodForReposInDays?: number;
 
     /**
      * Supported workspace classes
@@ -285,10 +285,10 @@ export namespace ConfigFile {
         if (licenseFile) {
             license = fs.readFileSync(filePathTelepresenceAware(licenseFile), "utf-8");
         }
-        let inactivityPeriodForRepos: number | undefined;
-        if (typeof config.inactivityPeriodForRepos === "number") {
-            if (config.inactivityPeriodForRepos >= 1) {
-                inactivityPeriodForRepos = config.inactivityPeriodForRepos;
+        let inactivityPeriodForReposInDays: number | undefined;
+        if (typeof config.inactivityPeriodForReposInDays === "number") {
+            if (config.inactivityPeriodForReposInDays >= 1) {
+                inactivityPeriodForReposInDays = config.inactivityPeriodForReposInDays;
             }
         }
 
@@ -320,7 +320,7 @@ export namespace ConfigFile {
                     ? new Date(config.workspaceGarbageCollection.startDate).getTime()
                     : Date.now(),
             },
-            inactivityPeriodForRepos,
+            inactivityPeriodForReposInDays,
         };
     }
 }

--- a/install/installer/cmd/testdata/render/aws-setup/output.golden
+++ b/install/installer/cmd/testdata/render/aws-setup/output.golden
@@ -4622,7 +4622,8 @@ data:
           "isDefault": true,
           "deprecated": false
         }
-      ]
+      ],
+      "inactivityPeriodForRepos": 0
     }
 kind: ConfigMap
 metadata:
@@ -8725,7 +8726,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: a745ecf007657309c326826c2afb6f0782aa50415678f1c73d45307f02acfa54
+        gitpod.io/checksum_config: 298e3ce510237650c971c6334d65f392b9e8f5d77de19725d18a47f557166260
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/aws-setup/output.golden
+++ b/install/installer/cmd/testdata/render/aws-setup/output.golden
@@ -4623,7 +4623,7 @@ data:
           "deprecated": false
         }
       ],
-      "inactivityPeriodForRepos": 0
+      "inactivityPeriodForReposInDays": 0
     }
 kind: ConfigMap
 metadata:
@@ -8726,7 +8726,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 298e3ce510237650c971c6334d65f392b9e8f5d77de19725d18a47f557166260
+        gitpod.io/checksum_config: fd86888d2f9c7f51bb9750b65b15cd977c82ac9b65da17c233d69e77ff81f7b6
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/azure-setup/output.golden
+++ b/install/installer/cmd/testdata/render/azure-setup/output.golden
@@ -4485,7 +4485,8 @@ data:
           "isDefault": true,
           "deprecated": false
         }
-      ]
+      ],
+      "inactivityPeriodForRepos": 0
     }
 kind: ConfigMap
 metadata:
@@ -8576,7 +8577,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: a745ecf007657309c326826c2afb6f0782aa50415678f1c73d45307f02acfa54
+        gitpod.io/checksum_config: 298e3ce510237650c971c6334d65f392b9e8f5d77de19725d18a47f557166260
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/azure-setup/output.golden
+++ b/install/installer/cmd/testdata/render/azure-setup/output.golden
@@ -4486,7 +4486,7 @@ data:
           "deprecated": false
         }
       ],
-      "inactivityPeriodForRepos": 0
+      "inactivityPeriodForReposInDays": 0
     }
 kind: ConfigMap
 metadata:
@@ -8577,7 +8577,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 298e3ce510237650c971c6334d65f392b9e8f5d77de19725d18a47f557166260
+        gitpod.io/checksum_config: fd86888d2f9c7f51bb9750b65b15cd977c82ac9b65da17c233d69e77ff81f7b6
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -5433,7 +5433,7 @@ data:
           "deprecated": false
         }
       ],
-      "inactivityPeriodForRepos": 0
+      "inactivityPeriodForReposInDays": 0
     }
 kind: ConfigMap
 metadata:
@@ -10145,7 +10145,7 @@ spec:
     metadata:
       annotations:
         gitpod.io: hello
-        gitpod.io/checksum_config: 93acc06ca13a51f80658aad79bdd848d5a5d306fd54d8334e2cf81a9287d0717
+        gitpod.io/checksum_config: adce5b1504123c4829f44704c10821db8bc7db39338458e33611c719c2ea3730
         hello: world
       creationTimestamp: null
       labels:

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -5432,7 +5432,8 @@ data:
           "isDefault": true,
           "deprecated": false
         }
-      ]
+      ],
+      "inactivityPeriodForRepos": 0
     }
 kind: ConfigMap
 metadata:
@@ -10144,7 +10145,7 @@ spec:
     metadata:
       annotations:
         gitpod.io: hello
-        gitpod.io/checksum_config: a7fdc707c129e43ce4768f9df84743a94f1232de05359df0078db77748e5a0b3
+        gitpod.io/checksum_config: 93acc06ca13a51f80658aad79bdd848d5a5d306fd54d8334e2cf81a9287d0717
         hello: world
       creationTimestamp: null
       labels:

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -4672,7 +4672,8 @@ data:
           "isDefault": true,
           "deprecated": false
         }
-      ]
+      ],
+      "inactivityPeriodForRepos": 0
     }
 kind: ConfigMap
 metadata:
@@ -9002,7 +9003,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: a4e77dfdb4f0f6103762722c99d4ba4eaf570a7c3d9fbc3e292a2d48cb17ad24
+        gitpod.io/checksum_config: b7325a45b71d40d54658a88593a38c211c473b695087e5fe62f74b84dafd5161
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -4673,7 +4673,7 @@ data:
           "deprecated": false
         }
       ],
-      "inactivityPeriodForRepos": 0
+      "inactivityPeriodForReposInDays": 0
     }
 kind: ConfigMap
 metadata:
@@ -9003,7 +9003,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: b7325a45b71d40d54658a88593a38c211c473b695087e5fe62f74b84dafd5161
+        gitpod.io/checksum_config: 92d9e5b1395f8b3b192de00b493801b656c63073991c1bfc87a90f5205e63226
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/gcp-setup/output.golden
+++ b/install/installer/cmd/testdata/render/gcp-setup/output.golden
@@ -4447,7 +4447,7 @@ data:
           "deprecated": false
         }
       ],
-      "inactivityPeriodForRepos": 0
+      "inactivityPeriodForReposInDays": 0
     }
 kind: ConfigMap
 metadata:
@@ -8506,7 +8506,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: b8f30bd66cac6b6a0cac0757ebfc70648572c1939a66c612d13828ac56c6c5b4
+        gitpod.io/checksum_config: 523af97345a32d8d9acb8801c04bad6b148943cd5d58f47cbac85d9466e892f3
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/gcp-setup/output.golden
+++ b/install/installer/cmd/testdata/render/gcp-setup/output.golden
@@ -4446,7 +4446,8 @@ data:
           "isDefault": true,
           "deprecated": false
         }
-      ]
+      ],
+      "inactivityPeriodForRepos": 0
     }
 kind: ConfigMap
 metadata:
@@ -8505,7 +8506,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 6992584742d8c0130c85e9635aefdcfbb7d252a4e968a7a38f7d296f8600acc5
+        gitpod.io/checksum_config: b8f30bd66cac6b6a0cac0757ebfc70648572c1939a66c612d13828ac56c6c5b4
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/http-proxy/output.golden
+++ b/install/installer/cmd/testdata/render/http-proxy/output.golden
@@ -4895,7 +4895,8 @@ data:
           "isDefault": true,
           "deprecated": false
         }
-      ]
+      ],
+      "inactivityPeriodForRepos": 0
     }
 kind: ConfigMap
 metadata:
@@ -10423,7 +10424,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: a4e77dfdb4f0f6103762722c99d4ba4eaf570a7c3d9fbc3e292a2d48cb17ad24
+        gitpod.io/checksum_config: b7325a45b71d40d54658a88593a38c211c473b695087e5fe62f74b84dafd5161
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/http-proxy/output.golden
+++ b/install/installer/cmd/testdata/render/http-proxy/output.golden
@@ -4896,7 +4896,7 @@ data:
           "deprecated": false
         }
       ],
-      "inactivityPeriodForRepos": 0
+      "inactivityPeriodForReposInDays": 0
     }
 kind: ConfigMap
 metadata:
@@ -10424,7 +10424,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: b7325a45b71d40d54658a88593a38c211c473b695087e5fe62f74b84dafd5161
+        gitpod.io/checksum_config: 92d9e5b1395f8b3b192de00b493801b656c63073991c1bfc87a90f5205e63226
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/insecure-s3-setup/output.golden
+++ b/install/installer/cmd/testdata/render/insecure-s3-setup/output.golden
@@ -4807,7 +4807,7 @@ data:
           "deprecated": false
         }
       ],
-      "inactivityPeriodForRepos": 0
+      "inactivityPeriodForReposInDays": 0
     }
 kind: ConfigMap
 metadata:
@@ -9149,7 +9149,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: b7325a45b71d40d54658a88593a38c211c473b695087e5fe62f74b84dafd5161
+        gitpod.io/checksum_config: 92d9e5b1395f8b3b192de00b493801b656c63073991c1bfc87a90f5205e63226
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/insecure-s3-setup/output.golden
+++ b/install/installer/cmd/testdata/render/insecure-s3-setup/output.golden
@@ -4806,7 +4806,8 @@ data:
           "isDefault": true,
           "deprecated": false
         }
-      ]
+      ],
+      "inactivityPeriodForRepos": 0
     }
 kind: ConfigMap
 metadata:
@@ -9148,7 +9149,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: a4e77dfdb4f0f6103762722c99d4ba4eaf570a7c3d9fbc3e292a2d48cb17ad24
+        gitpod.io/checksum_config: b7325a45b71d40d54658a88593a38c211c473b695087e5fe62f74b84dafd5161
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -4893,7 +4893,7 @@ data:
           "deprecated": false
         }
       ],
-      "inactivityPeriodForRepos": 0
+      "inactivityPeriodForReposInDays": 0
     }
 kind: ConfigMap
 metadata:
@@ -9378,7 +9378,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: b7325a45b71d40d54658a88593a38c211c473b695087e5fe62f74b84dafd5161
+        gitpod.io/checksum_config: 92d9e5b1395f8b3b192de00b493801b656c63073991c1bfc87a90f5205e63226
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -4892,7 +4892,8 @@ data:
           "isDefault": true,
           "deprecated": false
         }
-      ]
+      ],
+      "inactivityPeriodForRepos": 0
     }
 kind: ConfigMap
 metadata:
@@ -9377,7 +9378,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: a4e77dfdb4f0f6103762722c99d4ba4eaf570a7c3d9fbc3e292a2d48cb17ad24
+        gitpod.io/checksum_config: b7325a45b71d40d54658a88593a38c211c473b695087e5fe62f74b84dafd5161
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/shortname/output.golden
+++ b/install/installer/cmd/testdata/render/shortname/output.golden
@@ -4893,7 +4893,7 @@ data:
           "deprecated": false
         }
       ],
-      "inactivityPeriodForRepos": 0
+      "inactivityPeriodForReposInDays": 0
     }
 kind: ConfigMap
 metadata:
@@ -9378,7 +9378,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 2df6090dc29119c83104d9f49298b49bc4c7065f665e2560abff5a4a56db2130
+        gitpod.io/checksum_config: 188b6e909382eb4d7a3d2b03ae08c562d87cea8e683d13f09a8e8463e4ae0536
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/shortname/output.golden
+++ b/install/installer/cmd/testdata/render/shortname/output.golden
@@ -4892,7 +4892,8 @@ data:
           "isDefault": true,
           "deprecated": false
         }
-      ]
+      ],
+      "inactivityPeriodForRepos": 0
     }
 kind: ConfigMap
 metadata:
@@ -9377,7 +9378,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 0593a3a8ac33ff63223473b306970682e9063d55b590448b6329a0a41df72fca
+        gitpod.io/checksum_config: 2df6090dc29119c83104d9f49298b49bc4c7065f665e2560abff5a4a56db2130
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -4905,7 +4905,7 @@ data:
           "deprecated": false
         }
       ],
-      "inactivityPeriodForRepos": 0
+      "inactivityPeriodForReposInDays": 0
     }
 kind: ConfigMap
 metadata:
@@ -9390,7 +9390,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: b7325a45b71d40d54658a88593a38c211c473b695087e5fe62f74b84dafd5161
+        gitpod.io/checksum_config: 92d9e5b1395f8b3b192de00b493801b656c63073991c1bfc87a90f5205e63226
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -4904,7 +4904,8 @@ data:
           "isDefault": true,
           "deprecated": false
         }
-      ]
+      ],
+      "inactivityPeriodForRepos": 0
     }
 kind: ConfigMap
 metadata:
@@ -9389,7 +9390,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: a4e77dfdb4f0f6103762722c99d4ba4eaf570a7c3d9fbc3e292a2d48cb17ad24
+        gitpod.io/checksum_config: b7325a45b71d40d54658a88593a38c211c473b695087e5fe62f74b84dafd5161
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
+++ b/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
@@ -5226,7 +5226,7 @@ data:
           "deprecated": false
         }
       ],
-      "inactivityPeriodForRepos": 0
+      "inactivityPeriodForReposInDays": 0
     }
 kind: ConfigMap
 metadata:
@@ -9822,7 +9822,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: b7325a45b71d40d54658a88593a38c211c473b695087e5fe62f74b84dafd5161
+        gitpod.io/checksum_config: 92d9e5b1395f8b3b192de00b493801b656c63073991c1bfc87a90f5205e63226
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
+++ b/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
@@ -5225,7 +5225,8 @@ data:
           "isDefault": true,
           "deprecated": false
         }
-      ]
+      ],
+      "inactivityPeriodForRepos": 0
     }
 kind: ConfigMap
 metadata:
@@ -9821,7 +9822,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: a4e77dfdb4f0f6103762722c99d4ba4eaf570a7c3d9fbc3e292a2d48cb17ad24
+        gitpod.io/checksum_config: b7325a45b71d40d54658a88593a38c211c473b695087e5fe62f74b84dafd5161
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
+++ b/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
@@ -4896,7 +4896,7 @@ data:
           "deprecated": false
         }
       ],
-      "inactivityPeriodForRepos": 0
+      "inactivityPeriodForReposInDays": 0
     }
 kind: ConfigMap
 metadata:
@@ -9381,7 +9381,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: b7325a45b71d40d54658a88593a38c211c473b695087e5fe62f74b84dafd5161
+        gitpod.io/checksum_config: 92d9e5b1395f8b3b192de00b493801b656c63073991c1bfc87a90f5205e63226
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
+++ b/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
@@ -4895,7 +4895,8 @@ data:
           "isDefault": true,
           "deprecated": false
         }
-      ]
+      ],
+      "inactivityPeriodForRepos": 0
     }
 kind: ConfigMap
 metadata:
@@ -9380,7 +9381,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: a4e77dfdb4f0f6103762722c99d4ba4eaf570a7c3d9fbc3e292a2d48cb17ad24
+        gitpod.io/checksum_config: b7325a45b71d40d54658a88593a38c211c473b695087e5fe62f74b84dafd5161
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/pkg/components/server/configmap.go
+++ b/install/installer/pkg/components/server/configmap.go
@@ -176,6 +176,14 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		return nil
 	})
 
+	inactivityPeriodForRepos := 0
+	_ = ctx.WithExperimental(func(cfg *experimental.Config) error {
+		if cfg.WebApp != nil && cfg.WebApp.Server != nil && cfg.WebApp.Server.InactivityPeriodForRepos != nil {
+			inactivityPeriodForRepos = *cfg.WebApp.Server.InactivityPeriodForRepos
+		}
+		return nil
+	})
+
 	// todo(sje): all these values are configurable
 	scfg := ConfigSerialized{
 		Version:               ctx.VersionManifest.Version,
@@ -263,7 +271,8 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 			// default limit for all cloneURLs
 			"*": 50,
 		},
-		WorkspaceClasses: workspaceClasses,
+		WorkspaceClasses:         workspaceClasses,
+		InactivityPeriodForRepos: inactivityPeriodForRepos,
 	}
 
 	fc, err := common.ToJSONString(scfg)

--- a/install/installer/pkg/components/server/configmap.go
+++ b/install/installer/pkg/components/server/configmap.go
@@ -176,10 +176,10 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		return nil
 	})
 
-	inactivityPeriodForRepos := 0
+	inactivityPeriodForReposInDays := 0
 	_ = ctx.WithExperimental(func(cfg *experimental.Config) error {
-		if cfg.WebApp != nil && cfg.WebApp.Server != nil && cfg.WebApp.Server.InactivityPeriodForRepos != nil {
-			inactivityPeriodForRepos = *cfg.WebApp.Server.InactivityPeriodForRepos
+		if cfg.WebApp != nil && cfg.WebApp.Server != nil && cfg.WebApp.Server.InactivityPeriodForReposInDays != nil {
+			inactivityPeriodForReposInDays = *cfg.WebApp.Server.InactivityPeriodForReposInDays
 		}
 		return nil
 	})
@@ -271,8 +271,8 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 			// default limit for all cloneURLs
 			"*": 50,
 		},
-		WorkspaceClasses:         workspaceClasses,
-		InactivityPeriodForRepos: inactivityPeriodForRepos,
+		WorkspaceClasses:               workspaceClasses,
+		InactivityPeriodForReposInDays: inactivityPeriodForReposInDays,
 	}
 
 	fc, err := common.ToJSONString(scfg)

--- a/install/installer/pkg/components/server/types.go
+++ b/install/installer/pkg/components/server/types.go
@@ -52,9 +52,9 @@ type ConfigSerialized struct {
 	CodeSync                   CodeSync                   `json:"codeSync"`
 	// PrebuildLimiter defines the number of prebuilds allowed for each cloneURL in a given 1 minute interval
 	// Key of "*" defines the default limit, unless there exists a cloneURL in the map which overrides it.
-	PrebuildLimiter          map[string]int   `json:"prebuildLimiter"`
-	WorkspaceClasses         []WorkspaceClass `json:"workspaceClasses"`
-	InactivityPeriodForRepos int              `json:"inactivityPeriodForRepos"`
+	PrebuildLimiter                map[string]int   `json:"prebuildLimiter"`
+	WorkspaceClasses               []WorkspaceClass `json:"workspaceClasses"`
+	InactivityPeriodForReposInDays int              `json:"inactivityPeriodForReposInDays"`
 }
 type CodeSyncResources struct {
 	RevLimit int32 `json:"revLimit"`

--- a/install/installer/pkg/components/server/types.go
+++ b/install/installer/pkg/components/server/types.go
@@ -52,8 +52,9 @@ type ConfigSerialized struct {
 	CodeSync                   CodeSync                   `json:"codeSync"`
 	// PrebuildLimiter defines the number of prebuilds allowed for each cloneURL in a given 1 minute interval
 	// Key of "*" defines the default limit, unless there exists a cloneURL in the map which overrides it.
-	PrebuildLimiter  map[string]int   `json:"prebuildLimiter"`
-	WorkspaceClasses []WorkspaceClass `json:"workspaceClasses"`
+	PrebuildLimiter          map[string]int   `json:"prebuildLimiter"`
+	WorkspaceClasses         []WorkspaceClass `json:"workspaceClasses"`
+	InactivityPeriodForRepos int              `json:"inactivityPeriodForRepos"`
 }
 type CodeSyncResources struct {
 	RevLimit int32 `json:"revLimit"`

--- a/install/installer/pkg/config/v1/experimental/experimental.go
+++ b/install/installer/pkg/config/v1/experimental/experimental.go
@@ -232,6 +232,7 @@ type ServerConfig struct {
 	EnableLocalApp                    *bool             `json:"enableLocalApp"`
 	RunDbDeleter                      *bool             `json:"runDbDeleter"`
 	DisableWorkspaceGarbageCollection bool              `json:"disableWorkspaceGarbageCollection"`
+	InactivityPeriodForRepos          *int              `json:"inactivityPeriodForRepos"`
 
 	// @deprecated use containerRegistry.privateBaseImageAllowList instead
 	DefaultBaseImageRegistryWhiteList []string `json:"defaultBaseImageRegistryWhitelist"`

--- a/install/installer/pkg/config/v1/experimental/experimental.go
+++ b/install/installer/pkg/config/v1/experimental/experimental.go
@@ -232,7 +232,7 @@ type ServerConfig struct {
 	EnableLocalApp                    *bool             `json:"enableLocalApp"`
 	RunDbDeleter                      *bool             `json:"runDbDeleter"`
 	DisableWorkspaceGarbageCollection bool              `json:"disableWorkspaceGarbageCollection"`
-	InactivityPeriodForRepos          *int              `json:"inactivityPeriodForRepos"`
+	InactivityPeriodForReposInDays    *int              `json:"inactivityPeriodForReposInDays"`
 
 	// @deprecated use containerRegistry.privateBaseImageAllowList instead
 	DefaultBaseImageRegistryWhiteList []string `json:"defaultBaseImageRegistryWhitelist"`


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Actually add `inactivityPeriodForRepos` to the `server-config` ConfigMap in the installer.

Follow-up to https://github.com/gitpod-io/gitpod/pull/9976 so that we can actually enable this in production.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/pull/9976

## How to test
<!-- Provide steps to test this PR -->

1. Should build and pass tests

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
