### PR TITLE
[dashboard] usage in avatar menu

### DIFF
--- a/components/dashboard/src/Menu.tsx
+++ b/components/dashboard/src/Menu.tsx
@@ -42,6 +42,7 @@ export default function Menu() {
     const team = getCurrentTeam(location, teams);
     const { setCurrency, setIsStudent, setIsChargebeeCustomer } = useContext(PaymentContext);
     const [teamBillingMode, setTeamBillingMode] = useState<BillingMode | undefined>(undefined);
+    const [userBillingMode, setUserBillingMode] = useState<BillingMode | undefined>(undefined);
     const { project, setProject } = useContext(ProjectContext);
     const [isFeedbackFormVisible, setFeedbackFormVisible] = useState<boolean>(false);
 
@@ -51,6 +52,7 @@ export default function Menu() {
         getGitpodService()
             .server.getUserProjects()
             .then((projects) => setHasIndividualProjects(projects.length > 0));
+        getGitpodService().server.getBillingModeForUser().then(setUserBillingMode);
     }, []);
 
     const match = useRouteMatch<{ segment1?: string; segment2?: string; segment3?: string }>(
@@ -449,6 +451,14 @@ export default function Menu() {
                                         title: "Settings",
                                         link: "/settings",
                                     },
+                                    ...(BillingMode.showUsageBasedBilling(userBillingMode)
+                                        ? [
+                                              {
+                                                  title: "Usage",
+                                                  link: "/usage",
+                                              },
+                                          ]
+                                        : []),
                                     {
                                         title: "Docs",
                                         href: "https://www.gitpod.io/docs/",

--- a/components/dashboard/src/settings/settings-menu.ts
+++ b/components/dashboard/src/settings/settings-menu.ts
@@ -16,7 +16,6 @@ import {
     settingsPathTeams,
     settingsPathVariables,
     settingsPathSSHKeys,
-    settingsPathUsage,
 } from "./settings.routes";
 
 export default function getSettingsMenu(params: { userBillingMode?: BillingMode }) {
@@ -81,14 +80,6 @@ function renderBillingMenuEntries(billingMode?: BillingMode) {
                     title: "Billing",
                     link: [settingsPathBilling],
                 },
-                ...(BillingMode.showUsageBasedBilling(billingMode)
-                    ? [
-                          {
-                              title: "Usage",
-                              link: [settingsPathUsage],
-                          },
-                      ]
-                    : []),
                 // We need to allow access to "Team Plans" here, at least for owners.
                 ...(BillingMode.showTeamSubscriptionUI(billingMode)
                     ? [

--- a/components/dashboard/src/settings/settings.routes.ts
+++ b/components/dashboard/src/settings/settings.routes.ts
@@ -11,7 +11,6 @@ export const settingsPathAccount = "/account";
 export const settingsPathIntegrations = "/integrations";
 export const settingsPathNotifications = "/notifications";
 export const settingsPathBilling = "/billing";
-export const settingsPathUsage = "/usage";
 export const settingsPathPlans = "/plans";
 export const settingsPathPreferences = "/preferences";
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Moves personal `usage` action from settings to to avatar context menu:

<img width="549" alt="Screenshot 2022-11-14 at 12 04 56" src="https://user-images.githubusercontent.com/372735/201644706-2337b46c-171b-492d-91fb-48984cad9042.png">


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #14636

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-payment
- [x] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
