### PR TITLE
[server] Remove gitpod_server_api_calls_user_total metric

### DIFF
--- a/components/server/src/code-sync/code-sync-service.ts
+++ b/components/server/src/code-sync/code-sync-service.ts
@@ -31,7 +31,6 @@ import {
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 import { v4 as uuidv4 } from "uuid";
 import { accessCodeSyncStorage, UserRateLimiter } from "../auth/rate-limiter";
-import { increaseApiCallUserCounter } from "../prometheus-metrics";
 import { Config } from "../config";
 import { CachingBlobServiceClientProvider } from "@gitpod/content-service/lib/sugar";
 
@@ -106,7 +105,6 @@ export class CodeSyncService {
             }
 
             const id = req.user.id;
-            increaseApiCallUserCounter(accessCodeSyncStorage, id);
             try {
                 await UserRateLimiter.instance(this.config.rateLimiter).consume(id, accessCodeSyncStorage);
             } catch (e) {

--- a/components/server/src/prometheus-metrics.ts
+++ b/components/server/src/prometheus-metrics.ts
@@ -12,7 +12,6 @@ export function registerServerMetrics(registry: prometheusClient.Registry) {
     registry.registerMetric(apiConnectionClosedCounter);
     registry.registerMetric(apiCallCounter);
     registry.registerMetric(apiCallDurationHistogram);
-    registry.registerMetric(apiCallUserCounter);
     registry.registerMetric(httpRequestTotal);
     registry.registerMetric(httpRequestDuration);
     registry.registerMetric(messagebusTopicReads);
@@ -73,16 +72,6 @@ export const apiCallDurationHistogram = new prometheusClient.Histogram({
 
 export function observeAPICallsDuration(method: string, statusCode: number, duration: number) {
     apiCallDurationHistogram.observe({ method, statusCode }, duration);
-}
-
-const apiCallUserCounter = new prometheusClient.Counter({
-    name: "gitpod_server_api_calls_user_total",
-    help: "Total amount of API calls per user",
-    labelNames: ["method", "user"],
-});
-
-export function increaseApiCallUserCounter(method: string, user: string) {
-    apiCallUserCounter.inc({ method, user });
 }
 
 const httpRequestTotal = new prometheusClient.Counter({

--- a/components/server/src/websocket/websocket-connection-manager.ts
+++ b/components/server/src/websocket/websocket-connection-manager.ts
@@ -40,7 +40,6 @@ import {
     increaseApiCallCounter,
     increaseApiConnectionClosedCounter,
     increaseApiConnectionCounter,
-    increaseApiCallUserCounter,
     observeAPICallsDuration,
     apiCallDurationHistogram,
 } from "../prometheus-metrics";
@@ -377,12 +376,6 @@ class GitpodJsonRpcProxyFactory<T extends object> extends JsonRpcProxyFactory<T>
     }
 
     protected async onRequest(method: string, ...args: any[]): Promise<any> {
-        if (!this.rateLimiter.user.startsWith("session-")) {
-            increaseApiCallUserCounter(method, this.rateLimiter.user);
-        } else {
-            increaseApiCallUserCounter(method, "anonymous");
-        }
-
         const span = TraceContext.startSpan(method, undefined);
         const ctx = { span };
         const userId = this.clientMetadata.userId;

--- a/operations/observability/mixins/meta/dashboards/components/meta-overview.json
+++ b/operations/observability/mixins/meta/dashboards/components/meta-overview.json
@@ -430,7 +430,7 @@
             "uid": "P4169E866C3094E38"
           },
           "exemplar": true,
-          "expr": "sum(rate(gitpod_server_api_calls_user_total{cluster=~\"$cluster\", method=~\"ts.*\"}[5m])) by (cluster, method) * 60",
+          "expr": "sum(rate(gitpod_server_api_calls_total{cluster=~\"$cluster\", method=~\"ts.*\"}[5m])) by (cluster, method) * 60",
           "interval": "",
           "legendFormat": "{{cluster}} {{method}}",
           "refId": "A"

--- a/operations/observability/mixins/meta/dashboards/components/server.json
+++ b/operations/observability/mixins/meta/dashboards/components/server.json
@@ -1134,7 +1134,7 @@
             "uid": "$datasource"
           },
           "exemplar": true,
-          "expr": "sum(rate(gitpod_server_api_calls_user_total{cluster=~\"$cluster\", method=~\"ts.*\"}[5m])) by (cluster, method) * 60",
+          "expr": "sum(rate(gitpod_server_api_calls_total{cluster=~\"$cluster\", method=~\"ts.*\"}[5m])) by (cluster, method) * 60",
           "interval": "",
           "legendFormat": "{{cluster}} {{method}}",
           "refId": "A"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Pushing the User ID into metric labels results in unbounded cardinality for the metric. See [thread](https://gitpod.slack.com/archives/C02EN94AEPL/p1666904970956639)

If needed, we can use `gitpod_server_api_calls_total` instead.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes Unbounded metrics cardinality

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`

/hold for review from team IDE