### PR TITLE
[JetBrains Gateway Plugin] Publish automatically to stable channel

### DIFF
--- a/components/ide/jetbrains/gateway-plugin/build.gradle.kts
+++ b/components/ide/jetbrains/gateway-plugin/build.gradle.kts
@@ -155,7 +155,7 @@ tasks {
         var pluginChannel: String? = System.getenv("JB_GATEWAY_GITPOD_PLUGIN_CHANNEL")
         if (pluginChannel.isNullOrBlank()) {
             pluginChannel = if (pluginVersion.contains("-main.")) {
-                "Nightly"
+                "Stable"
             } else {
                 "Dev"
             }


### PR DESCRIPTION
## Description
As discussed, now that we publish only when relevant changes are found, we can automate the stable release. We will stop using `Nightly` from now and consider removing the channel until we need it again.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #9101

## How to test
N/A

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
