### PR TITLE
[JetBrains] Ensure prebuilt workspaces using Maven Wrapper are properly initialized in IntelliJ IDEA

### DIFF
--- a/components/ide/jetbrains/backend-plugin/gradle.properties
+++ b/components/ide/jetbrains/backend-plugin/gradle.properties
@@ -10,7 +10,7 @@ platformType=IU
 platformDownloadSources=true
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
-platformPlugins=Git4Idea, org.jetbrains.plugins.terminal, com.jetbrains.codeWithMe
+platformPlugins=Git4Idea, org.jetbrains.plugins.terminal, com.jetbrains.codeWithMe, org.jetbrains.idea.maven
 # Opt-out flag for bundling Kotlin standard library.
 # See https://plugins.jetbrains.com/docs/intellij/kotlin.html#kotlin-standard-library for details.
 kotlin.stdlib.default.dependency=false

--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/optional/GitpodForceUpdateMavenProjectsActivity.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/optional/GitpodForceUpdateMavenProjectsActivity.kt
@@ -1,0 +1,22 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package io.gitpod.jetbrains.remote.optional
+
+import com.intellij.openapi.diagnostic.thisLogger
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.startup.StartupActivity
+import org.jetbrains.idea.maven.project.MavenProjectsManager
+
+class GitpodForceUpdateMavenProjectsActivity : StartupActivity.RequiredForSmartMode {
+    override fun runActivity(project: Project) {
+        val mavenProjectManager = MavenProjectsManager.getInstance(project)
+
+        if (!mavenProjectManager.isMavenizedProject) return
+
+        mavenProjectManager.forceUpdateAllProjectsOrFindAllAvailablePomFiles()
+
+        thisLogger().warn("gitpod: Forced the update of Maven Project.")
+    }
+}

--- a/components/ide/jetbrains/backend-plugin/src/main/resources/META-INF/maven.xml
+++ b/components/ide/jetbrains/backend-plugin/src/main/resources/META-INF/maven.xml
@@ -1,0 +1,10 @@
+<!--
+ Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ Licensed under the GNU Affero General Public License (AGPL).
+ See License-AGPL.txt in the project root for license information.
+-->
+<idea-plugin>
+    <extensions defaultExtensionNs="com.intellij">
+        <backgroundPostStartupActivity implementation="io.gitpod.jetbrains.remote.optional.GitpodForceUpdateMavenProjectsActivity"/>
+    </extensions>
+</idea-plugin>

--- a/components/ide/jetbrains/backend-plugin/src/main/resources/META-INF/plugin.xml
+++ b/components/ide/jetbrains/backend-plugin/src/main/resources/META-INF/plugin.xml
@@ -12,10 +12,10 @@
     <vendor>Gitpod</vendor>
     <description>Provides integrations within a Gitpod workspace.</description>
 
-
     <!-- Product and plugin compatibility requirements -->
     <!-- https://plugins.jetbrains.com/docs/intellij/plugin-compatibility.html -->
     <depends>com.intellij.modules.platform</depends>
+    <depends optional="true" config-file="maven.xml">org.jetbrains.idea.maven</depends>
     <dependencies>
         <plugin id="Git4Idea"/>
         <plugin id="org.jetbrains.plugins.terminal"/>


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Currently, repositories using Maven Wrapper may fail to be loaded as a Maven Project if they are prebuilt with some specific file combination and then opened in JetBrains IntelliJ IDEA in Gitpod.

