### PR TITLE
[public-api] Implement experimental ListTeams

### DIFF
--- a/components/public-api-server/pkg/apiv1/team.go
+++ b/components/public-api-server/pkg/apiv1/team.go
@@ -8,16 +8,15 @@ import (
 	"context"
 	"fmt"
 
-	protocol "github.com/gitpod-io/gitpod/gitpod-protocol"
-	"github.com/relvacode/iso8601"
-	"google.golang.org/protobuf/types/known/timestamppb"
-
 	connect "github.com/bufbuild/connect-go"
 	"github.com/gitpod-io/gitpod/common-go/log"
+	protocol "github.com/gitpod-io/gitpod/gitpod-protocol"
 	"github.com/gitpod-io/gitpod/public-api-server/pkg/auth"
 	"github.com/gitpod-io/gitpod/public-api-server/pkg/proxy"
 	v1 "github.com/gitpod-io/gitpod/public-api/experimental/v1"
 	"github.com/gitpod-io/gitpod/public-api/experimental/v1/v1connect"
+	"github.com/relvacode/iso8601"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func NewTeamsService(pool proxy.ServerConnectionPool) *TeamService {
@@ -41,38 +40,82 @@ func (s *TeamService) CreateTeam(ctx context.Context, req *connect.Request[v1.Cr
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("Name is a required argument when creating a team."))
 	}
 
-	server, err := s.connectionPool.Get(ctx, token)
+	conn, err := s.connectionPool.Get(ctx, token)
 	if err != nil {
 		log.Log.WithError(err).Error("Failed to get connection to server.")
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
 
-	team, err := server.CreateTeam(ctx, req.Msg.GetName())
+	created, err := conn.CreateTeam(ctx, req.Msg.GetName())
 	if err != nil {
+		log.WithError(err).Error("Failed to create team.")
 		return nil, proxy.ConvertError(err)
 	}
 
-	members, err := server.GetTeamMembers(ctx, team.ID)
+	team, err := s.toTeamAPIResponse(ctx, conn, created)
 	if err != nil {
-		return nil, proxy.ConvertError(err)
-	}
-
-	invite, err := server.GetGenericInvite(ctx, team.ID)
-	if err != nil {
-		return nil, proxy.ConvertError(err)
+		log.WithError(err).Error("Failed to populate team with details.")
+		return nil, err
 	}
 
 	return connect.NewResponse(&v1.CreateTeamResponse{
-		Team: &v1.Team{
-			Id:      team.ID,
-			Name:    team.Name,
-			Slug:    team.Slug,
-			Members: teamMembersToAPIResponse(members),
-			TeamInvitation: &v1.TeamInvitation{
-				Id: invite.ID,
-			},
-		},
+		Team: team,
 	}), nil
+}
+
+func (s *TeamService) ListTeams(ctx context.Context, req *connect.Request[v1.ListTeamsRequest]) (*connect.Response[v1.ListTeamsResponse], error) {
+	token := auth.TokenFromContext(ctx)
+
+	conn, err := s.connectionPool.Get(ctx, token)
+	if err != nil {
+		log.Log.WithError(err).Error("Failed to get connection to server.")
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
+
+	teams, err := conn.GetTeams(ctx)
+	if err != nil {
+		log.WithError(err).Error("Failed to list teams from server.")
+		return nil, proxy.ConvertError(err)
+	}
+
+	var response []*v1.Team
+	for _, t := range teams {
+		team, err := s.toTeamAPIResponse(ctx, conn, t)
+		if err != nil {
+			log.WithError(err).Error("Failed to populate team with details.")
+			return nil, err
+		}
+
+		response = append(response, team)
+	}
+
+	return connect.NewResponse(&v1.ListTeamsResponse{
+		Teams: response,
+	}), nil
+}
+
+func (s *TeamService) toTeamAPIResponse(ctx context.Context, conn protocol.APIInterface, team *protocol.Team) (*v1.Team, error) {
+	members, err := conn.GetTeamMembers(ctx, team.ID)
+	if err != nil {
+		log.WithError(err).Error("Failed to get team members.")
+		return nil, proxy.ConvertError(err)
+	}
+
+	invite, err := conn.GetGenericInvite(ctx, team.ID)
+	if err != nil {
+		log.WithError(err).Error("Failed to get generic invite.")
+		return nil, proxy.ConvertError(err)
+	}
+
+	return &v1.Team{
+		Id:      team.ID,
+		Name:    team.Name,
+		Slug:    team.Slug,
+		Members: teamMembersToAPIResponse(members),
+		TeamInvitation: &v1.TeamInvitation{
+			Id: invite.ID,
+		},
+	}, nil
 }
 
 func teamMembersToAPIResponse(members []*protocol.TeamMemberInfo) []*v1.TeamMember {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Implements experimental `TeamsService.ListTeams`

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Part of https://github.com/gitpod-io/gitpod/issues/14310
* Depends on https://github.com/gitpod-io/gitpod/pull/14300
* Depends on https://github.com/gitpod-io/gitpod/pull/14152
* Used in https://github.com/gitpod-io/gitpod/pull/14313

## How to test
<!-- Provide steps to test this PR -->
Unit tests.

1. Open up preview, log-in
2. Obtain a token by running the below in the browser console
	```javascript
	await window._gp.gitpodService.server.generateNewGitpodToken({ type: 1, scopes: ["function:getGitpodTokenScopes",
		"function:createTeam",
		"function:getTeamMembers",
		"function:getGenericInvite",
		"function:getTeams",
		"resource:default",]})
	```
3. Set your credentials on the command line:
	```bash
	BEARER_TOKEN="<token>"
	```
4. Create a couple of teams, adjusting the `<team_name_X>` variable
```
	curl \
    --header 'Content-Type: application/json' \
    --header "Authorization: Bearer $BEARER_TOKEN" \
    --data '{ "name": "<team_name_1>" }' \
    https://api.mp-papi-list-teams.preview.gitpod-dev.com/gitpod.experimental.v1.TeamsService/CreateTeam

	curl \
    --header 'Content-Type: application/json' \
    --header "Authorization: Bearer $BEARER_TOKEN" \
    --data '{ "name": "<team_name_2>" }' \
    https://api.mp-papi-list-teams.preview.gitpod-dev.com/gitpod.experimental.v1.TeamsService/CreateTeam
```
6. Hit the list endpoint, adjusting the `<team_name>` variable
```bash
	curl \
    --header 'Content-Type: application/json' \
    --header "Authorization: Bearer $BEARER_TOKEN" \
    --data '{ }' \
    https://api.mp-papi-list-teams.preview.gitpod-dev.com/gitpod.experimental.v1.TeamsService/ListTeams
```

```json
{
  "teams": [
    {
      "id": "47fd227c-19b0-49e2-8ee6-7e00ddb6526a",
      "name": "milans2",
      "slug": "milans2",
      "members": [
        {
          "userId": "c269e49a-4c20-4d65-b762-6acac9df7aa5",
          "role": "TEAM_ROLE_OWNER"
        }
      ],
      "teamInvitation": {
        "id": "redacted"
      }
    },
    {
      "id": "97532eb7-54d3-452c-98f9-321024382fba",
      "name": "milans1",
      "slug": "milans1",
      "members": [
        {
          "userId": "c269e49a-4c20-4d65-b762-6acac9df7aa5",
          "role": "TEAM_ROLE_OWNER"
        }
      ],
      "teamInvitation": {
        "id": "8743a6f7-b103-4c87-9d02-8ed531e8cfaa"
      }
    },
    {
      "id": "ae8e46e9-071f-4a19-877e-5a681794fa65",
      "name": "foobaz",
      "slug": "foobaz",
      "members": [
        {
          "userId": "c269e49a-4c20-4d65-b762-6acac9df7aa5",
          "role": "TEAM_ROLE_OWNER"
        }
      ],
      "teamInvitation": {
        "id": "redacted"
      }
    }
  ]
}
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
