### PR TITLE
[installer-tests] Fail cleanup job when any environment  cleanup fails

### DIFF
--- a/install/tests/cleanup.sh
+++ b/install/tests/cleanup.sh
@@ -2,6 +2,8 @@
 #
 #
 
+declare -g rc=0
+
 cleanup() {
     TF_VAR_TEST_ID=$1
     cloud=$(echo "$TF_VAR_TEST_ID" | sed 's/\(.*\)-/\1 /' | xargs | awk '{print $2}')
@@ -18,6 +20,7 @@ cleanup() {
     export TF_VAR_TEST_ID=$TF_VAR_TEST_ID
 
     make cleanup cloud=$cloud
+    (( rc |= $? ))
 
     CUSTOMERID=$(replicated customer ls --app "${REPLICATED_APP}" | grep "$TF_VAR_TEST_ID" | awk '{print $1}')
 
@@ -57,3 +60,5 @@ for i in $(gsutil ls gs://nightly-tests/tf-state); do
     cleanup "$TF_VAR_TEST_ID"
 
 done
+
+exit $rc

--- a/install/tests/cleanup.sh
+++ b/install/tests/cleanup.sh
@@ -26,7 +26,7 @@ cleanup() {
     echo "Trying to archive replicated license"
 
     curl --request POST \
-    --url https://api.replicated.com/vendor/v3/customer/$CUSTOMERID/archive \
+    --url "https://api.replicated.com/vendor/v3/customer/$CUSTOMERID/archive" \
     --header "Authorization: ${REPLICATED_API_TOKEN}" || echo "Couldn't delete replicated licese"
 }
 


### PR DESCRIPTION
## Description
In [this werft job](https://werft.gitpod-dev.com/job/gitpod-cleanup-installer-tests-main.135) we have several CI jobs that aren't getting cleaned up (and may have been lingering for a while) but the CI job is passing.

This came up because I have a preview environment that passed the 10 hour threshold yesterday that hasn't been cleaned up so closer inspection is warranted. After we dig into this issue we need to confirm that we don't have stale self-hosted preview environments burning cloud spend.

## Related Issue(s)

## How to test

TBD

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
