### PR TITLE
Fix workspace alerts path

### DIFF
--- a/.werft/observability/manifests/monitoring-satellite.yaml
+++ b/.werft/observability/manifests/monitoring-satellite.yaml
@@ -41,7 +41,7 @@ imports:
     - gitURL: https://github.com/gitpod-io/gitpod
       path: operations/observability/mixins/workspace/rules/central
     - gitURL: https://github.com/gitpod-io/gitpod
-      path: operations/observability/mixins/workspace/satellite/rules
+      path: operations/observability/mixins/workspace/rules/satellite
     - gitURL: https://github.com/gitpod-io/gitpod
       path: operations/observability/mixins/meta/rules
     - gitURL: https://github.com/gitpod-io/gitpod

--- a/.werft/observability/manifests/monitoring-satellite.yaml
+++ b/.werft/observability/manifests/monitoring-satellite.yaml
@@ -39,7 +39,7 @@ imports:
     - gitURL: https://github.com/gitpod-io/observability
       path: monitoring-satellite/manifests/probers
     - gitURL: https://github.com/gitpod-io/gitpod
-      path: operations/observability/mixins/workspace/central/rules
+      path: operations/observability/mixins/workspace/rules/central
     - gitURL: https://github.com/gitpod-io/gitpod
       path: operations/observability/mixins/workspace/satellite/rules
     - gitURL: https://github.com/gitpod-io/gitpod

--- a/.werft/observability/manifests/monitoring-satellite.yaml
+++ b/.werft/observability/manifests/monitoring-satellite.yaml
@@ -39,7 +39,9 @@ imports:
     - gitURL: https://github.com/gitpod-io/observability
       path: monitoring-satellite/manifests/probers
     - gitURL: https://github.com/gitpod-io/gitpod
-      path: operations/observability/mixins/workspace/rules
+      path: operations/observability/mixins/workspace/central/rules
+    - gitURL: https://github.com/gitpod-io/gitpod
+      path: operations/observability/mixins/workspace/satellite/rules
     - gitURL: https://github.com/gitpod-io/gitpod
       path: operations/observability/mixins/meta/rules
     - gitURL: https://github.com/gitpod-io/gitpod


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
In https://github.com/gitpod-io/gitpod/pull/13850, we split workspace alerts into 2 different folders but forgot to update their paths in the configuration used for previews.

This PR fixes the import pathes.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
