### PR TITLE
Minor improvements to the Stripe subscription cancellation flow

### DIFF
--- a/components/server/ee/src/user/stripe-service.ts
+++ b/components/server/ee/src/user/stripe-service.ts
@@ -117,7 +117,7 @@ export class StripeService {
 
     async cancelSubscription(subscriptionId: string): Promise<void> {
         await reportStripeOutcome("subscriptions_cancel", () => {
-            return this.getStripe().subscriptions.del(subscriptionId);
+            return this.getStripe().subscriptions.del(subscriptionId, { invoice_now: true });
         });
     }
 

--- a/components/server/ee/src/user/user-deletion-service.ts
+++ b/components/server/ee/src/user/user-deletion-service.ts
@@ -8,13 +8,16 @@ import { injectable, inject } from "inversify";
 import { UserDeletionService } from "../../../src/user/user-deletion-service";
 import { SubscriptionService } from "@gitpod/gitpod-payment-endpoint/lib/accounting/subscription-service";
 import { Plans } from "@gitpod/gitpod-protocol/lib/plans";
+import { AttributionId } from "@gitpod/gitpod-protocol/lib/attribution";
 import { ChargebeeService } from "./chargebee-service";
+import { StripeService } from "./stripe-service";
 import { TeamSubscriptionService } from "@gitpod/gitpod-payment-endpoint/lib/accounting";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 
 @injectable()
 export class UserDeletionServiceEE extends UserDeletionService {
     @inject(ChargebeeService) protected readonly chargebeeService: ChargebeeService;
+    @inject(StripeService) protected readonly stripeService: StripeService;
     @inject(SubscriptionService) protected readonly subscriptionService: SubscriptionService;
     @inject(TeamSubscriptionService) protected readonly teamSubscriptionService: TeamSubscriptionService;
 
@@ -27,14 +30,14 @@ export class UserDeletionServiceEE extends UserDeletionService {
         const errors = [];
         if (this.config.enablePayment) {
             const now = new Date();
-            const subscriptions = await this.subscriptionService.getNotYetCancelledSubscriptions(
+            const chargebeeSubscriptions = await this.subscriptionService.getNotYetCancelledSubscriptions(
                 user,
                 now.toISOString(),
             );
-            for (const subscription of subscriptions) {
+            for (const chargebeeSubscription of chargebeeSubscriptions) {
                 try {
-                    const planId = subscription.planId!;
-                    const paymentReference = subscription.paymentReference;
+                    const planId = chargebeeSubscription.planId!;
+                    const paymentReference = chargebeeSubscription.paymentReference;
                     if (Plans.isFreeNonTransientPlan(planId)) {
                         // only delete those plans that are persisted in the DB
                         await this.subscriptionService.unsubscribe(user.id, now.toISOString(), planId);
@@ -58,8 +61,8 @@ export class UserDeletionServiceEE extends UserDeletionService {
                             throw new Error("Cannot delete user subscription from GitHub");
                         } else {
                             // cancel Chargebee subscriptions
-                            const subscriptionId = subscription.uid;
-                            const chargebeeSubscriptionId = subscription.paymentReference!;
+                            const subscriptionId = chargebeeSubscription.uid;
+                            const chargebeeSubscriptionId = chargebeeSubscription.paymentReference!;
                             await this.chargebeeService.cancelSubscription(
                                 chargebeeSubscriptionId,
                                 { userId: user.id },
@@ -69,8 +72,22 @@ export class UserDeletionServiceEE extends UserDeletionService {
                     }
                 } catch (error) {
                     errors.push(error);
-                    log.error("Error cancelling subscription", error, { subscription });
+                    log.error("Error cancelling Chargebee user subscription", error, {
+                        subscription: chargebeeSubscription,
+                    });
                 }
+            }
+            // Also cancel any usage-based (Stripe) subscription
+            const subscriptionId = await this.stripeService.findUncancelledSubscriptionByAttributionId(
+                AttributionId.render({ kind: "user", userId: user.id }),
+            );
+            try {
+                if (subscriptionId) {
+                    await this.stripeService.cancelSubscription(subscriptionId);
+                }
+            } catch (error) {
+                errors.push(error);
+                log.error("Error cancelling Stripe user subscription", error, { subscriptionId });
             }
         }
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

These are the definitely-valuable parts salvaged from my [proration effort](https://github.com/gitpod-io/gitpod/pull/14148) (which ended up not working out):

- Immediately issue a final invoice when cancelling Stripe subscriptions from Gitpod (currently, we're letting Stripe wait until the end of the month)

- When deleting a user account, also cancel any individual Stripe subscription (we forgot to do this until now)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

1. Create a team called "Gitpod [Something]"
2. Go to `/billing`
3. Upgrade your user to usage-based billing by adding a payment method
4. Then, delete your user -- this should both:
  a. automatically cancel your individual Stripe subscription (double-check in the Stripe dashboard)
  b. immediately issue a final invoice (it's going to be in draft for 1h, but at least Stripe won't wait until the end of the month to create it)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
