### PR TITLE
[server] Add metric for completed image builds

### DIFF
--- a/components/server/src/prometheus-metrics.ts
+++ b/components/server/src/prometheus-metrics.ts
@@ -21,6 +21,7 @@ export function registerServerMetrics(registry: prometheusClient.Registry) {
     registry.registerMetric(prebuildsStartedTotal);
     registry.registerMetric(stripeClientRequestsCompletedDurationSeconds);
     registry.registerMetric(imageBuildsStartedTotal);
+    registry.registerMetric(imageBuildsCompletedTotal);
 }
 
 const loginCounter = new prometheusClient.Counter({
@@ -174,4 +175,14 @@ export const imageBuildsStartedTotal = new prometheusClient.Counter({
 
 export function increaseImageBuildsStartedTotal() {
     imageBuildsStartedTotal.inc();
+}
+
+export const imageBuildsCompletedTotal = new prometheusClient.Counter({
+    name: "gitpod_server_image_builds_completed_total",
+    help: "counter of the total number of image builds recorded as completed on server",
+    labelNames: ["outcome"],
+});
+
+export function increaseImageBuildsCompletedTotal(outcome: "succeeded" | "failed") {
+    imageBuildsCompletedTotal.inc({ outcome });
 }


### PR DESCRIPTION
## Description

Add a counter for completed image builds `gitpod_server_image_builds_completed_total` to `server` with dimensions for successful and failed image builds.

Increment the relevant counter when an image build succeeds or fails. 

## Related Issue(s)
Part of https://github.com/gitpod-io/gitpod/issues/12960

## How to test

(tbd once preview envs are working again).

## Release Notes
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
