### PR TITLE
[gitpod-protocol] Add getGenericInvite to golang client

### DIFF
--- a/components/gitpod-protocol/go/gitpod-service.go
+++ b/components/gitpod-protocol/go/gitpod-service.go
@@ -84,9 +84,10 @@ type APIInterface interface {
 	TrackEvent(ctx context.Context, event *RemoteTrackMessage) (err error)
 	GetSupportedWorkspaceClasses(ctx context.Context) (res []*SupportedWorkspaceClass, err error)
 
-	CreateTeam(ctx context.Context, params string) (*Team, error)
-	GetTeamMembers(ctx context.Context, params string) ([]*TeamMemberInfo, error)
-	JoinTeam(ctx context.Context, params string) (*Team, error)
+	CreateTeam(ctx context.Context, teamName string) (*Team, error)
+	GetTeamMembers(ctx context.Context, teamID string) ([]*TeamMemberInfo, error)
+	JoinTeam(ctx context.Context, teamID string) (*Team, error)
+	GetGenericInvite(ctx context.Context, teamID string) (*TeamMembershipInvite, error)
 
 	InstanceUpdates(ctx context.Context, instanceID string) (<-chan *WorkspaceInstance, error)
 }
@@ -207,6 +208,15 @@ const (
 	FunctionTrackEvent FunctionName = "trackEvent"
 	// FunctionGetSupportedWorkspaceClasses is the name of the getSupportedWorkspaceClasses function
 	FunctionGetSupportedWorkspaceClasses FunctionName = "getSupportedWorkspaceClasses"
+
+	// FunctionCreateTeam is the name of the createTeam function
+	FunctionCreateTeam FunctionName = "createTeam"
+	// FunctionJoinTeam is the name of the joinTeam function
+	FunctionJoinTeam FunctionName = "joinTeam"
+	// FunctionGetTeamMembers is the name of the getTeamMembers function
+	FunctionGetTeamMembers FunctionName = "getTeamMembers"
+	// FunctionGetGenericInvite is the name of the getGenericInvite function
+	FunctionGetGenericInvite FunctionName = "getGenericInvite"
 
 	// FunctionOnInstanceUpdate is the name of the onInstanceUpdate callback function
 	FunctionOnInstanceUpdate = "onInstanceUpdate"
@@ -1392,7 +1402,7 @@ func (gp *APIoverJSONRPC) CreateTeam(ctx context.Context, teamName string) (res 
 		return
 	}
 	_params := []interface{}{teamName}
-	err = gp.C.Call(ctx, "createTeam", _params, &res)
+	err = gp.C.Call(ctx, string(FunctionCreateTeam), _params, &res)
 	return
 }
 
@@ -1402,7 +1412,7 @@ func (gp *APIoverJSONRPC) GetTeamMembers(ctx context.Context, teamID string) (re
 		return
 	}
 	_params := []interface{}{teamID}
-	err = gp.C.Call(ctx, "getTeamMembers", _params, &res)
+	err = gp.C.Call(ctx, string(FunctionGetTeamMembers), _params, &res)
 	return
 }
 
@@ -1412,7 +1422,17 @@ func (gp *APIoverJSONRPC) JoinTeam(ctx context.Context, inviteID string) (res *T
 		return
 	}
 	_params := []interface{}{inviteID}
-	err = gp.C.Call(ctx, "joinTeam", _params, &res)
+	err = gp.C.Call(ctx, string(FunctionJoinTeam), _params, &res)
+	return
+}
+
+func (gp *APIoverJSONRPC) GetGenericInvite(ctx context.Context, teamID string) (res *TeamMembershipInvite, err error) {
+	if gp == nil {
+		err = errNotConnected
+		return
+	}
+	_params := []interface{}{teamID}
+	err = gp.C.Call(ctx, string(FunctionGetGenericInvite), _params, &res)
 	return
 }
 
@@ -2130,4 +2150,13 @@ type TeamMemberInfo struct {
 	AvatarUrl    string         `json:"avatarUrl,omitempty"`
 	Role         TeamMemberRole `json:"role,omitempty"`
 	MemberSince  string         `json:"memberSince,omitempty"`
+}
+
+type TeamMembershipInvite struct {
+	ID               string         `json:"id,omitempty"`
+	TeamID           string         `json:"teamId,omitempty"`
+	Role             TeamMemberRole `json:"role,omitempty"`
+	CreationTime     string         `json:"creationTime,omitempty"`
+	InvalidationTime string         `json:"invalidationTime,omitempty"`
+	InvitedEmail     string         `json:"invitedEmail,omitempty"`
 }

--- a/components/gitpod-protocol/go/mock.go
+++ b/components/gitpod-protocol/go/mock.go
@@ -110,18 +110,18 @@ func (mr *MockAPIInterfaceMockRecorder) ControlAdmission(ctx, id, level interfac
 }
 
 // CreateTeam mocks base method.
