### PR TITLE
chore: split IDE integration tests

### DIFF
--- a/.werft/ide-integration-tests-startup.sh
+++ b/.werft/ide-integration-tests-startup.sh
@@ -18,6 +18,7 @@ declare SIGNAL # used to record signal caught by trap
 
 context_name=$1
 context_repo=$2
+annotation_withIntegrationTests=$3
 
 function cleanup ()
 {
@@ -79,6 +80,8 @@ git config --global user.email roboquat@gitpod.io
 git remote set-url origin https://oauth2:"${ROBOQUAT_TOKEN}"@github.com/gitpod-io/gitpod.git
 
 werft log phase "build preview environment" "build preview environment"
+
+echo "annotation_withIntegrationTests=${annotation_withIntegrationTests}"
 
 REVISION=$(git show -s --format="%h" HEAD)
 
@@ -164,7 +167,12 @@ args+=( "-namespace=default" )
 [[ "$USERNAME" != "" ]] && args+=( "-username=$USERNAME" )
 args+=( "-timeout=60m" )
 
-IDE_TEST_LIST=(/workspace/test/tests/ide/ssh /workspace/test/tests/ide/vscode /workspace/test/tests/ide/jetbrains)
+IDE_TESTS_DIR="/workspace/test/tests/ide"
+JETBRAINS_TESTS="$IDE_TESTS_DIR/jetbrains"
+VSCODE_TESTS="$IDE_TESTS_DIR/vscode"
+SSH_TESTS="$IDE_TESTS_DIR/ssh"
+
+IDE_TEST_LIST=("$SSH_TESTS $VSCODE_TESTS $JETBRAINS_TESTS")
 for TEST_PATH in "${IDE_TEST_LIST[@]}"
 do
     TEST_NAME=$(basename "${TEST_PATH}")

--- a/.werft/ide-integration-tests-startup.yaml
+++ b/.werft/ide-integration-tests-startup.yaml
@@ -64,5 +64,6 @@ pod:
         - .werft/ide-integration-tests-startup.sh
         - "{{ .Name }}"
         - "{{ .Repository.Repo }}"
+        - "{{ .Annotations.withIntegrationTests }}"
 plugins:
   cron: "0 3 * * *"

--- a/test/run.sh
+++ b/test/run.sh
@@ -20,7 +20,12 @@ FAILURE_COUNT=0
 LOGS_DIR=$(mktemp -d)
 
 WEBAPP_TEST_LIST="$THIS_DIR/tests/components/database $THIS_DIR/tests/components/server"
-IDE_TEST_LIST="$THIS_DIR/tests/ide/ssh $THIS_DIR/tests/ide/vscode $THIS_DIR/tests/ide/jetbrains"
+
+JETBRAINS_TESTS="$THIS_DIR/tests/ide/jetbrains"
+VSCODE_TESTS="$THIS_DIR/tests/ide/vscode"
+SSH_TESTS="$THIS_DIR/tests/ide/ssh"
+IDE_TEST_LIST="$SSH_TESTS $VSCODE_TESTS $JETBRAINS_TESTS"
+
 WORKSPACE_TEST_LIST="$THIS_DIR/tests/components/content-service $THIS_DIR/tests/components/image-builder $THIS_DIR/tests/components/ws-daemon $THIS_DIR/tests/components/ws-manager $THIS_DIR/tests/workspace"
 
 case $TEST_SUITE in
@@ -29,6 +34,15 @@ case $TEST_SUITE in
     ;;
   "ide")
     TEST_LIST="$IDE_TEST_LIST"
+    ;;
+  "jetbrains")
+    TEST_LIST="$JETBRAINS_TESTS"
+    ;;
+  "vscode")
+    TEST_LIST="$VSCODE_TESTS"
+    ;;
+  "ssh")
+    TEST_LIST="$SSH_TESTS"
     ;;
   "workspace")
     TEST_LIST="${WORKSPACE_TEST_LIST}"


### PR DESCRIPTION
## Description
Split IDE tests into `vscode`, `jetbrains`, `ssh` to allow running specific IDE-related tests only for faster feedback loop.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #14481 

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
