### PR TITLE
[installer] Bump helm upgrade timeout to 15 minutes

### DIFF
--- a/install/installer/scripts/kots-install.sh
+++ b/install/installer/scripts/kots-install.sh
@@ -176,7 +176,7 @@ EOF
 
     # If certificate secret already exists, set the timeout to 5m
     CERT_SECRET=$(kubectl get secrets -n "${NAMESPACE}" https-certificates -o jsonpath='{.metadata.name}' || echo '')
-    HELM_TIMEOUT="5m"
+    HELM_TIMEOUT="15m"
     if [ "${CERT_SECRET}" = "" ]; then
         HELM_TIMEOUT="1h"
     fi


### PR DESCRIPTION
## Description

During customer upgrades we observed an otherwise healthy upgrade process hit the 5 minute timeout period; this may have been triggered by a slow but otherwise acceptable image pull. This pull request triples the upgrade timeout to prevent spurious rollbacks. 

## Related Issue(s)

Fixes #14444

## How to test

Upgrade a Gitpod Self Hosted environment; while the upgrade is running jam the installation process so the upgrade cannot complete in under 5 minutes. (Something evil like SIGSTOPing the kubelet on a node may work).

## Release Notes

```release-note
[installer] Increase KOTS upgrade timeout to 15min
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
