### PR TITLE
[db] Add a `deleted` column to the `d_b_workspace_cluster` table

### DIFF
--- a/components/gitpod-db/src/typeorm/entity/db-workspace-cluster.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-workspace-cluster.ts
@@ -91,4 +91,8 @@ export class DBWorkspaceCluster implements WorkspaceCluster {
         length: 60,
     })
     applicationCluster: string;
+
+    // This column triggers the db-sync deletion mechanism. It's not intended for public consumption.
+    @Column()
+    deleted: boolean;
 }

--- a/components/gitpod-db/src/typeorm/migration/1667375160684-AddDeletedColumnToWorkspaceClusterTable.ts
+++ b/components/gitpod-db/src/typeorm/migration/1667375160684-AddDeletedColumnToWorkspaceClusterTable.ts
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddDeletedColumnToWorkspaceClusterTable1667375160684 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            "ALTER TABLE d_b_workspace_cluster ADD COLUMN `deleted` tinyint(4) NOT NULL DEFAULT '0'",
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {}
+}

--- a/components/gitpod-db/src/workspace-cluster-db.spec.db.ts
+++ b/components/gitpod-db/src/workspace-cluster-db.spec.db.ts
@@ -37,7 +37,7 @@ export class WorkspaceClusterDBSpec {
     }
 
     @test public async findByName() {
-        const wsc1: DBWorkspaceCluster = {
+        const wsc1: DBWorkspaceCluster = dbWorkspaceCluster({
             name: "eu71",
             applicationCluster: "eu02",
             url: "some-url",
@@ -45,8 +45,8 @@ export class WorkspaceClusterDBSpec {
             score: 100,
             maxScore: 100,
             govern: true,
-        };
-        const wsc1a: DBWorkspaceCluster = {
+        });
+        const wsc1a: DBWorkspaceCluster = dbWorkspaceCluster({
             name: "eu71",
             applicationCluster: "us02",
             url: "some-url",
@@ -54,8 +54,8 @@ export class WorkspaceClusterDBSpec {
             score: 0,
             maxScore: 0,
             govern: false,
-        };
-        const wsc2: DBWorkspaceCluster = {
+        });
+        const wsc2: DBWorkspaceCluster = dbWorkspaceCluster({
             name: "us71",
             applicationCluster: "eu02",
             url: "some-url",
@@ -63,7 +63,7 @@ export class WorkspaceClusterDBSpec {
             score: 0,
             maxScore: 0,
             govern: false,
-        };
+        });
 
         await this.db.save(wsc1);
         await this.db.save(wsc1a);
@@ -89,7 +89,7 @@ export class WorkspaceClusterDBSpec {
     }
 
     @test public async deleteByName() {
-        const wsc1: DBWorkspaceCluster = {
+        const wsc1: DBWorkspaceCluster = dbWorkspaceCluster({
             name: "eu71",
             applicationCluster: "eu02",
             url: "some-url",
@@ -97,8 +97,8 @@ export class WorkspaceClusterDBSpec {
             score: 100,
             maxScore: 100,
             govern: true,
-        };
-        const wsc1a: DBWorkspaceCluster = {
+        });
+        const wsc1a: DBWorkspaceCluster = dbWorkspaceCluster({
             name: "eu71",
             applicationCluster: "us02",
             url: "some-url",
@@ -106,8 +106,8 @@ export class WorkspaceClusterDBSpec {
             score: 0,
             maxScore: 0,
             govern: false,
-        };
-        const wsc2: DBWorkspaceCluster = {
+        });
+        const wsc2: DBWorkspaceCluster = dbWorkspaceCluster({
             name: "us71",
             applicationCluster: "eu02",
             url: "some-url",
@@ -115,7 +115,7 @@ export class WorkspaceClusterDBSpec {
             score: 0,
             maxScore: 0,
             govern: false,
-        };
+        });
 
         await this.db.save(wsc1);
         await this.db.save(wsc1a);
@@ -129,7 +129,7 @@ export class WorkspaceClusterDBSpec {
     }
 
     @test public async testFindFilteredByName() {
-        const wsc1: DBWorkspaceCluster = {
+        const wsc1: DBWorkspaceCluster = dbWorkspaceCluster({
             name: "eu71",
             applicationCluster: "eu02",
             url: "some-url",
@@ -137,8 +137,8 @@ export class WorkspaceClusterDBSpec {
             score: 100,
             maxScore: 100,
             govern: true,
-        };
-        const wsc1a: DBWorkspaceCluster = {
+        });
+        const wsc1a: DBWorkspaceCluster = dbWorkspaceCluster({
             name: "eu71",
             applicationCluster: "us02",
             url: "some-url",
@@ -146,8 +146,8 @@ export class WorkspaceClusterDBSpec {
             score: 0,
             maxScore: 0,
             govern: false,
-        };
-        const wsc2: DBWorkspaceCluster = {
+        });
+        const wsc2: DBWorkspaceCluster = dbWorkspaceCluster({
             name: "us71",
             applicationCluster: "eu02",
             url: "some-url",
@@ -155,7 +155,7 @@ export class WorkspaceClusterDBSpec {
             score: 0,
             maxScore: 0,
             govern: false,
-        };
+        });
 
         await this.db.save(wsc1);
         await this.db.save(wsc1a);
@@ -168,7 +168,7 @@ export class WorkspaceClusterDBSpec {
     }
 
     @test public async testFindFilteredByApplicationCluster() {
-        const wsc1: DBWorkspaceCluster = {
+        const wsc1: DBWorkspaceCluster = dbWorkspaceCluster({
             name: "eu71",
             applicationCluster: "eu02",
             url: "some-url",
@@ -176,8 +176,8 @@ export class WorkspaceClusterDBSpec {
             score: 100,
             maxScore: 100,
             govern: true,
-        };
-        const wsc1a: DBWorkspaceCluster = {
+        });
+        const wsc1a: DBWorkspaceCluster = dbWorkspaceCluster({
             name: "eu71",
             applicationCluster: "us02",
             url: "some-url",
@@ -185,8 +185,8 @@ export class WorkspaceClusterDBSpec {
             score: 0,
             maxScore: 0,
             govern: false,
-        };
-        const wsc2: DBWorkspaceCluster = {
+        });
+        const wsc2: DBWorkspaceCluster = dbWorkspaceCluster({
             name: "us71",
             applicationCluster: "us02",
             url: "some-url",
@@ -194,7 +194,7 @@ export class WorkspaceClusterDBSpec {
             score: 100,
             maxScore: 100,
             govern: true,
-        };
+        });
 
         await this.db.save(wsc1);
         await this.db.save(wsc1a);
@@ -242,6 +242,10 @@ export class WorkspaceClusterDBSpec {
         expect(wscs2.length).to.equal(2);
         expect(wscs2).to.deep.include.members(expectedClusters2);
     }
+}
+
+function dbWorkspaceCluster(cluster: Omit<DBWorkspaceCluster, "deleted">): DBWorkspaceCluster {
+    return { ...cluster, deleted: false };
 }
 
 module.exports = WorkspaceClusterDBSpec;


### PR DESCRIPTION
## Description

Add a `deleted` column to the `d_b_workspace_cluster` table. This will allow rows to be soft-deleted in a follow-up PR.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of #9198 and #13800 

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
