### PR TITLE
[installer] Add a configmap for Toxiproxy behind the experimental `slowDatabase` flag

### DIFF
--- a/install/installer/pkg/components/toxiproxy/configmap.go
+++ b/install/installer/pkg/components/toxiproxy/configmap.go
@@ -4,13 +4,43 @@
 package toxiproxy
 
 import (
+	"fmt"
+
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/pointer"
+)
+
+const (
+	configFilename = "toxiproxy.json"
 )
 
 func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
+	var (
+		dbHost = "cloudsqlproxy"
+		dbPort = 3306
+	)
+
+	if pointer.BoolDeref(ctx.Config.Database.InCluster, false) {
+		dbHost = "db"
+	}
+
+	txcfg := []ToxiproxyConfig{
+		{
+			Name:     "mysql",
+			Listen:   fmt.Sprintf("[::]:%d", dbPort),
+			Upstream: fmt.Sprintf("%s:%d", dbHost, dbPort),
+			Enabled:  true,
+		},
+	}
+
+	serialized, err := common.ToJSONString(txcfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal toxiproxy config: %w", err)
+	}
+
 	return []runtime.Object{
 		&corev1.ConfigMap{
 			TypeMeta: common.TypeMetaConfigmap,
@@ -19,6 +49,9 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 				Namespace:   ctx.Namespace,
 				Labels:      common.CustomizeLabel(ctx, Component, common.TypeMetaConfigmap),
 				Annotations: common.CustomizeAnnotation(ctx, Component, common.TypeMetaConfigmap),
+			},
+			Data: map[string]string{
+				configFilename: string(serialized),
 			},
 		},
 	}, nil

--- a/install/installer/pkg/components/toxiproxy/constants.go
+++ b/install/installer/pkg/components/toxiproxy/constants.go
@@ -4,8 +4,11 @@
 package toxiproxy
 
 const (
-	Component         = "toxiproxy"
-	HttpContainerPort = 8474
-	HttpServicePort   = 8474
-	HttpPortName      = "http"
+	Component               = "toxiproxy"
+	HttpPortName            = "http"
+	HttpContainerPort       = 8474
+	HttpServicePort         = 8474
+	MySqlProxyPortName      = "mysql"
+	MySqlProxyContainerPort = 3306
+	MySqlProxyServicePort   = 3306
 )

--- a/install/installer/pkg/components/toxiproxy/deployment.go
+++ b/install/installer/pkg/components/toxiproxy/deployment.go
@@ -4,6 +4,8 @@
 package toxiproxy
 
 import (
+	"path/filepath"
+
 	"github.com/gitpod-io/gitpod/installer/pkg/cluster"
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 	appsv1 "k8s.io/api/apps/v1"
@@ -83,6 +85,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 						Containers: []corev1.Container{{
 							Name:            Component,
 							Image:           ctx.ImageName(imageRegistry, imageName, imageTag),
+							Args:            []string{"-config", filepath.Join(configMountPath, configFilename)},
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							Resources: common.ResourceRequirements(ctx, Component, Component, corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{

--- a/install/installer/pkg/components/toxiproxy/service.go
+++ b/install/installer/pkg/components/toxiproxy/service.go
@@ -15,6 +15,11 @@ func service(ctx *common.RenderContext) ([]runtime.Object, error) {
 			ContainerPort: HttpContainerPort,
 			ServicePort:   HttpServicePort,
 		},
+		{
+			Name:          MySqlProxyPortName,
+			ContainerPort: MySqlProxyContainerPort,
+			ServicePort:   MySqlProxyServicePort,
+		},
 	}
 
 	return common.GenerateService(Component, servicePorts)(ctx)

--- a/install/installer/pkg/components/toxiproxy/types.go
+++ b/install/installer/pkg/components/toxiproxy/types.go
@@ -1,0 +1,11 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
+package toxiproxy
+
+type ToxiproxyConfig struct {
+	Name     string `json:"name"`
+	Listen   string `json:"listen"`
+	Upstream string `json:"upstream"`
+	Enabled  bool   `json:"enabled"`
+}


### PR DESCRIPTION
## Description

Configure Toxiproxy using a configmap containing a toxiproxy configuration file. 

The config file sets up an upstream for the mysql database.

Builds on:
https://github.com/gitpod-io/gitpod/pull/14359
https://github.com/gitpod-io/gitpod/pull/14423
https://github.com/gitpod-io/gitpod/pull/14430

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of #9198 .

Depends on https://github.com/gitpod-io/gitpod/pull/14423 and https://github.com/gitpod-io/gitpod/pull/14430.
## How to test

1. In the preview environment for this PR, port forward to the `mysql` Toxiproxy proxy:
```
kubectl port-forward svc/toxiproxy 3306:3306
```
2. Connect to the database through Toxiproxy with eg, `mycli -u gitpod gitpod`.

These two steps show that Toxiproxy has been configured to listen on port 3306 and proxy the upstream `mysql` instance.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation


## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-slow-database
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
