### PR TITLE
[server] Revert #14185

### DIFF
--- a/components/server/src/prometheus-metrics.ts
+++ b/components/server/src/prometheus-metrics.ts
@@ -21,7 +21,6 @@ export function registerServerMetrics(registry: prometheusClient.Registry) {
     registry.registerMetric(instanceStartsFailedTotal);
     registry.registerMetric(prebuildsStartedTotal);
     registry.registerMetric(stripeClientRequestsCompletedDurationSeconds);
-    registry.registerMetric(imageBuildsStartedTotal);
 }
 
 const loginCounter = new prometheusClient.Counter({
@@ -176,13 +175,4 @@ export const stripeClientRequestsCompletedDurationSeconds = new prometheusClient
 
 export function observeStripeClientRequestsCompleted(operation: string, outcome: string, durationInSeconds: number) {
     stripeClientRequestsCompletedDurationSeconds.observe({ operation, outcome }, durationInSeconds);
-}
-
-export const imageBuildsStartedTotal = new prometheusClient.Counter({
-    name: "gitpod_server_image_builds_started_total",
-    help: "counter of the total number of image builds started on server",
-});
-
-export function increaseImageBuildsStartedTotal() {
-    imageBuildsStartedTotal.inc();
 }

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -114,7 +114,6 @@ import { ExtendedUser } from "@gitpod/ws-manager/lib/constraints";
 import {
     FailedInstanceStartReason,
     increaseFailedInstanceStartCounter,
-    increaseImageBuildsStartedTotal,
     increaseSuccessfulInstanceStartCounter,
 } from "../prometheus-metrics";
 import { ContextParser } from "./context-parser-service";
@@ -1211,7 +1210,6 @@ export class WorkspaceStarter {
         const span = TraceContext.startSpan("buildWorkspaceImage", ctx);
 
         try {
-            increaseImageBuildsStartedTotal();
             // Start build...
             const client = await this.getImageBuilderClient(user, workspace, instance);
             const { src, auth, disposable } = await this.prepareBuildRequest(


### PR DESCRIPTION
## Description

Revert #14185.

The metric was added incorrectly and is actually incrementing on all workspace starts, not just image builds.

The metric is re-added correctly in #14204 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of #12960 

## How to test

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
