### PR TITLE
Add script to debug build cache sizes

### DIFF
--- a/dev/preview/BUILD.yaml
+++ b/dev/preview/BUILD.yaml
@@ -33,3 +33,9 @@ scripts:
   - name: deploy-gitpod
     description: Deploys Gitpod to an existing preview environment
     script: ./workflow/preview/deploy-gitpod.sh
+
+  - name: debug-build-size
+    description: Use this to debug build cache sizes
+    script: |
+      DEBUG_BUILD_CACHE_SIZES=true leeway run dev/preview:build
+      ./workflow/preview/debug-build-cache-size.sh

--- a/dev/preview/workflow/preview/build.sh
+++ b/dev/preview/workflow/preview/build.sh
@@ -70,3 +70,15 @@ leeway build \
     --dont-retag \
     --dont-test \
     install/installer:app
+
+# shellcheck disable=SC2016
+if [[ -n "${DEBUG_BUILD_CACHE_SIZES}" ]]; then
+    rm -f /tmp/collect.txt
+    leeway collect \
+        -DSEGMENT_IO_TOKEN="$(kubectl --context=dev -n werft get secret self-hosted -o jsonpath='{.data.segmentIOToken}' | base64 -d)" \
+        -DREPLICATED_API_TOKEN="$(kubectl --context=dev -n werft get secret replicated -o jsonpath='{.data.token}' | base64 -d)" \
+        -DREPLICATED_APP="$(kubectl --context=dev -n werft get secret replicated -o jsonpath='{.data.app}' | base64 -d)" \
+        -Dversion="${VERSION}" \
+        --format-string '{{ range $n := . }}{{ $n.Metadata.FullName }}{{"\t"}}{{ $n.Metadata.Version }}{{"\n"}}{{end}}' \
+    > /tmp/collect.txt
+fi

