### PR TITLE
[supervisor] Force build of container image

### DIFF
--- a/components/supervisor/openssh/leeway.Dockerfile
+++ b/components/supervisor/openssh/leeway.Dockerfile
@@ -22,6 +22,9 @@
 # This Dockerfile was taken from https://github.com/ep76/docker-openssh-static and adapted.
 FROM alpine:3.16 AS builder
 
+# trigger manual rebuild increasing the value
+ENV TRIGGER_REBUILD=1
+
 ARG openssh_url=https://github.com/openssh/openssh-portable/archive/refs/tags/V_9_0_P1.tar.gz
 
 WORKDIR /build


### PR DESCRIPTION
## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
