### PR TITLE
[server] Do not fail joining a team you're already a member of

### DIFF
--- a/components/dashboard/src/teams/JoinTeam.tsx
+++ b/components/dashboard/src/teams/JoinTeam.tsx
@@ -23,20 +23,7 @@ export default function () {
                     throw new Error("This invite URL is incorrect.");
                 }
 
-                let team;
-                try {
-                    team = await getGitpodService().server.joinTeam(inviteId);
-                } catch (error) {
-                    const message: string | undefined = error && typeof error.message === "string" && error.message;
-                    const regExp = /You are already a member of this team. \((.*)\)/;
-                    const match = message && regExp.exec(message);
-                    if (match && match[1]) {
-                        const slug = match[1];
-                        history.push(`/t/${slug}/members`);
-                        return;
-                    }
-                    throw error;
-                }
+                const team = await getGitpodService().server.joinTeam(inviteId);
                 const teams = await getGitpodService().server.getTeams();
                 setTeams(teams);
 

--- a/components/gitpod-db/src/team-db.ts
+++ b/components/gitpod-db/src/team-db.ts
@@ -23,7 +23,7 @@ export interface TeamDB {
     findTeamsByUser(userId: string): Promise<Team[]>;
     findTeamsByUserAsSoleOwner(userId: string): Promise<Team[]>;
     createTeam(userId: string, name: string): Promise<Team>;
-    addMemberToTeam(userId: string, teamId: string): Promise<void>;
+    addMemberToTeam(userId: string, teamId: string): Promise<"added" | "already_member">;
     setTeamMemberRole(userId: string, teamId: string, role: TeamMemberRole): Promise<void>;
     setTeamMemberSubscription(userId: string, teamId: string, subscriptionId: string): Promise<void>;
     removeMemberFromTeam(userId: string, teamId: string): Promise<void>;

--- a/components/gitpod-db/src/typeorm/team-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/team-db-impl.ts
@@ -176,7 +176,7 @@ export class TeamDBImpl implements TeamDB {
         }
     }
 
-    public async addMemberToTeam(userId: string, teamId: string): Promise<void> {
+    public async addMemberToTeam(userId: string, teamId: string): Promise<"added" | "already_member"> {
         const teamRepo = await this.getTeamRepo();
         const team = await teamRepo.findOne(teamId);
         if (!team || !!team.deleted) {
@@ -185,7 +185,8 @@ export class TeamDBImpl implements TeamDB {
         const membershipRepo = await this.getMembershipRepo();
         const membership = await membershipRepo.findOne({ teamId, userId, deleted: false });
         if (!!membership) {
-            throw new ResponseError(ErrorCodes.CONFLICT, `You are already a member of this team. (${team.slug})`);
+            // already a member, this is the desired outcome
+            return "already_member";
         }
         await membershipRepo.save({
             id: uuidv4(),
@@ -194,6 +195,7 @@ export class TeamDBImpl implements TeamDB {
             role: "member",
             creationTime: new Date().toISOString(),
         });
+        return "added";
     }
 
     public async setTeamMemberRole(userId: string, teamId: string, role: TeamMemberRole): Promise<void> {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

The current semantics (and also error handling complexity) doesn't make it worth to fail the request when joining a team you're already a member of. After all, the desired outcome is achieved so we can treat it as a success.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
1. Preview
2. Join team you're already a member of
3. See no error, transition to the team.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
