### PR TITLE
[server] introduce incremental workspaces

### DIFF
--- a/components/dashboard/src/settings/selectClass.tsx
+++ b/components/dashboard/src/settings/selectClass.tsx
@@ -57,7 +57,6 @@ export default function SelectWorkspaceClass(props: SelectWorkspaceClassProps) {
     } else {
         return (
             <div>
-                <h3 className="mt-12">Workspaces</h3>
                 <p className="text-base text-gray-500 dark:text-gray-400">
                     Choose the workspace machine type for your workspaces.
                 </p>

--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -12,7 +12,6 @@ import {
     WhitelistedRepository,
     WorkspaceImageBuild,
     AuthProviderInfo,
-    CreateWorkspaceMode,
     Token,
     UserEnvVarValue,
     Terms,
@@ -421,7 +420,12 @@ export namespace GitpodServer {
     }
     export interface CreateWorkspaceOptions {
         contextUrl: string;
-        mode?: CreateWorkspaceMode;
+        // whether running prebuilds should be ignored.
+        ignoreRunningPrebuild?: boolean;
+        // whether running workspaces on the same context should be ignored. If false (default) users will be asked.
+        ignoreRunningWorkspaceOnSameCommit?: boolean;
+        // whether older prebuilds can be used and incrementally updated.
+        allowUsingPreviousPrebuilds?: boolean;
         forceDefaultConfig?: boolean;
     }
     export interface StartWorkspaceOptions {

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -211,6 +211,12 @@ export interface AdditionalUserData {
     dotfileRepo?: string;
     // preferred workspace classes
     workspaceClasses?: WorkspaceClasses;
+    // whether running prebuilds should be ignored on start
+    ignoreRunnningPrebuilds?: boolean;
+    // whether new workspaces can start on older prebuilds and incrementally update
+    allowUsingPreviousPrebuilds?: boolean;
+    // whether running workspaces for the same git context should be ignored on start so that users are not prompted
+    ignoreRunningWorkspaceOnSameCommit?: boolean;
     // additional user profile data
     profile?: ProfileDetails;
 }
@@ -1376,19 +1382,6 @@ export interface WorkspaceCreationResult {
     runningPrebuildWorkspaceID?: string;
 }
 export type RunningWorkspacePrebuildStarting = "queued" | "starting" | "running";
-
-export enum CreateWorkspaceMode {
-    // Default returns a running prebuild if there is any, otherwise creates a new workspace (using a prebuild if one is available)
-    Default = "default",
-    // ForceNew creates a new workspace irrespective of any running prebuilds. This mode is guaranteed to actually create a workspace - but may degrade user experience as currently runnig prebuilds are ignored.
-    ForceNew = "force-new",
-    // UsePrebuild polls the database waiting for a currently running prebuild to become available. This mode exists to handle the db-sync delay.
-    UsePrebuild = "use-prebuild",
-    // SelectIfRunning returns a list of currently running workspaces for the context URL if there are any, otherwise falls back to Default mode
-    SelectIfRunning = "select-if-running",
-    // UseLastSuccessfulPrebuild returns ...
-    UseLastSuccessfulPrebuild = "use-last-successful-prebuild",
-}
 
 export namespace WorkspaceCreationResult {
     export function is(data: any): data is WorkspaceCreationResult {


### PR DESCRIPTION
## Description
This introduces a feature flag for enabling incremental workspaces.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
See #12582

## How to test
<!-- Provide steps to test this PR -->
- Start a workspace on a branch that has a finished prebuild down the commit history and see how that prebuild is used for your workspaces and the regular init phases run.
- Start a workspace on a branch where a prebuild is running on the head of the branch and verify that you no longer see the "waiting for prebuild" screen but get a workspace using the youngest (commit history based), finished prebuild.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
