### PR TITLE
[server] incremental workspaces

### DIFF
--- a/components/dashboard/src/components/CheckBox.tsx
+++ b/components/dashboard/src/components/CheckBox.tsx
@@ -37,7 +37,10 @@ function CheckBox(props: {
             <div className="flex flex-col ml-2">
                 <label
                     htmlFor={checkboxId}
-                    className="text-gray-800 dark:text-gray-100 text-md font-semibold cursor-pointer tracking-wide"
+                    className={
+                        "text-md font-semibold cursor-pointer tracking-wide " +
+                        (inputProps.disabled ? "text-gray-500 dark:text-gray-400" : "text-gray-800 dark:text-gray-100")
+                    }
                 >
                     {props.title}
                 </label>

--- a/components/dashboard/src/projects/Project.tsx
+++ b/components/dashboard/src/projects/Project.tsx
@@ -378,17 +378,7 @@ export default function () {
                                                     )}
                                                 </a>
                                                 <span className="flex-grow" />
-                                                <a
-                                                    href={
-                                                        prebuild
-                                                            ? gitpodHostUrl
-                                                                  .withContext(
-                                                                      `open-prebuild/${prebuild.info.id}/${prebuild.info.changeUrl}`,
-                                                                  )
-                                                                  .toString()
-                                                            : gitpodHostUrl.withContext(`${branch.url}`).toString()
-                                                    }
-                                                >
+                                                <a href={gitpodHostUrl.withContext(`${branch.url}`).toString()}>
                                                     <button
                                                         className={`primary mr-2 py-2 opacity-0 group-hover:opacity-100`}
                                                     >

--- a/components/dashboard/src/projects/ProjectSettings.tsx
+++ b/components/dashboard/src/projects/ProjectSettings.tsx
@@ -90,6 +90,18 @@ export default function () {
                 checked={!project.settings?.keepOutdatedPrebuildsRunning}
                 onChange={({ target }) => updateProjectSettings({ keepOutdatedPrebuildsRunning: !target.checked })}
             />
+            <h3 className="mt-12">Workspace Starts</h3>
+            <CheckBox
+                title={<span>Incrementally update from old prebuilds</span>}
+                desc={
+                    <span>
+                        Whether new workspaces can be started based on prebuilds that ran on older Git commits and get
+                        incrementally updated.
+                    </span>
+                }
+                checked={!!project.settings?.allowUsingPreviousPrebuilds}
+                onChange={({ target }) => updateProjectSettings({ allowUsingPreviousPrebuilds: target.checked })}
+            />
             {showPersistentVolumeClaimUI && (
                 <>
                     <br></br>

--- a/components/dashboard/src/projects/ProjectSettings.tsx
+++ b/components/dashboard/src/projects/ProjectSettings.tsx
@@ -63,14 +63,7 @@ export default function () {
         <ProjectSettingsPage project={project}>
             <h3>Prebuilds</h3>
             <CheckBox
-                title={
-                    <span>
-                        Enable Incremental Prebuilds{" "}
-                        <PillLabel type="warn" className="font-semibold mt-2 ml-2 py-0.5 px-2 self-center">
-                            Beta
-                        </PillLabel>
-                    </span>
-                }
+                title={<span>Enable Incremental Prebuilds </span>}
                 desc={
                     <span>
                         When possible, use an earlier successful prebuild as a base to create new prebuilds. This can
@@ -90,28 +83,73 @@ export default function () {
                 checked={!project.settings?.keepOutdatedPrebuildsRunning}
                 onChange={({ target }) => updateProjectSettings({ keepOutdatedPrebuildsRunning: !target.checked })}
             />
-            <h3 className="mt-12">Workspace Starts</h3>
             <CheckBox
-                title={<span>Incrementally update from old prebuilds</span>}
+                title={
+                    <span>
+                        Use Last Successful Prebuild{" "}
+                        <PillLabel type="warn" className="font-semibold mt-2 ml-2 py-0.5 px-2 self-center">
+                            Alpha
+                        </PillLabel>
+                    </span>
+                }
                 desc={
                     <span>
-                        Whether new workspaces can be started based on prebuilds that ran on older Git commits and get
-                        incrementally updated.
+                        Skip waiting for prebuilds in progress and use the last successful prebuild from previous
+                        commits on the same branch.
                     </span>
                 }
                 checked={!!project.settings?.allowUsingPreviousPrebuilds}
-                onChange={({ target }) => updateProjectSettings({ allowUsingPreviousPrebuilds: target.checked })}
+                onChange={({ target }) =>
+                    updateProjectSettings({
+                        allowUsingPreviousPrebuilds: target.checked,
+                        // we are disabling prebuild cancellation when incremental workspaces are enabled
+                        keepOutdatedPrebuildsRunning: target.checked || project?.settings?.keepOutdatedPrebuildsRunning,
+                    })
+                }
             />
+            <div className="flex mt-4 max-w-2xl">
+                <div className="flex flex-col ml-6">
+                    <label
+                        htmlFor="prebuildNthCommit"
+                        className="text-gray-800 dark:text-gray-100 text-md font-semibold cursor-pointer tracking-wide"
+                    >
+                        Skip Prebuilds
+                    </label>
+                    <input
+                        type="number"
+                        id="prebuildNthCommit"
+                        min="0"
+                        max="100"
+                        step="5"
+                        className="mt-2"
+                        disabled={!project.settings?.allowUsingPreviousPrebuilds}
+                        value={
+                            project.settings?.prebuildEveryNthCommit === undefined
+                                ? 0
+                                : project.settings?.prebuildEveryNthCommit
+                        }
+                        onChange={({ target }) =>
+                            updateProjectSettings({
+                                prebuildEveryNthCommit: Math.abs(Math.min(Number.parseInt(target.value), 100)) || 0,
+                            })
+                        }
+                    />
+                    <div className="text-gray-500 dark:text-gray-400 text-sm mt-2">
+                        The number of commits that are skipped between prebuilds.
+                    </div>
+                </div>
+            </div>
+
             {showPersistentVolumeClaimUI && (
                 <>
                     <br></br>
-                    <h3 className="mt-12">Workspace Persistence</h3>
+                    <h3 className="mt-12">Workspaces</h3>
                     <CheckBox
                         title={
                             <span>
                                 Enable Persistent Volume Claim{" "}
                                 <PillLabel type="warn" className="font-semibold mt-2 ml-2 py-0.5 px-2 self-center">
-                                    Experimental
+                                    Alpha
                                 </PillLabel>
                             </span>
                         }

--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -12,7 +12,6 @@ import {
     WhitelistedRepository,
     WorkspaceImageBuild,
     AuthProviderInfo,
-    CreateWorkspaceMode,
     Token,
     UserEnvVarValue,
     Terms,
@@ -422,7 +421,10 @@ export namespace GitpodServer {
     }
     export interface CreateWorkspaceOptions {
         contextUrl: string;
-        mode?: CreateWorkspaceMode;
+        // whether running workspaces on the same context should be ignored. If false (default) users will be asked.
+        ignoreRunningWorkspaceOnSameCommit?: boolean;
+        ignoreRunningPrebuild?: boolean;
+        allowUsingPreviousPrebuilds?: boolean;
         forceDefaultConfig?: boolean;
     }
     export interface StartWorkspaceOptions {

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -1381,19 +1381,6 @@ export interface WorkspaceCreationResult {
 }
 export type RunningWorkspacePrebuildStarting = "queued" | "starting" | "running";
 
-export enum CreateWorkspaceMode {
-    // Default returns a running prebuild if there is any, otherwise creates a new workspace (using a prebuild if one is available)
-    Default = "default",
-    // ForceNew creates a new workspace irrespective of any running prebuilds. This mode is guaranteed to actually create a workspace - but may degrade user experience as currently runnig prebuilds are ignored.
-    ForceNew = "force-new",
-    // UsePrebuild polls the database waiting for a currently running prebuild to become available. This mode exists to handle the db-sync delay.
-    UsePrebuild = "use-prebuild",
-    // SelectIfRunning returns a list of currently running workspaces for the context URL if there are any, otherwise falls back to Default mode
-    SelectIfRunning = "select-if-running",
-    // UseLastSuccessfulPrebuild returns ...
-    UseLastSuccessfulPrebuild = "use-last-successful-prebuild",
-}
-
 export namespace WorkspaceCreationResult {
     export function is(data: any): data is WorkspaceCreationResult {
         return (

--- a/components/gitpod-protocol/src/teams-projects-protocol.ts
+++ b/components/gitpod-protocol/src/teams-projects-protocol.ts
@@ -19,6 +19,8 @@ export interface ProjectSettings {
     keepOutdatedPrebuildsRunning?: boolean;
     // whether new workspaces can start on older prebuilds and incrementally update
     allowUsingPreviousPrebuilds?: boolean;
+    // how many commits in the commit history a prebuild is good (undefined and 0 means every commit is prebuilt)
+    prebuildEveryNthCommit?: number;
 }
 
 export interface Project {
@@ -122,7 +124,6 @@ export interface StartPrebuildResult {
     wsid: string;
     done: boolean;
 }
-
 export interface Team {
     id: string;
     name: string;

--- a/components/gitpod-protocol/src/teams-projects-protocol.ts
+++ b/components/gitpod-protocol/src/teams-projects-protocol.ts
@@ -17,6 +17,8 @@ export interface ProjectSettings {
     useIncrementalPrebuilds?: boolean;
     usePersistentVolumeClaim?: boolean;
     keepOutdatedPrebuildsRunning?: boolean;
+    // whether new workspaces can start on older prebuilds and incrementally update
+    allowUsingPreviousPrebuilds?: boolean;
 }
 
 export interface Project {

--- a/components/server/ee/src/prebuilds/bitbucket-app.ts
+++ b/components/server/ee/src/prebuilds/bitbucket-app.ts
@@ -156,12 +156,14 @@ export class BitbucketApp {
                 { span },
                 { user, project: projectAndOwner.project, context, commitInfo },
             );
-            await this.webhookEvents.updateEvent(event.id, {
-                prebuildStatus: "prebuild_triggered",
-                status: "processed",
-                prebuildId: ws.prebuildId,
-            });
-            return ws;
+            if (!ws.done) {
+                await this.webhookEvents.updateEvent(event.id, {
+                    prebuildStatus: "prebuild_triggered",
+                    status: "processed",
+                    prebuildId: ws.prebuildId,
+                });
+                return ws;
+            }
         } catch (e) {
             console.error("Error processing Bitbucket webhook event", e);
             await this.webhookEvents.updateEvent(event.id, {

--- a/components/server/ee/src/prebuilds/bitbucket-server-app.ts
+++ b/components/server/ee/src/prebuilds/bitbucket-server-app.ts
@@ -154,12 +154,14 @@ export class BitbucketServerApp {
                     commitInfo,
                 },
             );
-            await this.webhookEvents.updateEvent(event.id, {
-                prebuildStatus: "prebuild_triggered",
-                status: "processed",
-                prebuildId: ws.prebuildId,
-            });
-            return ws;
+            if (!ws.done) {
+                await this.webhookEvents.updateEvent(event.id, {
+                    prebuildStatus: "prebuild_triggered",
+                    status: "processed",
+                    prebuildId: ws.prebuildId,
+                });
+                return ws;
+            }
         } catch (e) {
             console.error("Error processing Bitbucket Server webhook event", e);
             await this.webhookEvents.updateEvent(event.id, {

--- a/components/server/ee/src/prebuilds/github-enterprise-app.ts
+++ b/components/server/ee/src/prebuilds/github-enterprise-app.ts
@@ -184,12 +184,14 @@ export class GitHubEnterpriseApp {
                     commitInfo,
                 },
             );
-            await this.webhookEvents.updateEvent(event.id, {
-                prebuildStatus: "prebuild_triggered",
-                status: "processed",
-                prebuildId: ws.prebuildId,
-            });
-            return ws;
+            if (!ws.done) {
+                await this.webhookEvents.updateEvent(event.id, {
+                    prebuildStatus: "prebuild_triggered",
+                    status: "processed",
+                    prebuildId: ws.prebuildId,
+                });
+                return ws;
+            }
         } catch (e) {
             log.error("Error processing GitHub Enterprise webhook event.", e);
             await this.webhookEvents.updateEvent(event.id, {

--- a/components/server/ee/src/prebuilds/prebuild-manager.ts
+++ b/components/server/ee/src/prebuilds/prebuild-manager.ts
@@ -46,6 +46,7 @@ export interface StartPrebuildParams {
     context: CommitContext;
     project?: Project;
     commitInfo?: CommitInfo;
+    forcePrebuild?: boolean;
 }
 
 const PREBUILD_LIMITER_WINDOW_SECONDS = 60;
@@ -115,7 +116,7 @@ export class PrebuildManager {
 
     async startPrebuild(
         ctx: TraceContext,
-        { context, project, user, commitInfo }: StartPrebuildParams,
+        { context, project, user, commitInfo, forcePrebuild }: StartPrebuildParams,
     ): Promise<StartPrebuildResult> {
         const span = TraceContext.startSpan("startPrebuild", ctx);
         const cloneURL = context.repository.cloneUrl;
@@ -130,15 +131,15 @@ export class PrebuildManager {
             const existingPB = await this.findNonFailedPrebuiltWorkspace({ span }, cloneURL, commitSHAIdentifier);
 
             // If the existing prebuild is failed, it will be retriggered in the afterwards
+            const config = await this.fetchConfig({ span }, user, context);
             if (existingPB) {
                 // If the existing prebuild is based on an outdated project config, we also want to retrigger it.
                 const existingPBWS = await this.workspaceDB.trace({ span }).findById(existingPB.buildWorkspaceId);
                 const existingConfig = existingPBWS?.config;
-                const newConfig = await this.fetchConfig({ span }, user, context);
                 log.debug(
                     `startPrebuild | commits: ${commitSHAIdentifier}, existingPB: ${
                         existingPB.id
-                    }, existingConfig: ${JSON.stringify(existingConfig)}, newConfig: ${JSON.stringify(newConfig)}}`,
+                    }, existingConfig: ${JSON.stringify(existingConfig)}, newConfig: ${JSON.stringify(config)}}`,
                 );
                 const filterPrebuildTasks = (tasks: TaskConfig[] = []) =>
                     tasks
@@ -151,7 +152,7 @@ export class PrebuildManager {
                         .filter((task) => Object.keys(task).length > 0);
                 const isSameConfig =
                     JSON.stringify(filterPrebuildTasks(existingConfig?.tasks)) ===
-                    JSON.stringify(filterPrebuildTasks(newConfig?.tasks));
+                    JSON.stringify(filterPrebuildTasks(config?.tasks));
                 // If there is an existing prebuild that isn't failed and it's based on the current config, we return it here instead of triggering a new prebuild.
                 if (isSameConfig) {
                     return { prebuildId: existingPB.id, wsid: existingPB.buildWorkspaceId, done: true };
@@ -173,11 +174,30 @@ export class PrebuildManager {
                 normalizedContextURL: context.normalizedContextURL,
             };
 
-            if (this.shouldPrebuildIncrementally(context.repository.cloneUrl, project)) {
+            const { commitHistory, additionalRepositoryCommitHistories } =
+                await this.incrementalPrebuildsService.getCommitHistoryForContext(context, user);
+
+            const prebuildEveryNthCommit = project?.settings?.prebuildEveryNthCommit || 0;
+            if (!forcePrebuild && prebuildEveryNthCommit > 0) {
+                const history = {
+                    commitHistory: commitHistory?.slice(0, prebuildEveryNthCommit),
+                    additionalRepositoryCommitHistories: additionalRepositoryCommitHistories?.map((repoHist) => ({
+                        cloneUrl: repoHist.cloneUrl,
+                        commitHistory: repoHist.commitHistory.slice(0, prebuildEveryNthCommit),
+                    })),
+                };
+                const prebuild = await this.incrementalPrebuildsService.findGoodBaseForIncrementalBuild(
+                    context,
+                    config,
+                    history,
+                    user,
+                );
+                if (prebuild) {
+                    return { prebuildId: prebuild.id, wsid: prebuild.buildWorkspaceId, done: true };
+                }
+            } else if (this.shouldPrebuildIncrementally(context.repository.cloneUrl, project)) {
                 // We store the commit histories in the `StartPrebuildContext` in order to pass them down to
                 // `WorkspaceFactoryEE.createForStartPrebuild`.
-                const { commitHistory, additionalRepositoryCommitHistories } =
-                    await this.incrementalPrebuildsService.getCommitHistoryForContext(context, user);
                 if (commitHistory) {
                     prebuildContext.commitHistory = commitHistory;
                 }

--- a/components/server/ee/src/prebuilds/prebuild-manager.ts
+++ b/components/server/ee/src/prebuilds/prebuild-manager.ts
@@ -191,6 +191,7 @@ export class PrebuildManager {
             const workspace = await this.workspaceFactory.createForContext(
                 { span },
                 user,
+                project,
                 prebuildContext,
                 context.normalizedContextURL!,
             );

--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -2662,6 +2662,7 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
             context,
             user,
             project,
+            forcePrebuild: true,
         });
 
         this.analytics.track({

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -30,7 +30,6 @@ import {
     AuthProviderInfo,
     CommitContext,
     Configuration,
-    CreateWorkspaceMode,
     DisposableCollection,
     GetWorkspaceTimeoutResult,
     GitpodClient as GitpodApiClient,
@@ -1053,12 +1052,11 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         traceAPIParams(ctx, { options });
 
         const contextUrl = options.contextUrl;
-        const mode = options.mode || CreateWorkspaceMode.Default;
         let normalizedContextUrl: string = "";
         let logContext: LogContext = {};
 
         try {
-            const user = this.checkAndBlockUser("createWorkspace", { mode });
+            const user = this.checkAndBlockUser("createWorkspace", { options });
             await this.checkTermsAcceptance();
 
             const envVars = this.userDB.getEnvVars(user.id);
@@ -1070,7 +1068,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
             normalizedContextUrl = this.contextParser.normalizeContextURL(contextUrl);
             let runningForContextPromise: Promise<WorkspaceInfo[]> = Promise.resolve([]);
             const contextPromise = this.contextParser.handle(ctx, user, normalizedContextUrl);
-            if (mode === CreateWorkspaceMode.SelectIfRunning) {
+            if (!options.ignoreRunningWorkspaceOnSameCommit) {
                 runningForContextPromise = this.findRunningInstancesForContext(
                     ctx,
                     contextPromise,
@@ -1153,14 +1151,22 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
                 }
             }
 
-            if (mode === CreateWorkspaceMode.SelectIfRunning && context.forceCreateNewWorkspace !== true) {
+            if (!options.ignoreRunningWorkspaceOnSameCommit && !context.forceCreateNewWorkspace) {
                 const runningForContext = await runningForContextPromise;
                 if (runningForContext.length > 0) {
                     return { existingWorkspaces: runningForContext };
                 }
             }
-
-            const prebuiltWorkspace = await this.findPrebuiltWorkspace(ctx, user, context, mode);
+            const project = CommitContext.is(context)
+                ? await this.projectDB.findProjectByCloneUrl(context.repository.cloneUrl)
+                : undefined;
+            const prebuiltWorkspace = await this.findPrebuiltWorkspace(
+                ctx,
+                user,
+                context,
+                options.ignoreRunningPrebuild,
+                options.allowUsingPreviousPrebuilds || project?.settings?.allowUsingPreviousPrebuilds,
+            );
             if (WorkspaceCreationResult.is(prebuiltWorkspace)) {
                 ctx.span?.log({ prebuild: "running" });
                 return prebuiltWorkspace as WorkspaceCreationResult;
@@ -1170,7 +1176,13 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
                 context = prebuiltWorkspace;
             }
 
-            const workspace = await this.workspaceFactory.createForContext(ctx, user, context, normalizedContextUrl);
+            const workspace = await this.workspaceFactory.createForContext(
+                ctx,
+                user,
+                project,
+                context,
+                normalizedContextUrl,
+            );
             await this.mayStartWorkspace(ctx, user, workspace, runningInstancesPromise);
             try {
                 await this.guardAccess({ kind: "workspace", subject: workspace }, "create");
@@ -1242,10 +1254,11 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
     }
 
     protected async findPrebuiltWorkspace(
-        ctx: TraceContext,
+        parentCtx: TraceContext,
         user: User,
         context: WorkspaceContext,
-        mode: CreateWorkspaceMode,
+        ignoreRunningPrebuild?: boolean,
+        allowUsingPreviousPrebuilds?: boolean,
     ): Promise<WorkspaceCreationResult | PrebuiltWorkspaceContext | undefined> {
         // prebuilds are an EE feature
         return undefined;


### PR DESCRIPTION
## Description
Introduces a project setting that allows for starting workspaces on the successful prebuild on the direct linear commit history. Enabling this will always skip the "prebuild-in-progress" view.
It also allows specifying the number of commits to skip in between prebuilds.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #12583

## How to test
- create a team & project
- go to the settings and enable 'incremental prebuilds' set the number of commits to 1
- start a workspace.
- push a commit (no config change!) and verify that no prebuild is running
- start a workspace and verify that it is based on the first prebuild
- push a commit (no config change!) and verify that a prebuild gets triggered
- push a commit that changes the init task in the gitpod.yml and verify that a prebuild gets triggered

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Introduced a new project setting that allows starting workspaces based on the last successful prebuild in the git commit history.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
