### PR TITLE
[integration-test] support jetbrains integration test in build job

### DIFF
--- a/.werft/build.yaml
+++ b/.werft/build.yaml
@@ -218,6 +218,11 @@ pod:
         secretKeyRef:
           name: integration-test-user
           key: token
+    - name: ROBOQUAT_TOKEN
+      valueFrom:
+        secretKeyRef:
+          name: github-roboquat-automatic-changelog
+          key: token
     command:
       - bash
       - -c

--- a/test/tests/ide/jetbrains/gateway_test.go
+++ b/test/tests/ide/jetbrains/gateway_test.go
@@ -185,11 +185,11 @@ func JetBrainsIDETest(ctx context.Context, t *testing.T, cfg *envconf.Config, id
 }
 
 func TestGoLand(t *testing.T) {
-	if roboquatToken == "" {
-		t.Skip("this test need github action run permission")
-	}
 	integration.SkipWithoutUsername(t, username)
 	integration.SkipWithoutUserToken(t, userToken)
+	if roboquatToken == "" {
+		t.Fatal("this test need github action run permission")
+	}
 	f := features.New("Start a workspace using GoLand").
 		WithLabel("component", "IDE").
 		WithLabel("ide", "GoLand").
@@ -204,11 +204,11 @@ func TestGoLand(t *testing.T) {
 }
 
 func TestIntellij(t *testing.T) {
-	if roboquatToken == "" {
-		t.Skip("this test need github action run permission")
-	}
 	integration.SkipWithoutUsername(t, username)
 	integration.SkipWithoutUserToken(t, userToken)
+	if roboquatToken == "" {
+		t.Fatal("this test need github action run permission")
+	}
 	f := features.New("Start a workspace using Intellij").
 		WithLabel("component", "IDE").
 		WithLabel("ide", "Intellij").
@@ -223,11 +223,11 @@ func TestIntellij(t *testing.T) {
 }
 
 func TestPhpStorm(t *testing.T) {
-	if roboquatToken == "" {
-		t.Skip("this test need github action run permission")
-	}
 	integration.SkipWithoutUsername(t, username)
 	integration.SkipWithoutUserToken(t, userToken)
+	if roboquatToken == "" {
+		t.Fatal("this test need github action run permission")
+	}
 	f := features.New("Start a workspace using PhpStorm").
 		WithLabel("component", "IDE").
 		WithLabel("ide", "PhpStorm").
@@ -242,11 +242,11 @@ func TestPhpStorm(t *testing.T) {
 }
 
 func TestPyCharm(t *testing.T) {
-	if roboquatToken == "" {
-		t.Skip("this test need github action run permission")
-	}
 	integration.SkipWithoutUsername(t, username)
 	integration.SkipWithoutUserToken(t, userToken)
+	if roboquatToken == "" {
+		t.Fatal("this test need github action run permission")
+	}
 	f := features.New("Start a workspace using Pycharm").
 		WithLabel("component", "IDE").
 		WithLabel("ide", "Pycharm").
@@ -261,11 +261,11 @@ func TestPyCharm(t *testing.T) {
 }
 
 func TestRubyMine(t *testing.T) {
-	if roboquatToken == "" {
-		t.Skip("this test need github action run permission")
-	}
 	integration.SkipWithoutUsername(t, username)
 	integration.SkipWithoutUserToken(t, userToken)
+	if roboquatToken == "" {
+		t.Fatal("this test need github action run permission")
+	}
 	f := features.New("Start a workspace using RubyMine").
 		WithLabel("component", "IDE").
 		WithLabel("ide", "RubyMine").
@@ -280,11 +280,11 @@ func TestRubyMine(t *testing.T) {
 }
 
 func TestWebStorm(t *testing.T) {
-	if roboquatToken == "" {
-		t.Skip("this test need github action run permission")
-	}
 	integration.SkipWithoutUsername(t, username)
 	integration.SkipWithoutUserToken(t, userToken)
+	if roboquatToken == "" {
+		t.Fatal("this test need github action run permission")
+	}
 	f := features.New("Start a workspace using WebStorm").
 		WithLabel("component", "IDE").
 		WithLabel("ide", "WebStorm").


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
[integration-test] support jetbrains integration test in build job

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
see this werft job, it can start jetbrains integration test https://werft.gitpod-dev.com/job/gitpod-custom-pd-inte.1

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
