### PR TITLE
[server] Fix UBP free tier edge case + tests

### DIFF
--- a/components/server/ee/src/billing/billing-mode.spec.db.ts
+++ b/components/server/ee/src/billing/billing-mode.spec.db.ts
@@ -40,95 +40,25 @@ import Stripe from "stripe";
 import { Config } from "../../../src/config";
 import { BillingModes, BillingModesImpl } from "./billing-mode";
 import * as deepEqualInAnyOrder from "deep-equal-in-any-order";
-import {
-    UsageServiceDefinition,
-    UsageServiceClient,
-    GetCostCenterResponse,
-    CostCenter_BillingStrategy,
-    GetBalanceResponse,
-    SetCostCenterResponse,
-    ReconcileUsageResponse,
-    ListUsageRequest_Ordering,
-    ListUsageResponse,
-    ResetUsageResponse,
-    ResetUsageRequest,
-} from "@gitpod/usage-api/lib/usage/v1/usage.pb";
-import { CallOptions } from "nice-grpc-common";
+import { CostCenter_BillingStrategy } from "@gitpod/usage-api/lib/usage/v1/usage.pb";
+import { UsageService } from "../../../src/user/usage-service";
 chai.use(deepEqualInAnyOrder);
 const expect = chai.expect;
 
 type StripeSubscription = Pick<Stripe.Subscription, "id"> & { customer: string };
