### PR TITLE
[installer] Add a toxiproxy deployment behind the experimental `slowDatabase` flag.

### DIFF
--- a/install/installer/pkg/components/toxiproxy/constants.go
+++ b/install/installer/pkg/components/toxiproxy/constants.go
@@ -5,4 +5,5 @@ package toxiproxy
 
 const (
 	Component = "toxiproxy"
+	HttpPort  = 8474
 )

--- a/install/installer/pkg/components/toxiproxy/deployment.go
+++ b/install/installer/pkg/components/toxiproxy/deployment.go
@@ -1,0 +1,111 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
+package toxiproxy
+
+import (
+	"github.com/gitpod-io/gitpod/installer/pkg/cluster"
+	"github.com/gitpod-io/gitpod/installer/pkg/common"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/pointer"
+)
+
+const (
+	configmapVolume = "config"
+	configMountPath = "/config"
+
+	imageRegistry = "ghcr.io"
+	imageName     = "shopify/toxiproxy"
+	imageTag      = "2.5.0"
+)
+
+func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
+	labels := common.CustomizeLabel(ctx, Component, common.TypeMetaDeployment)
+
+	configHash, err := common.ObjectHash(configmap(ctx))
+	if err != nil {
+		return nil, err
+	}
+
+	volumes := []corev1.Volume{
+		{
+			Name: configmapVolume,
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: Component,
+					},
+				},
+			},
+		},
+	}
+
+	volumeMounts := []corev1.VolumeMount{
+		{
+			Name:      configmapVolume,
+			ReadOnly:  true,
+			MountPath: configMountPath,
+		},
+	}
+
+	return []runtime.Object{
+		&appsv1.Deployment{
+			TypeMeta: common.TypeMetaDeployment,
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      Component,
+				Namespace: ctx.Namespace,
+				Labels:    labels,
+				Annotations: common.CustomizeAnnotation(ctx, Component, common.TypeMetaDeployment, func() map[string]string {
+					return map[string]string{
+						common.AnnotationConfigChecksum: configHash,
+					}
+				}),
+			},
+			Spec: appsv1.DeploymentSpec{
+				Selector: &metav1.LabelSelector{MatchLabels: common.DefaultLabels(Component)},
+				Replicas: common.Replicas(ctx, Component),
+				Strategy: common.DeploymentStrategy,
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        Component,
+						Namespace:   ctx.Namespace,
+						Labels:      labels,
+						Annotations: common.CustomizeAnnotation(ctx, Component, common.TypeMetaDeployment),
+					},
+					Spec: corev1.PodSpec{
+						Affinity:           common.NodeAffinity(cluster.AffinityLabelMeta),
+						ServiceAccountName: Component,
+						DNSPolicy:          "ClusterFirst",
+						Volumes:            volumes,
+						Containers: []corev1.Container{{
+							Name:            Component,
+							Image:           ctx.ImageName(imageRegistry, imageName, imageTag),
+							ImagePullPolicy: corev1.PullIfNotPresent,
+							Resources: common.ResourceRequirements(ctx, Component, Component, corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									"cpu":    resource.MustParse("100m"),
+									"memory": resource.MustParse("64Mi"),
+								},
+							}),
+							Ports: []corev1.ContainerPort{{
+								Name:          "http",
+								ContainerPort: HttpPort,
+							}},
+							SecurityContext: &corev1.SecurityContext{
+								Privileged: pointer.Bool(false),
+							},
+							Env:          common.CustomizeEnvvar(ctx, Component, common.MergeEnv(common.DefaultEnv(&ctx.Config))),
+							VolumeMounts: volumeMounts,
+						},
+							*common.KubeRBACProxyContainerWithConfig(ctx),
+						},
+					},
+				},
+			},
+		},
+	}, nil
+}

--- a/install/installer/pkg/components/toxiproxy/objects.go
+++ b/install/installer/pkg/components/toxiproxy/objects.go
@@ -16,6 +16,7 @@ func Objects(ctx *common.RenderContext) ([]runtime.Object, error) {
 	}
 
 	return common.CompositeRenderFunc(
+		deployment,
 		configmap,
 		common.DefaultServiceAccount(Component),
 	)(ctx)

--- a/install/installer/pkg/components/toxiproxy/objects_test.go
+++ b/install/installer/pkg/components/toxiproxy/objects_test.go
@@ -28,7 +28,7 @@ func TestObjects_RenderedWhenExperimentalConfigSet(t *testing.T) {
 	objects, err := Objects(ctx)
 	require.NoError(t, err)
 	require.NotEmpty(t, objects, "must render objects because experimental config is specified")
-	require.Len(t, objects, 2, "should render expected k8s objects")
+	require.Len(t, objects, 3, "should render expected k8s objects")
 }
 
 func renderContextWithSlowDatabaseEnabled(t *testing.T) *common.RenderContext {


### PR DESCRIPTION
## Description

https://github.com/gitpod-io/gitpod/pull/14359 added support for the new `experimental.webapp.slowDatabase` config setting, installing a placeholder configmap when the flag was set. This PR builds on that by rendering a [Toxiproxy](https://github.com/Shopify/toxiproxy) deployment when the flag is set.

Subsequent PRs will add a service and a real configmap in addition to the deployment.

## Related Issue(s)
Part of #9198

## How to test

* Run `previewctl install-context` on this branch. This sets your kube context to the preview environment for this branch (one that was created with the new `with-slow-database` annotation).
* `kubectl get pods` shows a `toxiproxy` pod running in the cluster.
* Port-forward to the `toxiproxy` pod: `kubectl port-forward deploy/toxiproxy 8474:8474`
* Run `docker run --net=host --rm --entrypoint="/toxiproxy-cli" -it ghcr.io/shopify/toxiproxy:2.5.0 list` to list proxies registered with `toxiproxy` (none yet).
* Run `docker run --net=host --rm --entrypoint="/toxiproxy-cli" -it ghcr.io/shopify/toxiproxy:2.5.0 create -l :3306 -u mysql:3306 mysql` to register a proxy to the in-cluster `mysql` instance.
* Run `docker run --net=host --rm --entrypoint="/toxiproxy-cli" -it ghcr.io/shopify/toxiproxy:2.5.0 toxic add -t latency -a latency=5000 mysql` to add `5s` of latency to the `mysql` proxy.
* Port forward to the `mysql` proxy: `kubectl port-forward deploy/toxiproxy 3306:3306`
* Connect to the in-cluster `mysql` through the proxy, eg using `mycli` (`brew install mycli`): `mycli -u gitpod gitpod`.
* Observe the `5s` latency in the connection.


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-slow-database
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
