### PR TITLE
[supervisor] remove unnecessary close channel

### DIFF
--- a/components/supervisor/cmd/init.go
+++ b/components/supervisor/cmd/init.go
@@ -84,7 +84,6 @@ var initCmd = &cobra.Command{
 				defer close(terminationDone)
 				slog.TerminateSync(ctx, runCommand.Process.Pid)
 				terminateAllProcesses(ctx, slog)
-				close(supervisorDone)
 			}()
 			// wait for either successful termination or the timeout
 			select {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
[supervisor] remove unnecessary close channel

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #14014

## How to test
<!-- Provide steps to test this PR -->
1. start workspace with this branch in gitpod.io, connect to preview environment via kubectl
2. start a workspace in preview environment, it should work
3. use `kubectl get pods -l component=workspace` to get workspace pod name
4. use `kubectl logs ws-xxxxxx -f` to see workspace log
5. stop your workspace, and observe log, there should not have `panic: close of closed channel` error output

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
