### PR TITLE
Remove download workspace button from admin

### DIFF
--- a/components/dashboard/src/admin/WorkspaceDetail.tsx
+++ b/components/dashboard/src/admin/WorkspaceDetail.tsx
@@ -5,7 +5,6 @@
  */
 
 import { User, WorkspaceAndInstance, ContextURL } from "@gitpod/gitpod-protocol";
-import { GitpodHostUrl } from "@gitpod/gitpod-protocol/lib/util/gitpod-host-url";
 import dayjs from "dayjs";
 import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
@@ -66,18 +65,6 @@ export default function WorkspaceDetail(props: { workspace: WorkspaceAndInstance
                     </div>
                     <p>{getProject(WorkspaceAndInstance.toWorkspace(workspace))}</p>
                 </div>
-                <button
-                    className="secondary ml-3"
-                    onClick={() => {
-                        window.location.href = new GitpodHostUrl(window.location.href)
-                            .with({
-                                pathname: `/workspace-download/get/${workspace.workspaceId}`,
-                            })
-                            .toString();
-                    }}
-                >
-                    Download Workspace
-                </button>
                 <button
                     className="danger ml-3"
                     disabled={activity || workspace.phase === "stopped"}

--- a/components/dashboard/src/workspaces/WorkspaceEntry.tsx
+++ b/components/dashboard/src/workspaces/WorkspaceEntry.tsx
@@ -57,11 +57,6 @@ export function WorkspaceEntry({ desc, model, isAdmin, stopWorkspace }: Props) {
         pathname: "/start/",
         hash: "#" + ws.id,
     });
-    const downloadURL = new GitpodHostUrl(window.location.href)
-        .with({
-            pathname: `/workspace-download/get/${ws.id}`,
-        })
-        .toString();
     const menuEntries: ContextMenuEntry[] = [
         {
             title: "Open",
@@ -91,8 +86,22 @@ export function WorkspaceEntry({ desc, model, isAdmin, stopWorkspace }: Props) {
     }
     menuEntries.push({
         title: "Download",
-        href: downloadURL,
-        download: `${ws.id}.tar`,
+        customContent: (
+            <div className="">
+                <span className="block text-gray-300">Download</span>
+                <span className="text-gray-400">
+                    Deprecated.{" "}
+                    <a
+                        href="https://github.com/gitpod-io/gitpod/issues/7901"
+                        className="gp-link"
+                        target="_blank"
+                        rel="noreferrer"
+                    >
+                        Learn more
+                    </a>
+                </span>
+            </div>
+        ),
     });
     if (!isAdmin) {
         menuEntries.push(


### PR DESCRIPTION
## Description

Remove download workspace button from admin.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/14381 https://github.com/gitpod-io/gitpod/issues/14382

## How to test

1. Go to **/admin/workspaces**.
2. Search for a workspace.
3. Notice the _Download Workspace_ button is now missing.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Remove download workspace button from admin
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
