### PR TITLE
ws-manager: Allow extra time for workspace to receive SIGKILL

### DIFF
--- a/components/ws-manager/pkg/manager/testdata/cdwp_admission.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_admission.golden
@@ -220,6 +220,7 @@
                 }
             ],
             "restartPolicy": "Never",
+            "terminationGracePeriodSeconds": 180,
             "serviceAccountName": "workspace",
             "automountServiceAccountToken": false,
             "securityContext": {

--- a/components/ws-manager/pkg/manager/testdata/cdwp_affinity.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_affinity.golden
@@ -207,6 +207,7 @@
                 }
             ],
             "restartPolicy": "Never",
+            "terminationGracePeriodSeconds": 180,
             "serviceAccountName": "workspace",
             "automountServiceAccountToken": false,
             "securityContext": {

--- a/components/ws-manager/pkg/manager/testdata/cdwp_class.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_class.golden
@@ -221,6 +221,7 @@
                 }
             ],
             "restartPolicy": "Never",
+            "terminationGracePeriodSeconds": 180,
             "dnsPolicy": "None",
             "serviceAccountName": "workspace",
             "automountServiceAccountToken": false,

--- a/components/ws-manager/pkg/manager/testdata/cdwp_class_notfound.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_class_notfound.golden
@@ -211,6 +211,7 @@
                 }
             ],
             "restartPolicy": "Never",
+            "terminationGracePeriodSeconds": 180,
             "serviceAccountName": "workspace",
             "automountServiceAccountToken": false,
             "securityContext": {

--- a/components/ws-manager/pkg/manager/testdata/cdwp_customcerts.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_customcerts.golden
@@ -229,6 +229,7 @@
                 }
             ],
             "restartPolicy": "Never",
+            "terminationGracePeriodSeconds": 180,
             "serviceAccountName": "workspace",
             "automountServiceAccountToken": false,
             "securityContext": {

--- a/components/ws-manager/pkg/manager/testdata/cdwp_debug_workspace_pod.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_debug_workspace_pod.golden
@@ -208,6 +208,7 @@
                 }
             ],
             "restartPolicy": "Never",
+            "terminationGracePeriodSeconds": 180,
             "serviceAccountName": "workspace",
             "automountServiceAccountToken": false,
             "securityContext": {

--- a/components/ws-manager/pkg/manager/testdata/cdwp_empty_resource_req.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_empty_resource_req.golden
@@ -213,6 +213,7 @@
                 }
             ],
             "restartPolicy": "Never",
+            "terminationGracePeriodSeconds": 180,
             "serviceAccountName": "workspace",
             "automountServiceAccountToken": false,
             "securityContext": {

--- a/components/ws-manager/pkg/manager/testdata/cdwp_envvars.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_envvars.golden
@@ -253,6 +253,7 @@
                 }
             ],
             "restartPolicy": "Never",
+            "terminationGracePeriodSeconds": 180,
             "serviceAccountName": "workspace",
             "automountServiceAccountToken": false,
             "securityContext": {

--- a/components/ws-manager/pkg/manager/testdata/cdwp_fullworkspacebackup.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_fullworkspacebackup.golden
@@ -205,6 +205,7 @@
                 }
             ],
             "restartPolicy": "Never",
+            "terminationGracePeriodSeconds": 180,
             "serviceAccountName": "workspace",
             "automountServiceAccountToken": false,
             "securityContext": {

--- a/components/ws-manager/pkg/manager/testdata/cdwp_imagebuild.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_imagebuild.golden
@@ -238,6 +238,7 @@
                 }
             ],
             "restartPolicy": "Never",
+            "terminationGracePeriodSeconds": 180,
             "serviceAccountName": "workspace",
             "automountServiceAccountToken": false,
             "securityContext": {

--- a/components/ws-manager/pkg/manager/testdata/cdwp_imagebuild_template.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_imagebuild_template.golden
@@ -238,6 +238,7 @@
                 }
             ],
             "restartPolicy": "Never",
+            "terminationGracePeriodSeconds": 180,
             "serviceAccountName": "workspace",
             "automountServiceAccountToken": false,
             "securityContext": {

--- a/components/ws-manager/pkg/manager/testdata/cdwp_no_ideimage.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_no_ideimage.golden
@@ -210,6 +210,7 @@
                 }
             ],
             "restartPolicy": "Never",
+            "terminationGracePeriodSeconds": 180,
             "serviceAccountName": "workspace",
             "automountServiceAccountToken": false,
             "securityContext": {

--- a/components/ws-manager/pkg/manager/testdata/cdwp_prebuild.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_prebuild.golden
@@ -220,6 +220,7 @@
                 }
             ],
             "restartPolicy": "Never",
+            "terminationGracePeriodSeconds": 180,
             "serviceAccountName": "workspace",
             "automountServiceAccountToken": false,
             "securityContext": {

--- a/components/ws-manager/pkg/manager/testdata/cdwp_prebuild_template.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_prebuild_template.golden
@@ -220,6 +220,7 @@
                 }
             ],
             "restartPolicy": "Never",
+            "terminationGracePeriodSeconds": 180,
             "serviceAccountName": "workspace",
             "automountServiceAccountToken": false,
             "securityContext": {

--- a/components/ws-manager/pkg/manager/testdata/cdwp_prebuild_template_override_resources.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_prebuild_template_override_resources.golden
@@ -220,6 +220,7 @@
                 }
             ],
             "restartPolicy": "Never",
