### PR TITLE
[ws-manager-api] Run tests as part of CI

### DIFF
--- a/components/ws-manager-api/typescript/BUILD.yaml
+++ b/components/ws-manager-api/typescript/BUILD.yaml
@@ -8,9 +8,10 @@ packages:
       - "src/*.ts"
       - "src/*.js"
       - package.json
+      - mocha.opts
     config:
       packaging: library
-      dontTest: true
+      dontTest: false
       commands:
         build: ["yarn", "build"]
       yarnLock: ${coreYarnLockBase}/../yarn.lock

--- a/components/ws-manager-api/typescript/package.json
+++ b/components/ws-manager-api/typescript/package.json
@@ -29,6 +29,10 @@
     "grpc-tools": "^1.11.2",
     "grpc_tools_node_protoc_ts": "^5.3.2",
     "typescript": "~4.4.2",
-    "typescript-formatter": "^7.2.2"
+    "typescript-formatter": "^7.2.2",
+    "mocha": "^5.0.0",
+    "mocha-typescript": "^1.1.11",
+    "ts-node": "^9.0.0",
+    "chai": "^4.3.4"
   }
 }


### PR DESCRIPTION
## Description

`ws-manager-api` defines tests but the tests were never run in CI since `leeway` was instructed not to to run tests for this component (`dontTest: true` in the `BUILD.yaml`)

This PR adds the necessary dev dependencies to allow `leeway` to run the tests and starts running them as part of our CI process.

## Related Issue(s)

Related to https://github.com/gitpod-io/leeway/issues/105 as this was initially thought to be a problem with `leeway`.

## How to test

The werft build now fails if the tests defined in `ws-manager-api/typescript` fail.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
