### PR TITLE
runc-facade: squashes rare runc errors

### DIFF
--- a/components/docker-up/docker-up/main.go
+++ b/components/docker-up/docker-up/main.go
@@ -59,6 +59,7 @@ var aptUpdated = false
 const (
 	dockerSocketFN = "/var/run/docker.sock"
 	gitpodUserId   = 33333
+	containerIf    = "ceth0"
 )
 
 func main() {
@@ -135,7 +136,6 @@ func runWithinNetns() (err error) {
 	}
 	args = append(args, userArgs...)
 
-	containerIf := "ceth0"
 	netIface, err := netlink.LinkByName(containerIf)
 	if err != nil {
 		return xerrors.Errorf("cannot get container network device %s: %w", containerIf, err)

--- a/components/image-builder-bob/cmd/runc-facade/main.go
+++ b/components/image-builder-bob/cmd/runc-facade/main.go
@@ -11,10 +11,13 @@ import (
 	"path/filepath"
 	"syscall"
 
+	"github.com/gitpod-io/gitpod/common-go/log"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/xerrors"
 )
+
+const RETRY = 2
 
 func main() {
 	log := logrus.New()
@@ -95,9 +98,16 @@ func createAndRunc(runcPath, bundle string) error {
 		}
 	}
 
-	err = syscall.Exec(runcPath, os.Args, os.Environ())
-	if err != nil {
-		return xerrors.Errorf("exec %s: %w", runcPath, err)
+	// See here for more details on why retries are necessary.
+	// https://github.com/gitpod-io/gitpod/issues/12365
+	for i := 0; i <= RETRY; i++ {
+		err = syscall.Exec(runcPath, os.Args, os.Environ())
+		if err == nil {
+			return err
+		} else {
+			log.WithError(err).Warn("runc failed")
+		}
 	}
-	return nil
+
+	return xerrors.Errorf("exec %s: %w", runcPath, err)
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/12365

## How to test
<!-- Provide steps to test this PR -->

Open a workspace and run docker-compose following README
https://utam0k-run30561c5246.preview.gitpod-dev.com/#https://github.com/spearki/gitpod-runc-issue-repro

```console
$ ./generate.sh 20 > docker-compose.yml
$ docker compose up -d --force-recreate
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
More stable docker-compose behavior with lots of containers
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
