### PR TITLE
[usage] List cost centers with expired billing time

### DIFF
--- a/components/usage/pkg/apiv1/usage.go
+++ b/components/usage/pkg/apiv1/usage.go
@@ -236,6 +236,19 @@ func (s *UsageService) SetCostCenter(ctx context.Context, in *v1.SetCostCenterRe
 	}, nil
 }
 
+func (s UsageService) ResetUsage(ctx context.Context, req *v1.ResetUsageRequest) (*v1.ResetUsageResponse, error) {
+	now := time.Now()
+	costCentersToUpdate, err := s.costCenterManager.ListLatestCostCentersWithBillingTimeBefore(ctx, db.CostCenter_Other, now)
+	if err != nil {
+		log.WithError(err).Error("Failed to list cost centers to update.")
+		return nil, status.Errorf(codes.Internal, "Failed to identify expired cost centers for Other billing strategy")
+	}
+
+	log.Infof("Identified %d expired cost centers at relative to %s", len(costCentersToUpdate), now.Format(time.RFC3339))
+
+	return &v1.ResetUsageResponse{}, nil
+}
+
 func (s *UsageService) ReconcileUsage(ctx context.Context, req *v1.ReconcileUsageRequest) (*v1.ReconcileUsageResponse, error) {
 	from := req.GetFrom().AsTime()
 	to := req.GetTo().AsTime()


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

* Implements ResetUsage to initially only report how many Cost centers it finds with expired NextBillingTime
* Implements underlying SQL search
  * Tested SQL query against prod. On the full CostCenter dataset this takes ~4 secs.
  * We can add an index on NextBillingTime to speed this up
* This RPC doesn't yet get invoked by the ResetUsage Job, to test, we'll invoke it manually through grpcurl.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* https://github.com/gitpod-io/gitpod/issues/14178

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
