### PR TITLE
Create resources to monitor Pyrra

### DIFF
--- a/operations/observability/mixins/self-hosted/rules/pyrra/service.yaml
+++ b/operations/observability/mixins/self-hosted/rules/pyrra/service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: pyrra
+    port: metrics
+  name: pyrra-kubernetes-metrics
+  namespace: monitoring-central
+spec:
+  ports:
+  - name: metrics
+    port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app.kubernetes.io/component: kubernetes
+    app.kubernetes.io/name: pyrra
+    app.kubernetes.io/part-of: kube-prometheus
+  sessionAffinity: None
+  type: ClusterIP

--- a/operations/observability/mixins/self-hosted/rules/pyrra/servicemonitor.yaml
+++ b/operations/observability/mixins/self-hosted/rules/pyrra/servicemonitor.yaml
@@ -1,0 +1,15 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: pyrra
+spec:
+  jobLabel: 'app.kubernetes.io/name'
+  namespaceSelector:
+    matchNames:
+    - monitoring-central
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: pyrra
+      port: metrics
+  endpoints:
+  - port: metrics


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
We recently added an SLO for Pyrra itself, but we've noticed that [we're not collecting the necessary metrics yet](https://pyrra.gitpod.io/objectives?expr={__name__=%22pyrra-reconciliations%22,%20namespace=%22monitoring-central%22,%20team=%22delivery-operations-experience%22}&grouping={}&from=1668433035343&to=1668436635343) (Notice the `No data` in the dashboards). This PR creates the necessary resources to collect those metrics.


https://github.com/gitpod-io/ops/pull/6726 will deploy them into the monitoring-central cluster

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
You can manually deploy those resources to our monitoring-central cluster and notice that we'll start collecting metrics from Pyrra.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
