### PR TITLE
[usage] Setup usage reset job

### DIFF
--- a/components/usage/pkg/scheduler/reset_usage_job.go
+++ b/components/usage/pkg/scheduler/reset_usage_job.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package scheduler
+
+import (
+	"time"
+
+	"github.com/gitpod-io/gitpod/common-go/log"
+)
+
+func NewResetUsageJobSpec(schedule time.Duration) (JobSpec, error) {
+	spec := &ResetUsageJobSpec{}
+	return NewPeriodicJobSpec(schedule, "reset_usage", WithoutConcurrentRun(spec))
+}
+
+type ResetUsageJobSpec struct {
+}
+
+func (j *ResetUsageJobSpec) Run() (err error) {
+	log.Info("Running reset usage job.")
+
+	return nil
+}

--- a/components/usage/pkg/server/server.go
+++ b/components/usage/pkg/server/server.go
@@ -27,9 +27,13 @@ import (
 )
 
 type Config struct {
-	// ControllerSchedule determines how frequently to run the Usage/Billing controller.
-	// When ControllerSchedule is empty, the background controller is disabled.
-	ControllerSchedule string `json:"controllerSchedule,omitempty"`
+	// LedgerSchedule determines how frequently to run the Usage/Billing controller.
+	// When LedgerSchedule is empty, the background controller is disabled.
+	LedgerSchedule string `json:"controllerSchedule,omitempty"`
+
+	// ResetUsageSchedule determines how frequently to run the Usage Reset job.
+	// When empty, the job is disabled.
+	ResetUsageSchedule string `json:"resetUsageSchedule,omitempty"`
 
 	CreditsPerMinuteByWorkspaceClass map[string]float64 `json:"creditsPerMinuteByWorkspaceClass,omitempty"`
 
@@ -117,10 +121,9 @@ func Start(cfg Config, version string) error {
 	}
 
 	var schedulerJobSpecs []scheduler.JobSpec
-
-	if cfg.ControllerSchedule != "" {
+	if cfg.LedgerSchedule != "" {
 		// we do not run the controller if there is no schedule defined.
-		schedule, err := time.ParseDuration(cfg.ControllerSchedule)
+		schedule, err := time.ParseDuration(cfg.LedgerSchedule)
 		if err != nil {
 			return fmt.Errorf("failed to parse schedule duration: %w", err)
 		}
@@ -136,6 +139,20 @@ func Start(cfg Config, version string) error {
 
 	} else {
 		log.Info("No controller schedule specified, controller will be disabled.")
+	}
+
+	if cfg.ResetUsageSchedule != "" {
+		schedule, err := time.ParseDuration(cfg.ResetUsageSchedule)
+		if err != nil {
+			return fmt.Errorf("failed to parse reset usage schedule as duration: %w", err)
+		}
+
+		spec, err := scheduler.NewResetUsageJobSpec(schedule)
+		if err != nil {
+			return fmt.Errorf("failed to setup reset usage job: %w", err)
+		}
+
+		schedulerJobSpecs = append(schedulerJobSpecs, spec)
 	}
 
 	sched := scheduler.New(schedulerJobSpecs...)

--- a/install/installer/pkg/components/usage/configmap.go
+++ b/install/installer/pkg/components/usage/configmap.go
@@ -5,6 +5,7 @@ package usage
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/gitpod-io/gitpod/common-go/baseserver"
 	"github.com/gitpod-io/gitpod/usage/pkg/db"
@@ -19,7 +20,8 @@ import (
 
 func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 	cfg := server.Config{
-		ControllerSchedule: "", // By default controller is disabled
+		LedgerSchedule:     "", // By default controller is disabled
+		ResetUsageSchedule: time.Duration(5 * time.Minute).String(),
 		Server: &baseserver.Configuration{
 			Services: baseserver.ServicesConfiguration{
 				GRPC: &baseserver.ServerConfiguration{
@@ -53,7 +55,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 
 	if expUsageConfig != nil {
 		if expUsageConfig.Schedule != "" {
-			cfg.ControllerSchedule = expUsageConfig.Schedule
+			cfg.LedgerSchedule = expUsageConfig.Schedule
 		}
 		if expUsageConfig.DefaultSpendingLimit != nil {
 			cfg.DefaultSpendingLimit = *expUsageConfig.DefaultSpendingLimit

--- a/install/installer/pkg/components/usage/configmap_test.go
+++ b/install/installer/pkg/components/usage/configmap_test.go
@@ -23,6 +23,7 @@ func TestConfigMap_ContainsSchedule(t *testing.T) {
 	require.JSONEq(t,
 		`{
        "controllerSchedule": "2m",
+	   "resetUsageSchedule": "5m0s",
        "stripeCredentialsFile": "stripe-secret/apikeys",
 	   "defaultSpendingLimit": {
 		"forUsers": 1000000000,


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Initial setup for usage reset job. Currently does nothing but logs when it's triggered. 
Config in the installer will be added in subsequent PR.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Part of https://github.com/gitpod-io/gitpod/issues/14178

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
