### PR TITLE
[install/tests] Document integration test scm setup steps

### DIFF
--- a/install/tests/Makefile
+++ b/install/tests/Makefile
@@ -200,7 +200,7 @@ aws-kubeconfig:
 	aws eks update-kubeconfig --name gp-${TF_VAR_TEST_ID} --region eu-west-1 --kubeconfig ${KUBECONFIG} || echo "No cluster present"
 	@echo -e "\033[0;33mAWS service account credentials fetched, run 'source $$(pwd)/$${TF_VAR_TEST_ID}-creds' to load them into your environment\033[0;m"
 
-# GitHub SCM integration can configured prior to install. To enable the integration,
+# GitHub SCM integration can be configured prior to install. To enable the integration,
 # set the `GITHUB_SCM_OAUTH` variable to a path containing the following contents:
 #
 # ```yaml

--- a/install/tests/Makefile
+++ b/install/tests/Makefile
@@ -200,6 +200,32 @@ aws-kubeconfig:
 	aws eks update-kubeconfig --name gp-${TF_VAR_TEST_ID} --region eu-west-1 --kubeconfig ${KUBECONFIG} || echo "No cluster present"
 	@echo -e "\033[0;33mAWS service account credentials fetched, run 'source $$(pwd)/$${TF_VAR_TEST_ID}-creds' to load them into your environment\033[0;m"
 
+# GitHub SCM integration can configured prior to install. To enable the integration,
+# set the `GITHUB_SCM_OAUTH` variable to a path containing the following contents:
+#
+# ```yaml
+# description: ""
+# host: github.com
+# icon: ""
+# id: Public-GitHub
+# oauth:
+#   clientId: <client-id>
+#   clientSecret: <client-secret>
+#   settingsUrl: https://github.com/settings/apps/new
+# type: GitHub
+# ```
+#
+# Credentials can be fetched with the following:
+#
+# ```
+# export GITHUB_SCM_OAUTH="/workspace/gitpod/install/tests/github.yaml"
+# kubectl -n werft get secret self-hosted-github-oauth -ojson | jq -r '.data.provider | @base64d' > $GITHUB_SCM_OAUTH
+# make get-github-config
+# ```
+#
+# Note: The credentials needed to interact with werft may differ from the credentials used to interact
+# with cloud resources created by the CI pipelines. Care may be necessary to switch kubectl credentials
+# depending on the context.
 get-github-config: check-var-DOMAIN check-var-TF_VAR_TEST_ID
 ifneq ($(GITHUB_SCM_OAUTH),)
 	@export SCM_OAUTH=./manifests/github-oauth.yaml && \


### PR DESCRIPTION
## Description

When interacting with clusters created by the CI pipelines it may be necessary to manually configure the gitpod configuration and run the `kots-install` make target. This commit adds some documentation for the steps needed to initialize the GitHub SCM integration outside of a werft job or CI run.

## How to test

This assumes that you have a cluster running but gitpod is not installed.

```bash
export cloud=gcp
export DOMAIN="tests.gitpod-self-hosted.com"
export GCP_ZONE="europe-west1-d"
export TF_VAR_TEST_ID="some-lovely-cluster-name"
make get-github-config generate-kots-config install-kots
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
