### PR TITLE
[gitpod-protocol] Add ResetGenericInvite to golang client

### DIFF
--- a/components/gitpod-protocol/go/gitpod-service.go
+++ b/components/gitpod-protocol/go/gitpod-service.go
@@ -90,6 +90,7 @@ type APIInterface interface {
 	GetTeamMembers(ctx context.Context, teamID string) ([]*TeamMemberInfo, error)
 	JoinTeam(ctx context.Context, teamID string) (*Team, error)
 	GetGenericInvite(ctx context.Context, teamID string) (*TeamMembershipInvite, error)
+	ResetGenericInvite(ctx context.Context, teamID string) (*TeamMembershipInvite, error)
 
 	InstanceUpdates(ctx context.Context, instanceID string) (<-chan *WorkspaceInstance, error)
 }
@@ -223,6 +224,8 @@ const (
 	FunctionGetTeamMembers FunctionName = "getTeamMembers"
 	// FunctionGetGenericInvite is the name of the getGenericInvite function
 	FunctionGetGenericInvite FunctionName = "getGenericInvite"
+	// FunctionResetGenericInvite is the name of the resetGenericInvite function
+	FunctionResetGenericInvite FunctionName = "resetGenericInvite"
 
 	// FunctionOnInstanceUpdate is the name of the onInstanceUpdate callback function
 	FunctionOnInstanceUpdate = "onInstanceUpdate"
@@ -1459,6 +1462,16 @@ func (gp *APIoverJSONRPC) GetGenericInvite(ctx context.Context, teamID string) (
 	}
 	_params := []interface{}{teamID}
 	err = gp.C.Call(ctx, string(FunctionGetGenericInvite), _params, &res)
+	return
+}
+
+func (gp *APIoverJSONRPC) ResetGenericInvite(ctx context.Context, teamID string) (res *TeamMembershipInvite, err error) {
+	if gp == nil {
+		err = errNotConnected
+		return
+	}
+	_params := []interface{}{teamID}
+	err = gp.C.Call(ctx, string(FunctionResetGenericInvite), _params, &res)
 	return
 }
 

--- a/components/gitpod-protocol/go/mock.go
+++ b/components/gitpod-protocol/go/mock.go
@@ -792,6 +792,21 @@ func (mr *MockAPIInterfaceMockRecorder) RegisterGithubApp(ctx, installationID in
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterGithubApp", reflect.TypeOf((*MockAPIInterface)(nil).RegisterGithubApp), ctx, installationID)
 }
 
+// ResetGenericInvite mocks base method.
+func (m *MockAPIInterface) ResetGenericInvite(ctx context.Context, teamID string) (*TeamMembershipInvite, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ResetGenericInvite", ctx, teamID)
+	ret0, _ := ret[0].(*TeamMembershipInvite)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ResetGenericInvite indicates an expected call of ResetGenericInvite.
+func (mr *MockAPIInterfaceMockRecorder) ResetGenericInvite(ctx, teamID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetGenericInvite", reflect.TypeOf((*MockAPIInterface)(nil).ResetGenericInvite), ctx, teamID)
+}
+
 // SendHeartBeat mocks base method.
 func (m *MockAPIInterface) SendHeartBeat(ctx context.Context, options *SendHeartBeatOptions) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Will be needed to ResetTeamInvite by PublicAPI

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Part of https://github.com/gitpod-io/gitpod/issues/14384

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
