### PR TITLE
[usage] Fix config binding

### DIFF
--- a/install/installer/pkg/components/usage/configmap.go
+++ b/install/installer/pkg/components/usage/configmap.go
@@ -58,9 +58,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		if expUsageConfig.Schedule != "" {
 			cfg.LedgerSchedule = expUsageConfig.Schedule
 		}
-		if expUsageConfig.ResetUsageSchedule != "" {
-			cfg.ResetUsageSchedule = expUsageConfig.ResetUsageSchedule
-		}
+		cfg.ResetUsageSchedule = expUsageConfig.ResetUsageSchedule
 		if expUsageConfig.DefaultSpendingLimit != nil {
 			cfg.DefaultSpendingLimit = *expUsageConfig.DefaultSpendingLimit
 		}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

The config can use empty string to disable the job, but here we ignored that config because it was empty 🤦 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
