### PR TITLE
[dashboard] Run unit tests in CI

### DIFF
--- a/components/dashboard/BUILD.yaml
+++ b/components/dashboard/BUILD.yaml
@@ -21,9 +21,9 @@ packages:
     config:
       commands:
         build: ["yarn", "build"]
-        test: ["yarn", "test"]
+        test: ["yarn", "test:unit"]
       yarnLock: ${coreYarnLockBase}/yarn.lock
-      dontTest: true
+      dontTest: false
       packaging: archive
   - name: static
     type: generic


### PR DESCRIPTION
## Description

The dashboard defines some unit tests that were never run in CI due to `dontTest: true` being specified in the `BUILD.yaml`.

This PR switches that flag to `false` to ensure that the unit tests are run as part of our CI pipeline and changes the `test` command to run unit tests only.

See [some internal discussion](https://gitpod.slack.com/archives/C02EN94AEPL/p1667905681838389).

## Related Issue(s)

https://github.com/gitpod-io/gitpod/pull/14502

## How to test

The CI build fails if a dashboard unit test fails.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
