### PR TITLE
[pvc] remove fsgroup

### DIFF
--- a/components/ws-manager/pkg/manager/create.go
+++ b/components/ws-manager/pkg/manager/create.go
@@ -594,14 +594,6 @@ func (m *Manager) createDefiniteWorkspacePod(startContext *startWorkspaceContext
 			// not needed, since it is using dedicated disk
 			pod.Spec.Containers[0].VolumeMounts[0].MountPropagation = nil
 
-			// pavel: 133332 is the Gitpod UID (33333) shifted by 99999. The shift happens inside the workspace container due to the user namespace use.
-			// We set this magical ID to make sure that gitpod user inside the workspace can write into /workspace folder mounted by PVC
-			gitpodGUID := int64(133332)
-			pod.Spec.SecurityContext.FSGroup = &gitpodGUID
-			// only do chown if there is a mismatch
-			fsGroupChangePolicy := corev1.FSGroupChangeOnRootMismatch
-			pod.Spec.SecurityContext.FSGroupChangePolicy = &fsGroupChangePolicy
-
 			// add init container to chown workspace subpath, so that it is owned by gitpod user (there is no k8s native way of doing this as of right now)
 			pod.Spec.InitContainers = append(pod.Spec.InitContainers, corev1.Container{
 				Name:            "chown-workspace",


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Since we are now using init container to fix `/workspace` ownership, there is no need to mess with fsGroup anymore and it prevents k8s from running chown behind the scenes when mounting PVC. (so it would mount pvc faster).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
none
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-integration-tests=workspace
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
