### PR TITLE
[ws-daemon] Force build of container image

### DIFF
--- a/components/ws-daemon/debug.Dockerfile
+++ b/components/ws-daemon/debug.Dockerfile
@@ -15,6 +15,9 @@ RUN apk add --no-cache curl file \
 
 FROM ubuntu:22.04
 
+# trigger manual rebuild increasing the value
+ENV TRIGGER_REBUILD=1
+
 ## Installing coreutils is super important here as otherwise the loopback device creation fails!
 ARG CLOUD_SDK_VERSION=402.0.0
 ENV CLOUD_SDK_VERSION=$CLOUD_SDK_VERSION

--- a/components/ws-daemon/leeway.Dockerfile
+++ b/components/ws-daemon/leeway.Dockerfile
@@ -11,6 +11,9 @@ RUN apk add --no-cache curl file \
 
 FROM ubuntu:22.04
 
+# trigger manual rebuild increasing the value
+ENV TRIGGER_REBUILD=1
+
 ## Installing coreutils is super important here as otherwise the loopback device creation fails!
 ARG CLOUD_SDK_VERSION=402.0.0
 ENV CLOUD_SDK_VERSION=$CLOUD_SDK_VERSION


### PR DESCRIPTION
## Description

Address openssl CVE issue

## How to test
- Check openssl version in ws-daemon is 3.0.2

## Release Notes
```release-note
NONE
```

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-integration-tests=workspace
      Valid options are `all`, `workspace`, `webapp`, `ide`
