### PR TITLE
[JetBrains] Update Gradle to the same version used in other components (v7.3.1)

### DIFF
--- a/dev/jetbrains-test/gradle/wrapper/gradle-wrapper.properties
+++ b/dev/jetbrains-test/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
In other components from Gitpod we're using Gradle v7.3.1. So we'll also use in `jetbrains-test`.
<img width="1290" alt="image" src="https://user-images.githubusercontent.com/418083/199985010-c0c18782-67c7-4cb3-8737-f87c6704fc4f.png">

This fixes this warning  [[Reported Internally](https://gitpod.slack.com/archives/C01KGM9BH54/p1667565060291469)] from VS Code:
![image](https://user-images.githubusercontent.com/418083/199985318-24f92243-a9b1-4da9-97bb-43a8bc1a33aa.png)

## How to test
<!-- Provide steps to test this PR -->
Open this branch in gitpod.io using VS Code and confirm if there's no warning about Gradle.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
