### PR TITLE
[jb] sync initial options

### DIFF
--- a/components/ide/jetbrains/image/hot-deploy.sh
+++ b/components/ide/jetbrains/image/hot-deploy.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+# Licensed under the GNU Affero General Public License (AGPL).
+# See License-AGPL.txt in the project root for license information.
+
+set -Eeuo pipefail
+
+# Login in GCloud to reuse remote caches
+ROOT_DIR="$(dirname "$0")/../../../.."
+
+source "$ROOT_DIR/dev/preview/workflow/lib/ensure-gcloud-auth.sh"
+ensure_gcloud_auth
+
+# This script builds the backend JB ide image and updates the IDE config map.
+
+product=${1:-intellij}
+echo "Product: $product"
+
+qualifier=${2:-latest}
+echo "Qualifier: $qualifier"
+
+if [ "$qualifier" == "stable" ]; then
+    component=$product
+else
+    component=$product-$qualifier
+fi
+
+version="dev-$component-image-$(date +%F_T"%H-%M-%S")"
+echo "Image Version: $version"
+
+bldfn="/tmp/build-$version.tar.gz"
+
+docker ps &> /dev/null || (echo "You need a working Docker daemon. Maybe set DOCKER_HOST?"; exit 1)
+leeway build -Dversion="$version" -DimageRepoBase=eu.gcr.io/gitpod-core-dev/build ".:$component" --save "$bldfn" --dont-retag
+dev_image="$(tar xfO "$bldfn" ./imgnames.txt | head -n1)"
+echo "Dev Image: $dev_image"
+
+if [ "$qualifier" == "stable" ]; then
+    prop="image"
+else
+    prop="latestImage"
+fi
+
+cf_patch=$(kubectl get cm ide-config -o=json | jq '.data."config.json"' |jq -r)
+cf_patch=$(echo "$cf_patch" |jq ".ideOptions.options.$product.$prop = \"$dev_image\"")
+cf_patch=$(echo "$cf_patch" |jq tostring)
+cf_patch="{\"data\": {\"config.json\": $cf_patch}}"
+
+kubectl patch cm ide-config --type=merge -p "$cf_patch"
+
+kubectl rollout restart deployment ide-service


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

- Configure IntelliJ
- Start a workspace on https://github.com/akosyakov/parcel-demo/tree/jb-proxy-test
- Check that proxy settings are configured in the settings view of marketplace for the host.
- That jap buddy plugin is installed already.
- Also you can check output of tinyproxy running in the terminal.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[JetBrains] Preconfigure global settings for JB backend.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