-class UsageServiceClientMock implements UsageServiceClient {
+class UsageServiceMock implements UsageService {
     constructor(protected readonly subscription?: StripeSubscription) {}
 
-    async getCostCenter(
-        request: { attributionId?: string | undefined },
-        options?: CallOptions | undefined,
-    ): Promise<GetCostCenterResponse> {
-        if (!request.attributionId) {
-            return { costCenter: undefined };
-        }
+    async getCurrentBalance(attributionId: AttributionId): Promise<{ usedCredits: number; usageLimit: number }> {
+        throw new Error("Mock: not implemented");
+    }
 
+    async getCurrentBillingStategy(attributionId: AttributionId): Promise<CostCenter_BillingStrategy | undefined> {
         let billingStrategy = CostCenter_BillingStrategy.BILLING_STRATEGY_OTHER;
         if (this.subscription !== undefined) {
             billingStrategy = CostCenter_BillingStrategy.BILLING_STRATEGY_STRIPE;
         }
-
-        return {
-            costCenter: {
-                attributionId: request.attributionId,
-                billingStrategy,
-                nextBillingTime: new Date(), // does not matter here.
-                spendingLimit: 1234,
-            },
-        };
-    }
-
-    async getBalance(
-        request: { attributionId?: string | undefined },
-        options?: CallOptions | undefined,
-    ): Promise<GetBalanceResponse> {
-        throw new Error("Mock: not implemented");
-    }
-
-    async setCostCenter(
-        request: {
-            costCenter?:
-                | {
-                      attributionId?: string | undefined;
-                      spendingLimit?: number | undefined;
-                      billingStrategy?: CostCenter_BillingStrategy | undefined;
-                      nextBillingTime?: Date | undefined;
-                  }
-                | undefined;
-        },
-        options?: CallOptions | undefined,
-    ): Promise<SetCostCenterResponse> {
-        throw new Error("Mock: not implemented");
-    }
-
-    async reconcileUsage(
-        request: { from?: Date | undefined; to?: Date | undefined },
-        options?: CallOptions | undefined,
-    ): Promise<ReconcileUsageResponse> {
-        throw new Error("Mock: not implemented");
-    }
-
-    async listUsage(
-        request: {
-            attributionId?: string | undefined;
-            from?: Date | undefined;
-            to?: Date | undefined;
-            order?: ListUsageRequest_Ordering | undefined;
-            pagination?: { perPage?: number | undefined; page?: number | undefined } | undefined;
-        },
-        options?: CallOptions | undefined,
-    ): Promise<ListUsageResponse> {
-        throw new Error("Mock: not implemented");
-    }
-
-    async resetUsage(request: ResetUsageRequest, options?: CallOptions | undefined): Promise<ResetUsageResponse> {
-        throw new Error("Mock: not implemented");
+        return billingStrategy;
     }
 }
 
@@ -367,6 +297,18 @@ class BillingModeSpec {
                 },
             },
             {
+                name: "user: UBP free tier, chargebee paid personal (inactive)",
+                subject: user(),
+                config: {
+                    enablePayment: true,
+                    usageBasedPricingEnabled: true,
+                    subscriptions: [subscription(Plans.PERSONAL_EUR, cancellationDate, cancellationDate)],
+                },
+                expectation: {
+                    mode: "usage-based",
+                },
+            },
+            {
                 name: "user: stripe paid, chargebee paid personal (inactive) + team seat (inactive)",
                 subject: user(),
                 config: {
@@ -451,6 +393,7 @@ class BillingModeSpec {
                 expectation: {
                     mode: "chargebee",
                     paid: true,
+                    teamNames: ["team-123"],
                 },
             },
             {
@@ -479,7 +422,6 @@ class BillingModeSpec {
                 expectation: {
                     mode: "chargebee",
                     canUpgradeToUBB: true,
-                    teamNames: ["team-123"],
                 },
             },
             {
@@ -558,9 +500,7 @@ class BillingModeSpec {
                     bind(SubscriptionService).toSelf().inSingletonScope();
                     bind(BillingModes).to(BillingModesImpl).inSingletonScope();
 
-                    bind(UsageServiceDefinition.name).toConstantValue(
-                        new UsageServiceClientMock(test.config.stripeSubscription),
-                    );
+                    bind(UsageService).toConstantValue(new UsageServiceMock(test.config.stripeSubscription));
                     bind(ConfigCatClientFactory).toConstantValue(
                         () =>
                             new ConfigCatClientMock({

--- a/components/server/ee/src/billing/billing-mode.ts
+++ b/components/server/ee/src/billing/billing-mode.ts
@@ -125,7 +125,7 @@ export class BillingModesImpl implements BillingModes {
             await this.teamSubscriptionDb.findTeamSubscriptions({ userId: user.id })
         ).filter((ts) => TeamSubscription.isActive(ts, now.toISOString()));
 
-        let canUpgradeToUBB = false;
+        let canUpgradeToUBB: boolean | undefined = undefined;
         if (cbPersonalSubscriptions.length > 0) {
             if (cbPersonalSubscriptions.every((s) => Subscription.isCancelled(s, now.toISOString()))) {
                 // The user has one or more paid subscriptions, but all of them have already been cancelled
@@ -168,7 +168,7 @@ export class BillingModesImpl implements BillingModes {
             // UBB is greedy: once a user has at least a paid team membership, they should benefit from it!
             return usageBased();
         }
-        if (hasCbPaidTeamMembership || hasCbPaidTeamSeat || canUpgradeToUBB) {
+        if (hasCbPaidTeamMembership || hasCbPaidTeamSeat) {
             // Q: How to test the free-tier, then? A: Make sure you have no CB paid seats anymore
             // For that we lists all Team Subscriptions/Team Memberships that are "blocking" you, and display them in the UI somewhere.
             const result: BillingMode = { mode: "chargebee", canUpgradeToUBB }; // UBB is enabled, but no seat nor subscription yet.


### PR DESCRIPTION
## Description
We missed a gap when changing UBP semantics during earlier changes. This now ensures that you definitely are subject to "UBP free tier" if you don't:
 - have an active personal subscription
 - have an active Team Seat/Membership

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #14552 

## How to test
Run unit tests in [a workspace](https://gitpod.io/#github.com/gitpod-io/gitpod/compare/gpl/bm-ubp-free):
 - `leeway build components/gitpod-db:dbtest-init`
 - `(cd components/server && yarn db-test)`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
fix rollout behavior of Usage-Based Pricing
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
