### PR TITLE
[public-api] Proxy Cookies to downstream for auth

### DIFF
--- a/components/public-api-server/pkg/auth/context.go
+++ b/components/public-api-server/pkg/auth/context.go
@@ -34,6 +34,13 @@ func NewAccessToken(token string) Token {
 	}
 }
 
+func NewCookieToken(cookie string) Token {
+	return Token{
+		Type:  CookieTokenType,
+		Value: cookie,
+	}
+}
+
 func TokenToContext(ctx context.Context, token Token) context.Context {
 	return context.WithValue(ctx, authContextKey, token)
 }

--- a/components/public-api-server/pkg/auth/context_test.go
+++ b/components/public-api-server/pkg/auth/context_test.go
@@ -20,10 +20,7 @@ func TestTokenToAndFromContext_AccessToken(t *testing.T) {
 }
 
 func TestTokenToAndFromContext_CookieToken(t *testing.T) {
-	token := Token{
-		Type:  CookieTokenType,
-		Value: "my_token",
-	}
+	token := NewCookieToken("my_token")
 
 	extracted, err := TokenFromContext(TokenToContext(context.Background(), token))
 	require.NoError(t, err)

--- a/components/public-api-server/pkg/auth/middleware_test.go
+++ b/components/public-api-server/pkg/auth/middleware_test.go
@@ -42,7 +42,7 @@ func TestNewServerInterceptor(t *testing.T) {
 		{
 			Name:          "no headers return Unathenticated",
 			Headers:       nil,
-			ExpectedError: connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("empty authorization header: %w", NoAccessToken)),
+			ExpectedError: connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("No access token or cookie credentials available on request.")),
 		},
 		{
 			Name:          "authorization header with bearer token returns ok",

--- a/install/installer/pkg/components/public-api-server/configmap.go
+++ b/install/installer/pkg/components/public-api-server/configmap.go
@@ -35,7 +35,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 	})
 
 	cfg := config.Configuration{
-		GitpodServiceURL:               fmt.Sprintf("wss://%s/api/v1", ctx.Config.Domain),
+		GitpodServiceURL:               fmt.Sprintf("wss://%s/api/gitpod", ctx.Config.Domain),
 		StripeWebhookSigningSecretPath: stripeSecretPath,
 		BillingServiceAddress:          net.JoinHostPort(fmt.Sprintf("%s.%s.svc.cluster.local", usage.Component, ctx.Namespace), strconv.Itoa(usage.GRPCServicePort)),
 		Server: &baseserver.Configuration{

--- a/install/installer/pkg/components/public-api-server/configmap_test.go
+++ b/install/installer/pkg/components/public-api-server/configmap_test.go
@@ -5,8 +5,9 @@ package public_api_server
 
 import (
 	"fmt"
-	"github.com/gitpod-io/gitpod/installer/pkg/config/v1/experimental"
 	"testing"
+
+	"github.com/gitpod-io/gitpod/installer/pkg/config/v1/experimental"
 
 	"github.com/gitpod-io/gitpod/common-go/baseserver"
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
@@ -30,7 +31,7 @@ func TestConfigMap(t *testing.T) {
 	})
 
 	expectedConfiguration := config.Configuration{
-		GitpodServiceURL:               "wss://test.domain.everything.awesome.is/api/v1",
+		GitpodServiceURL:               "wss://test.domain.everything.awesome.is/api/gitpod",
 		BillingServiceAddress:          fmt.Sprintf("usage.%s.svc.cluster.local:9001", ctx.Namespace),
 		StripeWebhookSigningSecretPath: stripeSecretPath,
 		Server: &baseserver.Configuration{


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Cookies on the request are sent downstream to Server to use as authentication. We support both Access Tokens, and Cookies.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
Unit tests

See it on dashboard in [this PRs preview](https://github.com/gitpod-io/gitpod/pull/14403).

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
