### PR TITLE
Add galleryHost label

### DIFF
--- a/install/installer/cmd/testdata/render/aws-setup/output.golden
+++ b/install/installer/cmd/testdata/render/aws-setup/output.golden
@@ -3590,6 +3590,13 @@ data:
                   "unknown"
                 ],
                 "defaultValue": "unknown"
+              },
+              {
+                "name": "galleryHost",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
               }
             ]
           },
@@ -4122,6 +4129,13 @@ data:
                   "unknown"
                 ],
                 "defaultValue": "unknown"
+              },
+              {
+                "name": "galleryHost",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
               }
             ]
           }
@@ -4140,6 +4154,13 @@ data:
                   "unknown"
                 ],
                 "defaultValue": "unknown"
+              },
+              {
+                "name": "galleryHost",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
               }
             ],
             "buckets": [
@@ -4155,7 +4176,15 @@ data:
           {
             "name": "gitpod_vscode_extension_gallery_query_duration_seconds",
             "help": "Duration of extension gallery query in seconds",
-            "labels": null,
+            "labels": [
+              {
+                "name": "galleryHost",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              }
+            ],
             "buckets": [
               0.1,
               0.5,
@@ -8006,7 +8035,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3b484bff26b16b51cc8e2df68b21ecb4a69ce4cd7a98de9fc2b568210918e948
+        gitpod.io/checksum_config: a15b2b182f09debb86b167e728add4f9d341bc9706bc4e330e1d4a5c9d4deee9
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/azure-setup/output.golden
+++ b/install/installer/cmd/testdata/render/azure-setup/output.golden
@@ -3507,6 +3507,13 @@ data:
                   "unknown"
                 ],
                 "defaultValue": "unknown"
+              },
+              {
+                "name": "galleryHost",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
               }
             ]
           },
@@ -4039,6 +4046,13 @@ data:
                   "unknown"
                 ],
                 "defaultValue": "unknown"
+              },
+              {
+                "name": "galleryHost",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
               }
             ]
           }
@@ -4057,6 +4071,13 @@ data:
                   "unknown"
                 ],
                 "defaultValue": "unknown"
+              },
+              {
+                "name": "galleryHost",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
               }
             ],
             "buckets": [
@@ -4072,7 +4093,15 @@ data:
           {
             "name": "gitpod_vscode_extension_gallery_query_duration_seconds",
             "help": "Duration of extension gallery query in seconds",
-            "labels": null,
+            "labels": [
+              {
+                "name": "galleryHost",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              }
+            ],
             "buckets": [
               0.1,
               0.5,
@@ -7839,7 +7868,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3b484bff26b16b51cc8e2df68b21ecb4a69ce4cd7a98de9fc2b568210918e948
+        gitpod.io/checksum_config: a15b2b182f09debb86b167e728add4f9d341bc9706bc4e330e1d4a5c9d4deee9
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -4324,6 +4324,13 @@ data:
                   "unknown"
                 ],
                 "defaultValue": "unknown"
+              },
+              {
+                "name": "galleryHost",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
               }
             ]
           },
@@ -4856,6 +4863,13 @@ data:
                   "unknown"
                 ],
                 "defaultValue": "unknown"
+              },
+              {
+                "name": "galleryHost",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
               }
             ]
           }
@@ -4874,6 +4888,13 @@ data:
                   "unknown"
                 ],
                 "defaultValue": "unknown"
+              },
+              {
+                "name": "galleryHost",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
               }
             ],
             "buckets": [
@@ -4889,7 +4910,15 @@ data:
           {
             "name": "gitpod_vscode_extension_gallery_query_duration_seconds",
             "help": "Duration of extension gallery query in seconds",
-            "labels": null,
+            "labels": [
+              {
+                "name": "galleryHost",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              }
+            ],
             "buckets": [
               0.1,
               0.5,
@@ -9277,7 +9306,7 @@ spec:
     metadata:
       annotations:
         gitpod.io: hello
-        gitpod.io/checksum_config: 05679fb283e29bcb12e216617962028f947e33d2e525e7ad0a06ce75f5df6fb3
+        gitpod.io/checksum_config: 74ecbbd8492d8fefde88122798e66f4d886da1cc357b33e62d71b3d80dcc2234
         hello: world
       creationTimestamp: null
       labels:

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -3648,6 +3648,13 @@ data:
                   "unknown"
                 ],
                 "defaultValue": "unknown"
+              },
+              {
+                "name": "galleryHost",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
               }
             ]
           },
