### PR TITLE
Fix conflicting PrometheusRules

### DIFF
--- a/operations/observability/mixins/meta/rules/public-api.yaml
+++ b/operations/observability/mixins/meta/rules/public-api.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     prometheus: k8s
     role: alert-rules
-  name: server-monitoring-rules
+  name: public-api-monitoring-rules
 spec:
   groups:
   - name: public-api


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Looks like it is a copy-paste mistake 😛 

The resource name conflicts with [this one](https://github.com/gitpod-io/gitpod/blob/9a3afd75377ba2aa4af354a7d047a050643bd1cc/operations/observability/mixins/meta/rules/server.yaml#L11)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
