### PR TITLE
[dashboard] Better surface errors when Gitpod fails to get your Stripe subscription details

### DIFF
--- a/components/dashboard/src/components/BillingAccountSelector.tsx
+++ b/components/dashboard/src/components/BillingAccountSelector.tsx
@@ -12,12 +12,14 @@ import { TeamsContext } from "../teams/teams-context";
 import { UserContext } from "../user-context";
 import SelectableCardSolid from "../components/SelectableCardSolid";
 import { ReactComponent as Spinner } from "../icons/Spinner.svg";
+import Alert from "./Alert";
 
 export function BillingAccountSelector(props: { onSelected?: () => void }) {
     const { user, setUser } = useContext(UserContext);
     const { teams } = useContext(TeamsContext);
     const [teamsAvailableForAttribution, setTeamsAvailableForAttribution] = useState<Team[] | undefined>();
     const [membersByTeam, setMembersByTeam] = useState<Record<string, TeamMemberInfo[]>>({});
+    const [errorMessage, setErrorMessage] = useState<string | undefined>();
 
     useEffect(() => {
         if (!teams) {
@@ -25,7 +27,7 @@ export function BillingAccountSelector(props: { onSelected?: () => void }) {
             return;
         }
 
-        // Fetch the liust of teams we can actually attribute to
+        // Fetch the list of teams we can actually attribute to
         getGitpodService()
             .server.listAvailableUsageAttributionIds()
             .then((attrIds) => {
@@ -42,6 +44,10 @@ export function BillingAccountSelector(props: { onSelected?: () => void }) {
                 setTeamsAvailableForAttribution(
                     teamsAvailableForAttribution.sort((a, b) => (a.name > b.name ? 1 : -1)),
                 );
+            })
+            .catch((error) => {
+                console.error("Could not get list of available billing accounts.", error);
+                setErrorMessage(`Could not get list of available billing accounts. ${error?.message || String(error)}`);
             });
 
         const members: Record<string, TeamMemberInfo[]> = {};
@@ -74,6 +80,11 @@ export function BillingAccountSelector(props: { onSelected?: () => void }) {
 
     return (
         <>
+            {errorMessage && (
+                <Alert className="max-w-xl mt-2" closable={false} showIcon={true} type="error">
+                    {errorMessage}
+                </Alert>
+            )}
             {teamsAvailableForAttribution === undefined && <Spinner className="m-2 h-5 w-5 animate-spin" />}
             {teamsAvailableForAttribution && (
                 <div>

--- a/components/dashboard/src/components/BillingAccountSelector.tsx
+++ b/components/dashboard/src/components/BillingAccountSelector.tsx
@@ -51,14 +51,15 @@ export function BillingAccountSelector(props: { onSelected?: () => void }) {
             });
 
         const members: Record<string, TeamMemberInfo[]> = {};
-        teams.forEach(async (team) => {
-            try {
-                members[team.id] = await getGitpodService().server.getTeamMembers(team.id);
-            } catch (error) {
-                console.error("Could not get members of team", team, error);
-            }
-        });
-        setMembersByTeam(members);
+        Promise.all(
+            teams.map(async (team) => {
+                try {
+                    members[team.id] = await getGitpodService().server.getTeamMembers(team.id);
+                } catch (error) {
+                    console.warn("Could not get members of team", team, error);
+                }
+            }),
+        ).then(() => setMembersByTeam(members));
     }, [teams]);
 
     const setUsageAttributionTeam = async (team?: Team) => {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

In some rare edge cases, it can happen that Gitpod fails to get your Stripe subscription details (for example, one of these cases can be that a Stripe customer has two active Subscriptions for some reason, but there could exist other rare edge cases).

In these cases, Gitpod's backend throws an error. However, until now, the front-end only logged this error to the console, without showing it visibly in the UI. This PR fixes the latter, by visibly showing any such error message in the UI, so that users are at least aware that something went wrong.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/14034

## How to test
<!-- Provide steps to test this PR -->

1. Upgrade your team to usage-based
2. In the Stripe test dashboard, manually create a duplicate Subscription for your team's Customer (pick any subscription details)
3. Visit your team's billing UI -- an error message should be shown near the top

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
