### PR TITLE
[JetBrains] Run jetbrains integration tests when creating automated PR for JB updates

### DIFF
--- a/.github/workflows/jetbrains-update-plugin-platform-template.yml
+++ b/.github/workflows/jetbrains-update-plugin-platform-template.yml
@@ -88,7 +88,9 @@ jobs:
                       ```
 
                       ## Werft options:
-                      - [ ] /werft with-preview
+                      - [x] /werft with-preview
+                      - [x] /werft with-large-vm
+                      - [x] /werft with-integration-tests=jetbrains
 
                       _This PR was created automatically with GitHub Actions using [this](https://github.com/gitpod-io/gitpod/blob/main/.github/workflows/jetbrains-update-plugin-platform-template.yml) template._
                   commit-message: "Update Platform Version of ${{ inputs.pluginName }} to ${{ steps.latest-version.outputs.result }}"
@@ -121,6 +123,7 @@ jobs:
                       ## Werft options:
                       - [x] /werft with-preview
                       - [x] /werft with-large-vm
+                      - [x] /werft with-integration-tests=jetbrains
 
                       _This PR was created automatically with GitHub Actions using [this](https://github.com/gitpod-io/gitpod/blob/main/.github/workflows/jetbrains-update-plugin-platform-template.yml) template._
                   commit-message: "Update Platform Version of ${{ inputs.pluginName }} to ${{ steps.latest-version.outputs.result }}"

--- a/.github/workflows/jetbrains-updates.yml
+++ b/.github/workflows/jetbrains-updates.yml
@@ -57,6 +57,7 @@ jobs:
                       -->
                       - [x] /werft with-preview
                       - [x] /werft with-large-vm
+                      - [x] /werft with-integration-tests=jetbrains
 
                       _This PR was created automatically with GitHub Actions using [this](https://github.com/gitpod-io/gitpod/blob/main/.github/workflows/jetbrains-updates.yml) GHA_
                   commit-message: "[JetBrains] Update IDE images to new build version"


### PR DESCRIPTION
## Description
Requires https://github.com/gitpod-io/gitpod/pull/14534 to be merged

In PRs where we update JB SDK versions, we should trigger the jetbrains integration tests. Especially now that we've decided to [auto-approval](https://github.com/gitpod-io/gitpod/pull/14527) for backend-latest updates.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Relates #14481

## How to test
<!-- Provide steps to test this PR -->
N/A

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`
