### PR TITLE
[server] Break dependency of content-service on gitpod-protocol, and usage-api on gitpod-protocol

### DIFF
--- a/components/content-service-api/typescript/BUILD.yaml
+++ b/components/content-service-api/typescript/BUILD.yaml
@@ -1,8 +1,6 @@
 packages:
   - name: lib
     type: yarn
-    deps:
-      - components/gitpod-protocol:lib
     srcs:
       - "src/*.ts"
       - "src/*.js"

--- a/components/content-service-api/typescript/package.json
+++ b/components/content-service-api/typescript/package.json
@@ -11,7 +11,6 @@
     "lib"
   ],
   "dependencies": {
-    "@gitpod/gitpod-protocol": "0.1.5",
     "@grpc/grpc-js": "^1.3.7",
     "google-protobuf": "^3.19.1",
     "inversify": "^5.0.1",

--- a/components/gitpod-protocol/BUILD.yaml
+++ b/components/gitpod-protocol/BUILD.yaml
@@ -13,6 +13,8 @@ packages:
       - package.json
       - mocha.opts
       - "data/*.json"
+    deps:
+      - components/usage-api/typescript:lib
     config:
       packaging: library
       yarnLock: ${coreYarnLockBase}/yarn.lock

--- a/components/server/src/code-sync/code-sync-service.ts
+++ b/components/server/src/code-sync/code-sync-service.ts
@@ -32,7 +32,7 @@ import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 import { v4 as uuidv4 } from "uuid";
 import { accessCodeSyncStorage, UserRateLimiter } from "../auth/rate-limiter";
 import { Config } from "../config";
-import { CachingBlobServiceClientProvider } from "@gitpod/content-service/lib/sugar";
+import { CachingBlobServiceClientProvider } from "../util/content-service-sugar";
 
 // By default: 5 kind of resources * 20 revs * 1Mb = 100Mb max in the content service for user data.
 const defaultRevLimit = 20;

--- a/components/server/src/container-module.ts
+++ b/components/server/src/container-module.ts
@@ -91,7 +91,6 @@ import { PrometheusClientCallMetrics } from "@gitpod/gitpod-protocol/lib/messagi
 import { IClientCallMetrics } from "@gitpod/gitpod-protocol/lib/util/grpc";
 import { DebugApp } from "@gitpod/gitpod-protocol/lib/util/debug-app";
 import { LocalMessageBroker, LocalRabbitMQBackedMessageBroker } from "./messaging/local-message-broker";
-import { contentServiceBinder } from "@gitpod/content-service/lib/sugar";
 import { ReferrerPrefixParser } from "./workspace/referrer-prefix-context-parser";
 import { InstallationAdminTelemetryDataProvider } from "./installation-admin/telemetry-data-provider";
 import { IDEService } from "./ide-service";
@@ -112,6 +111,7 @@ import { IDEServiceClient, IDEServiceDefinition } from "@gitpod/ide-service-api/
 import { prometheusClientMiddleware } from "@gitpod/gitpod-protocol/lib/util/nice-grpc";
 import { UsageService, UsageServiceImpl } from "./user/usage-service";
 import { OpenPrebuildPrefixContextParser } from "./workspace/open-prebuild-prefix-context-parser";
+import { contentServiceBinder } from "./util/content-service-sugar";
 
 export const productionContainerModule = new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(Config).toConstantValue(ConfigFile.fromFile());

--- a/components/server/src/storage/content-service-client.ts
+++ b/components/server/src/storage/content-service-client.ts
@@ -19,13 +19,13 @@ import {
     WorkspaceSnapshotExistsRequest,
     WorkspaceSnapshotExistsResponse,
 } from "@gitpod/content-service/lib/workspace_pb";
+import { SnapshotUrl } from "@gitpod/gitpod-protocol";
+import { inject, injectable } from "inversify";
 import {
     CachingContentServiceClientProvider,
     CachingIDEPluginClientProvider,
     CachingWorkspaceServiceClientProvider,
-} from "@gitpod/content-service/lib/sugar";
-import { SnapshotUrl } from "@gitpod/gitpod-protocol";
-import { inject, injectable } from "inversify";
+} from "../util/content-service-sugar";
 import { StorageClient } from "./storage-client";
 
 @injectable()

