### PR TITLE
Optionally consume Leeway from git

### DIFF
--- a/.werft/build.yaml
+++ b/.werft/build.yaml
@@ -241,6 +241,15 @@ pod:
           echo "done" \
         ) | werft log slice "chowning /workspace and $GOCACHE"
 
+        {{ if .Annotations.leewayfromgit }}
+        ( \
+          LEEWAY_SRC="github.com/gitpod-io/leeway@{{ .Annotations.leewayfromgit }}" && \
+          echo "Installing Leeway from $LEEWAY_SRC" && \
+          GOBIN=$(pwd) go install "$LEEWAY_SRC" && \
+          sudo mv leeway $(dirname $(which leeway))
+        ) | werft log slice "Building fresh Leeway binary from source"
+        {{ end }}
+
         ( \
           mkdir -p /workspace/.ssh && \
           cp /mnt/secrets/harvester-vm-ssh-keys/id_rsa /workspace/.ssh/id_rsa_harvester_vm && \


### PR DESCRIPTION
## Description
Optionally install leeway from git. This is helpful to test new versions of leeway before releasing them.

## Related Issue(s)
Fixes #

## How to test
`werft run github -a leeway-from-git=true` from CI to bypass job protection.


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
