### PR TITLE
[JetBrains] Fix JDWP error triggered when running `launch-dev-server.sh`

### DIFF
--- a/components/ide/jetbrains/backend-plugin/launch-dev-server.sh
+++ b/components/ide/jetbrains/backend-plugin/launch-dev-server.sh
@@ -71,7 +71,7 @@ if [ ! -d "$TEST_DIR" ]; then
 fi
 
 export JB_DEV=true
-export JAVA_TOOL_OPTIONS="$JAVA_TOOL_OPTIONS -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:$DEBUG_PORT"
+export JAVA_TOOL_OPTIONS="$JAVA_TOOL_OPTIONS -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=127.0.0.1:$DEBUG_PORT"
 
 # Set default config and system directories under /workspace to preserve between restarts
 export IJ_HOST_CONFIG_BASE_DIR=/workspace/.config/JetBrains


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Fix JDWP error "_transport error 202: socket creation failed: Address family not supported by protocol_" by setting an IPv4 address.

Error details:
```
Picked up JAVA_TOOL_OPTIONS:  -Xmx12884m -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:44444
CompileCommand: exclude com/intellij/openapi/vfs/impl/FilePartNodeRoot.trieDescend bool exclude = true
ERROR: transport error 202: socket creation failed: Address family not supported by protocol
ERROR: JDWP Transport dt_socket failed to initialize, TRANSPORT_INIT(510)
JDWP exit error AGENT_ERROR_TRANSPORT_INIT(197): No transports initialized [src/jdk.jdwp.agent/share/native/libjdwp/debugInit.c:734]
```

See [internal discussion](https://gitpod.slack.com/archives/C02CBKZEVS8/p1668175666969379).

## How to test
<!-- Provide steps to test this PR -->
- Open the branch of this PR in Gitpod
- Run `cd components/ide/jetbrains/backend-plugin/`
- Run `./launch-dev-server.sh` and confirm if the dev server starts. You should see no error about "Address family not supported by protocol".

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
