### PR TITLE
[tests] Fix parallel workspace tests failure catching

### DIFF
--- a/test/run.sh
+++ b/test/run.sh
@@ -85,8 +85,8 @@ if [ "$TEST_SUITE" == "workspace" ]; then
   set +e
   # shellcheck disable=SC2086
   go test -v $TEST_LIST "${args[@]}" -run '.*[^.SerialOnly]$' 2>&1 | tee "${LOG_FILE}" | werft log slice "test-${TEST_NAME}-parallel"
-  set -e
   RC=${PIPESTATUS[0]}
+  set -e
 
   if [ "${RC}" -ne "0" ]; then
     FAILURE_COUNT=$((FAILURE_COUNT+1))
@@ -99,8 +99,8 @@ if [ "$TEST_SUITE" == "workspace" ]; then
   set +e
   # shellcheck disable=SC2086
   go test -v $TEST_LIST "${args[@]}" -run '.*SerialOnly$' -p 1 2>&1 | tee "${LOG_FILE}" | werft log slice "test-${TEST_NAME}-serial-only"
-  set -e
   RC=${PIPESTATUS[0]}
+  set -e
 
   if [ "${RC}" -ne "0" ]; then
     FAILURE_COUNT=$((FAILURE_COUNT+1))


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Access `PIPESTATUS` right after running `go test` to check for non-zero exit code, otherwise the var gets reset and will always be 0

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #14687

## How to test
<!-- Provide steps to test this PR -->

Run workspace e2e tests, check that a test failure fails the pipeline

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-integration-tests=workspace
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
