### PR TITLE
Add `toxic-config` component to configure Toxiproxy instances with latency toxics

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -29,6 +29,7 @@
 /components/image-builder-mk3 @gitpod-io/engineering-workspace
 /components/installation-telemetry @gitpod-io/engineering-delivery-operations-experience
 /components/kots-config-check @gitpod-io/engineering-delivery-operations-experience
+/components/toxic-config @gitpod-io/engineering-webapp
 /install @gitpod-io/engineering-delivery-operations-experience
 /install/installer @gitpod-io/engineering-delivery-operations-experience
 # For testdata a single review from anyone who is allowed to review PRs is sufficent.

--- a/components/BUILD.yaml
+++ b/components/BUILD.yaml
@@ -66,6 +66,7 @@ packages:
       - components/server:docker
       - components/service-waiter:docker
       - components/supervisor:docker
+      - components/toxic-config:docker
       - components/installation-telemetry:docker
       - components/workspacekit:docker
       - components/ws-daemon:docker
@@ -119,6 +120,7 @@ packages:
       - components/service-waiter:app
       - components/supervisor:app
       - components/supervisor/frontend:app
+      - components/toxic-config:app
       - components/installation-telemetry:app
       - components/workspacekit:app
       - components/ws-daemon:app

--- a/components/toxic-config/BUILD.yaml
+++ b/components/toxic-config/BUILD.yaml
@@ -1,0 +1,29 @@
+packages:
+  - name: app
+    type: go
+    srcs:
+      - "**/*.go"
+      - "go.mod"
+      - "go.sum"
+    deps:
+      - components/common-go:lib
+    env:
+      - CGO_ENABLED=0
+      - GOOS=linux
+    config:
+      packaging: app
+  - name: docker
+    type: docker
+    deps:
+      - :app
+    argdeps:
+      - imageRepoBase
+    config:
+      buildArgs:
+        VERSION: ${version}
+      dockerfile: leeway.Dockerfile
+      metadata:
+        helm-component: toxic-config
+      image:
+        - ${imageRepoBase}/toxic-config:${version}
+        - ${imageRepoBase}/toxic-config:commit-${__git_commit}

