### PR TITLE
Remove appInstallationId from Project

### DIFF
--- a/components/dashboard/src/projects/NewProject.tsx
+++ b/components/dashboard/src/projects/NewProject.tsx
@@ -230,7 +230,7 @@ export default function NewProject() {
                 slug: repoSlug,
                 cloneUrl: repo.cloneUrl,
                 ...(User.is(teamOrUser) ? { userId: teamOrUser.id } : { teamId: teamOrUser.id }),
-                appInstallationId: String(repo.installationId),
+                appInstallationId: "",
             });
 
             setProject(project);

--- a/components/dashboard/src/service/service-mock.ts
+++ b/components/dashboard/src/service/service-mock.ts
@@ -41,7 +41,7 @@ const team1: Team = {
     creationTime: t1,
 };
 const pr1: Project = {
-    appInstallationId: "app1",
+    appInstallationId: "",
     cloneUrl: "https://github.com/AlexTugarev/txt.git",
     creationTime: t1,
     id: "pr1",

--- a/components/gitpod-db/src/project-db.spec.db.ts
+++ b/components/gitpod-db/src/project-db.spec.db.ts
@@ -51,7 +51,6 @@ class ProjectDBSpec {
             slug: "some-project",
             cloneUrl: "some-random-clone-url",
             userId: user.id,
-            appInstallationId: "app-1",
         });
         const searchTerm = "rand";
         const storedProject = await this.projectDb.storeProject(project);

--- a/components/gitpod-protocol/src/teams-projects-protocol.ts
+++ b/components/gitpod-protocol/src/teams-projects-protocol.ts
@@ -41,11 +41,12 @@ export interface Project {
 }
 
 export namespace Project {
-    export const create = (project: Omit<Project, "id" | "creationTime">): Project => {
+    export const create = (project: Omit<Project, "id" | "creationTime" | "appInstallationId">): Project => {
         return {
             ...project,
             id: uuidv4(),
             creationTime: new Date().toISOString(),
+            appInstallationId: "",
         };
     };
 

--- a/components/server/src/projects/projects-service.ts
+++ b/components/server/src/projects/projects-service.ts
@@ -144,7 +144,6 @@ export class ProjectsService {
             slug: uniqueSlug,
             cloneUrl,
             ...(!!userId ? { userId } : { teamId }),
-            appInstallationId,
         });
         await this.projectDB.storeProject(project);
         await this.onDidCreateProject(project, installer);


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

I haven't been able to track down any usage of this that would cause issues for Gitpod.

For now, the appInstallationId is set to the empty string. If we continue to observe no issues, it will be removed entirely from the codebase.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
Creating Projects continues to work

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