@@ -4180,6 +4187,13 @@ data:
                   "unknown"
                 ],
                 "defaultValue": "unknown"
+              },
+              {
+                "name": "galleryHost",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
               }
             ]
           }
@@ -4198,6 +4212,13 @@ data:
                   "unknown"
                 ],
                 "defaultValue": "unknown"
+              },
+              {
+                "name": "galleryHost",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
               }
             ],
             "buckets": [
@@ -4213,7 +4234,15 @@ data:
           {
             "name": "gitpod_vscode_extension_gallery_query_duration_seconds",
             "help": "Duration of extension gallery query in seconds",
-            "labels": null,
+            "labels": [
+              {
+                "name": "galleryHost",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              }
+            ],
             "buckets": [
               0.1,
               0.5,
@@ -8280,7 +8309,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3b484bff26b16b51cc8e2df68b21ecb4a69ce4cd7a98de9fc2b568210918e948
+        gitpod.io/checksum_config: a15b2b182f09debb86b167e728add4f9d341bc9706bc4e330e1d4a5c9d4deee9
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/gcp-setup/output.golden
+++ b/install/installer/cmd/testdata/render/gcp-setup/output.golden
@@ -3478,6 +3478,13 @@ data:
                   "unknown"
                 ],
                 "defaultValue": "unknown"
+              },
+              {
+                "name": "galleryHost",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
               }
             ]
           },
@@ -4010,6 +4017,13 @@ data:
                   "unknown"
                 ],
                 "defaultValue": "unknown"
+              },
+              {
+                "name": "galleryHost",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
               }
             ]
           }
@@ -4028,6 +4042,13 @@ data:
                   "unknown"
                 ],
                 "defaultValue": "unknown"
+              },
+              {
+                "name": "galleryHost",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
               }
             ],
             "buckets": [
@@ -4043,7 +4064,15 @@ data:
           {
             "name": "gitpod_vscode_extension_gallery_query_duration_seconds",
             "help": "Duration of extension gallery query in seconds",
-            "labels": null,
+            "labels": [
+              {
+                "name": "galleryHost",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              }
+            ],
             "buckets": [
               0.1,
               0.5,
@@ -7894,7 +7923,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3b484bff26b16b51cc8e2df68b21ecb4a69ce4cd7a98de9fc2b568210918e948
+        gitpod.io/checksum_config: a15b2b182f09debb86b167e728add4f9d341bc9706bc4e330e1d4a5c9d4deee9
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/http-proxy/output.golden
+++ b/install/installer/cmd/testdata/render/http-proxy/output.golden
@@ -3817,6 +3817,13 @@ data:
                   "unknown"
                 ],
                 "defaultValue": "unknown"
+              },
+              {
+                "name": "galleryHost",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
               }
             ]
           },
@@ -4349,6 +4356,13 @@ data:
                   "unknown"
                 ],
                 "defaultValue": "unknown"
+              },
+              {
+                "name": "galleryHost",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
               }
             ]
           }
@@ -4367,6 +4381,13 @@ data:
                   "unknown"
                 ],
                 "defaultValue": "unknown"
+              },
+              {
+                "name": "galleryHost",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
               }
             ],
             "buckets": [
@@ -4382,7 +4403,15 @@ data:
           {
             "name": "gitpod_vscode_extension_gallery_query_duration_seconds",
             "help": "Duration of extension gallery query in seconds",
-            "labels": null,
+            "labels": [
+              {
+                "name": "galleryHost",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              }
+            ],
             "buckets": [
               0.1,
               0.5,
@@ -9245,7 +9274,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3b484bff26b16b51cc8e2df68b21ecb4a69ce4cd7a98de9fc2b568210918e948
+        gitpod.io/checksum_config: a15b2b182f09debb86b167e728add4f9d341bc9706bc4e330e1d4a5c9d4deee9
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/insecure-s3-setup/output.golden
+++ b/install/installer/cmd/testdata/render/insecure-s3-setup/output.golden
@@ -3728,6 +3728,13 @@ data:
                   "unknown"
                 ],
                 "defaultValue": "unknown"
+              },
+              {
+                "name": "galleryHost",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
               }
             ]
           },
