### PR TITLE
[Gitpod CLI] Display helper for unknown subcommands

### DIFF
--- a/components/gitpod-cli/cmd/ports.go
+++ b/components/gitpod-cli/cmd/ports.go
@@ -11,6 +11,7 @@ import (
 var portsCmd = &cobra.Command{
 	Use:   "ports",
 	Short: "Interact with workspace ports.",
+	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
 			_ = cmd.Help()

--- a/components/gitpod-cli/cmd/tasks.go
+++ b/components/gitpod-cli/cmd/tasks.go
@@ -12,9 +12,10 @@ import (
 var tasksCmd = &cobra.Command{
 	Use:   "tasks",
 	Short: "Interact with workspace tasks",
+	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
-			cmd.Help()
+			_ = cmd.Help()
 		}
 	},
 }


### PR DESCRIPTION
## Description
Running unknown subcommands of `ports` and `tasks` would not return any output which is an odd and confusing behaviour.

The reason being that the helper is only triggered when there are no args. Unknown subcommands that don't match registered subcommands are considered arguments and the helper is only displayed when there are no arguments.

<img width="730" alt="Screenshot 2022-11-11 at 19 46 06" src="https://user-images.githubusercontent.com/2318450/201409881-e10e3185-15ef-4685-b246-9db4d7017ade.png">


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
1. Start a workspace 
2. Run `gp ports XXX` observe how the helper and an error are displayed
3. Run `gp ports list` to make sure subcommands continue to work
4. Run `gp tasks XXX` observe how the helper and an error are displayed
5. Run `gp tasks list` to make sure subcommands continue to work

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[Gitpod CLI] Display helper for unknown subcommands
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
