### PR TITLE
[observability] add vscode install extension failure alert rule

### DIFF
--- a/operations/observability/mixins/IDE/rules/vscode.yaml
+++ b/operations/observability/mixins/IDE/rules/vscode.yaml
@@ -1,0 +1,27 @@
+# Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+# Licensed under the GNU Affero General Public License (AGPL).
+# See License-AGPL.txt in the project root for license information.
+
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: k8s
+    role: alert-rules
+  name: openvsx-proxy-monitoring-rules
+  namespace: monitoring-satellite
+spec:
+  groups:
+  - name: vscode
+    rules:
+    - alert: VSCodeExtensionInstallFailuresRatioTooHigh
+      labels:
+        severity: critical
+      for: 20m
+      annotations:
+        runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/VSCodeExtensionInstallFailuresRatioTooHigh.md
+        summary: Open-VSX registry is possibly down
+        description: Open-VSX registry or our openvsx-mirror is possibly down. Some user cannot install VSCode extensions.
+        dashboard_url: https://grafana.gitpod.io/d/oLzOteZ4z/vs-code-browser-overview
+      expr: |
+          sum(rate(gitpod_vscode_extension_gallery_operation_total{status="failure",operation="install"}[2m]))/sum(rate(gitpod_vscode_extension_gallery_operation_total{operation="install"}[2m])) > 0.25


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
[observability] add vscode install extension failure alert rule

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
