### PR TITLE
kubecdl: use label filter to find the exact cluster

### DIFF
--- a/dev/kubecdl/main.go
+++ b/dev/kubecdl/main.go
@@ -127,7 +127,7 @@ func getNodeName(clusterName, project string) (nodeName, zone string, err error)
 		Zone string `json:"zone"`
 	}
 
-	out, err := exec.Command("gcloud", "compute", "instances", "list", "--format=json", "--quiet", "--project", project, "--filter=name~server-ws-.*"+clusterName).CombinedOutput()
+	out, err := exec.Command("gcloud", "compute", "instances", "list", "--format=json", "--quiet", "--project", project, "--filter", "labels.cluster-name>=ws-"+clusterName+" AND labels.cluster-name<=ws-"+clusterName).CombinedOutput()
 	if err != nil {
 		return "", "", fmt.Errorf("failed to describe node instances: %s: %w", string(out), err)
 	}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
According to https://cloud.google.com/sdk/gcloud/reference/topic/filters#Operator-Terms
The operators `=` and `:` are deprecated.
If we want to test equality, we should use `key <= value AND key >= value`.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
Create two cluster name
- ephemeral-74
- ephemeral-74-1

Download the kubeconfig
```console
kubecdl ephemeral-74
kubecdl ephemeral-74-1
```

Then, run these commands without hitting the error `x509: certificate signed by unknown authority`. 
```console
kubectx ephemeral-74
kubectx ephemeral-74-1
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
None

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