-func (m *MockAPIInterface) CreateTeam(ctx context.Context, params string) (*Team, error) {
+func (m *MockAPIInterface) CreateTeam(ctx context.Context, teamName string) (*Team, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateTeam", ctx, params)
+	ret := m.ctrl.Call(m, "CreateTeam", ctx, teamName)
 	ret0, _ := ret[0].(*Team)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateTeam indicates an expected call of CreateTeam.
-func (mr *MockAPIInterfaceMockRecorder) CreateTeam(ctx, params interface{}) *gomock.Call {
+func (mr *MockAPIInterfaceMockRecorder) CreateTeam(ctx, teamName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTeam", reflect.TypeOf((*MockAPIInterface)(nil).CreateTeam), ctx, params)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTeam", reflect.TypeOf((*MockAPIInterface)(nil).CreateTeam), ctx, teamName)
 }
 
 // CreateWorkspace mocks base method.
@@ -343,6 +343,21 @@ func (mr *MockAPIInterfaceMockRecorder) GetFeaturedRepositories(ctx interface{})
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFeaturedRepositories", reflect.TypeOf((*MockAPIInterface)(nil).GetFeaturedRepositories), ctx)
 }
 
+// GetGenericInvite mocks base method.
+func (m *MockAPIInterface) GetGenericInvite(ctx context.Context, teamID string) (*TeamMembershipInvite, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetGenericInvite", ctx, teamID)
+	ret0, _ := ret[0].(*TeamMembershipInvite)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetGenericInvite indicates an expected call of GetGenericInvite.
+func (mr *MockAPIInterfaceMockRecorder) GetGenericInvite(ctx, teamID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGenericInvite", reflect.TypeOf((*MockAPIInterface)(nil).GetGenericInvite), ctx, teamID)
+}
+
 // GetGitpodTokenScopes mocks base method.
 func (m *MockAPIInterface) GetGitpodTokenScopes(ctx context.Context, tokenHash string) ([]string, error) {
 	m.ctrl.T.Helper()
@@ -494,18 +509,18 @@ func (mr *MockAPIInterfaceMockRecorder) GetSupportedWorkspaceClasses(ctx interfa
 }
 
 // GetTeamMembers mocks base method.
-func (m *MockAPIInterface) GetTeamMembers(ctx context.Context, params string) ([]*TeamMemberInfo, error) {
+func (m *MockAPIInterface) GetTeamMembers(ctx context.Context, teamID string) ([]*TeamMemberInfo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetTeamMembers", ctx, params)
+	ret := m.ctrl.Call(m, "GetTeamMembers", ctx, teamID)
 	ret0, _ := ret[0].([]*TeamMemberInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetTeamMembers indicates an expected call of GetTeamMembers.
-func (mr *MockAPIInterfaceMockRecorder) GetTeamMembers(ctx, params interface{}) *gomock.Call {
+func (mr *MockAPIInterfaceMockRecorder) GetTeamMembers(ctx, teamID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTeamMembers", reflect.TypeOf((*MockAPIInterface)(nil).GetTeamMembers), ctx, params)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTeamMembers", reflect.TypeOf((*MockAPIInterface)(nil).GetTeamMembers), ctx, teamID)
 }
 
 // GetToken mocks base method.
@@ -704,18 +719,18 @@ func (mr *MockAPIInterfaceMockRecorder) IsWorkspaceOwner(ctx, workspaceID interf
 }
 
 // JoinTeam mocks base method.
-func (m *MockAPIInterface) JoinTeam(ctx context.Context, params string) (*Team, error) {
+func (m *MockAPIInterface) JoinTeam(ctx context.Context, teamID string) (*Team, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "JoinTeam", ctx, params)
+	ret := m.ctrl.Call(m, "JoinTeam", ctx, teamID)
 	ret0, _ := ret[0].(*Team)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // JoinTeam indicates an expected call of JoinTeam.
-func (mr *MockAPIInterfaceMockRecorder) JoinTeam(ctx, params interface{}) *gomock.Call {
+func (mr *MockAPIInterfaceMockRecorder) JoinTeam(ctx, teamID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "JoinTeam", reflect.TypeOf((*MockAPIInterface)(nil).JoinTeam), ctx, params)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "JoinTeam", reflect.TypeOf((*MockAPIInterface)(nil).JoinTeam), ctx, teamID)
 }
 
 // OpenPort mocks base method.


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Adds support for `getGenericInvite` in the Go client for gitpod-protocol (server)

A couple of drive-by fixes to define (and use) function names as per existing pattern.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
* Builds on CI. Unused anywhere currently but needed for https://github.com/gitpod-io/gitpod/pull/14152

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
