### PR TITLE
[public-api] Add test for CreateToken when feature flag enabled

### DIFF
--- a/components/common-go/experiments/flags.go
+++ b/components/common-go/experiments/flags.go
@@ -6,11 +6,10 @@ package experiments
 
 import "context"
 
-// IsMyFirstFeatureFlagEnabled example usage of a flag
-func IsMyFirstFeatureFlagEnabled(ctx context.Context, client Client, attributes Attributes) bool {
-	return client.GetBoolValue(ctx, "isMyFirstFeatureEnabled", false, attributes)
-}
+const (
+	PersonalAccessTokensEnabledFlag = "personalAccessTokensEnabled"
+)
 
 func IsPersonalAccessTokensEnabled(ctx context.Context, client Client, attributes Attributes) bool {
-	return client.GetBoolValue(ctx, "personalAccessTokensEnabled", false, attributes)
+	return client.GetBoolValue(ctx, PersonalAccessTokensEnabledFlag, false, attributes)
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Ensures we have coverage for both cases of the feature flag. Currently returns unimplemented, but will be extended in future PRs.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
