### PR TITLE
[local-preview] Update status messages to depend on echo's

### DIFF
--- a/install/preview/entrypoint.sh
+++ b/install/preview/entrypoint.sh
@@ -197,6 +197,7 @@ done
 
 ctr images pull "docker.io/gitpod/workspace-full:latest" >/dev/null &
 
+echo "images pulled"
 /gitpod-installer render --use-experimental-config --config config.yaml --output-split-files /var/lib/rancher/k3s/server/manifests/gitpod
 
 # store files in `gitpod.debug` for debugging purposes
@@ -235,6 +236,7 @@ mv -f /app/manifests/coredns.yaml /var/lib/rancher/k3s/server/manifests/custom-c
 for f in /var/lib/rancher/k3s/server/manifests/gitpod/*.yaml; do (cat "$f"; echo) >> /var/lib/rancher/k3s/server/manifests/gitpod.yaml; done
 rm -rf /var/lib/rancher/k3s/server/manifests/gitpod
 
+echo "manifests generated"
 # waits for gitpod pods to be ready, and manually runs the `gitpod-telemetry` cronjob
 run_telemetry(){
   # wait for the k3s cluster to be ready and Gitpod workloads are added

--- a/install/preview/prettylog/main.go
+++ b/install/preview/prettylog/main.go
@@ -31,8 +31,8 @@ var (
 	}{
 		{Msg: "checking prerequisites", Fail: "requires a system with at least", Success: "Gitpod Domain:", Status: "checking prerequisites"},
 		{Msg: "preparing system", Success: "extracting images to download ahead"},
-		{Msg: "downloading images", Success: "--output-split-files"},
-		{Msg: "preparing Gitpod preview installation", Success: "rm -rf /var/lib/rancher/k3s/server/manifests/gitpod"},
+		{Msg: "downloading images", Success: "images pulled"},
+		{Msg: "preparing Gitpod preview installation", Success: "manifests generated"},
 		{Msg: "starting Gitpod", Success: "Gitpod pods are ready", Status: "starting gitpod"},
 		{Msg: fmt.Sprintf("Gitpod is running. Visit https://%s to access the dashboard", os.Getenv("DOMAIN")), Status: "gitpod ready"},
 	}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

With the removal of `-x` option in bash, We can't rely on the
commands anymore and instead have to start using `echo` messages
to match statuses in `prettylog`.

This PR updates the remaining statuses on the
same.

Signed-off-by: Tarun Pothulapati <tarun@gitpod.io>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

Run `docker run -p 443:443 --privileged --name gitpod -it  --mount type=volume,source=gitpod,destination=/var/gitpod eu.gcr.io/gitpod-core-dev/build/local-preview:tar-update-success-messages.1`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[local-preview] Update status messages to depend on echo's
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [x] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
