### PR TITLE
[JetBrains] Run the GitHub Action only when `backend-plugin/gradle-latest.properties` changes

### DIFF
--- a/.github/workflows/jetbrains-auto-update.yml
+++ b/.github/workflows/jetbrains-auto-update.yml
@@ -1,9 +1,11 @@
-name: JB Nightly
+name: JB Update Latest IDE Images
 on:
   workflow_dispatch:
-  schedule:
-    # At 11:00 on every day.
-    - cron: "0 11 * * *"
+  push:
+    branches:
+      - "main"
+    paths:
+      - "components/ide/jetbrains/backend-plugin/gradle-latest.properties"
 
 jobs:
   intellij:


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Run the GitHub Action only when `backend-plugin/gradle-latest.properties` changes.

Because now we update the Latest IDE Images based on the `platformVersion` described in that file.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
- https://github.com/gitpod-io/gitpod/issues/13654

## How to test
<!-- Provide steps to test this PR -->
It can only be tested after merged into `main` branch and having a change on `components/ide/jetbrains/backend-plugin/gradle-latest.properties` file.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```