--- a/dev/preview/workflow/preview/debug-build-cache-size.sh
+++ b/dev/preview/workflow/preview/debug-build-cache-size.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+echo
+echo "Finding the size of each package"
+echo
+
+# shellcheck disable=SC2012
+ls -lh --sort=size /tmp/cache/*.tar.gz | while read -r line
+do
+    IFS=" " read -r -a info <<< "$line"
+    IFS="/" read -r -a path <<< "${info[8]}"
+    size=${info[4]}
+    version=${path[3]//.tar.gz/}
+    package=$(grep "$version" /tmp/collect.txt)
+    if [[ -n "${package}" ]]; then
+        printf "%s\t%s\n" "${size}" "${package}"
+    fi
+done


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This introduces a Leeway script that we can use to debug the build size cache of the packages that are relevant for preview environments.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

Part of https://github.com/gitpod-io/ops/issues/5814

## How to test
<!-- Provide steps to test this PR -->

```sh
leeway run dev/preview:debug-build-size
```

```
Finding the size of each package

1.1G    components/ide/jetbrains/image:download-intellij-latest                3698fb6fc813dbd04a41cbe5d27a207975182489
992M    components/ide/jetbrains/image:download-intellij                       12eed37c1e41cddfcfca5d8ed1ba4b3ba1576c2c
693M    components/ide/jetbrains/image:download-pycharm-latest                 67e6685d2da09fa7e45532887a37bf1f5a354339
666M    components/ide/jetbrains/image:download-pycharm                        be2718b99d17c838f44d397818b9053ac20744d0
649M    components/ide/jetbrains/image:download-goland-latest                  d1498d3d1cbaefdfda55b3bea1879b1bccb85942
629M    components/ide/jetbrains/image:download-phpstorm-latest                5e94eaafa57ad0047952d3fe63e3914778f5d14b
626M    components/ide/jetbrains/image:download-goland                         8394a46c9cb389a0ac99f291b1d28d5f73ea64e5
610M    components/ide/jetbrains/image:download-rubymine-latest                fad65bc48c48031eec9aa9a10d1a474a948439ae
598M    components/ide/jetbrains/image:download-phpstorm                       d7bba1f539d7ce5777108c61b3a281754b2bb7e2
584M    components/ide/jetbrains/image:download-rubymine                       4a6784ed4c0d5d2cb05757a6612053088bf898cc
566M    components/ide/jetbrains/image:download-webstorm-latest                5127b41226e8db7154322560be5bc231e1fbe76e
545M    components/ide/jetbrains/image:download-webstorm                       16887c21115ace702cf14f9e77873b8c6e43f3d1
152M    components/docker-up:bin-docker-up                                     639d0c6716342e766b87934f5c8acd14cf56e58e
148M    test:app                                                               0e063200cc3c2d0ca17bf89ae4a95c74162e95fa
113M    components/ee/db-sync:app                                              5083e9f3416cb439bf9e2d02f621b683ac88fe83
93M     components/ide/jetbrains/backend-plugin:plugin-latest                  38188783d3ee585c37fa88f20a47b66d93c8e37e
93M     components/ide/jetbrains/backend-plugin:plugin-stable                  559b4ef5e6e4c0480a9bad506221cdc2ddd0874c
91M     components/server:app                                                  38418d98e51fb0443a74dc0ca02bb687555931ae
89M     components/docker-up:app                                               05556dfacf61b831a30e91da19862a7245db821a
84M     components/dashboard:app                                               27e016c06c26714666d9b251576b530e8e50517a
49M     components/ws-manager-bridge:app                                       69386b68e499363607b4eca2464b1f71d8726997
47M     components/ee/payment-endpoint:app                                     5d9e30436e48d1fe810883e6878d9782696bcb15
36M     components/supervisor-api/java:lib                                     f8ee547b595200c5e908497090bbe373183e6b19
33M     components/local-app:app                                               698c14a5ab72a4d4c75730075a8bf275a5ce2382
32M     components/ws-daemon:app                                               f8eeb8a5843c74f8ced7bd20fabe98f8c5776e10
24M     components/ws-proxy:app                                                d2c587b305233235471dea7cdb88414a3f4c3553
23M     install/installer:app                                                  abb9de570aff85fbc769b9fc22aaca59573940d7
23M     components/gitpod-db:migrations                                        fc1f840cc314f62f50eb0e18ad21e2891df017b4
20M     install/installer:raw-app                                              a5360fa84dd1184587b390fa742676ce7baad683
18M     dev/ready-probe-labeler:app                                            5f582a322620016f0db812a4ed349aa9f2f468c2
14M     components/ws-manager:app                                              893ab89aeca8e72a04c8c67e42181cfbebe94ee3
14M     components/supervisor/openssh:app                                      7f42f99194e44bd0f2de53569f3f3342cbfb5815
14M     components/supervisor/openssh:docker-build                             659bff64bbdc2d10a97c9d627cdd568cbb5bc17b
12M     components/licensor/typescript:lib                                     395abf3d9bc2e75766191a5d2f2136a8d765bdaf
12M     components/image-builder-bob:app                                       8db50761bcade0181d82aabbb6d10e3b1e500a86
11M     components/ee/agent-smith:app                                          232bbf468ca410aabddb02037a4297eebf828940
9.6M    components/ide-service:app                                             b8f37c34cecc7cae2d13e17f78f8cb5ffad0b038
9.3M    components/registry-facade:app                                         15398deee0e5221feecc996f936fd33a6d7c66c5
8.6M    components/ide-metrics:app                                             0cb7ca378d22b9e26c6363db23a01dddb7126cae
8.6M    components/blobserve:app                                               8a434d1ec1d1cde854a25986bf14a6570265be00
8.3M    components/ws-daemon:content-initializer                               4b3280347cd371bb26bdd67cf00d15b77c6d3314
7.6M    components/supervisor/frontend:app                                     c873ed834c922809acf4471796e0fbd7979fcacd
7.4M    components/ide/code-desktop/status:app                                 25a1b2153be4e0017dfcdd2795931755cf0997ca
7.1M    components/content-service:app                                         61a8384774332f4db343f3788de9bb2f420b0113
6.9M    components/supervisor:app                                              7c2ea469f19b356149193a0aad407ee142d6af07
6.1M    components/usage:app                                                   60ed47b3d8bbb7575b74bf9aba5ecf0fdbde8444
5.5M    components/image-builder-mk3:app                                       c0c55fbaeb93b17b91ddd63c6d985c869500b69e
5.1M    components/public-api-server:app                                       6a0192206b9db43fc3baa16b7fa5c4e64d7129e9
5.0M    components/gitpod-protocol/java:lib                                    fc5b746b8d34e94851ddcfd792712303e583a426
4.9M    components/local-app:app-darwin-amd64                                  48254c1f0e65d309c0a46116e0405f10649f9a91
4.9M    components/workspacekit:app                                            20faa75547c30bc0734f600d7158b04d48fc09e1
4.9M    components/local-app:app-linux-amd64                                   6328c8345bc87ee58638477b219220e63496e473
4.8M    components/local-app:app-windows-amd64                                 1562f5bde23fa147412181ead148c7da2f842f26
4.7M    components/local-app:app-darwin-arm64                                  88dd2af26c8fb5271a05640bd6df78c9d2374a61
4.7M    components/local-app:app-windows-386                                   bd0bb8183b600a0232b548790101c72d64c198b0
4.7M    components/ide/jetbrains/cli:app                                       4c211e477205996c3e771f966ad909b0c8a90a73
4.6M    components/gitpod-cli:app                                              ce37f91e27763d4fa11b85730f1c7d2fe76f17df
4.4M    components/local-app:app-linux-arm64                                   e29d4824074a6d9db43f125dd4eca2197afe4556
4.4M    components/local-app:app-windows-arm64                                 f15ba317d0d0ee342ca5ce0232ea8a703c3e9338
4.2M    components/ide/jetbrains/image/status:app                              01935b78ce9e4ad68d3dbbe6ebea54ef739b8300
4.0M    components/ide/code/codehelper:app                                     e34b4a494a6bc5b0468f0a4ecc72a8dd9adaeb95
3.8M    components/ws-daemon/seccomp-profile-installer:profile                 38da8adc9c62acff9eee2e59d6c9ed13f6c8528a
3.8M    components/ws-daemon/seccomp-profile-installer:app                     3ba872b24d83916d0420753f8257f5e8aad9432e
3.8M    components/openvsx-proxy:app                                           cb9c6a01061b66c246e6e56cb1f6baefeff04b7a
3.5M    components:all-docker                                                  302b807d95c2da46abcf360f145883a1cfe30f37
3.1M    components/ws-daemon/nsinsider:app                                     c4bdc3c32a0c58b72e6dda0d2d4f6c68fe1068ae
3.0M    components/service-waiter:app                                          ab3672a4a42c0b1a061b56ecee8a09d217476d0d
2.7M    components/kots-config-check/registry:app                              afd1b48fa6e8d9ec47471402ae7b91291d2a3f6e
2.7M    components/installation-telemetry:app                                  bf7172ad9edb5812f0c6fbc9132c4263f01d7c9a
2.6M    components/image-builder-bob:runc-facade                               901dbe2ecec7cf057121853eba70959ca380781d
2.1M    dev/addlicense:app                                                     f153510422337dcd13463bc4081dd6cbba780265
1.7M    dev/version-manifest:app                                               fdcb383b6ade5e0aaf26badcbb3e56067edcf881
1.7M    components/docker-up:bin-runc-facade                                   824e89649d487f619c1f544d2bb5519e180719dd
873K    components/workspacekit:fuse-overlayfs                                 a0ad599f52e5c3ab725dba81d9996131ef7eebca
753K    components/ws-daemon:lib                                               8fe5379157c7857fbc03447bfa96d8c522220069
462K    components/ide/jetbrains/image:pycharm-latest                          69c9b1ec7d0f1ffc8e678b0b25f85675d92f03f1
457K    components/gitpod-db:lib                                               4ea49406fa2d935aed403c360494d61b7d78a008
452K    components/ide/jetbrains/image:pycharm                                 dd313b084c6140e422390005d2c78dcc4575d442
414K    components/ide/jetbrains/image:rubymine-latest                         b3ebc0dfa2c566b87eb6d424cc0f16799ad2ab7a
397K    components/ide/jetbrains/image:rubymine                                75dab4fcfeed0c2dbffe8b262dc969c88bd05789
394K    components/ee/payment-endpoint:lib                                     41f5aa2f47b078a322cc44d237d6c91c5136d1e8
387K    components/server:docker                                               9cfdc2fe1ab4482b8224f14e227b6d0f859e3f23
369K    components/gitpod-db:dbtest                                            adcbd037cccd28f49d61f2a3c48f9f4026708989
365K    components/ee/payment-endpoint:dbtest                                  071831065ecca04d37d58ca9030339b7d078d686
289K    components/ee/db-sync:docker                                           aa507ee39bc3c1a2a91c62a01c9c8fcd1d2aed76
284K    components/ws-manager-bridge:docker                                    e3e6bfda54dea5263db4eb4c9c7b249e2254572a
269K    components/ee/payment-endpoint:docker                                  03ff21a5be67840df320c1700d2cea6b421efcb7
268K    components/ee/db-sync:dbtest                                           ce8db9310804f0b4573374c95561773928966351
257K    components/gitpod-protocol:lib                                         6d49ec7e31f7ad8cd575ab8a2e6891c66baf28c8
178K    components/ide/jetbrains/image:intellij-latest                         05d464e34e1c4f69ca803dd3d1216bf3f988c6a2
174K    components/ide-metrics-api/typescript-grpcweb:lib                      6ba3a2cd6c5f5e6e4491e49069671b3141a4986d
173K    components/ide/jetbrains/backend-plugin:latest                         2434d3a0944010a7de3ab3180a9f1ce8ec6f6604
173K    components/ide/jetbrains/backend-plugin:stable                         5e263be9ef2f71a026e029f4295479b3f9b112ab
171K    components/ide/jetbrains/image:intellij                                1bdabb5625c5c1ed36b1ab9a7ffa456aefd4874d
168K    components/dashboard:static                                            a4f9e46feab9446fca9f68326310f38bf91f3fd5
119K    components/ide/jetbrains/image:phpstorm-latest                         5e6a81e8599e90d06742c309cb4583961f36cb93
117K    components/ide/jetbrains/image:webstorm-latest                         f474aee3a5fddd9163ca6aeb2f4e41e1eaf3bb79
117K    components/ide/jetbrains/image:webstorm                                3a6de207778a7911927f087f3559d77ff2bfc42f
116K    components/ide/jetbrains/image:phpstorm                                4a5c1537e8b8e8621818ef331b3d5615251021be
109K    components/ide/jetbrains/image:goland                                  0ac164123b4a3edb107c0782b21a4c62fef80ee2
107K    components/ide/jetbrains/image:goland-latest                           538a6f042d4d264a150fa948055ce516f44d06b7
107K    components/registry-facade:lib                                         55d15ff4c3ca5ee72c4b9bc4ee2cf90f6a313e87
92K     components/ws-daemon-api/typescript:lib                                e2356397e77906bb3927c07dfcd94d7e2a5ec737
91K     components/content-service:lib                                         a62c9cd695548f354b24ce6ae6bf1f558dea7499
84K     components/content-service-api/typescript:lib                          21040bf9b2665720dda88f46bc7a28e7fbc76169
81K     components/blobserve:lib                                               cc31166b61b3a67a3ebac5cacb5c902d94946326
76K     components/ws-proxy:lib                                                d7d4ebb7dab339a453658f403e3f937b98eb8c13
75K     components/ws-manager-api/typescript:lib                               6b89aef3f2dcb54060211e5ca9684031ddd31cb1
72K     components/usage:docker                                                0f7fc2d7cd7196b0c71d0db2524951bacc5641fd
71K     components/common-go:lib                                               59402d842fa641811d40d2bef4b62e4b8faf5705
69K     components/usage:lib                                                   5224b171f1768ad3c63126782c5dac3a38526e7e
64K     components/ws-manager-api/go:lib                                       15d7af86f495f4285a31bd36a53dac0b0c373341
63K     components/supervisor-api/typescript-grpc:lib                          85ccfe44640f3cff58b965e34401c39f8d418b3e
63K     components/supervisor-api/go:lib                                       7a9f98ee36ac60138f37d7b758474e7d23586f8a
62K     components/image-builder-api/typescript:lib                            42072bf285989ddb067ff5a2843c6196f34f9699
61K     components/ee/agent-smith:lib                                          95756e6e37c1c0cf0af90a257c1894f485a5b894
60K     components/supervisor-api/typescript-grpcweb:lib                       416f75324d00579e595c2d293e8f186588e91fc2
56K     components/content-service-api/go:lib                                  640439dc0844aa73fa33ebf4f86d9ab31e98e4ac
54K     components/usage-api/typescript:lib                                    b8e7c36ceebe55976adaa2644020f3274a9f25ae
54K     components/public-api/typescript:lib                                   38a2e4afa409bcae518423b7114e8f8b78c49551
50K     components/gitpod-messagebus:lib                                       240366d54315ff23063d55a278aecd8b070e5163
47K     components/gitpod-protocol/go:lib                                      4f553d6eabe3c1b62128fe092deeceba019d1839
46K     components/gitpod-db:docker                                            fe30f3287b0218491171cd4076799bf0a139d4f9
46K     components/public-api/go:lib                                           9452c614bc93d549123af834f2210cfbeb361d8b
41K     components/openvsx-proxy:lib                                           91d3cea25ef83cc2ea580e104c15684131b2829c
39K     components/dashboard:docker                                            f3c620de9ceae7a5fd51bbcebf25f5f29c08d90b
39K     components/ws-manager-bridge-api/typescript:lib                        60d0d9ac368e20aeac45a7b7b28f4ce94ae78277
37K     components/supervisor:docker                                           c07ef4b3376814f6eb91acdf7f6213edf9f27f80
35K     components/image-builder-api/go:lib                                    8cb2e7497c4e872d719546859fcc1797fb4c4c00
29K     components/ide-metrics-api/go:lib                                      f3d363d97226d7f00edf4b9f42b33705b019165f
28K     components/ws-daemon-api/go:lib                                        3115f7f0706e4f78da95b33e82116696bf07fb70
25K     components/ide-service-api/go:lib                                      47db89ae0a082eaec0b06e8609fc54f82d4ba926
24K     components/usage-api/go:lib                                            475ecdc48dfdcee81cf0bef99e3e3104f3af106d
15K     components/registry-facade-api/go:lib                                  47eb14a38b519172c105aa9bc6e3647bcfe094bb
15K     components/supervisor-api:proto                                        f9faf88ec5cc092a3757e377c28a1ebbda6fecd3
12K     components/licensor:lib                                                5d6d62d8b0bbcc2f7fe08c2dbdfa471b9bebb8f3
9.9K    components/ide-proxy:docker                                            fdc1133c55c138aac3bf9bbf31a08f51788dfd87
9.9K    components/local-app:docker                                            89024e6f94efa2fad78fcc94c2148194102a6518
9.1K    components/local-app-api/go:lib                                        fd11e7b0555bc8c5b41969e9bf99421f0ae9caf6
8.6K    components/ide-metrics-api:proto                                       5c4940cc1c13da3337bc1807e04019962182e5e3
7.7K    test:docker                                                            fe8864ce5b07a902f086bd73bb74d849e09fe710
6.6K    components/public-api-server:docker                                    9cd54f35aaad9a63f33722974506e0c5a34872b7
6.1K    components/ide/code:docker                                             74d8eefaa08611dc6ec3f0e36a724bb39e677d6c
5.8K    components/ee/agent-smith:docker                                       c32f015111e3b8144a94d190d3c15ff734a1d25d
5.6K    components/ws-daemon:docker                                            e6d492f293357a217c826d2658e355c38602c2ef
5.4K    components/ide-service-api/typescript:lib                              bc45a69020db7bdea246e3dcb4804cb3165535b4
5.2K    components/ws-proxy:docker                                             33a6eb4f70dcca67d7e37438c8a6aff53a2d2115
5.2K    components/image-builder-mk3:docker                                    b10059fb448ebee0533a80296a52086d0e3a21b1
5.0K    components/ws-manager:docker                                           41d4d95c99d19dac8a2f157c0f4b62299aa6b0bb
4.9K    components/gitpod-protocol:gitpod-schema                               52f85219c63d3a540d999a3ae294fb510465f3e5
4.6K    components/docker-up:docker                                            b4e7cafa6bca54af90b570e6433ab1bbe48bfa4d
4.3K    components/ws-daemon/seccomp-profile-installer:docker                  9fd7dcb5779183293b40d01240ee101c133a4a0b
4.3K    components/image-builder-bob:docker                                    db2ae0892721af7c732b7c9a65692ebacc673add
4.2K    components/workspacekit:docker                                         8b936dba86cdcd2cbdb6cfdfda81302a14495501
4.1K    components/registry-facade:docker                                      8d3d25ee6175266c4dfb7ed86c86329bb429b00b
4.1K    components/blobserve:docker                                            dbed35a0e376a7b43e7192c018d820e5fd54c3f4
4.0K    components/ws-manager:userns-test-fixtures                             2fc558906b8625d0c2d22f50c83c3383c6271a9a
3.9K    components/ide/code-desktop:docker-insiders                            d983af166f1932144e3fa85553d850b3e31eb0e8
3.9K    components/ide/code-desktop:docker                                     b662f18d1e58754f03632bbe2e4f83c76e011be1
3.7K    components/content-service:docker                                      b774a505cec38194065443f406c43a6499da788f
3.6K    components/ide-service:docker                                          d92b9d09135315e6b9c478069f5d4a20912ffeea
3.6K    components/ide-metrics:docker                                          e0a51f8017aafdc7b575462027d3ca94e7ff2833
3.1K    components/kots-config-check/registry:docker                           4044044a767725b7fef17a024d2d87267f7cc5c2
3.0K    components/installation-telemetry:docker                               967c93ac991ce7211111f9abb37da5645ed105f2
3.0K    components/openvsx-proxy:docker                                        7970ad8ec2541c0dafb09b39397272ff96c4cd21
3.0K    components/service-waiter:docker                                       3bfde8b88c9f850f243274bff13ce7eef03b1482
2.2K    install/installer/pkg/components/database/incluster/init:init-scripts  731375c4d4fec46e68ccca2f24fe9298c7245d30
2.0K    components/kots-config-check/storage:docker                            b06db88b3822da5e174069396403f12e38f9b05b
2.0K    components/registry-facade/ca-updater:docker                           9e9cca138ea2c435d95125434d77c1239ac0a9b8
2.0K    components/kots-config-check/certificate:docker                        e9c50f7d6252a4e512725ff2adc916697c0731f0
2.0K    components/kots-config-check/database:docker                           630529843cbac54b5ac900028c23a8708330aa5c
1.9K    components/ws-daemon/shiftfs-module-loader:docker                      e4683f95fa2323335b89f44f3b9512d9ea459cbf
1.9K    components/proxy:docker                                                0acadee1bcf01db02110f78c02e492b5b9ca934a
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
