### PR TITLE
[preview] Add support for new `with-slow-database` annotation

### DIFF
--- a/.werft/jobs/build/deploy-to-preview-environment.ts
+++ b/.werft/jobs/build/deploy-to-preview-environment.ts
@@ -133,6 +133,7 @@ export async function deployToPreviewEnvironment(werft: Werft, jobConfig: JobCon
         analytics: deploymentConfig.analytics,
         withEELicense: deploymentConfig.installEELicense,
         workspaceFeatureFlags: workspaceFeatureFlags,
+        withSlowDatabase: jobConfig.withSlowDatabase,
     });
     try {
         werft.log(phases.DEPLOY, "deploying using installer");

--- a/.werft/jobs/build/installer/installer.ts
+++ b/.werft/jobs/build/installer/installer.ts
@@ -14,6 +14,7 @@ export type InstallerOptions = {
     analytics?: Analytics;
     withEELicense: boolean;
     workspaceFeatureFlags: string[];
+    withSlowDatabase: boolean;
 };
 
 export class Installer {
@@ -32,6 +33,7 @@ export class Installer {
             PREVIEW_NAME: this.options.previewName,
             GITPOD_ANALYTICS_SEGMENT_TOKEN: this.options.analytics?.token || "",
             GITPOD_WORKSPACE_FEATURE_FLAGS: this.options.workspaceFeatureFlags.join(" "),
+            GITPOD_WITH_SLOW_DATABASE: this.options.withSlowDatabase,
             GITPOD_WITH_EE_LICENSE: this.options.withEELicense,
         };
         const variables = Object.entries(environment)

--- a/.werft/jobs/build/job-config.ts
+++ b/.werft/jobs/build/job-config.ts
@@ -30,6 +30,7 @@ export interface JobConfig {
     withSelfHostedPreview: boolean;
     withObservability: boolean;
     withLocalPreview: boolean;
+    withSlowDatabase: boolean;
     workspaceFeatureFlags: string[];
     previewEnvironment: PreviewEnvironmentConfig;
     repository: Repository;
@@ -102,6 +103,7 @@ export function jobConfig(werft: Werft, context: any): JobConfig {
     const withLocalPreview = "with-local-preview" in buildConfig || mainBuild
     const recreatePreview = "recreate-preview" in buildConfig
     const recreateVm = mainBuild || "recreate-vm" in buildConfig;
+    const withSlowDatabase = "with-slow-database" in buildConfig && !mainBuild;
 
     const withIntegrationTests = parseWithIntegrationTests(werft, sliceId, buildConfig["with-integration-tests"]);
     const withPreview = decideWithPreview({werft, sliceID: sliceId, buildConfig, mainBuild, withIntegrationTests})
@@ -173,6 +175,7 @@ export function jobConfig(werft: Werft, context: any): JobConfig {
         certIssuer,
         recreatePreview,
         recreateVm,
+        withSlowDatabase,
     };
 
     werft.logOutput(sliceId, JSON.stringify(jobConfig, null, 2));

--- a/dev/preview/workflow/preview/deploy-gitpod.sh
+++ b/dev/preview/workflow/preview/deploy-gitpod.sh
@@ -26,6 +26,7 @@ GITPOD_PROXY_SECRET_NAME="proxy-config-certificates";
 GITPOD_ANALYTICS_SEGMENT_TOKEN="${GITPOD_ANALYTICS_SEGMENT_TOKEN:-}"
 GITPOD_WITH_EE_LICENSE="${GITPOD_WITH_EE_LICENSE:-true}"
 GITPOD_WORKSPACE_FEATURE_FLAGS="${GITPOD_WORKSPACE_FEATURE_FLAGS:-}"
+GITPOD_WITH_SLOW_DATABASE="${GITPOD_WITH_SLOW_DATABASE:-false}"
 
 VERSION="${VERSION:-${PREVIEW_NAME}-dev}"
 INSTALLER_BINARY_PATH="$(mktemp "/tmp/XXXXXX.installer")}"
@@ -443,6 +444,14 @@ yq w -i "${INSTALLER_CONFIG_PATH}" experimental.webapp.proxy.configcat.pollInter
 yq w -i "${INSTALLER_CONFIG_PATH}" 'workspace.templates.default.spec.containers[+].name' "workspace"
 yq w -i "${INSTALLER_CONFIG_PATH}" 'workspace.templates.default.spec.containers.(name==workspace).env[+].name' "GITPOD_PREVENT_METADATA_ACCESS"
 yq w -i "${INSTALLER_CONFIG_PATH}" 'workspace.templates.default.spec.containers.(name==workspace).env.(name==GITPOD_PREVENT_METADATA_ACCESS).value' "true"
+
+#
+# configureSlowDatabase
+#
+if [[ "${GITPOD_WITH_SLOW_DATABASE}" == "true" ]]
+then
+  yq w -i "${INSTALLER_CONFIG_PATH}" "experimental.webapp.slowDatabase" "true"
+fi
 
 #
 # includeAnalytics


### PR DESCRIPTION
## Description

Add support for new `with-slow-database` annotation on Werft jobs that build preview environments.

If the new `with-slow-database`  annotation is set on the job, pass the new `experimental.webapp.slowDatabase=true` flag to the installer.

Support for the experimental installer flag is added in the dependent PR (https://github.com/gitpod-io/gitpod/pull/14359).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of #9198 

Depends on https://github.com/gitpod-io/gitpod/pull/14359

## How to test

Create a preview environment from this branch with:

```bash
werft run github -j .werft/build.yaml -a with-preview=true -a with-clean-slate-deployment=true -a with-slow-database=true
```

In the preview environment notice that the placeholder `toxiproxy` configmap is present.

Recreate the preview environment without the `with-slow-database` annotation:

```bash
werft run github -j .werft/build.yaml -a with-preview=true -a with-clean-slate-deployment=true
```

See that the placeholder `toxiproxy` configmap is not present in the environment.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
