### PR TITLE
ws-manager: Monitor a event about deleting a pod

### DIFF
--- a/components/ws-manager/cmd/run.go
+++ b/components/ws-manager/cmd/run.go
@@ -18,7 +18,9 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -199,6 +201,7 @@ var runCmd = &cobra.Command{
 			Client:  mgr.GetClient(),
 			Log:     ctrl.Log.WithName("controllers").WithName("Pod"),
 			Scheme:  mgr.GetScheme(),
+			Pods:    make(map[types.NamespacedName]corev1.Pod),
 		}).SetupWithManager(mgr)
 		if err != nil {
 			log.WithError(err).Fatal("unable to create controller", "controller", "Pod")


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

For some reason, we are not currently monitoring for events of pod erasure, i.e., workspace deletion. This prevents the ws-manager subscriber from sending the event that the workspace is stopped. This is the fix for that.

## Related Issue(s)

Part of https://github.com/gitpod-io/gitpod/issues/13197

## How to test
<!-- Provide steps to test this PR -->

Run the integration test and log subscribe log
(Later I will give a PR about the integration test that contains code that will not work without this modification)


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