+            "terminationGracePeriodSeconds": 180,
             "serviceAccountName": "workspace",
             "automountServiceAccountToken": false,
             "securityContext": {

--- a/components/ws-manager/pkg/manager/testdata/cdwp_readinessprobe.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_readinessprobe.golden
@@ -216,6 +216,7 @@
                 }
             ],
             "restartPolicy": "Never",
+            "terminationGracePeriodSeconds": 180,
             "serviceAccountName": "workspace",
             "automountServiceAccountToken": false,
             "securityContext": {

--- a/components/ws-manager/pkg/manager/testdata/cdwp_secrets.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_secrets.golden
@@ -225,6 +225,7 @@
                 }
             ],
             "restartPolicy": "Never",
+            "terminationGracePeriodSeconds": 180,
             "serviceAccountName": "workspace",
             "automountServiceAccountToken": false,
             "securityContext": {

--- a/components/ws-manager/pkg/manager/testdata/cdwp_sshkeys.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_sshkeys.golden
@@ -217,6 +217,7 @@
                 }
             ],
             "restartPolicy": "Never",
+            "terminationGracePeriodSeconds": 180,
             "serviceAccountName": "workspace",
             "automountServiceAccountToken": false,
             "securityContext": {

--- a/components/ws-manager/pkg/manager/testdata/cdwp_sys_envvars.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_sys_envvars.golden
@@ -257,6 +257,7 @@
                 }
             ],
             "restartPolicy": "Never",
+            "terminationGracePeriodSeconds": 180,
             "serviceAccountName": "workspace",
             "automountServiceAccountToken": false,
             "securityContext": {

--- a/components/ws-manager/pkg/manager/testdata/cdwp_tasks.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_tasks.golden
@@ -220,6 +220,7 @@
                 }
             ],
             "restartPolicy": "Never",
+            "terminationGracePeriodSeconds": 180,
             "serviceAccountName": "workspace",
             "automountServiceAccountToken": false,
             "securityContext": {

--- a/components/ws-manager/pkg/manager/testdata/cdwp_template.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_template.golden
@@ -216,6 +216,7 @@
                 }
             ],
             "restartPolicy": "Never",
+            "terminationGracePeriodSeconds": 180,
             "serviceAccountName": "workspace",
             "automountServiceAccountToken": false,
             "securityContext": {

--- a/components/ws-manager/pkg/manager/testdata/cdwp_timeout.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_timeout.golden
@@ -221,6 +221,7 @@
                 }
             ],
             "restartPolicy": "Never",
+            "terminationGracePeriodSeconds": 180,
             "serviceAccountName": "workspace",
             "automountServiceAccountToken": false,
             "securityContext": {

--- a/components/ws-manager/pkg/manager/testdata/cdwp_userns.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_userns.golden
@@ -216,6 +216,7 @@
                 }
             ],
             "restartPolicy": "Never",
+            "terminationGracePeriodSeconds": 180,
             "serviceAccountName": "workspace",
             "automountServiceAccountToken": false,
             "securityContext": {

--- a/components/ws-manager/pkg/manager/testdata/cdwp_with_ephemeral_storage.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_with_ephemeral_storage.golden
@@ -235,6 +235,7 @@
                 }
             ],
             "restartPolicy": "Never",
+            "terminationGracePeriodSeconds": 180,
             "serviceAccountName": "workspace",
             "automountServiceAccountToken": false,
             "securityContext": {

--- a/components/ws-manager/pkg/manager/testdata/cdwp_withaffinity_regular.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_withaffinity_regular.golden
@@ -216,6 +216,7 @@
                 }
             ],
             "restartPolicy": "Never",
+            "terminationGracePeriodSeconds": 180,
             "serviceAccountName": "workspace",
             "automountServiceAccountToken": false,
             "securityContext": {

--- a/components/ws-manager/pkg/manager/testdata/cdwp_withaffinityheadless.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_withaffinityheadless.golden
@@ -238,6 +238,7 @@
                 }
             ],
             "restartPolicy": "Never",
+            "terminationGracePeriodSeconds": 180,
             "serviceAccountName": "workspace",
             "automountServiceAccountToken": false,
             "securityContext": {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

By default, pod accepts SIGKILL 30 seconds after receiving SIGTERM.
This means that workspace processes must be processed for termination within 30 seconds.
This may be too short for large software such as dockerd, which will clean up the overlay directory and other files when it receives a SIGTERM. (maybe)
https://github.com/moby/moby/blob/0910306bf970603ce787466a98e4294ba81af841/cmd/dockerd/trap/trap.go#L41
If the cleanup is not done in time within 30 seconds, the container's overlay directory will remain uncluttered and causes https://github.com/gitpod-io/gitpod/issues/11183
Therefore, set this to 3 minutes, which gives you a little more time. There is currently no basis for this number, so we are looking for great ideas.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Mitigation https://github.com/gitpod-io/gitpod/issues/11183

## How to test
<!-- Provide steps to test this PR -->

Please give me the idea

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
The processes in the workspace are given up to 3 minutes after receiving SIGTERM.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
