### PR TITLE
[observability] Adjusting openvsx-mirror and code-browser dashboard

### DIFF
--- a/operations/observability/mixins/IDE/dashboards/components/code-browser.json
+++ b/operations/observability/mixins/IDE/dashboards/components/code-browser.json
@@ -134,7 +134,7 @@
             "uid": "P4169E866C3094E38"
           },
           "editorMode": "code",
-          "expr": "sum(rate(gitpod_vscode_web_load_total{status='failed',galleryHost=~\"$galleryHost\"}[2m])) /sum(rate(gitpod_vscode_web_load_total{status='loading',galleryHost=~\"$galleryHost\"}[2m]))",
+          "expr": "sum(rate(gitpod_vscode_web_load_total{status='failed',galleryHost=~\"$gallery\"}[2m])) /sum(rate(gitpod_vscode_web_load_total{status='loading',galleryHost=~\"$gallery\"}[2m]))",
           "legendFormat": "total_ratio",
           "range": true,
           "refId": "A"
@@ -243,7 +243,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(gitpod_vscode_extension_gallery_query_total{galleryHost=~\"$galleryHost\"}[2m]))",
+          "expr": "sum(rate(gitpod_vscode_extension_gallery_query_total{galleryHost=~\"$gallery\"}[2m]))",
           "legendFormat": "rate",
           "range": true,
           "refId": "A"
@@ -339,7 +339,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(1, sum(rate(gitpod_vscode_extension_gallery_query_duration_seconds_bucket{galleryHost=~\"$galleryHost\"}[1m])) by (le))",
+          "expr": "histogram_quantile(1, sum(rate(gitpod_vscode_extension_gallery_query_duration_seconds_bucket{galleryHost=~\"$gallery\"}[1m])) by (le))",
           "legendFormat": "max",
           "range": true,
           "refId": "A"
@@ -350,7 +350,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum(rate(gitpod_vscode_extension_gallery_query_duration_seconds_bucket{galleryHost=~\"$galleryHost\"}[1m])) by (le))",
+          "expr": "histogram_quantile(0.99, sum(rate(gitpod_vscode_extension_gallery_query_duration_seconds_bucket{galleryHost=~\"$gallery\"}[1m])) by (le))",
           "hide": false,
           "legendFormat": "P99",
           "range": true,
@@ -362,7 +362,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum(rate(gitpod_vscode_extension_gallery_query_duration_seconds_bucket{galleryHost=~\"$galleryHost\"}[1m])) by (le))",
+          "expr": "histogram_quantile(0.95, sum(rate(gitpod_vscode_extension_gallery_query_duration_seconds_bucket{galleryHost=~\"$gallery\"}[1m])) by (le))",
           "hide": false,
           "legendFormat": "P95",
           "range": true,
@@ -374,7 +374,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.5, sum(rate(gitpod_vscode_extension_gallery_query_duration_seconds_bucket{galleryHost=~\"$galleryHost\"}[1m])) by (le))",
+          "expr": "histogram_quantile(0.5, sum(rate(gitpod_vscode_extension_gallery_query_duration_seconds_bucket{galleryHost=~\"$gallery\"}[1m])) by (le))",
           "hide": false,
           "legendFormat": "mean",
           "range": true,
@@ -472,7 +472,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(gitpod_vscode_extension_gallery_query_total{status=\"failure\",errorCode!=\"canceled\",galleryHost=~\"$galleryHost\"}[2m]))/sum(rate(gitpod_vscode_extension_gallery_query_total{galleryHost=~\"$galleryHost\"}[2m]))",
+          "expr": "sum(rate(gitpod_vscode_extension_gallery_query_total{status=\"failure\",errorCode!=\"canceled\",galleryHost=~\"$gallery\"}[2m]))/sum(rate(gitpod_vscode_extension_gallery_query_total{galleryHost=~\"$gallery\"}[2m]))",
           "legendFormat": "total ratio",
           "range": true,
           "refId": "A"
@@ -569,7 +569,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by (statusCode) (rate(gitpod_vscode_extension_gallery_query_total{status=\"failure\",errorCode!=\"canceled\",galleryHost=~\"$galleryHost\"}[2m]))/ignoring(statusCode) group_left sum(rate(gitpod_vscode_extension_gallery_query_total{galleryHost=~\"$galleryHost\"}[2m]))",
+          "expr": "sum by (statusCode) (rate(gitpod_vscode_extension_gallery_query_total{status=\"failure\",errorCode!=\"canceled\",galleryHost=~\"$gallery\"}[2m]))/ignoring(statusCode) group_left sum(rate(gitpod_vscode_extension_gallery_query_total{galleryHost=~\"$gallery\"}[2m]))",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -665,7 +665,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by (errorCode) (rate(gitpod_vscode_extension_gallery_query_total{status=\"failure\",galleryHost=~\"$galleryHost\"}[2m]))/ignoring(errorCode) group_left sum(rate(gitpod_vscode_extension_gallery_query_total{galleryHost=~\"$galleryHost\"}[2m]))",
+          "expr": "sum by (errorCode) (rate(gitpod_vscode_extension_gallery_query_total{status=\"failure\",galleryHost=~\"$gallery\"}[2m]))/ignoring(errorCode) group_left sum(rate(gitpod_vscode_extension_gallery_query_total{galleryHost=~\"$gallery\"}[2m]))",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -773,7 +773,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(gitpod_vscode_extension_gallery_operation_total{operation=~\"$operation\",galleryHost=~\"$galleryHost\"}[2m]))",
+          "expr": "sum(rate(gitpod_vscode_extension_gallery_operation_total{operation=~\"$operation\",galleryHost=~\"$gallery\"}[2m]))",
           "legendFormat": "rate",
           "range": true,
           "refId": "A"
@@ -869,7 +869,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(gitpod_vscode_extension_gallery_operation_total{status=\"failure\",operation=~\"$operation\",galleryHost=~\"$galleryHost\"}[2m]))/sum(rate(gitpod_vscode_extension_gallery_operation_total{operation=~\"$operation\",galleryHost=~\"$galleryHost\"}[2m]))",
+          "expr": "sum(rate(gitpod_vscode_extension_gallery_operation_total{status=\"failure\",operation=~\"$operation\",galleryHost=~\"$gallery\"}[2m]))/sum(rate(gitpod_vscode_extension_gallery_operation_total{operation=~\"$operation\",galleryHost=~\"$gallery\"}[2m]))",
           "legendFormat": "total ratio",
           "range": true,
           "refId": "A"
@@ -965,7 +965,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by (operation) (rate(gitpod_vscode_extension_gallery_operation_total{status=\"failure\",operation=~\"$operation\",galleryHost=~\"$galleryHost\"}[2m]))/ignoring(operation) group_left sum(rate(gitpod_vscode_extension_gallery_operation_total{operation=~\"$operation\",galleryHost=~\"$galleryHost\"}[2m]))",
+          "expr": "sum by (operation) (rate(gitpod_vscode_extension_gallery_operation_total{status=\"failure\",operation=~\"$operation\",galleryHost=~\"$gallery\"}[2m]))/ignoring(operation) group_left sum(rate(gitpod_vscode_extension_gallery_operation_total{operation=~\"$operation\",galleryHost=~\"$gallery\"}[2m]))",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -1060,7 +1060,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(1, sum(rate(gitpod_vscode_extension_gallery_operation_duration_seconds_bucket{operation=~\"$operation\",galleryHost=~\"$galleryHost\"}[1m])) by (le))",
+          "expr": "histogram_quantile(1, sum(rate(gitpod_vscode_extension_gallery_operation_duration_seconds_bucket{operation=~\"$operation\",galleryHost=~\"$gallery\"}[1m])) by (le))",
           "legendFormat": "max",
           "range": true,
           "refId": "A"
@@ -1071,7 +1071,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum(rate(gitpod_vscode_extension_gallery_operation_duration_seconds_bucket{operation=~\"$operation\",galleryHost=~\"$galleryHost\"}[1m])) by (le))",
+          "expr": "histogram_quantile(0.99, sum(rate(gitpod_vscode_extension_gallery_operation_duration_seconds_bucket{operation=~\"$operation\",galleryHost=~\"$gallery\"}[1m])) by (le))",
           "hide": false,
           "legendFormat": "P99",
           "range": true,
@@ -1083,7 +1083,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum(rate(gitpod_vscode_extension_gallery_operation_duration_seconds_bucket{operation=~\"$operation\",galleryHost=~\"$galleryHost\"}[1m])) by (le))",
+          "expr": "histogram_quantile(0.95, sum(rate(gitpod_vscode_extension_gallery_operation_duration_seconds_bucket{operation=~\"$operation\",galleryHost=~\"$gallery\"}[1m])) by (le))",
           "hide": false,
           "legendFormat": "P95",
           "range": true,
@@ -1095,7 +1095,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.5, sum(rate(gitpod_vscode_extension_gallery_operation_duration_seconds_bucket{operation=~\"$operation\",galleryHost=~\"$galleryHost\"}[1m])) by (le))",
+          "expr": "histogram_quantile(0.5, sum(rate(gitpod_vscode_extension_gallery_operation_duration_seconds_bucket{operation=~\"$operation\",galleryHost=~\"$gallery\"}[1m])) by (le))",
           "hide": false,
           "legendFormat": "mean",
           "range": true,
@@ -1191,7 +1191,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(1, sum(rate(gitpod_vscode_extension_gallery_operation_duration_seconds_bucket{operation=~\"$operation\",galleryHost=~\"$galleryHost\"}[1m])) by (le, operation))",
+          "expr": "histogram_quantile(1, sum(rate(gitpod_vscode_extension_gallery_operation_duration_seconds_bucket{operation=~\"$operation\",galleryHost=~\"$gallery\"}[1m])) by (le, operation))",
           "legendFormat": "{{operation}} - max",
           "range": true,
           "refId": "A"
@@ -1202,7 +1202,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum(rate(gitpod_vscode_extension_gallery_operation_duration_seconds_bucket{operation=~\"$operation\",galleryHost=~\"$galleryHost\"}[1m])) by (le, operation))",
+          "expr": "histogram_quantile(0.99, sum(rate(gitpod_vscode_extension_gallery_operation_duration_seconds_bucket{operation=~\"$operation\",galleryHost=~\"$gallery\"}[1m])) by (le, operation))",
           "hide": false,
           "legendFormat": "{{operation}} - P99",
           "range": true,
@@ -1214,7 +1214,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum(rate(gitpod_vscode_extension_gallery_operation_duration_seconds_bucket{operation=~\"$operation\",galleryHost=~\"$galleryHost\"}[1m])) by (le, operation))",
+          "expr": "histogram_quantile(0.95, sum(rate(gitpod_vscode_extension_gallery_operation_duration_seconds_bucket{operation=~\"$operation\",galleryHost=~\"$gallery\"}[1m])) by (le, operation))",
           "hide": false,
           "legendFormat": "{{operation}} - P95",
           "range": true,
@@ -1226,7 +1226,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.5, sum(rate(gitpod_vscode_extension_gallery_operation_duration_seconds_bucket{operation=~\"$operation\",galleryHost=~\"$galleryHost\"}[1m])) by (le, operation))",
+          "expr": "histogram_quantile(0.5, sum(rate(gitpod_vscode_extension_gallery_operation_duration_seconds_bucket{operation=~\"$operation\",galleryHost=~\"$gallery\"}[1m])) by (le, operation))",
           "hide": false,
           "legendFormat": "{{operation}} - mean",
           "range": true,
@@ -1307,7 +1307,7 @@
         "hide": 0,
         "includeAll": true,
         "multi": true,
-        "name": "galleryHost",
+        "name": "gallery",
         "options": [],
         "query": {
           "query": "label_values(gitpod_vscode_extension_gallery_operation_total, galleryHost)",

--- a/operations/observability/mixins/IDE/dashboards/components/openvsx-mirror.json
+++ b/operations/observability/mixins/IDE/dashboards/components/openvsx-mirror.json
@@ -179,6 +179,7 @@
             }
           },
           "mappings": [],
+          "max": 1,
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -249,6 +250,7 @@
             "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
+            "axisSoftMax": 1,
             "barAlignment": 0,
             "drawStyle": "bars",
             "fillOpacity": 0,
@@ -320,7 +322,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by (status) (rate(http_client_requests_seconds_count{cluster=~\"$cluster\", pod=~\"$pod\",outcome!~\"SUCCESS|REDIRECTION|CLIENT_ERROR\"})[2m])/ignoring(status) group_left sum(rate(http_client_requests_seconds_count{cluster=~\"$cluster\", pod=~\"$pod\"})[2m])",
+          "expr": "sum by (status) (rate(http_client_requests_seconds_count{cluster=~\"$cluster\", pod=~\"$pod\",outcome!~\"SUCCESS|REDIRECTION\"})[2m])/ignoring(status) group_left sum(rate(http_client_requests_seconds_count{cluster=~\"$cluster\", pod=~\"$pod\"})[2m])",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PR adjusting openvsx-mirror and code-browser dashboard

for openvsx-mirror

1. add max value for error ratio
2. include CLEIENT_ERROR in `failure ratio by status code`

for code-browser rename  `galleryHost` to `gallery`

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
