### PR TITLE
[ci] Fix werft job definition

### DIFF
--- a/.werft/jobs/build/deploy-to-preview-environment.ts
+++ b/.werft/jobs/build/deploy-to-preview-environment.ts
@@ -4,9 +4,9 @@ import { MonitoringSatelliteInstaller } from "../../observability/monitoring-sat
 
 import { PREVIEW_K3S_KUBECONFIG_PATH } from "./const";
 import { Werft } from "../../util/werft";
-import { JobConfig } from "./job-config";
+import { Analytics, JobConfig } from "./job-config";
 import * as VM from "../../vm/vm";
-import { Analytics, Installer } from "./installer/installer";
+import { Installer } from "./installer/installer";
 import { previewNameFromBranchName } from "../../util/preview";
 import { SpanStatusCode } from "@opentelemetry/api";
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Fixes failing werft jobs on main due to 

```
/workspace/node_modules/ts-node/src/index.ts:513
    return new TSError(diagnosticText, diagnosticCodes)
           ^
TSError: ⨯ Unable to compile TypeScript:
.werft/jobs/build/deploy-to-preview-environment.ts(9,10): error TS2459: Module '"./installer/installer"' declares 'Analytics' locally, but it is not exported.
```

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
