### PR TITLE
[registry-facade] Add additional GetBlob error logs

### DIFF
--- a/components/registry-facade/pkg/registry/blob.go
+++ b/components/registry-facade/pkg/registry/blob.go
@@ -172,12 +172,13 @@ func (bh *blobHandler) getBlob(w http.ResponseWriter, r *http.Request) {
 
 		n, err := io.CopyBuffer(w, rc, *bp)
 		if err != nil {
-			log.WithError(err).Error("unable to return blob")
+			bh.Metrics.BlobDownloadCounter.WithLabelValues(src.Name(), "false").Inc()
+			log.WithField("blobSource", src.Name()).WithField("baseRef", bh.Spec.BaseRef).WithError(err).Error("unable to return blob")
 			return err
 		}
 
 		bh.Metrics.BlobDownloadSpeedHist.WithLabelValues(src.Name()).Observe(float64(n) / time.Since(t0).Seconds())
-		bh.Metrics.BlobDownloadCounter.WithLabelValues(src.Name()).Inc()
+		bh.Metrics.BlobDownloadCounter.WithLabelValues(src.Name(), "true").Inc()
 		bh.Metrics.BlobDownloadSizeCounter.WithLabelValues(src.Name()).Add(float64(n))
 
 		if dontCache {

--- a/components/registry-facade/pkg/registry/metrics.go
+++ b/components/registry-facade/pkg/registry/metrics.go
@@ -93,7 +93,7 @@ func newMetrics(reg prometheus.Registerer, upstream bool) (*metrics, error) {
 	blobDownloadCounter := prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "blob_req_dl_total",
 		Help: "number of blob download requests",
-	}, []string{"blobSource"})
+	}, []string{"blobSource", "ok"})
 	err = reg.Register(blobDownloadCounter)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Description

We don't have enough details about the base reference and additionally improve the `BlobDownloadCounter` metric to get details about the result of the operation

## Related Issue(s)
xref: https://github.com/gitpod-io/gitpod/issues/14264

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
