### PR TITLE
[dashboard] ResetTeamInvitation uses Public API

### DIFF
--- a/components/dashboard/src/teams/Members.tsx
+++ b/components/dashboard/src/teams/Members.tsx
@@ -96,8 +96,10 @@ export default function () {
         // reset genericInvite first to prevent races on double click
         if (genericInviteId) {
             setGenericInviteId(undefined);
-            const newInvite = await getGitpodService().server.resetGenericInvite(team!.id);
-            setGenericInviteId(newInvite.id);
+            const newInviteId = usePublicApiTeamsService
+                ? (await teamsService.resetTeamInvitation({ teamId: team!.id })).teamInvitation?.id
+                : (await getGitpodService().server.resetGenericInvite(team!.id)).id;
+            setGenericInviteId(newInviteId);
         }
     };
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Dashboard uses Public API when resetting team invitations.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Fixes https://github.com/gitpod-io/gitpod/issues/14384

## How to test
<!-- Provide steps to test this PR -->

1. Preview env, open dev console
2. Create a team
3. Reset team invitation, observe request made to `ResetTeamInvitation`, observe OK response

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
