### PR TITLE
[JetBrains] Fix the IDE version to download in GitHub Action

### DIFF
--- a/.github/workflows/jetbrains-auto-update-template.yml
+++ b/.github/workflows/jetbrains-auto-update-template.yml
@@ -41,17 +41,18 @@ jobs:
         uses: google-github-actions/setup-gcloud@v0
         with:
           project_id: ${{ secrets.projectId }}
-      - name: Get Current Platform Version
-        id: current-version
+      - name: Get Platform Version from JetBrains EAP Backend Plugin
+        id: platform-version
         run: |
-          CURRENT_VERSION=$(cat ./components/ide/jetbrains/backend-plugin/gradle-latest.properties | grep platformVersion= | sed 's/platformVersion=//')
-          echo "::set-output name=result::$CURRENT_VERSION"
-          echo $CURRENT_VERSION
-      - name: Find next version
+          PLATFORM_VERSION=$(cat ./components/ide/jetbrains/backend-plugin/gradle-latest.properties | grep platformVersion= | sed 's/platformVersion=//' | sed 's/-EAP-CANDIDATE-SNAPSHOT//')
+          echo "::set-output name=result::$PLATFORM_VERSION"
+          echo $PLATFORM_VERSION
+      - name: Find IDE version to download
         id: ide-version
         run: |
-          curl -sL https://www.jetbrains.com/intellij-repository/snapshots/index.json > index.json
-          IDE_VERSION=$(cat index.json| jq -r -c '.artifacts[] | select(.content | . != null and . != "") | select(.groupId | . == "com.jetbrains.intellij.idea") | select(.version | . == "${{ steps.current-version.outputs.result }}") | .content')
+          curl -sL "https://data.services.jetbrains.com/products/releases?code=${{ inputs.productCode }}&type=eap,rc,release&platform=linux" > releases.json
+          IDE_VERSION=$(cat releases.json | jq -r -c 'first(.${{ inputs.productCode }}[] | select(.build | contains("${{ steps.platform-version.outputs.result }}")) | .build)')
+          rm releases.json
           echo "::set-output name=result::$IDE_VERSION"
           echo $IDE_VERSION
       - name: Leeway build


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Fix the IDE version to download in GitHub Action.

This change is required because the 'patch' number can differ from the Snapshot. For example:
- Snapshot: 223.7255.1
- IDE Build Number: 223.7255.83

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
- https://github.com/gitpod-io/gitpod/issues/13654

## How to test
<!-- Provide steps to test this PR -->
No need to test. See the dry-run of the build [here](https://github.com/gitpod-io/gitpod/actions/runs/3368013104).

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```