### PR TITLE
fix incremental workspaces

### DIFF
--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -1007,11 +1007,10 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
                 }
             } else {
                 log.debug(logCtx, "Looking for prebuilt workspace: ", logPayload);
-                if (!allowUsingPreviousPrebuilds) {
-                    prebuiltWorkspace = await this.workspaceDb
-                        .trace(ctx)
-                        .findPrebuiltWorkspaceByCommit(cloneUrl, commitSHAs);
-                } else {
+                prebuiltWorkspace = await this.workspaceDb
+                    .trace(ctx)
+                    .findPrebuiltWorkspaceByCommit(cloneUrl, commitSHAs);
+                if (!prebuiltWorkspace && allowUsingPreviousPrebuilds) {
                     const { config } = await this.configProvider.fetchConfig({}, user, context);
                     const history = await this.incrementalPrebuildsService.getCommitHistoryForContext(context, user);
                     prebuiltWorkspace = await this.incrementalPrebuildsService.findGoodBaseForIncrementalBuild(


### PR DESCRIPTION
## Description
The current logic when `allowUsingPreviousPrebuilds` was enabled would always use a previous prebuild because the history doesn't look at the current commit. 
This change makes it so that the previous prebuild logic only is used when there is no prebuild for the current commit.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
You can test it by 
- creating a project 
- pushing two commits on the same branch so that both commits get prebuilds
- enable the project setting for `allowUsingPreviousPrebuilds`
- start a workspace on the branch and verify that it in fact starts with a full prebuild and the init task doesn't run.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
