### PR TITLE
test: Enables workspace integration tests to run in parallel

### DIFF
--- a/test/pkg/integration/agent.go
+++ b/test/pkg/integration/agent.go
@@ -19,13 +19,13 @@ import (
 
 // ServeAgent is the main entrypoint for agents. It establishes flags and starts an RPC server
 // on a port passed as flag.
-func ServeAgent(rcvr interface{}) {
+func ServeAgent(done chan struct{}, rcvr interface{}) {
 	defaultPort, _ := strconv.Atoi(os.Getenv("AGENT_RPC_PORT"))
 	port := flag.Int("rpc-port", defaultPort, "the port on wich to run the RPC server on")
 	flag.Parse()
 
 	ta := &testAgent{
-		Done: make(chan struct{}),
+		Done: done,
 	}
 
 	err := rpc.RegisterName("TestAgent", ta)
@@ -56,7 +56,7 @@ func ServeAgent(rcvr interface{}) {
 
 	select {
 	case <-sigChan:
-	case <-ta.Done:
+	case <-done:
 	}
 	fmt.Println("shutting down")
 }

--- a/test/pkg/integration/apis.go
+++ b/test/pkg/integration/apis.go
@@ -255,6 +255,10 @@ func (c *ComponentAPI) CreateOAuth2Token(user string, scopes []string) (string, 
 	return tkn, nil
 }
 
+func (c *ComponentAPI) ClearGitpodServerClientCache() {
+	c.serverStatus.Client = map[string]*gitpod.APIoverJSONRPC{}
+}
+
 // GitpodServer provides access to the Gitpod server API
 func (c *ComponentAPI) GitpodServer(opts ...GitpodServerOpt) (gitpod.APIInterface, error) {
 	var options gitpodServerOpts

--- a/test/pkg/integration/cgroup.go
+++ b/test/pkg/integration/cgroup.go
@@ -2,15 +2,13 @@
 // Licensed under the GNU Affero General Public License (AGPL).
 // See License-AGPL.txt in the project root for license information.
 
-package common
+package integration
 
 import (
-	"net/rpc"
-
 	agent "github.com/gitpod-io/gitpod/test/pkg/agent/workspace/api"
 )
 
-func IsCgroupV2(rsa *rpc.Client) (bool, error) {
+func IsCgroupV2(rsa *RpcClient) (bool, error) {
 	var resp agent.ExecResponse
 	err := rsa.Call("WorkspaceAgent.Exec", &agent.ExecRequest{
 		Dir:     "/",

--- a/test/pkg/integration/git-client.go
+++ b/test/pkg/integration/git-client.go
@@ -2,27 +2,26 @@
 // Licensed under the GNU Affero General Public License (AGPL).
 // See License-AGPL.txt in the project root for license information.
 
-package common
+package integration
 
 import (
 	"fmt"
-	"net/rpc"
 	"strings"
 
 	agent "github.com/gitpod-io/gitpod/test/pkg/agent/workspace/api"
 )
 
 type GitClient struct {
-	*rpc.Client
+	rpc *RpcClient
 }
 
-func Git(rsa *rpc.Client) GitClient {
+func Git(rsa *RpcClient) GitClient {
 	return GitClient{rsa}
 }
 
 func (g GitClient) GetBranch(workspaceRoot string, ignoreError bool) (string, error) {
 	var resp agent.ExecResponse
-	err := g.Call("WorkspaceAgent.Exec", &agent.ExecRequest{
+	err := g.rpc.Call("WorkspaceAgent.Exec", &agent.ExecRequest{
 		Dir:     workspaceRoot,
 		Command: "git",
 		Args:    []string{"rev-parse", "--abbrev-ref", "HEAD"},
@@ -46,7 +45,7 @@ func (g GitClient) Add(dir string, files ...string) error {
 		args = append(args, files...)
 	}
 	var resp agent.ExecResponse
-	err := g.Call("WorkspaceAgent.Exec", &agent.ExecRequest{
+	err := g.rpc.Call("WorkspaceAgent.Exec", &agent.ExecRequest{
 		Dir:     dir,
 		Command: "git",
 		Args:    args,
@@ -62,7 +61,7 @@ func (g GitClient) Add(dir string, files ...string) error {
 
 func (g GitClient) ConfigSafeDirectory() error {
 	var resp agent.ExecResponse
-	err := g.Call("WorkspaceAgent.Exec", &agent.ExecRequest{
+	err := g.rpc.Call("WorkspaceAgent.Exec", &agent.ExecRequest{
 		Command: "git",
 		Args:    []string{"config", "--global", "--add", "safe.directory", "'*'"},
 	}, &resp)
@@ -78,7 +77,7 @@ func (g GitClient) ConfigSafeDirectory() error {
 func (g GitClient) ConfigUserName(dir string) error {
 	args := []string{"config", "--local", "user.name", "integration-test"}
 	var resp agent.ExecResponse
-	err := g.Call("WorkspaceAgent.Exec", &agent.ExecRequest{
+	err := g.rpc.Call("WorkspaceAgent.Exec", &agent.ExecRequest{
 		Dir:     dir,
 		Command: "git",
 		Args:    args,
@@ -95,7 +94,7 @@ func (g GitClient) ConfigUserName(dir string) error {
 func (g GitClient) ConfigUserEmail(dir string, files ...string) error {
 	args := []string{"config", "--local", "user.email", "integration-test@gitpod.io"}
 	var resp agent.ExecResponse
-	err := g.Call("WorkspaceAgent.Exec", &agent.ExecRequest{
+	err := g.rpc.Call("WorkspaceAgent.Exec", &agent.ExecRequest{
 		Dir:     dir,
 		Command: "git",
 		Args:    args,
@@ -115,7 +114,7 @@ func (g GitClient) Commit(dir string, message string, all bool) error {
 		args = append(args, "--all")
 	}
 	var resp agent.ExecResponse
-	err := g.Call("WorkspaceAgent.Exec", &agent.ExecRequest{
+	err := g.rpc.Call("WorkspaceAgent.Exec", &agent.ExecRequest{
 		Dir:     dir,
 		Command: "git",
 		Args:    args,
@@ -138,7 +137,7 @@ func (g GitClient) Push(dir string, force bool, moreArgs ...string) error {
 		args = append(args, "--force")
 	}
 	var resp agent.ExecResponse
-	err := g.Call("WorkspaceAgent.Exec", &agent.ExecRequest{
+	err := g.rpc.Call("WorkspaceAgent.Exec", &agent.ExecRequest{
 		Dir:     dir,
 		Command: "git",
 		Args:    args,

--- a/test/pkg/integration/git-client.go
+++ b/test/pkg/integration/git-client.go
@@ -12,7 +12,7 @@ import (
 )
 
 type GitClient struct {
-	rpc *RpcClient
+	rpcClient *RpcClient
 }
 
 func Git(rsa *RpcClient) GitClient {
@@ -21,7 +21,7 @@ func Git(rsa *RpcClient) GitClient {
 
 func (g GitClient) GetBranch(workspaceRoot string, ignoreError bool) (string, error) {
 	var resp agent.ExecResponse
-	err := g.rpc.Call("WorkspaceAgent.Exec", &agent.ExecRequest{
+	err := g.rpcClient.Call("WorkspaceAgent.Exec", &agent.ExecRequest{
 		Dir:     workspaceRoot,
 		Command: "git",
 		Args:    []string{"rev-parse", "--abbrev-ref", "HEAD"},
@@ -45,7 +45,7 @@ func (g GitClient) Add(dir string, files ...string) error {
 		args = append(args, files...)
 	}
 	var resp agent.ExecResponse
-	err := g.rpc.Call("WorkspaceAgent.Exec", &agent.ExecRequest{
+	err := g.rpcClient.Call("WorkspaceAgent.Exec", &agent.ExecRequest{
 		Dir:     dir,
 		Command: "git",
 		Args:    args,
@@ -61,7 +61,7 @@ func (g GitClient) Add(dir string, files ...string) error {
 
 func (g GitClient) ConfigSafeDirectory() error {
 	var resp agent.ExecResponse
-	err := g.rpc.Call("WorkspaceAgent.Exec", &agent.ExecRequest{
+	err := g.rpcClient.Call("WorkspaceAgent.Exec", &agent.ExecRequest{
 		Command: "git",
 		Args:    []string{"config", "--global", "--add", "safe.directory", "'*'"},
 	}, &resp)
@@ -77,7 +77,7 @@ func (g GitClient) ConfigSafeDirectory() error {
 func (g GitClient) ConfigUserName(dir string) error {
 	args := []string{"config", "--local", "user.name", "integration-test"}
 	var resp agent.ExecResponse
-	err := g.rpc.Call("WorkspaceAgent.Exec", &agent.ExecRequest{
+	err := g.rpcClient.Call("WorkspaceAgent.Exec", &agent.ExecRequest{
 		Dir:     dir,
 		Command: "git",
 		Args:    args,
@@ -94,7 +94,7 @@ func (g GitClient) ConfigUserName(dir string) error {
 func (g GitClient) ConfigUserEmail(dir string, files ...string) error {
 	args := []string{"config", "--local", "user.email", "integration-test@gitpod.io"}
 	var resp agent.ExecResponse
-	err := g.rpc.Call("WorkspaceAgent.Exec", &agent.ExecRequest{
+	err := g.rpcClient.Call("WorkspaceAgent.Exec", &agent.ExecRequest{
 		Dir:     dir,
 		Command: "git",
 		Args:    args,
@@ -114,7 +114,7 @@ func (g GitClient) Commit(dir string, message string, all bool) error {
 		args = append(args, "--all")
 	}
 	var resp agent.ExecResponse
-	err := g.rpc.Call("WorkspaceAgent.Exec", &agent.ExecRequest{
+	err := g.rpcClient.Call("WorkspaceAgent.Exec", &agent.ExecRequest{
 		Dir:     dir,
 		Command: "git",
 		Args:    args,
@@ -137,7 +137,7 @@ func (g GitClient) Push(dir string, force bool, moreArgs ...string) error {
 		args = append(args, "--force")
 	}
 	var resp agent.ExecResponse
-	err := g.rpc.Call("WorkspaceAgent.Exec", &agent.ExecRequest{
+	err := g.rpcClient.Call("WorkspaceAgent.Exec", &agent.ExecRequest{
 		Dir:     dir,
 		Command: "git",
 		Args:    args,

--- a/test/pkg/integration/integration.go
+++ b/test/pkg/integration/integration.go
@@ -394,7 +394,6 @@ L:
 		if lastError != nil {
 			return false, nil
 		}
-
 		return true, nil
 	})
 	if waitErr == wait.ErrWaitTimeout {

--- a/test/pkg/integration/workspace.go
+++ b/test/pkg/integration/workspace.go
@@ -401,7 +401,7 @@ func LaunchWorkspaceFromContextURL(t *testing.T, ctx context.Context, contextURL
 	}()
 
 	t.Log("wait for workspace to be fully up and running")
-	wsState, err := WaitForWorkspaceStart(ctx, wi.LatestInstance.ID, resp.CreatedWorkspaceID, api)
+	wsState, err := WaitForWorkspaceStart(t, ctx, wi.LatestInstance.ID, resp.CreatedWorkspaceID, api)
 	if err != nil {
 		return nil, nil, xerrors.Errorf("failed to wait for the workspace to start up: %w", err)
 	}

--- a/test/pkg/integration/workspace.go
+++ b/test/pkg/integration/workspace.go
@@ -219,7 +219,7 @@ func LaunchWorkspaceDirectly(t *testing.T, ctx context.Context, api *ComponentAP
 	t.Logf("attemp to start up the workspace directly: %s, %s", instanceID, workspaceID)
 	sresp, err := wsm.StartWorkspace(sctx, req)
 	if err != nil {
-		return nil, nil, xerrors.Errorf("cannot start workspace: %q", err)
+		return nil, nil, xerrors.Errorf("cannot start workspace: %w", err)
 	}
 	t.Log("successfully sent workspace start request")
 
@@ -275,14 +275,27 @@ func LaunchWorkspaceFromContextURL(t *testing.T, ctx context.Context, contextURL
 	cctx, ccancel := context.WithTimeout(context.Background(), perCallTimeout)
 	defer ccancel()
 
-	t.Logf("attemp to create the workspace: %s", contextURL)
-	resp, err := server.CreateWorkspace(cctx, &protocol.CreateWorkspaceOptions{
-		ContextURL:                         contextURL,
-		IgnoreRunningPrebuild:              true,
-		IgnoreRunningWorkspaceOnSameCommit: true,
-	})
-	if err != nil {
-		return nil, nil, xerrors.Errorf("cannot start workspace: %w", err)
+	var resp *protocol.WorkspaceCreationResult
+	for i := 0; i < 3; i++ {
+		t.Logf("attemp to create the workspace: %s", contextURL)
+		resp, err = server.CreateWorkspace(cctx, &protocol.CreateWorkspaceOptions{
+			ContextURL:                         contextURL,
+			IgnoreRunningPrebuild:              true,
+			IgnoreRunningWorkspaceOnSameCommit: true,
+		})
+		if err != nil {
+			scode := status.Code(err)
+			if scode == codes.NotFound || scode == codes.Unavailable {
+				time.Sleep(1 * time.Second)
+				server, err = api.GitpodServer(append(defaultServerOpts, serverOpts...)...)
+				if err != nil {
+					return nil, nil, xerrors.Errorf("cannot start server: %w", err)
+				}
+				continue
+			}
+			return nil, nil, xerrors.Errorf("cannot start workspace: %w", err)
+		}
+		break
 	}
 
 	t.Logf("attemp to get the workspace information: %s", resp.CreatedWorkspaceID)
@@ -323,6 +336,11 @@ func LaunchWorkspaceFromContextURL(t *testing.T, ctx context.Context, contextURL
 
 func stopWsF(t *testing.T, instanceID string, api *ComponentAPI) StopWorkspaceFunc {
 	return func(waitForStop bool, api *ComponentAPI) (*wsmanapi.WorkspaceStatus, error) {
+		parallelLimiter = make(chan struct{}, ParallelLunchableWorkspaceLimit)
+		defer func() {
+			<-parallelLimiter
+		}()
+
 		sctx, scancel := context.WithTimeout(context.Background(), perCallTimeout)
 		defer scancel()
 
@@ -423,11 +441,16 @@ func WaitForWorkspaceStart(ctx context.Context, instanceID string, api *Componen
 	var sub wsmanapi.WorkspaceManager_SubscribeClient
 	for i := 0; i < 5; i++ {
 		sub, err = wsman.Subscribe(ctx, &wsmanapi.SubscribeRequest{})
-		if status.Code(err) == codes.NotFound {
-			time.Sleep(1 * time.Second)
-			continue
-		}
 		if err != nil {
+			scode := status.Code(err)
+			if scode == codes.NotFound || scode == codes.Unavailable {
+				time.Sleep(1 * time.Second)
+				wsman, err = api.WorkspaceManager()
+				if err != nil {
+					return nil, err
+				}
+				continue
+			}
 			return nil, xerrors.Errorf("cannot listen for workspace updates: %w", err)
 		}
 		defer func() {

--- a/test/pkg/integration/workspace.go
+++ b/test/pkg/integration/workspace.go
@@ -25,13 +25,15 @@ import (
 )
 
 const (
-	gitpodBuiltinUserID = "builtin-user-workspace-probe-0000000"
-	perCallTimeout      = 5 * time.Minute
+	gitpodBuiltinUserID             = "builtin-user-workspace-probe-0000000"
+	perCallTimeout                  = 5 * time.Minute
+	ParallelLunchableWorkspaceLimit = 2
 )
 
 var (
 	ErrWorkspaceInstanceStopping = fmt.Errorf("workspace instance is stopping")
 	ErrWorkspaceInstanceStopped  = fmt.Errorf("workspace instance has stopped")
+	parallelLimiter              = make(chan struct{}, ParallelLunchableWorkspaceLimit)
 )
 
 type launchWorkspaceDirectlyOptions struct {
@@ -103,6 +105,7 @@ type StopWorkspaceFunc = func(waitForStop bool, api *ComponentAPI) (*wsmanapi.Wo
 // Whenever possible prefer this function over LaunchWorkspaceFromContextURL, because
 // it has fewer prerequisites.
 func LaunchWorkspaceDirectly(t *testing.T, ctx context.Context, api *ComponentAPI, opts ...LaunchWorkspaceDirectlyOpt) (*LaunchWorkspaceDirectlyResult, StopWorkspaceFunc, error) {
+	var stopWs StopWorkspaceFunc
 	options := launchWorkspaceDirectlyOptions{
 		BaseImage: "docker.io/gitpod/workspace-full:latest",
 	}
@@ -123,6 +126,11 @@ func LaunchWorkspaceDirectly(t *testing.T, ctx context.Context, api *ComponentAP
 		return nil, nil, err
 	}
 
+	parallelLimiter <- struct{}{}
+	defer func() {
+		<-parallelLimiter
+	}()
+
 	var workspaceImage string
 	if options.BaseImage != "" {
 		for {
@@ -138,7 +146,8 @@ func LaunchWorkspaceDirectly(t *testing.T, ctx context.Context, api *ComponentAP
 		}
 	}
 	if workspaceImage == "" {
-		return nil, nil, xerrors.Errorf("cannot start workspaces without a workspace image (required by registry-facade resolver)")
+		err = xerrors.Errorf("cannot start workspaces without a workspace image (required by registry-facade resolver)")
+		return nil, nil, err
 	}
 
 	ideImage := options.IdeImage
@@ -149,7 +158,8 @@ func LaunchWorkspaceDirectly(t *testing.T, ctx context.Context, api *ComponentAP
 		}
 		ideImage = cfg.IDEOptions.Options.Code.Image
 		if ideImage == "" {
-			return nil, nil, xerrors.Errorf("cannot start workspaces without an IDE image (required by registry-facade resolver)")
+			err = xerrors.Errorf("cannot start workspaces without an IDE image (required by registry-facade resolver)")
+			return nil, nil, err
 		}
 	}
 
@@ -213,10 +223,10 @@ func LaunchWorkspaceDirectly(t *testing.T, ctx context.Context, api *ComponentAP
 	}
 	t.Log("successfully sent workspace start request")
 
-	stopWs := stopWsF(t, req.Id, api)
+	stopWs = stopWsF(t, req.Id, api)
 	defer func() {
 		if err != nil {
-			stopWs(false, api)
+			_, _ = stopWs(false, api)
 		}
 	}()
 
@@ -240,15 +250,25 @@ func LaunchWorkspaceDirectly(t *testing.T, ctx context.Context, api *ComponentAP
 //
 // When possible, prefer the less complex LaunchWorkspaceDirectly.
 func LaunchWorkspaceFromContextURL(t *testing.T, ctx context.Context, contextURL string, username string, api *ComponentAPI, serverOpts ...GitpodServerOpt) (*protocol.WorkspaceInfo, StopWorkspaceFunc, error) {
-	var defaultServerOpts []GitpodServerOpt
+	var (
+		defaultServerOpts []GitpodServerOpt
+		stopWs            StopWorkspaceFunc
+		err               error
+	)
+
 	if username != "" {
 		defaultServerOpts = []GitpodServerOpt{WithGitpodUser(username)}
 	}
 
+	parallelLimiter <- struct{}{}
+	defer func() {
+		<-parallelLimiter
+	}()
+
 	t.Log("prepare for a connection with gitpod server")
 	server, err := api.GitpodServer(append(defaultServerOpts, serverOpts...)...)
 	if err != nil {
-		return nil, nil, xerrors.Errorf("cannot start server: %q", err)
+		return nil, nil, xerrors.Errorf("cannot start server: %w", err)
 	}
 	t.Log("established a connection with gitpod server")
 
@@ -262,13 +282,13 @@ func LaunchWorkspaceFromContextURL(t *testing.T, ctx context.Context, contextURL
 		IgnoreRunningWorkspaceOnSameCommit: true,
 	})
 	if err != nil {
-		return nil, nil, xerrors.Errorf("cannot start workspace: %q", err)
+		return nil, nil, xerrors.Errorf("cannot start workspace: %w", err)
 	}
 
 	t.Logf("attemp to get the workspace information: %s", resp.CreatedWorkspaceID)
 	wi, err := server.GetWorkspace(ctx, resp.CreatedWorkspaceID)
 	if err != nil {
-		return nil, nil, xerrors.Errorf("cannot get workspace: %q", err)
+		return nil, nil, xerrors.Errorf("cannot get workspace: %w", err)
 	}
 	if wi.LatestInstance == nil {
 		return nil, nil, xerrors.Errorf("CreateWorkspace did not start the workspace")
@@ -281,7 +301,7 @@ func LaunchWorkspaceFromContextURL(t *testing.T, ctx context.Context, contextURL
 		wi.LatestInstance.IdeURL = resp.WorkspaceURL
 	}
 
-	stopWs := stopWsF(t, wi.LatestInstance.ID, api)
+	stopWs = stopWsF(t, wi.LatestInstance.ID, api)
 	defer func() {
 		if err != nil {
 			_, _ = stopWs(false, api)

--- a/test/run.sh
+++ b/test/run.sh
@@ -59,7 +59,7 @@ args=()
 args+=( "-kubeconfig=${KUBECONFIG:-/home/gitpod/.kube/config}" )
 args+=( "-namespace=default" )
 args+=( "-timeout=60m" )
-args+=( "-p=1" )
+# args+=( "-p=2" )
 
 if [[ "${GITPOD_REPO_ROOT:-}" != "" ]]; then
   echo "Running in Gitpod workspace. Fetching USERNAME and USER_TOKEN" | werft log slice "test-setup"

--- a/test/tests/components/server/server_test.go
+++ b/test/tests/components/server/server_test.go
@@ -94,7 +94,7 @@ func TestStartWorkspace(t *testing.T) {
 				t.Fatal("CreateWorkspace did not start the workspace")
 			}
 
-			_, err = integration.WaitForWorkspaceStart(ctx, nfo.LatestInstance.ID, api)
+			_, err = integration.WaitForWorkspaceStart(t, ctx, nfo.LatestInstance.ID, resp.CreatedWorkspaceID, api)
 			if err != nil {
 				t.Fatalf("cannot get workspace: %q", err)
 			}

--- a/test/tests/components/ws-manager/additional_repositories_test.go
+++ b/test/tests/components/ws-manager/additional_repositories_test.go
@@ -74,12 +74,12 @@ func TestAdditionalRepositories(t *testing.T) {
 						t.Fatal(err)
 					}
 
-					defer func() {
+					t.Cleanup(func() {
 						// stop workspace in defer function to prevent we forget to stop the workspace
 						if err := stopWorkspace(t, cfg, stopWs); err != nil {
 							t.Errorf("cannot stop workspace: %q", err)
 						}
-					}()
+					})
 
 					rsa, closer, err := integration.Instrument(integration.ComponentWorkspace, "workspace", cfg.Namespace(), kubeconfig, cfg.Client(),
 						integration.WithInstanceID(ws.Req.Id),

--- a/test/tests/components/ws-manager/additional_repositories_test.go
+++ b/test/tests/components/ws-manager/additional_repositories_test.go
@@ -23,7 +23,7 @@ import (
 func TestAdditionalRepositories(t *testing.T) {
 	f := features.New("additional-repositories").
 		WithLabel("component", "ws-manager").
-		Assess("can open a workspace using the additionalRepositories property", func(_ context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+		Assess("can open a workspace using the additionalRepositories property", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			tests := []struct {
 				Name       string
 				ContextURL string
@@ -41,11 +41,13 @@ func TestAdditionalRepositories(t *testing.T) {
 				},
 			}
 
-			ctx, cancel := context.WithTimeout(context.Background(), time.Duration(5*len(tests))*time.Minute)
-			defer cancel()
-
 			for _, test := range tests {
 				t.Run(test.Name, func(t *testing.T) {
+					t.Parallel()
+
+					ctx, cancel := context.WithTimeout(context.Background(), time.Duration(5*len(tests))*time.Minute)
+					defer cancel()
+
 					api := integration.NewComponentAPI(ctx, cfg.Namespace(), kubeconfig, cfg.Client())
 					t.Cleanup(func() {
 						api.Done(t)

--- a/test/tests/components/ws-manager/content_test.go
+++ b/test/tests/components/ws-manager/content_test.go
@@ -25,7 +25,7 @@ import (
 func TestBackup(t *testing.T) {
 	f := features.New("backup").
 		WithLabel("component", "ws-manager").
-		Assess("it should start a workspace, create a file and successfully create a backup", func(_ context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+		Assess("it should start a workspace, create a file and successfully create a backup", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			tests := []struct {
 				Name             string
 				ContextURL       string
@@ -54,11 +54,13 @@ func TestBackup(t *testing.T) {
 					FF:               []wsmanapi.WorkspaceFeatureFlag{wsmanapi.WorkspaceFeatureFlag_PERSISTENT_VOLUME_CLAIM},
 				},
 			}
-			ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
-			defer cancel()
-
 			for _, test := range tests {
 				t.Run(test.Name, func(t *testing.T) {
+					t.Parallel()
+
+					ctx, cancel := context.WithTimeout(context.Background(), time.Duration(5*len(tests))*time.Minute)
+					defer cancel()
+
 					api := integration.NewComponentAPI(ctx, cfg.Namespace(), kubeconfig, cfg.Client())
 					t.Cleanup(func() {
 						api.Done(t)

--- a/test/tests/components/ws-manager/content_test.go
+++ b/test/tests/components/ws-manager/content_test.go
@@ -129,12 +129,6 @@ func TestBackup(t *testing.T) {
 						t.Fatal(err)
 					}
 
-					t.Logf("status is nil?: %v", lastStatusWs1 == nil)
-					if lastStatusWs1 != nil && lastStatusWs1.Conditions != nil {
-						t.Logf("vs is nil?: %v", lastStatusWs1.Conditions.VolumeSnapshot == nil)
-					} else {
-						t.Logf("not found vs")
-					}
 					ws2, stopWs2, err := integration.LaunchWorkspaceDirectly(t, ctx, api,
 						integration.WithRequestModifier(func(w *wsmanapi.StartWorkspaceRequest) error {
 							w.ServicePrefix = ws1.Req.ServicePrefix
@@ -145,12 +139,10 @@ func TestBackup(t *testing.T) {
 							w.Spec.WorkspaceLocation = ws1.Req.Spec.WorkspaceLocation
 
 							if !reflect.DeepEqual(w.Spec.FeatureFlags, []wsmanapi.WorkspaceFeatureFlag{wsmanapi.WorkspaceFeatureFlag_PERSISTENT_VOLUME_CLAIM}) {
-								t.Log("return not pvc")
 								return nil
 							}
 
 							if lastStatusWs1 != nil && lastStatusWs1.Conditions != nil && lastStatusWs1.Conditions.VolumeSnapshot != nil {
-								t.Logf("use the VolumeSnapshot from the first workspace")
 								w.Spec.VolumeSnapshot = lastStatusWs1.Conditions.VolumeSnapshot
 							}
 							return nil
@@ -160,7 +152,7 @@ func TestBackup(t *testing.T) {
 						t.Fatal(err)
 					}
 					t.Cleanup(func() {
-						sctx, scancel := context.WithTimeout(context.Background(), 5*time.Minute)
+						sctx, scancel := context.WithTimeout(context.Background(), 10*time.Minute)
 						defer scancel()
 
 						sapi := integration.NewComponentAPI(sctx, cfg.Namespace(), kubeconfig, cfg.Client())
@@ -198,7 +190,7 @@ func TestBackup(t *testing.T) {
 						}
 					}
 					if !found {
-						t.Fatalf("did not find foobar.txt from previous workspace instance: len(ls.Files): %v", len(ls.Files))
+						t.Fatal("did not find foobar.txt from previous workspace instance")
 					}
 				})
 			}

--- a/test/tests/components/ws-manager/content_test.go
+++ b/test/tests/components/ws-manager/content_test.go
@@ -58,7 +58,7 @@ func TestBackup(t *testing.T) {
 				t.Run(test.Name, func(t *testing.T) {
 					t.Parallel()
 
-					ctx, cancel := context.WithTimeout(context.Background(), time.Duration(5*len(tests))*time.Minute)
+					ctx, cancel := context.WithTimeout(context.Background(), time.Duration(10*len(tests))*time.Minute)
 					defer cancel()
 
 					api := integration.NewComponentAPI(ctx, cfg.Namespace(), kubeconfig, cfg.Client())
@@ -85,6 +85,187 @@ func TestBackup(t *testing.T) {
 					if err != nil {
 						t.Fatal(err)
 					}
+					t.Cleanup(func() {
+						if err != nil {
+							sctx, scancel := context.WithTimeout(context.Background(), 5*time.Minute)
+							defer scancel()
+
+							sapi := integration.NewComponentAPI(sctx, cfg.Namespace(), kubeconfig, cfg.Client())
+							defer sapi.Done(t)
+
+							_, err = stopWs1(true, sapi)
+							if err != nil {
+								t.Fatal(err)
+							}
+						}
+					})
+
+					rsa, closer, err := integration.Instrument(integration.ComponentWorkspace, "workspace", cfg.Namespace(), kubeconfig, cfg.Client(),
+						integration.WithInstanceID(ws1.Req.Id),
+						integration.WithContainer("workspace"),
+						integration.WithWorkspacekitLift(true),
+					)
+					if err != nil {
+						t.Fatal(err)
+					}
+					integration.DeferCloser(t, closer)
+
+					var resp agent.WriteFileResponse
+					err = rsa.Call("WorkspaceAgent.WriteFile", &agent.WriteFileRequest{
+						Path:    fmt.Sprintf("%s/foobar.txt", test.WorkspaceRoot),
+						Content: []byte("hello world"),
+						Mode:    0644,
+					}, &resp)
+					rsa.Close()
+					if err != nil {
+						if _, serr := stopWs1(true, api); serr != nil {
+							t.Errorf("cannot stop workspace: %q", serr)
+						}
+						t.Fatal(err)
+					}
+
+					lastStatusWs1, err := stopWs1(true, api)
+					if err != nil {
+						t.Fatal(err)
+					}
+
+					t.Logf("status is nil?: %v", lastStatusWs1 == nil)
+					if lastStatusWs1 != nil && lastStatusWs1.Conditions != nil {
+						t.Logf("vs is nil?: %v", lastStatusWs1.Conditions.VolumeSnapshot == nil)
+					} else {
+						t.Logf("not found vs")
+					}
+					ws2, stopWs2, err := integration.LaunchWorkspaceDirectly(t, ctx, api,
+						integration.WithRequestModifier(func(w *wsmanapi.StartWorkspaceRequest) error {
+							w.ServicePrefix = ws1.Req.ServicePrefix
+							w.Metadata.MetaId = ws1.Req.Metadata.MetaId
+							w.Metadata.Owner = ws1.Req.Metadata.Owner
+							w.Spec.FeatureFlags = ws1.Req.Spec.FeatureFlags
+							w.Spec.Initializer = ws1.Req.Spec.Initializer
+							w.Spec.WorkspaceLocation = ws1.Req.Spec.WorkspaceLocation
+
+							if !reflect.DeepEqual(w.Spec.FeatureFlags, []wsmanapi.WorkspaceFeatureFlag{wsmanapi.WorkspaceFeatureFlag_PERSISTENT_VOLUME_CLAIM}) {
+								t.Log("return not pvc")
+								return nil
+							}
+
+							if lastStatusWs1 != nil && lastStatusWs1.Conditions != nil && lastStatusWs1.Conditions.VolumeSnapshot != nil {
+								t.Logf("use the VolumeSnapshot from the first workspace")
+								w.Spec.VolumeSnapshot = lastStatusWs1.Conditions.VolumeSnapshot
+							}
+							return nil
+						}),
+					)
+					if err != nil {
+						t.Fatal(err)
+					}
+					t.Cleanup(func() {
+						sctx, scancel := context.WithTimeout(context.Background(), 5*time.Minute)
+						defer scancel()
+
+						sapi := integration.NewComponentAPI(sctx, cfg.Namespace(), kubeconfig, cfg.Client())
+						defer sapi.Done(t)
+
+						_, err = stopWs2(true, sapi)
+						if err != nil {
+							t.Errorf("cannot stop workspace: %q", err)
+						}
+					})
+
+					rsa, closer, err = integration.Instrument(integration.ComponentWorkspace, "workspace", cfg.Namespace(), kubeconfig, cfg.Client(),
+						integration.WithInstanceID(ws2.Req.Id),
+					)
+					if err != nil {
+						t.Fatal(err)
+					}
+					integration.DeferCloser(t, closer)
+
+					var ls agent.ListDirResponse
+					err = rsa.Call("WorkspaceAgent.ListDir", &agent.ListDirRequest{
+						Dir: test.WorkspaceRoot,
+					}, &ls)
+					if err != nil {
+						t.Fatal(err)
+					}
+					rsa.Close()
+
+					var found bool
+					for _, f := range ls.Files {
+						if filepath.Base(f) == "foobar.txt" {
+							t.Log("found the target file")
+							found = true
+							break
+						}
+					}
+					if !found {
+						t.Fatalf("did not find foobar.txt from previous workspace instance: len(ls.Files): %v", len(ls.Files))
+					}
+				})
+			}
+			return ctx
+		}).
+		Feature()
+
+	testEnv.Test(t, f)
+
+}
+
+// TestExistingWorkspaceEnablePVC tests enable PVC feature flag on the existing workspace
+func TestExistingWorkspaceEnablePVC(t *testing.T) {
+	f := features.New("backup").
+		WithLabel("component", "ws-manager").
+		Assess("it should enable PVC feature flag to the existing workspace without data loss", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			tests := []struct {
+				Name             string
+				ContextURL       string
+				WorkspaceRoot    string
+				CheckoutLocation string
+			}{
+				{
+					Name:             "pvc",
+					ContextURL:       "http://github.com/gitpod-io/template-golang-cli",
+					WorkspaceRoot:    "/workspace/template-golang-cli",
+					CheckoutLocation: "template-golang-cli",
+				},
+			}
+			for _, test := range tests {
+				t.Run(test.Name+"_pvc", func(t *testing.T) {
+					ctx, cancel := context.WithTimeout(context.Background(), time.Duration(5*len(tests))*time.Minute)
+					defer cancel()
+
+					api := integration.NewComponentAPI(ctx, cfg.Namespace(), kubeconfig, cfg.Client())
+					t.Cleanup(func() {
+						api.Done(t)
+					})
+
+					// Create a new workspace without the PVC feature flag
+					// TODO: change to use server API to launch the workspace, so we could run the integration test as the user code flow
+					//       which is client -> server -> ws-manager rather than client -> ws-manager directly
+					ws1, stopWs1, err := integration.LaunchWorkspaceDirectly(t, ctx, api, integration.WithRequestModifier(func(w *wsmanapi.StartWorkspaceRequest) error {
+						w.Spec.Initializer = &csapi.WorkspaceInitializer{
+							Spec: &csapi.WorkspaceInitializer_Git{
+								Git: &csapi.GitInitializer{
+									RemoteUri:        test.ContextURL,
+									CheckoutLocation: test.CheckoutLocation,
+									Config:           &csapi.GitConfig{},
+								},
+							},
+						}
+						w.Spec.WorkspaceLocation = test.CheckoutLocation
+						return nil
+					}))
+					if err != nil {
+						t.Fatal(err)
+					}
+					t.Cleanup(func() {
+						sctx, scancel := context.WithTimeout(context.Background(), 5*time.Minute)
+						defer scancel()
+
+						sapi := integration.NewComponentAPI(sctx, cfg.Namespace(), kubeconfig, cfg.Client())
+						defer sapi.Done(t)
+
+						_, _ = stopWs1(false, sapi)
+					})
 
 					rsa, closer, err := integration.Instrument(integration.ComponentWorkspace, "workspace", cfg.Namespace(), kubeconfig, cfg.Client(),
 						integration.WithInstanceID(ws1.Req.Id),
@@ -107,51 +288,45 @@ func TestBackup(t *testing.T) {
 					}, &resp)
 					rsa.Close()
 					if err != nil {
-						if _, err = stopWs1(true, api); err != nil {
+						if _, err := stopWs1(true, api); err != nil {
 							t.Errorf("cannot stop workspace: %q", err)
 						}
 						t.Fatal(err)
 					}
 
-					lastStatusWs1, err := stopWs1(true, api)
+					_, err = stopWs1(true, api)
 					if err != nil {
 						t.Fatal(err)
 					}
 
+					// Relaunch the workspace and enable the PVC feature flag
 					ws2, stopWs2, err := integration.LaunchWorkspaceDirectly(t, ctx, api,
 						integration.WithRequestModifier(func(w *wsmanapi.StartWorkspaceRequest) error {
 							w.ServicePrefix = ws1.Req.ServicePrefix
 							w.Metadata.MetaId = ws1.Req.Metadata.MetaId
 							w.Metadata.Owner = ws1.Req.Metadata.Owner
-							w.Spec.FeatureFlags = ws1.Req.Spec.FeatureFlags
+							w.Spec.FeatureFlags = []wsmanapi.WorkspaceFeatureFlag{wsmanapi.WorkspaceFeatureFlag_PERSISTENT_VOLUME_CLAIM}
 							w.Spec.Initializer = ws1.Req.Spec.Initializer
 							w.Spec.WorkspaceLocation = ws1.Req.Spec.WorkspaceLocation
-
-							if !reflect.DeepEqual(w.Spec.FeatureFlags, []wsmanapi.WorkspaceFeatureFlag{wsmanapi.WorkspaceFeatureFlag_PERSISTENT_VOLUME_CLAIM}) {
-								return nil
-							}
-
-							if lastStatusWs1 != nil && lastStatusWs1.Conditions != nil && lastStatusWs1.Conditions.VolumeSnapshot != nil {
-								w.Spec.VolumeSnapshot = lastStatusWs1.Conditions.VolumeSnapshot
-							}
 							return nil
 						}),
 					)
 					if err != nil {
 						t.Fatal(err)
 					}
-					defer func() {
-						sctx, scancel := context.WithTimeout(context.Background(), 5*time.Minute)
+
+					t.Cleanup(func() {
+						sctx, scancel := context.WithTimeout(context.Background(), 10*time.Minute)
 						defer scancel()
 
 						sapi := integration.NewComponentAPI(sctx, cfg.Namespace(), kubeconfig, cfg.Client())
 						defer sapi.Done(t)
 
-						_, err = stopWs2(true, sapi)
+						_, err := stopWs2(true, sapi)
 						if err != nil {
-							t.Errorf("cannot stop workspace: %q", err)
+							t.Fatal(err)
 						}
-					}()
+					})
 
 					rsa, closer, err = integration.Instrument(integration.ComponentWorkspace, "workspace", cfg.Namespace(), kubeconfig, cfg.Client(),
 						integration.WithInstanceID(ws2.Req.Id),
@@ -168,6 +343,7 @@ func TestBackup(t *testing.T) {
 					if err != nil {
 						t.Fatal(err)
 					}
+
 					rsa.Close()
 
 					var found bool
@@ -181,149 +357,6 @@ func TestBackup(t *testing.T) {
 						t.Fatal("did not find foobar.txt from previous workspace instance")
 					}
 				})
-			}
-			return ctx
-		}).
-		Feature()
-
-	testEnv.Test(t, f)
-
-}
-
-// TestExistingWorkspaceEnablePVC tests enable PVC feature flag on the existing workspace
-func TestExistingWorkspaceEnablePVC(t *testing.T) {
-	f := features.New("backup").
-		WithLabel("component", "ws-manager").
-		Assess("it should enable PVC feature flag to the existing workspace without data loss", func(_ context.Context, t *testing.T, cfg *envconf.Config) context.Context {
-			tests := []struct {
-				Name             string
-				ContextURL       string
-				WorkspaceRoot    string
-				CheckoutLocation string
-			}{
-				{
-					Name:             "pvc",
-					ContextURL:       "http://github.com/gitpod-io/template-golang-cli",
-					WorkspaceRoot:    "/workspace/template-golang-cli",
-					CheckoutLocation: "template-golang-cli",
-				},
-			}
-			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
-			defer cancel()
-
-			for _, test := range tests {
-				api := integration.NewComponentAPI(ctx, cfg.Namespace(), kubeconfig, cfg.Client())
-				t.Cleanup(func() {
-					api.Done(t)
-				})
-
-				// Create a new workspace without the PVC feature flag
-				// TODO: change to use server API to launch the workspace, so we could run the integration test as the user code flow
-				//       which is client -> server -> ws-manager rather than client -> ws-manager directly
-				ws1, stopWs1, err := integration.LaunchWorkspaceDirectly(t, ctx, api, integration.WithRequestModifier(func(w *wsmanapi.StartWorkspaceRequest) error {
-					w.Spec.Initializer = &csapi.WorkspaceInitializer{
-						Spec: &csapi.WorkspaceInitializer_Git{
-							Git: &csapi.GitInitializer{
-								RemoteUri:        test.ContextURL,
-								CheckoutLocation: test.CheckoutLocation,
-								Config:           &csapi.GitConfig{},
-							},
-						},
-					}
-					w.Spec.WorkspaceLocation = test.CheckoutLocation
-					return nil
-				}))
-				if err != nil {
-					t.Fatal(err)
-				}
-
-				rsa, closer, err := integration.Instrument(integration.ComponentWorkspace, "workspace", cfg.Namespace(), kubeconfig, cfg.Client(),
-					integration.WithInstanceID(ws1.Req.Id),
-					integration.WithContainer("workspace"),
-					integration.WithWorkspacekitLift(true),
-				)
-				if err != nil {
-					if _, err := stopWs1(true, api); err != nil {
-						t.Errorf("cannot stop workspace: %q", err)
-					}
-					t.Fatal(err)
-				}
-				integration.DeferCloser(t, closer)
-
-				var resp agent.WriteFileResponse
-				err = rsa.Call("WorkspaceAgent.WriteFile", &agent.WriteFileRequest{
-					Path:    fmt.Sprintf("%s/foobar.txt", test.WorkspaceRoot),
-					Content: []byte("hello world"),
-					Mode:    0644,
-				}, &resp)
-				rsa.Close()
-				if err != nil {
-					if _, err := stopWs1(true, api); err != nil {
-						t.Errorf("cannot stop workspace: %q", err)
-					}
-					t.Fatal(err)
-				}
-
-				_, err = stopWs1(true, api)
-				if err != nil {
-					t.Fatal(err)
-				}
-
-				// Relaunch the workspace and enable the PVC feature flag
-				ws2, stopWs2, err := integration.LaunchWorkspaceDirectly(t, ctx, api,
-					integration.WithRequestModifier(func(w *wsmanapi.StartWorkspaceRequest) error {
-						w.ServicePrefix = ws1.Req.ServicePrefix
-						w.Metadata.MetaId = ws1.Req.Metadata.MetaId
-						w.Metadata.Owner = ws1.Req.Metadata.Owner
-						w.Spec.FeatureFlags = []wsmanapi.WorkspaceFeatureFlag{wsmanapi.WorkspaceFeatureFlag_PERSISTENT_VOLUME_CLAIM}
-						w.Spec.Initializer = ws1.Req.Spec.Initializer
-						w.Spec.WorkspaceLocation = ws1.Req.Spec.WorkspaceLocation
-						return nil
-					}),
-				)
-				if err != nil {
-					t.Fatal(err)
-				}
-				t.Cleanup(func() {
-					sctx, scancel := context.WithTimeout(context.Background(), 5*time.Minute)
-					defer scancel()
-
-					sapi := integration.NewComponentAPI(sctx, cfg.Namespace(), kubeconfig, cfg.Client())
-					defer sapi.Done(t)
-					_, err = stopWs2(true, sapi)
-					if err != nil {
-						t.Errorf("cannot stop workspace: %q", err)
-					}
-				})
-
-				rsa, closer, err = integration.Instrument(integration.ComponentWorkspace, "workspace", cfg.Namespace(), kubeconfig, cfg.Client(),
-					integration.WithInstanceID(ws2.Req.Id),
-				)
-				if err != nil {
-					t.Fatal(err)
-				}
-				integration.DeferCloser(t, closer)
-
-				var ls agent.ListDirResponse
-				err = rsa.Call("WorkspaceAgent.ListDir", &agent.ListDirRequest{
-					Dir: test.WorkspaceRoot,
-				}, &ls)
-				if err != nil {
-					t.Fatal(err)
-				}
-
-				rsa.Close()
-
-				var found bool
-				for _, f := range ls.Files {
-					if filepath.Base(f) == "foobar.txt" {
-						found = true
-						break
-					}
-				}
-				if !found {
-					t.Fatal("did not find foobar.txt from previous workspace instance")
-				}
 			}
 			return ctx
 		}).
@@ -350,20 +383,7 @@ func TestMissingBackup(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			wsm, err := api.WorkspaceManager()
-			if err != nil {
-				if _, err := stopWs(true, api); err != nil {
-					t.Errorf("cannot stop workspace: %q", err)
-				}
-				t.Fatal(err)
-			}
-
-			_, err = wsm.StopWorkspace(ctx, &wsmanapi.StopWorkspaceRequest{Id: ws.Req.Id})
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			_, err = integration.WaitForWorkspaceStop(ctx, api, ws.Req.Id)
+			_, err = stopWs(true, api)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -391,7 +411,12 @@ func TestMissingBackup(t *testing.T) {
 			}
 			for _, test := range tests {
 				t.Run(test.Name+"_backup_init", func(t *testing.T) {
-					testws, stopWs, err := integration.LaunchWorkspaceDirectly(t, ctx, api, integration.WithRequestModifier(func(w *wsmanapi.StartWorkspaceRequest) error {
+					t.Parallel()
+
+					ctx, cancel := context.WithTimeout(context.Background(), time.Duration(5*len(tests))*time.Minute)
+					defer cancel()
+
+					testws, stopWs2, err := integration.LaunchWorkspaceDirectly(t, ctx, api, integration.WithRequestModifier(func(w *wsmanapi.StartWorkspaceRequest) error {
 						w.ServicePrefix = ws.Req.ServicePrefix
 						w.Metadata.MetaId = ws.Req.Metadata.MetaId
 						w.Metadata.Owner = ws.Req.Metadata.Owner
@@ -407,17 +432,27 @@ func TestMissingBackup(t *testing.T) {
 						t.Fatal(err)
 					}
 
+					t.Cleanup(func() {
+						sctx, scancel := context.WithTimeout(context.Background(), 5*time.Minute)
+						defer scancel()
+
+						sapi := integration.NewComponentAPI(sctx, cfg.Namespace(), kubeconfig, cfg.Client())
+						defer sapi.Done(t)
+
+						_, err := stopWs2(true, sapi)
+						if err != nil {
+							t.Fatal(err)
+						}
+					})
+
 					if testws.LastStatus == nil {
 						t.Fatal("did not receive a last status")
 						return
 					}
 					if testws.LastStatus.Conditions.Failed == "" {
-						_, err = stopWs(true, api)
-						if err != nil {
-							t.Errorf("cannot stop workspace: %q", err)
-						}
 						t.Errorf("restarted workspace did not fail despite missing backup, %v", testws)
 					}
+
 				})
 			}
 			return ctx

--- a/test/tests/components/ws-manager/dotfiles_test.go
+++ b/test/tests/components/ws-manager/dotfiles_test.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net/rpc"
 	"os"
 	"strings"
 	"testing"
@@ -152,7 +151,7 @@ func getHostUrl(ctx context.Context, t *testing.T, k8sClient klient.Client) stri
 	return strings.TrimPrefix(strings.Trim(string(hostUrlRaw), "\""), "https://")
 }
 
-func assertDotfiles(t *testing.T, rsa *rpc.Client) error {
+func assertDotfiles(t *testing.T, rsa *integration.RpcClient) error {
 	var ls agent.ListDirResponse
 	err := rsa.Call("WorkspaceAgent.ListDir", &agent.ListDirRequest{
 		Dir: "/home/gitpod/.dotfiles",

--- a/test/tests/components/ws-manager/dotfiles_test.go
+++ b/test/tests/components/ws-manager/dotfiles_test.go
@@ -30,6 +30,8 @@ func TestDotfiles(t *testing.T) {
 	integration.SkipWithoutUserToken(t, userToken)
 
 	f := features.New("dotfiles").WithLabel("component", "ws-manager").Assess("ensure dotfiles are loaded", func(_ context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+		t.Parallel()
+
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 		defer cancel()
 

--- a/test/tests/components/ws-manager/multi_repo_test.go
+++ b/test/tests/components/ws-manager/multi_repo_test.go
@@ -68,6 +68,8 @@ var repos = []struct {
 
 func TestMultiRepoWorkspaceSuccess(t *testing.T) {
 	f := features.New("multi-repo").WithLabel("component", "ws-manager").Assess("can create multi repo workspace", func(_ context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+		t.Parallel()
+
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 		defer cancel()
 

--- a/test/tests/components/ws-manager/multi_repo_test.go
+++ b/test/tests/components/ws-manager/multi_repo_test.go
@@ -6,7 +6,6 @@ package wsmanager
 
 import (
 	"context"
-	"net/rpc"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -18,7 +17,6 @@ import (
 	csapi "github.com/gitpod-io/gitpod/content-service/api"
 	agent "github.com/gitpod-io/gitpod/test/pkg/agent/workspace/api"
 	"github.com/gitpod-io/gitpod/test/pkg/integration"
-	"github.com/gitpod-io/gitpod/test/pkg/integration/common"
 	wsmanapi "github.com/gitpod-io/gitpod/ws-manager/api"
 )
 
@@ -148,7 +146,7 @@ func TestMultiRepoWorkspaceSuccess(t *testing.T) {
 	testEnv.Test(t, f)
 }
 
-func assertRepositories(t *testing.T, rsa *rpc.Client) {
+func assertRepositories(t *testing.T, rsa *integration.RpcClient) {
 	var ls agent.ListDirResponse
 	err := rsa.Call("WorkspaceAgent.ListDir", &agent.ListDirRequest{
 		Dir: "/workspace",
@@ -183,7 +181,7 @@ func assertRepositories(t *testing.T, rsa *rpc.Client) {
 		}
 	}
 
-	git := common.Git(rsa)
+	git := integration.Git(rsa)
 
 	for k, v := range expected {
 		if !v.Cloned {

--- a/test/tests/components/ws-manager/multi_repo_test.go
+++ b/test/tests/components/ws-manager/multi_repo_test.go
@@ -115,7 +115,7 @@ func TestMultiRepoWorkspaceSuccess(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		defer func() {
+		t.Cleanup(func() {
 			sctx, scancel := context.WithTimeout(context.Background(), 5*time.Minute)
 			defer scancel()
 
@@ -126,7 +126,7 @@ func TestMultiRepoWorkspaceSuccess(t *testing.T) {
 			if err != nil {
 				t.Errorf("cannot stop workspace: %q", err)
 			}
-		}()
+		})
 
 		rsa, closer, err := integration.Instrument(integration.ComponentWorkspace, "workspace", cfg.Namespace(), kubeconfig, cfg.Client(),
 			integration.WithInstanceID(ws.Req.Id),

--- a/test/tests/components/ws-manager/prebuild_test.go
+++ b/test/tests/components/ws-manager/prebuild_test.go
@@ -577,7 +577,7 @@ func TestOpenWorkspaceFromOutdatedPrebuild(t *testing.T) {
 							t.Errorf("cannot stop workspace: %q", err)
 						}
 					}()
-					prebuildSnapshot, prebuildVSInfo, err := watchStopWorkspaceAndFindSnapshot(ctx, ws.Req.Id, api)
+					prebuildSnapshot, prebuildVSInfo, err := watchStopWorkspaceAndFindSnapshot(t, ctx, ws.Req.Id, ws.WorkspaceID, api)
 					if err != nil {
 						t.Fatalf("stop workspace and find snapshot error: %v", err)
 					}

--- a/test/tests/components/ws-manager/prebuild_test.go
+++ b/test/tests/components/ws-manager/prebuild_test.go
@@ -34,7 +34,7 @@ import (
 func TestPrebuildWorkspaceTaskSuccess(t *testing.T) {
 	f := features.New("prebuild").
 		WithLabel("component", "ws-manager").
-		Assess("it should create a prebuild and succeed the defined tasks", func(_ context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+		Assess("it should create a prebuild and succeed the defined tasks", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			tests := []struct {
 				Name             string
 				ContextURL       string
@@ -63,11 +63,13 @@ func TestPrebuildWorkspaceTaskSuccess(t *testing.T) {
 					FF: []wsmanapi.WorkspaceFeatureFlag{wsmanapi.WorkspaceFeatureFlag_PERSISTENT_VOLUME_CLAIM},
 				},
 			}
-			ctx, cancel := context.WithTimeout(context.Background(), time.Duration(5*len(tests))*time.Minute)
-			defer cancel()
-
 			for _, test := range tests {
 				t.Run(test.Name, func(t *testing.T) {
+					t.Parallel()
+
+					ctx, cancel := context.WithTimeout(context.Background(), time.Duration(5*len(tests))*time.Minute)
+					defer cancel()
+
 					api := integration.NewComponentAPI(ctx, cfg.Namespace(), kubeconfig, cfg.Client())
 					t.Cleanup(func() {
 						api.Done(t)
@@ -135,6 +137,8 @@ func TestPrebuildWorkspaceTaskFail(t *testing.T) {
 	f := features.New("prebuild").
 		WithLabel("component", "server").
 		Assess("it should create a prebuild and fail after running the defined tasks", func(_ context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			t.Parallel()
+
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 			defer cancel()
 
@@ -218,7 +222,7 @@ func TestOpenWorkspaceFromPrebuild(t *testing.T) {
 
 	f := features.New("prebuild").
 		WithLabel("component", "ws-manager").
-		Assess("it should open workspace from prebuild successfully", func(_ context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+		Assess("it should open workspace from prebuild successfully", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			tests := []struct {
 				Name             string
 				ContextURL       string
@@ -241,11 +245,13 @@ func TestOpenWorkspaceFromPrebuild(t *testing.T) {
 				},
 			}
 
-			ctx, cancel := context.WithTimeout(context.Background(), time.Duration(10*len(tests))*time.Minute)
-			defer cancel()
-
 			for _, test := range tests {
 				t.Run(test.Name, func(t *testing.T) {
+					t.Parallel()
+
+					ctx, cancel := context.WithTimeout(context.Background(), time.Duration(10*len(tests))*time.Minute)
+					defer cancel()
+
 					isPVCEnable := reflect.DeepEqual(test.FF, []wsmanapi.WorkspaceFeatureFlag{wsmanapi.WorkspaceFeatureFlag_PERSISTENT_VOLUME_CLAIM})
 
 					api := integration.NewComponentAPI(ctx, cfg.Namespace(), kubeconfig, cfg.Client())
@@ -666,7 +672,7 @@ func TestOpenWorkspaceFromOutdatedPrebuild(t *testing.T) {
 func TestPrebuildAndRegularWorkspaceDifferentWorkspaceClass(t *testing.T) {
 	f := features.New("prebuild").
 		WithLabel("component", "ws-manager").
-		Assess("it should open workspace with different workspace class", func(_ context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+		Assess("it should open workspace with different workspace class", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			tests := []struct {
 				Name                             string
 				PrebuildWorkspaceClass           string
@@ -702,11 +708,13 @@ func TestPrebuildAndRegularWorkspaceDifferentWorkspaceClass(t *testing.T) {
 				},
 			}
 
-			ctx, cancel := context.WithTimeout(context.Background(), time.Duration(10*len(tests))*time.Minute)
-			defer cancel()
-
 			for _, test := range tests {
 				t.Run(test.Name, func(t *testing.T) {
+					t.Parallel()
+
+					ctx, cancel := context.WithTimeout(context.Background(), time.Duration(10*len(tests))*time.Minute)
+					defer cancel()
+
 					isPVCEnable := reflect.DeepEqual(test.FF, []wsmanapi.WorkspaceFeatureFlag{wsmanapi.WorkspaceFeatureFlag_PERSISTENT_VOLUME_CLAIM})
 
 					api := integration.NewComponentAPI(ctx, cfg.Namespace(), kubeconfig, cfg.Client())

--- a/test/tests/components/ws-manager/prebuild_test.go
+++ b/test/tests/components/ws-manager/prebuild_test.go
@@ -515,7 +515,7 @@ func TestOpenWorkspaceFromOutdatedPrebuild(t *testing.T) {
 
 	f := features.New("prebuild").
 		WithLabel("component", "ws-manager").
-		Assess("it should open a workspace from with an older prebuild initializer successfully and run the init task", func(_ context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+		Assess("it should open a workspace from with an older prebuild initializer successfully and run the init task", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			tests := []struct {
 				Name                    string
 				RemoteUri               string
@@ -535,11 +535,12 @@ func TestOpenWorkspaceFromOutdatedPrebuild(t *testing.T) {
 				},
 			}
 
-			ctx, cancel := context.WithTimeout(context.Background(), time.Duration(10*len(tests))*time.Minute)
-			defer cancel()
-
 			for _, test := range tests {
 				t.Run(test.Name, func(t *testing.T) {
+					t.Parallel()
+
+					ctx, cancel := context.WithTimeout(context.Background(), time.Duration(10*len(tests))*time.Minute)
+					defer cancel()
 
 					api := integration.NewComponentAPI(ctx, cfg.Namespace(), kubeconfig, cfg.Client())
 					t.Cleanup(func() {

--- a/test/tests/components/ws-manager/protected_secrets_test.go
+++ b/test/tests/components/ws-manager/protected_secrets_test.go
@@ -64,7 +64,7 @@ func TestProtectedSecrets(t *testing.T) {
 			t.Fatalf("cannot launch a workspace: %q", err)
 		}
 
-		defer func() {
+		t.Cleanup(func() {
 			sctx, scancel := context.WithTimeout(context.Background(), 5*time.Minute)
 			defer scancel()
 
@@ -75,7 +75,7 @@ func TestProtectedSecrets(t *testing.T) {
 			if err != nil {
 				t.Errorf("cannot stop workspace: %q", err)
 			}
-		}()
+		})
 
 		k8sClient := cfg.Client()
 		var wsPod corev1.Pod

--- a/test/tests/components/ws-manager/protected_secrets_test.go
+++ b/test/tests/components/ws-manager/protected_secrets_test.go
@@ -7,7 +7,6 @@ package wsmanager
 import (
 	"context"
 	"fmt"
-	"net/rpc"
 	"strings"
 	"testing"
 	"time"
@@ -129,7 +128,7 @@ func assertEnvSuppliedBySecret(t *testing.T, wsPod *corev1.Pod, secretEnv string
 	}
 }
 
-func assertEnvAvailableInWs(t *testing.T, rsa *rpc.Client) {
+func assertEnvAvailableInWs(t *testing.T, rsa *integration.RpcClient) {
 	var grepResp agent.ExecResponse
 	err := rsa.Call("WorkspaceAgent.Exec", &agent.ExecRequest{
 		Dir:     prebuildLogPath,

--- a/test/tests/components/ws-manager/protected_secrets_test.go
+++ b/test/tests/components/ws-manager/protected_secrets_test.go
@@ -29,6 +29,8 @@ const (
 
 func TestProtectedSecrets(t *testing.T) {
 	f := features.New("protected_secrets").WithLabel("component", "ws-manager").Assess("can use protected secrets", func(_ context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+		t.Parallel()
+
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 		defer cancel()
 

--- a/test/tests/components/ws-manager/tasks_test.go
+++ b/test/tests/components/ws-manager/tasks_test.go
@@ -56,7 +56,9 @@ func TestRegularWorkspaceTasks(t *testing.T) {
 		WithLabel("component", "ws-manager").
 		WithLabel("type", "tasks").
 		Assess("it can run workspace tasks", func(_ context.Context, t *testing.T, cfg *envconf.Config) context.Context {
-			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+			t.Parallel()
+
+			ctx, cancel := context.WithTimeout(context.Background(), time.Duration(5*len(tests))*time.Minute)
 			defer cancel()
 
 			api := integration.NewComponentAPI(ctx, cfg.Namespace(), kubeconfig, cfg.Client())

--- a/test/tests/components/ws-manager/wsmanager_test.go
+++ b/test/tests/components/ws-manager/wsmanager_test.go
@@ -20,6 +20,8 @@ func TestGetWorkspaces(t *testing.T) {
 	f := features.New("workspaces").
 		WithLabel("component", "ws-manager").
 		Assess("it should get workspaces", func(_ context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			t.Parallel()
+
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 			defer cancel()
 

--- a/test/tests/ide/vscode/python_ws_test.go
+++ b/test/tests/ide/vscode/python_ws_test.go
@@ -92,7 +92,7 @@ func TestPythonExtWorkspace(t *testing.T) {
 				stopWs(true, sapi)
 			}()
 
-			_, err = integration.WaitForWorkspaceStart(ctx, nfo.LatestInstance.ID, api)
+			_, err = integration.WaitForWorkspaceStart(t, ctx, nfo.LatestInstance.ID, api)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/test/tests/ide/vscode/python_ws_test.go
+++ b/test/tests/ide/vscode/python_ws_test.go
@@ -92,7 +92,7 @@ func TestPythonExtWorkspace(t *testing.T) {
 				stopWs(true, sapi)
 			}()
 
-			_, err = integration.WaitForWorkspaceStart(t, ctx, nfo.LatestInstance.ID, api)
+			_, err = integration.WaitForWorkspaceStart(t, ctx, nfo.LatestInstance.ID, nfo.Workspace.ID, api)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/test/tests/workspace/cgroup_v2_test.go
+++ b/test/tests/workspace/cgroup_v2_test.go
@@ -26,6 +26,8 @@ func TestCgroupV2(t *testing.T) {
 	f := features.New("cgroup v2").
 		WithLabel("component", "workspace").
 		Assess("it should create a new cgroup when cgroup v2 is enabled", func(_ context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			t.Parallel()
+
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 			defer cancel()
 

--- a/test/tests/workspace/cgroup_v2_test.go
+++ b/test/tests/workspace/cgroup_v2_test.go
@@ -19,7 +19,6 @@ import (
 
 	agent "github.com/gitpod-io/gitpod/test/pkg/agent/workspace/api"
 	"github.com/gitpod-io/gitpod/test/pkg/integration"
-	"github.com/gitpod-io/gitpod/test/pkg/integration/common"
 )
 
 func TestCgroupV2(t *testing.T) {
@@ -60,7 +59,7 @@ func TestCgroupV2(t *testing.T) {
 			defer rsa.Close()
 			integration.DeferCloser(t, closer)
 
-			cgv2, err := common.IsCgroupV2(rsa)
+			cgv2, err := integration.IsCgroupV2(rsa)
 			if err != nil {
 				t.Fatalf("unexpected error checking cgroup v2: %v", err)
 			}
@@ -75,7 +74,7 @@ func TestCgroupV2(t *testing.T) {
 				Command: "bash",
 				Args: []string{
 					"-c",
-					fmt.Sprintf("sudo mkdir %s", cgroupBase),
+					fmt.Sprintf("if [ ! -e %s ]; then sudo mkdir %s; fi", cgroupBase, cgroupBase),
 				},
 			}, &respNewCgroup)
 			if err != nil {

--- a/test/tests/workspace/contexts_test.go
+++ b/test/tests/workspace/contexts_test.go
@@ -14,7 +14,6 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/features"
 
 	"github.com/gitpod-io/gitpod/test/pkg/integration"
-	"github.com/gitpod-io/gitpod/test/pkg/integration/common"
 )
 
 type ContextTest struct {

--- a/test/tests/workspace/contexts_test.go
+++ b/test/tests/workspace/contexts_test.go
@@ -188,7 +188,7 @@ func runContextTests(t *testing.T, tests []ContextTest) {
 						}
 
 						// get actual from workspace
-						git := common.Git(rsa)
+						git := integration.Git(rsa)
 						err = git.ConfigSafeDirectory()
 						if err != nil {
 							t.Fatal(err)

--- a/test/tests/workspace/contexts_test.go
+++ b/test/tests/workspace/contexts_test.go
@@ -135,6 +135,10 @@ func runContextTests(t *testing.T, tests []ContextTest) {
 					if err := api.UpdateUserFeatureFlag(userId, ff.FF); err != nil {
 						t.Fatal(err)
 					}
+
+					if err := api.MakeUserUnleashedPlan(username); err != nil {
+						t.Fatal(err)
+					}
 				}()
 			}
 
@@ -160,7 +164,7 @@ func runContextTests(t *testing.T, tests []ContextTest) {
 							t.Fatal(err)
 						}
 
-						defer func() {
+						t.Cleanup(func() {
 							sctx, scancel := context.WithTimeout(context.Background(), 10*time.Minute)
 							defer scancel()
 
@@ -171,7 +175,7 @@ func runContextTests(t *testing.T, tests []ContextTest) {
 							if err != nil {
 								t.Fatal(err)
 							}
-						}()
+						})
 
 						rsa, closer, err := integration.Instrument(integration.ComponentWorkspace, "workspace", cfg.Namespace(), kubeconfig, cfg.Client(), integration.WithInstanceID(nfo.LatestInstance.ID))
 						if err != nil {

--- a/test/tests/workspace/docker_test.go
+++ b/test/tests/workspace/docker_test.go
@@ -20,6 +20,8 @@ func TestRunDocker(t *testing.T) {
 	f := features.New("docker").
 		WithLabel("component", "workspace").
 		Assess("it should start a container", func(_ context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			t.Parallel()
+
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 			defer cancel()
 

--- a/test/tests/workspace/docker_test.go
+++ b/test/tests/workspace/docker_test.go
@@ -6,6 +6,7 @@ package workspace
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -68,6 +69,10 @@ func TestRunDocker(t *testing.T) {
 			}
 
 			if resp.ExitCode != 0 {
+				if strings.Contains(resp.Stderr, "toomanyrequests") {
+					t.Skip("skip because we hit the rate limit of the dockerhub")
+					return ctx
+				}
 				t.Fatalf("docker run failed: %s\n%s", resp.Stdout, resp.Stderr)
 			}
 

--- a/test/tests/workspace/example_test.go
+++ b/test/tests/workspace/example_test.go
@@ -58,7 +58,7 @@ func TestWorkspaceInstrumentation(t *testing.T) {
 						t.Fatal(err)
 					}
 
-					defer func() {
+					t.Cleanup(func() {
 						sctx, scancel := context.WithTimeout(context.Background(), 5*time.Minute)
 						defer scancel()
 
@@ -69,7 +69,7 @@ func TestWorkspaceInstrumentation(t *testing.T) {
 						if err != nil {
 							t.Fatal(err)
 						}
-					}()
+					})
 
 					rsa, closer, err := integration.Instrument(integration.ComponentWorkspace, "workspace", cfg.Namespace(), kubeconfig, cfg.Client(), integration.WithInstanceID(nfo.LatestInstance.ID))
 					if err != nil {
@@ -117,7 +117,7 @@ func TestLaunchWorkspaceDirectly(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			defer func() {
+			t.Cleanup(func() {
 				sctx, scancel := context.WithTimeout(context.Background(), 5*time.Minute)
 				defer scancel()
 
@@ -128,7 +128,7 @@ func TestLaunchWorkspaceDirectly(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
-			}()
+			})
 
 			return ctx
 		}).

--- a/test/tests/workspace/example_test.go
+++ b/test/tests/workspace/example_test.go
@@ -38,7 +38,9 @@ func TestWorkspaceInstrumentation(t *testing.T) {
 		Assess("it can instrument a workspace", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			for _, test := range tests {
 				t.Run(test.ContextURL, func(t *testing.T) {
-					ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+					t.Parallel()
+
+					ctx, cancel := context.WithTimeout(context.Background(), time.Duration(5*len(tests))*time.Minute)
 					defer cancel()
 
 					api := integration.NewComponentAPI(ctx, cfg.Namespace(), kubeconfig, cfg.Client())
@@ -100,6 +102,8 @@ func TestLaunchWorkspaceDirectly(t *testing.T) {
 	f := features.New("workspace").
 		WithLabel("component", "server").
 		Assess("it can run workspace tasks", func(_ context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			t.Parallel()
+
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 			defer cancel()
 

--- a/test/tests/workspace/git_hooks_test.go
+++ b/test/tests/workspace/git_hooks_test.go
@@ -89,7 +89,7 @@ func TestGitHooks(t *testing.T) {
 							t.Fatal(err)
 						}
 
-						defer func() {
+						t.Cleanup(func() {
 							sctx, scancel := context.WithTimeout(context.Background(), 10*time.Minute)
 							defer scancel()
 
@@ -99,7 +99,7 @@ func TestGitHooks(t *testing.T) {
 							if _, err := stopWs(true, sapi); err != nil {
 								t.Fatal(err)
 							}
-						}()
+						})
 						rsa, closer, err := integration.Instrument(integration.ComponentWorkspace, "workspace", cfg.Namespace(), kubeconfig, cfg.Client(), integration.WithInstanceID(wsInfo.LatestInstance.ID))
 						if err != nil {
 							t.Fatal(err)

--- a/test/tests/workspace/git_test.go
+++ b/test/tests/workspace/git_test.go
@@ -125,8 +125,6 @@ func TestGitActions(t *testing.T) {
 	f := features.New("GitActions").
 		WithLabel("component", "workspace").
 		Assess("it can run git actions", func(_ context.Context, t *testing.T, cfg *envconf.Config) context.Context {
-			t.Parallel()
-
 			ctx, cancel := context.WithTimeout(context.Background(), time.Duration(5*len(tests))*time.Minute)
 			defer cancel()
 
@@ -146,6 +144,7 @@ func TestGitActions(t *testing.T) {
 			for _, ff := range ffs {
 				for _, test := range tests {
 					t.Run(test.ContextURL+"_"+ff.Name, func(t *testing.T) {
+						t.Parallel()
 						if test.Skip {
 							t.SkipNow()
 						}

--- a/test/tests/workspace/git_test.go
+++ b/test/tests/workspace/git_test.go
@@ -6,7 +6,6 @@ package workspace
 
 import (
 	"context"
-	"net/rpc"
 	"os"
 	"testing"
 	"time"
@@ -16,7 +15,6 @@ import (
 
 	agent "github.com/gitpod-io/gitpod/test/pkg/agent/workspace/api"
 	"github.com/gitpod-io/gitpod/test/pkg/integration"
-	"github.com/gitpod-io/gitpod/test/pkg/integration/common"
 )
 
 type GitTest struct {
@@ -27,7 +25,7 @@ type GitTest struct {
 	Action        GitFunc
 }
 
-type GitFunc func(rsa *rpc.Client, git common.GitClient, workspaceRoot string) error
+type GitFunc func(rsa *integration.RpcClient, git integration.GitClient, workspaceRoot string) error
 
 func TestGitActions(t *testing.T) {
 	userToken, _ := os.LookupEnv("USER_TOKEN")
@@ -39,7 +37,7 @@ func TestGitActions(t *testing.T) {
 			Name:          "create, add and commit",
 			ContextURL:    "github.com/gitpod-io/gitpod-test-repo/tree/integration-test/commit-and-push",
 			WorkspaceRoot: "/workspace/gitpod-test-repo",
-			Action: func(rsa *rpc.Client, git common.GitClient, workspaceRoot string) (err error) {
+			Action: func(rsa *integration.RpcClient, git integration.GitClient, workspaceRoot string) (err error) {
 				var resp agent.ExecResponse
 				err = rsa.Call("WorkspaceAgent.Exec", &agent.ExecRequest{
 					Dir:     workspaceRoot,
@@ -80,7 +78,7 @@ func TestGitActions(t *testing.T) {
 			Name:          "create, add and commit and PUSH",
 			ContextURL:    "github.com/gitpod-io/gitpod-test-repo/tree/integration-test/commit-and-push",
 			WorkspaceRoot: "/workspace/gitpod-test-repo",
-			Action: func(rsa *rpc.Client, git common.GitClient, workspaceRoot string) (err error) {
+			Action: func(rsa *integration.RpcClient, git integration.GitClient, workspaceRoot string) (err error) {
 				var resp agent.ExecResponse
 				err = rsa.Call("WorkspaceAgent.Exec", &agent.ExecRequest{
 					Dir:     workspaceRoot,
@@ -183,7 +181,7 @@ func TestGitActions(t *testing.T) {
 						defer rsa.Close()
 						integration.DeferCloser(t, closer)
 
-						git := common.Git(rsa)
+						git := integration.Git(rsa)
 						err = test.Action(rsa, git, test.WorkspaceRoot)
 						if err != nil {
 							t.Fatal(err)

--- a/test/tests/workspace/git_test.go
+++ b/test/tests/workspace/git_test.go
@@ -125,7 +125,9 @@ func TestGitActions(t *testing.T) {
 	f := features.New("GitActions").
 		WithLabel("component", "workspace").
 		Assess("it can run git actions", func(_ context.Context, t *testing.T, cfg *envconf.Config) context.Context {
-			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+			t.Parallel()
+
+			ctx, cancel := context.WithTimeout(context.Background(), time.Duration(5*len(tests))*time.Minute)
 			defer cancel()
 
 			api := integration.NewComponentAPI(ctx, cfg.Namespace(), kubeconfig, cfg.Client())

--- a/test/tests/workspace/k3s_test.go
+++ b/test/tests/workspace/k3s_test.go
@@ -15,7 +15,6 @@ import (
 
 	agent "github.com/gitpod-io/gitpod/test/pkg/agent/workspace/api"
 	"github.com/gitpod-io/gitpod/test/pkg/integration"
-	"github.com/gitpod-io/gitpod/test/pkg/integration/common"
 )
 
 const (
@@ -61,7 +60,7 @@ func TestK3s(t *testing.T) {
 			defer rsa.Close()
 			integration.DeferCloser(t, closer)
 
-			cgv2, err := common.IsCgroupV2(rsa)
+			cgv2, err := integration.IsCgroupV2(rsa)
 			if err != nil {
 				t.Fatalf("unexpected error checking cgroup v2: %v", err)
 			}

--- a/test/tests/workspace/k3s_test.go
+++ b/test/tests/workspace/k3s_test.go
@@ -27,6 +27,8 @@ func TestK3s(t *testing.T) {
 	f := features.New("k3s").
 		WithLabel("component", "workspace").
 		Assess("it should start a k3s when cgroup v2 enable", func(_ context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			t.Parallel()
+
 			ctx, cancel := context.WithTimeout(context.Background(), TIME_OUT)
 			defer cancel()
 

--- a/test/tests/workspace/mount_proc_test.go
+++ b/test/tests/workspace/mount_proc_test.go
@@ -48,6 +48,8 @@ func TestMountProc(t *testing.T) {
 	f := features.New("proc mount").
 		WithLabel("component", "workspace").
 		Assess("load test proc mount", func(_ context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			t.Parallel()
+
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 			defer cancel()
 

--- a/test/tests/workspace/mount_proc_test.go
+++ b/test/tests/workspace/mount_proc_test.go
@@ -7,7 +7,6 @@ package workspace
 import (
 	"context"
 	"fmt"
-	"net/rpc"
 	"sync"
 	"testing"
 	"time"
@@ -24,7 +23,7 @@ const (
 	parallel      = 5
 )
 
-func loadMountProc(t *testing.T, rsa *rpc.Client) {
+func loadMountProc(t *testing.T, rsa *integration.RpcClient) {
 	var resp agent.ExecResponse
 	err := rsa.Call("WorkspaceAgent.Exec", &agent.ExecRequest{
 		Dir:     "/",
@@ -48,10 +47,10 @@ func TestMountProc(t *testing.T) {
 	f := features.New("proc mount").
 		WithLabel("component", "workspace").
 		Assess("load test proc mount", func(_ context.Context, t *testing.T, cfg *envconf.Config) context.Context {
-			t.Parallel()
-
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 			defer cancel()
+
+			t.Parallel()
 
 			api := integration.NewComponentAPI(ctx, cfg.Namespace(), kubeconfig, cfg.Client())
 			t.Cleanup(func() {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Enables workspace integration tests to run in parallel. As a result of these improvements, the test takes about 20 minutes for large-vm and less than 30 minutes for regular vm.
To this end, I have done the following.
- Add the API for shutdown in the integration agent to be able to retry
- Run the test to restart ws-manager separately
- Make the parts that communicate with ws-manager, especially the part that monitors workspace status, less fragile


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes [13197](https://github.com/gitpod-io/gitpod/issues/13197)

## How to test
<!-- Provide steps to test this PR -->

```console
$ run.sh workspace
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## For the reviewers

Sorry for this too big PR :bow:  There should be no major changes in each test case; review specifically under `pkg/`.

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-integration-tests=workspace
      Valid options are `all`, `workspace`, `webapp`, `ide`