@@ -4260,6 +4267,13 @@ data:
                   "unknown"
                 ],
                 "defaultValue": "unknown"
+              },
+              {
+                "name": "galleryHost",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
               }
             ]
           }
@@ -4278,6 +4292,13 @@ data:
                   "unknown"
                 ],
                 "defaultValue": "unknown"
+              },
+              {
+                "name": "galleryHost",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
               }
             ],
             "buckets": [
@@ -4293,7 +4314,15 @@ data:
           {
             "name": "gitpod_vscode_extension_gallery_query_duration_seconds",
             "help": "Duration of extension gallery query in seconds",
-            "labels": null,
+            "labels": [
+              {
+                "name": "galleryHost",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              }
+            ],
             "buckets": [
               0.1,
               0.5,
@@ -8442,7 +8471,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3b484bff26b16b51cc8e2df68b21ecb4a69ce4cd7a98de9fc2b568210918e948
+        gitpod.io/checksum_config: a15b2b182f09debb86b167e728add4f9d341bc9706bc4e330e1d4a5c9d4deee9
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -3814,6 +3814,13 @@ data:
                   "unknown"
                 ],
                 "defaultValue": "unknown"
+              },
+              {
+                "name": "galleryHost",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
               }
             ]
           },
@@ -4346,6 +4353,13 @@ data:
                   "unknown"
                 ],
                 "defaultValue": "unknown"
+              },
+              {
+                "name": "galleryHost",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
               }
             ]
           }
@@ -4364,6 +4378,13 @@ data:
                   "unknown"
                 ],
                 "defaultValue": "unknown"
+              },
+              {
+                "name": "galleryHost",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
               }
             ],
             "buckets": [
@@ -4379,7 +4400,15 @@ data:
           {
             "name": "gitpod_vscode_extension_gallery_query_duration_seconds",
             "help": "Duration of extension gallery query in seconds",
-            "labels": null,
+            "labels": [
+              {
+                "name": "galleryHost",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              }
+            ],
             "buckets": [
               0.1,
               0.5,
@@ -8560,7 +8589,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3b484bff26b16b51cc8e2df68b21ecb4a69ce4cd7a98de9fc2b568210918e948
+        gitpod.io/checksum_config: a15b2b182f09debb86b167e728add4f9d341bc9706bc4e330e1d4a5c9d4deee9
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/shortname/output.golden
+++ b/install/installer/cmd/testdata/render/shortname/output.golden
@@ -3814,6 +3814,13 @@ data:
                   "unknown"
                 ],
                 "defaultValue": "unknown"
+              },
+              {
+                "name": "galleryHost",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
               }
             ]
           },
@@ -4346,6 +4353,13 @@ data:
                   "unknown"
                 ],
                 "defaultValue": "unknown"
+              },
+              {
+                "name": "galleryHost",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
               }
             ]
           }
@@ -4364,6 +4378,13 @@ data:
                   "unknown"
                 ],
                 "defaultValue": "unknown"
+              },
+              {
+                "name": "galleryHost",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
               }
             ],
             "buckets": [
@@ -4379,7 +4400,15 @@ data:
           {
             "name": "gitpod_vscode_extension_gallery_query_duration_seconds",
             "help": "Duration of extension gallery query in seconds",
-            "labels": null,
+            "labels": [
+              {
+                "name": "galleryHost",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              }
+            ],
             "buckets": [
               0.1,
               0.5,
@@ -8560,7 +8589,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3b484bff26b16b51cc8e2df68b21ecb4a69ce4cd7a98de9fc2b568210918e948
+        gitpod.io/checksum_config: a15b2b182f09debb86b167e728add4f9d341bc9706bc4e330e1d4a5c9d4deee9
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -3826,6 +3826,13 @@ data:
                   "unknown"
                 ],
                 "defaultValue": "unknown"
+              },
+              {
+                "name": "galleryHost",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
               }
             ]
           },
