### PR TITLE
[bitbucket-server] improve logging of webhook installation

### DIFF
--- a/components/server/ee/src/prebuilds/bitbucket-server-service.ts
+++ b/components/server/ee/src/prebuilds/bitbucket-server-service.ts
@@ -48,9 +48,7 @@ export class BitbucketServerService extends RepositoryService {
 
         const identity = user.identities.find((i) => i.authProviderId === this.authProviderConfig.id);
         if (!identity) {
-            console.error(
-                `Unexpected call of canInstallAutomatedPrebuilds. Not authorized with ${this.authProviderConfig.host}.`,
-            );
+            console.error(`BBS: no identity found.`, { host: this.authProviderConfig.host, userId: user.id, cloneUrl });
             return false;
         }
 
@@ -58,6 +56,7 @@ export class BitbucketServerService extends RepositoryService {
             await this.api.getWebhooks(user, { repoKind, repositorySlug: repoName, owner });
             // reading webhooks to check if admin scope is provided
         } catch (error) {
+            console.log(`BBS: could not read webhooks.`, error, { error, cloneUrl });
             return false;
         }
 
@@ -77,9 +76,7 @@ export class BitbucketServerService extends RepositoryService {
             return true;
         }
 
-        console.debug(
-            `User is not allowed to install webhooks.\n${JSON.stringify(identity)}\n${JSON.stringify(permission)}`,
-        );
+        console.log(`BBS: Not allowed to install webhooks.`, { permission });
         return false;
     }
 
@@ -97,7 +94,7 @@ export class BitbucketServerService extends RepositoryService {
         });
         const hookUrl = this.getHookUrl();
         if (existing.values && existing.values.some((hook) => hook.url && hook.url.indexOf(hookUrl) !== -1)) {
-            console.log(`BBS webhook already installed on ${cloneUrl}`);
+            console.log(`BBS webhook already installed.`, { cloneUrl });
             return;
         }
         const tokenEntry = await this.tokenService.createGitpodToken(
@@ -119,9 +116,9 @@ export class BitbucketServerService extends RepositoryService {
                     events: ["repo:refs_changed"],
                 },
             );
-            console.log("Installed Bitbucket Server Webhook for " + cloneUrl);
+            console.log("BBS: webhook installed.", { cloneUrl });
         } catch (error) {
-            console.error(`Couldn't install Bitbucket Server Webhook for ${cloneUrl}`, error);
+            console.error(`BBS: webhook installation failed.`, error, { cloneUrl, error });
         }
     }
 

--- a/components/server/src/bitbucket-server/bitbucket-server-api.ts
+++ b/components/server/src/bitbucket-server/bitbucket-server-api.ts
@@ -57,7 +57,7 @@ export class BitbucketServerApi {
             result = "error " + error?.message;
             throw error;
         } finally {
-            console.debug(`BitbucketServer GET ${fullUrl} - ${result}`);
+            console.log(`BBS: ${method} ${fullUrl} - ${result}`);
         }
     }
 


### PR DESCRIPTION
## Description
Extends logging around webhook installation to enable investigation of #13998.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related #13998

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
