### PR TITLE
[JetBrains] Auto-approve also EAP Gateway Plugin updates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -117,3 +117,4 @@
 #
 /CHANGELOG.md
 /components/ide/jetbrains/backend-plugin/gradle-latest.properties
+/components/ide/jetbrains/gateway-plugin/gradle-latest.properties

--- a/.github/workflows/jetbrains-update-plugin-platform-template.yml
+++ b/.github/workflows/jetbrains-update-plugin-platform-template.yml
@@ -130,13 +130,13 @@ jobs:
                       _This PR was created automatically with GitHub Actions using [this](https://github.com/gitpod-io/gitpod/blob/main/.github/workflows/jetbrains-update-plugin-platform-template.yml) template._
                   commit-message: "Update Platform Version of ${{ inputs.pluginName }} to ${{ steps.latest-version.outputs.result }}"
                   branch: "jetbrains/${{ inputs.pluginId }}-platform"
-                  labels: "team: IDE"
+                  labels: "team: IDE,editor: jetbrains"
                   team-reviewers: "engineering-ide"
                   token: ${{ secrets.roboquatRepoPat }}
                   committer: Robo Quat <roboquat@gitpod.io>
                   author: Robo Quat <roboquat@gitpod.io>
             - name: Auto Approve Pull Request
-              if: ${{ inputs.pluginId == 'backend-plugin' && steps.create-pr.outputs.pull-request-number }}
+              if: ${{ steps.create-pr.outputs.pull-request-number }}
               uses: hmarr/auto-approve-action@v3
               with:
                   pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
- Auto-approve also PRs related to EAP Gateway Plugin updates.
- Also label the created PR with "[editor: jetbrains](https://github.com/gitpod-io/gitpod/labels/editor%3A%20jetbrains)".
- Remove Code Owner from `/components/ide/jetbrains/gateway-plugin/gradle-latest.properties`

## How to test
<!-- Provide steps to test this PR -->
- No need to test.
- Check how auto-approval worked for the Backend Plugin: https://github.com/gitpod-io/gitpod/pull/14583

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```