### PR TITLE
Deactivate team scope selector on personal usage

### DIFF
--- a/components/dashboard/src/Menu.tsx
+++ b/components/dashboard/src/Menu.tsx
@@ -104,6 +104,7 @@ export default function Menu() {
         "account",
         "notifications",
         "billing",
+        "usage",
         "plans",
         "teams",
         "variables",


### PR DESCRIPTION
## Description

Following up from https://github.com/gitpod-io/gitpod/pull/14161, this will make sure the team scope selector becomes deactivated when visiting personal usage. See [relevant discussion](https://gitpod.slack.com/archives/C027AUU7BC3/p1666880393674419?thread_ts=1666879099.675049&cid=C027AUU7BC3) (internal).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/13968

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Deactivate team scope selector on personal usage
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [X] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
