### PR TITLE
[installer] Run the `toxic-config` component as a sidecar in the Toxiproxy pod

### DIFF
--- a/install/installer/cmd/testdata/render/aws-setup/output.golden
+++ b/install/installer/cmd/testdata/render/aws-setup/output.golden
@@ -1458,6 +1458,9 @@ data:
           "serviceWaiter": {
             "version": "test"
           },
+          "toxic-config": {
+            "version": "test"
+          },
           "usage": {
             "version": "test"
           },

--- a/install/installer/cmd/testdata/render/azure-setup/output.golden
+++ b/install/installer/cmd/testdata/render/azure-setup/output.golden
@@ -1415,6 +1415,9 @@ data:
           "serviceWaiter": {
             "version": "test"
           },
+          "toxic-config": {
+            "version": "test"
+          },
           "usage": {
             "version": "test"
           },

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -1672,6 +1672,9 @@ data:
           "serviceWaiter": {
             "version": "test"
           },
+          "toxic-config": {
+            "version": "test"
+          },
           "usage": {
             "version": "test"
           },

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -1462,6 +1462,9 @@ data:
           "serviceWaiter": {
             "version": "test"
           },
+          "toxic-config": {
+            "version": "test"
+          },
           "usage": {
             "version": "test"
           },

--- a/install/installer/cmd/testdata/render/gcp-setup/output.golden
+++ b/install/installer/cmd/testdata/render/gcp-setup/output.golden
@@ -1393,6 +1393,9 @@ data:
           "serviceWaiter": {
             "version": "test"
           },
+          "toxic-config": {
+            "version": "test"
+          },
           "usage": {
             "version": "test"
           },

--- a/install/installer/cmd/testdata/render/http-proxy/output.golden
+++ b/install/installer/cmd/testdata/render/http-proxy/output.golden
@@ -1531,6 +1531,9 @@ data:
           "serviceWaiter": {
             "version": "test"
           },
+          "toxic-config": {
+            "version": "test"
+          },
           "usage": {
             "version": "test"
           },

--- a/install/installer/cmd/testdata/render/insecure-s3-setup/output.golden
+++ b/install/installer/cmd/testdata/render/insecure-s3-setup/output.golden
@@ -1502,6 +1502,9 @@ data:
           "serviceWaiter": {
             "version": "test"
           },
+          "toxic-config": {
+            "version": "test"
+          },
           "usage": {
             "version": "test"
           },

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -1528,6 +1528,9 @@ data:
           "serviceWaiter": {
             "version": "test"
           },
+          "toxic-config": {
+            "version": "test"
+          },
           "usage": {
             "version": "test"
           },

--- a/install/installer/cmd/testdata/render/shortname/output.golden
+++ b/install/installer/cmd/testdata/render/shortname/output.golden
@@ -1528,6 +1528,9 @@ data:
           "serviceWaiter": {
             "version": "test"
           },
+          "toxic-config": {
+            "version": "test"
+          },
           "usage": {
             "version": "test"
           },

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -1540,6 +1540,9 @@ data:
           "serviceWaiter": {
             "version": "test"
           },
+          "toxic-config": {
+            "version": "test"
+          },
           "usage": {
             "version": "test"
           },

--- a/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
+++ b/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
@@ -1750,6 +1750,9 @@ data:
           "serviceWaiter": {
             "version": "test"
           },
+          "toxic-config": {
+            "version": "test"
+          },
           "usage": {
             "version": "test"
           },

--- a/install/installer/cmd/testdata/render/versions.yaml
+++ b/install/installer/cmd/testdata/render/versions.yaml
@@ -54,6 +54,8 @@ components:
     version: test
   serviceWaiter:
     version: test
+  toxic-config:
+    version: test
   usage:
     version: test
   workspace:

--- a/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
+++ b/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
@@ -1531,6 +1531,9 @@ data:
           "serviceWaiter": {
             "version": "test"
           },
+          "toxic-config": {
+            "version": "test"
+          },
           "usage": {
             "version": "test"
           },

--- a/install/installer/pkg/components/toxiproxy/configmap.go
+++ b/install/installer/pkg/components/toxiproxy/configmap.go
@@ -14,6 +14,7 @@ import (
 )
 
 const (
+	proxyName      = "mysql"
 	configFilename = "toxiproxy.json"
 )
 
