### PR TITLE
[usage] Use workspaceClass displayName in Usage view

### DIFF
--- a/components/dashboard/src/components/UsageView.tsx
+++ b/components/dashboard/src/components/UsageView.tsx
@@ -24,6 +24,7 @@ import { ReactComponent as UsageIcon } from "../images/usage-default.svg";
 import { toRemoteURL } from "../projects/render-utils";
 import { WorkspaceType } from "@gitpod/gitpod-protocol";
 import PillLabel from "./PillLabel";
+import { SupportedWorkspaceClass } from "@gitpod/gitpod-protocol/lib/workspace-class";
 
 interface UsageViewProps {
     attributionId: AttributionId;
@@ -39,6 +40,14 @@ function UsageView({ attributionId }: UsageViewProps) {
     const [endDateOfBillMonth, setEndDateOfBillMonth] = useState(Date.now());
     const [totalCreditsUsed, setTotalCreditsUsed] = useState<number>(0);
     const [isLoading, setIsLoading] = useState<boolean>(true);
+    const [supportedClasses, setSupportedClasses] = useState<SupportedWorkspaceClass[]>([]);
+
+    useEffect(() => {
+        (async () => {
+            const classes = await getGitpodService().server.getSupportedWorkspaceClasses();
+            setSupportedClasses(classes);
+        })();
+    }, []);
 
     useEffect(() => {
         loadPage(1);
@@ -79,6 +88,14 @@ function UsageView({ attributionId }: UsageViewProps) {
             return "Workspace";
         }
         return "Prebuild";
+    };
+
+    const getDisplayName = (workspaceClass: string) => {
+        const workspaceDisplayName = supportedClasses.find((wc) => wc.id === workspaceClass)?.displayName;
+        if (!workspaceDisplayName) {
+            return workspaceClass;
+        }
+        return workspaceDisplayName;
     };
 
     const isRunning = (usage: Usage) => {
@@ -270,10 +287,10 @@ function UsageView({ attributionId }: UsageViewProps) {
                                                             )}
                                                         </span>
                                                         <span className="text-sm text-gray-400 dark:text-gray-500">
-                                                            {
+                                                            {getDisplayName(
                                                                 (usage.metadata as WorkspaceInstanceUsageData)
-                                                                    .workspaceClass
-                                                            }
+                                                                    .workspaceClass,
+                                                            )}
                                                         </span>
                                                     </div>
                                                     <div className="flex flex-col col-span-5 my-auto">


### PR DESCRIPTION
## Description
This uses the `displayName` instead of the `id`

<img width="538" alt="Screenshot 2022-11-01 at 16 27 04" src="https://user-images.githubusercontent.com/8015191/199272070-c2a20967-a070-40c7-833e-03a7fca51cf8.png">
Note: This shows `Default` because it's using the preview env config.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Relates #13362

## How to test
1. Join [this team](https://lau-creditaf7e9c5013.preview.gitpod-dev.com/teams/join?inviteId=d5300183-4b74-4c03-977b-91634a09c7f4) OR create your own team with the name "Gitpod" (uppercase 'G') and run some workspaces.
2. Check out the /usage page and see the workspace class name.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
