### PR TITLE
[dashboard] Handle create team errors from Public API better

### DIFF
--- a/components/dashboard/src/projects/NewProject.tsx
+++ b/components/dashboard/src/projects/NewProject.tsx
@@ -23,6 +23,7 @@ import ErrorMessage from "../components/ErrorMessage";
 import Spinner from "../icons/Spinner.svg";
 import { publicApiTeamsToProtocol, publicApiTeamToProtocol, teamsService } from "../service/public-api";
 import { FeatureFlagContext } from "../contexts/FeatureFlagContext";
+import { ConnectError } from "@bufbuild/connect-web";
 
 export default function NewProject() {
     const location = useLocation();
@@ -745,7 +746,11 @@ function NewTeam(props: { onSuccess: (team: Team) => void }) {
             props.onSuccess(team);
         } catch (error) {
             console.error(error);
-            setError(error?.message || "Failed to create new team!");
+            if (error instanceof ConnectError) {
+                setError(error.rawMessage);
+            } else {
+                setError(error?.message || "Failed to create new team!");
+            }
         }
     };
 

--- a/components/dashboard/src/teams/NewTeam.tsx
+++ b/components/dashboard/src/teams/NewTeam.tsx
@@ -10,6 +10,7 @@ import { getGitpodService } from "../service/service";
 import { TeamsContext } from "./teams-context";
 import { publicApiTeamsToProtocol, publicApiTeamToProtocol, teamsService } from "../service/public-api";
 import { FeatureFlagContext } from "../contexts/FeatureFlagContext";
+import { ConnectError } from "@bufbuild/connect-web";
 
 export default function () {
     const { setTeams } = useContext(TeamsContext);
@@ -35,7 +36,11 @@ export default function () {
             history.push(`/t/${team.slug}`);
         } catch (error) {
             console.error(error);
-            setCreationError(error);
+            if (error instanceof ConnectError) {
+                setCreationError(new Error(error.rawMessage));
+            } else {
+                setCreationError(error);
+            }
         }
     };
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Show error message without error code

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/14482

## How to test
<!-- Provide steps to test this PR -->
1. Preview
2. Create one team
3. Create a team with duplicate name, observe error shown doesn't contain error code

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
