### PR TITLE
Support specifying workspace class in gitpod.yml

### DIFF
--- a/components/gitpod-protocol/data/gitpod-schema.json
+++ b/components/gitpod-protocol/data/gitpod-schema.json
@@ -309,6 +309,17 @@
                     "description": "the hard limit acts as a ceiling for the soft limit. For more details please check https://man7.org/linux/man-pages/man2/getrlimit.2.html"
                 }
             }
+        },
+        "workspaceRequirements": {
+            "type": "object",
+            "description": "Configure the requirements of the workspace.",
+            "additionalProperties": false,
+            "properties": {
+                "class": {
+                    "type": ["string", "array"],
+                    "description": "The class that should be used for the workspace."
+                }
+            }
         }
     },
     "additionalProperties": false,

--- a/components/gitpod-protocol/src/gitpod-file-parser.spec.ts
+++ b/components/gitpod-protocol/src/gitpod-file-parser.spec.ts
@@ -141,5 +141,27 @@ gitConfig:
             image: DEFAULT_IMAGE,
         });
     }
+
+    @test public testSingleWorkspaceClass() {
+        const content = `workspaceRequirements: \n class: g1-standard`;
+        const result = this.parser.parse(content, {}, DEFAULT_CONFIG);
+        expect(result.config).to.deep.equal({
+            workspaceRequirements: {
+                class: "g1-standard",
+            },
+            image: DEFAULT_IMAGE,
+        });
+    }
+
+    @test public testMultiWorkspaceClass() {
+        const content = `workspaceRequirements: \n class:\n` + `  - g1-standard\n` + `  - g1-large`;
+        const result = this.parser.parse(content, {}, DEFAULT_CONFIG);
+        expect(result.config).to.deep.equal({
+            workspaceRequirements: {
+                class: ["g1-standard", "g1-large"],
+            },
+            image: DEFAULT_IMAGE,
+        });
+    }
 }
 module.exports = new TestGitpodFileParser(); // Only to circumvent no usage warning :-/

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -818,6 +818,10 @@ export interface CoreDumpConfig {
     hardLimit?: number;
 }
 
+export interface WorkspaceRequirements {
+    class?: string | string[];
+}
+
 export interface WorkspaceConfig {
     mainConfiguration?: string;
     additionalRepositories?: RepositoryCloneInformation[];
@@ -831,6 +835,7 @@ export interface WorkspaceConfig {
     vscode?: VSCodeConfig;
     jetbrains?: JetBrainsConfig;
     coreDump?: CoreDumpConfig;
+    workspaceRequirements?: WorkspaceRequirements;
 
     /** deprecated. Enabled by default **/
     experimentalNetwork?: boolean;

--- a/components/server/src/workspace/workspace-classes.ts
+++ b/components/server/src/workspace/workspace-classes.ts
@@ -5,7 +5,7 @@
  */
 
 import { WorkspaceDB } from "@gitpod/gitpod-db/lib";
-import { User, Workspace } from "@gitpod/gitpod-protocol";
+import { User, Workspace, WorkspaceRequirements } from "@gitpod/gitpod-protocol";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 import { TraceContext } from "@gitpod/gitpod-protocol/lib/util/tracing";
 import { EntitlementService } from "../billing/entitlement-service";
@@ -213,5 +213,23 @@ export namespace WorkspaceClasses {
                 return getDefaultId(classes);
             }
         }
+    }
+
+    export function fromGitpodConfigOrDefault(
+        classes: WorkspaceClassesConfig,
+        requirements: WorkspaceRequirements | undefined,
+        defaultClass: string,
+    ): string {
+        let selected: string | undefined = undefined;
+        if (requirements?.class) {
+            if (Array.isArray(requirements.class)) {
+                selected = requirements.class.find((r) => classes.filter((c) => !c.deprecated).some((c) => r === c.id));
+            } else {
+                const singleClass = requirements.class as string;
+                selected = classes.filter((c) => !c.deprecated).find((c) => singleClass === c.id)?.id;
+            }
+        }
+
+        return selected ?? defaultClass;
     }
 }

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -225,9 +225,11 @@ export async function getWorkspaceClassForInstance(
             }
 
             if (workspace.type == "prebuild") {
-                if (user.additionalData?.workspaceClasses?.prebuild) {
-                    workspaceClass = user.additionalData?.workspaceClasses?.prebuild;
-                }
+                workspaceClass = WorkspaceClasses.fromGitpodConfigOrDefault(
+                    config,
+                    workspace.config.workspaceRequirements,
+                    WorkspaceClasses.getDefaultId(config),
+                );
             }
 
             if (!workspaceClass) {


### PR DESCRIPTION
## Description
Add support for specifying the workspace class in gitpod.yaml

```
workspaceRequirements:
  class: g1-standard
```


```
workspaceRequirements:
  class: 
    - g1-standard
    - g2-foo-bar
```

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/10963

## How to test
1. Prebuild class is taken from gitpod.yml (single workspace class specified)
   - Trigger a prebuild with https://fo-class-repo-config.preview.gitpod-dev.com/#prebuild/https://github.com/Furisto/gitpod-repro/tree/single-workspace-class
   - Check running prebuilds. Prebuild should run with 'small' workspace class
2. Prebuild class is taken from gitpod.yml (multiple workspace classes specified)
   - Trigger a prebuild with https://fo-class-repo-config.preview.gitpod-dev.com/#prebuild/https://github.com/Furisto/gitpod-repro/tree/multi-workspace-class-array
   - Check running prebuilds. Prebuild should run with the first available workspace class (`small`)
3. Default class is used for Prebuild if gitpod.yml does not specify a class
   - Trigger a prebuild of a random repository in the preview environment. Prebuild should run with `default` workspace class

-> **Delete all prebuilds in the database to ensure that the prebuild class is not used for regular workspaces**
1. Regular workspace class is taken from gitpod.yml (single workspace class specified)
    - Open https://github.com/Furisto/gitpod-repro/tree/single-workspace-class. 
    - Workspace should run with s`mall `workspace class
2. Regular workspace class is taken from gitpod.yml (multiple workspace classes specified)
    -  Open https://github.com/Furisto/gitpod-repro/tree/single-workspace-class. 
    - Workspace should run with first available workspace class (`small`)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
The workspace class for a workspace can now be specified in gitpod.yml
```

## Documentation
Does this PR require updates to the documentation at www.gitpod.io/docs?
Yes: https://github.com/gitpod-io/website/issues/2973



## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
