### PR TITLE
[public-api] Handle blocked user error

### DIFF
--- a/components/public-api-server/pkg/proxy/errors.go
+++ b/components/public-api-server/pkg/proxy/errors.go
@@ -47,5 +47,9 @@ func ConvertError(err error) error {
 		return connect.NewError(connect.CodeInternal, err)
 	}
 
+	if strings.Contains(s, "code 470") {
+		return connect.NewError(connect.CodePermissionDenied, err)
+	}
+
 	return connect.NewError(connect.CodeInternal, err)
 }

--- a/components/public-api-server/pkg/proxy/errors_test.go
+++ b/components/public-api-server/pkg/proxy/errors_test.go
@@ -34,6 +34,10 @@ func TestConvertError(t *testing.T) {
 			WebsocketError: errors.New("code 409"),
 			ExpectedStatus: connect.CodeAlreadyExists,
 		},
+		{
+			WebsocketError: errors.New("code 470"),
+			ExpectedStatus: connect.CodePermissionDenied,
+		},
 	}
 
 	for _, s := range scenarios {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Return Permission Denied when a blocked user error is returned by server/

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
