### PR TITLE
[supervisor] Only poll supported protocols

### DIFF
--- a/components/supervisor/pkg/ports/served-ports.go
+++ b/components/supervisor/pkg/ports/served-ports.go
@@ -83,7 +83,15 @@ func (p *PollingServedPortsObserver) Observe(ctx context.Context) (<-chan []Serv
 				visited = make(map[string]struct{})
 				ports   []ServedPort
 			)
-			for _, fn := range []string{fnNetTCP, fnNetTCP6} {
+
+			var protos []string
+			for _, path := range []string{fnNetTCP, fnNetTCP6} {
+				if _, err := os.Stat(path); err == nil {
+					protos = append(protos, path)
+				}
+			}
+
+			for _, fn := range protos {
 				fc, err := p.fileOpener(fn)
 				if err != nil {
 					errchan <- err


### PR DESCRIPTION
## Description

Enable error log `error while observing served ports` in scenarios when only IPV4 or IPV6 are available

fixes https://github.com/gitpod-io/gitpod/issues/14556

## How to test
- Open a workspace
- Check if IPV4 or IPV6 is not available
- Check workspace logs

## Release Notes
```release-note
NONE
```

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
