### PR TITLE
[public-api] Properly extract errors from Websocket RPC

### DIFF
--- a/components/public-api-server/pkg/apiv1/team_test.go
+++ b/components/public-api-server/pkg/apiv1/team_test.go
@@ -6,7 +6,6 @@ package apiv1
 
 import (
 	"context"
-	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -19,6 +18,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
+	"github.com/sourcegraph/jsonrpc2"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/testing/protocmp"
 )
@@ -43,7 +43,10 @@ func TestTeamsService_CreateTeam(t *testing.T) {
 		ctx := context.Background()
 		serverMock, client := setupTeamService(t)
 
-		serverMock.EXPECT().CreateTeam(gomock.Any(), name).Return(nil, errors.New("code 400"))
+		serverMock.EXPECT().CreateTeam(gomock.Any(), name).Return(nil, &jsonrpc2.Error{
+			Code:    400,
+			Message: "invalid request",
+		})
 
 		_, err := client.CreateTeam(ctx, connect.NewRequest(&v1.CreateTeamRequest{Name: name}))
 		require.Error(t, err)

--- a/components/public-api-server/pkg/apiv1/workspace_test.go
+++ b/components/public-api-server/pkg/apiv1/workspace_test.go
@@ -6,7 +6,6 @@ package apiv1
 
 import (
 	"context"
-	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -20,6 +19,7 @@ import (
 	"github.com/gitpod-io/gitpod/public-api/experimental/v1/v1connect"
 	"github.com/golang/mock/gomock"
 	"github.com/google/go-cmp/cmp"
+	"github.com/sourcegraph/jsonrpc2"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/testing/protocmp"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -70,7 +70,10 @@ func TestWorkspaceService_GetWorkspace(t *testing.T) {
 			serverMock.EXPECT().GetWorkspace(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, id string) (res *protocol.WorkspaceInfo, err error) {
 				w, ok := test.Workspaces[id]
 				if !ok {
-					return nil, errors.New("code 404")
+					return nil, &jsonrpc2.Error{
+						Code:    404,
+						Message: "not found",
+					}
 				}
 				return &w, nil
 			})
@@ -129,7 +132,10 @@ func TestWorkspaceService_GetOwnerToken(t *testing.T) {
 			serverMock.EXPECT().GetOwnerToken(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, workspaceID string) (res string, err error) {
 				w, ok := test.Tokens[workspaceID]
 				if !ok {
-					return "", errors.New("code 404")
+					return "", &jsonrpc2.Error{
+						Code:    404,
+						Message: "not found",
+					}
 				}
 				return w, nil
 			})

--- a/components/public-api-server/pkg/proxy/errors.go
+++ b/components/public-api-server/pkg/proxy/errors.go
@@ -5,9 +5,12 @@
 package proxy
 
 import (
-	"strings"
+	"errors"
+	"fmt"
 
 	"github.com/bufbuild/connect-go"
+	protocol "github.com/gitpod-io/gitpod/gitpod-protocol"
+	"github.com/sourcegraph/jsonrpc2"
 )
 
 func ConvertError(err error) error {
@@ -15,40 +18,43 @@ func ConvertError(err error) error {
 		return nil
 	}
 
-	s := err.Error()
+	return categorizeRPCError(err)
+}
 
-	// components/gitpod-protocol/src/messaging/error.ts
-	if strings.Contains(s, "code 400") {
-		return connect.NewError(connect.CodeInvalidArgument, err)
+func categorizeRPCError(err error) *connect.Error {
+	if err == nil {
+		return nil
 	}
 
-	// components/gitpod-protocol/src/messaging/error.ts
-	if strings.Contains(s, "code 401") {
-		return connect.NewError(connect.CodePermissionDenied, err)
+	if rpcErr := new(jsonrpc2.Error); errors.As(err, &rpcErr) {
+		switch rpcErr.Code {
+		case 400:
+			return connect.NewError(connect.CodeInvalidArgument, fmt.Errorf(rpcErr.Message))
+		// components/gitpod-protocol/src/messaging/error.ts
+		case 401:
+			return connect.NewError(connect.CodePermissionDenied, fmt.Errorf(rpcErr.Message))
+		// components/gitpod-protocol/src/messaging/error.ts
+		case 403:
+			return connect.NewError(connect.CodePermissionDenied, fmt.Errorf(rpcErr.Message))
+		// components/gitpod-protocol/src/messaging/error.ts
+		case 404:
+			return connect.NewError(connect.CodeNotFound, fmt.Errorf(rpcErr.Message))
+		// components/gitpod-protocol/src/messaging/error.ts
+		case 409:
+			return connect.NewError(connect.CodeAlreadyExists, fmt.Errorf(rpcErr.Message))
+		// components/gitpod-messagebus/src/jsonrpc-server.ts#47
+		case -32603:
+			return connect.NewError(connect.CodeInternal, fmt.Errorf(rpcErr.Message))
+		case 470:
+			return connect.NewError(connect.CodePermissionDenied, fmt.Errorf(rpcErr.Message))
+
+		default:
+			return connect.NewError(connect.CodeInternal, fmt.Errorf(rpcErr.Message))
+		}
 	}
 
-	// components/gitpod-protocol/src/messaging/error.ts
-	if strings.Contains(s, "code 403") {
-		return connect.NewError(connect.CodePermissionDenied, err)
-	}
-
-	// components/gitpod-protocol/src/messaging/error.ts
-	if strings.Contains(s, "code 404") {
-		return connect.NewError(connect.CodeNotFound, err)
-	}
-
-	// components/gitpod-protocol/src/messaging/error.ts
-	if strings.Contains(s, "code 409") {
-		return connect.NewError(connect.CodeAlreadyExists, err)
-	}
-
-	// components/gitpod-messagebus/src/jsonrpc-server.ts#47
-	if strings.Contains(s, "code -32603") {
-		return connect.NewError(connect.CodeInternal, err)
-	}
-
-	if strings.Contains(s, "code 470") {
-		return connect.NewError(connect.CodePermissionDenied, err)
+	if handshakeErr := new(protocol.ErrBadHandshake); errors.As(err, &handshakeErr) {
+		return connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("Failed to establish caller identity"))
 	}
 
 	return connect.NewError(connect.CodeInternal, err)

--- a/components/public-api-server/pkg/proxy/errors_test.go
+++ b/components/public-api-server/pkg/proxy/errors_test.go
@@ -10,40 +10,62 @@ import (
 	"testing"
 
 	"github.com/bufbuild/connect-go"
+	protocol "github.com/gitpod-io/gitpod/gitpod-protocol"
+	"github.com/sourcegraph/jsonrpc2"
 	"github.com/stretchr/testify/require"
 )
 
 func TestConvertError(t *testing.T) {
 	scenarios := []struct {
 		WebsocketError error
-		ExpectedStatus connect.Code
+		ExpectedError  error
 	}{
 		{
-			WebsocketError: errors.New("reconnecting-ws: bad handshake: code 401 - URL: wss://main.preview.gitpod-dev.com/api/v1 - headers: map[Authorization:[Bearer foo] Origin:[http://main.preview.gitpod-dev.com/]]"),
-			ExpectedStatus: connect.CodePermissionDenied,
+			WebsocketError: &protocol.ErrBadHandshake{
+				URL: "https://foo.bar",
+			},
+			ExpectedError: connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("Failed to establish caller identity")),
 		},
 		{
-			WebsocketError: errors.New("jsonrpc2: code -32603 message: Request getWorkspace failed with message: No workspace with id 'some-id' found."),
-			ExpectedStatus: connect.CodeInternal,
+			WebsocketError: &jsonrpc2.Error{
+				Code:    400,
+				Message: "user id is a required argument",
+			},
+			ExpectedError: connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("user id is a required argument")),
 		},
 		{
-			WebsocketError: errors.New("code 400"),
-			ExpectedStatus: connect.CodeInvalidArgument,
+			WebsocketError: &jsonrpc2.Error{
+				Code:    -32603,
+				Message: "Request getWorkspace failed with message: No workspace with id 'some-id' found.",
+			},
+			ExpectedError: connect.NewError(connect.CodeInternal, fmt.Errorf("Request getWorkspace failed with message: No workspace with id 'some-id' found.")),
 		},
 		{
-			WebsocketError: errors.New("code 409"),
-			ExpectedStatus: connect.CodeAlreadyExists,
+			WebsocketError: &jsonrpc2.Error{
+				Code:    409,
+				Message: "already exists",
+			},
+			ExpectedError: connect.NewError(connect.CodeAlreadyExists, fmt.Errorf("already exists")),
 		},
 		{
-			WebsocketError: errors.New("code 470"),
-			ExpectedStatus: connect.CodePermissionDenied,
+			WebsocketError: &jsonrpc2.Error{
+				Code:    470,
+				Message: "user blocked",
+			},
+			ExpectedError: connect.NewError(connect.CodePermissionDenied, fmt.Errorf("user blocked")),
+		},
+		{
+			WebsocketError: nil,
+			ExpectedError:  nil,
+		},
+		{
+			WebsocketError: errors.New("some other random error returns internal error"),
+			ExpectedError:  connect.NewError(connect.CodeInternal, fmt.Errorf("some other random error returns internal error")),
 		},
 	}
 
 	for _, s := range scenarios {
 		converted := ConvertError(s.WebsocketError)
-		require.Equal(t, s.ExpectedStatus, connect.CodeOf(converted))
-		// the error message should remain the same
-		require.Equal(t, fmt.Errorf("%s: %w", s.ExpectedStatus.String(), s.WebsocketError).Error(), converted.Error())
+		require.Equal(t, s.ExpectedError, converted)
 	}
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Improves handling of websocket errors. Instead of parsing strings, we use the underlying websocket error types.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Relates to https://github.com/gitpod-io/gitpod/issues/14482, but does not fix it (yet)

## How to test
<!-- Provide steps to test this PR -->
Unit

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
