### PR TITLE
Move previewctl install-context to `leeway run dev:preview`

### DIFF
--- a/dev/BUILD.yaml
+++ b/dev/BUILD.yaml
@@ -34,4 +34,5 @@ scripts:
     script: |
       leeway run dev/preview:create-preview
       leeway run dev/preview:build
+      previewctl install-context
       leeway run dev/preview:deploy-gitpod

--- a/dev/preview/BUILD.yaml
+++ b/dev/preview/BUILD.yaml
@@ -30,7 +30,6 @@ scripts:
       export TF_VAR_vm_memory="${TF_VAR_vm_memory:-12Gi}"
       export TF_VAR_vm_storage_class="${TF_VAR_vm_storage_class:-longhorn-gitpod-k3s-202209251218-onereplica}"
       ./workflow/preview/deploy-harvester.sh
-      previewctl install-context
 
   - name: delete-preview
     description: Delete an existing preview environment


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

`leeway run dev/preview:create-preview` is used in Werft where the contexts are installed separately, so moving it to `dev:preview` is better for now - this was motivated by a build failing on one of my branches because `previewctl install-context timed out in Werft`.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
No issue, follow up on https://github.com/gitpod-io/gitpod/pull/14399

## How to test
<!-- Provide steps to test this PR -->

See job [herre](https://werft.gitpod-dev.com/job/gitpod-build-mads-move-install-context-to-in-workspace-scr.1)

```sh
werft job run github -a with-preview=true
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

N/A

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
