### PR TITLE
[installer]: validate the node labels by kind in config

### DIFF
--- a/install/installer/pkg/cluster/affinity.go
+++ b/install/installer/pkg/cluster/affinity.go
@@ -13,10 +13,22 @@ const (
 	AffinityLabelWorkspacesHeadless = "gitpod.io/workload_workspace_headless"
 )
 
-var AffinityList = []string{
+var AffinityListMeta = []string{
 	AffinityLabelMeta,
 	AffinityLabelIDE,
+}
+
+var AffinityListWorkspace = []string{
 	AffinityLabelWorkspaceServices,
 	AffinityLabelWorkspacesRegular,
 	AffinityLabelWorkspacesHeadless,
 }
+
+var AffinityList = func() []string {
+	list := []string{}
+
+	list = append(list, AffinityListMeta...)
+	list = append(list, AffinityListWorkspace...)
+
+	return list
+}()

--- a/install/installer/pkg/cluster/checks.go
+++ b/install/installer/pkg/cluster/checks.go
@@ -24,40 +24,6 @@ const (
 	kubernetesVersionConstraint = ">= 1.21.0-0"
 )
 
-// checkAffinityLabels validates that the nodes have all the required affinity labels applied
-// It assumes all the values are `true`
-func checkAffinityLabels(ctx context.Context, config *rest.Config, namespace string) ([]ValidationError, error) {
-	nodes, err := listNodesFromContext(ctx, config)
-	if err != nil {
-		return nil, err
-	}
-
-	affinityList := map[string]bool{}
-	for _, affinity := range AffinityList {
-		affinityList[affinity] = false
-	}
-
-	var res []ValidationError
-	for _, node := range nodes {
-		for k, v := range node.GetLabels() {
-			if _, found := affinityList[k]; found {
-				affinityList[k] = v == "true"
-			}
-		}
-	}
-
-	// Check all the values in the map are `true`
-	for k, v := range affinityList {
-		if !v {
-			res = append(res, ValidationError{
-				Message: "Affinity label not found in cluster: " + k,
-				Type:    ValidationStatusError,
-			})
-		}
-	}
-	return res, nil
-}
-
 // checkCertManagerInstalled checks that cert-manager is installed as a cluster dependency
 func checkCertManagerInstalled(ctx context.Context, config *rest.Config, namespace string) ([]ValidationError, error) {
 	client, err := certmanager.NewForConfig(config)
@@ -91,7 +57,7 @@ func checkCertManagerInstalled(ctx context.Context, config *rest.Config, namespa
 
 // checkContainerDRuntime checks that the nodes are running with the containerd runtime
 func checkContainerDRuntime(ctx context.Context, config *rest.Config, namespace string) ([]ValidationError, error) {
-	nodes, err := listNodesFromContext(ctx, config)
+	nodes, err := ListNodesFromContext(ctx, config)
 	if err != nil {
 		return nil, err
 	}
@@ -139,7 +105,7 @@ func checkKubernetesVersion(ctx context.Context, config *rest.Config, namespace 
 		})
 	}
 
-	nodes, err := listNodesFromContext(ctx, config)
+	nodes, err := ListNodesFromContext(ctx, config)
 	if err != nil {
 		return nil, err
 	}
@@ -263,7 +229,7 @@ func checkKernelVersion(ctx context.Context, config *rest.Config, namespace stri
 		return nil, err
 	}
 
-	nodes, err := listNodesFromContext(ctx, config)
+	nodes, err := ListNodesFromContext(ctx, config)
 	if err != nil {
 		return nil, err
 	}

--- a/install/installer/pkg/cluster/validation.go
+++ b/install/installer/pkg/cluster/validation.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/version"
@@ -66,11 +67,6 @@ var ClusterChecks = ValidationChecks{
 		Check:       checkKubernetesVersion,
 	},
 	{
-		Name:        "affinity labels",
-		Check:       checkAffinityLabels,
-		Description: "all required affinity node labels " + fmt.Sprint(AffinityList) + " are present in the cluster",
-	},
-	{
 		Name:        "cert-manager installed",
 		Check:       checkCertManagerInstalled,
 		Description: "cert-manager is installed and has available issuer",
@@ -100,7 +96,7 @@ func (checks ValidationChecks) Validate(ctx context.Context, config *rest.Config
 	}
 	ctx = context.WithValue(ctx, keyClientset, client)
 
-	list, err := listNodesFromContext(ctx, config)
+	list, err := ListNodesFromContext(ctx, config)
 	if err != nil {
 		return nil, err
 	}
@@ -147,7 +143,7 @@ const (
 	keyClientset = "clientset"
 )
 
-func listNodesFromContext(ctx context.Context, config *rest.Config) ([]corev1.Node, error) {
+func ListNodesFromContext(ctx context.Context, config *rest.Config) ([]corev1.Node, error) {
 	client, err := clientsetFromContext(ctx, config)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
The Installer's `validate cluster` command checked the node labels as if the `kind` in the config file was always `Full`.

This removes this assumption and creates separate target affinities based upon the `kind`.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #14598

## How to test
<!-- Provide steps to test this PR -->
 - `go run . config init`
 - Set the `kind` in `gitpod.config.yaml` to either `Full`, `Meta` or `Workspace`
 - Run `go run . validate cluster`
 - The `affinity labels` check should be as below...

### Full

```json
{
  "name": "affinity labels",
  "description": "all required affinity node labels [gitpod.io/workload_meta gitpod.io/workload_ide gitpod.io/workload_workspace_services gitpod.io/workload_workspace_regular gitpod.io/workload_workspace_headless] are present in the cluster",
  "status": "OK"
}
```

### Meta

```json
{
  "name": "affinity labels",
  "description": "all required affinity node labels [gitpod.io/workload_meta gitpod.io/workload_ide] are present in the cluster",
  "status": "OK"
}
```

### Workspace

```json
{
  "name": "affinity labels",
  "description": "all required affinity node labels [gitpod.io/workload_workspace_services gitpod.io/workload_workspace_regular gitpod.io/workload_workspace_headless] are present in the cluster",
  "status": "OK"
}
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[installer]: validate the node labels by kind in config
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