@@ -4358,6 +4365,13 @@ data:
                   "unknown"
                 ],
                 "defaultValue": "unknown"
+              },
+              {
+                "name": "galleryHost",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
               }
             ]
           }
@@ -4376,6 +4390,13 @@ data:
                   "unknown"
                 ],
                 "defaultValue": "unknown"
+              },
+              {
+                "name": "galleryHost",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
               }
             ],
             "buckets": [
@@ -4391,7 +4412,15 @@ data:
           {
             "name": "gitpod_vscode_extension_gallery_query_duration_seconds",
             "help": "Duration of extension gallery query in seconds",
-            "labels": null,
+            "labels": [
+              {
+                "name": "galleryHost",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              }
+            ],
             "buckets": [
               0.1,
               0.5,
@@ -8572,7 +8601,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3b484bff26b16b51cc8e2df68b21ecb4a69ce4cd7a98de9fc2b568210918e948
+        gitpod.io/checksum_config: a15b2b182f09debb86b167e728add4f9d341bc9706bc4e330e1d4a5c9d4deee9
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
+++ b/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
@@ -4147,6 +4147,13 @@ data:
                   "unknown"
                 ],
                 "defaultValue": "unknown"
+              },
+              {
+                "name": "galleryHost",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
               }
             ]
           },
@@ -4679,6 +4686,13 @@ data:
                   "unknown"
                 ],
                 "defaultValue": "unknown"
+              },
+              {
+                "name": "galleryHost",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
               }
             ]
           }
@@ -4697,6 +4711,13 @@ data:
                   "unknown"
                 ],
                 "defaultValue": "unknown"
+              },
+              {
+                "name": "galleryHost",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
               }
             ],
             "buckets": [
@@ -4712,7 +4733,15 @@ data:
           {
             "name": "gitpod_vscode_extension_gallery_query_duration_seconds",
             "help": "Duration of extension gallery query in seconds",
-            "labels": null,
+            "labels": [
+              {
+                "name": "galleryHost",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              }
+            ],
             "buckets": [
               0.1,
               0.5,
@@ -9004,7 +9033,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3b484bff26b16b51cc8e2df68b21ecb4a69ce4cd7a98de9fc2b568210918e948
+        gitpod.io/checksum_config: a15b2b182f09debb86b167e728add4f9d341bc9706bc4e330e1d4a5c9d4deee9
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
+++ b/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
@@ -3817,6 +3817,13 @@ data:
                   "unknown"
                 ],
                 "defaultValue": "unknown"
+              },
+              {
+                "name": "galleryHost",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
               }
             ]
           },
@@ -4349,6 +4356,13 @@ data:
                   "unknown"
                 ],
                 "defaultValue": "unknown"
+              },
+              {
+                "name": "galleryHost",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
               }
             ]
           }
@@ -4367,6 +4381,13 @@ data:
                   "unknown"
                 ],
                 "defaultValue": "unknown"
+              },
+              {
+                "name": "galleryHost",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
               }
             ],
             "buckets": [
@@ -4382,7 +4403,15 @@ data:
           {
             "name": "gitpod_vscode_extension_gallery_query_duration_seconds",
             "help": "Duration of extension gallery query in seconds",
-            "labels": null,
+            "labels": [
+              {
+                "name": "galleryHost",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              }
+            ],
             "buckets": [
               0.1,
               0.5,
@@ -8563,7 +8592,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3b484bff26b16b51cc8e2df68b21ecb4a69ce4cd7a98de9fc2b568210918e948
+        gitpod.io/checksum_config: a15b2b182f09debb86b167e728add4f9d341bc9706bc4e330e1d4a5c9d4deee9
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/pkg/components/ide-metrics/configmap.go
+++ b/install/installer/pkg/components/ide-metrics/configmap.go
@@ -151,6 +151,10 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 					AllowValues:  []string{"success", "failure", "unknown"},
 					DefaultValue: "unknown",
 				},
+				{
+					Name:        "galleryHost",
+					AllowValues: []string{"*"},
+				},
 				// TODO(ak) errorCode - we should analyze error codes collect in analytics and categotize them here
 			},
 		},
