### PR TITLE
[usage] Deploy usage by default

### DIFF
--- a/dev/preview/workflow/preview/deploy-gitpod.sh
+++ b/dev/preview/workflow/preview/deploy-gitpod.sh
@@ -362,7 +362,6 @@ yq w -i "${INSTALLER_CONFIG_PATH}" sshGatewayHostKey.name "host-key"
 #
 # configureUsage
 #
-yq w -i "${INSTALLER_CONFIG_PATH}" experimental.webapp.usage.enabled "true"
 yq w -i "${INSTALLER_CONFIG_PATH}" experimental.webapp.usage.schedule "1m"
 yq w -i "${INSTALLER_CONFIG_PATH}" experimental.webapp.usage.billInstancesAfter "2022-08-11T08:05:32.499Z"
 yq w -i "${INSTALLER_CONFIG_PATH}" experimental.webapp.usage.defaultSpendingLimit.forUsers "500"

--- a/install/installer/cmd/testdata/render/aws-setup/output.golden
+++ b/install/installer/cmd/testdata/render/aws-setup/output.golden
@@ -361,6 +361,36 @@ spec:
     - Ingress
 
 ---
+# networking.k8s.io/v1/NetworkPolicy usage
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+  name: usage
+  namespace: default
+spec:
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              component: server
+        - podSelector:
+            matchLabels:
+              component: public-api-server
+      ports:
+        - port: 9001
+          protocol: TCP
+  podSelector:
+    matchLabels:
+      app: gitpod
+      component: usage
+  policyTypes:
+    - Ingress
+
+---
 # networking.k8s.io/v1/NetworkPolicy workspace-default
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -982,6 +1012,18 @@ metadata:
     app: gitpod
     component: server
   name: server
+  namespace: default
+---
+# v1/ServiceAccount usage
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+  name: usage
   namespace: default
 ---
 # v1/ServiceAccount workspace
@@ -2601,6 +2643,78 @@ data:
         app: gitpod
         component: public-api-server
       name: public-api-server
+      namespace: default
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      annotations:
+        gitpod.io/checksum_config: 2e5e440024a9f86e101eefce306c4888024c495f968ee92ee01e072aad7fa13e
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+      name: usage
+      namespace: default
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+      name: default-usage-rb-kube-rbac-proxy
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+      name: usage
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+      name: usage
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+      name: usage
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+        kind: service
+      name: usage
+      namespace: default
+    ---
+    apiVersion: networking.k8s.io/v1
+    kind: NetworkPolicy
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+      name: usage
       namespace: default
     ---
     apiVersion: v1
@@ -4950,6 +5064,48 @@ metadata:
   name: server-ide-config
   namespace: default
 ---
+# v1/ConfigMap usage
+apiVersion: v1
+data:
+  config.json: |-
+    {
+      "controllerSchedule": "15m0s",
+      "resetUsageSchedule": "15m0s",
+      "creditsPerMinuteByWorkspaceClass": {
+        "default": 0.1666666667
+      },
+      "server": {
+        "services": {
+          "grpc": {
+            "address": "0.0.0.0:9001"
+          }
+        }
+      },
+      "defaultSpendingLimit": {
+        "forTeams": 1000000000,
+        "forUsers": 1000000000,
+        "minForUsersOnStripe": 0
+      },
+      "stripePrices": {
+        "individualUsagePriceIds": {
+          "eur": "",
+          "usd": ""
+        },
+        "teamUsagePriceIds": {
+          "eur": "",
+          "usd": ""
+        }
+      }
+    }
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+  name: usage
+  namespace: default
+---
 # v1/ConfigMap workspace-templates
 apiVersion: v1
 kind: ConfigMap
@@ -5662,6 +5818,24 @@ subjects:
   name: server
   namespace: default
 ---
+# rbac.authorization.k8s.io/v1/ClusterRoleBinding default-usage-rb-kube-rbac-proxy
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+  name: default-usage-rb-kube-rbac-proxy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-kube-rbac-proxy
+subjects:
+- kind: ServiceAccount
+  name: usage
+  namespace: default
+---
 # rbac.authorization.k8s.io/v1/ClusterRoleBinding default-ws-daemon-rb
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -6332,6 +6506,24 @@ subjects:
 - kind: ServiceAccount
   name: server
 ---
+# rbac.authorization.k8s.io/v1/RoleBinding usage
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+  name: usage
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-ns-psp:restricted-root-user
+subjects:
+- kind: ServiceAccount
+  name: usage
+---
 # rbac.authorization.k8s.io/v1/RoleBinding workspace
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -6865,6 +7057,30 @@ spec:
   selector:
     app: gitpod
     component: server
+  type: ClusterIP
+status:
+  loadBalancer: {}
+---
+# v1/Service usage
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+    kind: service
+  name: usage
+  namespace: default
+spec:
+  ports:
+  - name: grpc
+    port: 9001
+    protocol: TCP
+    targetPort: 9001
+  selector:
+    app: gitpod
+    component: usage
   type: ClusterIP
 status:
   loadBalancer: {}
@@ -9360,6 +9576,191 @@ spec:
         secret:
           optional: true
           secretName: twilio-secret
+status: {}
+---
+# apps/v1/Deployment usage
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    gitpod.io/checksum_config: 2e5e440024a9f86e101eefce306c4888024c495f968ee92ee01e072aad7fa13e
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+  name: usage
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gitpod
+      component: usage
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+      name: usage
+      namespace: default
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: gitpod.io/workload_meta
+                operator: Exists
+      containers:
+      - args:
+        - run
+        - --config=/config.json
+        env:
+        - name: GITPOD_DOMAIN
+          value: gitpod.example.com
+        - name: GITPOD_INSTALLATION_SHORTNAME
+          value: default
+        - name: GITPOD_REGION
+          value: eu-west-2
+        - name: HOST_URL
+          value: https://gitpod.example.com
+        - name: KUBE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: KUBE_DOMAIN
+          value: svc.cluster.local
+        - name: LOG_LEVEL
+          value: info
+        - name: DB_HOST
+          valueFrom:
+            secretKeyRef:
+              key: host
+              name: aws-database
+        - name: DB_PORT
+          valueFrom:
+            secretKeyRef:
+              key: port
+              name: aws-database
+        - name: DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: aws-database
+        - name: DB_USERNAME
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: aws-database
+        - name: DB_ENCRYPTION_KEYS
+          valueFrom:
+            secretKeyRef:
+              key: encryptionKeys
+              name: aws-database
+        image: eu.gcr.io/gitpod-core-dev/build/usage:test
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /live
+            port: 9501
+            scheme: HTTP
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: usage
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /ready
+            port: 9501
+            scheme: HTTP
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          requests:
+            cpu: 100m
+            memory: 64Mi
+        securityContext:
+          privileged: false
+        volumeMounts:
+        - mountPath: /config.json
+          name: config
+          readOnly: true
+          subPath: config.json
+      - args:
+        - --logtostderr
+        - --insecure-listen-address=[$(IP)]:9500
+        - --upstream=http://127.0.0.1:9500/
+        env:
+        - name: IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay.io/brancz/kube-rbac-proxy:v0.12.0
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 9500
+          name: metrics
+        resources:
+          requests:
+            cpu: 1m
+            memory: 30Mi
+        securityContext:
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
+        terminationMessagePolicy: FallbackToLogsOnError
+      dnsPolicy: ClusterFirst
+      enableServiceLinks: false
+      initContainers:
+      - args:
+        - -v
+        - database
+        env:
+        - name: DB_HOST
+          valueFrom:
+            secretKeyRef:
+              key: host
+              name: aws-database
+        - name: DB_PORT
+          valueFrom:
+            secretKeyRef:
+              key: port
+              name: aws-database
+        - name: DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: aws-database
+        - name: DB_USERNAME
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: aws-database
+        - name: DB_ENCRYPTION_KEYS
+          valueFrom:
+            secretKeyRef:
+              key: encryptionKeys
+              name: aws-database
+        image: eu.gcr.io/gitpod-core-dev/build/service-waiter:test
+        name: database-waiter
+        resources: {}
+        securityContext:
+          privileged: false
+          runAsUser: 31001
+      restartPolicy: Always
+      serviceAccountName: usage
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - configMap:
+          name: usage
+        name: config
 status: {}
 ---
 # apps/v1/Deployment ws-manager

--- a/install/installer/cmd/testdata/render/azure-setup/output.golden
+++ b/install/installer/cmd/testdata/render/azure-setup/output.golden
@@ -361,6 +361,36 @@ spec:
     - Ingress
 
 ---
+# networking.k8s.io/v1/NetworkPolicy usage
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+  name: usage
+  namespace: default
+spec:
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              component: server
+        - podSelector:
+            matchLabels:
+              component: public-api-server
+      ports:
+        - port: 9001
+          protocol: TCP
+  podSelector:
+    matchLabels:
+      app: gitpod
+      component: usage
+  policyTypes:
+    - Ingress
+
+---
 # networking.k8s.io/v1/NetworkPolicy workspace-default
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -961,6 +991,18 @@ metadata:
     app: gitpod
     component: server
   name: server
+  namespace: default
+---
+# v1/ServiceAccount usage
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+  name: usage
   namespace: default
 ---
 # v1/ServiceAccount workspace
@@ -2518,6 +2560,78 @@ data:
         app: gitpod
         component: public-api-server
       name: public-api-server
+      namespace: default
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      annotations:
+        gitpod.io/checksum_config: 2e5e440024a9f86e101eefce306c4888024c495f968ee92ee01e072aad7fa13e
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+      name: usage
+      namespace: default
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+      name: default-usage-rb-kube-rbac-proxy
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+      name: usage
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+      name: usage
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+      name: usage
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+        kind: service
+      name: usage
+      namespace: default
+    ---
+    apiVersion: networking.k8s.io/v1
+    kind: NetworkPolicy
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+      name: usage
       namespace: default
     ---
     apiVersion: v1
@@ -4813,6 +4927,48 @@ metadata:
   name: server-ide-config
   namespace: default
 ---
+# v1/ConfigMap usage
+apiVersion: v1
+data:
+  config.json: |-
+    {
+      "controllerSchedule": "15m0s",
+      "resetUsageSchedule": "15m0s",
+      "creditsPerMinuteByWorkspaceClass": {
+        "default": 0.1666666667
+      },
+      "server": {
+        "services": {
+          "grpc": {
+            "address": "0.0.0.0:9001"
+          }
+        }
+      },
+      "defaultSpendingLimit": {
+        "forTeams": 1000000000,
+        "forUsers": 1000000000,
+        "minForUsersOnStripe": 0
+      },
+      "stripePrices": {
+        "individualUsagePriceIds": {
+          "eur": "",
+          "usd": ""
+        },
+        "teamUsagePriceIds": {
+          "eur": "",
+          "usd": ""
+        }
+      }
+    }
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+  name: usage
+  namespace: default
+---
 # v1/ConfigMap workspace-templates
 apiVersion: v1
 kind: ConfigMap
@@ -5521,6 +5677,24 @@ subjects:
   name: server
   namespace: default
 ---
+# rbac.authorization.k8s.io/v1/ClusterRoleBinding default-usage-rb-kube-rbac-proxy
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+  name: default-usage-rb-kube-rbac-proxy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-kube-rbac-proxy
+subjects:
+- kind: ServiceAccount
+  name: usage
+  namespace: default
+---
 # rbac.authorization.k8s.io/v1/ClusterRoleBinding default-ws-daemon-rb
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -6173,6 +6347,24 @@ subjects:
 - kind: ServiceAccount
   name: server
 ---
+# rbac.authorization.k8s.io/v1/RoleBinding usage
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+  name: usage
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-ns-psp:restricted-root-user
+subjects:
+- kind: ServiceAccount
+  name: usage
+---
 # rbac.authorization.k8s.io/v1/RoleBinding workspace
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -6710,6 +6902,30 @@ spec:
   selector:
     app: gitpod
     component: server
+  type: ClusterIP
+status:
+  loadBalancer: {}
+---
+# v1/Service usage
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+    kind: service
+  name: usage
+  namespace: default
+spec:
+  ports:
+  - name: grpc
+    port: 9001
+    protocol: TCP
+    targetPort: 9001
+  selector:
+    app: gitpod
+    component: usage
   type: ClusterIP
 status:
   loadBalancer: {}
@@ -9211,6 +9427,191 @@ spec:
         secret:
           optional: true
           secretName: twilio-secret
