### PR TITLE
[install/tests] Document integration test scm setup steps

### DIFF
--- a/install/tests/Makefile
+++ b/install/tests/Makefile
@@ -200,6 +200,26 @@ aws-kubeconfig:
 	aws eks update-kubeconfig --name gp-${TF_VAR_TEST_ID} --region eu-west-1 --kubeconfig ${KUBECONFIG} || echo "No cluster present"
 	@echo -e "\033[0;33mAWS service account credentials fetched, run 'source $$(pwd)/$${TF_VAR_TEST_ID}-creds' to load them into your environment\033[0;m"
 
+# GitHub SCM credentials are stored within the gitpod-core-dev cluster. Credentials must be presented
+# in the `SCM_GITHUB_OAUTH` variable in the following format:
+#
+# ```yaml
+# description: ""
+# host: github.com
+# icon: ""
+# id: Public-GitHub
+# oauth:
+#   clientId: <client-id>
+#   clientSecret: <client-secret>
+#   settingsUrl: https://github.com/settings/apps/new
+# type: GitHub
+# ```
+#
+# Credentials can be fetched with the following:
+#
+# ```
+# export GITHUB_SCM_OAUTH="$(kubectl -n werft get secret self-hosted-github-oauth -ojson | jq -r '.data.provider | @base64d')"
+# ```
 get-github-config: check-var-DOMAIN check-var-TF_VAR_TEST_ID
 ifneq ($(GITHUB_SCM_OAUTH),)
 	@export SCM_OAUTH=./manifests/github-oauth.yaml && \


### PR DESCRIPTION
## Description

This pull request adds inline documentation to the integration test makefile indicating how to manually setup the github scm credentials.

## Related Issue(s)

n/a

## How to test

Follow the provided instructions and run `make get-github-config`; verify that the rendered manifests will generate the appropriate SCM integration settings.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
