### PR TITLE
Fail build on error

### DIFF
--- a/components/ide/jetbrains/backend-plugin/build.sh
+++ b/components/ide/jetbrains/backend-plugin/build.sh
@@ -3,6 +3,8 @@
 # Licensed under the GNU Affero General Public License (AGPL).
 # See License-AGPL.txt in the project root for license information.
 
+set -e
+
 if [ "${NO_VERIFY_JB_PLUGIN}" == "true" ]; then
     echo "build.sh: skip verify plugin step"
 else


### PR DESCRIPTION
## Description
Fail build if any of script steps are ended with error.

## Release Notes
```release-note
NONE
```

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`