### PR TITLE
[public-api] Cleanup Workspace Service tests

### DIFF
--- a/components/public-api-server/pkg/apiv1/workspace_test.go
+++ b/components/public-api-server/pkg/apiv1/workspace_test.go
@@ -8,12 +8,12 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
 	fuzz "github.com/AdaLogics/go-fuzz-headers"
 	"github.com/bufbuild/connect-go"
-	"github.com/gitpod-io/gitpod/common-go/baseserver"
 	protocol "github.com/gitpod-io/gitpod/gitpod-protocol"
 	"github.com/gitpod-io/gitpod/public-api-server/pkg/auth"
 	v1 "github.com/gitpod-io/gitpod/public-api/experimental/v1"
@@ -30,21 +30,6 @@ func TestWorkspaceService_GetWorkspace(t *testing.T) {
 		bearerToken      = "bearer-token-for-tests"
 		foundWorkspaceID = "easycz-seer-xl8o1zacpyw"
 	)
-
-	srv := baseserver.NewForTests(t,
-		baseserver.WithHTTP(baseserver.MustUseRandomLocalAddress(t)),
-	)
-
-	connPool := &FakeServerConnPool{}
-
-	route, handler := v1connect.NewWorkspacesServiceHandler(NewWorkspaceService(connPool), connect.WithInterceptors(auth.NewServerInterceptor()))
-	srv.HTTPMux().Handle(route, handler)
-
-	baseserver.StartServerForTests(t, srv)
-
-	client := v1connect.NewWorkspacesServiceClient(http.DefaultClient, srv.HTTPAddress(), connect.WithInterceptors(
-		auth.NewClientInterceptor(bearerToken),
-	))
 
 	type Expectation struct {
 		Code     connect.Code
@@ -80,26 +65,22 @@ func TestWorkspaceService_GetWorkspace(t *testing.T) {
 
 	for _, test := range scenarios {
 		t.Run(test.name, func(t *testing.T) {
-			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
-			srv := protocol.NewMockAPIInterface(ctrl)
-			srv.EXPECT().GetWorkspace(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, id string) (res *protocol.WorkspaceInfo, err error) {
+			serverMock, client := setupWorkspacesService(t)
+
+			serverMock.EXPECT().GetWorkspace(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, id string) (res *protocol.WorkspaceInfo, err error) {
 				w, ok := test.Workspaces[id]
 				if !ok {
 					return nil, errors.New("code 404")
 				}
 				return &w, nil
 			})
-			connPool.api = srv
 
 			resp, err := client.GetWorkspace(context.Background(), connect.NewRequest(&v1.GetWorkspaceRequest{
 				WorkspaceId: test.WorkspaceID,
 			}))
 			requireErrorCode(t, test.Expect.Code, err)
 			if test.Expect.Response != nil {
-				if diff := cmp.Diff(test.Expect.Response, resp.Msg, protocmp.Transform()); diff != "" {
-					t.Errorf("unexpected difference:\n%v", diff)
-				}
+				requireEqualProto(t, test.Expect.Response, resp.Msg)
 			}
 		})
 	}
@@ -111,21 +92,6 @@ func TestWorkspaceService_GetOwnerToken(t *testing.T) {
 		foundWorkspaceID = "easycz-seer-xl8o1zacpyw"
 		ownerToken       = "some-owner-token"
 	)
-
-	srv := baseserver.NewForTests(t,
-		baseserver.WithHTTP(baseserver.MustUseRandomLocalAddress(t)),
-	)
-
-	connPool := &FakeServerConnPool{}
-
-	route, handler := v1connect.NewWorkspacesServiceHandler(NewWorkspaceService(connPool), connect.WithInterceptors(auth.NewServerInterceptor()))
-	srv.HTTPMux().Handle(route, handler)
-
-	baseserver.StartServerForTests(t, srv)
-
-	client := v1connect.NewWorkspacesServiceClient(http.DefaultClient, srv.HTTPAddress(), connect.WithInterceptors(
-		auth.NewClientInterceptor(bearerToken),
-	))
 
 	type Expectation struct {
 		Code     connect.Code
@@ -158,51 +124,29 @@ func TestWorkspaceService_GetOwnerToken(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
-			srv := protocol.NewMockAPIInterface(ctrl)
-			srv.EXPECT().GetOwnerToken(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, workspaceID string) (res string, err error) {
+			serverMock, client := setupWorkspacesService(t)
+
+			serverMock.EXPECT().GetOwnerToken(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, workspaceID string) (res string, err error) {
 				w, ok := test.Tokens[workspaceID]
 				if !ok {
 					return "", errors.New("code 404")
 				}
 				return w, nil
 			})
-			connPool.api = srv
 
 			resp, err := client.GetOwnerToken(context.Background(), connect.NewRequest(&v1.GetOwnerTokenRequest{
 				WorkspaceId: test.WorkspaceID,
 			}))
 			requireErrorCode(t, test.Expect.Code, err)
 			if test.Expect.Response != nil {
-				if diff := cmp.Diff(test.Expect.Response, resp.Msg, protocmp.Transform()); diff != "" {
-					t.Errorf("unexpected difference:\n%v", diff)
-				}
+				requireEqualProto(t, test.Expect.Response, resp.Msg)
 			}
 		})
 	}
 }
 
 func TestWorkspaceService_ListWorkspaces(t *testing.T) {
-	const (
-		bearerToken = "bearer-token-for-tests"
-	)
 	ctx := context.Background()
-
-	srv := baseserver.NewForTests(t,
-		baseserver.WithHTTP(baseserver.MustUseRandomLocalAddress(t)),
-	)
-
-	connPool := &FakeServerConnPool{}
-
-	route, handler := v1connect.NewWorkspacesServiceHandler(NewWorkspaceService(connPool), connect.WithInterceptors(auth.NewServerInterceptor()))
-	srv.HTTPMux().Handle(route, handler)
-
-	baseserver.StartServerForTests(t, srv)
-
-	client := v1connect.NewWorkspacesServiceClient(http.DefaultClient, srv.HTTPAddress(), connect.WithInterceptors(
-		auth.NewClientInterceptor(bearerToken),
-	))
 
 	type Expectation struct {
 		Code     connect.Code
@@ -281,15 +225,13 @@ func TestWorkspaceService_ListWorkspaces(t *testing.T) {
 				pagination = &v1.Pagination{PageSize: test.PageSize}
 			}
 
-			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
-			srv := protocol.NewMockAPIInterface(ctrl)
+			serverMock, client := setupWorkspacesService(t)
+
 			if test.Workspaces != nil {
-				srv.EXPECT().GetWorkspaces(gomock.Any(), gomock.Any()).Return(test.Workspaces, nil)
+				serverMock.EXPECT().GetWorkspaces(gomock.Any(), gomock.Any()).Return(test.Workspaces, nil)
 			} else if test.Setup != nil {
-				test.Setup(t, srv)
+				test.Setup(t, serverMock)
 			}
-			connPool.api = srv
 
 			resp, err := client.ListWorkspaces(ctx, connect.NewRequest(&v1.ListWorkspacesRequest{
 				Pagination: pagination,
@@ -431,6 +373,30 @@ func must[T any](t T, err error) T {
 		panic(err)
 	}
 	return t
+}
+
+func setupWorkspacesService(t *testing.T) (*protocol.MockAPIInterface, v1connect.WorkspacesServiceClient) {
+	t.Helper()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	serverMock := protocol.NewMockAPIInterface(ctrl)
+
+	svc := NewWorkspaceService(&FakeServerConnPool{
+		api: serverMock,
+	})
+
+	_, handler := v1connect.NewWorkspacesServiceHandler(svc, connect.WithInterceptors(auth.NewServerInterceptor()))
+
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	client := v1connect.NewWorkspacesServiceClient(http.DefaultClient, srv.URL, connect.WithInterceptors(
+		auth.NewClientInterceptor("auth-token"),
+	))
+
+	return serverMock, client
 }
 
 type FakeServerConnPool struct {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Follow-up to https://github.com/gitpod-io/gitpod/pull/14392#discussion_r1012742556

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
unit tests

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
