### PR TITLE
[gitpod-protocol] Add project APIs to Golang client

### DIFF
--- a/components/gitpod-protocol/go/gitpod-service.go
+++ b/components/gitpod-protocol/go/gitpod-service.go
@@ -84,6 +84,7 @@ type APIInterface interface {
 	TrackEvent(ctx context.Context, event *RemoteTrackMessage) (err error)
 	GetSupportedWorkspaceClasses(ctx context.Context) (res []*SupportedWorkspaceClass, err error)
 
+	// Teams
 	GetTeam(ctx context.Context, teamID string) (*Team, error)
 	GetTeams(ctx context.Context) ([]*Team, error)
 	CreateTeam(ctx context.Context, teamName string) (*Team, error)
@@ -94,6 +95,12 @@ type APIInterface interface {
 	ResetGenericInvite(ctx context.Context, teamID string) (*TeamMembershipInvite, error)
 	SetTeamMemberRole(ctx context.Context, teamID, userID string, role TeamMemberRole) error
 	RemoveTeamMember(ctx context.Context, teamID, userID string) error
+
+	// Projects
+	CreateProject(ctx context.Context, options *CreateProjectOptions) (*Project, error)
+	DeleteProject(ctx context.Context, projectID string) error
+	GetUserProjects(ctx context.Context) ([]*Project, error)
+	GetTeamProjects(ctx context.Context, teamID string) ([]*Project, error)
 
 	InstanceUpdates(ctx context.Context, instanceID string) (<-chan *WorkspaceInstance, error)
 }
@@ -215,6 +222,7 @@ const (
 	// FunctionGetSupportedWorkspaceClasses is the name of the getSupportedWorkspaceClasses function
 	FunctionGetSupportedWorkspaceClasses FunctionName = "getSupportedWorkspaceClasses"
 
+	// Teams
 	// FunctionGetTeam is the name of the getTeam function
 	FunctionGetTeam FunctionName = "getTeam"
 	// FunctionGetTeams is the name of the getTeams function
@@ -235,6 +243,12 @@ const (
 	FunctionRemoveTeamMember FunctionName = "removeTeamMember"
 	// FunctionDeleteTeam is the name of the deleteTeam function
 	FunctionDeleteTeam FunctionName = "deleteTeam"
+
+	// Projects
+	FunctionCreateProject   FunctionName = "createProject"
+	FunctionDeleteProject   FunctionName = "deleteProject"
+	FunctionGetUserProjects FunctionName = "getUserProjects"
+	FunctionGetTeamProjects FunctionName = "getTeamProjects"
 
 	// FunctionOnInstanceUpdate is the name of the onInstanceUpdate callback function
 	FunctionOnInstanceUpdate = "onInstanceUpdate"
@@ -1520,6 +1534,46 @@ func (gp *APIoverJSONRPC) DeleteTeam(ctx context.Context, teamID string) (err er
 	return
 }
 
+func (gp *APIoverJSONRPC) CreateProject(ctx context.Context, options *CreateProjectOptions) (res *Project, err error) {
+	if gp == nil {
+		err = errNotConnected
+		return
+	}
+	_params := []interface{}{options}
+	err = gp.C.Call(ctx, string(FunctionCreateProject), _params, nil)
+	return
+}
+
+func (gp *APIoverJSONRPC) DeleteProject(ctx context.Context, projectID string) (err error) {
+	if gp == nil {
+		err = errNotConnected
+		return
+	}
+	_params := []interface{}{projectID}
+	err = gp.C.Call(ctx, string(FunctionDeleteProject), _params, nil)
+	return
+}
+
+func (gp *APIoverJSONRPC) GetUserProjects(ctx context.Context) (res []*Project, err error) {
+	if gp == nil {
+		err = errNotConnected
+		return
+	}
+	_params := []interface{}{}
+	err = gp.C.Call(ctx, string(FunctionGetUserProjects), _params, nil)
+	return
+}
+
+func (gp *APIoverJSONRPC) GetTeamProjects(ctx context.Context, teamID string) (res []*Project, err error) {
+	if gp == nil {
+		err = errNotConnected
+		return
+	}
+	_params := []interface{}{teamID}
+	err = gp.C.Call(ctx, string(FunctionGetTeamProjects), _params, nil)
+	return
+}
+
 // PermissionName is the name of a permission
 type PermissionName string
 
@@ -2247,4 +2301,39 @@ type TeamMembershipInvite struct {
 	CreationTime     string         `json:"creationTime,omitempty"`
 	InvalidationTime string         `json:"invalidationTime,omitempty"`
 	InvitedEmail     string         `json:"invitedEmail,omitempty"`
+}
+
+type Project struct {
+	ID                string           `json:"id,omitempty"`
+	UserID            string           `json:"userId,omitempty"`
+	TeamID            string           `json:"teamId,omitempty"`
+	Name              string           `json:"name,omitempty"`
+	Slug              string           `json:"slug,omitempty"`
+	CloneURL          string           `json:"cloneUrl,omitempty"`
+	AppInstallationID string           `json:"appInstallationId,omitempty"`
+	Settings          *ProjectSettings `json:"settings,omitempty"`
+	CreationTime      string           `json:"creationTime,omitempty"`
+}
+
+type ProjectSettings struct {
+	UseIncrementalPrebuilds      bool                      `json:"useIncrementalPrebuilds,omitempty"`
+	UsePersistentVolumeClaim     bool                      `json:"usePersistentVolumeClaim,omitempty"`
+	KeepOutdatedPrebuildsRunning bool                      `json:"keepOutdatedPrebuildsRunning,omitempty"`
+	AllowUsingPreviousPrebuilds  bool                      `json:"allowUsingPreviousPrebuilds,omitempty"`
+	PrebuildEveryNthCommit       int                       `json:"prebuildEveryNthCommit,omitempty"`
+	WorkspaceClasses             *WorkspaceClassesSettings `json:"workspaceClasses,omitempty"`
+}
+
+type WorkspaceClassesSettings struct {
+	Regular  string `json:"regular,omitempty"`
+	Prebuild string `json:"prebuild,omitempty"`
+}
+
+type CreateProjectOptions struct {
+	UserID            string `json:"userId,omitempty"`
+	TeamID            string `json:"teamId,omitempty"`
+	Name              string `json:"name,omitempty"`
+	Slug              string `json:"slug,omitempty"`
+	CloneURL          string `json:"cloneUrl,omitempty"`
+	AppInstallationID string `json:"appInstallationId,omitempty"`
 }

--- a/components/gitpod-protocol/go/mock.go
+++ b/components/gitpod-protocol/go/mock.go
@@ -109,6 +109,21 @@ func (mr *MockAPIInterfaceMockRecorder) ControlAdmission(ctx, id, level interfac
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ControlAdmission", reflect.TypeOf((*MockAPIInterface)(nil).ControlAdmission), ctx, id, level)
 }
 
+// CreateProject mocks base method.
+func (m *MockAPIInterface) CreateProject(ctx context.Context, options *CreateProjectOptions) (*Project, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateProject", ctx, options)
+	ret0, _ := ret[0].(*Project)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateProject indicates an expected call of CreateProject.
+func (mr *MockAPIInterfaceMockRecorder) CreateProject(ctx, options interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateProject", reflect.TypeOf((*MockAPIInterface)(nil).CreateProject), ctx, options)
+}
+
 // CreateTeam mocks base method.
 func (m *MockAPIInterface) CreateTeam(ctx context.Context, teamName string) (*Team, error) {
 	m.ctrl.T.Helper()
@@ -193,6 +208,20 @@ func (m *MockAPIInterface) DeleteOwnAuthProvider(ctx context.Context, params *De
 func (mr *MockAPIInterfaceMockRecorder) DeleteOwnAuthProvider(ctx, params interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteOwnAuthProvider", reflect.TypeOf((*MockAPIInterface)(nil).DeleteOwnAuthProvider), ctx, params)
+}
+
+// DeleteProject mocks base method.
+func (m *MockAPIInterface) DeleteProject(ctx context.Context, projectID string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteProject", ctx, projectID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteProject indicates an expected call of DeleteProject.
+func (mr *MockAPIInterfaceMockRecorder) DeleteProject(ctx, projectID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteProject", reflect.TypeOf((*MockAPIInterface)(nil).DeleteProject), ctx, projectID)
 }
 
 // DeleteSSHPublicKey mocks base method.
@@ -552,6 +581,21 @@ func (mr *MockAPIInterfaceMockRecorder) GetTeamMembers(ctx, teamID interface{}) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTeamMembers", reflect.TypeOf((*MockAPIInterface)(nil).GetTeamMembers), ctx, teamID)
 }
 
+// GetTeamProjects mocks base method.
+func (m *MockAPIInterface) GetTeamProjects(ctx context.Context, teamID string) ([]*Project, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTeamProjects", ctx, teamID)
+	ret0, _ := ret[0].([]*Project)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetTeamProjects indicates an expected call of GetTeamProjects.
+func (mr *MockAPIInterfaceMockRecorder) GetTeamProjects(ctx, teamID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTeamProjects", reflect.TypeOf((*MockAPIInterface)(nil).GetTeamProjects), ctx, teamID)
+}
+
 // GetTeams mocks base method.
 func (m *MockAPIInterface) GetTeams(ctx context.Context) ([]*Team, error) {
 	m.ctrl.T.Helper()
@@ -580,6 +624,21 @@ func (m *MockAPIInterface) GetToken(ctx context.Context, query *GetTokenSearchOp
 func (mr *MockAPIInterfaceMockRecorder) GetToken(ctx, query interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetToken", reflect.TypeOf((*MockAPIInterface)(nil).GetToken), ctx, query)
+}
+
+// GetUserProjects mocks base method.
+func (m *MockAPIInterface) GetUserProjects(ctx context.Context) ([]*Project, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetUserProjects", ctx)
+	ret0, _ := ret[0].([]*Project)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetUserProjects indicates an expected call of GetUserProjects.
+func (mr *MockAPIInterfaceMockRecorder) GetUserProjects(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserProjects", reflect.TypeOf((*MockAPIInterface)(nil).GetUserProjects), ctx)
 }
 
 // GetUserStorageResource mocks base method.


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Add Project APIs to Golang bindings for server, such that they can be used from public-api.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Relates to https://github.com/gitpod-io/gitpod/issues/14606

## How to test
<!-- Provide steps to test this PR -->
CI builds

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