+status: {}
+---
+# apps/v1/Deployment usage
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    gitpod.io/checksum_config: 2e5e440024a9f86e101eefce306c4888024c495f968ee92ee01e072aad7fa13e
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+  name: usage
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gitpod
+      component: usage
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+      name: usage
+      namespace: default
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: gitpod.io/workload_meta
+                operator: Exists
+      containers:
+      - args:
+        - run
+        - --config=/config.json
+        env:
+        - name: GITPOD_DOMAIN
+          value: gitpod.example.com
+        - name: GITPOD_INSTALLATION_SHORTNAME
+          value: default
+        - name: GITPOD_REGION
+          value: uksouth
+        - name: HOST_URL
+          value: https://gitpod.example.com
+        - name: KUBE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: KUBE_DOMAIN
+          value: svc.cluster.local
+        - name: LOG_LEVEL
+          value: info
+        - name: DB_HOST
+          valueFrom:
+            secretKeyRef:
+              key: host
+              name: azure-database
+        - name: DB_PORT
+          valueFrom:
+            secretKeyRef:
+              key: port
+              name: azure-database
+        - name: DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: azure-database
+        - name: DB_USERNAME
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: azure-database
+        - name: DB_ENCRYPTION_KEYS
+          valueFrom:
+            secretKeyRef:
+              key: encryptionKeys
+              name: azure-database
+        image: eu.gcr.io/gitpod-core-dev/build/usage:test
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /live
+            port: 9501
+            scheme: HTTP
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: usage
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /ready
+            port: 9501
+            scheme: HTTP
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          requests:
+            cpu: 100m
+            memory: 64Mi
+        securityContext:
+          privileged: false
+        volumeMounts:
+        - mountPath: /config.json
+          name: config
+          readOnly: true
+          subPath: config.json
+      - args:
+        - --logtostderr
+        - --insecure-listen-address=[$(IP)]:9500
+        - --upstream=http://127.0.0.1:9500/
+        env:
+        - name: IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay.io/brancz/kube-rbac-proxy:v0.12.0
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 9500
+          name: metrics
+        resources:
+          requests:
+            cpu: 1m
+            memory: 30Mi
+        securityContext:
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
+        terminationMessagePolicy: FallbackToLogsOnError
+      dnsPolicy: ClusterFirst
+      enableServiceLinks: false
+      initContainers:
+      - args:
+        - -v
+        - database
+        env:
+        - name: DB_HOST
+          valueFrom:
+            secretKeyRef:
+              key: host
+              name: azure-database
+        - name: DB_PORT
+          valueFrom:
+            secretKeyRef:
+              key: port
+              name: azure-database
+        - name: DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: azure-database
+        - name: DB_USERNAME
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: azure-database
+        - name: DB_ENCRYPTION_KEYS
+          valueFrom:
+            secretKeyRef:
+              key: encryptionKeys
+              name: azure-database
+        image: eu.gcr.io/gitpod-core-dev/build/service-waiter:test
+        name: database-waiter
+        resources: {}
+        securityContext:
+          privileged: false
+          runAsUser: 31001
+      restartPolicy: Always
+      serviceAccountName: usage
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - configMap:
+          name: usage
+        name: config
 status: {}
 ---
 # apps/v1/Deployment ws-manager

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -361,6 +361,36 @@ spec:
     - Ingress
 
 ---
+# networking.k8s.io/v1/NetworkPolicy usage
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+  name: usage
+  namespace: default
+spec:
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              component: server
+        - podSelector:
+            matchLabels:
+              component: public-api-server
+      ports:
+        - port: 9001
+          protocol: TCP
+  podSelector:
+    matchLabels:
+      app: gitpod
+      component: usage
+  policyTypes:
+    - Ingress
+
+---
 # networking.k8s.io/v1/NetworkPolicy workspace-default
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -1088,6 +1118,23 @@ metadata:
     gitpod.io: hello
     hello: world
   name: server
+  namespace: default
+---
+# v1/ServiceAccount usage
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  annotations:
+    gitpod.io: hello
+    hello: world
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+    gitpod.io: hello
+    hello: world
+  name: usage
   namespace: default
 ---
 # v1/ServiceAccount workspace
@@ -3098,6 +3145,97 @@ data:
         app: gitpod
         component: public-api-server
       name: public-api-server
+      namespace: default
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      annotations:
+        gitpod.io: hello
+        gitpod.io/checksum_config: 59ca8e966956adc39d92abd7bde923298e98553020a90170a48d27dd551f9608
+        hello: world
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+        gitpod.io: hello
+        hello: world
+      name: usage
+      namespace: default
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+      name: default-usage-rb-kube-rbac-proxy
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+      name: usage
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      annotations:
+        gitpod.io: hello
+        hello: world
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+        gitpod.io: hello
+        hello: world
+      name: usage
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      annotations:
+        gitpod.io: hello
+        hello: world
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+        gitpod.io: hello
+        hello: world
+      name: usage
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      annotations:
+        gitpod.io: hello
+        hello: world
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+        gitpod.io: hello
+        hello: world
+        kind: service
+      name: usage
+      namespace: default
+    ---
+    apiVersion: networking.k8s.io/v1
+    kind: NetworkPolicy
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+      name: usage
       namespace: default
     ---
     apiVersion: v1
@@ -5799,6 +5937,53 @@ metadata:
   name: server-ide-config
   namespace: default
 ---
+# v1/ConfigMap usage
+apiVersion: v1
+data:
+  config.json: |-
+    {
+      "controllerSchedule": "15m0s",
+      "resetUsageSchedule": "15m0s",
+      "creditsPerMinuteByWorkspaceClass": {
+        "default": 0.1666666667
+      },
+      "server": {
+        "services": {
+          "grpc": {
+            "address": "0.0.0.0:9001"
+          }
+        }
+      },
+      "defaultSpendingLimit": {
+        "forTeams": 1000000000,
+        "forUsers": 1000000000,
+        "minForUsersOnStripe": 0
+      },
+      "stripePrices": {
+        "individualUsagePriceIds": {
+          "eur": "",
+          "usd": ""
+        },
+        "teamUsagePriceIds": {
+          "eur": "",
+          "usd": ""
+        }
+      }
+    }
+kind: ConfigMap
+metadata:
+  annotations:
+    gitpod.io: hello
+    hello: world
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+    gitpod.io: hello
+    hello: world
+  name: usage
+  namespace: default
+---
 # v1/ConfigMap workspace-templates
 apiVersion: v1
 kind: ConfigMap
@@ -6565,6 +6750,24 @@ subjects:
   name: server
   namespace: default
 ---
+# rbac.authorization.k8s.io/v1/ClusterRoleBinding default-usage-rb-kube-rbac-proxy
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+  name: default-usage-rb-kube-rbac-proxy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-kube-rbac-proxy
+subjects:
+- kind: ServiceAccount
+  name: usage
+  namespace: default
+---
 # rbac.authorization.k8s.io/v1/ClusterRoleBinding default-ws-daemon-rb
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -7234,6 +7437,24 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: server
+---
+# rbac.authorization.k8s.io/v1/RoleBinding usage
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+  name: usage
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-ns-psp:restricted-root-user
+subjects:
+- kind: ServiceAccount
+  name: usage
 ---
 # rbac.authorization.k8s.io/v1/RoleBinding workspace
 apiVersion: rbac.authorization.k8s.io/v1
@@ -7938,6 +8159,35 @@ spec:
   selector:
     app: gitpod
     component: server
+  type: ClusterIP
+status:
+  loadBalancer: {}
+---
+# v1/Service usage
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    gitpod.io: hello
+    hello: world
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+    gitpod.io: hello
+    hello: world
+    kind: service
+  name: usage
+  namespace: default
+spec:
+  ports:
+  - name: grpc
+    port: 9001
+    protocol: TCP
+    targetPort: 9001
+  selector:
+    app: gitpod
+    component: usage
   type: ClusterIP
 status:
   loadBalancer: {}
@@ -10825,6 +11075,200 @@ spec:
         secret:
           optional: true
           secretName: twilio-secret
+status: {}
+---
+# apps/v1/Deployment usage
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    gitpod.io: hello
+    gitpod.io/checksum_config: 59ca8e966956adc39d92abd7bde923298e98553020a90170a48d27dd551f9608
+    hello: world
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+    gitpod.io: hello
+    hello: world
+  name: usage
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gitpod
+      component: usage
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        gitpod.io: hello
+        hello: world
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+        gitpod.io: hello
+        hello: world
+      name: usage
+      namespace: default
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: gitpod.io/workload_meta
+                operator: Exists
+      containers:
+      - args:
+        - run
+        - --config=/config.json
+        env:
+        - name: GITPOD_DOMAIN
+          value: gitpod.example.com
+        - name: GITPOD_INSTALLATION_SHORTNAME
+          value: default
+        - name: GITPOD_REGION
+          value: local
+        - name: HOST_URL
+          value: https://gitpod.example.com
+        - name: KUBE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: KUBE_DOMAIN
+          value: svc.cluster.local
+        - name: LOG_LEVEL
+          value: info
+        - name: DB_HOST
+          valueFrom:
+            secretKeyRef:
+              key: host
+              name: mysql
+        - name: DB_PORT
+          valueFrom:
+            secretKeyRef:
+              key: port
+              name: mysql
+        - name: DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: mysql
+        - name: DB_USERNAME
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: mysql
+        - name: DB_ENCRYPTION_KEYS
+          valueFrom:
+            secretKeyRef:
+              key: encryptionKeys
+              name: mysql
+        image: eu.gcr.io/gitpod-core-dev/build/usage:test
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /live
+            port: 9501
+            scheme: HTTP
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: usage
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /ready
+            port: 9501
+            scheme: HTTP
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          requests:
+            cpu: 100m
+            memory: 64Mi
+        securityContext:
+          privileged: false
+        volumeMounts:
+        - mountPath: /config.json
+          name: config
+          readOnly: true
+          subPath: config.json
+      - args:
+        - --logtostderr
+        - --insecure-listen-address=[$(IP)]:9500
+        - --upstream=http://127.0.0.1:9500/
+        env:
+        - name: IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay.io/brancz/kube-rbac-proxy:v0.12.0
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 9500
+          name: metrics
+        resources:
+          requests:
+            cpu: 1m
+            memory: 30Mi
+        securityContext:
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
+        terminationMessagePolicy: FallbackToLogsOnError
+      dnsPolicy: ClusterFirst
+      enableServiceLinks: false
+      initContainers:
+      - args:
+        - -v
+        - database
+        env:
+        - name: DB_HOST
+          valueFrom:
+            secretKeyRef:
+              key: host
+              name: mysql
+        - name: DB_PORT
+          valueFrom:
+            secretKeyRef:
+              key: port
+              name: mysql
+        - name: DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: mysql
+        - name: DB_USERNAME
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: mysql
+        - name: DB_ENCRYPTION_KEYS
+          valueFrom:
+            secretKeyRef:
+              key: encryptionKeys
+              name: mysql
+        image: eu.gcr.io/gitpod-core-dev/build/service-waiter:test
+        name: database-waiter
+        resources: {}
+        securityContext:
+          privileged: false
+          runAsUser: 31001
+      restartPolicy: Always
+      serviceAccountName: usage
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - configMap:
+          name: usage
+        name: config
 status: {}
 ---
 # apps/v1/Deployment ws-manager

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -361,6 +361,36 @@ spec:
     - Ingress
 
 ---
+# networking.k8s.io/v1/NetworkPolicy usage
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+  name: usage
+  namespace: default
+spec:
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              component: server
+        - podSelector:
+            matchLabels:
+              component: public-api-server
+      ports:
+        - port: 9001
+          protocol: TCP
+  podSelector:
+    matchLabels:
+      app: gitpod
+      component: usage
+  policyTypes:
+    - Ingress
+
+---
 # networking.k8s.io/v1/NetworkPolicy workspace-default
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -961,6 +991,18 @@ metadata:
     app: gitpod
     component: server
   name: server
+  namespace: default
+---
+# v1/ServiceAccount usage
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+  name: usage
   namespace: default
 ---
 # v1/ServiceAccount workspace
@@ -2595,6 +2637,78 @@ data:
         app: gitpod
         component: public-api-server
       name: public-api-server
+      namespace: default
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      annotations:
+        gitpod.io/checksum_config: 2e5e440024a9f86e101eefce306c4888024c495f968ee92ee01e072aad7fa13e
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+      name: usage
+      namespace: default
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+      name: default-usage-rb-kube-rbac-proxy
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+      name: usage
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+      name: usage
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+      name: usage
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+        kind: service
+      name: usage
+      namespace: default
+    ---
+    apiVersion: networking.k8s.io/v1
+    kind: NetworkPolicy
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+      name: usage
       namespace: default
     ---
     apiVersion: v1
