### PR TITLE
[observability] Adjusting openvsx-mirror dashboard

### DIFF
--- a/operations/observability/mixins/IDE/dashboards/components/openvsx-mirror.json
+++ b/operations/observability/mixins/IDE/dashboards/components/openvsx-mirror.json
@@ -224,7 +224,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(http_client_requests_seconds_count{cluster=~\"$cluster\", pod=~\"$pod\",outcome!~\"SUCCESS|REDIRECTION\"})[2m])/sum(rate(http_client_requests_seconds_count{cluster=~\"$cluster\", pod=~\"$pod\"})[2m])",
+          "expr": "sum(rate(http_client_requests_seconds_count{cluster=~\"$cluster\", pod=~\"$pod\",outcome!~\"SUCCESS|REDIRECTION|CLIENT_ERROR\"})[2m])/sum(rate(http_client_requests_seconds_count{cluster=~\"$cluster\", pod=~\"$pod\"})[2m])",
           "legendFormat": "total ratio",
           "range": true,
           "refId": "A"
@@ -320,7 +320,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by (status) (rate(http_client_requests_seconds_count{cluster=~\"$cluster\", pod=~\"$pod\",outcome!~\"SUCCESS|REDIRECTION\"})[2m])/ignoring(status) group_left sum(rate(http_client_requests_seconds_count{cluster=~\"$cluster\", pod=~\"$pod\"})[2m])",
+          "expr": "sum by (status) (rate(http_client_requests_seconds_count{cluster=~\"$cluster\", pod=~\"$pod\",outcome!~\"SUCCESS|REDIRECTION|CLIENT_ERROR\"})[2m])/ignoring(status) group_left sum(rate(http_client_requests_seconds_count{cluster=~\"$cluster\", pod=~\"$pod\"})[2m])",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -414,227 +414,6 @@
         "x": 0,
         "y": 17
       },
-      "id": 36,
-      "panels": [],
-      "title": "JVM - Quartz Jobs",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "P4169E866C3094E38"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "s"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 18
-      },
-      "id": 39,
-      "options": {
-        "legend": {
-          "calcs": [
-            "max"
-          ],
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": true,
-          "sortBy": "Max",
-          "sortDesc": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "code",
-          "expr": "method_timed_seconds_max{cluster=~\"$cluster\", pod=~\"$pod\"}",
-          "hide": false,
-          "legendFormat": "{{class}}",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "longest in-progress timing",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "P4169E866C3094E38"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "none"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 18
-      },
-      "id": 38,
-      "options": {
-        "legend": {
-          "calcs": [
-            "max"
-          ],
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": true,
-          "sortBy": "Max",
-          "sortDesc": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "code",
-          "expr": "method_timed_seconds_active_count{cluster=~\"$cluster\", pod=~\"$pod\"}",
-          "hide": false,
-          "legendFormat": "{{class}}",
-          "range": true,
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "code",
-          "expr": "",
-          "hide": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "B"
-        }
-      ],
-      "title": "active in progress",
-      "type": "timeseries"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 26
-      },
       "id": 17,
       "panels": [],
       "title": "JVM - Memory/CPU",
@@ -702,7 +481,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 27
+        "y": 18
       },
       "id": 7,
       "options": {
@@ -824,7 +603,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 27
+        "y": 18
       },
       "id": 9,
       "options": {
@@ -919,7 +698,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 35
+        "y": 26
       },
       "id": 2,
       "options": {
@@ -969,6 +748,7 @@
             "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
+            "axisSoftMax": 1,
             "barAlignment": 0,
             "drawStyle": "line",
             "fillOpacity": 0,
@@ -1016,7 +796,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 35
+        "y": 26
       },
       "id": 4,
       "options": {
@@ -1057,7 +837,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 43
+        "y": 34
       },
       "id": 19,
       "panels": [


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PR Adjusting openvsx-mirror dashboard
1. add max value for gc overhead
2. remove `JVM - Quartz Jobs`
3. filter CLIENT_ERROR for error

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
