### PR TITLE
[db] Soft delete records in the `d_b_workspace_cluster` table

### DIFF
--- a/components/gitpod-db/src/typeorm/workspace-cluster-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/workspace-cluster-db-impl.ts
@@ -39,7 +39,7 @@ export class WorkspaceClusterDBImpl implements WorkspaceClusterDB {
 
     async findByName(name: string, applicationCluster: string): Promise<WorkspaceCluster | undefined> {
         const repo = await this.getRepo();
-        return repo.findOne({ name, applicationCluster });
+        return repo.findOne({ name, applicationCluster, deleted: false });
     }
 
     async findFiltered(predicate: WorkspaceClusterFilter): Promise<WorkspaceClusterWoTLS[]> {

--- a/components/gitpod-db/src/typeorm/workspace-cluster-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/workspace-cluster-db-impl.ts
@@ -58,7 +58,7 @@ export class WorkspaceClusterDBImpl implements WorkspaceClusterDB {
         let qb = repo
             .createQueryBuilder("wsc")
             .select(Object.keys(prototype).map((k) => `wsc.${k}`))
-            .where("TRUE = TRUE"); // make sure andWhere works
+            .where("wsc.deleted = 0");
         if (predicate.name !== undefined) {
             qb = qb.andWhere("wsc.name = :name", predicate);
         }

--- a/components/gitpod-db/src/typeorm/workspace-cluster-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/workspace-cluster-db-impl.ts
@@ -34,7 +34,7 @@ export class WorkspaceClusterDBImpl implements WorkspaceClusterDB {
 
     async deleteByName(name: string, applicationCluster: string): Promise<void> {
         const repo = await this.getRepo();
-        await repo.delete({ name, applicationCluster });
+        await repo.update({ name, applicationCluster }, { deleted: true });
     }
 
     async findByName(name: string, applicationCluster: string): Promise<WorkspaceCluster | undefined> {


### PR DESCRIPTION
## Description

Soft delete records in the `d_b_workspace_cluster` table. This will allow the table to be synced by `db-sync` in a subsequent PR.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of #9198 and #13800.

Follow up to https://github.com/gitpod-io/gitpod/pull/14340.

## How to test

Database unit tests.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