@@ -5000,6 +5114,48 @@ metadata:
   name: server-ide-config
   namespace: default
 ---
+# v1/ConfigMap usage
+apiVersion: v1
+data:
+  config.json: |-
+    {
+      "controllerSchedule": "15m0s",
+      "resetUsageSchedule": "15m0s",
+      "creditsPerMinuteByWorkspaceClass": {
+        "default": 0.1666666667
+      },
+      "server": {
+        "services": {
+          "grpc": {
+            "address": "0.0.0.0:9001"
+          }
+        }
+      },
+      "defaultSpendingLimit": {
+        "forTeams": 1000000000,
+        "forUsers": 1000000000,
+        "minForUsersOnStripe": 0
+      },
+      "stripePrices": {
+        "individualUsagePriceIds": {
+          "eur": "",
+          "usd": ""
+        },
+        "teamUsagePriceIds": {
+          "eur": "",
+          "usd": ""
+        }
+      }
+    }
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+  name: usage
+  namespace: default
+---
 # v1/ConfigMap workspace-templates
 apiVersion: v1
 kind: ConfigMap
@@ -5727,6 +5883,24 @@ subjects:
   name: server
   namespace: default
 ---
+# rbac.authorization.k8s.io/v1/ClusterRoleBinding default-usage-rb-kube-rbac-proxy
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+  name: default-usage-rb-kube-rbac-proxy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-kube-rbac-proxy
+subjects:
+- kind: ServiceAccount
+  name: usage
+  namespace: default
+---
 # rbac.authorization.k8s.io/v1/ClusterRoleBinding default-ws-daemon-rb
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -6379,6 +6553,24 @@ subjects:
 - kind: ServiceAccount
   name: server
 ---
+# rbac.authorization.k8s.io/v1/RoleBinding usage
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+  name: usage
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-ns-psp:restricted-root-user
+subjects:
+- kind: ServiceAccount
+  name: usage
+---
 # rbac.authorization.k8s.io/v1/RoleBinding workspace
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -6992,6 +7184,30 @@ spec:
   selector:
     app: gitpod
     component: server
+  type: ClusterIP
+status:
+  loadBalancer: {}
+---
+# v1/Service usage
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+    kind: service
+  name: usage
+  namespace: default
+spec:
+  ports:
+  - name: grpc
+    port: 9001
+    protocol: TCP
+    targetPort: 9001
+  selector:
+    app: gitpod
+    component: usage
   type: ClusterIP
 status:
   loadBalancer: {}
@@ -9637,6 +9853,191 @@ spec:
         secret:
           optional: true
           secretName: twilio-secret
+status: {}
+---
+# apps/v1/Deployment usage
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    gitpod.io/checksum_config: 2e5e440024a9f86e101eefce306c4888024c495f968ee92ee01e072aad7fa13e
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+  name: usage
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gitpod
+      component: usage
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+      name: usage
+      namespace: default
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: gitpod.io/workload_meta
+                operator: Exists
+      containers:
+      - args:
+        - run
+        - --config=/config.json
+        env:
+        - name: GITPOD_DOMAIN
+          value: gitpod.example.com
+        - name: GITPOD_INSTALLATION_SHORTNAME
+          value: default
+        - name: GITPOD_REGION
+          value: local
+        - name: HOST_URL
+          value: https://gitpod.example.com
+        - name: KUBE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: KUBE_DOMAIN
+          value: svc.cluster.local
+        - name: LOG_LEVEL
+          value: info
+        - name: DB_HOST
+          valueFrom:
+            secretKeyRef:
+              key: host
+              name: mysql
+        - name: DB_PORT
+          valueFrom:
+            secretKeyRef:
+              key: port
+              name: mysql
+        - name: DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: mysql
+        - name: DB_USERNAME
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: mysql
+        - name: DB_ENCRYPTION_KEYS
+          valueFrom:
+            secretKeyRef:
+              key: encryptionKeys
+              name: mysql
+        image: eu.gcr.io/gitpod-core-dev/build/usage:test
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /live
+            port: 9501
+            scheme: HTTP
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: usage
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /ready
+            port: 9501
+            scheme: HTTP
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          requests:
+            cpu: 100m
+            memory: 64Mi
+        securityContext:
+          privileged: false
+        volumeMounts:
+        - mountPath: /config.json
+          name: config
+          readOnly: true
+          subPath: config.json
+      - args:
+        - --logtostderr
+        - --insecure-listen-address=[$(IP)]:9500
+        - --upstream=http://127.0.0.1:9500/
+        env:
+        - name: IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay.io/brancz/kube-rbac-proxy:v0.12.0
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 9500
+          name: metrics
+        resources:
+          requests:
+            cpu: 1m
+            memory: 30Mi
+        securityContext:
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
+        terminationMessagePolicy: FallbackToLogsOnError
+      dnsPolicy: ClusterFirst
+      enableServiceLinks: false
+      initContainers:
+      - args:
+        - -v
+        - database
+        env:
+        - name: DB_HOST
+          valueFrom:
+            secretKeyRef:
+              key: host
+              name: mysql
+        - name: DB_PORT
+          valueFrom:
+            secretKeyRef:
+              key: port
+              name: mysql
+        - name: DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: mysql
+        - name: DB_USERNAME
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: mysql
+        - name: DB_ENCRYPTION_KEYS
+          valueFrom:
+            secretKeyRef:
+              key: encryptionKeys
+              name: mysql
+        image: eu.gcr.io/gitpod-core-dev/build/service-waiter:test
+        name: database-waiter
+        resources: {}
+        securityContext:
+          privileged: false
+          runAsUser: 31001
+      restartPolicy: Always
+      serviceAccountName: usage
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - configMap:
+          name: usage
+        name: config
 status: {}
 ---
 # apps/v1/Deployment ws-manager

--- a/install/installer/cmd/testdata/render/gcp-setup/output.golden
+++ b/install/installer/cmd/testdata/render/gcp-setup/output.golden
@@ -361,6 +361,36 @@ spec:
     - Ingress
 
 ---
+# networking.k8s.io/v1/NetworkPolicy usage
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+  name: usage
+  namespace: default
+spec:
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              component: server
+        - podSelector:
+            matchLabels:
+              component: public-api-server
+      ports:
+        - port: 9001
+          protocol: TCP
+  podSelector:
+    matchLabels:
+      app: gitpod
+      component: usage
+  policyTypes:
+    - Ingress
+
+---
 # networking.k8s.io/v1/NetworkPolicy workspace-default
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -957,6 +987,18 @@ metadata:
     app: gitpod
     component: server
   name: server
+  namespace: default
+---
+# v1/ServiceAccount usage
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+  name: usage
   namespace: default
 ---
 # v1/ServiceAccount workspace
@@ -2537,6 +2579,78 @@ data:
         app: gitpod
         component: public-api-server
       name: public-api-server
+      namespace: default
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      annotations:
+        gitpod.io/checksum_config: 2e5e440024a9f86e101eefce306c4888024c495f968ee92ee01e072aad7fa13e
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+      name: usage
+      namespace: default
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+      name: default-usage-rb-kube-rbac-proxy
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+      name: usage
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+      name: usage
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+      name: usage
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+        kind: service
+      name: usage
+      namespace: default
+    ---
+    apiVersion: networking.k8s.io/v1
+    kind: NetworkPolicy
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+      name: usage
       namespace: default
     ---
     apiVersion: v1
@@ -4774,6 +4888,48 @@ metadata:
   name: server-ide-config
   namespace: default
 ---
+# v1/ConfigMap usage
+apiVersion: v1
+data:
+  config.json: |-
+    {
+      "controllerSchedule": "15m0s",
+      "resetUsageSchedule": "15m0s",
+      "creditsPerMinuteByWorkspaceClass": {
+        "default": 0.1666666667
+      },
+      "server": {
+        "services": {
+          "grpc": {
+            "address": "0.0.0.0:9001"
+          }
+        }
+      },
+      "defaultSpendingLimit": {
+        "forTeams": 1000000000,
+        "forUsers": 1000000000,
+        "minForUsersOnStripe": 0
+      },
+      "stripePrices": {
+        "individualUsagePriceIds": {
+          "eur": "",
+          "usd": ""
+        },
+        "teamUsagePriceIds": {
+          "eur": "",
+          "usd": ""
+        }
+      }
+    }
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+  name: usage
+  namespace: default
+---
 # v1/ConfigMap workspace-templates
 apiVersion: v1
 kind: ConfigMap
@@ -5480,6 +5636,24 @@ subjects:
   name: server
   namespace: default
 ---
+# rbac.authorization.k8s.io/v1/ClusterRoleBinding default-usage-rb-kube-rbac-proxy
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+  name: default-usage-rb-kube-rbac-proxy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-kube-rbac-proxy
+subjects:
+- kind: ServiceAccount
+  name: usage
+  namespace: default
+---
 # rbac.authorization.k8s.io/v1/ClusterRoleBinding default-ws-daemon-rb
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -6150,6 +6324,24 @@ subjects:
 - kind: ServiceAccount
   name: server
 ---
+# rbac.authorization.k8s.io/v1/RoleBinding usage
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+  name: usage
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-ns-psp:restricted-root-user
+subjects:
+- kind: ServiceAccount
+  name: usage
+---
 # rbac.authorization.k8s.io/v1/RoleBinding workspace
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -6684,6 +6876,30 @@ spec:
   selector:
     app: gitpod
     component: server
+  type: ClusterIP
+status:
+  loadBalancer: {}
+---
+# v1/Service usage
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+    kind: service
+  name: usage
+  namespace: default
+spec:
+  ports:
+  - name: grpc
+    port: 9001
+    protocol: TCP
+    targetPort: 9001
+  selector:
+    app: gitpod
+    component: usage
   type: ClusterIP
 status:
   loadBalancer: {}
@@ -9128,6 +9344,179 @@ spec:
         secret:
           optional: true
           secretName: twilio-secret
+status: {}
+---
+# apps/v1/Deployment usage
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    gitpod.io/checksum_config: 2e5e440024a9f86e101eefce306c4888024c495f968ee92ee01e072aad7fa13e
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+  name: usage
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gitpod
+      component: usage
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+      name: usage
+      namespace: default
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: gitpod.io/workload_meta
+                operator: Exists
+      containers:
+      - args:
+        - run
+        - --config=/config.json
+        env:
+        - name: GITPOD_DOMAIN
+          value: gitpod.example.com
+        - name: GITPOD_INSTALLATION_SHORTNAME
+          value: default
+        - name: GITPOD_REGION
+          value: europe-west2
+        - name: HOST_URL
+          value: https://gitpod.example.com
+        - name: KUBE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: KUBE_DOMAIN
+          value: svc.cluster.local
+        - name: LOG_LEVEL
+          value: info
+        - name: DB_HOST
+          value: cloudsqlproxy
+        - name: DB_PORT
+          value: "3306"
+        - name: DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: gcp-database
+        - name: DB_USERNAME
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: gcp-database
+        - name: DB_ENCRYPTION_KEYS
+          valueFrom:
+            secretKeyRef:
+              key: encryptionKeys
+              name: gcp-database
+        image: eu.gcr.io/gitpod-core-dev/build/usage:test
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /live
+            port: 9501
+            scheme: HTTP
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: usage
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /ready
+            port: 9501
+            scheme: HTTP
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          requests:
+            cpu: 100m
+            memory: 64Mi
+        securityContext:
+          privileged: false
+        volumeMounts:
+        - mountPath: /config.json
+          name: config
+          readOnly: true
+          subPath: config.json
+      - args:
+        - --logtostderr
+        - --insecure-listen-address=[$(IP)]:9500
+        - --upstream=http://127.0.0.1:9500/
+        env:
+        - name: IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay.io/brancz/kube-rbac-proxy:v0.12.0
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 9500
+          name: metrics
+        resources:
+          requests:
+            cpu: 1m
+            memory: 30Mi
+        securityContext:
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
+        terminationMessagePolicy: FallbackToLogsOnError
+      dnsPolicy: ClusterFirst
+      enableServiceLinks: false
+      initContainers:
+      - args:
+        - -v
+        - database
+        env:
+        - name: DB_HOST
+          value: cloudsqlproxy
+        - name: DB_PORT
+          value: "3306"
+        - name: DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: gcp-database
+        - name: DB_USERNAME
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: gcp-database
+        - name: DB_ENCRYPTION_KEYS
+          valueFrom:
+            secretKeyRef:
+              key: encryptionKeys
+              name: gcp-database
+        image: eu.gcr.io/gitpod-core-dev/build/service-waiter:test
+        name: database-waiter
+        resources: {}
+        securityContext:
+          privileged: false
+          runAsUser: 31001
+      restartPolicy: Always
+      serviceAccountName: usage
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - configMap:
+          name: usage
+        name: config
 status: {}
 ---
 # apps/v1/Deployment ws-manager

