### PR TITLE
[public-api] Add alerts for no metrics and failing RPCs

### DIFF
--- a/operations/observability/mixins/meta/rules/public-api.yaml
+++ b/operations/observability/mixins/meta/rules/public-api.yaml
@@ -1,0 +1,32 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: k8s
+    role: alert-rules
+  name: server-monitoring-rules
+spec:
+  groups:
+  - name: public-api
+    rules:
+    - alert: PublicAPI_NoMetrics
+      expr: absent(up{job="public-api-server"}) == 1
+      for: 15m
+      labels:
+        severity: warning
+        team: webapp
+      annotations:
+        runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/PublicAPI_NoMetrics.md
+        summary: We have not been able to collect metrics from the Public API. This can indicate an issue with the instances, or with metrics collection. Investigation required.
+        description: Metrics for Public API are not available. Either the public-api-server pods are down, or there is a problem with metric collection and we are flying blind. Investigate.
+
+    - alert: PublicAPI_ServiceReturningServerErrors
+      expr: sum(increase(connect_server_handled_seconds_count{code=~"unknown|internal|unavailable|data_loss"}[1m])) by (package, call) > 1
+      for: 15m
+      labels:
+        severity: warning
+        team: webapp
+      annotations:
+        runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/PublicAPI_ServiceReturningServerErrors.md
+        summary: PublicAPI serves multiple different Services and RPC. There have been failing requests due to server errors. Investigation required.
+        description: Service {{ $labels.package }}.{{ $labels.call }} has returned {{ printf "%.2f" $value }} server errors in the last 10 minutes.


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

* Sends alerts to webapp slack for now

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
