### PR TITLE
Add dashboard URL button to argocd alerts

### DIFF
--- a/operations/observability/mixins/self-hosted/rules/argocd/prometheusRules.yaml
+++ b/operations/observability/mixins/self-hosted/rules/argocd/prometheusRules.yaml
@@ -21,6 +21,7 @@ spec:
       annotations:
         description: App {{ $labels.name }} in {{ $labels.label_environment }} is stuck in `Unknown` for 1h. ArgoCD is probably generating errors when trying to compare live and desired manifests.
         summary: App {{ $labels.name }} is stuck in `Unknown` state.
+        dashboard_url: https://grafana.gitpod.io/d/argocd-apps/argocd?refresh=30s&var-environment={{ $labels.label_environment }}&var-team={{ $labels.team }}
       expr: label_replace(argocd_app_info{sync_status="Unknown"} * on(name) group_left(label_environment, label_team) argocd_app_labels, "team", "$1", "label_team", "(.*)")
       labels:
         severity: warning
@@ -29,6 +30,7 @@ spec:
       annotations:
         description: App {{ $labels.name }} in {{ $labels.label_environment }} is `OutOfSync` for more than an entire day. The live manifests do not match with what is desired in git!
         summary: App {{ $labels.name }} is stuck in `OutOfSync` state.
+        dashboard_url: https://grafana.gitpod.io/d/argocd-apps/argocd?refresh=30s&var-environment={{ $labels.label_environment }}&var-team={{ $labels.team }}
       expr: label_replace(argocd_app_info{sync_status="OutOfSync"} * on(name) group_left(label_environment, label_team) argocd_app_labels, "team", "$1", "label_team", "(.*)")
       labels:
         severity: warning
@@ -37,6 +39,7 @@ spec:
       annotations:
         description: App {{ $labels.name }} in {{ $labels.label_environment }} is stuck in `Progressing` for 1h. It is possible that the application is left in a weird state.
         summary: App {{ $labels.name }} is stuck in `Progressing` state.
+        dashboard_url: https://grafana.gitpod.io/d/argocd-apps/argocd?refresh=30s&var-environment={{ $labels.label_environment }}&var-team={{ $labels.team }}
       expr: label_replace(argocd_app_info{health_status="Progressing"} * on(name) group_left(label_environment, label_team) argocd_app_labels, "team", "$1", "label_team", "(.*)")
       labels:
         severity: warning
@@ -45,6 +48,7 @@ spec:
       annotations:
         description: App {{ $labels.name }} in {{ $labels.label_environment }} is stuck in `Degraded`. This means that the synchronization failed requires investigation.
         summary: App {{ $labels.name }} is stuck in `Degraded` state.
+        dashboard_url: https://grafana.gitpod.io/d/argocd-apps/argocd?refresh=30s&var-environment={{ $labels.label_environment }}&var-team={{ $labels.team }}
       expr: label_replace(argocd_app_info{health_status="Degraded"} * on(name) group_left(label_environment, label_team) argocd_app_labels, "team", "$1", "label_team", "(.*)")
       labels:
         severity: warning


### PR DESCRIPTION
Signed-off-by: ArthurSens <arthursens2005@gmail.com>

## Description
<!-- Describe your changes in detail -->
To make navigation and debugging easier :)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
