### PR TITLE
Update stable to `1.73`

### DIFF
--- a/install/installer/cmd/testdata/render/aws-setup/output.golden
+++ b/install/installer/cmd/testdata/render/aws-setup/output.golden
@@ -3264,7 +3264,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2eb8dce567174ddb2efe12e30e8375cb2ffc4af3",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-f17f584e2e252f3c1e877d28ea1edd1ab137a831",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {
@@ -4633,7 +4633,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2eb8dce567174ddb2efe12e30e8375cb2ffc4af3",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-f17f584e2e252f3c1e877d28ea1edd1ab137a831",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/azure-setup/output.golden
+++ b/install/installer/cmd/testdata/render/azure-setup/output.golden
@@ -3181,7 +3181,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2eb8dce567174ddb2efe12e30e8375cb2ffc4af3",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-f17f584e2e252f3c1e877d28ea1edd1ab137a831",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {
@@ -4496,7 +4496,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2eb8dce567174ddb2efe12e30e8375cb2ffc4af3",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-f17f584e2e252f3c1e877d28ea1edd1ab137a831",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -3993,7 +3993,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2eb8dce567174ddb2efe12e30e8375cb2ffc4af3",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-f17f584e2e252f3c1e877d28ea1edd1ab137a831",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {
@@ -5448,7 +5448,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2eb8dce567174ddb2efe12e30e8375cb2ffc4af3",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-f17f584e2e252f3c1e877d28ea1edd1ab137a831",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -3322,7 +3322,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2eb8dce567174ddb2efe12e30e8375cb2ffc4af3",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-f17f584e2e252f3c1e877d28ea1edd1ab137a831",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {
@@ -4683,7 +4683,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2eb8dce567174ddb2efe12e30e8375cb2ffc4af3",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-f17f584e2e252f3c1e877d28ea1edd1ab137a831",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/gcp-setup/output.golden
+++ b/install/installer/cmd/testdata/render/gcp-setup/output.golden
@@ -3152,7 +3152,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2eb8dce567174ddb2efe12e30e8375cb2ffc4af3",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-f17f584e2e252f3c1e877d28ea1edd1ab137a831",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {
@@ -4457,7 +4457,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2eb8dce567174ddb2efe12e30e8375cb2ffc4af3",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-f17f584e2e252f3c1e877d28ea1edd1ab137a831",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/http-proxy/output.golden
+++ b/install/installer/cmd/testdata/render/http-proxy/output.golden
@@ -3491,7 +3491,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2eb8dce567174ddb2efe12e30e8375cb2ffc4af3",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-f17f584e2e252f3c1e877d28ea1edd1ab137a831",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {
@@ -4906,7 +4906,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2eb8dce567174ddb2efe12e30e8375cb2ffc4af3",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-f17f584e2e252f3c1e877d28ea1edd1ab137a831",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/insecure-s3-setup/output.golden
+++ b/install/installer/cmd/testdata/render/insecure-s3-setup/output.golden
@@ -3402,7 +3402,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2eb8dce567174ddb2efe12e30e8375cb2ffc4af3",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-f17f584e2e252f3c1e877d28ea1edd1ab137a831",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {
@@ -4817,7 +4817,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2eb8dce567174ddb2efe12e30e8375cb2ffc4af3",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-f17f584e2e252f3c1e877d28ea1edd1ab137a831",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -3488,7 +3488,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2eb8dce567174ddb2efe12e30e8375cb2ffc4af3",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-f17f584e2e252f3c1e877d28ea1edd1ab137a831",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {
@@ -4903,7 +4903,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2eb8dce567174ddb2efe12e30e8375cb2ffc4af3",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-f17f584e2e252f3c1e877d28ea1edd1ab137a831",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/shortname/output.golden
+++ b/install/installer/cmd/testdata/render/shortname/output.golden
@@ -3488,7 +3488,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2eb8dce567174ddb2efe12e30e8375cb2ffc4af3",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-f17f584e2e252f3c1e877d28ea1edd1ab137a831",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {
@@ -4903,7 +4903,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2eb8dce567174ddb2efe12e30e8375cb2ffc4af3",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-f17f584e2e252f3c1e877d28ea1edd1ab137a831",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -3500,7 +3500,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2eb8dce567174ddb2efe12e30e8375cb2ffc4af3",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-f17f584e2e252f3c1e877d28ea1edd1ab137a831",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {
@@ -4915,7 +4915,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2eb8dce567174ddb2efe12e30e8375cb2ffc4af3",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-f17f584e2e252f3c1e877d28ea1edd1ab137a831",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
+++ b/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
@@ -3821,7 +3821,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2eb8dce567174ddb2efe12e30e8375cb2ffc4af3",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-f17f584e2e252f3c1e877d28ea1edd1ab137a831",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {
@@ -5236,7 +5236,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2eb8dce567174ddb2efe12e30e8375cb2ffc4af3",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-f17f584e2e252f3c1e877d28ea1edd1ab137a831",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
+++ b/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
@@ -3491,7 +3491,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2eb8dce567174ddb2efe12e30e8375cb2ffc4af3",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-f17f584e2e252f3c1e877d28ea1edd1ab137a831",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {
@@ -4906,7 +4906,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2eb8dce567174ddb2efe12e30e8375cb2ffc4af3",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-f17f584e2e252f3c1e877d28ea1edd1ab137a831",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/pkg/components/workspace/ide/constants.go
+++ b/install/installer/pkg/components/workspace/ide/constants.go
@@ -6,7 +6,7 @@ package ide
 
 const (
 	CodeIDEImage                = "ide/code"
-	CodeIDEImageStableVersion   = "commit-2eb8dce567174ddb2efe12e30e8375cb2ffc4af3" // stable version that will be updated manually on demand
+	CodeIDEImageStableVersion   = "commit-f17f584e2e252f3c1e877d28ea1edd1ab137a831" // stable version that will be updated manually on demand
 	CodeDesktopIDEImage         = "ide/code-desktop"
 	CodeDesktopInsidersIDEImage = "ide/code-desktop-insiders"
 	IntelliJDesktopIDEImage     = "ide/intellij"


### PR DESCRIPTION
## Description
Updates the stable image of VS Code Browser to `1.73.0`

## Related Issue(s)
A part of https://github.com/gitpod-io/gitpod/issues/14272.

## How to test
Open the preview environment, select VS Code Browser (non-`latest`) and in the <kbd>About</kbd> dialog check that we are on `1.73.0`.

## Release Notes
```release-note
NONE
```

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`