### PR TITLE
[loadgen] Move workspace stress repository

### DIFF
--- a/dev/loadgen/configs/prod-benchmark-pvc.yaml
+++ b/dev/loadgen/configs/prod-benchmark-pvc.yaml
@@ -19,7 +19,7 @@ featureFlags:
 #   authUser: ""
 #   authPassword: ""
 repos:
-  - cloneURL: https://github.com/Furisto/workspace-stress
+  - cloneURL: https://github.com/gitpod-io/workspace-stress
     cloneTarget: main
     score: 20
     workspaceImage: registry.hub.docker.com/gitpod/workspace-full:latest

--- a/dev/loadgen/configs/prod-benchmark.yaml
+++ b/dev/loadgen/configs/prod-benchmark.yaml
@@ -12,7 +12,7 @@ environment:
 workspaceClass: "g1-standard"
 workspaceTimeout: 1h
 repos:
-  - cloneURL: https://github.com/Furisto/workspace-stress
+  - cloneURL: https://github.com/gitpod-io/workspace-stress
     cloneTarget: main
     score: 20
     workspaceImage: registry.hub.docker.com/gitpod/workspace-full:latest

--- a/dev/loadgen/configs/workspace-preview-benchmark-pvc.yaml
+++ b/dev/loadgen/configs/workspace-preview-benchmark-pvc.yaml
@@ -13,7 +13,7 @@ featureFlags:
 # from core.proto: PERSISTENT_VOLUME_CLAIM = 7;
   - 7
 repos:
-  - cloneURL: https://github.com/Furisto/workspace-stress
+  - cloneURL: https://github.com/gitpod-io/workspace-stress
     cloneTarget: main
     score: 20
     workspaceImage: registry.hub.docker.com/gitpod/workspace-full:latest

--- a/dev/loadgen/configs/workspace-preview-benchmark.yaml
+++ b/dev/loadgen/configs/workspace-preview-benchmark.yaml
@@ -9,7 +9,7 @@ environment:
 workspaceClass: ""
 workspaceTimeout: 1h
 repos:
-  - cloneURL: https://github.com/Furisto/workspace-stress
+  - cloneURL: https://github.com/gitpod-io/workspace-stress
     cloneTarget: main
     score: 20
     workspaceImage: registry.hub.docker.com/gitpod/workspace-full:latest


### PR DESCRIPTION
## Description
Move workspace stress repository to the [gitpod-io org](https://github.com/gitpod-io/workspace-stress)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/11485

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
