### PR TITLE
Fix 'gp open' command to open files in JetBrains Client instead of the backend IDE

### DIFF
--- a/components/ide/jetbrains/backend-plugin/launch-dev-server.sh
+++ b/components/ide/jetbrains/backend-plugin/launch-dev-server.sh
@@ -81,7 +81,8 @@ export IJ_HOST_SYSTEM_BASE_DIR=/workspace/.cache/JetBrains
 export CWM_HOST_STATUS_OVER_HTTP_TOKEN=gitpod
 
 # Build and move idea-cli, then overwrite environment variables initially defined by `components/ide/jetbrains/image/leeway.Dockerfile`
-IDEA_CLI_DEV_PATH=$TEST_BACKEND_DIR/bin/idea-cli-dev
+# Note: IDEA_CLI_DEV_PATH path needs to be the same string used in components/ide/jetbrains/cli/cmd/root.go
+IDEA_CLI_DEV_PATH=/ide-desktop/bin/idea-cli-dev
 (cd ../cli && go build -o $IDEA_CLI_DEV_PATH)
 export EDITOR="$IDEA_CLI_DEV_PATH open"
 export VISUAL="$EDITOR"


### PR DESCRIPTION
## Description

Fix `gp open` command to open files in JetBrains Client instead of the backend IDE.

These changes also affects `gp preview` command, so it needs to be tested.

## How to test

1. Open the preview environment generated for this branch
2. Choose the  _Stable_  version of IntelliJ IDEA as your preferred editor
3. Start a workspace using this repository: https://github.com/gitpod-io/spring-petclinic
4. Verify that the workspace starts successfully
5. Verify that the IDE opens successfully
6. Run `gp open .gitignore` and confirm it opens the .gitignore file in the editor
7. Run `gp open --wait .gitpod.yml` and confirm it opens Gitpod Configuration file and will only exit the command line when you click "Release" on the top bar displayed in the editor
8. Run `gp preview https://gitpod.io` and confirm Gitpod Website opens in your browser
9. Repeat the same steps above, but now using the _Latest Release (Unstable)_ version of IntelliJ IDEA

## Release Notes

```release-note
Fix 'gp open' command to open files in JetBrains Client instead of the backend IDE
```

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
