### PR TITLE
[usage] Start triggering ResetUsage RPC

### DIFF
--- a/components/usage/pkg/scheduler/reset_usage_job.go
+++ b/components/usage/pkg/scheduler/reset_usage_job.go
@@ -5,21 +5,33 @@
 package scheduler
 
 import (
+	"context"
+	"fmt"
 	"time"
 
 	"github.com/gitpod-io/gitpod/common-go/log"
+	v1 "github.com/gitpod-io/gitpod/usage-api/v1"
 )
 
-func NewResetUsageJobSpec(schedule time.Duration) (JobSpec, error) {
-	spec := &ResetUsageJobSpec{}
+func NewResetUsageJobSpec(schedule time.Duration, usageClient v1.UsageServiceClient) (JobSpec, error) {
+	spec := &ResetUsageJobSpec{
+		usageClient: usageClient,
+	}
 	return NewPeriodicJobSpec(schedule, "reset_usage", WithoutConcurrentRun(spec))
 }
 
 type ResetUsageJobSpec struct {
+	usageClient v1.UsageServiceClient
 }
 
 func (j *ResetUsageJobSpec) Run() (err error) {
 	log.Info("Running reset usage job.")
+	ctx := context.Background()
+
+	_, err = j.usageClient.ResetUsage(ctx, &v1.ResetUsageRequest{})
+	if err != nil {
+		return fmt.Errorf("failed to reset usage: %w", err)
+	}
 
 	return nil
 }

--- a/components/usage/pkg/server/server.go
+++ b/components/usage/pkg/server/server.go
@@ -147,7 +147,7 @@ func Start(cfg Config, version string) error {
 			return fmt.Errorf("failed to parse reset usage schedule as duration: %w", err)
 		}
 
-		spec, err := scheduler.NewResetUsageJobSpec(schedule)
+		spec, err := scheduler.NewResetUsageJobSpec(schedule, v1.NewUsageServiceClient(selfConnection))
 		if err != nil {
 			return fmt.Errorf("failed to setup reset usage job: %w", err)
 		}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Periodic job triggers Reset Usage RPC.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Part of https://github.com/gitpod-io/gitpod/issues/14178

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
