### PR TITLE
[server] Don't count user errors in failed image builds metrics

### DIFF
--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -1273,10 +1273,6 @@ export class WorkspaceStarter {
                 // ...and wait for the build to finish
                 buildResult = await result.buildPromise;
                 if (buildResult.getStatus() == BuildStatus.DONE_FAILURE) {
-                    // Register a failed image build only if the image actually needed to be built; ie the build was not a no-op.
-                    if (result.actuallyNeedsBuild) {
-                        increaseImageBuildsCompletedTotal("failed");
-                    }
                     throw new Error(buildResult.getMessage());
                 }
             } catch (err) {
@@ -1352,6 +1348,7 @@ export class WorkspaceStarter {
                     `workspace image build failed: ${message}`,
                 );
                 err = new StartInstanceError("imageBuildFailed", err);
+                increaseImageBuildsCompletedTotal("failed");
             }
             this.analytics.track({
                 userId: user.id,


### PR DESCRIPTION
## Description

https://github.com/gitpod-io/gitpod/pull/14296 added a `gitpod_server_image_builds_completed_total` counter metric, but the metric's "failed" dimension was incorrectly incremented when an image build failed for user errors, rather than just for system errors as intended. 

This PR excludes image build failures that look like they were due to user error from the metric.

## Related Issue(s)

Part of https://github.com/gitpod-io/gitpod/issues/12960.

## How to test

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
