### PR TITLE
[JetBrains] Improve code readability

### DIFF
--- a/components/ide/jetbrains/backend-plugin/build.gradle.kts
+++ b/components/ide/jetbrains/backend-plugin/build.gradle.kts
@@ -23,17 +23,16 @@ plugins {
 }
 
 group = properties("pluginGroup")
+val environmentName = properties("environmentName")
 var pluginVersion = properties("pluginVersion")
 
-val environmentName = properties("environmentName")
-if (!environmentName.isNullOrBlank()) {
-    pluginVersion += "-" + environmentName
+if (environmentName.isNotBlank()) {
+    pluginVersion += "-$environmentName"
 }
 
 project(":") {
     kotlin {
-        var excludedPackage = "stable"
-        if (environmentName == excludedPackage) excludedPackage = "latest"
+        val excludedPackage = if (environmentName == "latest") "stable" else "latest"
         sourceSets["main"].kotlin.exclude("io/gitpod/jetbrains/remote/${excludedPackage}/**")
     }
 

--- a/components/ide/jetbrains/gateway-plugin/build.gradle.kts
+++ b/components/ide/jetbrains/gateway-plugin/build.gradle.kts
@@ -29,14 +29,13 @@ group = properties("pluginGroup")
 val environmentName = properties("environmentName")
 var pluginVersion = properties("pluginVersion")
 
-if (!environmentName.isNullOrBlank()) {
-    pluginVersion += "-" + environmentName
+if (environmentName.isNotBlank()) {
+    pluginVersion += "-$environmentName"
 }
 
 project(":") {
     kotlin {
-        var excludedPackage = "stable"
-        if (environmentName == excludedPackage) excludedPackage = "latest"
+        val excludedPackage = if (environmentName == "latest") "stable" else "latest"
         sourceSets["main"].kotlin.exclude("io/gitpod/jetbrains/gateway/${excludedPackage}/**")
     }
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Tiny PR to improve code readability and ensure Backend and Gateway plugins have the same code.

Environment Name can never be null, as it has a default value set in `gradle.properties`, but it can be overridden as an empty string, so we need to check if it's not blank.

And the other code was hard to read. Although there's a repeated string now, it's easier to understand that it will exclude its opposite ("stable" <-> "latest").

## How to test
<!-- Provide steps to test this PR -->
No need to test.
But if you want to test, you can use the preview environment and confirm if both Stable and EAP IntelliJ IDE opens correctly and displays a terminal as soon as you open the workspace.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Werft options:

- [x] /werft with-preview
- [x] /werft with-large-vm