### PR TITLE
[gitpod-protocol] Add support for getTeams to golang client

### DIFF
--- a/components/gitpod-protocol/go/gitpod-service.go
+++ b/components/gitpod-protocol/go/gitpod-service.go
@@ -84,6 +84,7 @@ type APIInterface interface {
 	TrackEvent(ctx context.Context, event *RemoteTrackMessage) (err error)
 	GetSupportedWorkspaceClasses(ctx context.Context) (res []*SupportedWorkspaceClass, err error)
 
+	GetTeams(ctx context.Context) ([]*Team, error)
 	CreateTeam(ctx context.Context, teamName string) (*Team, error)
 	GetTeamMembers(ctx context.Context, teamID string) ([]*TeamMemberInfo, error)
 	JoinTeam(ctx context.Context, teamID string) (*Team, error)
@@ -209,6 +210,8 @@ const (
 	// FunctionGetSupportedWorkspaceClasses is the name of the getSupportedWorkspaceClasses function
 	FunctionGetSupportedWorkspaceClasses FunctionName = "getSupportedWorkspaceClasses"
 
+	// FunctionGetTeams is the name of the getTeams function
+	FunctionGetTeams FunctionName = "getTeams"
 	// FunctionCreateTeam is the name of the createTeam function
 	FunctionCreateTeam FunctionName = "createTeam"
 	// FunctionJoinTeam is the name of the joinTeam function
@@ -1393,6 +1396,16 @@ func (gp *APIoverJSONRPC) GetSupportedWorkspaceClasses(ctx context.Context) (res
 	}
 	_params := []interface{}{}
 	err = gp.C.Call(ctx, "getSupportedWorkspaceClasses", _params, &res)
+	return
+}
+
+func (gp *APIoverJSONRPC) GetTeams(ctx context.Context) (res []*Team, err error) {
+	if gp == nil {
+		err = errNotConnected
+		return
+	}
+	_params := []interface{}{}
+	err = gp.C.Call(ctx, string(FunctionGetTeams), _params, &res)
 	return
 }
 

--- a/components/gitpod-protocol/go/mock.go
+++ b/components/gitpod-protocol/go/mock.go
@@ -523,6 +523,21 @@ func (mr *MockAPIInterfaceMockRecorder) GetTeamMembers(ctx, teamID interface{}) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTeamMembers", reflect.TypeOf((*MockAPIInterface)(nil).GetTeamMembers), ctx, teamID)
 }
 
+// GetTeams mocks base method.
+func (m *MockAPIInterface) GetTeams(ctx context.Context) ([]*Team, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTeams", ctx)
+	ret0, _ := ret[0].([]*Team)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetTeams indicates an expected call of GetTeams.
+func (mr *MockAPIInterfaceMockRecorder) GetTeams(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTeams", reflect.TypeOf((*MockAPIInterface)(nil).GetTeams), ctx)
+}
+
 // GetToken mocks base method.
 func (m *MockAPIInterface) GetToken(ctx context.Context, query *GetTokenSearchOptions) (*Token, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Extends gitpod-protocol client with getTeams

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Part of https://github.com/gitpod-io/gitpod/issues/14310

## How to test
<!-- Provide steps to test this PR -->
Builds. Unused yet, will be used by https://github.com/gitpod-io/gitpod/pull/14301

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
