### PR TITLE
Update team creation link in projects

### DIFF
--- a/components/dashboard/src/Menu.tsx
+++ b/components/dashboard/src/Menu.tsx
@@ -301,7 +301,7 @@ export default function Menu() {
                 }))
                 .sort((a, b) => (a.title.toLowerCase() > b.title.toLowerCase() ? 1 : -1)),
             {
-                slug: "teams/new",
+                slug: "new",
                 title: "Create a new team",
                 customContent: (
                     <div className="w-full text-gray-400 flex items-center">

--- a/components/dashboard/src/projects/Projects.tsx
+++ b/components/dashboard/src/projects/Projects.tsx
@@ -134,8 +134,8 @@ export default function () {
                 <div className="app-container pt-2">
                     <Alert type={"message"} closable={false} showIcon={true} className="flex rounded mb-2 w-full">
                         We'll remove projects under personal accounts in Q1'2023.{" "}
-                        <Link to="/new" className="gp-link">
-                            Create a team.
+                        <Link to="/teams/new" className="gp-link">
+                            Create a team
                         </Link>
                     </Alert>
                 </div>


### PR DESCRIPTION
## Description

Following up from https://github.com/gitpod-io/gitpod/pull/13920, to update the correct line of code.

## How to test

See instructions in https://github.com/gitpod-io/gitpod/pull/13920.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [X] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
