### PR TITLE
[usage] Make reset usage task configurable through installer

### DIFF
--- a/install/installer/pkg/components/usage/configmap.go
+++ b/install/installer/pkg/components/usage/configmap.go
@@ -22,7 +22,7 @@ import (
 func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 	cfg := server.Config{
 		LedgerSchedule:     "", // By default controller is disabled
-		ResetUsageSchedule: time.Duration(5 * time.Minute).String(),
+		ResetUsageSchedule: time.Duration(15 * time.Minute).String(),
 		Server: &baseserver.Configuration{
 			Services: baseserver.ServicesConfiguration{
 				GRPC: &baseserver.ServerConfiguration{
@@ -57,6 +57,9 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 	if expUsageConfig != nil {
 		if expUsageConfig.Schedule != "" {
 			cfg.LedgerSchedule = expUsageConfig.Schedule
+		}
+		if expUsageConfig.ResetUsageSchedule != "" {
+			cfg.ResetUsageSchedule = expUsageConfig.ResetUsageSchedule
 		}
 		if expUsageConfig.DefaultSpendingLimit != nil {
 			cfg.DefaultSpendingLimit = *expUsageConfig.DefaultSpendingLimit

--- a/install/installer/pkg/components/usage/configmap_test.go
+++ b/install/installer/pkg/components/usage/configmap_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestConfigMap_ContainsSchedule(t *testing.T) {
-	ctx := renderContextWithUsageConfig(t, &experimental.UsageConfig{Enabled: true, Schedule: "2m"})
+	ctx := renderContextWithUsageConfig(t, &experimental.UsageConfig{Enabled: true, Schedule: "2m", ResetUsageSchedule: "5m"})
 
 	objs, err := configmap(ctx)
 	require.NoError(t, err)
@@ -23,7 +23,7 @@ func TestConfigMap_ContainsSchedule(t *testing.T) {
 	require.JSONEq(t,
 		`{
        "controllerSchedule": "2m",
-	   "resetUsageSchedule": "5m0s",
+	   "resetUsageSchedule": "5m",
        "stripeCredentialsFile": "stripe-secret/apikeys",
 	   "defaultSpendingLimit": {
 		"forUsers": 1000000000,

--- a/install/installer/pkg/config/v1/experimental/experimental.go
+++ b/install/installer/pkg/config/v1/experimental/experimental.go
@@ -262,6 +262,7 @@ type PublicAPIConfig struct {
 type UsageConfig struct {
 	Enabled                          bool                     `json:"enabled"`
 	Schedule                         string                   `json:"schedule"`
+	ResetUsageSchedule               string                   `json:"resetUsageSchedule"`
 	BillInstancesAfter               *time.Time               `json:"billInstancesAfter"`
 	DefaultSpendingLimit             *db.DefaultSpendingLimit `json:"defaultSpendingLimit"`
 	CreditsPerMinuteByWorkspaceClass map[string]float64       `json:"creditsPerMinuteByWorkspaceClass"`


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Makes reset usage configurable through the installer config.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
