### PR TITLE
Building locally will produce a unique version every time

### DIFF
--- a/dev/preview/workflow/preview/build.sh
+++ b/dev/preview/workflow/preview/build.sh
@@ -13,7 +13,11 @@ import "ensure-gcloud-auth.sh"
 
 ensure_gcloud_auth
 
-VERSION="$(preview-name-from-branch)-dev"
+if [[ "${VERSION:-}" == "" ]]; then
+    VERSION="$(preview-name-from-branch)-dev-$(date +%F_T%H-%M-%S)"
+    log_info "VERSION is not set - using $VERSION"
+    echo "$VERSION" > /tmp/local-dev-version
+fi
 
 # We have quite a few Leeway packages whose hash includes files from .gitignore.
 # Some of these files (such as build folders) are populated as part of our prebuilds

--- a/dev/preview/workflow/preview/deploy-gitpod.sh
+++ b/dev/preview/workflow/preview/deploy-gitpod.sh
@@ -30,7 +30,16 @@ GITPOD_WITH_EE_LICENSE="${GITPOD_WITH_EE_LICENSE:-true}"
 GITPOD_WORKSPACE_FEATURE_FLAGS="${GITPOD_WORKSPACE_FEATURE_FLAGS:-}"
 GITPOD_WITH_SLOW_DATABASE="${GITPOD_WITH_SLOW_DATABASE:-false}"
 
-VERSION="${VERSION:-${PREVIEW_NAME}-dev}"
+if [[ "${VERSION:-}" == "" ]]; then
+  if [[ ! -f  /tmp/local-dev-version ]]; then
+    log_error "VERSION is not set and no fallback version exists in /tmp/local-dev-version."
+    log_info "Please run leeway run dev/preview:build or set VERSION"
+    exit 1
+  fi
+  VERSION="$(cat /tmp/local-dev-version)"
+  log_info "VERSION is not set - using value from /tmp/local-dev-version which is $VERSION"
+fi
+
 INSTALLER_BINARY_PATH="$(mktemp "/tmp/XXXXXX.installer")}"
 INSTALLER_CONFIG_PATH="${INSTALLER_CONFIG_PATH:-$(mktemp "/tmp/XXXXXX.gitpod.config.yaml")}"
 INSTALLER_RENDER_PATH="k8s.yaml" # k8s.yaml is hardcoded in post-prcess.sh - we can fix that later.


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This PR changes `leeway run dev:preview` and related scripts such that we produce a new unique `version` every time.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/14474

Part of https://github.com/gitpod-io/ops/issues/5747

## How to test
<!-- Provide steps to test this PR -->

The happy path (in workspace)

```sh
leeway run dev:preview
```

Verifying that we handle the case where people directly invoke `leeway run dev/preview:deploy-gitpod` in a workspace where they haven't yet built it.

```
rm -f /tmp/local-dev-version
leeway run dev/preview:deploy-gitpod
ERROR: VERSION is not set and no fallback version exists in /tmp/local-dev-version.
INFO: Please run leeway run dev/preview:build or set VERSION
```

And a quick test that this didn't break Werft ([job](https://werft.gitpod-dev.com/job/gitpod-build-mads-hartmann-build-sh-should-bump-14474.1))

``sh
werft job run github -a with-preview=true
``

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
