### PR TITLE
[server] Add counter metric for image build starts

### DIFF
--- a/components/server/src/prometheus-metrics.ts
+++ b/components/server/src/prometheus-metrics.ts
@@ -21,6 +21,7 @@ export function registerServerMetrics(registry: prometheusClient.Registry) {
     registry.registerMetric(instanceStartsFailedTotal);
     registry.registerMetric(prebuildsStartedTotal);
     registry.registerMetric(stripeClientRequestsCompletedDurationSeconds);
+    registry.registerMetric(imageBuildsStartedTotal);
 }
 
 const loginCounter = new prometheusClient.Counter({
@@ -175,4 +176,13 @@ export const stripeClientRequestsCompletedDurationSeconds = new prometheusClient
 
 export function observeStripeClientRequestsCompleted(operation: string, outcome: string, durationInSeconds: number) {
     stripeClientRequestsCompletedDurationSeconds.observe({ operation, outcome }, durationInSeconds);
+}
+
+export const imageBuildsStartedTotal = new prometheusClient.Counter({
+    name: "gitpod_server_image_builds_started_total",
+    help: "counter of the total number of image builds started on server",
+});
+
+export function increaseImageBuildsStartedTotal() {
+    imageBuildsStartedTotal.inc();
 }

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -114,6 +114,7 @@ import { ExtendedUser } from "@gitpod/ws-manager/lib/constraints";
 import {
     FailedInstanceStartReason,
     increaseFailedInstanceStartCounter,
+    increaseImageBuildsStartedTotal,
     increaseSuccessfulInstanceStartCounter,
 } from "../prometheus-metrics";
 import { ContextParser } from "./context-parser-service";
@@ -1254,6 +1255,10 @@ export class WorkspaceStarter {
                 );
 
             const result = await client.build({ span }, req, imageBuildLogInfo);
+
+            if (result.actuallyNeedsBuild) {
+                increaseImageBuildsStartedTotal();
+            }
 
             // Update the workspace now that we know what the name of the workspace image will be (which doubles as buildID)
             workspace.imageNameResolved = result.ref;


### PR DESCRIPTION
## Description

Re-do of #14185 (reverted in #14203), this time incrementing the metric only on image builds.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of #12960 

## How to test

* Port-forward to the server metrics port: `kubectl port-forward deploy/server 9500:9500`
* Hit the `server` metrics endpoint at `:9500/metrics` and look for the `gitpod_server_image_builds_started_total` metric.
* Start an image build
* See the counter increase.
* Start a workspace that doesn't require an image build.
* See that the counter does not increase.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
