### PR TITLE
[server] add logs to debug persistence error with userId

### DIFF
--- a/components/gitpod-db/src/typeorm/auth-code-repository-db.ts
+++ b/components/gitpod-db/src/typeorm/auth-code-repository-db.ts
@@ -56,9 +56,13 @@ export class AuthCodeRepositoryDB implements OAuthAuthCodeRepository {
         };
     }
     public async persist(authCode: DBOAuthAuthCodeEntry): Promise<void> {
-        const authCodeRepo = await this.getOauthAuthCodeRepo();
-        authCode.id = uuidv4();
-        authCodeRepo.save(authCode);
+        try {
+            const authCodeRepo = await this.getOauthAuthCodeRepo();
+            authCode.id = uuidv4();
+            authCodeRepo.save(authCode);
+        } catch (error) {
+            console.error("Error while persisting an DBOAuthAuthCodeEntry.", error, { error });
+        }
     }
     public async isRevoked(authCodeCode: string): Promise<boolean> {
         const authCode = await this.getByIdentifier(authCodeCode);


### PR DESCRIPTION
Debugging https://github.com/gitpod-io/gitpod/issues/14464



## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
