### PR TITLE
Fix timeseries_total recording rule

### DIFF
--- a/.werft/observability/manifests/monitoring-satellite.yaml
+++ b/.werft/observability/manifests/monitoring-satellite.yaml
@@ -44,5 +44,7 @@ imports:
       path: operations/observability/mixins/meta/rules
     - gitURL: https://github.com/gitpod-io/gitpod
       path: operations/observability/mixins/IDE/rules
+    - gitURL: https://github.com/gitpod-io/gitpod
+      path: operations/observability/mixins/self-hosted/rules/cardinality-analysis
     - gitURL: https://github.com/gitpod-io/observability
       path: monitoring-satellite/manifests/crds

--- a/operations/observability/mixins/self-hosted/rules/cardinality-analysis/promrules.yaml
+++ b/operations/observability/mixins/self-hosted/rules/cardinality-analysis/promrules.yaml
@@ -19,5 +19,5 @@ spec:
     - record: metrics_total
       expr: count(count({__name__!=""}) by (__name__))
 
-    - record: __name__:timeseries_total
-      expr: count({__name__!=""}) by (__name__)
+    - record: metric:timeseries_total
+      expr: label_join(count by (__name__) ({__name__!=""}), "metric", "", "__name__")


### PR DESCRIPTION
Signed-off-by: ArthurSens <arthursens2005@gmail.com>

## Description
<!-- Describe your changes in detail -->
After https://github.com/gitpod-io/gitpod/pull/14235, we got alerted about [failures in rule evaluation](https://gitpod.slack.com/archives/C03MWBB5MP1/p1666879535467859). After some [investigation](https://groups.google.com/g/prometheus-users/c/ydz4E6HmI38), I've came up with a fix

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Connect to the cluster from the preview environment of this PR
* Open Prometheus UI via `kubectl port-forward -n monitoring-satellite prometheus-k8s-0 9090`
* Query the metric `metric:timeseries_total`, you should see results

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
