### PR TITLE
Use proper variable interpolation in Leeway script

### DIFF
--- a/components/BUILD.yaml
+++ b/components/BUILD.yaml
@@ -301,7 +301,7 @@ scripts:
       query="insert into d_b_user(id,name,creationDate,rolesOrPermissions,additionalData) values('builtin-user-agent-smith-0000000', 'agent-smith', DATE_FORMAT(NOW(3), '%Y-%m-%dT%T.%fZ'),'[\"admin\"]','{\"emailNotificationSettings\": {\"allowsChangelogMail\": false, \"allowsOnboardingMail\": true}}') on duplicate key update id=id;"
       mysql -e "$query" -u$DB_USERNAME -p$DB_PASSWORD -h 127.0.0.1 gitpod
 
-      query="insert into d_b_gitpod_token(tokenHash,name,type,userId,scopes,created,deleted) VALUES('$TOKEN','agent-smith',0,'builtin-user-agent-smith-0000000','function:adminBlockUser', '2021-03-16T10:28:57.608Z', false) on duplicate key update tokenHash=tokenHash;"
+      query="insert into d_b_gitpod_token(tokenHash,name,type,userId,scopes,created,deleted) VALUES('${TOKEN}','agent-smith',0,'builtin-user-agent-smith-0000000','function:adminBlockUser', '2021-03-16T10:28:57.608Z', false) on duplicate key update tokenHash=tokenHash;"
       mysql -e "$query" -u$DB_USERNAME -p$DB_PASSWORD -h 127.0.0.1 gitpod
 
       kill $PID || true


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

In https://github.com/gitpod-io/gitpod/pull/14183 the agent smith token was passed to `leeway run components:add-smith-token` as a leeway argument using `-DTOKEN=...` instead of an environment variable. It turns out that Leeway does variable interpolation only when using the full `${VARIABLE}` syntax so $TOKEN was evaluated by bash instead and contains the empty string.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

Follow up to https://github.com/gitpod-io/gitpod/pull/14183

## How to test
<!-- Provide steps to test this PR -->

Verified that the token is now in the DB (before this change it was empty)

```
# In one shell
kubectl port-forward statefulsets/mysql 3306:3306

# In another
export DB_USERNAME=$(kubectl get secrets mysql -o jsonpath="{.data.username}" | base64 -d)
export DB_PASSWORD=$(kubectl get secrets mysql -o jsonpath="{.data.password}" | base64 -d)
mysql -u${DB_USERNAME} -p${DB_PASSWORD} -h 127.0.0.1 gitpod
# select tokenHash, name, userId from d_b_gitpod_token;
```

To test it works I want it to block something. So I add `watch` to the list of "very" forbidden binaries.

```
EDITOR='code --wait' kubectl edit cm agent-smith
```

Add the following

```
"blocklists": {
  "very": {
    "binaries": ["watch"]
  }
},
```

Restart agent smith and tail the logs

```
kubectl delete pod agent-smith-2fwtr
kubectl logs -f agent-smith-fdddd
```

In a workspace in your preview environment use the `watch` commands, .e.g.

```
watch ls
```

It blocked the workspace, and from the logs of agent smith

```
Defaulted container "agent-smith" out of: agent-smith, kube-rbac-proxy
{"addr":"127.0.0.1:6060","file":"pprof.go:26","func":"Serve","level":"info","message":"serving pprof service","serviceContext":{"service":"agent-smith","version":"commit-172bf96007c979ca18c54d46c307a4aa7e9c2cbc"},"severity":"INFO","time":"2022-11-03T13:47:38Z"}
{"addr":"127.0.0.1:9500","file":"run.go:56","func":"func3","level":"info","message":"started Prometheus metrics server","serviceContext":{"service":"agent-smith","version":"commit-172bf96007c979ca18c54d46c307a4aa7e9c2cbc"},"severity":"INFO","time":"2022-11-03T13:47:38Z"}
{"file":"run.go:102","func":"func3","level":"info","message":"agent smith is up and running","namespace":"default","serviceContext":{"service":"agent-smith","version":"commit-172bf96007c979ca18c54d46c307a4aa7e9c2cbc"},"severity":"INFO","time":"2022-11-03T13:47:38Z"}
{"file":"export.go:69","func":"Info","level":"info","message":"procfs detector started","serviceContext":{"service":"agent-smith","version":"commit-172bf96007c979ca18c54d46c307a4aa7e9c2cbc"},"severity":"INFO","time":"2022-11-03T13:47:38Z"}
{"file":"agent.go:317","func":"Penalize","infringement":[{"Description":"graded.composite.commandline: matched \"watch\"","Kind":"very blocklisted executable","CommandLine":["watch","ls"]}],"instanceId":"d6f2d46e-f227-4af5-b870-707d53e89e32","level":"info","message":"stopping workspace and blocking user","serviceContext":{"service":"agent-smith","version":"commit-172bf96007c979ca18c54d46c307a4aa7e9c2cbc"},"severity":"INFO","time":"2022-11-03T13:48:08Z","userId":"4701f025-9637-4244-ae87-47b2bfa0b2c2","workspaceId":""}
{"file":"export.go:114","func":"Infof","level":"info","message":"Blocking user 4701f025-9637-4244-ae87-47b2bfa0b2c2 - workspace ","serviceContext":{"service":"agent-smith","version":"commit-172bf96007c979ca18c54d46c307a4aa7e9c2cbc"},"severity":"INFO","time":"2022-11-03T13:48:08Z"}
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
