### PR TITLE
[werft] Update previews to use analytics token from secret

### DIFF
--- a/.werft/jobs/build/deploy-to-preview-environment.ts
+++ b/.werft/jobs/build/deploy-to-preview-environment.ts
@@ -36,10 +36,10 @@ interface DeploymentConfig {
     domain: string;
     monitoringDomain: string;
     url: string;
-    analytics?: Analytics;
     cleanSlateDeployment: boolean;
     installEELicense: boolean;
     withObservability: boolean;
+    analytics: Analytics;
 }
 
 export async function deployToPreviewEnvironment(werft: Werft, jobConfig: JobConfig) {
@@ -51,14 +51,6 @@ export async function deployToPreviewEnvironment(werft: Werft, jobConfig: JobCon
     const monitoringDomain = `${destname}.preview.gitpod-dev.com`;
     const url = `https://${domain}`;
 
-    let analytics: Analytics | null;
-    if ((jobConfig.analytics || "").startsWith("segment|")) {
-        analytics = {
-            type: "segment",
-            token: jobConfig.analytics!.substring("segment|".length),
-        };
-    }
-
     const deploymentConfig: DeploymentConfig = {
         version,
         destname,
@@ -66,10 +58,10 @@ export async function deployToPreviewEnvironment(werft: Werft, jobConfig: JobCon
         domain,
         monitoringDomain,
         url,
-        analytics,
         cleanSlateDeployment,
         installEELicense,
         withObservability,
+        analytics: jobConfig.analytics,
     };
 
     // We set all attributes to false as default and only set it to true once the each process is complete.

--- a/.werft/jobs/build/installer/installer.ts
+++ b/.werft/jobs/build/installer/installer.ts
@@ -1,11 +1,7 @@
 import { execStream } from "../../../util/shell";
 import { Werft } from "../../../util/werft";
+import { Analytics } from "../job-config";
 import { CORE_DEV_KUBECONFIG_PATH, PREVIEW_K3S_KUBECONFIG_PATH } from "../const";
-
-export type Analytics = {
-    type: string;
-    token: string;
-};
 
 export type InstallerOptions = {
     werft: Werft;
@@ -31,7 +27,7 @@ export class Installer {
             DEV_KUBE_CONTEXT: "gke_gitpod-core-dev_europe-west1-b_core-dev",
             PREVIEW_K3S_KUBE_PATH: PREVIEW_K3S_KUBECONFIG_PATH,
             PREVIEW_NAME: this.options.previewName,
-            GITPOD_ANALYTICS_SEGMENT_TOKEN: this.options.analytics?.token || "",
+            GITPOD_ANALYTICS: this.options.analytics,
             GITPOD_WORKSPACE_FEATURE_FLAGS: this.options.workspaceFeatureFlags.join(" "),
             GITPOD_WITH_SLOW_DATABASE: this.options.withSlowDatabase,
             GITPOD_WITH_EE_LICENSE: this.options.withEELicense,

--- a/.werft/jobs/build/job-config.ts
+++ b/.werft/jobs/build/job-config.ts
@@ -4,8 +4,10 @@ import {previewNameFromBranchName} from "../../util/preview";
 
 type WithIntegrationTests = "skip" | "all" | "workspace" | "ide" | "webapp";
 
+export type Analytics = "skip" | "segment";
+
 export interface JobConfig {
-    analytics: string;
+    analytics: Analytics;
     buildConfig: any;
     cleanSlateDeployment: boolean;
     cluster: string;
@@ -93,7 +95,7 @@ export function jobConfig(werft: Werft, context: any): JobConfig {
     const publishToNpm = "publish-to-npm" in buildConfig || mainBuild;
     const publishToJBMarketplace = "publish-to-jb-marketplace" in buildConfig || mainBuild;
     const publishToKots = "publish-to-kots" in buildConfig || withSelfHostedPreview || mainBuild;
-    const analytics = buildConfig["analytics"];
+
     const localAppVersion = mainBuild || "with-localapp-version" in buildConfig ? version : "unknown";
     const retag = "with-retag" in buildConfig ? "" : "--dont-retag";
     const cleanSlateDeployment = mainBuild || "with-clean-slate-deployment" in buildConfig;
@@ -105,6 +107,7 @@ export function jobConfig(werft: Werft, context: any): JobConfig {
     const recreateVm = mainBuild || "recreate-vm" in buildConfig;
     const withSlowDatabase = "with-slow-database" in buildConfig && !mainBuild;
 
+    const analytics = parseAnalytics(werft, sliceId, buildConfig["analytics"])
     const withIntegrationTests = parseWithIntegrationTests(werft, sliceId, buildConfig["with-integration-tests"]);
     const withPreview = decideWithPreview({werft, sliceID: sliceId, buildConfig, mainBuild, withIntegrationTests})
 
@@ -224,6 +227,17 @@ function decideWithPreview(options: { werft: Werft, sliceID: string, buildConfig
 
     return false
 }
+
+export function parseAnalytics(werft: Werft, sliceId: string, value: string): Analytics {
+    switch (value) {
+        case "segment":
+            return "segment"
+    }
+
+    werft.log(sliceId, "Analytics is not enabled")
+    return "skip";
+}
+
 
 export function parseWithIntegrationTests(werft: Werft, sliceID: string, value?: string): WithIntegrationTests {
     switch (value) {


### PR DESCRIPTION

## Description
<!-- Describe your changes in detail -->

Currently, Analytics in preview environments are broken through werft as we need to pass the write key through attributes which means we would leak it.

This PR fixes that by instead updating weft to read them from a Kubernetes secret (This is already added into the cluster. See https://github.com/gitpod-io/ops/pull/6614). This means users now enable analytics by using setting `analytics: segment` and we read `segment-staging-write-key` to make it work. This secret is set to the staging segment source right now.

Signed-off-by: Tarun Pothulapati <tarun@gitpod.io>


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/14509

## How to test
<!-- Provide steps to test this PR -->

Run the following and see analytic events in the `staging trusted` segment source.

```
leeway run dev/preview:build
leeway run dev/preview:create-preview
GITPOD_ANALYTICS=segment leeway run dev/preview:deploy-gitpod
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
