### PR TITLE
[preview] Enable ws-daemon cpu limiting

### DIFF
--- a/.werft/jobs/build/installer/post-process.sh
+++ b/.werft/jobs/build/installer/post-process.sh
@@ -287,7 +287,11 @@ while [ "$documentIndex" -le "$DOCS" ]; do
       yq r k8s.yaml -d "$documentIndex" > /tmp/"$NAME"-"$KIND"-overrides.yaml
       # Parse and update the JSON, and write it to a file
       yq r /tmp/"$NAME"-"$KIND"-overrides.yaml 'data.[config.json]' \
-      | jq ".service.address = $WS_DAEMON_PORT" > /tmp/"$NAME"-"$KIND"-overrides.json
+      | jq ".service.address = $WS_DAEMON_PORT" \
+      | jq ".daemon.cpulimit.enabled = true" \
+      | jq ".daemon.cpulimit.totalBandwidth = 12" \
+      | jq ".daemon.cpulimit.limit = 2" \
+      | jq ".daemon.cpulimit.burstLimit = 6" > /tmp/"$NAME"-"$KIND"-overrides.json
       # Give the port a colon prefix, ("5678" to ":5678")
       # jq would not have it, hence the usage of sed to do the transformation
       PORT_NUM_FORMAT_EXPR="s/\"address\": $WS_DAEMON_PORT/\"address\": \":$WS_DAEMON_PORT\"/"


### PR DESCRIPTION
## Description
Enable ws-daemon cpu limiting in preview environments so that it does not have to be manually activated every time when someone wants to work on cpu limiting

## Related Issue(s)
n.a.

## How to test
1. generate a config like so: ./installer init > config.yaml
2. generate a k8s manifest like so: ./installer render -n $(kubens -c) -c config.yaml > k8s.yaml
3. fake a license and feature file like so: echo "foo" > /tmp/license && echo '"bar"' > /tmp/defaultFeatureFlags
4. call this script like so: ./.werft/jobs/build/installer/post-process.sh 1234 5678 2 your-branch-just-dashes


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-integration-tests=workspace
      Valid options are `all`, `workspace`, `webapp`, `ide`
