### PR TITLE
[dashboard] Use PublicAPI to DeleteTeam

### DIFF
--- a/components/dashboard/src/teams/TeamSettings.tsx
+++ b/components/dashboard/src/teams/TeamSettings.tsx
@@ -10,6 +10,8 @@ import { useContext, useEffect, useState } from "react";
 import { Redirect, useLocation } from "react-router";
 import ConfirmationModal from "../components/ConfirmationModal";
 import { PageWithSubMenu } from "../components/PageWithSubMenu";
+import { FeatureFlagContext } from "../contexts/FeatureFlagContext";
+import { teamsService } from "../service/public-api";
 import { getGitpodService, gitpodHostUrl } from "../service/service";
 import { UserContext } from "../user-context";
 import { getCurrentTeam, TeamsContext } from "./teams-context";
@@ -39,6 +41,7 @@ export default function TeamSettings() {
     const [isUserOwner, setIsUserOwner] = useState(true);
     const { teams } = useContext(TeamsContext);
     const { user } = useContext(UserContext);
+    const { usePublicApiTeamsService } = useContext(FeatureFlagContext);
     const [billingMode, setBillingMode] = useState<BillingMode | undefined>(undefined);
     const location = useLocation();
     const team = getCurrentTeam(location, teams);
@@ -65,7 +68,11 @@ export default function TeamSettings() {
         if (!team || !user) {
             return;
         }
-        await getGitpodService().server.deleteTeam(team.id);
+
+        usePublicApiTeamsService
+            ? await teamsService.deleteTeam({ teamId: team.id })
+            : await getGitpodService().server.deleteTeam(team.id);
+
         document.location.href = gitpodHostUrl.asDashboard().toString();
     };
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Use DeleteTeam from PublicAPI (implemented in https://github.com/gitpod-io/gitpod/pull/14573) when deleting teams

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Depends on https://github.com/gitpod-io/gitpod/pull/14573

## How to test
<!-- Provide steps to test this PR -->

1. Preview
2. Create team
3. Delete team

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
