### PR TITLE
[JetBrains EAP] Auto-approve PRs created for updating Backend Plugin's SDK

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -115,3 +115,4 @@
 # that user as an owner in case we need to manually approve changes
 #
 /CHANGELOG.md
+/components/ide/jetbrains/backend-plugin/gradle-latest.properties

--- a/.github/workflows/jetbrains-update-plugin-platform-template.yml
+++ b/.github/workflows/jetbrains-update-plugin-platform-template.yml
@@ -24,6 +24,8 @@ jobs:
     update-plugin-platform:
         name: Update Platform Version from ${{ inputs.pluginName }}
         runs-on: ubuntu-latest
+        permissions:
+          pull-requests: write
         env:
             SNAPSHOTS_HTML_FILENAME: snapshots.html
         steps:
@@ -95,6 +97,7 @@ jobs:
                   # We can't use `team-reviewers` until we resolve https://github.com/gitpod-io/gitpod/issues/12194
                   # team-reviewers: "engineering-ide"
             - name: Create Pull Request for Backend Plugin
+              id: create-pr
               if: ${{ inputs.pluginId == 'backend-plugin' && steps.latest-version.outputs.result != steps.current-version.outputs.result }}
               uses: peter-evans/create-pull-request@v4
               with:
@@ -125,6 +128,11 @@ jobs:
                   labels: "team: IDE"
                   # We can't use `team-reviewers` until we resolve https://github.com/gitpod-io/gitpod/issues/12194
                   # team-reviewers: "engineering-ide"
+            - name: Auto Approve Pull Request
+              if: ${{ inputs.pluginId == 'backend-plugin' && steps.create-pr.outputs.pull-request-number }}
+              uses: hmarr/auto-approve-action@v3
+              with:
+                pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
             - name: Get previous job's status
               id: lastrun
               uses: filiptronicek/get-last-job-status@main


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
We want PRs related to EAP JetBrains Backend Plugin SDK updates (like [PR#14349](https://github.com/gitpod-io/gitpod/pull/14349)) to be automatically accepted.

This PR makes it take the output from [Create Pull Request](https://github.com/peter-evans/create-pull-request) and pass it to [Auto Approve](https://github.com/marketplace/actions/auto-approve), which in turn approves it, so the automatically-created PR should be approved right away, and if the Werft Build passes, @roboquat will merge it without any human interaction.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
- Resolves https://github.com/gitpod-io/gitpod/issues/14480

## How to test
<!-- Provide steps to test this PR -->
Couldn't think of a way to test it. We'll need to see how it behaves when a new EAP IntelliJ SDK version is released.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```