### PR TITLE
Add links to explore cardinality metrics

### DIFF
--- a/operations/observability/mixins/self-hosted/dashboards/observability/cardinality-management-overview.json
+++ b/operations/observability/mixins/self-hosted/dashboards/observability/cardinality-management-overview.json
@@ -239,6 +239,12 @@
             "displayMode": "auto",
             "inspect": false
           },
+          "links": [
+            {
+              "title": "Explore",
+              "url": "https://grafana.gitpod.io/explore?orgId=1&left=%7B%22datasource%22:%22P4169E866C3094E38%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22editorMode%22:%22code%22,%22expr%22:%22%7B__name__%3D%5C%22${__data.fields.metric}%5C%22%7D%22,%22legendFormat%22:%22__auto%22,%22range%22:false,%22instant%22:true,%22exemplar%22:false%7D%5D,%22range%22:%7B%22from%22:%22now-5m%22,%22to%22:%22now%22%7D%7D"
+            }
+          ],
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -381,6 +387,12 @@
             "displayMode": "auto",
             "inspect": false
           },
+          "links": [
+            {
+              "title": "Explore",
+              "url": "https://grafana.gitpod.io/explore?orgId=1&left=%7B%22datasource%22:%22P4169E866C3094E38%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22editorMode%22:%22code%22,%22expr%22:%22%7B${__data.fields.Label}%21%3D%5C%22%5C%22%7D%22,%22legendFormat%22:%22__auto%22,%22range%22:false,%22instant%22:true,%22exemplar%22:false%7D%5D,%22range%22:%7B%22from%22:%22now-5m%22,%22to%22:%22now%22%7D%7D"
+            }
+          ],
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -475,9 +487,21 @@
           "legendFormat": "{{label}}",
           "range": false,
           "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sort_desc(\r\n    topk(15, \r\n        sum(cardinality_exporter_memory_by_label_bytes{cluster=~\"$cluster\"}) by (label)\r\n    )\r\n)",
+          "hide": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "C"
         }
       ],
-      "title": "Top 10 labels by unique value count",
+      "title": "Top 15 labels by unique value count",
       "transformations": [
         {
           "id": "seriesToColumns",


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
I'm adding links to the cardinality tables, so one can quickly jump from an overview to a detailed query with Grafana Explore

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
