### PR TITLE
Log JSON as strings not an array of bytes

### DIFF
--- a/components/image-builder-mk3/pkg/orchestrator/orchestrator.go
+++ b/components/image-builder-mk3/pkg/orchestrator/orchestrator.go
@@ -151,7 +151,7 @@ func (o *Orchestrator) ResolveBaseImage(ctx context.Context, req *protocol.Resol
 
 	reqs, _ := protojson.Marshal(req)
 	safeReqs, _ := log.RedactJSON(reqs)
-	log.WithField("req", safeReqs).Debug("ResolveBaseImage")
+	log.WithField("req", string(safeReqs)).Debug("ResolveBaseImage")
 
 	reqauth := o.AuthResolver.ResolveRequestAuth(req.Auth)
 
@@ -173,7 +173,7 @@ func (o *Orchestrator) ResolveWorkspaceImage(ctx context.Context, req *protocol.
 
 	reqs, _ := protojson.Marshal(req)
 	safeReqs, _ := log.RedactJSON(reqs)
-	log.WithField("req", safeReqs).Debug("ResolveWorkspaceImage")
+	log.WithField("req", string(safeReqs)).Debug("ResolveWorkspaceImage")
 
 	reqauth := o.AuthResolver.ResolveRequestAuth(req.Auth)
 	baseref, err := o.getBaseImageRef(ctx, req.Source, reqauth)

--- a/components/ws-manager/pkg/manager/manager.go
+++ b/components/ws-manager/pkg/manager/manager.go
@@ -1360,12 +1360,12 @@ func (m *Manager) onChange(ctx context.Context, status *api.WorkspaceStatus) {
 	if status.Conditions.Failed != "" {
 		status, _ := protojson.Marshal(status)
 		safeStatus, _ := log.RedactJSON(status)
-		clog.WithField("status", safeStatus).Error("workspace failed")
+		clog.WithField("status", string(safeStatus)).Error("workspace failed")
 	}
 	if status.Phase == 0 {
 		status, _ := protojson.Marshal(status)
 		safeStatus, _ := log.RedactJSON(status)
-		clog.WithField("status", safeStatus).Error("workspace in UNKNOWN phase")
+		clog.WithField("status", string(safeStatus)).Error("workspace in UNKNOWN phase")
 	}
 }
 


### PR DESCRIPTION
## Description

Without an explicit conversion, the log will contain the Base64 representation

## How to test
- Open a workspace
- Check ws-manager logs and search for the `status` field. The value should be readable

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
