### PR TITLE
[kots] merge custom docker config correctly

### DIFF
--- a/install/installer/scripts/kots-install.sh
+++ b/install/installer/scripts/kots-install.sh
@@ -162,6 +162,7 @@ EOF
             | base64 -d \
             > /tmp/currentconfig.json
 
+        echo "${REGISTRY_DOCKER_CONFIG_JSON}" > /tmp/userconfig.json
         echo "Gitpod: update the in-cluster registry secret"
         REGISTRY_SECRET="$(jq -s '.[0] * .[1]' /tmp/userconfig.json /tmp/currentconfig.json | base64 -w 0)"
         export REGISTRY_SECRET


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This PR fixes the issue when a custom docker config json file is uploaded by the user.

Signed-off-by: Tarun Pothulapati <tarun@gitpod.io>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/14365

## How to test
<!-- Provide steps to test this PR -->


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[kots] merge custom docker config correctly
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