--- a/install/installer/cmd/testdata/render/http-proxy/output.golden
+++ b/install/installer/cmd/testdata/render/http-proxy/output.golden
@@ -361,6 +361,36 @@ spec:
     - Ingress
 
 ---
+# networking.k8s.io/v1/NetworkPolicy usage
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+  name: usage
+  namespace: default
+spec:
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              component: server
+        - podSelector:
+            matchLabels:
+              component: public-api-server
+      ports:
+        - port: 9001
+          protocol: TCP
+  podSelector:
+    matchLabels:
+      app: gitpod
+      component: usage
+  policyTypes:
+    - Ingress
+
+---
 # networking.k8s.io/v1/NetworkPolicy workspace-default
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -998,6 +1028,18 @@ metadata:
     app: gitpod
     component: server
   name: server
+  namespace: default
+---
+# v1/ServiceAccount usage
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+  name: usage
   namespace: default
 ---
 # v1/ServiceAccount workspace
@@ -2704,6 +2746,78 @@ data:
         app: gitpod
         component: public-api-server
       name: public-api-server
+      namespace: default
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      annotations:
+        gitpod.io/checksum_config: 2e5e440024a9f86e101eefce306c4888024c495f968ee92ee01e072aad7fa13e
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+      name: usage
+      namespace: default
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+      name: default-usage-rb-kube-rbac-proxy
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+      name: usage
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+      name: usage
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+      name: usage
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+        kind: service
+      name: usage
+      namespace: default
+    ---
+    apiVersion: networking.k8s.io/v1
+    kind: NetworkPolicy
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+      name: usage
       namespace: default
     ---
     apiVersion: v1
@@ -5223,6 +5337,48 @@ metadata:
   name: server-ide-config
   namespace: default
 ---
+# v1/ConfigMap usage
+apiVersion: v1
+data:
+  config.json: |-
+    {
+      "controllerSchedule": "15m0s",
+      "resetUsageSchedule": "15m0s",
+      "creditsPerMinuteByWorkspaceClass": {
+        "default": 0.1666666667
+      },
+      "server": {
+        "services": {
+          "grpc": {
+            "address": "0.0.0.0:9001"
+          }
+        }
+      },
+      "defaultSpendingLimit": {
+        "forTeams": 1000000000,
+        "forUsers": 1000000000,
+        "minForUsersOnStripe": 0
+      },
+      "stripePrices": {
+        "individualUsagePriceIds": {
+          "eur": "",
+          "usd": ""
+        },
+        "teamUsagePriceIds": {
+          "eur": "",
+          "usd": ""
+        }
+      }
+    }
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+  name: usage
+  namespace: default
+---
 # v1/ConfigMap workspace-templates
 apiVersion: v1
 kind: ConfigMap
@@ -5969,6 +6125,24 @@ subjects:
   name: server
   namespace: default
 ---
+# rbac.authorization.k8s.io/v1/ClusterRoleBinding default-usage-rb-kube-rbac-proxy
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+  name: default-usage-rb-kube-rbac-proxy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-kube-rbac-proxy
+subjects:
+- kind: ServiceAccount
+  name: usage
+  namespace: default
+---
 # rbac.authorization.k8s.io/v1/ClusterRoleBinding default-ws-daemon-rb
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -6639,6 +6813,24 @@ subjects:
 - kind: ServiceAccount
   name: server
 ---
+# rbac.authorization.k8s.io/v1/RoleBinding usage
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+  name: usage
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-ns-psp:restricted-root-user
+subjects:
+- kind: ServiceAccount
+  name: usage
+---
 # rbac.authorization.k8s.io/v1/RoleBinding workspace
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -7275,6 +7467,30 @@ spec:
   selector:
     app: gitpod
     component: server
+  type: ClusterIP
+status:
+  loadBalancer: {}
+---
+# v1/Service usage
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+    kind: service
+  name: usage
+  namespace: default
+spec:
+  ports:
+  - name: grpc
+    port: 9001
+    protocol: TCP
+    targetPort: 9001
+  selector:
+    app: gitpod
+    component: usage
   type: ClusterIP
 status:
   loadBalancer: {}
@@ -11300,6 +11516,311 @@ spec:
         secret:
           optional: true
           secretName: twilio-secret
+status: {}
+---
+# apps/v1/Deployment usage
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    gitpod.io/checksum_config: 2e5e440024a9f86e101eefce306c4888024c495f968ee92ee01e072aad7fa13e
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+  name: usage
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gitpod
+      component: usage
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+      name: usage
+      namespace: default
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: gitpod.io/workload_meta
+                operator: Exists
+      containers:
+      - args:
+        - run
+        - --config=/config.json
+        env:
+        - name: GITPOD_DOMAIN
+          value: gitpod.example.com
+        - name: GITPOD_INSTALLATION_SHORTNAME
+          value: default
+        - name: GITPOD_REGION
+          value: local
+        - name: HOST_URL
+          value: https://gitpod.example.com
+        - name: KUBE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: KUBE_DOMAIN
+          value: svc.cluster.local
+        - name: LOG_LEVEL
+          value: info
+        - name: HTTP_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: httpProxy
+              name: http-proxy-settings
+              optional: true
+        - name: http_proxy
+          valueFrom:
+            secretKeyRef:
+              key: httpProxy
+              name: http-proxy-settings
+              optional: true
+        - name: HTTPS_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: httpsProxy
+              name: http-proxy-settings
+              optional: true
+        - name: https_proxy
+          valueFrom:
+            secretKeyRef:
+              key: httpsProxy
+              name: http-proxy-settings
+              optional: true
+        - name: CUSTOM_NO_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: noProxy
+              name: http-proxy-settings
+              optional: true
+        - name: custom_no_proxy
+          valueFrom:
+            secretKeyRef:
+              key: noProxy
+              name: http-proxy-settings
+              optional: true
+        - name: NO_PROXY
+          value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
+        - name: no_proxy
+          value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
+        - name: DB_HOST
+          valueFrom:
+            secretKeyRef:
+              key: host
+              name: mysql
+        - name: DB_PORT
+          valueFrom:
+            secretKeyRef:
+              key: port
+              name: mysql
+        - name: DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: mysql
+        - name: DB_USERNAME
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: mysql
+        - name: DB_ENCRYPTION_KEYS
+          valueFrom:
+            secretKeyRef:
+              key: encryptionKeys
+              name: mysql
+        image: eu.gcr.io/gitpod-core-dev/build/usage:test
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /live
+            port: 9501
+            scheme: HTTP
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: usage
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /ready
+            port: 9501
+            scheme: HTTP
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          requests:
+            cpu: 100m
+            memory: 64Mi
+        securityContext:
+          privileged: false
+        volumeMounts:
+        - mountPath: /config.json
+          name: config
+          readOnly: true
+          subPath: config.json
+      - args:
+        - --logtostderr
+        - --insecure-listen-address=[$(IP)]:9500
+        - --upstream=http://127.0.0.1:9500/
+        env:
+        - name: IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: HTTP_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: httpProxy
+              name: http-proxy-settings
+              optional: true
+        - name: http_proxy
+          valueFrom:
+            secretKeyRef:
+              key: httpProxy
+              name: http-proxy-settings
+              optional: true
+        - name: HTTPS_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: httpsProxy
+              name: http-proxy-settings
+              optional: true
+        - name: https_proxy
+          valueFrom:
+            secretKeyRef:
+              key: httpsProxy
+              name: http-proxy-settings
+              optional: true
+        - name: CUSTOM_NO_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: noProxy
+              name: http-proxy-settings
+              optional: true
+        - name: custom_no_proxy
+          valueFrom:
+            secretKeyRef:
+              key: noProxy
+              name: http-proxy-settings
+              optional: true
+        - name: NO_PROXY
+          value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
+        - name: no_proxy
+          value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
+        image: quay.io/brancz/kube-rbac-proxy:v0.12.0
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 9500
+          name: metrics
+        resources:
+          requests:
+            cpu: 1m
+            memory: 30Mi
+        securityContext:
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
+        terminationMessagePolicy: FallbackToLogsOnError
+      dnsPolicy: ClusterFirst
+      enableServiceLinks: false
+      initContainers:
+      - args:
+        - -v
+        - database
+        env:
+        - name: DB_HOST
+          valueFrom:
+            secretKeyRef:
+              key: host
+              name: mysql
+        - name: DB_PORT
+          valueFrom:
+            secretKeyRef:
+              key: port
+              name: mysql
+        - name: DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: mysql
+        - name: DB_USERNAME
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: mysql
+        - name: DB_ENCRYPTION_KEYS
+          valueFrom:
+            secretKeyRef:
+              key: encryptionKeys
+              name: mysql
+        - name: HTTP_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: httpProxy
+              name: http-proxy-settings
+              optional: true
+        - name: http_proxy
+          valueFrom:
+            secretKeyRef:
+              key: httpProxy
+              name: http-proxy-settings
+              optional: true
+        - name: HTTPS_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: httpsProxy
+              name: http-proxy-settings
+              optional: true
+        - name: https_proxy
+          valueFrom:
+            secretKeyRef:
+              key: httpsProxy
+              name: http-proxy-settings
+              optional: true
+        - name: CUSTOM_NO_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: noProxy
+              name: http-proxy-settings
+              optional: true
+        - name: custom_no_proxy
+          valueFrom:
+            secretKeyRef:
+              key: noProxy
+              name: http-proxy-settings
+              optional: true
+        - name: NO_PROXY
+          value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
+        - name: no_proxy
+          value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
+        image: eu.gcr.io/gitpod-core-dev/build/service-waiter:test
+        name: database-waiter
+        resources: {}
+        securityContext:
+          privileged: false
+          runAsUser: 31001
+      restartPolicy: Always
+      serviceAccountName: usage
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - configMap:
+          name: usage
+        name: config
 status: {}
 ---
 # apps/v1/Deployment ws-manager

--- a/install/installer/cmd/testdata/render/insecure-s3-setup/output.golden
+++ b/install/installer/cmd/testdata/render/insecure-s3-setup/output.golden
@@ -361,6 +361,36 @@ spec:
     - Ingress
 
 ---
+# networking.k8s.io/v1/NetworkPolicy usage
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+  name: usage
+  namespace: default
+spec:
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              component: server
+        - podSelector:
+            matchLabels:
+              component: public-api-server
+      ports:
+        - port: 9001
+          protocol: TCP
+  podSelector:
+    matchLabels:
+      app: gitpod
+      component: usage
+  policyTypes:
+    - Ingress
+
+---
 # networking.k8s.io/v1/NetworkPolicy workspace-default
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -982,6 +1012,18 @@ metadata:
     app: gitpod
     component: server
   name: server
+  namespace: default
+---
+# v1/ServiceAccount usage
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+  name: usage
   namespace: default
 ---
 # v1/ServiceAccount workspace
@@ -2675,6 +2717,78 @@ data:
         app: gitpod
         component: public-api-server
       name: public-api-server
+      namespace: default
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      annotations:
+        gitpod.io/checksum_config: 2e5e440024a9f86e101eefce306c4888024c495f968ee92ee01e072aad7fa13e
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+      name: usage
+      namespace: default
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+      name: default-usage-rb-kube-rbac-proxy
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+      name: usage
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+      name: usage
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+      name: usage
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+        kind: service
+      name: usage
+      namespace: default
+    ---
+    apiVersion: networking.k8s.io/v1
+    kind: NetworkPolicy
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+      name: usage
       namespace: default
     ---
     apiVersion: v1
@@ -5134,6 +5248,48 @@ metadata:
   name: server-ide-config
   namespace: default
 ---
+# v1/ConfigMap usage
+apiVersion: v1
+data:
+  config.json: |-
+    {
+      "controllerSchedule": "15m0s",
+      "resetUsageSchedule": "15m0s",
+      "creditsPerMinuteByWorkspaceClass": {
+        "default": 0.1666666667
+      },
+      "server": {
+        "services": {
+          "grpc": {
+            "address": "0.0.0.0:9001"
+          }
+        }
+      },
+      "defaultSpendingLimit": {
+        "forTeams": 1000000000,
+        "forUsers": 1000000000,
+        "minForUsersOnStripe": 0
+      },
+      "stripePrices": {
+        "individualUsagePriceIds": {
+          "eur": "",
+          "usd": ""
+        },
+        "teamUsagePriceIds": {
+          "eur": "",
+          "usd": ""
+        }
+      }
+    }
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+  name: usage
+  namespace: default
+---
 # v1/ConfigMap workspace-templates
 apiVersion: v1
 kind: ConfigMap