@@ -29,7 +30,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 
 	txcfg := []ToxiproxyConfig{
 		{
-			Name:     "mysql",
+			Name:     proxyName,
 			Listen:   fmt.Sprintf("[::]:%d", dbPort),
 			Upstream: fmt.Sprintf("%s:%d", dbHost, dbPort),
 			Enabled:  true,

--- a/install/installer/pkg/components/toxiproxy/constants.go
+++ b/install/installer/pkg/components/toxiproxy/constants.go
@@ -5,6 +5,7 @@ package toxiproxy
 
 const (
 	Component               = "toxiproxy"
+	ConfigComponent         = "toxic-config"
 	HttpPortName            = "http"
 	HttpContainerPort       = 8474
 	HttpServicePort         = 8474

--- a/install/installer/pkg/components/toxiproxy/deployment.go
+++ b/install/installer/pkg/components/toxiproxy/deployment.go
@@ -4,6 +4,7 @@
 package toxiproxy
 
 import (
+	"fmt"
 	"path/filepath"
 
 	"github.com/gitpod-io/gitpod/installer/pkg/cluster"
@@ -102,6 +103,15 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 							},
 							Env:          common.CustomizeEnvvar(ctx, Component, common.MergeEnv(common.DefaultEnv(&ctx.Config))),
 							VolumeMounts: volumeMounts,
+						}, {
+							Name:  "toxic-config",
+							Image: ctx.ImageName(ctx.Config.Repository, ConfigComponent, ctx.VersionManifest.Components.ToxicConfig.Version),
+							Args: []string{
+								fmt.Sprintf("--proxy=%s", proxyName),
+								"--latency=1000",
+								"--jitter=250",
+								"--wait=true",
+							},
 						},
 							*common.KubeRBACProxyContainerWithConfig(ctx),
 						},

--- a/install/installer/pkg/components/toxiproxy/objects_test.go
+++ b/install/installer/pkg/components/toxiproxy/objects_test.go
@@ -40,7 +40,10 @@ func renderContextWithSlowDatabaseEnabled(t *testing.T) *common.RenderContext {
 				SlowDatabase: true,
 			},
 		},
-	}, versions.Manifest{}, "test-namespace")
+	}, versions.Manifest{
+		Version:    "test",
+		Components: versions.Components{ToxicConfig: versions.Versioned{Version: "test"}},
+	}, "test-namespace")
 	require.NoError(t, err)
 
 	return ctx

--- a/install/installer/pkg/config/versions/versions.go
+++ b/install/installer/pkg/config/versions/versions.go
@@ -38,6 +38,7 @@ type Components struct {
 	RegistryFacade        Versioned `json:"registryFacade"`
 	Server                Versioned `json:"server"`
 	ServiceWaiter         Versioned `json:"serviceWaiter"`
+	ToxicConfig           Versioned `json:"toxic-config"`
 	Usage                 Versioned `json:"usage"`
 	Workspace             struct {
 		CodeImage        Versioned `json:"codeImage"`


### PR DESCRIPTION
## Description

As part of #9198 we will run a [Toxiproxy](https://github.com/Shopify/toxiproxy/) instance in the application cluster to allow us to simulate a high-latency connection to the Gitpod database.

https://github.com/gitpod-io/gitpod/pull/14473 added a new component, `toxic-config`, intended to run as a sidecar container in a Kubernetes pod alongside Toxiproxy, that configures a given proxy with a [latency toxic](https://github.com/Shopify/toxiproxy/blob/master/README.md#latency).

This PR makes that new component run as a sidecar in the Toxiproxy component to ensure that the `mysql` component is configured with latency.

## Related Issue(s)
Part of #9198 

## How to test

1. Port forward to Toxiproxy:
```
kubectl port-forward svc/toxiproxy 8474:8474
```

2. Verify that the sidecar container successfully configured the `mysql` proxy:

```
kubcectl logs deploy/toxiproxy -c toxic-config
```

3. Verify that the `mysql` proxy has been configured with a latency toxic:

```
docker run --rm --net=host --entrypoint="/toxiproxy-cli" -it ghcr.io/shopify/toxiproxy inspect mysql
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-slow-database
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
