### PR TITLE
[openvsx-proxy] re-enable requests_total metric

### DIFF
--- a/components/openvsx-proxy/pkg/errorhandler.go
+++ b/components/openvsx-proxy/pkg/errorhandler.go
@@ -15,9 +15,6 @@ import (
 func (o *OpenVSXProxy) ErrorHandler(rw http.ResponseWriter, r *http.Request, e error) {
 	reqid := r.Context().Value(REQUEST_ID_CTX).(string)
 	key, ok := r.Context().Value(REQUEST_CACHE_KEY_CTX).(string)
-	if !ok {
-		return
-	}
 
 	logFields := logrus.Fields{
 		LOG_FIELD_FUNC:       "error_handler",
@@ -38,6 +35,10 @@ func (o *OpenVSXProxy) ErrorHandler(rw http.ResponseWriter, r *http.Request, e e
 
 	log.WithFields(logFields).WithError(e).Warn("handling error")
 	o.metrics.IncStatusCounter(r, "error")
+
+	if !ok {
+		return
+	}
 
 	if key == "" {
 		log.WithFields(logFields).Error("cache key header is missing")

--- a/components/openvsx-proxy/pkg/modifyresponse.go
+++ b/components/openvsx-proxy/pkg/modifyresponse.go
@@ -20,9 +20,6 @@ import (
 func (o *OpenVSXProxy) ModifyResponse(r *http.Response) error {
 	reqid := r.Request.Context().Value(REQUEST_ID_CTX).(string)
 	key, ok := r.Request.Context().Value(REQUEST_CACHE_KEY_CTX).(string)
-	if !ok {
-		return nil
-	}
 
 	logFields := logrus.Fields{
 		LOG_FIELD_FUNC:            "response_handler",
@@ -44,6 +41,10 @@ func (o *OpenVSXProxy) ModifyResponse(r *http.Response) error {
 
 	log.WithFields(logFields).Debug("handling response")
 	o.metrics.IncStatusCounter(r.Request, strconv.Itoa(r.StatusCode))
+
+	if !ok {
+		return nil
+	}
 
 	if key == "" {
 		log.WithFields(logFields).Error("cache key header is missing - sending response as is")


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
For _Status Code of Request_ [[1]](https://grafana.gitpod.io/d/HNOvmGpxgd/openvsx-proxy?orgId=1&refresh=5s&from=now-1h&to=now&viewPanel=4)

<img width="726" alt="image" src="https://user-images.githubusercontent.com/20944364/201938815-d049eefa-85a5-44f3-a357-053f1c21c51a.png">

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
- Open workspace in preview env
- Make sure extensions related things not broken (install, uninstall, search)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