@@ -5863,6 +6019,24 @@ subjects:
   name: server
   namespace: default
 ---
+# rbac.authorization.k8s.io/v1/ClusterRoleBinding default-usage-rb-kube-rbac-proxy
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+  name: default-usage-rb-kube-rbac-proxy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-kube-rbac-proxy
+subjects:
+- kind: ServiceAccount
+  name: usage
+  namespace: default
+---
 # rbac.authorization.k8s.io/v1/ClusterRoleBinding default-ws-daemon-rb
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -6533,6 +6707,24 @@ subjects:
 - kind: ServiceAccount
   name: server
 ---
+# rbac.authorization.k8s.io/v1/RoleBinding usage
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+  name: usage
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-ns-psp:restricted-root-user
+subjects:
+- kind: ServiceAccount
+  name: usage
+---
 # rbac.authorization.k8s.io/v1/RoleBinding workspace
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -7142,6 +7334,30 @@ spec:
   selector:
     app: gitpod
     component: server
+  type: ClusterIP
+status:
+  loadBalancer: {}
+---
+# v1/Service usage
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+    kind: service
+  name: usage
+  namespace: default
+spec:
+  ports:
+  - name: grpc
+    port: 9001
+    protocol: TCP
+    targetPort: 9001
+  selector:
+    app: gitpod
+    component: usage
   type: ClusterIP
 status:
   loadBalancer: {}
@@ -9783,6 +9999,191 @@ spec:
         secret:
           optional: true
           secretName: twilio-secret
+status: {}
+---
+# apps/v1/Deployment usage
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    gitpod.io/checksum_config: 2e5e440024a9f86e101eefce306c4888024c495f968ee92ee01e072aad7fa13e
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+  name: usage
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gitpod
+      component: usage
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+      name: usage
+      namespace: default
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: gitpod.io/workload_meta
+                operator: Exists
+      containers:
+      - args:
+        - run
+        - --config=/config.json
+        env:
+        - name: GITPOD_DOMAIN
+          value: gitpod.example.com
+        - name: GITPOD_INSTALLATION_SHORTNAME
+          value: default
+        - name: GITPOD_REGION
+          value: local
+        - name: HOST_URL
+          value: https://gitpod.example.com
+        - name: KUBE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: KUBE_DOMAIN
+          value: svc.cluster.local
+        - name: LOG_LEVEL
+          value: info
+        - name: DB_HOST
+          valueFrom:
+            secretKeyRef:
+              key: host
+              name: mysql
+        - name: DB_PORT
+          valueFrom:
+            secretKeyRef:
+              key: port
+              name: mysql
+        - name: DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: mysql
+        - name: DB_USERNAME
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: mysql
+        - name: DB_ENCRYPTION_KEYS
+          valueFrom:
+            secretKeyRef:
+              key: encryptionKeys
+              name: mysql
+        image: eu.gcr.io/gitpod-core-dev/build/usage:test
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /live
+            port: 9501
+            scheme: HTTP
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: usage
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /ready
+            port: 9501
+            scheme: HTTP
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          requests:
+            cpu: 100m
+            memory: 64Mi
+        securityContext:
+          privileged: false
+        volumeMounts:
+        - mountPath: /config.json
+          name: config
+          readOnly: true
+          subPath: config.json
+      - args:
+        - --logtostderr
+        - --insecure-listen-address=[$(IP)]:9500
+        - --upstream=http://127.0.0.1:9500/
+        env:
+        - name: IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay.io/brancz/kube-rbac-proxy:v0.12.0
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 9500
+          name: metrics
+        resources:
+          requests:
+            cpu: 1m
+            memory: 30Mi
+        securityContext:
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
+        terminationMessagePolicy: FallbackToLogsOnError
+      dnsPolicy: ClusterFirst
+      enableServiceLinks: false
+      initContainers:
+      - args:
+        - -v
+        - database
+        env:
+        - name: DB_HOST
+          valueFrom:
+            secretKeyRef:
+              key: host
+              name: mysql
+        - name: DB_PORT
+          valueFrom:
+            secretKeyRef:
+              key: port
+              name: mysql
+        - name: DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: mysql
+        - name: DB_USERNAME
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: mysql
+        - name: DB_ENCRYPTION_KEYS
+          valueFrom:
+            secretKeyRef:
+              key: encryptionKeys
+              name: mysql
+        image: eu.gcr.io/gitpod-core-dev/build/service-waiter:test
+        name: database-waiter
+        resources: {}
+        securityContext:
+          privileged: false
+          runAsUser: 31001
+      restartPolicy: Always
+      serviceAccountName: usage
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - configMap:
+          name: usage
+        name: config
 status: {}
 ---
 # apps/v1/Deployment ws-manager

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -361,6 +361,36 @@ spec:
     - Ingress
 
 ---
+# networking.k8s.io/v1/NetworkPolicy usage
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+  name: usage
+  namespace: default
+spec:
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              component: server
+        - podSelector:
+            matchLabels:
+              component: public-api-server
+      ports:
+        - port: 9001
+          protocol: TCP
+  podSelector:
+    matchLabels:
+      app: gitpod
+      component: usage
+  policyTypes:
+    - Ingress
+
+---
 # networking.k8s.io/v1/NetworkPolicy workspace-default
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -998,6 +1028,18 @@ metadata:
     app: gitpod
     component: server
   name: server
+  namespace: default
+---
+# v1/ServiceAccount usage
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+  name: usage
   namespace: default
 ---
 # v1/ServiceAccount workspace
@@ -2701,6 +2743,78 @@ data:
         app: gitpod
         component: public-api-server
       name: public-api-server
+      namespace: default
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      annotations:
+        gitpod.io/checksum_config: 2e5e440024a9f86e101eefce306c4888024c495f968ee92ee01e072aad7fa13e
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+      name: usage
+      namespace: default
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+      name: default-usage-rb-kube-rbac-proxy
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+      name: usage
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+      name: usage
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+      name: usage
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+        kind: service
+      name: usage
+      namespace: default
+    ---
+    apiVersion: networking.k8s.io/v1
+    kind: NetworkPolicy
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+      name: usage
       namespace: default
     ---
     apiVersion: v1
@@ -5220,6 +5334,48 @@ metadata:
   name: server-ide-config
   namespace: default
 ---
+# v1/ConfigMap usage
+apiVersion: v1
+data:
+  config.json: |-
+    {
+      "controllerSchedule": "15m0s",
+      "resetUsageSchedule": "15m0s",
+      "creditsPerMinuteByWorkspaceClass": {
+        "default": 0.1666666667
+      },
+      "server": {
+        "services": {
+          "grpc": {
+            "address": "0.0.0.0:9001"
+          }
+        }
+      },
+      "defaultSpendingLimit": {
+        "forTeams": 1000000000,
+        "forUsers": 1000000000,
+        "minForUsersOnStripe": 0
+      },
+      "stripePrices": {
+        "individualUsagePriceIds": {
+          "eur": "",
+          "usd": ""
+        },
+        "teamUsagePriceIds": {
+          "eur": "",
+          "usd": ""
+        }
+      }
+    }
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+  name: usage
+  namespace: default
+---
 # v1/ConfigMap workspace-templates
 apiVersion: v1
 kind: ConfigMap
@@ -5966,6 +6122,24 @@ subjects:
   name: server
   namespace: default
 ---
+# rbac.authorization.k8s.io/v1/ClusterRoleBinding default-usage-rb-kube-rbac-proxy
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+  name: default-usage-rb-kube-rbac-proxy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-kube-rbac-proxy
+subjects:
+- kind: ServiceAccount
+  name: usage
+  namespace: default
+---
 # rbac.authorization.k8s.io/v1/ClusterRoleBinding default-ws-daemon-rb
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -6636,6 +6810,24 @@ subjects:
 - kind: ServiceAccount
   name: server
 ---
+# rbac.authorization.k8s.io/v1/RoleBinding usage
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+  name: usage
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-ns-psp:restricted-root-user
+subjects:
+- kind: ServiceAccount
+  name: usage
+---
 # rbac.authorization.k8s.io/v1/RoleBinding workspace
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -7272,6 +7464,30 @@ spec:
   selector:
     app: gitpod
     component: server
+  type: ClusterIP
+status:
+  loadBalancer: {}
+---
+# v1/Service usage
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+    kind: service
+  name: usage
+  namespace: default
+spec:
+  ports:
+  - name: grpc
+    port: 9001
+    protocol: TCP
+    targetPort: 9001
+  selector:
+    app: gitpod
+    component: usage
   type: ClusterIP
 status:
   loadBalancer: {}
@@ -10012,6 +10228,191 @@ spec:
         secret:
           optional: true
           secretName: twilio-secret
+status: {}
+---
+# apps/v1/Deployment usage
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    gitpod.io/checksum_config: 2e5e440024a9f86e101eefce306c4888024c495f968ee92ee01e072aad7fa13e
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+  name: usage
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gitpod
+      component: usage
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+      name: usage
+      namespace: default
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: gitpod.io/workload_meta
+                operator: Exists
+      containers:
+      - args:
+        - run
+        - --config=/config.json
+        env:
+        - name: GITPOD_DOMAIN
+          value: gitpod.example.com
+        - name: GITPOD_INSTALLATION_SHORTNAME
+          value: default
+        - name: GITPOD_REGION
+          value: local
+        - name: HOST_URL
+          value: https://gitpod.example.com
+        - name: KUBE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: KUBE_DOMAIN
+          value: svc.cluster.local
+        - name: LOG_LEVEL
+          value: info
+        - name: DB_HOST
+          valueFrom:
+            secretKeyRef:
+              key: host
+              name: mysql
+        - name: DB_PORT
+          valueFrom:
+            secretKeyRef:
+              key: port
+              name: mysql
+        - name: DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: mysql
+        - name: DB_USERNAME
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: mysql
+        - name: DB_ENCRYPTION_KEYS
+          valueFrom:
+            secretKeyRef:
+              key: encryptionKeys
+              name: mysql
+        image: eu.gcr.io/gitpod-core-dev/build/usage:test
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /live
+            port: 9501
+            scheme: HTTP
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: usage
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /ready
+            port: 9501
+            scheme: HTTP
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          requests:
+            cpu: 100m
+            memory: 64Mi
+        securityContext:
+          privileged: false
+        volumeMounts:
+        - mountPath: /config.json
+          name: config
+          readOnly: true
+          subPath: config.json
+      - args:
+        - --logtostderr
+        - --insecure-listen-address=[$(IP)]:9500
+        - --upstream=http://127.0.0.1:9500/
+        env:
+        - name: IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay.io/brancz/kube-rbac-proxy:v0.12.0
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 9500
+          name: metrics
+        resources:
+          requests:
+            cpu: 1m
+            memory: 30Mi
+        securityContext:
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
+        terminationMessagePolicy: FallbackToLogsOnError
+      dnsPolicy: ClusterFirst
+      enableServiceLinks: false
+      initContainers:
+      - args:
+        - -v
+        - database
+        env:
+        - name: DB_HOST
+          valueFrom:
+            secretKeyRef:
+              key: host
+              name: mysql
+        - name: DB_PORT
+          valueFrom:
+            secretKeyRef:
+              key: port
+              name: mysql
+        - name: DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: mysql
+        - name: DB_USERNAME
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: mysql
+        - name: DB_ENCRYPTION_KEYS
+          valueFrom:
+            secretKeyRef:
+              key: encryptionKeys
+              name: mysql
+        image: eu.gcr.io/gitpod-core-dev/build/service-waiter:test
+        name: database-waiter
+        resources: {}
+        securityContext:
+          privileged: false
+          runAsUser: 31001
+      restartPolicy: Always
+      serviceAccountName: usage
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - configMap:
+          name: usage
+        name: config
 status: {}
 ---
 # apps/v1/Deployment ws-manager

--- a/install/installer/cmd/testdata/render/shortname/output.golden
+++ b/install/installer/cmd/testdata/render/shortname/output.golden
@@ -361,6 +361,36 @@ spec:
     - Ingress
 
 ---
+# networking.k8s.io/v1/NetworkPolicy usage
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+  name: usage
+  namespace: default
+spec:
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              component: server
+        - podSelector:
+            matchLabels:
+              component: public-api-server
+      ports:
+        - port: 9001
+          protocol: TCP
+  podSelector:
+    matchLabels:
+      app: gitpod
+      component: usage
+  policyTypes:
+    - Ingress
+
+---
 # networking.k8s.io/v1/NetworkPolicy workspace-default
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -998,6 +1028,18 @@ metadata:
     app: gitpod
     component: server
   name: server
