### PR TITLE
[loadgen] Allow parallel runs

### DIFF
--- a/dev/loadgen/.gitignore
+++ b/dev/loadgen/.gitignore
@@ -1,4 +1,3 @@
-stats.json
 /wsman-tls/
-/benchmark-result.json
 /loadgen
+/results/

--- a/dev/loadgen/README.md
+++ b/dev/loadgen/README.md
@@ -57,7 +57,7 @@ In order to configure the benchmark, you can use the configuration file
 | repo.auth.authUser | The user that should be used for authentication |
 | repo.auth.authPassword | The password that should be used for authentication |
 
-After the benchmark has completed, you will find a benchmark-result.json file in your working directory, that contains information about every started workspace.
+After the benchmark has completed, the command will print where the results are stored (this will be a `benchmark-result.json` file inside a unique directory under `results/`). This results file contains information about every started workspace.
 
 ```
 [


### PR DESCRIPTION
## Description
Updates `loadgen [benchmark|run]` to allow parallel runs:
- Results now save to a unique directory under `results/`, e.g.:
  ```
  /workspace/gitpod/dev/loadgen/results/
    benchmark-0cb17d13-7715-4480-85e1-b0111c487e3d/
      benchmark-result.json
      stats.json
    run-b0805a7e-8db9-4448-9201-f4dd279ad447/
      stats.json
  ```
- Add a new `loadgen-session-id` annotation to started workspaces. This is used to identify which workspaces belong to which `loadgen` session, and used as a filter when calling ws-manager APIs, so that each loadgen only looks at its own workspaces

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #14213

## How to test

- Open a new workspace
- Setup loadgen and run `loadgen benchmark` twice against the same cluster
- Cancel one `loadgen`, observe it shuts down only workspaces created by this loadgen, and exits when done (does not get stuck waiting for active workspaces from the parallel loadgen)
- Cancel the second `loadgen`
- See the results of each run are stored in unique directories

Same for `loadgen run`

Example output:
```console
$ loadgen benchmark --tls wsman-tls/ --host localhost:12001 configs/workspace-preview-benchmark.yaml 
INFO[0000] Results will be saved in dir results/benchmark-4f06df9a-32e3-4242-8a48-34611acdc166 
INFO[0000] load worker started                           worker=3
INFO[0000] load worker started                           worker=2
INFO[0000] load worker started                           worker=4
INFO[0000] load worker started                           worker=1
INFO[0000] load worker started                           worker=0
INFO[0000] selecting repo https://github.com/gitpod-io/template-python-django 
spinning up: [█████████████████████████████████████████████████████↖                                                     ] ? p/s 1/2INFO[0001] selecting repo https://github.com/gitpod-io/template-typescript-react 
spinning up: [██████████████████████████████████████████████████████████████████████████████████████████████████████████↗] 1 p/s 2/2INFO[0002] Waiting for workspaces to enter running phase 
INFO[0022] load generation completed successfully       
Waiting for 2 minutes before deleting workspaces
INFO[0142] Saved benchmark results to results/benchmark-4f06df9a-32e3-4242-8a48-34611acdc166/benchmark-result.json 
INFO[0142] stopping 2 workspaces                        
INFO[0147] Time taken to stop workspaces: 5.104211088s  
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
