### PR TITLE
[public-api] Implement ProjectsService.ListProjects

### DIFF
--- a/components/public-api-server/pkg/apiv1/pagination.go
+++ b/components/public-api-server/pkg/apiv1/pagination.go
@@ -36,3 +36,22 @@ func paginationToDB(p *v1.Pagination) db.Pagination {
 		PageSize: int(validated.GetPageSize()),
 	}
 }
+
+func pageFromResults[T any](results []T, p *v1.Pagination) []T {
+	pagination := validatePagination(p)
+
+	size := len(results)
+
+	start := int((pagination.Page - 1) * pagination.PageSize)
+	end := int(pagination.Page * pagination.PageSize)
+
+	if start > size {
+		return nil
+	}
+
+	if end > size {
+		end = size
+	}
+
+	return results[start:end]
+}

--- a/components/public-api-server/pkg/apiv1/pagination_test.go
+++ b/components/public-api-server/pkg/apiv1/pagination_test.go
@@ -75,5 +75,33 @@ func TestValidatePagination(t *testing.T) {
 			Page:     9,
 		}))
 	})
+}
+
+func TestPageFromResults(t *testing.T) {
+	var results []int
+	for i := 0; i < 26; i++ {
+		results = append(results, i)
+	}
+
+	require.EqualValues(t, results[0:25], pageFromResults(results, &v1.Pagination{}), "defaults to first page and 25 records")
+	require.EqualValues(t, results[0:5], pageFromResults(results, &v1.Pagination{
+		PageSize: 5,
+	}), "defaults to first page, 10 records")
+	require.EqualValues(t, results[5:10], pageFromResults(results, &v1.Pagination{
+		PageSize: 5,
+		Page:     2,
+	}), "second page, 5 records")
+	require.EqualValues(t, results[10:15], pageFromResults(results, &v1.Pagination{
+		PageSize: 5,
+		Page:     3,
+	}), "third page, 5 records")
+	require.EqualValues(t, results[25:], pageFromResults(results, &v1.Pagination{
+		PageSize: 5,
+		Page:     6,
+	}), "last page, 5 records")
+	require.Len(t, pageFromResults(results, &v1.Pagination{
+		PageSize: 5,
+		Page:     7,
+	}), 0, "out of bound page, 5 records")
 
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Implements ListProjects API on Public API.

The API is modal, depending on which arguments are supplied.
* If userID is supplied, we use `getUserProjects` from server
* If teamID is supplied, we use `getTeamProjects` from server
* Both are not allowed

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Fixes https://github.com/gitpod-io/gitpod/issues/14896

## How to test
<!-- Provide steps to test this PR -->
Unit tests

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
