### PR TITLE
Introduce a single Leeway entrypoint script

### DIFF
--- a/dev/BUILD.yaml
+++ b/dev/BUILD.yaml
@@ -28,3 +28,10 @@ packages:
       image:
         - ${imageRepoBase}/dev-utils:${version}
         - ${imageRepoBase}/dev-utils:commit-${__git_commit}
+scripts:
+  - name: preview
+    description: Build Gitpod, create a preview environment, and deploy to it
+    script: |
+      leeway run dev/preview:create-preview
+      leeway run dev/preview:build
+      leeway run dev/preview:deploy-gitpod

--- a/dev/preview/BUILD.yaml
+++ b/dev/preview/BUILD.yaml
@@ -30,6 +30,7 @@ scripts:
       export TF_VAR_vm_memory="${TF_VAR_vm_memory:-12Gi}"
       export TF_VAR_vm_storage_class="${TF_VAR_vm_storage_class:-longhorn-gitpod-k3s-202209251218-onereplica}"
       ./workflow/preview/deploy-harvester.sh
+      previewctl install-context
 
   - name: delete-preview
     description: Delete an existing preview environment


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This introduces a single top-level command `leeway run dev:preview` which delegates to our other Leeway scripts in `dev/preview`. I also changed `dev/preview:create-preview` so that it ensures the kubectx is installed (https://github.com/gitpod-io/gitpod/issues/14468).

With this PR you can open a Gitpod workspace and simply run `leeway run dev:preview` and it will Build Gitpod, create a preview environment, and deploy to it.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/14361
Fixes https://github.com/gitpod-io/gitpod/issues/14468

## How to test
<!-- Provide steps to test this PR -->

```sh
leeway run dev:preview
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
