### PR TITLE
[installer-tests] call the autoscaler module for aws tests

### DIFF
--- a/install/tests/Makefile
+++ b/install/tests/Makefile
@@ -34,7 +34,12 @@ tf-ws: check-var-cloud
 tf-plan: check-var-cloud tf-ws
 	$(MAKE) -C ${TF_MOD} plan
 
-tf-apply: check-var-cloud tf-ws
+tf-aws-autoscaler-apply:
+ifeq ($(cloud), aws)
+	$(MAKE) -C ${TF_MOD} install-cluster-autoscaler
+endif
+
+tf-apply: check-var-cloud tf-ws tf-aws-autoscaler-apply
 	@echo "Get kubeconfig of existing cluster(if any)..."
 	$(MAKE) get-kubeconfig || echo "No pre-existing cluster"
 	@echo "Run terraform apply"
@@ -453,6 +458,7 @@ self_signed ?= false
 check-gitpod-installation: delete-cm-setup check-kots-app check-var-TF_VAR_TEST_ID
 	@echo "Curling https://${TF_VAR_TEST_ID}.${DOMAIN}/api/version"
 ifeq (true,$(self_signed))
+	@gsutil cp gs://nightly-tests/tf-state/${TF_VAR_TEST_ID}-ca.pem ca.pem || echo "No ca file found"
 	export SSL_CERT_FILE=./ca.pem
 endif
 	@curl -i -X GET https://${TF_VAR_TEST_ID}.${DOMAIN}/api/version || { echo "**Error**: Curling Gitpod endpoint failed"; exit 1; }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Currently we are not calling the autoscaler module during test runs. This PR fixes it

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