In summary:
- When you use a prebuild of a repository containing a `.xml` file inside `.idea` folder, it won't load the Maven Projects correctly.
  _You can see this behaviour by [selecting Stable IntelliJ IDEA](https://gitpod.io/preferences) and starting a workspace from [this URL](https://gitpod.io/#prebuild/https://github.com/gitpod-io/spring-petclinic/tree/felladrin/prebuilt-maven-project-without-iml-file)._
- There's no problem if the repository has no `.idea` folder.
  _You can see this behaviour by [selecting Stable IntelliJ IDEA](https://gitpod.io/preferences) and starting a workspace from [this URL](https://gitpod.io/#prebuild/https://github.com/gitpod-io/spring-petclinic/tree/felladrin/prebuilt-maven-project-without-idea-folder)._
- There's no problem if it has the files `.idea/misc.xml`, `.idea/modules.xml`, and `.idea/spring-petclinic.iml`.
  _You can see this behaviour by [selecting Stable IntelliJ IDEA](https://gitpod.io/preferences) and starting a workspace from [this URL](https://gitpod.io/#prebuild/https://github.com/gitpod-io/spring-petclinic/tree/e2abf7109a5a828b614717d634243454281ace8d)._
- There's no problem if the workspace hasn't been prebuilt.

This PR reinitializes the Maven Project Manager after the IDE is loaded, so it overcomes the issue of Maven Project not being detected when JetBrains Client connects.

References:
- [IntelliJ Platform Plugin SDK > Optional Plugin Dependencies](https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html#optional-plugin-dependencies)
- [IntelliJ Platform Plugin SDK > Plugin Components > Project Open](https://plugins.jetbrains.com/docs/intellij/plugin-components.html#project-open)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
- Fixes https://github.com/gitpod-io/gitpod/issues/10185
- Fixes https://github.com/gitpod-io/gitpod/issues/13100
- https://github.com/gitpod-io/gitpod/issues/6740
- https://github.com/gitpod-io/gitpod/issues/10578
- [YouTrack: ProjectService not being loaded inside an optional import](https://youtrack.jetbrains.com/issue/IDEA-255610)

## How to test
<!-- Provide steps to test this PR -->
1. Open the preview environment of this PR: https://ak-init-maven.preview.gitpod-dev.com/
2. Select _IntelliJ IDEA_ as your editor. It works for both Stable and EAP versions.
3. Access the following URL to start the prebuild of a workspace using Maven Wrapper and not containing .idea folder: https://ak-init-maven.preview.gitpod-dev.com/#prebuild/https://github.com/gitpod-io/spring-petclinic/tree/felladrin/prebuilt-maven-project-without-iml-file
4. Wait for the prebuild to finish and the workspace to start.
5. Confirm if the IDE opens and the Sync of Maven Modules start automatically:
    <img width="1431" alt="image" src="https://user-images.githubusercontent.com/418083/201870697-9859aef1-85a0-4cab-a974-c446bd086cea.png">
6. Confirm if Run Configurations works appropriately by clicking the Play / Debug icons:
    | | |
    | --- | --- |
    | <img width="448" alt="image" src="https://user-images.githubusercontent.com/418083/201881214-6a28847c-fd46-4f31-ab4d-1ce9b5047474.png"> | <img width="692" alt="image" src="https://user-images.githubusercontent.com/418083/201881233-fa56123c-f295-4e8d-a934-475f4ad28716.png"> |

### (Optional) Extra tests you can run on this Preview Environment

- Try a non-prebuilt workspace containing Maven Wrapper.
- Try another IDE (e.g. PyCharm) to confirm this addition isn't affecting the IDE to load.
- Try the [empty repository](https://github.com/gitpod-io/empty).

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[JetBrains] Fixed an issue preventing prebuilt workspaces using Maven Wrapper from properly initializing in IntelliJ IDEA.
```

## Post-merge actions

- [ ] Delete files `.idea/modules.xml` and `.idea/spring-petclinic.iml` from https://github.com/Gitpod-Samples/spring-petclinic
- [ ] Delete branches `felladrin/prebuilt-maven-project-without-idea-folder` and `felladrin/prebuilt-maven-project-without-iml-file` from https://github.com/Gitpod-Samples/spring-petclinic

## Werft options:

- [x] /werft with-preview
- [x] /werft with-large-vm
