### PR TITLE
[dashboard] avoid unbound getUserProjects calls

### DIFF
--- a/components/dashboard/src/App.tsx
+++ b/components/dashboard/src/App.tsx
@@ -275,6 +275,9 @@ function App() {
     }, [user]);
 
     useEffect(() => {
+        if (!teams) {
+            return;
+        }
         // Refresh billing mode (side effect on other components per UserContext!)
         refreshUserBillingMode();
     }, [teams]);

--- a/components/dashboard/src/Menu.tsx
+++ b/components/dashboard/src/Menu.tsx
@@ -46,9 +46,12 @@ export default function Menu() {
     const [isFeedbackFormVisible, setFeedbackFormVisible] = useState<boolean>(false);
 
     const [hasIndividualProjects, setHasIndividualProjects] = useState(false);
-    getGitpodService()
-        .server.getUserProjects()
-        .then((projects) => setHasIndividualProjects(projects.length > 0));
+
+    useEffect(() => {
+        getGitpodService()
+            .server.getUserProjects()
+            .then((projects) => setHasIndividualProjects(projects.length > 0));
+    }, []);
 
     const match = useRouteMatch<{ segment1?: string; segment2?: string; segment3?: string }>(
         "/(t/)?:segment1/:segment2?/:segment3?",


### PR DESCRIPTION
This is a small clean-up and should remove unnecessary calls to server.


## How to test
Dashboard should load as usual. 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
