### PR TITLE
[server, gitpod-protocol] Add getTeam

### DIFF
--- a/components/gitpod-protocol/go/gitpod-service.go
+++ b/components/gitpod-protocol/go/gitpod-service.go
@@ -84,6 +84,7 @@ type APIInterface interface {
 	TrackEvent(ctx context.Context, event *RemoteTrackMessage) (err error)
 	GetSupportedWorkspaceClasses(ctx context.Context) (res []*SupportedWorkspaceClass, err error)
 
+	GetTeam(ctx context.Context, teamID string) (*Team, error)
 	GetTeams(ctx context.Context) ([]*Team, error)
 	CreateTeam(ctx context.Context, teamName string) (*Team, error)
 	GetTeamMembers(ctx context.Context, teamID string) ([]*TeamMemberInfo, error)
@@ -210,6 +211,8 @@ const (
 	// FunctionGetSupportedWorkspaceClasses is the name of the getSupportedWorkspaceClasses function
 	FunctionGetSupportedWorkspaceClasses FunctionName = "getSupportedWorkspaceClasses"
 
+	// FunctionGetTeam is the name of the getTeam function
+	FunctionGetTeam FunctionName = "getTeam"
 	// FunctionGetTeams is the name of the getTeams function
 	FunctionGetTeams FunctionName = "getTeams"
 	// FunctionCreateTeam is the name of the createTeam function
@@ -1396,6 +1399,16 @@ func (gp *APIoverJSONRPC) GetSupportedWorkspaceClasses(ctx context.Context) (res
 	}
 	_params := []interface{}{}
 	err = gp.C.Call(ctx, "getSupportedWorkspaceClasses", _params, &res)
+	return
+}
+
+func (gp *APIoverJSONRPC) GetTeam(ctx context.Context, teamID string) (res *Team, err error) {
+	if gp == nil {
+		err = errNotConnected
+		return
+	}
+	_params := []interface{}{teamID}
+	err = gp.C.Call(ctx, string(FunctionGetTeam), _params, &res)
 	return
 }
 

--- a/components/gitpod-protocol/go/mock.go
+++ b/components/gitpod-protocol/go/mock.go
@@ -508,6 +508,21 @@ func (mr *MockAPIInterfaceMockRecorder) GetSupportedWorkspaceClasses(ctx interfa
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSupportedWorkspaceClasses", reflect.TypeOf((*MockAPIInterface)(nil).GetSupportedWorkspaceClasses), ctx)
 }
 
+// GetTeam mocks base method.
+func (m *MockAPIInterface) GetTeam(ctx context.Context, teamID string) (*Team, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTeam", ctx, teamID)
+	ret0, _ := ret[0].(*Team)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetTeam indicates an expected call of GetTeam.
+func (mr *MockAPIInterfaceMockRecorder) GetTeam(ctx, teamID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTeam", reflect.TypeOf((*MockAPIInterface)(nil).GetTeam), ctx, teamID)
+}
+
 // GetTeamMembers mocks base method.
 func (m *MockAPIInterface) GetTeamMembers(ctx context.Context, teamID string) ([]*TeamMemberInfo, error) {
 	m.ctrl.T.Helper()

--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -165,6 +165,7 @@ export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, 
     deleteSSHPublicKey(id: string): Promise<void>;
 
     // Teams
+    getTeam(teamId: string): Promise<Team>;
     getTeams(): Promise<Team[]>;
     getTeamMembers(teamId: string): Promise<TeamMemberInfo[]>;
     createTeam(name: string): Promise<Team>;

--- a/components/server/src/auth/rate-limiter.ts
+++ b/components/server/src/auth/rate-limiter.ts
@@ -96,6 +96,7 @@ const defaultFunctions: FunctionsConfig = {
     setProjectEnvironmentVariable: { group: "default", points: 1 },
     getProjectEnvironmentVariables: { group: "default", points: 1 },
     deleteProjectEnvironmentVariable: { group: "default", points: 1 },
+    getTeam: { group: "default", points: 1 },
     getTeams: { group: "default", points: 1 },
     getTeamMembers: { group: "default", points: 1 },
     createTeam: { group: "default", points: 1 },


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Adds support for looking up teams by ID. While this is currently not used by dashboard, it's needed to support `GetTeam` RPC on the Public API.

This is because the Public API does not surface the TeamMembers as a first class resorouce, rather, it's a property of a Team. As a result, when for example listing TeamMembers in the dashboard, we need to `GetTeam`. This PR makes that lookup direct, rather than listing teams and filtering.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Part of https://github.com/gitpod-io/gitpod/issues/14335

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
