### PR TITLE
[installer] Add a placeholder for an experimental toxiproxy component

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -50,6 +50,7 @@
 /install/installer/pkg/components/server @gitpod-io/engineering-webapp
 /install/installer/pkg/components/server/ide @gitpod-io/engineering-ide
 /install/installer/pkg/components/usage @gitpod-io/engineering-webapp
+/install/installer/pkg/components/toxiproxy @gitpod-io/engineering-webapp
 /install/installer/pkg/components/usage-api @gitpod-io/engineering-webapp
 /install/installer/pkg/components/workspace @gitpod-io/engineering-workspace
 /install/installer/pkg/components/workspace/ide @gitpod-io/engineering-ide

--- a/install/installer/pkg/components/components-webapp/components.go
+++ b/install/installer/pkg/components/components-webapp/components.go
@@ -20,6 +20,7 @@ import (
 	public_api_server "github.com/gitpod-io/gitpod/installer/pkg/components/public-api-server"
 	"github.com/gitpod-io/gitpod/installer/pkg/components/rabbitmq"
 	"github.com/gitpod-io/gitpod/installer/pkg/components/server"
+	"github.com/gitpod-io/gitpod/installer/pkg/components/toxiproxy"
 	"github.com/gitpod-io/gitpod/installer/pkg/components/usage"
 	wsmanagerbridge "github.com/gitpod-io/gitpod/installer/pkg/components/ws-manager-bridge"
 )
@@ -41,6 +42,7 @@ var Objects = common.CompositeRenderFunc(
 	wsmanagerbridge.Objects,
 	public_api_server.Objects,
 	usage.Objects,
+	toxiproxy.Objects,
 )
 
 var Helm = common.CompositeHelmFunc(

--- a/install/installer/pkg/components/toxiproxy/configmap.go
+++ b/install/installer/pkg/components/toxiproxy/configmap.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
+package toxiproxy
+
+import (
+	"github.com/gitpod-io/gitpod/installer/pkg/common"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
+	return []runtime.Object{
+		&corev1.ConfigMap{
+			TypeMeta: common.TypeMetaConfigmap,
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        Component,
+				Namespace:   ctx.Namespace,
+				Labels:      common.CustomizeLabel(ctx, Component, common.TypeMetaConfigmap),
+				Annotations: common.CustomizeAnnotation(ctx, Component, common.TypeMetaConfigmap),
+			},
+		},
+	}, nil
+}

--- a/install/installer/pkg/components/toxiproxy/constants.go
+++ b/install/installer/pkg/components/toxiproxy/constants.go
@@ -1,0 +1,8 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
+package toxiproxy
+
+const (
+	Component = "toxiproxy"
+)

