### PR TITLE
Adjust ownership of alerts related to the observability-stack and add alert for Prometheus restarting

### DIFF
--- a/operations/observability/mixins/self-hosted/rules/observability-stack/alertmanager.yaml
+++ b/operations/observability/mixins/self-hosted/rules/observability-stack/alertmanager.yaml
@@ -27,7 +27,7 @@ spec:
       for: 10m
       labels:
         severity: critical
-        team: platform
+        team: delivery-operations-experience
     - alert: AlertmanagerFailedToSendAlerts
       annotations:
         description: Alertmanager {{ $labels.namespace }}/{{ $labels.pod}} failed to send {{ $value | humanizePercentage }} of notifications to {{ $labels.integration }}.
@@ -42,4 +42,4 @@ spec:
       for: 5m
       labels:
         severity: warning
-        team: platform
+        team: delivery-operations-experience

--- a/operations/observability/mixins/self-hosted/rules/observability-stack/kube-state-metrics.yaml
+++ b/operations/observability/mixins/self-hosted/rules/observability-stack/kube-state-metrics.yaml
@@ -28,4 +28,4 @@ spec:
       for: 15m
       labels:
         severity: critical
-        team: platform
+        team: delivery-operations-experience

--- a/operations/observability/mixins/self-hosted/rules/observability-stack/prometheus-operator.yaml
+++ b/operations/observability/mixins/self-hosted/rules/observability-stack/prometheus-operator.yaml
@@ -25,7 +25,7 @@ spec:
       for: 15m
       labels:
         severity: warning
-        team: platform
+        team: delivery-operations-experience
     - alert: PrometheusOperatorWatchErrors
       annotations:
         description: Errors while performing watch operations in controller {{$labels.controller}} in {{$labels.namespace}} namespace.
@@ -35,7 +35,7 @@ spec:
       for: 15m
       labels:
         severity: warning
-        team: platform
+        team: delivery-operations-experience
     - alert: PrometheusOperatorReconcileErrors
       annotations:
         description: '{{ $value | humanizePercentage }} of reconciling operations failed for {{ $labels.controller }} controller in {{ $labels.namespace }} namespace.'
@@ -45,7 +45,7 @@ spec:
       for: 10m
       labels:
         severity: warning
-        team: platform
+        team: delivery-operations-experience
     - alert: ConfigReloaderSidecarErrors
       annotations:
         description: |-
@@ -57,4 +57,4 @@ spec:
       for: 10m
       labels:
         severity: warning
-        team: platform
+        team: delivery-operations-experience

--- a/operations/observability/mixins/self-hosted/rules/observability-stack/prometheus.yaml
+++ b/operations/observability/mixins/self-hosted/rules/observability-stack/prometheus.yaml
@@ -58,3 +58,13 @@ spec:
       labels:
         severity: warning
         team: delivery-operations-experience
+    - alert: PrometheusCrashlooped
+      annotations:
+        description: Prometheus' container restarted in the last 5m. While this alert will resolve itself if prometheus stopped crashing, it is important to understand why it crashed in the first place.
+        summary: Prometheus has just crashlooped.
+      expr: |
+        increase(kube_pod_container_status_restarts_total{cluster=~"$cluster", pod="prometheus-k8s-0", container="prometheus"}[5m]) > 0
+      for: 15m
+      labels:
+        severity: info
+        team: delivery-operations-experience

--- a/operations/observability/mixins/self-hosted/rules/observability-stack/prometheus.yaml
+++ b/operations/observability/mixins/self-hosted/rules/observability-stack/prometheus.yaml
@@ -27,7 +27,7 @@ spec:
       for: 10m
       labels:
         severity: critical
-        team: platform
+        team: delivery-operations-experience
     - alert: PrometheusRemoteStorageFailures
       annotations:
         description: Prometheus {{$labels.namespace}}/{{$labels.pod}} failed to send {{ printf "%.1f" $value }}% of the samples to {{ $labels.remote_name}}:{{ $labels.url }}
@@ -47,7 +47,7 @@ spec:
       for: 15m
       labels:
         severity: critical
-        team: platform
+        team: delivery-operations-experience
     - alert: PrometheusRuleFailures
       annotations:
         description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed to evaluate {{ printf "%.0f" $value }} rules in the last 5m.
@@ -57,4 +57,4 @@ spec:
       for: 15m
       labels:
         severity: warning
-        team: platform
+        team: delivery-operations-experience


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PR does 2 things:

* Move alerts for the observability stack to a folder owned by @gitpod-io/engineering-delivery-operations-experience
* Add one alert that notifies #team-delivery-operations-experience-alerts in slack when Prometheus restarts

@liam-j-bennett, I'm curious about what do you think about this new alert since I'm also unsure about it 😬.

This won't give us any false-positive, but will only trigger after a problem occurs. It's a reactive approach. Do we want something that is more proactive? I'm not sure about how we'd avoid false positives here

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
