### PR TITLE
Fix missing datasource variable

### DIFF
--- a/operations/observability/mixins/self-hosted/dashboards/observability/observability.json
+++ b/operations/observability/mixins/self-hosted/dashboards/observability/observability.json
@@ -24,7 +24,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 84,
+  "id": null,
   "links": [
     {
       "asDropdown": false,
@@ -1291,14 +1291,23 @@
     "list": [
       {
         "current": {
-          "selected": true,
-          "text": [
-            "All"
-          ],
-          "value": [
-            "$__all"
-          ]
+          "selected": false,
+          "text": "VictoriaMetrics",
+          "value": "VictoriaMetrics"
         },
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": {},
         "datasource": {
           "type": "prometheus",
           "uid": "$datasource"
@@ -1330,6 +1339,6 @@
   "timezone": "",
   "title": "Observability",
   "uid": "1hcljDH4k",
-  "version": 42,
+  "version": 1,
   "weekStart": ""
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
https://github.com/gitpod-io/gitpod/pull/14168 introduced a dashboard focused on the health of our observability stack and it was created manually in Grafana. When backporting the JSON we missed to create a datasource variable, and now we're getting errors opening [the dashboard](https://grafana.gitpod.io/d/1hcljDH4k/observability?orgId=1)

![image](https://user-images.githubusercontent.com/24193764/198101086-476cddc6-1f93-4259-bf8d-8dcbea700663.png)

This PR just created the variable, so the dashboard loads successfully.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
