### PR TITLE
[ws-daemon] Create missing LVM device and special files

### DIFF
--- a/components/ws-daemon/debug.Dockerfile
+++ b/components/ws-daemon/debug.Dockerfile
@@ -31,6 +31,7 @@ RUN apt update \
       python3-crcmod \
       gnupg \
       aria2 \
+      lvm2 \
   && echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
   && curl -sSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - \
   && apt update && apt install -y --no-install-recommends  google-cloud-sdk=${CLOUD_SDK_VERSION}-0 \

--- a/components/ws-daemon/leeway.Dockerfile
+++ b/components/ws-daemon/leeway.Dockerfile
@@ -30,6 +30,7 @@ RUN apt update \
       apt-transport-https \
       python3-crcmod \
       aria2 \
+      lvm2 \
   && echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
   && curl -sSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - \
   && apt update && apt install -y --no-install-recommends  google-cloud-sdk=${CLOUD_SDK_VERSION}-0 \

--- a/components/ws-daemon/pkg/cgroup/plugin_iolimit_v1.go
+++ b/components/ws-daemon/pkg/cgroup/plugin_iolimit_v1.go
@@ -61,7 +61,7 @@ const (
 )
 
 // TODO: enable custom configuration
-var blockDevices = []string{"sd*", "md*", "nvme0n*"}
+var blockDevices = []string{"dm*", "sd*", "md*", "nvme0n*"}
 
 func buildLimits(writeBytesPerSecond, readBytesPerSecond, writeIOPs, readIOPs int64) ioLimitOptions {
 	return ioLimitOptions{

--- a/components/ws-daemon/pkg/content/hooks.go
+++ b/components/ws-daemon/pkg/content/hooks.go
@@ -110,6 +110,8 @@ func hookInstallQuota(xfs *quota.XFS, isHard bool) session.WorkspaceLivecycleHoo
 
 		size := quota.Size(ws.StorageQuota)
 
+		log.WithFields(ws.OWI()).WithField("size", size).WithField("directory", ws.Location).Debug("setting disk quota")
+
 		var (
 			prj int
 			err error


### PR DESCRIPTION
## Description

Without LVM devices and special files (symlinks), we cannot enforce disk quotas.
In installations without LVM this is a NOOP.

## How to test
- Create an ephemeral cluster using LVM
- Open a workspace
- Run `fallocate -l 100G /workspace/should-fail`
- Should return with an error
 
## Release Notes
```release-note
NONE
```

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
