### PR TITLE
[JetBrains] Set the GitHub Action to run also on schedule

### DIFF
--- a/.github/workflows/jetbrains-auto-update.yml
+++ b/.github/workflows/jetbrains-auto-update.yml
@@ -1,6 +1,9 @@
 name: JB Update Latest IDE Images
 on:
   workflow_dispatch:
+  schedule:
+    # At 11:00 on every day.
+    - cron: "0 11 * * *"
   push:
     branches:
       - "main"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Set the GitHub Action to run also on schedule because some IDEs may be updated to the same version of `gradle-latest.properties` only a few days later.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
- https://github.com/gitpod-io/gitpod/pull/14318

## How to test
<!-- Provide steps to test this PR -->
No tests needed. It was the same before we merged [the last PR about this file](https://github.com/gitpod-io/gitpod/pull/14318).

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```