### PR TITLE
[installer] Add a toxiproxy service behind the experimental `slowDatabase` flag

### DIFF
--- a/install/installer/pkg/components/toxiproxy/constants.go
+++ b/install/installer/pkg/components/toxiproxy/constants.go
@@ -4,6 +4,8 @@
 package toxiproxy
 
 const (
-	Component = "toxiproxy"
-	HttpPort  = 8474
+	Component         = "toxiproxy"
+	HttpContainerPort = 8474
+	HttpServicePort   = 8474
+	HttpPortName      = "http"
 )

--- a/install/installer/pkg/components/toxiproxy/deployment.go
+++ b/install/installer/pkg/components/toxiproxy/deployment.go
@@ -79,7 +79,6 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 					Spec: corev1.PodSpec{
 						Affinity:           common.NodeAffinity(cluster.AffinityLabelMeta),
 						ServiceAccountName: Component,
-						DNSPolicy:          "ClusterFirst",
 						Volumes:            volumes,
 						Containers: []corev1.Container{{
 							Name:            Component,

--- a/install/installer/pkg/components/toxiproxy/deployment.go
+++ b/install/installer/pkg/components/toxiproxy/deployment.go
@@ -91,8 +91,8 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 								},
 							}),
 							Ports: []corev1.ContainerPort{{
-								Name:          "http",
-								ContainerPort: HttpPort,
+								Name:          HttpPortName,
+								ContainerPort: HttpContainerPort,
 							}},
 							SecurityContext: &corev1.SecurityContext{
 								Privileged: pointer.Bool(false),

--- a/install/installer/pkg/components/toxiproxy/objects.go
+++ b/install/installer/pkg/components/toxiproxy/objects.go
@@ -17,6 +17,7 @@ func Objects(ctx *common.RenderContext) ([]runtime.Object, error) {
 
 	return common.CompositeRenderFunc(
 		deployment,
+		service,
 		configmap,
 		common.DefaultServiceAccount(Component),
 	)(ctx)

--- a/install/installer/pkg/components/toxiproxy/objects_test.go
+++ b/install/installer/pkg/components/toxiproxy/objects_test.go
@@ -28,7 +28,7 @@ func TestObjects_RenderedWhenExperimentalConfigSet(t *testing.T) {
 	objects, err := Objects(ctx)
 	require.NoError(t, err)
 	require.NotEmpty(t, objects, "must render objects because experimental config is specified")
-	require.Len(t, objects, 3, "should render expected k8s objects")
+	require.Len(t, objects, 4, "should render expected k8s objects")
 }
 
 func renderContextWithSlowDatabaseEnabled(t *testing.T) *common.RenderContext {

--- a/install/installer/pkg/components/toxiproxy/service.go
+++ b/install/installer/pkg/components/toxiproxy/service.go
@@ -1,0 +1,21 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
+package toxiproxy
+
+import (
+	"github.com/gitpod-io/gitpod/installer/pkg/common"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func service(ctx *common.RenderContext) ([]runtime.Object, error) {
+	servicePorts := []common.ServicePort{
+		{
+			Name:          HttpPortName,
+			ContainerPort: HttpContainerPort,
+			ServicePort:   HttpServicePort,
+		},
+	}
+
+	return common.GenerateService(Component, servicePorts)(ctx)
+}


### PR DESCRIPTION
## Description

https://github.com/gitpod-io/gitpod/pull/14423 added a Toxiproxy deployment behind the new experimental `webapp.slowDatabase` installer config flag.

This PR builds on that to add a kubernetes service in addition to the deployment.

## Related Issue(s)

Part of #9198.

Depends on https://github.com/gitpod-io/gitpod/pull/14423.

## How to test

1. In the preview environment for this branch, `kubectl get svc` shows a `toxiproxy` service.
2. Port-forward to the service: `kubectl port-forward svc/toxiproxy 8474:8474`.
3. Run `Run docker run --net=host --rm --entrypoint="/toxiproxy-cli" -it ghcr.io/shopify/toxiproxy:2.5.0 list`.

This shows that the service is correctly sending traffic to the `toxiproxy` deployment.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-slow-database
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