+  namespace: default
+---
+# v1/ServiceAccount usage
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+  name: usage
   namespace: default
 ---
 # v1/ServiceAccount workspace
@@ -2701,6 +2743,78 @@ data:
         app: gitpod
         component: public-api-server
       name: public-api-server
+      namespace: default
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      annotations:
+        gitpod.io/checksum_config: 2e5e440024a9f86e101eefce306c4888024c495f968ee92ee01e072aad7fa13e
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+      name: usage
+      namespace: default
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+      name: default-usage-rb-kube-rbac-proxy
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+      name: usage
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+      name: usage
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+      name: usage
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+        kind: service
+      name: usage
+      namespace: default
+    ---
+    apiVersion: networking.k8s.io/v1
+    kind: NetworkPolicy
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+      name: usage
       namespace: default
     ---
     apiVersion: v1
@@ -5220,6 +5334,48 @@ metadata:
   name: server-ide-config
   namespace: default
 ---
+# v1/ConfigMap usage
+apiVersion: v1
+data:
+  config.json: |-
+    {
+      "controllerSchedule": "15m0s",
+      "resetUsageSchedule": "15m0s",
+      "creditsPerMinuteByWorkspaceClass": {
+        "default": 0.1666666667
+      },
+      "server": {
+        "services": {
+          "grpc": {
+            "address": "0.0.0.0:9001"
+          }
+        }
+      },
+      "defaultSpendingLimit": {
+        "forTeams": 1000000000,
+        "forUsers": 1000000000,
+        "minForUsersOnStripe": 0
+      },
+      "stripePrices": {
+        "individualUsagePriceIds": {
+          "eur": "",
+          "usd": ""
+        },
+        "teamUsagePriceIds": {
+          "eur": "",
+          "usd": ""
+        }
+      }
+    }
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+  name: usage
+  namespace: default
+---
 # v1/ConfigMap workspace-templates
 apiVersion: v1
 kind: ConfigMap
@@ -5966,6 +6122,24 @@ subjects:
   name: server
   namespace: default
 ---
+# rbac.authorization.k8s.io/v1/ClusterRoleBinding default-usage-rb-kube-rbac-proxy
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+  name: default-usage-rb-kube-rbac-proxy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-kube-rbac-proxy
+subjects:
+- kind: ServiceAccount
+  name: usage
+  namespace: default
+---
 # rbac.authorization.k8s.io/v1/ClusterRoleBinding default-ws-daemon-rb
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -6636,6 +6810,24 @@ subjects:
 - kind: ServiceAccount
   name: server
 ---
+# rbac.authorization.k8s.io/v1/RoleBinding usage
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+  name: usage
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-ns-psp:restricted-root-user
+subjects:
+- kind: ServiceAccount
+  name: usage
+---
 # rbac.authorization.k8s.io/v1/RoleBinding workspace
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -7272,6 +7464,30 @@ spec:
   selector:
     app: gitpod
     component: server
+  type: ClusterIP
+status:
+  loadBalancer: {}
+---
+# v1/Service usage
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+    kind: service
+  name: usage
+  namespace: default
+spec:
+  ports:
+  - name: grpc
+    port: 9001
+    protocol: TCP
+    targetPort: 9001
+  selector:
+    app: gitpod
+    component: usage
   type: ClusterIP
 status:
   loadBalancer: {}
@@ -10012,6 +10228,191 @@ spec:
         secret:
           optional: true
           secretName: twilio-secret
+status: {}
+---
+# apps/v1/Deployment usage
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    gitpod.io/checksum_config: 2e5e440024a9f86e101eefce306c4888024c495f968ee92ee01e072aad7fa13e
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+  name: usage
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gitpod
+      component: usage
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+      name: usage
+      namespace: default
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: gitpod.io/workload_meta
+                operator: Exists
+      containers:
+      - args:
+        - run
+        - --config=/config.json
+        env:
+        - name: GITPOD_DOMAIN
+          value: gitpod.example.com
+        - name: GITPOD_INSTALLATION_SHORTNAME
+          value: dev
+        - name: GITPOD_REGION
+          value: local
+        - name: HOST_URL
+          value: https://gitpod.example.com
+        - name: KUBE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: KUBE_DOMAIN
+          value: svc.cluster.local
+        - name: LOG_LEVEL
+          value: info
+        - name: DB_HOST
+          valueFrom:
+            secretKeyRef:
+              key: host
+              name: mysql
+        - name: DB_PORT
+          valueFrom:
+            secretKeyRef:
+              key: port
+              name: mysql
+        - name: DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: mysql
+        - name: DB_USERNAME
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: mysql
+        - name: DB_ENCRYPTION_KEYS
+          valueFrom:
+            secretKeyRef:
+              key: encryptionKeys
+              name: mysql
+        image: eu.gcr.io/gitpod-core-dev/build/usage:test
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /live
+            port: 9501
+            scheme: HTTP
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: usage
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /ready
+            port: 9501
+            scheme: HTTP
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          requests:
+            cpu: 100m
+            memory: 64Mi
+        securityContext:
+          privileged: false
+        volumeMounts:
+        - mountPath: /config.json
+          name: config
+          readOnly: true
+          subPath: config.json
+      - args:
+        - --logtostderr
+        - --insecure-listen-address=[$(IP)]:9500
+        - --upstream=http://127.0.0.1:9500/
+        env:
+        - name: IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay.io/brancz/kube-rbac-proxy:v0.12.0
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 9500
+          name: metrics
+        resources:
+          requests:
+            cpu: 1m
+            memory: 30Mi
+        securityContext:
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
+        terminationMessagePolicy: FallbackToLogsOnError
+      dnsPolicy: ClusterFirst
+      enableServiceLinks: false
+      initContainers:
+      - args:
+        - -v
+        - database
+        env:
+        - name: DB_HOST
+          valueFrom:
+            secretKeyRef:
+              key: host
+              name: mysql
+        - name: DB_PORT
+          valueFrom:
+            secretKeyRef:
+              key: port
+              name: mysql
+        - name: DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: mysql
+        - name: DB_USERNAME
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: mysql
+        - name: DB_ENCRYPTION_KEYS
+          valueFrom:
+            secretKeyRef:
+              key: encryptionKeys
+              name: mysql
+        image: eu.gcr.io/gitpod-core-dev/build/service-waiter:test
+        name: database-waiter
+        resources: {}
+        securityContext:
+          privileged: false
+          runAsUser: 31001
+      restartPolicy: Always
+      serviceAccountName: usage
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - configMap:
+          name: usage
+        name: config
 status: {}
 ---
 # apps/v1/Deployment ws-manager

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -361,6 +361,36 @@ spec:
     - Ingress
 
 ---
+# networking.k8s.io/v1/NetworkPolicy usage
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+  name: usage
+  namespace: default
+spec:
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              component: server
+        - podSelector:
+            matchLabels:
+              component: public-api-server
+      ports:
+        - port: 9001
+          protocol: TCP
+  podSelector:
+    matchLabels:
+      app: gitpod
+      component: usage
+  policyTypes:
+    - Ingress
+
+---
 # networking.k8s.io/v1/NetworkPolicy workspace-default
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -998,6 +1028,18 @@ metadata:
     app: gitpod
     component: server
   name: server
+  namespace: default
+---
+# v1/ServiceAccount usage
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+  name: usage
   namespace: default
 ---
 # v1/ServiceAccount workspace
@@ -2713,6 +2755,78 @@ data:
         app: gitpod
         component: public-api-server
       name: public-api-server
+      namespace: default
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      annotations:
+        gitpod.io/checksum_config: 2e5e440024a9f86e101eefce306c4888024c495f968ee92ee01e072aad7fa13e
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+      name: usage
+      namespace: default
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+      name: default-usage-rb-kube-rbac-proxy
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+      name: usage
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+      name: usage
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+      name: usage
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+        kind: service
+      name: usage
+      namespace: default
+    ---
+    apiVersion: networking.k8s.io/v1
+    kind: NetworkPolicy
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+      name: usage
       namespace: default
     ---
     apiVersion: v1
@@ -5232,6 +5346,48 @@ metadata:
   name: server-ide-config
   namespace: default
 ---
+# v1/ConfigMap usage
+apiVersion: v1
+data:
+  config.json: |-
+    {
+      "controllerSchedule": "15m0s",
+      "resetUsageSchedule": "15m0s",
+      "creditsPerMinuteByWorkspaceClass": {
+        "default": 0.1666666667
+      },
+      "server": {
+        "services": {
+          "grpc": {
+            "address": "0.0.0.0:9001"
+          }
+        }
+      },
+      "defaultSpendingLimit": {
+        "forTeams": 1000000000,
+        "forUsers": 1000000000,
+        "minForUsersOnStripe": 0
+      },
+      "stripePrices": {
+        "individualUsagePriceIds": {
+          "eur": "",
+          "usd": ""
+        },
+        "teamUsagePriceIds": {
+          "eur": "",
+          "usd": ""
+        }
+      }
+    }
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+  name: usage
+  namespace: default
+---
 # v1/ConfigMap workspace-templates
 apiVersion: v1
 kind: ConfigMap
@@ -5978,6 +6134,24 @@ subjects:
   name: server
   namespace: default
 ---
+# rbac.authorization.k8s.io/v1/ClusterRoleBinding default-usage-rb-kube-rbac-proxy
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+  name: default-usage-rb-kube-rbac-proxy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-kube-rbac-proxy
+subjects:
+- kind: ServiceAccount
+  name: usage
+  namespace: default
+---
 # rbac.authorization.k8s.io/v1/ClusterRoleBinding default-ws-daemon-rb
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -6648,6 +6822,24 @@ subjects:
 - kind: ServiceAccount
   name: server
 ---
+# rbac.authorization.k8s.io/v1/RoleBinding usage
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+  name: usage
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-ns-psp:restricted-root-user
+subjects:
+- kind: ServiceAccount
+  name: usage
+---
 # rbac.authorization.k8s.io/v1/RoleBinding workspace
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -7284,6 +7476,30 @@ spec:
   selector:
     app: gitpod
     component: server
+  type: ClusterIP
+status:
+  loadBalancer: {}
+---
+# v1/Service usage
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+    kind: service
+  name: usage
+  namespace: default
+spec:
+  ports:
+  - name: grpc
+    port: 9001
+    protocol: TCP
+    targetPort: 9001
+  selector:
+    app: gitpod
+    component: usage
   type: ClusterIP
 status:
   loadBalancer: {}
@@ -10024,6 +10240,191 @@ spec:
         secret:
           optional: true
           secretName: twilio-secret
+status: {}
+---
+# apps/v1/Deployment usage
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    gitpod.io/checksum_config: 2e5e440024a9f86e101eefce306c4888024c495f968ee92ee01e072aad7fa13e
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+  name: usage
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gitpod
+      component: usage
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+      name: usage
+      namespace: default
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: gitpod.io/workload_meta
+                operator: Exists
+      containers:
+      - args:
+        - run
+        - --config=/config.json
+        env:
+        - name: GITPOD_DOMAIN
+          value: gitpod.example.com
+        - name: GITPOD_INSTALLATION_SHORTNAME
+          value: default
+        - name: GITPOD_REGION
+          value: local
+        - name: HOST_URL
+          value: https://gitpod.example.com
+        - name: KUBE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: KUBE_DOMAIN
+          value: svc.cluster.local
+        - name: LOG_LEVEL
+          value: info
+        - name: DB_HOST
+          valueFrom:
+            secretKeyRef:
+              key: host
+              name: mysql
+        - name: DB_PORT
+          valueFrom:
+            secretKeyRef:
+              key: port
+              name: mysql
+        - name: DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: mysql
+        - name: DB_USERNAME
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: mysql
+        - name: DB_ENCRYPTION_KEYS
+          valueFrom:
+            secretKeyRef:
+              key: encryptionKeys
+              name: mysql
+        image: eu.gcr.io/gitpod-core-dev/build/usage:test
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /live
+            port: 9501
+            scheme: HTTP
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: usage
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /ready
+            port: 9501
+            scheme: HTTP
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          requests:
+            cpu: 100m
+            memory: 64Mi
+        securityContext:
+          privileged: false
+        volumeMounts:
+        - mountPath: /config.json
+          name: config
+          readOnly: true
+          subPath: config.json
+      - args:
+        - --logtostderr
+        - --insecure-listen-address=[$(IP)]:9500
+        - --upstream=http://127.0.0.1:9500/
+        env:
+        - name: IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay.io/brancz/kube-rbac-proxy:v0.12.0
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 9500
+          name: metrics
+        resources:
+          requests:
+            cpu: 1m
+            memory: 30Mi
+        securityContext:
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
+        terminationMessagePolicy: FallbackToLogsOnError
+      dnsPolicy: ClusterFirst
+      enableServiceLinks: false
+      initContainers:
+      - args:
+        - -v
+        - database
+        env:
+        - name: DB_HOST
+          valueFrom:
+            secretKeyRef:
+              key: host
+              name: mysql
+        - name: DB_PORT
+          valueFrom:
+            secretKeyRef:
+              key: port
+              name: mysql
+        - name: DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: mysql
+        - name: DB_USERNAME
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: mysql
+        - name: DB_ENCRYPTION_KEYS
+          valueFrom:
+            secretKeyRef:
+              key: encryptionKeys
+              name: mysql
+        image: eu.gcr.io/gitpod-core-dev/build/service-waiter:test
+        name: database-waiter
+        resources: {}
+        securityContext:
+          privileged: false
+          runAsUser: 31001
+      restartPolicy: Always
+      serviceAccountName: usage
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - configMap:
+          name: usage
+        name: config
 status: {}
 ---
 # apps/v1/Deployment ws-manager

