### PR TITLE
[preview] Add config option for cert-issuer

### DIFF
--- a/.werft/jobs/build/prepare.ts
+++ b/.werft/jobs/build/prepare.ts
@@ -89,7 +89,7 @@ function configureStaticClustersAccess() {
 
 async function decideHarvesterVMCreation(werft: Werft, config: JobConfig) {
     // always try to create - usually it will be no-op, but if tf changed for any reason we would reconcile
-    if (config.withPreview && (!vmExists({ name: config.previewEnvironment.destname }) || config.cleanSlateDeployment)) {
+    if (config.withPreview && (!vmExists({ name: config.previewEnvironment.destname }) || config.cleanSlateDeployment || config.recreatePreview || config.recreateVm)) {
         await createVM(werft, config);
     }
     werft.done(prepareSlices.BOOT_VM);
@@ -101,19 +101,16 @@ async function createVM(werft: Werft, config: JobConfig) {
     const cpu = config.withLargeVM ? 12 : 6;
     const memory = config.withLargeVM ? 24 : 12;
 
-    // -replace=... forces recreation of the resource
-    const planArgs = config.cleanSlateDeployment ? "-replace=harvester_virtualmachine.harvester" : ""
-
     const environment = {
         // We pass the GCP credentials explicitly, otherwise for some reason TF doesn't pick them up
         "GOOGLE_BACKEND_CREDENTIALS": GCLOUD_SERVICE_ACCOUNT_PATH,
         "GOOGLE_APPLICATION_CREDENTIALS": GCLOUD_SERVICE_ACCOUNT_PATH,
+        "TF_VAR_cert_issuer": config.certIssuer,
         "TF_VAR_kubeconfig_path": GLOBAL_KUBECONFIG_PATH,
         "TF_VAR_preview_name": config.previewEnvironment.destname,
         "TF_VAR_vm_cpu": `${cpu}`,
         "TF_VAR_vm_memory": `${memory}Gi`,
-        "TF_VAR_vm_storage_class": "longhorn-gitpod-k3s-202209251218-onereplica",
-        "TF_CLI_ARGS_plan": planArgs
+        "TF_VAR_vm_storage_class": "longhorn-gitpod-k3s-202209251218-onereplica"
     }
 
     const variables = Object
@@ -122,9 +119,16 @@ async function createVM(werft: Werft, config: JobConfig) {
         .map(([key, value]) => `${key}="${value}"`)
         .join(" ")
 
-    if (config.cleanSlateDeployment) {
+    if (config.recreatePreview){
+        werft.log(prepareSlices.BOOT_VM, "Recreating environment");
+        await execStream(`${variables} \
+                                   leeway run dev/preview:delete-preview`, {slice: prepareSlices.BOOT_VM});
+    }else if (config.cleanSlateDeployment || config.recreateVm) {
         werft.log(prepareSlices.BOOT_VM, "Cleaning previously created VM");
-        await execStream(`${variables} leeway run dev/preview:create-preview`, {slice: prepareSlices.BOOT_VM});
+        // -replace=... forces recreation of the resource
+        await execStream(`${variables} \
+                                   TF_CLI_ARGS_plan=-replace=harvester_virtualmachine.harvester \
+                                   leeway run dev/preview:create-preview`, {slice: prepareSlices.BOOT_VM});
     }
 
     werft.log(prepareSlices.BOOT_VM, "Creating  VM");

--- a/dev/preview/BUILD.yaml
+++ b/dev/preview/BUILD.yaml
@@ -11,6 +11,7 @@ scripts:
   - name: create-preview
     description: Provisions a new preview environment
     script: |
+      export TF_VAR_cert_issuer="${TF_VAR_cert_issuer:-zerossl-issuer-gitpod-core-dev}"
       export TF_VAR_dev_kube_path="${TF_VAR_dev_kube_path:-/home/gitpod/.kube/config}"
       export TF_VAR_dev_kube_context="${TF_VAR_dev_kube_context:-dev}"
       export TF_VAR_harvester_kube_path="${TF_VAR_harvester_kube_path:-/home/gitpod/.kube/config}"

--- a/dev/preview/infrastructure/harvester/cert.tf
+++ b/dev/preview/infrastructure/harvester/cert.tf
@@ -21,7 +21,7 @@ resource "kubernetes_manifest" "cert" {
       ]
       issuerRef = {
         kind = "ClusterIssuer"
-        name = "zerossl-issuer-gitpod-core-dev"
+        name = var.cert_issuer
       }
       renewBefore = "24h0m0s"
       secretName  = "harvester-${var.preview_name}"

--- a/dev/preview/infrastructure/harvester/variables.tf
+++ b/dev/preview/infrastructure/harvester/variables.tf
@@ -44,3 +44,9 @@ variable "harvester_ingress_ip" {
   default     = "159.69.172.117"
   description = "Ingress IP in Harvester cluster"
 }
+
+variable "cert_issuer" {
+  type        = string
+  default     = "zerossl-issuer-gitpod-core-dev"
+  description = "Certificate issuer"
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Add annotations:
- `cert-issuer` - ability to choose the issuer for the cert of the preview env. `[zerossl, letsencrypt]`
- `recreate-preview` - nuke the whole preview infra and recreate from scratch (including deps). Should be used sparingly, does not replace `with-clean-slate-deployment`
- `recreate-vm` == `with-clean-slate-deployment`, but shorter

Fix a small issue with passing `with-clean-slate-deployment` - where the VM would get recreated twice, since the flag is set for both applies.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://gitpod.slack.com/archives/C032A46PWR0/p1667198847703189

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
