### PR TITLE
[GitHub Action] Use Large VM for Preview Environments related to JetBrains IDEs

### DIFF
--- a/.github/workflows/jetbrains-update-plugin-platform-template.yml
+++ b/.github/workflows/jetbrains-update-plugin-platform-template.yml
@@ -117,6 +117,7 @@ jobs:
 
                       ## Werft options:
                       - [x] /werft with-preview
+                      - [x] /werft with-large-vm
 
                       _This PR was created automatically with GitHub Actions using [this](https://github.com/gitpod-io/gitpod/blob/main/.github/workflows/jetbrains-update-plugin-platform-template.yml) template._
                   commit-message: "Update Platform Version of ${{ inputs.pluginName }} to ${{ steps.latest-version.outputs.result }}"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Use Large VM for Preview Environments related to JetBrains IDEs. Otherwise, due to a lack of memory, the workspace gets stuck, ruining the test.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Check this PR as an example:
- https://github.com/gitpod-io/gitpod/pull/14349/

## How to test
<!-- Provide steps to test this PR -->
No need to test. It's just an addition of Werft Annotation for future PRs.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```