--- a/install/installer/pkg/components/toxiproxy/objects.go
+++ b/install/installer/pkg/components/toxiproxy/objects.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
+package toxiproxy
+
+import (
+	"github.com/gitpod-io/gitpod/installer/pkg/common"
+	"github.com/gitpod-io/gitpod/installer/pkg/config/v1/experimental"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func Objects(ctx *common.RenderContext) ([]runtime.Object, error) {
+	cfg := getExperimentalToxiproxyConfig(ctx)
+	if cfg == nil || !cfg.Enabled {
+		return nil, nil
+	}
+
+	return common.CompositeRenderFunc(
+		configmap,
+		common.DefaultServiceAccount(Component),
+	)(ctx)
+}
+
+func getExperimentalWebAppConfig(ctx *common.RenderContext) *experimental.WebAppConfig {
+	var experimentalCfg *experimental.Config
+	_ = ctx.WithExperimental(func(ucfg *experimental.Config) error {
+		experimentalCfg = ucfg
+		return nil
+	})
+
+	if experimentalCfg == nil || experimentalCfg.WebApp == nil {
+		return nil
+	}
+
+	return experimentalCfg.WebApp
+}
+
+func getExperimentalToxiproxyConfig(ctx *common.RenderContext) *experimental.ToxiproxyConfig {
+	experimentalWebAppCfg := getExperimentalWebAppConfig(ctx)
+	if experimentalWebAppCfg == nil || experimentalWebAppCfg.Toxiproxy == nil {
+		return nil
+	}
+
+	return experimentalWebAppCfg.Toxiproxy
+}

--- a/install/installer/pkg/components/toxiproxy/objects.go
+++ b/install/installer/pkg/components/toxiproxy/objects.go
@@ -10,8 +10,8 @@ import (
 )
 
 func Objects(ctx *common.RenderContext) ([]runtime.Object, error) {
-	cfg := getExperimentalToxiproxyConfig(ctx)
-	if cfg == nil || !cfg.Enabled {
+	cfg := getExperimentalWebAppConfig(ctx)
+	if cfg == nil || !cfg.SlowDatabase {
 		return nil, nil
 	}
 
@@ -33,13 +33,4 @@ func getExperimentalWebAppConfig(ctx *common.RenderContext) *experimental.WebApp
 	}
 
 	return experimentalCfg.WebApp
-}
-
-func getExperimentalToxiproxyConfig(ctx *common.RenderContext) *experimental.ToxiproxyConfig {
-	experimentalWebAppCfg := getExperimentalWebAppConfig(ctx)
-	if experimentalWebAppCfg == nil || experimentalWebAppCfg.Toxiproxy == nil {
-		return nil
-	}
-
-	return experimentalWebAppCfg.Toxiproxy
 }

--- a/install/installer/pkg/components/toxiproxy/objects_test.go
+++ b/install/installer/pkg/components/toxiproxy/objects_test.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
+package toxiproxy
+
+import (
+	"testing"
+
+	"github.com/gitpod-io/gitpod/installer/pkg/common"
+	"github.com/gitpod-io/gitpod/installer/pkg/config/v1"
+	"github.com/gitpod-io/gitpod/installer/pkg/config/v1/experimental"
+	"github.com/gitpod-io/gitpod/installer/pkg/config/versions"
+	"github.com/stretchr/testify/require"
+)
+
+func TestObjects_NotRenderedByDefault(t *testing.T) {
+	ctx, err := common.NewRenderContext(config.Config{}, versions.Manifest{}, "test-namespace")
+	require.NoError(t, err)
+
+	objects, err := Objects(ctx)
+	require.NoError(t, err)
+	require.Empty(t, objects, "no objects should be rendered with default config")
+}
+
+func TestObjects_RenderedWhenExperimentalConfigSet(t *testing.T) {
+	ctx := renderContextWithToxiproxyEnabled(t)
+
+	objects, err := Objects(ctx)
+	require.NoError(t, err)
+	require.NotEmpty(t, objects, "must render objects because experimental config is specified")
+	require.Len(t, objects, 2, "should render expected k8s objects")
+}
+
+func renderContextWithToxiproxyEnabled(t *testing.T) *common.RenderContext {
+	ctx, err := common.NewRenderContext(config.Config{
+		Experimental: &experimental.Config{
+			WebApp: &experimental.WebAppConfig{
+				Toxiproxy: &experimental.ToxiproxyConfig{Enabled: true},
+			},
+		},
+	}, versions.Manifest{}, "test-namespace")
+	require.NoError(t, err)
+
+	return ctx
+}

--- a/install/installer/pkg/components/toxiproxy/objects_test.go
+++ b/install/installer/pkg/components/toxiproxy/objects_test.go
@@ -23,7 +23,7 @@ func TestObjects_NotRenderedByDefault(t *testing.T) {
 }
 
 func TestObjects_RenderedWhenExperimentalConfigSet(t *testing.T) {
-	ctx := renderContextWithToxiproxyEnabled(t)
+	ctx := renderContextWithSlowDatabaseEnabled(t)
 
 	objects, err := Objects(ctx)
 	require.NoError(t, err)
@@ -31,11 +31,13 @@ func TestObjects_RenderedWhenExperimentalConfigSet(t *testing.T) {
 	require.Len(t, objects, 2, "should render expected k8s objects")
 }
 
-func renderContextWithToxiproxyEnabled(t *testing.T) *common.RenderContext {
+func renderContextWithSlowDatabaseEnabled(t *testing.T) *common.RenderContext {
+	t.Helper()
+
 	ctx, err := common.NewRenderContext(config.Config{
 		Experimental: &experimental.Config{
 			WebApp: &experimental.WebAppConfig{
-				Toxiproxy: &experimental.ToxiproxyConfig{Enabled: true},
+				SlowDatabase: true,
 			},
 		},
 	}, versions.Manifest{}, "test-namespace")

--- a/install/installer/pkg/config/v1/experimental/experimental.go
+++ b/install/installer/pkg/config/v1/experimental/experimental.go
@@ -177,6 +177,10 @@ type StripeConfig struct {
 	TeamUsagePriceIDs       StripePriceIDs `json:"teamUsagePriceIds"`
 }
 
+type ToxiproxyConfig struct {
+	Enabled bool `json:"enabled"`
+}
+
 type WebAppConfig struct {
 	PublicAPI              *PublicAPIConfig       `json:"publicApi,omitempty"`
 	Server                 *ServerConfig          `json:"server,omitempty"`
@@ -189,6 +193,7 @@ type WebAppConfig struct {
 	ConfigcatKey           string                 `json:"configcatKey"`
 	WorkspaceClasses       []WebAppWorkspaceClass `json:"workspaceClasses"`
 	Stripe                 *StripeConfig          `json:"stripe,omitempty"`
+	Toxiproxy              *ToxiproxyConfig       `json:"toxiproxy,omitempty"`
 }
 
 type WorkspaceDefaults struct {

--- a/install/installer/pkg/config/v1/experimental/experimental.go
+++ b/install/installer/pkg/config/v1/experimental/experimental.go
@@ -177,10 +177,6 @@ type StripeConfig struct {
 	TeamUsagePriceIDs       StripePriceIDs `json:"teamUsagePriceIds"`
 }
 
-type ToxiproxyConfig struct {
-	Enabled bool `json:"enabled"`
-}
-
 type WebAppConfig struct {
 	PublicAPI              *PublicAPIConfig       `json:"publicApi,omitempty"`
 	Server                 *ServerConfig          `json:"server,omitempty"`
@@ -193,7 +189,7 @@ type WebAppConfig struct {
 	ConfigcatKey           string                 `json:"configcatKey"`
 	WorkspaceClasses       []WebAppWorkspaceClass `json:"workspaceClasses"`
 	Stripe                 *StripeConfig          `json:"stripe,omitempty"`
-	Toxiproxy              *ToxiproxyConfig       `json:"toxiproxy,omitempty"`
+	SlowDatabase           bool                   `json:"slowDatabase,omitempty"`
 }
 
 type WorkspaceDefaults struct {


### PR DESCRIPTION
## Description

Add a new `experimental.webapp.slowDatabase` experimental flag to the installer. When the new flag is set, render an empty placeholder Toxiproxy configmap.

As part of #9198, [Toxiproxy](https://github.com/Shopify/toxiproxy) will be used to inject latency into database connections to allow us to measure and test the UX of working with a distant database (eg a US database from the EU).

The new component is a placeholder, rendering an empty configmap. In subsequent PRs, the component will be extended to add a Toxiproxy deployment, service and config file.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of #9198 

## How to test

Installer unit tests.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