--- a/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
+++ b/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
@@ -361,6 +361,36 @@ spec:
     - Ingress
 
 ---
+# networking.k8s.io/v1/NetworkPolicy usage
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+  name: usage
+  namespace: default
+spec:
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              component: server
+        - podSelector:
+            matchLabels:
+              component: public-api-server
+      ports:
+        - port: 9001
+          protocol: TCP
+  podSelector:
+    matchLabels:
+      app: gitpod
+      component: usage
+  policyTypes:
+    - Ingress
+
+---
 # networking.k8s.io/v1/NetworkPolicy workspace-default
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -1220,6 +1250,18 @@ metadata:
     app: gitpod
     component: server
   name: server
+  namespace: default
+---
+# v1/ServiceAccount usage
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+  name: usage
   namespace: default
 ---
 # v1/ServiceAccount workspace
@@ -2989,6 +3031,78 @@ data:
         app: gitpod
         component: public-api-server
       name: public-api-server
+      namespace: default
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      annotations:
+        gitpod.io/checksum_config: 2e5e440024a9f86e101eefce306c4888024c495f968ee92ee01e072aad7fa13e
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+      name: usage
+      namespace: default
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+      name: default-usage-rb-kube-rbac-proxy
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+      name: usage
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+      name: usage
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+      name: usage
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+        kind: service
+      name: usage
+      namespace: default
+    ---
+    apiVersion: networking.k8s.io/v1
+    kind: NetworkPolicy
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+      name: usage
       namespace: default
     ---
     apiVersion: v1
@@ -5553,6 +5667,48 @@ metadata:
   name: server-ide-config
   namespace: default
 ---
+# v1/ConfigMap usage
+apiVersion: v1
+data:
+  config.json: |-
+    {
+      "controllerSchedule": "15m0s",
+      "resetUsageSchedule": "15m0s",
+      "creditsPerMinuteByWorkspaceClass": {
+        "default": 0.1666666667
+      },
+      "server": {
+        "services": {
+          "grpc": {
+            "address": "0.0.0.0:9001"
+          }
+        }
+      },
+      "defaultSpendingLimit": {
+        "forTeams": 1000000000,
+        "forUsers": 1000000000,
+        "minForUsersOnStripe": 0
+      },
+      "stripePrices": {
+        "individualUsagePriceIds": {
+          "eur": "",
+          "usd": ""
+        },
+        "teamUsagePriceIds": {
+          "eur": "",
+          "usd": ""
+        }
+      }
+    }
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+  name: usage
+  namespace: default
+---
 # v1/ConfigMap workspace-templates
 apiVersion: v1
 kind: ConfigMap
@@ -6382,6 +6538,24 @@ subjects:
   name: server
   namespace: default
 ---
+# rbac.authorization.k8s.io/v1/ClusterRoleBinding default-usage-rb-kube-rbac-proxy
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+  name: default-usage-rb-kube-rbac-proxy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-kube-rbac-proxy
+subjects:
+- kind: ServiceAccount
+  name: usage
+  namespace: default
+---
 # rbac.authorization.k8s.io/v1/ClusterRoleBinding default-ws-daemon-rb
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -7080,6 +7254,24 @@ subjects:
 - kind: ServiceAccount
   name: server
 ---
+# rbac.authorization.k8s.io/v1/RoleBinding usage
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+  name: usage
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-ns-psp:restricted-root-user
+subjects:
+- kind: ServiceAccount
+  name: usage
+---
 # rbac.authorization.k8s.io/v1/RoleBinding workspace
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -7716,6 +7908,30 @@ spec:
   selector:
     app: gitpod
     component: server
+  type: ClusterIP
+status:
+  loadBalancer: {}
+---
+# v1/Service usage
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+    kind: service
+  name: usage
+  namespace: default
+spec:
+  ports:
+  - name: grpc
+    port: 9001
+    protocol: TCP
+    targetPort: 9001
+  selector:
+    app: gitpod
+    component: usage
   type: ClusterIP
 status:
   loadBalancer: {}
@@ -10456,6 +10672,191 @@ spec:
         secret:
           optional: true
           secretName: twilio-secret
+status: {}
+---
+# apps/v1/Deployment usage
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    gitpod.io/checksum_config: 2e5e440024a9f86e101eefce306c4888024c495f968ee92ee01e072aad7fa13e
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+  name: usage
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gitpod
+      component: usage
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+      name: usage
+      namespace: default
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: gitpod.io/workload_meta
+                operator: Exists
+      containers:
+      - args:
+        - run
+        - --config=/config.json
+        env:
+        - name: GITPOD_DOMAIN
+          value: gitpod.example.com
+        - name: GITPOD_INSTALLATION_SHORTNAME
+          value: default
+        - name: GITPOD_REGION
+          value: local
+        - name: HOST_URL
+          value: https://gitpod.example.com
+        - name: KUBE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: KUBE_DOMAIN
+          value: svc.cluster.local
+        - name: LOG_LEVEL
+          value: info
+        - name: DB_HOST
+          valueFrom:
+            secretKeyRef:
+              key: host
+              name: mysql
+        - name: DB_PORT
+          valueFrom:
+            secretKeyRef:
+              key: port
+              name: mysql
+        - name: DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: mysql
+        - name: DB_USERNAME
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: mysql
+        - name: DB_ENCRYPTION_KEYS
+          valueFrom:
+            secretKeyRef:
+              key: encryptionKeys
+              name: mysql
+        image: eu.gcr.io/gitpod-core-dev/build/usage:test
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /live
+            port: 9501
+            scheme: HTTP
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: usage
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /ready
+            port: 9501
+            scheme: HTTP
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          requests:
+            cpu: 100m
+            memory: 64Mi
+        securityContext:
+          privileged: false
+        volumeMounts:
+        - mountPath: /config.json
+          name: config
+          readOnly: true
+          subPath: config.json
+      - args:
+        - --logtostderr
+        - --insecure-listen-address=[$(IP)]:9500
+        - --upstream=http://127.0.0.1:9500/
+        env:
+        - name: IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay.io/brancz/kube-rbac-proxy:v0.12.0
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 9500
+          name: metrics
+        resources:
+          requests:
+            cpu: 1m
+            memory: 30Mi
+        securityContext:
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
+        terminationMessagePolicy: FallbackToLogsOnError
+      dnsPolicy: ClusterFirst
+      enableServiceLinks: false
+      initContainers:
+      - args:
+        - -v
+        - database
+        env:
+        - name: DB_HOST
+          valueFrom:
+            secretKeyRef:
+              key: host
+              name: mysql
+        - name: DB_PORT
+          valueFrom:
+            secretKeyRef:
+              key: port
+              name: mysql
+        - name: DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: mysql
+        - name: DB_USERNAME
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: mysql
+        - name: DB_ENCRYPTION_KEYS
+          valueFrom:
+            secretKeyRef:
+              key: encryptionKeys
+              name: mysql
+        image: eu.gcr.io/gitpod-core-dev/build/service-waiter:test
+        name: database-waiter
+        resources: {}
+        securityContext:
+          privileged: false
+          runAsUser: 31001
+      restartPolicy: Always
+      serviceAccountName: usage
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - configMap:
+          name: usage
+        name: config
 status: {}
 ---
 # apps/v1/Deployment ws-manager

--- a/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
+++ b/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
@@ -361,6 +361,36 @@ spec:
     - Ingress
 
 ---
+# networking.k8s.io/v1/NetworkPolicy usage
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+  name: usage
+  namespace: default
+spec:
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              component: server
+        - podSelector:
+            matchLabels:
+              component: public-api-server
+      ports:
+        - port: 9001
+          protocol: TCP
+  podSelector:
+    matchLabels:
+      app: gitpod
+      component: usage
+  policyTypes:
+    - Ingress
+
+---
 # networking.k8s.io/v1/NetworkPolicy workspace-default
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -998,6 +1028,18 @@ metadata:
     app: gitpod
     component: server
   name: server
+  namespace: default
+---
+# v1/ServiceAccount usage
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+  name: usage
   namespace: default
 ---
 # v1/ServiceAccount workspace
@@ -2704,6 +2746,78 @@ data:
         app: gitpod
         component: public-api-server
       name: public-api-server
+      namespace: default
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      annotations:
+        gitpod.io/checksum_config: 2e5e440024a9f86e101eefce306c4888024c495f968ee92ee01e072aad7fa13e
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+      name: usage
+      namespace: default
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+      name: default-usage-rb-kube-rbac-proxy
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+      name: usage
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+      name: usage
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+      name: usage
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+        kind: service
+      name: usage
+      namespace: default
+    ---
+    apiVersion: networking.k8s.io/v1
+    kind: NetworkPolicy
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+      name: usage
       namespace: default
     ---
     apiVersion: v1
@@ -5223,6 +5337,48 @@ metadata:
   name: server-ide-config
   namespace: default
 ---
+# v1/ConfigMap usage
+apiVersion: v1
+data:
+  config.json: |-
+    {
+      "controllerSchedule": "15m0s",
+      "resetUsageSchedule": "15m0s",
+      "creditsPerMinuteByWorkspaceClass": {
+        "default": 0.1666666667
+      },
+      "server": {
+        "services": {
+          "grpc": {
+            "address": "0.0.0.0:9001"
+          }
+        }
+      },
+      "defaultSpendingLimit": {
+        "forTeams": 1000000000,
+        "forUsers": 1000000000,
+        "minForUsersOnStripe": 0
+      },
+      "stripePrices": {
+        "individualUsagePriceIds": {
+          "eur": "",
+          "usd": ""
+        },
+        "teamUsagePriceIds": {
+          "eur": "",
+          "usd": ""
+        }
+      }
+    }
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+  name: usage
+  namespace: default
+---
 # v1/ConfigMap workspace-templates
 apiVersion: v1
 kind: ConfigMap
@@ -5969,6 +6125,24 @@ subjects:
   name: server
   namespace: default
 ---
+# rbac.authorization.k8s.io/v1/ClusterRoleBinding default-usage-rb-kube-rbac-proxy
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+  name: default-usage-rb-kube-rbac-proxy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-kube-rbac-proxy
+subjects:
+- kind: ServiceAccount
+  name: usage
+  namespace: default
+---
 # rbac.authorization.k8s.io/v1/ClusterRoleBinding default-ws-daemon-rb
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -6639,6 +6813,24 @@ subjects:
 - kind: ServiceAccount
   name: server
 ---
+# rbac.authorization.k8s.io/v1/RoleBinding usage
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+  name: usage
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-ns-psp:restricted-root-user
+subjects:
+- kind: ServiceAccount
+  name: usage
+---
 # rbac.authorization.k8s.io/v1/RoleBinding workspace
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -7275,6 +7467,30 @@ spec:
   selector:
     app: gitpod
     component: server
+  type: ClusterIP
+status:
+  loadBalancer: {}
+---
+# v1/Service usage
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+    kind: service
+  name: usage
+  namespace: default
+spec:
+  ports:
+  - name: grpc
+    port: 9001
+    protocol: TCP
+    targetPort: 9001
+  selector:
+    app: gitpod
+    component: usage
   type: ClusterIP
 status:
   loadBalancer: {}
@@ -10015,6 +10231,191 @@ spec:
         secret:
           optional: true
           secretName: twilio-secret
