### PR TITLE
[openvsx-proxy] switch to debug instead of info

### DIFF
--- a/components/openvsx-proxy/pkg/errorhandler.go
+++ b/components/openvsx-proxy/pkg/errorhandler.go
@@ -67,6 +67,6 @@ func (o *OpenVSXProxy) ErrorHandler(rw http.ResponseWriter, r *http.Request, e e
 	}
 	rw.WriteHeader(cached.StatusCode)
 	rw.Write(cached.Body)
-	log.WithFields(logFields).Info("used cached response due to a proxy error")
+	log.WithFields(logFields).Debug("used cached response due to a proxy error")
 	o.metrics.BackupCacheServeCounter.Inc()
 }

--- a/components/openvsx-proxy/pkg/handler.go
+++ b/components/openvsx-proxy/pkg/handler.go
@@ -43,7 +43,7 @@ func (o *OpenVSXProxy) Handler(p *httputil.ReverseProxy) func(http.ResponseWrite
 			"request_content_length": strconv.FormatInt(r.ContentLength, 10),
 		}
 
-		log.WithFields(logFields).Info("handling request")
+		log.WithFields(logFields).Debug("handling request")
 		r = r.WithContext(context.WithValue(r.Context(), REQUEST_ID_CTX, reqid))
 
 		key, err := o.key(r)
@@ -101,7 +101,7 @@ func (o *OpenVSXProxy) Handler(p *httputil.ReverseProxy) func(http.ResponseWrite
 		}
 
 		duration := time.Since(start)
-		log.WithFields(logFields).WithFields(o.DurationLogFields(duration)).Info("processing request finished")
+		log.WithFields(logFields).WithFields(o.DurationLogFields(duration)).Debug("processing request finished")
 		o.metrics.DurationRequestProcessingHistogram.Observe(duration.Seconds())
 
 		p.ServeHTTP(rw, r)

--- a/components/openvsx-proxy/pkg/modifyresponse.go
+++ b/components/openvsx-proxy/pkg/modifyresponse.go
@@ -39,7 +39,7 @@ func (o *OpenVSXProxy) ModifyResponse(r *http.Response) error {
 			Info("processing response finished")
 	}(start)
 
-	log.WithFields(logFields).Info("handling response")
+	log.WithFields(logFields).Debug("handling response")
 	o.metrics.IncStatusCounter(r.Request, strconv.Itoa(r.StatusCode))
 
 	if key == "" {
@@ -85,7 +85,7 @@ func (o *OpenVSXProxy) ModifyResponse(r *http.Response) error {
 		r.Body = ioutil.NopCloser(bytes.NewBuffer(cached.Body))
 		r.ContentLength = int64(len(cached.Body))
 		r.StatusCode = cached.StatusCode
-		log.WithFields(logFields).Info("used cache response due to an upstream error")
+		log.WithFields(logFields).Debug("used cache response due to an upstream error")
 		o.metrics.BackupCacheServeCounter.Inc()
 		return nil
 	}
@@ -100,7 +100,7 @@ func (o *OpenVSXProxy) ModifyResponse(r *http.Response) error {
 	if err != nil {
 		log.WithFields(logFields).WithError(err).Error("error storing response to cache")
 	} else {
-		log.WithFields(logFields).Info("successfully stored response to cache")
+		log.WithFields(logFields).Debug("successfully stored response to cache")
 	}
 
 	r.Body = ioutil.NopCloser(bytes.NewBuffer(rawBody))

--- a/components/openvsx-proxy/pkg/prometheus.go
+++ b/components/openvsx-proxy/pkg/prometheus.go
@@ -47,7 +47,7 @@ func (p *Prometheus) Start(cfg *Config) {
 				log.WithError(err).Error("Prometheus metrics server failed")
 			}
 		}()
-		log.WithField("addr", cfg.PrometheusAddr).Info("started Prometheus metrics server")
+		log.WithField("addr", cfg.PrometheusAddr).Debug("started Prometheus metrics server")
 	}
 
 	p.createMetrics()


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

We produce to many useless logs in OpenVSX proxy for each request. Instead let's use debug by default and if we need more verbose logging we can enable it via configmap log level option.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
