### PR TITLE
[JetBrains] Update JB Nightly GHA Workflow to download specific build 

### DIFF
--- a/.github/workflows/jetbrains-auto-update-template.yml
+++ b/.github/workflows/jetbrains-auto-update-template.yml
@@ -41,12 +41,26 @@ jobs:
         uses: google-github-actions/setup-gcloud@v0
         with:
           project_id: ${{ secrets.projectId }}
+      - name: Get Current Platform Version
+        id: current-version
+        run: |
+          CURRENT_VERSION=$(cat ./components/ide/jetbrains/backend-plugin/gradle-latest.properties | grep platformVersion= | sed 's/platformVersion=//')
+          echo "::set-output name=result::$CURRENT_VERSION"
+          echo $CURRENT_VERSION
+      - name: Find next version
+        id: ide-version
+        run: |
+          curl -sL https://www.jetbrains.com/intellij-repository/snapshots/index.json > index.json
+          IDE_VERSION=$(cat index.json| jq -r -c '.artifacts[] | select(.content | . != null and . != "") | select(.groupId | . == "com.jetbrains.intellij.idea") | select(.version | . == "${{ steps.current-version.outputs.result }}") | .content')
+          echo "::set-output name=result::$IDE_VERSION"
+          echo $IDE_VERSION
       - name: Leeway build
+        if: ${{ steps.ide-version.outputs.result }}
         run: |
           gcloud auth configure-docker --quiet
           export LEEWAY_WORKSPACE_ROOT=$(pwd)
           cd components/ide/jetbrains/image
-          leeway build -Dversion=latest -DimageRepoBase=eu.gcr.io/gitpod-core-dev/build .:${{ inputs.productId }}-latest
+          leeway build -Dversion=latest -DimageRepoBase=eu.gcr.io/gitpod-core-dev/build -DbuildNumber=${{ steps.ide-version.outputs.result }} .:${{ inputs.productId }}-latest
       - name: Get previous job's status
         id: lastrun
         uses: filiptronicek/get-last-job-status@main

--- a/components/ide/jetbrains/image/BUILD.js
+++ b/components/ide/jetbrains/image/BUILD.js
@@ -76,9 +76,11 @@ const generateIDEDownloadPackage = function (ideConfig, qualifier) {
     if (qualifier === "stable") {
         pkg.env.push(`JETBRAINS_BACKEND_URL=${args[`${ideConfig.name}DownloadUrl`]}`);
     } else {
-        pkg.env.push(
-            `JETBRAINS_BACKEND_URL=${`https://download.jetbrains.com/product?type=release,rc,eap&distribution=linux&code=${ideConfig.productCode}`}`,
-        );
+        let url = `https://download.jetbrains.com/product?type=release,rc,eap&distribution=linux&code=${ideConfig.productCode}`;
+        if (args["buildNumber"]) {
+            url = `${url}&build=${args["buildNumber"]}`;
+        }
+        pkg.env.push(`JETBRAINS_BACKEND_URL=${url}`);
     }
     return pkg;
 };


### PR DESCRIPTION
## Description
Updating the JB Nightly job to publish IDE images of a specific build number (aligned with backend-plugin `gradle-latest.properties`), to avoid compatibility issues.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Relates https://github.com/gitpod-io/gitpod/issues/13654

## How to test
Tested by dispatching the GHA workflow manually [[1]](https://github.com/gitpod-io/gitpod/actions/runs/3362492142)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
