### PR TITLE
Remove legacy branch-namespace script

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -54,7 +54,6 @@ tasks:
       leeway exec --package components/supervisor-api/java:lib --package components/gitpod-protocol/java:lib -- ./gradlew build
       leeway exec --package components/ide/jetbrains/backend-plugin:plugin-latest --package components/ide/jetbrains/gateway-plugin:publish-latest --parallel -- ./gradlew buildPlugin
   - name: TypeScript
-    before: scripts/branch-namespace.sh
     init: yarn --network-timeout 100000 && yarn build
   - name: Go
     before: pre-commit install --install-hooks

--- a/scripts/branch-namespace.sh
+++ b/scripts/branch-namespace.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-source ./dev/preview/util/preview-name-from-branch.sh
-
-currentContext=$(kubectl config current-context 2>&1) || error "cannot set kubectl namespace: no current context"
-namespace="staging-$(preview-name-from-branch)"
-
-echo "Setting kubectl namespace: $namespace"
-kubectl config set-context "$currentContext" --namespace "$namespace"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

The script was back from the time when preview environments were hosted in core-dev in separate namespaces. We no longer have core-dev-based preview environments, so the script is no longer needed.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
No issue, just tidying.

## How to test
<!-- Provide steps to test this PR -->

Before

![Screenshot 2022-11-08 at 14 34 18](https://user-images.githubusercontent.com/83561/200578451-2233f97d-5201-417e-b2a0-5459f976a404.png)

After

![Screenshot 2022-11-08 at 14 34 24](https://user-images.githubusercontent.com/83561/200578463-a182d260-c468-49ca-a3c2-7e5ebb452d59.png)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`