### PR TITLE
[public-api] Parametrize connection URL based on token

### DIFF
--- a/components/public-api-server/pkg/proxy/conn_test.go
+++ b/components/public-api-server/pkg/proxy/conn_test.go
@@ -6,6 +6,7 @@ package proxy
 
 import (
 	"context"
+	"net/url"
 	"testing"
 
 	gitpod "github.com/gitpod-io/gitpod/gitpod-protocol"
@@ -46,4 +47,17 @@ func TestConnectionPool(t *testing.T) {
 	require.Equal(t, 2, pool.cache.Len(), "must keep only last two connectons")
 	require.True(t, pool.cache.Contains(barToken))
 	require.True(t, pool.cache.Contains(bazToken))
+}
+
+func TestEndpointBasedOnToken(t *testing.T) {
+	u, err := url.Parse("wss://gitpod.io")
+	require.NoError(t, err)
+
+	endpointForAccessToken, err := getEndpointBasedOnToken(auth.NewAccessToken("foo"), u)
+	require.NoError(t, err)
+	require.Equal(t, "wss://gitpod.io/api/v1", endpointForAccessToken)
+
+	endpointForCookie, err := getEndpointBasedOnToken(auth.NewCookieToken("foo"), u)
+	require.NoError(t, err)
+	require.Equal(t, "wss://gitpod.io/api/gitpod", endpointForCookie)
 }

--- a/install/installer/pkg/components/public-api-server/configmap.go
+++ b/install/installer/pkg/components/public-api-server/configmap.go
@@ -35,7 +35,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 	})
 
 	cfg := config.Configuration{
-		GitpodServiceURL:               fmt.Sprintf("wss://%s/api/gitpod", ctx.Config.Domain),
+		GitpodServiceURL:               fmt.Sprintf("wss://%s", ctx.Config.Domain),
 		StripeWebhookSigningSecretPath: stripeSecretPath,
 		BillingServiceAddress:          net.JoinHostPort(fmt.Sprintf("%s.%s.svc.cluster.local", usage.Component, ctx.Namespace), strconv.Itoa(usage.GRPCServicePort)),
 		Server: &baseserver.Configuration{

--- a/install/installer/pkg/components/public-api-server/configmap_test.go
+++ b/install/installer/pkg/components/public-api-server/configmap_test.go
@@ -31,7 +31,7 @@ func TestConfigMap(t *testing.T) {
 	})
 
 	expectedConfiguration := config.Configuration{
-		GitpodServiceURL:               "wss://test.domain.everything.awesome.is/api/gitpod",
+		GitpodServiceURL:               "wss://test.domain.everything.awesome.is",
 		BillingServiceAddress:          fmt.Sprintf("usage.%s.svc.cluster.local:9001", ctx.Namespace),
 		StripeWebhookSigningSecretPath: stripeSecretPath,
 		Server: &baseserver.Configuration{


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Turns out that the `api/v1` endpoint doens't accept Cookies
And that the `api/gitpod` endpoint doens't accept Bearer Tokens ...

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
unit

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
