### PR TITLE
[public-api] Implement member_since on TeamMember

### DIFF
--- a/components/public-api-server/go.mod
+++ b/components/public-api-server/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/google/uuid v1.1.2
 	github.com/gorilla/handlers v1.5.1
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
+	github.com/hashicorp/golang-lru v0.5.4
 	github.com/prometheus/client_golang v1.13.0
 	github.com/relvacode/iso8601 v1.1.0
 	github.com/sirupsen/logrus v1.8.1
@@ -34,7 +35,6 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
-	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/heptiolabs/healthcheck v0.0.0-20211123025425-613501dd5deb // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect

--- a/components/public-api-server/go.sum
+++ b/components/public-api-server/go.sum
@@ -153,7 +153,6 @@ github.com/grpc-ecosystem/go-grpc-middleware v1.3.0/go.mod h1:z0ButlSOZa5vEBq9m2
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 h1:Ovs26xHkKqVztRpIrF/92BcuyuQ/YW4NSIpoGtfXNho=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
-github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+dAcgU=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=

--- a/components/public-api-server/pkg/apiv1/team.go
+++ b/components/public-api-server/pkg/apiv1/team.go
@@ -7,7 +7,10 @@ package apiv1
 import (
 	"context"
 	"fmt"
+
 	protocol "github.com/gitpod-io/gitpod/gitpod-protocol"
+	"github.com/relvacode/iso8601"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	connect "github.com/bufbuild/connect-go"
 	"github.com/gitpod-io/gitpod/common-go/log"
@@ -77,8 +80,9 @@ func teamMembersToAPIResponse(members []*protocol.TeamMemberInfo) []*v1.TeamMemb
 
 	for _, m := range members {
 		result = append(result, &v1.TeamMember{
-			UserId: m.UserId,
-			Role:   teamRoleToAPIResponse(m.Role),
+			UserId:      m.UserId,
+			Role:        teamRoleToAPIResponse(m.Role),
+			MemberSince: parseTimeStamp(m.MemberSince),
 		})
 	}
 
@@ -94,4 +98,13 @@ func teamRoleToAPIResponse(role protocol.TeamMemberRole) v1.TeamRole {
 	default:
 		return v1.TeamRole_TEAM_ROLE_UNSPECIFIED
 	}
+}
+
+func parseTimeStamp(s string) *timestamppb.Timestamp {
+	parsed, err := iso8601.ParseString(s)
+	if err != nil {
+		return &timestamppb.Timestamp{}
+	}
+
+	return timestamppb.New(parsed)
 }

--- a/components/public-api-server/pkg/apiv1/team_test.go
+++ b/components/public-api-server/pkg/apiv1/team_test.go
@@ -7,6 +7,11 @@ package apiv1
 import (
 	"context"
 	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
 	"github.com/bufbuild/connect-go"
 	protocol "github.com/gitpod-io/gitpod/gitpod-protocol"
 	"github.com/gitpod-io/gitpod/public-api-server/pkg/auth"
@@ -17,18 +22,16 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/testing/protocmp"
-	"net/http"
-	"net/http/httptest"
-	"testing"
-	"time"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func TestTeamsService_CreateTeam(t *testing.T) {
 
 	var (
-		name = "Shiny New Team"
-		slug = "shiny-new-team"
-		id   = uuid.New().String()
+		name        = "Shiny New Team"
+		slug        = "shiny-new-team"
+		id          = uuid.New().String()
+		memberSince = "2022-10-10T10:10:10.000Z"
 	)
 
 	t.Run("returns invalid argument when name is empty", func(t *testing.T) {
@@ -60,14 +63,14 @@ func TestTeamsService_CreateTeam(t *testing.T) {
 				PrimaryEmail: "alice@alice.com",
 				AvatarUrl:    "",
 				Role:         protocol.TeamMember_Owner,
-				MemberSince:  "",
+				MemberSince:  memberSince,
 			}, {
 				UserId:       uuid.New().String(),
 				FullName:     "Bob Bob",
 				PrimaryEmail: "bob@bob.com",
 				AvatarUrl:    "",
 				Role:         protocol.TeamMember_Member,
-				MemberSince:  "",
+				MemberSince:  memberSince,
 			},
 		}
 		inviteID := uuid.New().String()
@@ -100,12 +103,14 @@ func TestTeamsService_CreateTeam(t *testing.T) {
 				Slug: slug,
 				Members: []*v1.TeamMember{
 					{
-						UserId: teamMembers[0].UserId,
-						Role:   teamRoleToAPIResponse(teamMembers[0].Role),
+						UserId:      teamMembers[0].UserId,
+						Role:        teamRoleToAPIResponse(teamMembers[0].Role),
+						MemberSince: timestamppb.New(time.Date(2022, 10, 10, 10, 10, 10, 0, time.UTC)),
 					},
 					{
-						UserId: teamMembers[1].UserId,
-						Role:   teamRoleToAPIResponse(teamMembers[1].Role),
+						UserId:      teamMembers[1].UserId,
+						Role:        teamRoleToAPIResponse(teamMembers[1].Role),
+						MemberSince: timestamppb.New(time.Date(2022, 10, 10, 10, 10, 10, 0, time.UTC)),
 					},
 				},
 				TeamInvitation: &v1.TeamInvitation{


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Needed to show on the Team Member's view when a member joined.

Server stores them as ISO8601 so had to use a library. We already use that library in the usage component so we know it works.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
unit tests

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
