### PR TITLE
[db-sync] Introduce SyncPeriod (with upper limit now - 5s)

### DIFF
--- a/components/ee/db-sync/src/export.ts
+++ b/components/ee/db-sync/src/export.ts
@@ -66,7 +66,7 @@ export class TableUpdate {
             dataQueryParams.push(this.start);
         }
         if (this.end) {
-            timeConditions.push(`${this.table.timeColumn} <= ?`);
+            timeConditions.push(`${this.table.timeColumn} < ?`);
             dataQueryParams.push(this.end);
         }
         if (this.table.expiryColumn) {

--- a/components/ee/db-sync/src/export.ts
+++ b/components/ee/db-sync/src/export.ts
@@ -12,7 +12,7 @@ import { injectable, multiInject } from "inversify";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 
 export class TableUpdate {
-    constructor(protected table: TableDescription, protected start?: Date, protected end?: Date) { }
+    constructor(protected table: TableDescription, protected start?: Date, protected end?: Date) {}
     protected columns: string[];
     protected updateColumns: string[];
     protected _updates?: string[];
@@ -29,7 +29,7 @@ export class TableUpdate {
     public async populate(conn: Connection): Promise<void> {
         let description: any[];
         try {
-            description = await query(conn, `DESCRIBE ${this.table.name}`) as any[];
+            description = (await query(conn, `DESCRIBE ${this.table.name}`)) as any[];
         } catch (err) {
             // TODO(cw): for the time being we might have more tables in the replication list than we actually have
             //           in the database, due to the gitpod-com move. Once we've resolved this situation, missing tables
@@ -41,19 +41,23 @@ export class TableUpdate {
         }
 
         // check that timeColumn is a timestamp
-        const timeField = description.find(f => f.Field == this.table.timeColumn);
-        if(!timeField) {
-            throw new Error(`Table ${this.table.name} has no column ${this.table.timeColumn} configured for time-based sync`);
-        } else if(!(timeField.Type as string).toLowerCase().startsWith("timestamp")) {
-            throw new Error(`${this.table.name}'s time-column ${this.table.timeColumn} is not a timestamp, but ${timeField.Type}`);
+        const timeField = description.find((f) => f.Field == this.table.timeColumn);
+        if (!timeField) {
+            throw new Error(
+                `Table ${this.table.name} has no column ${this.table.timeColumn} configured for time-based sync`,
+            );
+        } else if (!(timeField.Type as string).toLowerCase().startsWith("timestamp")) {
+            throw new Error(
+                `${this.table.name}'s time-column ${this.table.timeColumn} is not a timestamp, but ${timeField.Type}`,
+            );
         }
 
-        this.columns = description.map(f => f.Field as string);
+        this.columns = description.map((f) => f.Field as string);
         this.updateColumns = this.columns
             // do not update primary keys
-            .filter(f => !this.table.primaryKeys.find(pk => f == pk))
+            .filter((f) => !this.table.primaryKeys.find((pk) => f == pk))
             // actually ignore the ignore columns
-            .filter(f => !(this.table.ignoreColumns || []).find(ic => f == ic));
+            .filter((f) => !(this.table.ignoreColumns || []).find((ic) => f == ic));
 
         let dataQueryParams: any[] = [];
         let timeConditions = [];
@@ -66,44 +70,52 @@ export class TableUpdate {
             dataQueryParams.push(this.end);
         }
         if (this.table.expiryColumn) {
-            timeConditions.push(`${this.table.expiryColumn} >= UNIX_TIMESTAMP(UTC_TIMESTAMP())`)
+            timeConditions.push(`${this.table.expiryColumn} >= UNIX_TIMESTAMP(UTC_TIMESTAMP())`);
         }
         let condition = "";
         if (timeConditions.length > 0) {
             condition = `WHERE ${timeConditions.join(" AND ")}`;
         }
 
-        const dataQuery = `SELECT ${this.columns.map(escapeWithBackticks).join(", ")} FROM \`${this.table.name}\` ${condition}`;
+        const dataQuery = `SELECT ${this.columns.map(escapeWithBackticks).join(", ")} FROM \`${
+            this.table.name
+        }\` ${condition}`;
         const deletionsAndUpdates = await new Promise<string[][]>((resolve, reject) => {
             const updates: string[] = [];
             const deletions: string[] = [];
             try {
                 conn.query({ sql: dataQuery, values: dataQueryParams })
                     .stream()
-                    .pipe(new Transform({
-                        objectMode: true,
-                        transform: (data: any, encoding, cb) => {
-                            if(data[this.table.timeColumn] > Date.now()) {
-                                const pk = this.table.primaryKeys.map(pk => data[pk]).join(", ");
-                                console.warn(`Row (${this.table.name}: ${pk}) was modified in the future. Possible time sync issue between database and db-sync.`);
-                            }
+                    .pipe(
+                        new Transform({
+                            objectMode: true,
+                            transform: (data: any, encoding, cb) => {
+                                if (data[this.table.timeColumn] > Date.now()) {
+                                    const pk = this.table.primaryKeys.map((pk) => data[pk]).join(", ");
+                                    console.warn(
+                                        `Row (${this.table.name}: ${pk}) was modified in the future. Possible time sync issue between database and db-sync.`,
+                                    );
+                                }
 
-                            const deletionStatement = this.getDeletionStatement(data);
-                            if (deletionStatement) {
-                                deletions.push(deletionStatement);
-                            }
+                                const deletionStatement = this.getDeletionStatement(data);
+                                if (deletionStatement) {
+                                    deletions.push(deletionStatement);
+                                }
 
-                            this.getUpdateStatement(data).forEach(s => updates.push(s));
+                                this.getUpdateStatement(data).forEach((s) => updates.push(s));
 
-                            cb();
-                        }
-                    }))
-                    .on('error', (err) => reject(new Error(`Error while exporting ${this.table.name}: ${err}`)))
-                    .on('finish', () => {
-                        console.debug(`Export of ${this.table.name} done: ${deletions.length} deletions, ${updates.length} updates`);
-                        resolve([ deletions, updates ]);
+                                cb();
+                            },
+                        }),
+                    )
+                    .on("error", (err) => reject(new Error(`Error while exporting ${this.table.name}: ${err}`)))
+                    .on("finish", () => {
+                        console.debug(
+                            `Export of ${this.table.name} done: ${deletions.length} deletions, ${updates.length} updates`,
+                        );
+                        resolve([deletions, updates]);
                     });
-            } catch(err) {
+            } catch (err) {
                 reject(new Error(`Error while exporting ${this.table.name}: ${err}`));
             }
         });
@@ -113,7 +125,7 @@ export class TableUpdate {
     }
 
     protected shouldDelete(row: any): boolean {
-        if(!this.table.deletionColumn) {
+        if (!this.table.deletionColumn) {
             return false;
         }
 
@@ -121,7 +133,7 @@ export class TableUpdate {
     }
 
     protected getDeletionStatement(row: any): string | undefined {
-        if(!this.shouldDelete(row)) {
+        if (!this.shouldDelete(row)) {
             return;
         }
 
@@ -134,22 +146,29 @@ export class TableUpdate {
             return [];
         }
 
-        const pkValues = this.table.primaryKeys.map(c => escape(row[c], true));
-        const updateValues = this.updateColumns.map(c => escape(row[c], true));
-        const updates = this.updateColumns.map((c, i) => `${escapeWithBackticks(c)}=${updateValues[i]}`).join(", ")
+        const pkValues = this.table.primaryKeys.map((c) => escape(row[c], true));
+        const updateValues = this.updateColumns.map((c) => escape(row[c], true));
+        const updates = this.updateColumns.map((c, i) => `${escapeWithBackticks(c)}=${updateValues[i]}`).join(", ");
         const updateConditions = this.getUpdateConditions(row);
 
-        let result = [`INSERT${forceInsert ? '' : ' IGNORE'} INTO ${this.table.name} (${(this.table.primaryKeys.concat(this.updateColumns)).map(escapeWithBackticks).join(", ")}) VALUES (${(pkValues.concat(updateValues)).join(", ")});`];
-        if(!forceInsert) {
+        let result = [
+            `INSERT${forceInsert ? "" : " IGNORE"} INTO ${this.table.name} (${this.table.primaryKeys
+                .concat(this.updateColumns)
+                .map(escapeWithBackticks)
+                .join(", ")}) VALUES (${pkValues.concat(updateValues).join(", ")});`,
+        ];
+        if (!forceInsert) {
             result.push(`UPDATE ${this.table.name} SET ${updates} WHERE ${updateConditions};`);
         }
         return result;
     }
 
     protected getUpdateConditions(row: any): string {
-        return this.table.primaryKeys.map(pk => `${escapeWithBackticks(pk)}=${escape(row[pk])}`).concat([`${this.table.timeColumn}<=${escape(row[this.table.timeColumn])}`]).join(" AND ");
+        return this.table.primaryKeys
+            .map((pk) => `${escapeWithBackticks(pk)}=${escape(row[pk])}`)
+            .concat([`${this.table.timeColumn}<=${escape(row[this.table.timeColumn])}`])
+            .join(" AND ");
     }
-
 }
 
 @injectable()
@@ -157,32 +176,38 @@ export class TableUpdateProvider {
     @multiInject(TableDescriptionProvider)
     protected readonly descriptionProvider: TableDescriptionProvider[];
 
-    public async getAllStatementsForAllTables(conn: Connection, tableSet?: string, start_date?: Date, end_date?: Date): Promise<{ deletions: string[], updates: string[] }> {
-        const provider = tableSet ? this.descriptionProvider.find(v => v.name == tableSet) : this.descriptionProvider[0];
-        if(!provider) {
+    public async getAllStatementsForAllTables(
+        conn: Connection,
+        tableSet?: string,
+        start_date?: Date,
+        end_date?: Date,
+    ): Promise<{ deletions: string[]; updates: string[] }> {
+        const provider = tableSet
+            ? this.descriptionProvider.find((v) => v.name == tableSet)
+            : this.descriptionProvider[0];
+        if (!provider) {
             throw new Error(`Unknown table set ${tableSet} or no table description providers registered`);
         }
-        const tableUpdates = provider.getSortedTables().map(t => new TableUpdate(t, start_date, end_date));
-        await Promise.all(tableUpdates.map(t => t.populate(conn)));
+        const tableUpdates = provider.getSortedTables().map((t) => new TableUpdate(t, start_date, end_date));
+        await Promise.all(tableUpdates.map((t) => t.populate(conn)));
 
         // when collecting the deletions do so in the inverse order as during update (delete dependency targes first)
         const deletions = [];
-        for(var stmts of tableUpdates.reverse()) {
-            for(var stmt of stmts.deletions || []) {
+        for (var stmts of tableUpdates.reverse()) {
+            for (var stmt of stmts.deletions || []) {
                 deletions.push(stmt);
             }
         }
         const updates = [];
-        for(var stmts of tableUpdates) {
-            for(var stmt of stmts.updates || []) {
+        for (var stmts of tableUpdates) {
+            for (var stmt of stmts.updates || []) {
                 updates.push(stmt);
             }
         }
         return { deletions, updates };
     }
-
 }
 
 function escapeWithBackticks(val: string): string {
-    return "`" + val + "`"
+    return "`" + val + "`";
 }


### PR DESCRIPTION
## Description
This intended to be a small and pragmatic fix to db-sync to make it more reliable before we can retire it completely.
Before, it would always sync from ´[previousRun, ...now`. Also, it was using the local processes clock, which is obviously out-of-sync with the DB's.

This PR addresses this by:
- introducing an upperBound of "now - 5s" for SyncPeriods
- use the DB's clock to establish that SyncPeriod
- (fix a minor comparison error in export.ts which made us double-sync on millisecond matches)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #14560 

## How to test
 - `leeway build components/gitpod-db:dbtest-init`
 - `(components/ee/db-sync && yarn db-test)`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
