### PR TITLE
Upgrade gcloud CLI to 408.0.0

### DIFF
--- a/dev/image/Dockerfile
+++ b/dev/image/Dockerfile
@@ -146,7 +146,7 @@ ARG GCS_DIR=/opt/google-cloud-sdk
 ENV PATH=$GCS_DIR/bin:$PATH
 RUN sudo chown gitpod: /opt \
     && mkdir $GCS_DIR \
-    && curl -fsSL https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-400.0.0-linux-x86_64.tar.gz \
+    && curl -fsSL https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-408.0.0-linux-x86_64.tar.gz \
     | tar -xzvC /opt \
     && /opt/google-cloud-sdk/install.sh --quiet --usage-reporting=false --bash-completion=true \
     --additional-components gke-gcloud-auth-plugin docker-credential-gcr alpha beta \


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

TBD

TODO: Open a separate PR which upgrades Leeway to the latest version and removes (--dont-retag) flag

### Notes

`gcloud storage` was promoted to GA in 402.0.0 (2022-09-13) ([link](https://cloud.google.com/sdk/docs/release-notes#40200_2022-09-13))

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of https://github.com/gitpod-io/ops/issues/5814
Part of https://github.com/gitpod-io/gitpod/issues/13714

## How to test
<!-- Provide steps to test this PR -->

On a workspace off main

```sh
# Modify ./dev/preview/workflow/preview/build.sh to use --dry-run to not time actual build
gcloud auth login --no-launch-browser
time leeway run dev/preview:build
```

On a workspace from this branch

```sh
# Modify ./dev/preview/workflow/preview/build.sh to use --dry-run to not time actual build
go install github.com/gitpod-io/leeway@mads-use-gcloud
which leeway
# verify it uses the one from /workspace/go/bin/leeway
gcloud auth login --no-launch-browser
time leeway run dev/preview:build
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