--- a/components/server/src/util/content-service-sugar.ts
+++ b/components/server/src/util/content-service-sugar.ts
@@ -7,11 +7,11 @@
 import { inject, injectable, interfaces, optional } from "inversify";
 import * as grpc from "@grpc/grpc-js";
 import { createClientCallMetricsInterceptor, IClientCallMetrics } from "@gitpod/gitpod-protocol/lib/util/grpc";
-import { IDEPluginServiceClient } from "./ideplugin_grpc_pb";
-import { ContentServiceClient } from "./content_grpc_pb";
-import { BlobServiceClient } from "./blobs_grpc_pb";
-import { WorkspaceServiceClient } from "./workspace_grpc_pb";
-import { HeadlessLogServiceClient } from "./headless-log_grpc_pb";
+import { IDEPluginServiceClient } from "@gitpod/content-service/lib/ideplugin_grpc_pb";
+import { ContentServiceClient } from "@gitpod/content-service/lib/content_grpc_pb";
+import { BlobServiceClient } from "@gitpod/content-service/lib/blobs_grpc_pb";
+import { WorkspaceServiceClient } from "@gitpod/content-service/lib/workspace_grpc_pb";
+import { HeadlessLogServiceClient } from "@gitpod/content-service/lib/headless-log_grpc_pb";
 
 export const ContentServiceClientConfig = Symbol("ContentServiceClientConfig");
 export const ContentServiceClientCallMetrics = Symbol("ContentServiceClientCallMetrics");

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -158,7 +158,6 @@ import { HeadlessLogService, HeadlessLogEndpoint } from "./headless-log-service"
 import { InvalidGitpodYMLError } from "./config-provider";
 import { ProjectsService } from "../projects/projects-service";
 import { LocalMessageBroker } from "../messaging/local-message-broker";
-import { CachingBlobServiceClientProvider } from "@gitpod/content-service/lib/sugar";
 import { IDEOptions } from "@gitpod/gitpod-protocol/lib/ide-protocol";
 import { PartialProject } from "@gitpod/gitpod-protocol/src/teams-projects-protocol";
 import { ClientMetadata, traceClientMetadata } from "../websocket/websocket-connection-manager";
@@ -181,6 +180,7 @@ import { IDEService } from "../ide-service";
 import { MessageBusIntegration } from "./messagebus-integration";
 import { AttributionId } from "@gitpod/gitpod-protocol/lib/attribution";
 import * as grpc from "@grpc/grpc-js";
+import { CachingBlobServiceClientProvider } from "../util/content-service-sugar";
 
 // shortcut
 export const traceWI = (ctx: TraceContext, wi: Omit<LogContext, "userId">) => TraceContext.setOWI(ctx, wi); // userId is already taken care of in WebsocketConnectionManager

--- a/components/server/src/workspace/headless-log-service.ts
+++ b/components/server/src/workspace/headless-log-service.ts
@@ -32,7 +32,7 @@ import {
     LogDownloadURLResponse,
 } from "@gitpod/content-service/lib/headless-log_pb";
 import { HEADLESS_LOG_DOWNLOAD_PATH_PREFIX } from "./headless-log-controller";
-import { CachingHeadlessLogServiceClientProvider } from "@gitpod/content-service/lib/sugar";
+import { CachingHeadlessLogServiceClientProvider } from "../util/content-service-sugar";
 
 export type HeadlessLogEndpoint = {
     url: string;

--- a/components/usage-api/typescript/BUILD.yaml
+++ b/components/usage-api/typescript/BUILD.yaml
@@ -1,8 +1,6 @@
 packages:
   - name: lib
     type: yarn
-    deps:
-      - components/gitpod-protocol:lib
     srcs:
       - src/**
       - package.json
@@ -14,16 +12,3 @@ packages:
         build: ["yarn", "build"]
       yarnLock: ${coreYarnLockBase}/../yarn.lock
       tsconfig: tsconfig.json
-
-  - name: publish
-    type: generic
-    env:
-      - DO_PUBLISH=${publishToNPM}
-    argdeps:
-      - npmPublishTrigger
-    deps:
-      - :lib
-      - components/gitpod-protocol:scripts
-    config:
-      commands:
-        - ["node", "components-gitpod-protocol--scripts/publish.js", "${version}", "components-usage-api-typescript--lib/package"]


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Moves `sugar.ts` into server, which is the only user of those definitions. This removes the dependency of `content-service` on `gitpod-protocol`

Removes publish step for `usage-api`, we don't need to publish these definitions to NPM anyway. This removes the dependency on `gitpod-protocol` which contains the publishing scripts.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
CI passes

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
