### PR TITLE
[registry-facade] Remove redis sentinel and add TLS support

### DIFF
--- a/components/registry-facade-api/go/config/config.go
+++ b/components/registry-facade-api/go/config/config.go
@@ -80,10 +80,11 @@ type RedisCacheConfig struct {
 
 	SingleHostAddress string `json:"singleHostAddr,omitempty"`
 
-	MasterName    string   `json:"masterName,omitempty"`
-	SentinelAddrs []string `json:"sentinelAddrs,omitempty"`
-	Username      string   `json:"username,omitempty"`
-	Password      string   `json:"-" env:"REDIS_PASSWORD"`
+	Username string `json:"username,omitempty"`
+	Password string `json:"-" env:"REDIS_PASSWORD"`
+
+	UseTLS             bool `json:"useTLS,omitempty"`
+	InsecureSkipVerify bool `json:"insecureSkipVerify,omitempty"`
 }
 
 type IPFSCacheConfig struct {

--- a/install/installer/pkg/components/registry-facade/configmap.go
+++ b/install/installer/pkg/components/registry-facade/configmap.go
@@ -38,10 +38,11 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		if ucfg.Workspace.RegistryFacade.RedisCache.Enabled {
 			cacheCfg := ucfg.Workspace.RegistryFacade.RedisCache
 			redisCache = &regfac.RedisCacheConfig{
-				Enabled:       true,
-				MasterName:    cacheCfg.MasterName,
-				SentinelAddrs: cacheCfg.SentinelAddrs,
-				Username:      cacheCfg.Username,
+				Enabled:            true,
+				SingleHostAddress:  cacheCfg.SingleHostAddress,
+				Username:           cacheCfg.Username,
+				UseTLS:             cacheCfg.UseTLS,
+				InsecureSkipVerify: cacheCfg.InsecureSkipVerify,
 			}
 		}
 

--- a/install/installer/pkg/config/v1/experimental/experimental.go
+++ b/install/installer/pkg/config/v1/experimental/experimental.go
@@ -92,11 +92,12 @@ type WorkspaceConfig struct {
 			IPFSAddr string `json:"ipfsAddr"`
 		} `json:"ipfsCache"`
 		RedisCache struct {
-			Enabled        bool     `json:"enabled"`
-			MasterName     string   `json:"masterName"`
-			SentinelAddrs  []string `json:"sentinelAddrs"`
-			Username       string   `json:"username"`
-			PasswordSecret string   `json:"passwordSecret"`
+			Enabled            bool   `json:"enabled"`
+			SingleHostAddress  string `json:"singleHostAddr"`
+			Username           string `json:"username"`
+			PasswordSecret     string `json:"passwordSecret"`
+			UseTLS             bool   `json:"useTLS"`
+			InsecureSkipVerify bool   `json:"insecureSkipVerify"`
 		} `json:"redisCache"`
 	} `json:"registryFacade"`
 


### PR DESCRIPTION
## Description

Refactor `registry-facade` Redis connection removing support for `sentinel` and at the same time adding support for TLS connections.

The goal is to simplify the code and avoid some of the `go-redis` issues with context timeouts.

## Related Issue(s)
xref: https://github.com/gitpod-io/ops/pull/5949

## How to test
- Use the same instructions from https://github.com/gitpod-io/ops/pull/5949

## Release Notes
```release-note
NONE
```

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-integration-tests=workspace
      Valid options are `all`, `workspace`, `webapp`, `ide`
