### PR TITLE
[previewctl] fix branch flag and rename structs

### DIFF
--- a/dev/preview/previewctl/cmd/get_name.go
+++ b/dev/preview/previewctl/cmd/get_name.go
@@ -12,17 +12,17 @@ import (
 	"github.com/gitpod-io/gitpod/previewctl/pkg/preview"
 )
 
-func newGetNameCmd(branch string) *cobra.Command {
+func newGetNameCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "get-name",
 		Short: "Returns the name of the preview for the corresponding branch.",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			branch, err := preview.GetName(branch)
+			previewName, err := preview.GetName(branch)
 			if err != nil {
 				return err
 			}
 
-			fmt.Println(branch)
+			fmt.Println(previewName)
 
 			return nil
 		},

--- a/dev/preview/previewctl/cmd/install_context.go
+++ b/dev/preview/previewctl/cmd/install_context.go
@@ -42,7 +42,7 @@ func newInstallContextCmd(logger *logrus.Logger) *cobra.Command {
 	}
 
 	// Used to ensure that we only install contexts
-	var lastSuccessfulPreviewEnvironment *preview.Preview = nil
+	var lastSuccessfulPreviewEnvironment *preview.Config = nil
 
 	install := func(timeout time.Duration) error {
 		name, err := preview.GetName(branch)

--- a/dev/preview/previewctl/cmd/list_previews.go
+++ b/dev/preview/previewctl/cmd/list_previews.go
@@ -13,17 +13,12 @@ import (
 	"github.com/gitpod-io/gitpod/previewctl/pkg/preview"
 )
 
-func listPreviewsCmd(logger *logrus.Logger) *cobra.Command {
-
+func newListPreviewsCmd(logger *logrus.Logger) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "List all existing Preview Environments.",
+		Short: "List all existing Config Environments.",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if branch != "" {
-				logger.Warn("Branch flag is ignored for 'list' command.")
-			}
-
-			p, err := preview.New(branch, logger)
+			p, err := preview.New("", logger)
 			if err != nil {
 				return err
 			}

--- a/dev/preview/previewctl/cmd/root.go
+++ b/dev/preview/previewctl/cmd/root.go
@@ -36,9 +36,9 @@ func NewRootCmd(logger *logrus.Logger) *cobra.Command {
 
 	cmd.AddCommand(
 		newInstallContextCmd(logger),
-		newGetNameCmd(branch),
-		listPreviewsCmd(logger),
-		SSHPreviewCmd(logger),
+		newGetNameCmd(),
+		newListPreviewsCmd(logger),
+		newSSHPreviewCmd(logger),
 		newGetCredentialsCommand(logger),
 	)
 

--- a/dev/preview/previewctl/cmd/ssh_vm.go
+++ b/dev/preview/previewctl/cmd/ssh_vm.go
@@ -11,13 +11,11 @@ import (
 	"github.com/gitpod-io/gitpod/previewctl/pkg/preview"
 )
 
-func SSHPreviewCmd(logger *logrus.Logger) *cobra.Command {
-
+func newSSHPreviewCmd(logger *logrus.Logger) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "ssh",
 		Short: "SSH into a preview's Virtual Machine.",
 		RunE: func(cmd *cobra.Command, args []string) error {
-
 			err := preview.SSHPreview(branch)
 			if err != nil {
 				logger.WithFields(logrus.Fields{"err": err}).Fatal("Failed to SSH preview's VM.")


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
* Fix the passing of the branch flag used in subcommands
   * The flag is bound to the variable when the command is executed. Passing it to the function that creates the command, means that it's empty. 
* Rename the the `Preview` struct. `preview.Preview` -> `preview.Config`
   * Doesn't stutter 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
