### PR TITLE
[integration-tests] Set VSX_REGISTRY_URL to fix workspace tests

### DIFF
--- a/test/pkg/integration/workspace.go
+++ b/test/pkg/integration/workspace.go
@@ -179,6 +179,14 @@ func LaunchWorkspaceDirectly(t *testing.T, ctx context.Context, api *ComponentAP
 				Email:    "integration-test@gitpod.io",
 			},
 			Admission: wsmanapi.AdmissionLevel_ADMIT_OWNER_ONLY,
+			Envvars: []*wsmanapi.EnvironmentVariable{
+				// VSX_REGISTRY_URL is set by server, since we start the workspace directly
+				// from ws-manager in these tests we need to set it here ourselves.
+				{
+					Name:  "VSX_REGISTRY_URL",
+					Value: "http://open-vsx.gitpod.io/",
+				},
+			},
 		},
 	}
 	for _, m := range options.Mods {

--- a/test/tests/components/ws-manager/dotfiles_test.go
+++ b/test/tests/components/ws-manager/dotfiles_test.go
@@ -57,12 +57,12 @@ func TestDotfiles(t *testing.T) {
 		}
 
 		swr := func(req *wsmanapi.StartWorkspaceRequest) error {
-			req.Spec.Envvars = []*wsmanapi.EnvironmentVariable{
-				{
+			req.Spec.Envvars = append(req.Spec.Envvars,
+				&wsmanapi.EnvironmentVariable{
 					Name:  "SUPERVISOR_DOTFILE_REPO",
 					Value: "https://github.com/gitpod-io/test-dotfiles-support",
 				},
-				{
+				&wsmanapi.EnvironmentVariable{
 					Name: "THEIA_SUPERVISOR_TOKENS",
 					Value: fmt.Sprintf(`[{
 						"token": "%v",
@@ -73,7 +73,7 @@ func TestDotfiles(t *testing.T) {
 						"reuse": 4
 					}]`, tokenId, getHostUrl(ctx, t, cfg.Client())),
 				},
-			}
+			)
 
 			req.Spec.Initializer = &csapi.WorkspaceInitializer{
 				Spec: &csapi.WorkspaceInitializer_Git{

--- a/test/tests/components/ws-manager/protected_secrets_test.go
+++ b/test/tests/components/ws-manager/protected_secrets_test.go
@@ -38,12 +38,10 @@ func TestProtectedSecrets(t *testing.T) {
 		})
 
 		swr := func(req *wsmanapi.StartWorkspaceRequest) error {
-			req.Spec.Envvars = []*wsmanapi.EnvironmentVariable{
-				{
-					Name:  SECRET_NAME,
-					Value: SECRET_VALUE,
-				},
-			}
+			req.Spec.Envvars = append(req.Spec.Envvars, &wsmanapi.EnvironmentVariable{
+				Name:  SECRET_NAME,
+				Value: SECRET_VALUE,
+			})
 
 			req.Spec.Initializer = &csapi.WorkspaceInitializer{
 				Spec: &csapi.WorkspaceInitializer_Git{


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Fix workspace integration tests, see https://gitpod.slack.com/archives/C01KGM9BH54/p1667868092950329

## Related Issue(s)
<!-- List the issue(s) this PR solves -->


## How to test
<!-- Provide steps to test this PR -->

Run integration tests

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-integration-tests=workspace
      Valid options are `all`, `workspace`, `webapp`, `ide`
