### PR TITLE
[server] incremental workspaces (1 of 2)

### DIFF
--- a/components/dashboard/src/projects/Project.tsx
+++ b/components/dashboard/src/projects/Project.tsx
@@ -378,17 +378,7 @@ export default function () {
                                                     )}
                                                 </a>
                                                 <span className="flex-grow" />
-                                                <a
-                                                    href={
-                                                        prebuild
-                                                            ? gitpodHostUrl
-                                                                  .withContext(
-                                                                      `open-prebuild/${prebuild.info.id}/${prebuild.info.changeUrl}`,
-                                                                  )
-                                                                  .toString()
-                                                            : gitpodHostUrl.withContext(`${branch.url}`).toString()
-                                                    }
-                                                >
+                                                <a href={gitpodHostUrl.withContext(`${branch.url}`).toString()}>
                                                     <button
                                                         className={`primary mr-2 py-2 opacity-0 group-hover:opacity-100`}
                                                     >

--- a/components/dashboard/src/projects/ProjectSettings.tsx
+++ b/components/dashboard/src/projects/ProjectSettings.tsx
@@ -90,6 +90,18 @@ export default function () {
                 checked={!project.settings?.keepOutdatedPrebuildsRunning}
                 onChange={({ target }) => updateProjectSettings({ keepOutdatedPrebuildsRunning: !target.checked })}
             />
+            <h3 className="mt-12">Workspace Starts</h3>
+            <CheckBox
+                title={<span>Incrementally update from old prebuilds</span>}
+                desc={
+                    <span>
+                        Whether new workspaces can be started based on prebuilds that ran on older Git commits and get
+                        incrementally updated.
+                    </span>
+                }
+                checked={!!project.settings?.allowUsingPreviousPrebuilds}
+                onChange={({ target }) => updateProjectSettings({ allowUsingPreviousPrebuilds: target.checked })}
+            />
             {showPersistentVolumeClaimUI && (
                 <>
                     <br></br>

--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -12,7 +12,6 @@ import {
     WhitelistedRepository,
     WorkspaceImageBuild,
     AuthProviderInfo,
-    CreateWorkspaceMode,
     Token,
     UserEnvVarValue,
     Terms,
@@ -422,7 +421,10 @@ export namespace GitpodServer {
     }
     export interface CreateWorkspaceOptions {
         contextUrl: string;
-        mode?: CreateWorkspaceMode;
+        // whether running workspaces on the same context should be ignored. If false (default) users will be asked.
+        ignoreRunningWorkspaceOnSameCommit?: boolean;
+        ignoreRunningPrebuild?: boolean;
+        allowUsingPreviousPrebuilds?: boolean;
         forceDefaultConfig?: boolean;
     }
     export interface StartWorkspaceOptions {

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -1381,19 +1381,6 @@ export interface WorkspaceCreationResult {
 }
 export type RunningWorkspacePrebuildStarting = "queued" | "starting" | "running";
 
-export enum CreateWorkspaceMode {
-    // Default returns a running prebuild if there is any, otherwise creates a new workspace (using a prebuild if one is available)
-    Default = "default",
-    // ForceNew creates a new workspace irrespective of any running prebuilds. This mode is guaranteed to actually create a workspace - but may degrade user experience as currently runnig prebuilds are ignored.
-    ForceNew = "force-new",
-    // UsePrebuild polls the database waiting for a currently running prebuild to become available. This mode exists to handle the db-sync delay.
-    UsePrebuild = "use-prebuild",
-    // SelectIfRunning returns a list of currently running workspaces for the context URL if there are any, otherwise falls back to Default mode
-    SelectIfRunning = "select-if-running",
-    // UseLastSuccessfulPrebuild returns ...
-    UseLastSuccessfulPrebuild = "use-last-successful-prebuild",
-}
-
 export namespace WorkspaceCreationResult {
     export function is(data: any): data is WorkspaceCreationResult {
         return (

--- a/components/gitpod-protocol/src/teams-projects-protocol.ts
+++ b/components/gitpod-protocol/src/teams-projects-protocol.ts
@@ -17,6 +17,8 @@ export interface ProjectSettings {
     useIncrementalPrebuilds?: boolean;
     usePersistentVolumeClaim?: boolean;
     keepOutdatedPrebuildsRunning?: boolean;
+    // whether new workspaces can start on older prebuilds and incrementally update
+    allowUsingPreviousPrebuilds?: boolean;
 }
 
 export interface Project {

--- a/components/server/ee/src/prebuilds/prebuild-manager.ts
+++ b/components/server/ee/src/prebuilds/prebuild-manager.ts
@@ -191,6 +191,7 @@ export class PrebuildManager {
             const workspace = await this.workspaceFactory.createForContext(
                 { span },
                 user,
+                project,
                 prebuildContext,
                 context.normalizedContextURL!,
             );

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -30,7 +30,6 @@ import {
     AuthProviderInfo,
     CommitContext,
     Configuration,
-    CreateWorkspaceMode,
     DisposableCollection,
     GetWorkspaceTimeoutResult,
     GitpodClient as GitpodApiClient,
@@ -1053,12 +1052,11 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         traceAPIParams(ctx, { options });
 
         const contextUrl = options.contextUrl;
-        const mode = options.mode || CreateWorkspaceMode.Default;
         let normalizedContextUrl: string = "";
         let logContext: LogContext = {};
 
         try {
-            const user = this.checkAndBlockUser("createWorkspace", { mode });
+            const user = this.checkAndBlockUser("createWorkspace", { options });
             await this.checkTermsAcceptance();
 
             const envVars = this.userDB.getEnvVars(user.id);
@@ -1070,7 +1068,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
             normalizedContextUrl = this.contextParser.normalizeContextURL(contextUrl);
             let runningForContextPromise: Promise<WorkspaceInfo[]> = Promise.resolve([]);
             const contextPromise = this.contextParser.handle(ctx, user, normalizedContextUrl);
-            if (mode === CreateWorkspaceMode.SelectIfRunning) {
+            if (!options.ignoreRunningWorkspaceOnSameCommit) {
                 runningForContextPromise = this.findRunningInstancesForContext(
                     ctx,
                     contextPromise,
@@ -1153,14 +1151,22 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
                 }
             }
 
-            if (mode === CreateWorkspaceMode.SelectIfRunning && context.forceCreateNewWorkspace !== true) {
+            if (!options.ignoreRunningWorkspaceOnSameCommit && !context.forceCreateNewWorkspace) {
                 const runningForContext = await runningForContextPromise;
                 if (runningForContext.length > 0) {
                     return { existingWorkspaces: runningForContext };
                 }
             }
-
-            const prebuiltWorkspace = await this.findPrebuiltWorkspace(ctx, user, context, mode);
+            const project = CommitContext.is(context)
+                ? await this.projectDB.findProjectByCloneUrl(context.repository.cloneUrl)
+                : undefined;
+            const prebuiltWorkspace = await this.findPrebuiltWorkspace(
+                ctx,
+                user,
+                context,
+                options.ignoreRunningPrebuild,
+                options.allowUsingPreviousPrebuilds || project?.settings?.allowUsingPreviousPrebuilds,
+            );
             if (WorkspaceCreationResult.is(prebuiltWorkspace)) {
                 ctx.span?.log({ prebuild: "running" });
                 return prebuiltWorkspace as WorkspaceCreationResult;
@@ -1170,7 +1176,13 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
                 context = prebuiltWorkspace;
             }
 
-            const workspace = await this.workspaceFactory.createForContext(ctx, user, context, normalizedContextUrl);
+            const workspace = await this.workspaceFactory.createForContext(
+                ctx,
+                user,
+                project,
+                context,
+                normalizedContextUrl,
+            );
             await this.mayStartWorkspace(ctx, user, workspace, runningInstancesPromise);
             try {
                 await this.guardAccess({ kind: "workspace", subject: workspace }, "create");
@@ -1242,10 +1254,11 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
     }
 
     protected async findPrebuiltWorkspace(
-        ctx: TraceContext,
+        parentCtx: TraceContext,
         user: User,
         context: WorkspaceContext,
-        mode: CreateWorkspaceMode,
+        ignoreRunningPrebuild?: boolean,
+        allowUsingPreviousPrebuilds?: boolean,
     ): Promise<WorkspaceCreationResult | PrebuiltWorkspaceContext | undefined> {
         // prebuilds are an EE feature
         return undefined;


### PR DESCRIPTION
# Attention
> **Please review and approve #14461 which includes these changes**


## Description
This change adds a project preference that allows to generally use previous prebuilds and incrementally update the workspace when creating a workspace:

<img width="726" alt="Screenshot 2022-11-06 at 21 38 35" src="https://user-images.githubusercontent.com/372735/200193878-967c4a04-23df-4646-99f6-9d46bb6ba784.png">

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
See #12582

## How to test
<!-- Provide steps to test this PR -->
- create a team and a project
- enable the project setting
- start a prebuild on that project
- start a workspace while a prebuild is running and see that you get a workspace starting from git.
- wait for the prebuild to finish
- add a commit on top so that a prebuild is running again
- start a workspace while a prebuild is running and see that you get a workspace starting from git.
- change the new preference in project settings
- start a workspace while the prebuild is running and see that you get a workspace based on the previous prebuild.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Introduces new project setting to use old prebuilds on workspace start
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