+status: {}
+---
+# apps/v1/Deployment usage
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    gitpod.io/checksum_config: 2e5e440024a9f86e101eefce306c4888024c495f968ee92ee01e072aad7fa13e
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: usage
+  name: usage
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gitpod
+      component: usage
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: usage
+      name: usage
+      namespace: default
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: gitpod.io/workload_meta
+                operator: Exists
+      containers:
+      - args:
+        - run
+        - --config=/config.json
+        env:
+        - name: GITPOD_DOMAIN
+          value: gitpod.example.com
+        - name: GITPOD_INSTALLATION_SHORTNAME
+          value: default
+        - name: GITPOD_REGION
+          value: local
+        - name: HOST_URL
+          value: https://gitpod.example.com
+        - name: KUBE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: KUBE_DOMAIN
+          value: svc.cluster.local
+        - name: LOG_LEVEL
+          value: info
+        - name: DB_HOST
+          valueFrom:
+            secretKeyRef:
+              key: host
+              name: mysql
+        - name: DB_PORT
+          valueFrom:
+            secretKeyRef:
+              key: port
+              name: mysql
+        - name: DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: mysql
+        - name: DB_USERNAME
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: mysql
+        - name: DB_ENCRYPTION_KEYS
+          valueFrom:
+            secretKeyRef:
+              key: encryptionKeys
+              name: mysql
+        image: eu.gcr.io/gitpod-core-dev/build/usage:test
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /live
+            port: 9501
+            scheme: HTTP
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: usage
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /ready
+            port: 9501
+            scheme: HTTP
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          requests:
+            cpu: 100m
+            memory: 64Mi
+        securityContext:
+          privileged: false
+        volumeMounts:
+        - mountPath: /config.json
+          name: config
+          readOnly: true
+          subPath: config.json
+      - args:
+        - --logtostderr
+        - --insecure-listen-address=[$(IP)]:9500
+        - --upstream=http://127.0.0.1:9500/
+        env:
+        - name: IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: quay.io/brancz/kube-rbac-proxy:v0.12.0
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 9500
+          name: metrics
+        resources:
+          requests:
+            cpu: 1m
+            memory: 30Mi
+        securityContext:
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
+        terminationMessagePolicy: FallbackToLogsOnError
+      dnsPolicy: ClusterFirst
+      enableServiceLinks: false
+      initContainers:
+      - args:
+        - -v
+        - database
+        env:
+        - name: DB_HOST
+          valueFrom:
+            secretKeyRef:
+              key: host
+              name: mysql
+        - name: DB_PORT
+          valueFrom:
+            secretKeyRef:
+              key: port
+              name: mysql
+        - name: DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: mysql
+        - name: DB_USERNAME
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: mysql
+        - name: DB_ENCRYPTION_KEYS
+          valueFrom:
+            secretKeyRef:
+              key: encryptionKeys
+              name: mysql
+        image: eu.gcr.io/gitpod-core-dev/build/service-waiter:test
+        name: database-waiter
+        resources: {}
+        securityContext:
+          privileged: false
+          runAsUser: 31001
+      restartPolicy: Always
+      serviceAccountName: usage
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - configMap:
+          name: usage
+        name: config
 status: {}
 ---
 # apps/v1/Deployment ws-manager

--- a/install/installer/pkg/components/usage/configmap.go
+++ b/install/installer/pkg/components/usage/configmap.go
@@ -21,7 +21,7 @@ import (
 
 func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 	cfg := server.Config{
-		LedgerSchedule:     "", // By default controller is disabled
+		LedgerSchedule:     time.Duration(15 * time.Minute).String(),
 		ResetUsageSchedule: time.Duration(15 * time.Minute).String(),
 		Server: &baseserver.Configuration{
 			Services: baseserver.ServicesConfiguration{
@@ -35,6 +35,12 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 			ForTeams:            1_000_000_000,
 			ForUsers:            1_000_000_000,
 			MinForUsersOnStripe: 0,
+		},
+
+		// This is the default configuration, used in self-hosted installs.
+		// For SaaS, we explicitly configure it based on workspace classes below.
+		CreditsPerMinuteByWorkspaceClass: map[string]float64{
+			"default": 0.1666666667,
 		},
 	}
 
@@ -55,22 +61,23 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 	expUsageConfig := getExperimentalUsageConfig(ctx)
 
 	if expUsageConfig != nil {
-		if expUsageConfig.Schedule != "" {
-			cfg.LedgerSchedule = expUsageConfig.Schedule
-		}
+		cfg.LedgerSchedule = expUsageConfig.Schedule
 		cfg.ResetUsageSchedule = expUsageConfig.ResetUsageSchedule
+
 		if expUsageConfig.DefaultSpendingLimit != nil {
 			cfg.DefaultSpendingLimit = *expUsageConfig.DefaultSpendingLimit
 		}
 	}
 
 	workspaceClassConfig := getExperimentalWorkspaceClassConfig(ctx)
-
-	cfg.CreditsPerMinuteByWorkspaceClass = make(map[string]float64)
-	for _, v := range workspaceClassConfig {
-		if v.Credits != nil {
-			cfg.CreditsPerMinuteByWorkspaceClass[v.Id] = v.Credits.PerMinute
+	if len(workspaceClassConfig) > 0 {
+		creditsPerMinuteByWorkspaceClass := make(map[string]float64)
+		for _, v := range workspaceClassConfig {
+			if v.Credits != nil {
+				cfg.CreditsPerMinuteByWorkspaceClass[v.Id] = v.Credits.PerMinute
+			}
 		}
+		cfg.CreditsPerMinuteByWorkspaceClass = creditsPerMinuteByWorkspaceClass
 	}
 
 	_ = ctx.WithExperimental(func(ucfg *experimental.Config) error {

--- a/install/installer/pkg/components/usage/configmap_test.go
+++ b/install/installer/pkg/components/usage/configmap_test.go
@@ -5,14 +5,29 @@ package usage
 
 import (
 	"testing"
+	"time"
 
+	"github.com/gitpod-io/gitpod/installer/pkg/common"
+	config "github.com/gitpod-io/gitpod/installer/pkg/config/v1"
 	"github.com/gitpod-io/gitpod/installer/pkg/config/v1/experimental"
+	"github.com/gitpod-io/gitpod/installer/pkg/config/versions"
+	"github.com/gitpod-io/gitpod/usage/pkg/db"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 )
 
-func TestConfigMap_ContainsSchedule(t *testing.T) {
-	ctx := renderContextWithUsageConfig(t, &experimental.UsageConfig{Enabled: true, Schedule: "2m", ResetUsageSchedule: "5m"})
+func TestConfigMap_WithExperimentalOptions(t *testing.T) {
+	billinstancesAfter := time.Date(2022, 10, 10, 10, 10, 10, 0, time.UTC)
+	ctx := renderContextWithUsageConfig(t, &experimental.UsageConfig{
+		Schedule:           "2m",
+		ResetUsageSchedule: "5m",
+		BillInstancesAfter: &billinstancesAfter,
+		DefaultSpendingLimit: &db.DefaultSpendingLimit{
+			ForTeams:            123,
+			ForUsers:            456,
+			MinForUsersOnStripe: 7,
+		},
+	})
 
 	objs, err := configmap(ctx)
 	require.NoError(t, err)
@@ -25,6 +40,116 @@ func TestConfigMap_ContainsSchedule(t *testing.T) {
        "controllerSchedule": "2m",
 	   "resetUsageSchedule": "5m",
        "stripeCredentialsFile": "stripe-secret/apikeys",
+	   "creditsPerMinuteByWorkspaceClass": {
+		"default": 0.1666666667
+	   },
+	   "defaultSpendingLimit": {
+		"forUsers": 456,
+		"forTeams": 123,
+		"minForUsersOnStripe": 7
+	   },
+	   "stripePrices": {
+		"individualUsagePriceIds": {
+		  "eur": "",
+		  "usd": ""
+		},
+		"teamUsagePriceIds": {
+		  "eur": "",
+		  "usd": ""
+		}
+	   },
+       "server": {
+         "services": {
+           "grpc": {
+             "address": "0.0.0.0:9001"
+           }
+         }
+       }
+     }`,
+		cfgmap.Data[configJSONFilename],
+	)
+}
+
+func TestConfigMap_WithExperimentalOptions_EmptySchedule(t *testing.T) {
+	billinstancesAfter := time.Date(2022, 10, 10, 10, 10, 10, 0, time.UTC)
+	ctx := renderContextWithUsageConfig(t, &experimental.UsageConfig{
+		Schedule:           "", // empty specifies job is disabled
+		ResetUsageSchedule: "", // empty specifies job is disabled
+		BillInstancesAfter: &billinstancesAfter,
+		DefaultSpendingLimit: &db.DefaultSpendingLimit{
+			ForTeams:            123,
+			ForUsers:            456,
+			MinForUsersOnStripe: 7,
+		},
+	})
+
+	objs, err := configmap(ctx)
+	require.NoError(t, err)
+
+	cfgmap, ok := objs[0].(*corev1.ConfigMap)
+	require.True(t, ok)
+
+	require.JSONEq(t,
+		`{
+       "stripeCredentialsFile": "stripe-secret/apikeys",
+	   "creditsPerMinuteByWorkspaceClass": {
+		"default": 0.1666666667
+	   },
+	   "defaultSpendingLimit": {
+		"forUsers": 456,
+		"forTeams": 123,
+		"minForUsersOnStripe": 7
+	   },
+	   "stripePrices": {
+		"individualUsagePriceIds": {
+		  "eur": "",
+		  "usd": ""
+		},
+		"teamUsagePriceIds": {
+		  "eur": "",
+		  "usd": ""
+		}
+	   },
+       "server": {
+         "services": {
+           "grpc": {
+             "address": "0.0.0.0:9001"
+           }
+         }
+       }
+     }`,
+		cfgmap.Data[configJSONFilename],
+	)
+}
+
+func TestConfigMap_DefaultOptions(t *testing.T) {
+	ctx, err := common.NewRenderContext(config.Config{
+		Domain: "test.domain.everything.awesome.is",
+	}, versions.Manifest{
+		Components: versions.Components{
+			Usage: versions.Versioned{
+				Version: "commit-test-latest",
+			},
+			ServiceWaiter: versions.Versioned{
+				Version: "commit-test-latest",
+			},
+		},
+	}, "test-namespace")
+	require.NoError(t, err)
+
+	objs, err := configmap(ctx)
+	require.NoError(t, err)
+
+	cfgmap, ok := objs[0].(*corev1.ConfigMap)
+	require.True(t, ok)
+
+	require.JSONEq(t,
+		`{
+       "controllerSchedule": "15m0s",
+	   "resetUsageSchedule": "15m0s",
+	   "creditsPerMinuteByWorkspaceClass": {
+		"default": 0.1666666667
+	   },
 	   "defaultSpendingLimit": {
 		"forUsers": 1000000000,
 		"forTeams": 1000000000,

--- a/install/installer/pkg/components/usage/objects.go
+++ b/install/installer/pkg/components/usage/objects.go
@@ -4,19 +4,12 @@
 package usage
 
 import (
-	"github.com/gitpod-io/gitpod/common-go/log"
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 	"github.com/gitpod-io/gitpod/installer/pkg/config/v1/experimental"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
 func Objects(ctx *common.RenderContext) ([]runtime.Object, error) {
-	cfg := getExperimentalUsageConfig(ctx)
-	if cfg == nil {
-		return nil, nil
-	}
-
-	log.Debug("Detected experimental.WebApp.Usage configuration", cfg)
 	return common.CompositeRenderFunc(
 		deployment,
 		rolebinding,

--- a/install/installer/pkg/config/v1/experimental/experimental.go
+++ b/install/installer/pkg/config/v1/experimental/experimental.go
@@ -267,7 +267,6 @@ type PublicAPIConfig struct {
 }
 
 type UsageConfig struct {
-	Enabled                          bool                     `json:"enabled"`
 	Schedule                         string                   `json:"schedule"`
 	ResetUsageSchedule               string                   `json:"resetUsageSchedule"`
 	BillInstancesAfter               *time.Time               `json:"billInstancesAfter"`


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This PR will deploy the usage component by default in all installations.

It uses the following defaults:
* Usage Ledger schedule - 15m
* Reset Usage schedule - 15m
* WorkspaceClass Credit cost - default: 0.1666666667

* No Stripe API Key, No Stripe prices
	* This will effectively disable stripe integration, and the BillingService

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related to https://github.com/gitpod-io/gitpod/issues/14129

## How to test
<!-- Provide steps to test this PR -->
Usage component is deployed in preview

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