--- a/components/toxic-config/README.md
+++ b/components/toxic-config/README.md
@@ -1,0 +1,13 @@
+# toxic-config
+
+Configures a given [Toxiproxy](https://github.com/Shopify/toxiproxy) proxy with a latency toxic.
+
+For example, with a Toxiproxy instance running on `localhost:8474` with a proxy called `mysql` configured:
+
+```
+go run . --proxy mysql --latency=1000 --jitter=250
+```
+
+will configure the `mysql` proxy with a [latency toxic](https://github.com/Shopify/toxiproxy#latency) with `latency` and `jitter` set to the provided values.
+
+`toxic-config` is intended to run as a sidecar container in a Kubernetes pod alongside the Toxiproxy instance to be configured.

--- a/components/toxic-config/go.mod
+++ b/components/toxic-config/go.mod
@@ -1,0 +1,65 @@
+module github.com/gitpod-io/gitpod/toxic-config
+
+go 1.19
+
+require (
+	github.com/Shopify/toxiproxy/v2 v2.5.0
+	github.com/gitpod-io/gitpod/common-go v0.0.0-00010101000000-000000000000
+)
+
+require (
+	github.com/sirupsen/logrus v1.8.1 // indirect
+	golang.org/x/sys v0.0.0-20220909162455-aba9fc2a8ff2 // indirect
+)
+
+replace github.com/gitpod-io/gitpod/common-go => ../common-go // leeway
+
+replace k8s.io/api => k8s.io/api v0.24.4 // leeway indirect from components/common-go:lib
+
+replace k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.24.4 // leeway indirect from components/common-go:lib
+
+replace k8s.io/apimachinery => k8s.io/apimachinery v0.24.4 // leeway indirect from components/common-go:lib
+
+replace k8s.io/apiserver => k8s.io/apiserver v0.24.4 // leeway indirect from components/common-go:lib
+
+replace k8s.io/cli-runtime => k8s.io/cli-runtime v0.24.4 // leeway indirect from components/common-go:lib
+
+replace k8s.io/client-go => k8s.io/client-go v0.24.4 // leeway indirect from components/common-go:lib
+
+replace k8s.io/cloud-provider => k8s.io/cloud-provider v0.24.4 // leeway indirect from components/common-go:lib
+
+replace k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.24.4 // leeway indirect from components/common-go:lib
+
+replace k8s.io/code-generator => k8s.io/code-generator v0.24.4 // leeway indirect from components/common-go:lib
+
+replace k8s.io/component-base => k8s.io/component-base v0.24.4 // leeway indirect from components/common-go:lib
+
+replace k8s.io/cri-api => k8s.io/cri-api v0.24.4 // leeway indirect from components/common-go:lib
+
+replace k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.24.4 // leeway indirect from components/common-go:lib
+
+replace k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.24.4 // leeway indirect from components/common-go:lib
+
+replace k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.24.4 // leeway indirect from components/common-go:lib
+
+replace k8s.io/kube-proxy => k8s.io/kube-proxy v0.24.4 // leeway indirect from components/common-go:lib
+
+replace k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.24.4 // leeway indirect from components/common-go:lib
+
+replace k8s.io/kubelet => k8s.io/kubelet v0.24.4 // leeway indirect from components/common-go:lib
+
+replace k8s.io/legacy-cloud-providers => k8s.io/legacy-cloud-providers v0.24.4 // leeway indirect from components/common-go:lib
+
+replace k8s.io/metrics => k8s.io/metrics v0.24.4 // leeway indirect from components/common-go:lib
+
+replace k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.24.4 // leeway indirect from components/common-go:lib
+
+replace k8s.io/component-helpers => k8s.io/component-helpers v0.24.4 // leeway indirect from components/common-go:lib
+
+replace k8s.io/controller-manager => k8s.io/controller-manager v0.24.4 // leeway indirect from components/common-go:lib
+
+replace k8s.io/kubectl => k8s.io/kubectl v0.24.4 // leeway indirect from components/common-go:lib
+
+replace k8s.io/mount-utils => k8s.io/mount-utils v0.24.4 // leeway indirect from components/common-go:lib
+
+replace k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.24.4 // leeway indirect from components/common-go:lib

--- a/components/toxic-config/go.sum
+++ b/components/toxic-config/go.sum
@@ -1,0 +1,15 @@
+github.com/Shopify/toxiproxy/v2 v2.5.0 h1:i4LPT+qrSlKNtQf5QliVjdP08GyAH8+BUIc9gT0eahc=
+github.com/Shopify/toxiproxy/v2 v2.5.0/go.mod h1:yhM2epWtAmel9CB8r2+L+PCmhH6yH2pITaPAo7jxJl0=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
+github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220909162455-aba9fc2a8ff2 h1:wM1k/lXfpc5HdkJJyW9GELpd8ERGdnh8sMGL6Gzq3Ho=
+golang.org/x/sys v0.0.0-20220909162455-aba9fc2a8ff2/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=

--- a/components/toxic-config/leeway.Dockerfile
+++ b/components/toxic-config/leeway.Dockerfile
@@ -1,0 +1,22 @@
+# Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+# Licensed under the GNU Affero General Public License (AGPL).
+# See License-AGPL.txt in the project root for license information.
+
+FROM alpine:3.16
+
+# Ensure latest packages are present, like security updates.
+RUN  apk upgrade --no-cache \
+  && apk add --no-cache ca-certificates
+
+RUN adduser -S -D -H -h /app -u 1000 appuser
+COPY components-toxic-config--app/toxic-config /app/toxic-config
+RUN chown -R appuser /app
+
+USER appuser
+
+ARG __GIT_COMMIT
+ARG VERSION
+
+ENV GITPOD_BUILD_GIT_COMMIT=${__GIT_COMMIT}
+ENV GITPOD_BUILD_VERSION=${VERSION}
+ENTRYPOINT [ "/app/toxic-config" ]

--- a/components/toxic-config/main.go
+++ b/components/toxic-config/main.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package main
+
+import (
+	"flag"
+	"time"
+
+	"github.com/gitpod-io/gitpod/common-go/log"
+
+	toxiproxy "github.com/Shopify/toxiproxy/v2/client"
+)
+
+var (
+	proxyName string
+	latency   int
+	jitter    int
+	wait      bool
+)
+
+func main() {
+	flag.StringVar(&proxyName, "proxy", "mysql", "the name of the proxy to which latency should be added")
+	flag.IntVar(&latency, "latency", 1000, "latency in milliseconds")
+	flag.IntVar(&jitter, "jitter", 250, "jitter in milliseconds")
+	flag.BoolVar(&wait, "wait", false, "whether the process should wait indefinitely after running")
+
+	flag.Parse()
+
+	client := toxiproxy.NewClient(":8474")
+
+	var (
+		proxies map[string]*toxiproxy.Proxy
+		err     error
+	)
+	for {
+		proxies, err = client.Proxies()
+		if err != nil {
+			log.WithError(err).Print("Failed to list proxies")
+			log.Println("Retrying in 1s...")
+			time.Sleep(1 * time.Second)
+		} else {
+			break
+		}
+	}
+
+	proxy, ok := proxies[proxyName]
+	if !ok {
+		log.Fatalf("Failed to find proxy %q", proxyName)
+	}
+
+	toxic, err := proxy.AddToxic(
+		"latency",
+		"latency",
+		"downstream",
+		1.0,
+		toxiproxy.Attributes{"latency": latency, "jitter": jitter},
+	)
+	if err != nil {
+		log.Fatalf("Failed to add toxic: %s", err)
+	}
+
+	log.Printf("Toxic added: %s", toxic.Name)
+
+	if wait {
+		select {}
+	}
+}


### PR DESCRIPTION
## Description

As part of #9198 we will run a [Toxiproxy](https://github.com/Shopify/toxiproxy/) instance in the application cluster to allow us to simulate a high-latency connection to the Gitpod database. Installation and configuration of this Toxiproxy instance is done in some preceding PRs:

* https://github.com/gitpod-io/gitpod/pull/14359
* https://github.com/gitpod-io/gitpod/pull/14388
* https://github.com/gitpod-io/gitpod/pull/14423
* https://github.com/gitpod-io/gitpod/pull/14430
* https://github.com/gitpod-io/gitpod/pull/14437

Toxiproxy allows declarative configuration of proxies via a config file, but configuration of [toxics](https://github.com/Shopify/toxiproxy/blob/master/README.md#toxics) has to be done dynamically while Toxiproxy is running.

This PR adds a new component `toxic-config`, intended to run as a sidecar container in a Kubernetes pod alongside Toxiproxy, that configures a given proxy with a [latency toxic](https://github.com/Shopify/toxiproxy/blob/master/README.md#latency).

For example, with a Toxiproxy instance running on `localhost:8474` with a proxy called `mysql` configured:

```
go run . --proxy mysql --latency=1000 --jitter=250
```

will configure the `mysql` proxy with a [latency toxic](https://github.com/Shopify/toxiproxy#latency) with `latency` and `jitter` set to the provided values.


A later PR will run this process as a sidecar container in the Toxiproxy pod.

## Related Issue(s)

Part of #9198

## How to test

* Port forward to the `toxiproxy` service in the preview environment:
```
kubectl port-forward svc/toxiproxy 8474:8474
```

* Run `toxic-config` against the `toxiproxy` instance:

```
cd components/toxic-config
go run . --proxy mysql --latency=1000 --jitter=250
```

* See that the `mysql` proxy now has a `latency` toxic configured.
```
docker run --rm --net=host --entrypoint="/toxiproxy-cli" -it ghcr.io/shopify/toxiproxy inspect mysql
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-slow-database
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
