### PR TITLE
[supervisor] Fix adduser on buxybox/alpine

### DIFF
--- a/components/supervisor/pkg/supervisor/user.go
+++ b/components/supervisor/pkg/supervisor/user.go
@@ -260,7 +260,7 @@ var adduserCommands = []func(*user.User) []string{
 		return []string{"adduser", "--home", opts.HomeDir, "--shell", defaultShell, "--disabled-login", "--gid", opts.Gid, "--uid", opts.Uid, opts.Username}
 	}, // Debian
 	func(opts *user.User) []string {
-		return []string{"adduser", "-h", opts.HomeDir, "-s", defaultShell, "-D", "-G", opts.Gid, "-u", opts.Uid, opts.Username}
+		return []string{"adduser", "-h", opts.HomeDir, "-s", defaultShell, "-D", "-G", gitpodGroupName, "-u", opts.Uid, opts.Username}
 	}, // Busybox
 	func(opts *user.User) []string {
 		return []string{"useradd", "-m", "--home-dir", opts.HomeDir, "--shell", defaultShell, "--gid", opts.Gid, "--uid", opts.Uid, opts.Username}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Fixes `adduser` to use the group name instead of group ID for the busybox/alpine adduser flavour.

See https://github.com/gitpod-io/gitpod/issues/12978#issuecomment-1300652319 for more context, the group name actually was used previously instead of the group ID before the logic got refactored into supervisor: https://github.com/gitpod-io/gitpod/blob/453cbeb9a135d0ca1449401206c113c384d5b10e/components/image-builder-mk3/workspace-image-layer/gitpod-layer/alpine/gitpod/layer.sh#L39

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Relates to #12978 

## How to test
<!-- Provide steps to test this PR -->

Test that workspaces based off busybox do not fail to start because `supervisor` fails to add the `gitpod` user (although a "plain" busybox image still won't start up properly, as it will now fail on some packages not being installed. Just doesn't fail on the `adduser` step anymore).

Test that e.g. Debian based workspaces still start up, e.g. `workspace-full`


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Fix supervisor failing to add the `gitpod` user on busybox workspace images
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
