### PR TITLE
[dashboard] Authenticate with Public API using Cookies instead of Tokens

### DIFF
--- a/components/dashboard/src/service/public-api.ts
+++ b/components/dashboard/src/service/public-api.ts
@@ -4,46 +4,16 @@
  * See License-AGPL.txt in the project root for license information.
  */
 
-import { createConnectTransport, createPromiseClient, Interceptor } from "@bufbuild/connect-web";
+import { createConnectTransport, createPromiseClient } from "@bufbuild/connect-web";
 import { Team as ProtocolTeam } from "@gitpod/gitpod-protocol/lib/teams-projects-protocol";
 import { TeamsService } from "@gitpod/public-api/lib/gitpod/experimental/v1/teams_connectweb";
 import { Team } from "@gitpod/public-api/lib/gitpod/experimental/v1/teams_pb";
 import { TeamMemberInfo, TeamMemberRole } from "@gitpod/gitpod-protocol";
 import { TeamMember, TeamRole } from "@gitpod/public-api/lib/gitpod/experimental/v1/teams_pb";
-import { getGitpodService } from "./service";
-
-let token: string | undefined;
-
-const authInterceptor: Interceptor = (next) => async (req) => {
-    if (!token) {
-        const newToken = await getGitpodService().server.generateNewGitpodToken({
-            type: 1,
-            scopes: [
-                "function:getGitpodTokenScopes",
-
-                "function:getWorkspace",
-                "function:getWorkspaces",
-
-                "function:createTeam",
-                "function:joinTeam",
-                "function:getTeams",
-                "function:getTeam",
-                "function:getTeamMembers",
-                "function:getGenericInvite",
-
-                "resource:default",
-            ],
-        });
-        token = newToken;
-    }
-
-    req.header.set("Authorization", `Bearer ${token}`);
-    return await next(req);
-};
 
 const transport = createConnectTransport({
     baseUrl: `${window.location.protocol}//api.${window.location.host}`,
-    interceptors: [authInterceptor],
+    credentials: "include",
 });
 
 export const teamsService = createPromiseClient(TeamsService, transport);


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Using existing Cookies to authenticate against Public API

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Depends on https://github.com/gitpod-io/gitpod/pull/14398

## How to test
<!-- Provide steps to test this PR -->
1. Open up preview
2. Sign in, open up console
3. Create Team, notice the request to HTTP `CreateTeam`, observe it's sending Cookies and receives an OK response

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
