### PR TITLE
[JetBrains] Add a step to check and approve the PR created for Gateway Plugin

### DIFF
--- a/.github/workflows/jetbrains-update-plugin-platform-template.yml
+++ b/.github/workflows/jetbrains-update-plugin-platform-template.yml
@@ -69,6 +69,7 @@ jobs:
                   sed -i 's/platformVersion=${{ steps.current-version.outputs.result }}/platformVersion=${{ steps.latest-version.outputs.result }}/' ${{ inputs.gradlePropertiesPath }}
                   git diff
             - name: Create Pull Request for Gateway Plugin
+              id: create-gateway-pr
               if: ${{ inputs.pluginId == 'gateway-plugin' && steps.latest-version.outputs.result != steps.current-version.outputs.result }}
               uses: peter-evans/create-pull-request@v4
               with:
@@ -100,8 +101,13 @@ jobs:
                   token: ${{ secrets.roboquatRepoPat }}
                   committer: Robo Quat <roboquat@gitpod.io>
                   author: Robo Quat <roboquat@gitpod.io>
+            - name: Approve Pull Request for Gateway Plugin
+              if: ${{ steps.create-gateway-pr.outputs.pull-request-number }}
+              uses: hmarr/auto-approve-action@v3
+              with:
+                  pull-request-number: ${{ steps.create-gateway-pr.outputs.pull-request-number }}
             - name: Create Pull Request for Backend Plugin
-              id: create-pr
+              id: create-backend-pr
               if: ${{ inputs.pluginId == 'backend-plugin' && steps.latest-version.outputs.result != steps.current-version.outputs.result }}
               uses: peter-evans/create-pull-request@v4
               with:
@@ -135,11 +141,11 @@ jobs:
                   token: ${{ secrets.roboquatRepoPat }}
                   committer: Robo Quat <roboquat@gitpod.io>
                   author: Robo Quat <roboquat@gitpod.io>
-            - name: Auto Approve Pull Request
-              if: ${{ steps.create-pr.outputs.pull-request-number }}
+            - name: Approve Pull Request for Backend Plugin
+              if: ${{ steps.create-backend-pr.outputs.pull-request-number }}
               uses: hmarr/auto-approve-action@v3
               with:
-                  pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
+                  pull-request-number: ${{ steps.create-backend-pr.outputs.pull-request-number }}
             - name: Get previous job's status
               id: lastrun
               uses: filiptronicek/get-last-job-status@main


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
In my [last PR](https://github.com/gitpod-io/gitpod/pull/14584), I didn't notice that an additional step was required to check and approve the PR created for Gateway Plugin.
For this reason, the _Auto Approve_ step was skipped (see [here](https://github.com/gitpod-io/gitpod/actions/runs/3438249496/jobs/5734064215)).
This PR fixes it.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
- https://github.com/gitpod-io/gitpod/pull/14584

## How to test
<!-- Provide steps to test this PR -->
Check the step added in the code changes. Check also the ID of both changed steps.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```