### PR TITLE
[dashboard] Use public-api to CreateTeams

### DIFF
--- a/components/dashboard/BUILD.yaml
+++ b/components/dashboard/BUILD.yaml
@@ -17,6 +17,7 @@ packages:
       - scripts/run-integration-tests.sh
     deps:
       - components/gitpod-protocol:lib
+      - components/public-api/typescript:lib
     config:
       commands:
         build: ["yarn", "build"]

--- a/components/dashboard/package.json
+++ b/components/dashboard/package.json
@@ -4,7 +4,9 @@
   "version": "0.0.0",
   "private": true,
   "dependencies": {
+    "@bufbuild/connect-web": "^0.2.1",
     "@gitpod/gitpod-protocol": "0.1.5",
+    "@gitpod/public-api": "0.1.5",
     "@stripe/react-stripe-js": "^1.7.2",
     "@stripe/stripe-js": "^1.29.0",
     "configcat-js": "^6.0.0",

--- a/components/dashboard/src/contexts/FeatureFlagContext.tsx
+++ b/components/dashboard/src/contexts/FeatureFlagContext.tsx
@@ -19,10 +19,12 @@ const FeatureFlagContext = createContext<{
     showPersistentVolumeClaimUI: boolean;
     showUsageView: boolean;
     showUseLastSuccessfulPrebuild: boolean;
+    usePublicApiTeamsService: boolean;
 }>({
     showPersistentVolumeClaimUI: false,
     showUsageView: false,
     showUseLastSuccessfulPrebuild: false,
+    usePublicApiTeamsService: false,
 });
 
 const FeatureFlagContextProvider: React.FC = ({ children }) => {
@@ -34,6 +36,7 @@ const FeatureFlagContextProvider: React.FC = ({ children }) => {
     const [showPersistentVolumeClaimUI, setShowPersistentVolumeClaimUI] = useState<boolean>(false);
     const [showUsageView, setShowUsageView] = useState<boolean>(false);
     const [showUseLastSuccessfulPrebuild, setShowUseLastSuccessfulPrebuild] = useState<boolean>(false);
+    const [usePublicApiTeamsService, setUsePublicApiTeamsService] = useState<boolean>(false);
 
     useEffect(() => {
         if (!user) return;
@@ -42,6 +45,7 @@ const FeatureFlagContextProvider: React.FC = ({ children }) => {
                 persistent_volume_claim: { defaultValue: true, setter: setShowPersistentVolumeClaimUI },
                 usage_view: { defaultValue: false, setter: setShowUsageView },
                 showUseLastSuccessfulPrebuild: { defaultValue: false, setter: setShowUseLastSuccessfulPrebuild },
+                usePublicApiTeamsService: { defaultValue: false, setter: setUsePublicApiTeamsService },
             };
             for (const [flagName, config] of Object.entries(featureFlags)) {
                 if (teams) {
@@ -74,7 +78,12 @@ const FeatureFlagContextProvider: React.FC = ({ children }) => {
 
     return (
         <FeatureFlagContext.Provider
-            value={{ showPersistentVolumeClaimUI, showUsageView, showUseLastSuccessfulPrebuild }}
+            value={{
+                showPersistentVolumeClaimUI,
+                showUsageView,
+                showUseLastSuccessfulPrebuild,
+                usePublicApiTeamsService,
+            }}
         >
             {children}
         </FeatureFlagContext.Provider>

--- a/components/dashboard/src/service/public-api.ts
+++ b/components/dashboard/src/service/public-api.ts
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { createConnectTransport, createPromiseClient, Interceptor } from "@bufbuild/connect-web";
+
+// Import service definition that you want to connect to.
+import { TeamsService } from "@gitpod/public-api/lib/gitpod/experimental/v1/teams_connectweb";
+import { getGitpodService } from "./service";
+
+let token: string | undefined;
+
+const authInterceptor: Interceptor = (next) => async (req) => {
+    if (!token) {
+        const newToken = await getGitpodService().server.generateNewGitpodToken({
+            type: 1,
+            scopes: [
+                "function:getGitpodTokenScopes",
+                "function:getWorkspace",
+                "function:getWorkspaces",
+                "function:createTeam",
+                "function:joinTeam",
+                "function:getTeamMembers",
+                "function:getGenericInvite",
+                "function:listenForWorkspaceInstanceUpdates",
+                "resource:default",
+            ],
+        });
+        token = newToken;
+    }
+
+    req.header.set("Authorization", `Bearer ${token}`);
+    return await next(req);
+};
+
+const transport = createConnectTransport({
+    baseUrl: `${window.location.protocol}//api.${window.location.host}`,
+    interceptors: [authInterceptor],
+});
+
+export const teamsService = createPromiseClient(TeamsService, transport);


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Depends on https://github.com/gitpod-io/gitpod/pull/14152
* Fixes https://github.com/gitpod-io/gitpod/issues/14309

The feature is enabled behind a feature flag.

## How to test
<!-- Provide steps to test this PR -->
* Use preview
* Create a new team (with DevTools open)
* Observe the request goes to `api.<domain>`
* Validate create workflow continues to behave the same

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
