### PR TITLE
[dashboard] Use public-api to JoinTeam

### DIFF
--- a/components/dashboard/src/service/public-api.ts
+++ b/components/dashboard/src/service/public-api.ts
@@ -5,9 +5,9 @@
  */
 
 import { createConnectTransport, createPromiseClient, Interceptor } from "@bufbuild/connect-web";
-
-// Import service definition that you want to connect to.
+import { Team as ProtocolTeam } from "@gitpod/gitpod-protocol/lib/teams-projects-protocol";
 import { TeamsService } from "@gitpod/public-api/lib/gitpod/experimental/v1/teams_connectweb";
+import { Team } from "@gitpod/public-api/lib/gitpod/experimental/v1/teams_pb";
 import { getGitpodService } from "./service";
 
 let token: string | undefined;
@@ -18,13 +18,17 @@ const authInterceptor: Interceptor = (next) => async (req) => {
             type: 1,
             scopes: [
                 "function:getGitpodTokenScopes",
+
                 "function:getWorkspace",
                 "function:getWorkspaces",
+
                 "function:createTeam",
                 "function:joinTeam",
+                "function:getTeams",
+                "function:getTeam",
                 "function:getTeamMembers",
                 "function:getGenericInvite",
-                "function:listenForWorkspaceInstanceUpdates",
+
                 "resource:default",
             ],
         });
@@ -41,3 +45,17 @@ const transport = createConnectTransport({
 });
 
 export const teamsService = createPromiseClient(TeamsService, transport);
+
+export function publicApiTeamToProtocol(team: Team): ProtocolTeam {
+    return {
+        id: team.id,
+        name: team.name,
+        slug: team.slug,
+        // We do not use the creationTime in the dashboard anywhere, se we keep it empty.
+        creationTime: "",
+    };
+}
+
+export function publicApiTeamsToProtocol(teams: Team[]): ProtocolTeam[] {
+    return teams.map(publicApiTeamToProtocol);
+}

--- a/components/public-api-server/pkg/apiv1/team_test.go
+++ b/components/public-api-server/pkg/apiv1/team_test.go
@@ -94,6 +94,7 @@ func TestTeamsService_ListTeams(t *testing.T) {
 		serverMock, client := setupTeamService(t)
 
 		teamMembers := []*protocol.TeamMemberInfo{
+<<<<<<< HEAD
 			newTeamMember(&protocol.TeamMemberInfo{
 				FullName: "Alice Alice",
 				Role:     protocol.TeamMember_Owner,
@@ -102,6 +103,31 @@ func TestTeamsService_ListTeams(t *testing.T) {
 				FullName: "Bob Bob",
 				Role:     protocol.TeamMember_Member,
 			}),
+=======
+			{
+				UserId:       uuid.New().String(),
+				FullName:     "Alice Alice",
+				PrimaryEmail: "alice@alice.com",
+				AvatarUrl:    "",
+				Role:         protocol.TeamMember_Owner,
+<<<<<<< HEAD
+				MemberSince:  memberSince,
+=======
+				MemberSince:  "",
+>>>>>>> 341fb7a4f ([public-api] Implement experimental ListTeams)
+			}, {
+				UserId:       uuid.New().String(),
+				FullName:     "Bob Bob",
+				PrimaryEmail: "bob@bob.com",
+				AvatarUrl:    "",
+				Role:         protocol.TeamMember_Member,
+<<<<<<< HEAD
+				MemberSince:  memberSince,
+=======
+				MemberSince:  "",
+>>>>>>> 341fb7a4f ([public-api] Implement experimental ListTeams)
+			},
+>>>>>>> dbb4e6399 ([public-api] Implement experimental ListTeams)
 		}
 		teams := []*protocol.Team{
 			newTeam(&protocol.Team{

--- a/components/public-api-server/pkg/apiv1/team_test.go
+++ b/components/public-api-server/pkg/apiv1/team_test.go
@@ -94,7 +94,6 @@ func TestTeamsService_ListTeams(t *testing.T) {
 		serverMock, client := setupTeamService(t)
 
 		teamMembers := []*protocol.TeamMemberInfo{
-<<<<<<< HEAD
 			newTeamMember(&protocol.TeamMemberInfo{
 				FullName: "Alice Alice",
 				Role:     protocol.TeamMember_Owner,
@@ -103,31 +102,6 @@ func TestTeamsService_ListTeams(t *testing.T) {
 				FullName: "Bob Bob",
 				Role:     protocol.TeamMember_Member,
 			}),
-=======
-			{
-				UserId:       uuid.New().String(),
-				FullName:     "Alice Alice",
-				PrimaryEmail: "alice@alice.com",
-				AvatarUrl:    "",
-				Role:         protocol.TeamMember_Owner,
-<<<<<<< HEAD
-				MemberSince:  memberSince,
-=======
-				MemberSince:  "",
->>>>>>> 341fb7a4f ([public-api] Implement experimental ListTeams)
-			}, {
-				UserId:       uuid.New().String(),
-				FullName:     "Bob Bob",
-				PrimaryEmail: "bob@bob.com",
-				AvatarUrl:    "",
-				Role:         protocol.TeamMember_Member,
-<<<<<<< HEAD
-				MemberSince:  memberSince,
-=======
-				MemberSince:  "",
->>>>>>> 341fb7a4f ([public-api] Implement experimental ListTeams)
-			},
->>>>>>> dbb4e6399 ([public-api] Implement experimental ListTeams)
 		}
 		teams := []*protocol.Team{
 			newTeam(&protocol.Team{

--- a/components/public-api-server/pkg/apiv1/team_test.go
+++ b/components/public-api-server/pkg/apiv1/team_test.go
@@ -179,6 +179,7 @@ func TestTeamService_GetTeam(t *testing.T) {
 }
 
 func TestTeamsService_JoinTeam(t *testing.T) {
+
 	var (
 		teamID   = uuid.New().String()
 		inviteID = uuid.New().String()


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Part of https://github.com/gitpod-io/gitpod/issues/14352
* Depends on https://github.com/gitpod-io/gitpod/pull/14328

## How to test
<!-- Provide steps to test this PR -->
1. Sing in to Preview
2. Open up dev console
3. Join team with this invite: https://mp-dash-join-team.preview.gitpod-dev.com/teams/join?inviteId=455eb032-3c0d-4df0-ae2e-7090e601ba28
4. Observe HTTP request made to `JoinTeam` targeting `api.<preview_domain>`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
