### PR TITLE
[ws-manager-bridge] Take the applicationCluster from config

### DIFF
--- a/components/ws-manager-bridge/src/cluster-service-server.ts
+++ b/components/ws-manager-bridge/src/cluster-service-server.ts
@@ -110,14 +110,6 @@ export class ClusterService implements IClusterServiceServer {
                     }
                 }
 
-                const applicationCluster = process.env.GITPOD_INSTALLATION_SHORTNAME;
-                if (applicationCluster === undefined) {
-                    throw new GRPCError(
-                        grpc.status.INTERNAL,
-                        "no GITPOD_INSTALLATION_SHORTNAME environment variable is set on the server",
-                    );
-                }
-
                 // store the ws-manager into the database
                 let perfereability = Preferability.NONE;
                 let govern = false;
@@ -152,7 +144,7 @@ export class ClusterService implements IClusterServiceServer {
                 const newCluster: WorkspaceCluster = {
                     name: req.name,
                     url: req.url,
-                    applicationCluster,
+                    applicationCluster: this.config.installation,
                     state,
                     score,
                     maxScore: 100,


### PR DESCRIPTION
## Description

When registering a new workspace cluster take the `applicationCluster` for the new ws cluster from config as happens elsewhere in this module rather than from the environment.

## Related Issue(s)
Part of #9198 

## How to test

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
