### PR TITLE
[usage]Actually reset usage during ResetUsage RPC

### DIFF
--- a/components/usage/pkg/db/cost_center_test.go
+++ b/components/usage/pkg/db/cost_center_test.go
@@ -58,6 +58,75 @@ func TestCostCenterManager_GetOrCreateCostCenter(t *testing.T) {
 	require.Equal(t, int32(500), userCC.SpendingLimit)
 }
 
+func TestCostCenterManager_GetOrCreateCostCenter_ResetsExpired(t *testing.T) {
+	conn := dbtest.ConnectForTests(t)
+	mnr := db.NewCostCenterManager(conn, db.DefaultSpendingLimit{
+		ForTeams: 0,
+		ForUsers: 500,
+	})
+
+	now := time.Now().UTC()
+	ts := time.Date(now.Year(), now.Month(), now.Day(), now.Hour(), now.Minute(), now.Second(), 0, time.UTC)
+	expired := ts.Add(-1 * time.Minute)
+	unexpired := ts.Add(1 * time.Minute)
+
+	expiredCC := db.CostCenter{
+		ID:              db.NewTeamAttributionID(uuid.New().String()),
+		CreationTime:    db.NewVarcharTime(now),
+		SpendingLimit:   0,
+		BillingStrategy: db.CostCenter_Other,
+		NextBillingTime: db.NewVarcharTime(expired),
+	}
+	unexpiredCC := db.CostCenter{
+		ID:              db.NewUserAttributionID(uuid.New().String()),
+		CreationTime:    db.NewVarcharTime(now),
+		SpendingLimit:   500,
+		BillingStrategy: db.CostCenter_Other,
+		NextBillingTime: db.NewVarcharTime(unexpired),
+	}
+	// Stripe billing strategy should not be reset
+	stripeCC := db.CostCenter{
+		ID:              db.NewUserAttributionID(uuid.New().String()),
+		CreationTime:    db.NewVarcharTime(now),
+		SpendingLimit:   0,
+		BillingStrategy: db.CostCenter_Stripe,
+		NextBillingTime: db.VarcharTime{},
+	}
+
+	dbtest.CreateCostCenters(t, conn,
+		dbtest.NewCostCenter(t, expiredCC),
+		dbtest.NewCostCenter(t, unexpiredCC),
+		dbtest.NewCostCenter(t, stripeCC),
+	)
+
+	// expired CostCenter should be reset, so we get a new CreationTime
+	retrievedExpiredCC, err := mnr.GetOrCreateCostCenter(context.Background(), expiredCC.ID)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		conn.Model(&db.CostCenter{}).Delete(retrievedExpiredCC.ID)
+	})
+	require.Equal(t, db.NewVarcharTime(expired).Time().AddDate(0, 1, 0), retrievedExpiredCC.NextBillingTime.Time())
+	require.Equal(t, expiredCC.ID, retrievedExpiredCC.ID)
+	require.Equal(t, expiredCC.BillingStrategy, retrievedExpiredCC.BillingStrategy)
+	require.WithinDuration(t, now, expiredCC.CreationTime.Time(), 3*time.Second, "new cost center creation time must be within 3 seconds of now")
+
+	// unexpired cost center must not be reset
+	retrievedUnexpiredCC, err := mnr.GetOrCreateCostCenter(context.Background(), unexpiredCC.ID)
+	require.NoError(t, err)
+	require.Equal(t, db.NewVarcharTime(unexpired).Time(), retrievedUnexpiredCC.NextBillingTime.Time())
+	require.Equal(t, unexpiredCC.ID, retrievedUnexpiredCC.ID)
+	require.Equal(t, unexpiredCC.BillingStrategy, retrievedUnexpiredCC.BillingStrategy)
+	require.WithinDuration(t, unexpiredCC.CreationTime.Time(), retrievedUnexpiredCC.CreationTime.Time(), 100*time.Millisecond)
+
+	// stripe cost center must not be reset
+	retrievedStripeCC, err := mnr.GetOrCreateCostCenter(context.Background(), stripeCC.ID)
+	require.NoError(t, err)
+	require.False(t, retrievedStripeCC.NextBillingTime.IsSet())
+	require.Equal(t, stripeCC.ID, retrievedStripeCC.ID)
+	require.Equal(t, stripeCC.BillingStrategy, retrievedStripeCC.BillingStrategy)
+	require.WithinDuration(t, stripeCC.CreationTime.Time(), retrievedStripeCC.CreationTime.Time(), 100*time.Millisecond)
+}
+
 func TestCostCenterManager_UpdateCostCenter(t *testing.T) {
 	conn := dbtest.ConnectForTests(t)
 	limits := db.DefaultSpendingLimit{
@@ -330,6 +399,52 @@ func TestCostCenter_ListLatestCostCentersWithBillingTimeBefore(t *testing.T) {
 		retrieved, err := mnr.ListLatestCostCentersWithBillingTimeBefore(context.Background(), db.CostCenter_Other, secondCreation.Add(7*24*time.Hour))
 		require.NoError(t, err)
 		require.Len(t, retrieved, 0)
+	})
+}
+
+func TestCostCenterManager_ResetUsage(t *testing.T) {
+	now := time.Now().UTC()
+	ts := time.Date(now.Year(), now.Month(), now.Day(), now.Hour(), now.Minute(), now.Second(), 0, time.UTC)
+
+	t.Run("errors when cost center is not Other", func(t *testing.T) {
+		conn := dbtest.ConnectForTests(t)
+		mnr := db.NewCostCenterManager(conn, db.DefaultSpendingLimit{
+			ForTeams: 0,
+			ForUsers: 500,
+		})
+		_, err := mnr.ResetUsage(context.Background(), db.CostCenter{
+			ID:              db.NewUserAttributionID(uuid.New().String()),
+			CreationTime:    db.NewVarcharTime(time.Now()),
+			SpendingLimit:   500,
+			BillingStrategy: db.CostCenter_Stripe,
+		})
+		require.Error(t, err)
+	})
+
+	t.Run("resets for teams", func(t *testing.T) {
+		conn := dbtest.ConnectForTests(t)
+		mnr := db.NewCostCenterManager(conn, db.DefaultSpendingLimit{
+			ForTeams: 0,
+			ForUsers: 500,
+		})
+		oldCC := db.CostCenter{
+			ID:              db.NewTeamAttributionID(uuid.New().String()),
+			CreationTime:    db.NewVarcharTime(time.Now()),
+			SpendingLimit:   0,
+			BillingStrategy: db.CostCenter_Other,
+			NextBillingTime: db.NewVarcharTime(ts),
+		}
+		newCC, err := mnr.ResetUsage(context.Background(), oldCC)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			conn.Model(&db.CostCenter{}).Delete(newCC)
+		})
+
+		require.Equal(t, oldCC.ID, newCC.ID)
+		require.EqualValues(t, 0, newCC.SpendingLimit)
+		require.Equal(t, db.CostCenter_Other, newCC.BillingStrategy)
+		require.Equal(t, ts.AddDate(0, 1, 0), newCC.NextBillingTime.Time())
+
 	})
 
 }

--- a/components/usage/pkg/db/dbtest/cost_center.go
+++ b/components/usage/pkg/db/dbtest/cost_center.go
@@ -37,9 +37,8 @@ func NewCostCenter(t *testing.T, record db.CostCenter) db.CostCenter {
 	if record.BillingStrategy != "" {
 		result.BillingStrategy = record.BillingStrategy
 	}
-	if record.NextBillingTime.IsSet() {
-		result.NextBillingTime = record.NextBillingTime
-	}
+
+	result.NextBillingTime = record.NextBillingTime
 
 	return result
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Reset during ResetUsage RPC.
Also resets usage when fetching a CostCenter, in case it has just expired.


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Part of https://github.com/gitpod-io/gitpod/issues/14178

## How to test
<!-- Provide steps to test this PR -->
Unit tests

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`

/hold