@@ -173,6 +177,10 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 					AllowValues:  []string{"canceled", "timeout", "failed", "unknown"},
 					DefaultValue: "unknown",
 				},
+				{
+					Name:        "galleryHost",
+					AllowValues: []string{"*"},
+				},
 			},
 		},
 	}
@@ -187,11 +195,21 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 					AllowValues:  []string{"install", "update", "uninstall", "unknown"},
 					DefaultValue: "unknown",
 				},
+				{
+					Name:        "galleryHost",
+					AllowValues: []string{"*"},
+				},
 			},
 			Buckets: []float64{0.1, 0.5, 1, 5, 10, 15, 30},
 		}, {
-			Name:    "gitpod_vscode_extension_gallery_query_duration_seconds",
-			Help:    "Duration of extension gallery query in seconds",
+			Name: "gitpod_vscode_extension_gallery_query_duration_seconds",
+			Help: "Duration of extension gallery query in seconds",
+			Labels: []config.LabelAllowList{
+				{
+					Name:        "galleryHost",
+					AllowValues: []string{"*"},
+				},
+			},
 			Buckets: []float64{0.1, 0.5, 1, 5, 10, 15, 30},
 		},
 	}

--- a/operations/observability/mixins/IDE/dashboards/components/code-browser.json
+++ b/operations/observability/mixins/IDE/dashboards/components/code-browser.json
@@ -134,7 +134,7 @@
             "uid": "P4169E866C3094E38"
           },
           "editorMode": "code",
-          "expr": "sum(rate(gitpod_vscode_web_load_total{status='failed'}[2m])) /sum(rate(gitpod_vscode_web_load_total{status='loading'}[2m]))",
+          "expr": "sum(rate(gitpod_vscode_web_load_total{status='failed',galleryHost=~\"$galleryHost\"}[2m])) /sum(rate(gitpod_vscode_web_load_total{status='loading',galleryHost=~\"$galleryHost\"}[2m]))",
           "legendFormat": "total_ratio",
           "range": true,
           "refId": "A"
@@ -243,7 +243,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(gitpod_vscode_extension_gallery_query_total[2m]))",
+          "expr": "sum(rate(gitpod_vscode_extension_gallery_query_total{galleryHost=~\"$galleryHost\"}[2m]))",
           "legendFormat": "rate",
           "range": true,
           "refId": "A"
@@ -339,7 +339,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(1, sum(rate(gitpod_vscode_extension_gallery_query_duration_seconds_bucket[1m])) by (le))",
+          "expr": "histogram_quantile(1, sum(rate(gitpod_vscode_extension_gallery_query_duration_seconds_bucket{galleryHost=~\"$galleryHost\"}[1m])) by (le))",
           "legendFormat": "max",
           "range": true,
           "refId": "A"
@@ -350,7 +350,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum(rate(gitpod_vscode_extension_gallery_query_duration_seconds_bucket[1m])) by (le))",
+          "expr": "histogram_quantile(0.99, sum(rate(gitpod_vscode_extension_gallery_query_duration_seconds_bucket{galleryHost=~\"$galleryHost\"}[1m])) by (le))",
           "hide": false,
           "legendFormat": "P99",
           "range": true,
@@ -362,7 +362,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum(rate(gitpod_vscode_extension_gallery_query_duration_seconds_bucket[1m])) by (le))",
+          "expr": "histogram_quantile(0.95, sum(rate(gitpod_vscode_extension_gallery_query_duration_seconds_bucket{galleryHost=~\"$galleryHost\"}[1m])) by (le))",
           "hide": false,
           "legendFormat": "P95",
           "range": true,
@@ -374,7 +374,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.5, sum(rate(gitpod_vscode_extension_gallery_query_duration_seconds_bucket[1m])) by (le))",
+          "expr": "histogram_quantile(0.5, sum(rate(gitpod_vscode_extension_gallery_query_duration_seconds_bucket{galleryHost=~\"$galleryHost\"}[1m])) by (le))",
           "hide": false,
           "legendFormat": "mean",
           "range": true,
