### PR TITLE
[dashboard] Fetch team members using public API

### DIFF
--- a/components/dashboard/src/service/public-api.ts
+++ b/components/dashboard/src/service/public-api.ts
@@ -8,6 +8,8 @@ import { createConnectTransport, createPromiseClient, Interceptor } from "@bufbu
 import { Team as ProtocolTeam } from "@gitpod/gitpod-protocol/lib/teams-projects-protocol";
 import { TeamsService } from "@gitpod/public-api/lib/gitpod/experimental/v1/teams_connectweb";
 import { Team } from "@gitpod/public-api/lib/gitpod/experimental/v1/teams_pb";
+import { TeamMemberInfo, TeamMemberRole } from "@gitpod/gitpod-protocol";
+import { TeamMember, TeamRole } from "@gitpod/public-api/lib/gitpod/experimental/v1/teams_pb";
 import { getGitpodService } from "./service";
 
 let token: string | undefined;
@@ -58,4 +60,29 @@ export function publicApiTeamToProtocol(team: Team): ProtocolTeam {
 
 export function publicApiTeamsToProtocol(teams: Team[]): ProtocolTeam[] {
     return teams.map(publicApiTeamToProtocol);
+}
+
+export function publicApiTeamMembersToProtocol(members: TeamMember[]): TeamMemberInfo[] {
+    return members.map(publicApiTeamMemberToProtocol);
+}
+
+export function publicApiTeamMemberToProtocol(member: TeamMember): TeamMemberInfo {
+    return {
+        userId: member.userId,
+        fullName: member.fullName,
+        avatarUrl: member.avatarUrl,
+        memberSince: member.memberSince?.toDate().toISOString() || "",
+        role: publicApiTeamRoleToProtocol(member.role),
+        primaryEmail: member.primaryEmail,
+    };
+}
+
+export function publicApiTeamRoleToProtocol(role: TeamRole): TeamMemberRole {
+    switch (role) {
+        case TeamRole.OWNER:
+            return "owner";
+        case TeamRole.MEMBER:
+        case TeamRole.UNSPECIFIED:
+            return "member";
+    }
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Retrieve team members from Public API, behind an experiment.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

1. Log in to preview, open up dev console.
2. Join my team: https://mp-dash-mec45944a41b.preview.gitpod-dev.com/teams/join?inviteId=7ea48015-a4cf-4197-b2f3-b3099d079468
3. Navigate to team members, observe request is made against `GetTeam`
4. The Members page continues to work as before

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
