### PR TITLE
Ask for gcloud login at the beginning of the build

### DIFF
--- a/dev/BUILD.yaml
+++ b/dev/BUILD.yaml
@@ -34,6 +34,8 @@ scripts:
     script: |
       export TF_INPUT=0
       export TF_IN_AUTOMATION=true
+      source "preview/workflow/lib/ensure-gcloud-auth.sh"
+      ensure_gcloud_auth
       leeway run dev/preview:create-preview
       leeway run dev/preview:build
       previewctl install-context


### PR DESCRIPTION
## Description
Ask for `gcloud login` at the beginning of the build. This login is required in the middle of the build. Asking at the beginning prevents surprises when people start the build, background the Gitpod workspace, and then come back to it later only to be surprised that the build was waiting for input. 

## Related Issue(s)
Fixes #

## How to test
a) Run `leeway run dev:preview` on a fresh workspace. 
b) Logout via `rm -rf ~/.config/gcloud/` and run `leeway run dev:preview`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