@@ -472,7 +472,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(gitpod_vscode_extension_gallery_query_total{status=\"failure\",errorCode!=\"canceled\"}[2m]))/sum(rate(gitpod_vscode_extension_gallery_query_total[2m]))",
+          "expr": "sum(rate(gitpod_vscode_extension_gallery_query_total{status=\"failure\",errorCode!=\"canceled\",galleryHost=~\"$galleryHost\"}[2m]))/sum(rate(gitpod_vscode_extension_gallery_query_total{galleryHost=~\"$galleryHost\"}[2m]))",
           "legendFormat": "total ratio",
           "range": true,
           "refId": "A"
@@ -569,7 +569,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by (statusCode) (rate(gitpod_vscode_extension_gallery_query_total{status=\"failure\",errorCode!=\"canceled\"}[2m]))/ignoring(statusCode) group_left sum(rate(gitpod_vscode_extension_gallery_query_total[2m]))",
+          "expr": "sum by (statusCode) (rate(gitpod_vscode_extension_gallery_query_total{status=\"failure\",errorCode!=\"canceled\",galleryHost=~\"$galleryHost\"}[2m]))/ignoring(statusCode) group_left sum(rate(gitpod_vscode_extension_gallery_query_total{galleryHost=~\"$galleryHost\"}[2m]))",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -665,7 +665,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by (errorCode) (rate(gitpod_vscode_extension_gallery_query_total{status=\"failure\"}[2m]))/ignoring(errorCode) group_left sum(rate(gitpod_vscode_extension_gallery_query_total[2m]))",
+          "expr": "sum by (errorCode) (rate(gitpod_vscode_extension_gallery_query_total{status=\"failure\",galleryHost=~\"$galleryHost\"}[2m]))/ignoring(errorCode) group_left sum(rate(gitpod_vscode_extension_gallery_query_total{galleryHost=~\"$galleryHost\"}[2m]))",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -773,7 +773,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(gitpod_vscode_extension_gallery_operation_total{operation=~\"$operation\"}[2m]))",
+          "expr": "sum(rate(gitpod_vscode_extension_gallery_operation_total{operation=~\"$operation\",galleryHost=~\"$galleryHost\"}[2m]))",
           "legendFormat": "rate",
           "range": true,
           "refId": "A"
@@ -869,7 +869,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(gitpod_vscode_extension_gallery_operation_total{status=\"failure\",operation=~\"$operation\"}[2m]))/sum(rate(gitpod_vscode_extension_gallery_operation_total{operation=~\"$operation\"}[2m]))",
+          "expr": "sum(rate(gitpod_vscode_extension_gallery_operation_total{status=\"failure\",operation=~\"$operation\",galleryHost=~\"$galleryHost\"}[2m]))/sum(rate(gitpod_vscode_extension_gallery_operation_total{operation=~\"$operation\",galleryHost=~\"$galleryHost\"}[2m]))",
           "legendFormat": "total ratio",
           "range": true,
           "refId": "A"
@@ -965,7 +965,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by (operation) (rate(gitpod_vscode_extension_gallery_operation_total{status=\"failure\",operation=~\"$operation\"}[2m]))/ignoring(operation) group_left sum(rate(gitpod_vscode_extension_gallery_operation_total{operation=~\"$operation\"}[2m]))",
+          "expr": "sum by (operation) (rate(gitpod_vscode_extension_gallery_operation_total{status=\"failure\",operation=~\"$operation\",galleryHost=~\"$galleryHost\"}[2m]))/ignoring(operation) group_left sum(rate(gitpod_vscode_extension_gallery_operation_total{operation=~\"$operation\",galleryHost=~\"$galleryHost\"}[2m]))",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -1060,7 +1060,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(1, sum(rate(gitpod_vscode_extension_gallery_operation_duration_seconds_bucket{operation=~\"$operation\"}[1m])) by (le))",
+          "expr": "histogram_quantile(1, sum(rate(gitpod_vscode_extension_gallery_operation_duration_seconds_bucket{operation=~\"$operation\",galleryHost=~\"$galleryHost\"}[1m])) by (le))",
           "legendFormat": "max",
           "range": true,
           "refId": "A"
@@ -1071,7 +1071,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum(rate(gitpod_vscode_extension_gallery_operation_duration_seconds_bucket{operation=~\"$operation\"}[1m])) by (le))",
+          "expr": "histogram_quantile(0.99, sum(rate(gitpod_vscode_extension_gallery_operation_duration_seconds_bucket{operation=~\"$operation\",galleryHost=~\"$galleryHost\"}[1m])) by (le))",
           "hide": false,
           "legendFormat": "P99",
           "range": true,
@@ -1083,7 +1083,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum(rate(gitpod_vscode_extension_gallery_operation_duration_seconds_bucket{operation=~\"$operation\"}[1m])) by (le))",
+          "expr": "histogram_quantile(0.95, sum(rate(gitpod_vscode_extension_gallery_operation_duration_seconds_bucket{operation=~\"$operation\",galleryHost=~\"$galleryHost\"}[1m])) by (le))",
           "hide": false,
           "legendFormat": "P95",
           "range": true,
@@ -1095,7 +1095,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.5, sum(rate(gitpod_vscode_extension_gallery_operation_duration_seconds_bucket{operation=~\"$operation\"}[1m])) by (le))",
+          "expr": "histogram_quantile(0.5, sum(rate(gitpod_vscode_extension_gallery_operation_duration_seconds_bucket{operation=~\"$operation\",galleryHost=~\"$galleryHost\"}[1m])) by (le))",
           "hide": false,
           "legendFormat": "mean",
           "range": true,
@@ -1191,7 +1191,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(1, sum(rate(gitpod_vscode_extension_gallery_operation_duration_seconds_bucket{operation=~\"$operation\"}[1m])) by (le, operation))",
+          "expr": "histogram_quantile(1, sum(rate(gitpod_vscode_extension_gallery_operation_duration_seconds_bucket{operation=~\"$operation\",galleryHost=~\"$galleryHost\"}[1m])) by (le, operation))",
           "legendFormat": "{{operation}} - max",
           "range": true,
           "refId": "A"
@@ -1202,7 +1202,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum(rate(gitpod_vscode_extension_gallery_operation_duration_seconds_bucket{operation=~\"$operation\"}[1m])) by (le, operation))",
+          "expr": "histogram_quantile(0.99, sum(rate(gitpod_vscode_extension_gallery_operation_duration_seconds_bucket{operation=~\"$operation\",galleryHost=~\"$galleryHost\"}[1m])) by (le, operation))",
           "hide": false,
           "legendFormat": "{{operation}} - P99",
           "range": true,
@@ -1214,7 +1214,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum(rate(gitpod_vscode_extension_gallery_operation_duration_seconds_bucket{operation=~\"$operation\"}[1m])) by (le, operation))",
+          "expr": "histogram_quantile(0.95, sum(rate(gitpod_vscode_extension_gallery_operation_duration_seconds_bucket{operation=~\"$operation\",galleryHost=~\"$galleryHost\"}[1m])) by (le, operation))",
           "hide": false,
           "legendFormat": "{{operation}} - P95",
           "range": true,
@@ -1226,7 +1226,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.5, sum(rate(gitpod_vscode_extension_gallery_operation_duration_seconds_bucket{operation=~\"$operation\"}[1m])) by (le, operation))",
+          "expr": "histogram_quantile(0.5, sum(rate(gitpod_vscode_extension_gallery_operation_duration_seconds_bucket{operation=~\"$operation\",galleryHost=~\"$galleryHost\"}[1m])) by (le, operation))",
           "hide": false,
           "legendFormat": "{{operation}} - mean",
           "range": true,
@@ -1288,6 +1288,36 @@
         "regex": "",
         "skipUrlSync": false,
         "type": "datasource"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(gitpod_vscode_extension_gallery_operation_total, galleryHost)",
+        "hide": 0,
+        "includeAll": true,
+        "multi": true,
+        "name": "galleryHost",
+        "options": [],
+        "query": {
+          "query": "label_values(gitpod_vscode_extension_gallery_operation_total, galleryHost)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
       }
     ]
   },


### PR DESCRIPTION
Add galleryHost label

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
