### PR TITLE
[Jetbrains] Use single copy to clipboard approach

### DIFF
--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/actions/ShareWorkspaceSnapshotAction.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/actions/ShareWorkspaceSnapshotAction.kt
@@ -10,12 +10,12 @@ import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.thisLogger
+import com.intellij.openapi.ide.CopyPasteManager
 import com.intellij.util.ExceptionUtil
-import io.gitpod.gitpodprotocol.api.entities.TakeSnapshotOptions
 import io.gitpod.gitpodprotocol.api.entities.Error
+import io.gitpod.gitpodprotocol.api.entities.TakeSnapshotOptions
 import io.gitpod.jetbrains.remote.GitpodManager
 import org.eclipse.lsp4j.jsonrpc.ResponseErrorException
-import java.awt.Toolkit
 import java.awt.datatransfer.StringSelection
 
 class ShareWorkspaceSnapshotAction : AnAction() {
@@ -61,8 +61,7 @@ class ShareWorkspaceSnapshotAction : AnAction() {
                         )
                         val copyUrlAction = NotificationAction.createSimple("Copy URL to Clipboard") {
                             val uri = "${workspaceInfo.gitpodHost}#snapshot/$snapshotId";
-                            val clipboard = Toolkit.getDefaultToolkit().systemClipboard
-                            clipboard.setContents(StringSelection(uri), null)
+                            CopyPasteManager.getInstance().setContents(StringSelection(uri))
                         }
                         notification.addAction(copyUrlAction)
                         notification.notify(null)


### PR DESCRIPTION
## Description
Very small PR to align how we interact with the clipboard in JetBrains backend-plugin. In a recent PR created by @felladrin [[1]](https://github.com/gitpod-io/gitpod/pull/14356/files#diff-5502e07b0ac56646b7243f5e9e77d4f82aac6b45bbb6cb69cf3ebf907b472cc2R12), we use `CopyPasteManager` from the intellij package. In the snapshot action we use one from `java.awt.Toolkit`. They both work but it's good to have a single approach for something like this.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
N/A

## How to test
In prev env this cannot be tested due to plan limitations. In prod:

<img width="460" alt="Screenshot 2022-11-02 at 22 39 04" src="https://user-images.githubusercontent.com/2318450/199607855-608e520f-ac85-48ab-8cd7-bcd4a46f52dd.png">

I've already tested with the following steps and it works, but for testing again:

1. Start a workspace for this branch
2. run `launch-dev-server.sh` from `backend-plugin`
3. Connect to the IDE and create a snapshot
4. Verify that the copy to clipboard of the snapshot URL works (it takes a couple of minute to create the snapshot)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
