### PR TITLE
chore(image-builder-bob): Reduce retry duration

### DIFF
--- a/test/pkg/integration/integration.go
+++ b/test/pkg/integration/integration.go
@@ -506,9 +506,7 @@ const (
 	ComponentContentService ComponentType = "content-service"
 	// ComponentWorkspace points to a workspace
 	ComponentWorkspace ComponentType = "workspace"
-	// ComponentImageBuilder points to the image-builder
-	ComponentImageBuilder ComponentType = "image-builder"
-	// ComponentImageBuilder points to the image-builder-mk3
+	// ComponentImageBuilderMK3 points to the image-builder-mk3
 	ComponentImageBuilderMK3 ComponentType = "image-builder-mk3"
 )
 


### PR DESCRIPTION
## Description
Small improvements for `image-builder-bob`'s retry logic for connecting to the buildkit daemon:
- Reduce exponential backoff attempts from 10 to 8. This will still retry for up to ~4 minutes (instead of ~17 minutes), but will error out sooner if there's a real issue.
  - From testing, the daemon usually starts in less
- Remove `time.Sleep` after last failed retry attempt, should reduce total wait time by ~half if there's an error (due to exponential backoff sleep times).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

## How to test
<!-- Provide steps to test this PR -->

Follow the [README](https://github.com/gitpod-io/gitpod/tree/main/components/image-builder-bob/README.md) to run `bob` locally in a workspace, up to and including trying to build an image. The image build should get stuck in `attempting to connect to buildkitd`, and quit after 8 attempts (because currently the daemon fails to start in a workspace due to #14003: root user can't write to `/workspace`).

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
