### PR TITLE
Add extension type for vscode gallery metrics

### DIFF
--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -7,7 +7,7 @@ defaultArgs:
   publishToNPM: true
   publishToJBMarketplace: true
   localAppVersion: unknown
-  codeCommit: d8823f0d382ef894b98c3f837a332e566d335a34
+  codeCommit: a3e6d2423bf8e1c6907233449138bcb0077088bf
   codeVersion: 1.73.1
   codeQuality: stable
   noVerifyJBPlugin: false

--- a/install/installer/cmd/testdata/render/aws-setup/output.golden
+++ b/install/installer/cmd/testdata/render/aws-setup/output.golden
@@ -3717,6 +3717,22 @@ data:
                   "*"
                 ],
                 "defaultValue": ""
+              },
+              {
+                "name": "extensionType",
+                "allowValues": [
+                  "critical",
+                  "normal",
+                  "unknown"
+                ],
+                "defaultValue": "unknown"
+              },
+              {
+                "name": "errorCode",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
               }
             ]
           },
@@ -4281,6 +4297,15 @@ data:
                   "*"
                 ],
                 "defaultValue": ""
+              },
+              {
+                "name": "extensionType",
+                "allowValues": [
+                  "critical",
+                  "normal",
+                  "unknown"
+                ],
+                "defaultValue": "unknown"
               }
             ],
             "buckets": [
@@ -8260,7 +8285,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: a15b2b182f09debb86b167e728add4f9d341bc9706bc4e330e1d4a5c9d4deee9
+        gitpod.io/checksum_config: 8dc3f0ab6f55fe55fa9fd75e56f26f015be0d577b669b308758e7fe07b6c406d
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/azure-setup/output.golden
+++ b/install/installer/cmd/testdata/render/azure-setup/output.golden
@@ -3634,6 +3634,22 @@ data:
                   "*"
                 ],
                 "defaultValue": ""
+              },
+              {
+                "name": "extensionType",
+                "allowValues": [
+                  "critical",
+                  "normal",
+                  "unknown"
+                ],
+                "defaultValue": "unknown"
+              },
+              {
+                "name": "errorCode",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
               }
             ]
           },
@@ -4198,6 +4214,15 @@ data:
                   "*"
                 ],
                 "defaultValue": ""
+              },
+              {
+                "name": "extensionType",
+                "allowValues": [
+                  "critical",
+                  "normal",
+                  "unknown"
+                ],
+                "defaultValue": "unknown"
               }
             ],
             "buckets": [
@@ -8093,7 +8118,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: a15b2b182f09debb86b167e728add4f9d341bc9706bc4e330e1d4a5c9d4deee9
+        gitpod.io/checksum_config: 8dc3f0ab6f55fe55fa9fd75e56f26f015be0d577b669b308758e7fe07b6c406d
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -4475,6 +4475,22 @@ data:
                   "*"
                 ],
                 "defaultValue": ""
+              },
+              {
+                "name": "extensionType",
+                "allowValues": [
+                  "critical",
+                  "normal",
+                  "unknown"
+                ],
+                "defaultValue": "unknown"
+              },
+              {
+                "name": "errorCode",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
               }
             ]
           },
@@ -5039,6 +5055,15 @@ data:
                   "*"
                 ],
                 "defaultValue": ""
+              },
+              {
+                "name": "extensionType",
+                "allowValues": [
+                  "critical",
+                  "normal",
+                  "unknown"
+                ],
+                "defaultValue": "unknown"
               }
             ],
             "buckets": [
@@ -9565,7 +9590,7 @@ spec:
     metadata:
       annotations:
         gitpod.io: hello
-        gitpod.io/checksum_config: 74ecbbd8492d8fefde88122798e66f4d886da1cc357b33e62d71b3d80dcc2234
+        gitpod.io/checksum_config: 0520a6aeb6064313dd082434007f162aa4ef117e40f6ca40543e52b5d86c032b
         hello: world
       creationTimestamp: null
       labels:

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -3775,6 +3775,22 @@ data:
                   "*"
                 ],
                 "defaultValue": ""
+              },
+              {
+                "name": "extensionType",
+                "allowValues": [
+                  "critical",
+                  "normal",
+                  "unknown"
+                ],
+                "defaultValue": "unknown"
+              },
+              {
+                "name": "errorCode",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
               }
             ]
           },
@@ -4339,6 +4355,15 @@ data:
                   "*"
                 ],
                 "defaultValue": ""
+              },
+              {
+                "name": "extensionType",
+                "allowValues": [
+                  "critical",
+                  "normal",
+                  "unknown"
+                ],
+                "defaultValue": "unknown"
               }
             ],
             "buckets": [
@@ -8534,7 +8559,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: a15b2b182f09debb86b167e728add4f9d341bc9706bc4e330e1d4a5c9d4deee9
+        gitpod.io/checksum_config: 8dc3f0ab6f55fe55fa9fd75e56f26f015be0d577b669b308758e7fe07b6c406d
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/gcp-setup/output.golden
+++ b/install/installer/cmd/testdata/render/gcp-setup/output.golden
@@ -3605,6 +3605,22 @@ data:
                   "*"
                 ],
                 "defaultValue": ""
+              },
+              {
+                "name": "extensionType",
+                "allowValues": [
+                  "critical",
+                  "normal",
+                  "unknown"
+                ],
+                "defaultValue": "unknown"
+              },
+              {
+                "name": "errorCode",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
               }
             ]
           },
@@ -4169,6 +4185,15 @@ data:
                   "*"
                 ],
                 "defaultValue": ""
+              },
+              {
+                "name": "extensionType",
+                "allowValues": [
+                  "critical",
+                  "normal",
+                  "unknown"
+                ],
+                "defaultValue": "unknown"
               }
             ],
             "buckets": [
@@ -8148,7 +8173,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: a15b2b182f09debb86b167e728add4f9d341bc9706bc4e330e1d4a5c9d4deee9
+        gitpod.io/checksum_config: 8dc3f0ab6f55fe55fa9fd75e56f26f015be0d577b669b308758e7fe07b6c406d
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/http-proxy/output.golden
+++ b/install/installer/cmd/testdata/render/http-proxy/output.golden
@@ -3944,6 +3944,22 @@ data:
                   "*"
                 ],
                 "defaultValue": ""
+              },
+              {
+                "name": "extensionType",
+                "allowValues": [
+                  "critical",
+                  "normal",
+                  "unknown"
+                ],
+                "defaultValue": "unknown"
+              },
+              {
+                "name": "errorCode",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
               }
             ]
           },
@@ -4508,6 +4524,15 @@ data:
                   "*"
                 ],
                 "defaultValue": ""
+              },
+              {
+                "name": "extensionType",
+                "allowValues": [
+                  "critical",
+                  "normal",
+                  "unknown"
+                ],
+                "defaultValue": "unknown"
               }
             ],
             "buckets": [
@@ -9499,7 +9524,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: a15b2b182f09debb86b167e728add4f9d341bc9706bc4e330e1d4a5c9d4deee9
+        gitpod.io/checksum_config: 8dc3f0ab6f55fe55fa9fd75e56f26f015be0d577b669b308758e7fe07b6c406d
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/insecure-s3-setup/output.golden
+++ b/install/installer/cmd/testdata/render/insecure-s3-setup/output.golden
@@ -3855,6 +3855,22 @@ data:
                   "*"
                 ],
                 "defaultValue": ""
+              },
+              {
+                "name": "extensionType",
+                "allowValues": [
+                  "critical",
+                  "normal",
+                  "unknown"
+                ],
+                "defaultValue": "unknown"
+              },
+              {
+                "name": "errorCode",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
               }
             ]
           },
@@ -4419,6 +4435,15 @@ data:
                   "*"
                 ],
                 "defaultValue": ""
+              },
+              {
+                "name": "extensionType",
+                "allowValues": [
+                  "critical",
+                  "normal",
+                  "unknown"
+                ],
+                "defaultValue": "unknown"
               }
             ],
             "buckets": [
@@ -8696,7 +8721,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: a15b2b182f09debb86b167e728add4f9d341bc9706bc4e330e1d4a5c9d4deee9
+        gitpod.io/checksum_config: 8dc3f0ab6f55fe55fa9fd75e56f26f015be0d577b669b308758e7fe07b6c406d
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -3941,6 +3941,22 @@ data:
                   "*"
                 ],
                 "defaultValue": ""
+              },
+              {
+                "name": "extensionType",
+                "allowValues": [
+                  "critical",
+                  "normal",
+                  "unknown"
+                ],
+                "defaultValue": "unknown"
+              },
+              {
+                "name": "errorCode",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
               }
             ]
           },
@@ -4505,6 +4521,15 @@ data:
                   "*"
                 ],
                 "defaultValue": ""
+              },
+              {
+                "name": "extensionType",
+                "allowValues": [
+                  "critical",
+                  "normal",
+                  "unknown"
+                ],
+                "defaultValue": "unknown"
               }
             ],
             "buckets": [
@@ -8814,7 +8839,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: a15b2b182f09debb86b167e728add4f9d341bc9706bc4e330e1d4a5c9d4deee9
+        gitpod.io/checksum_config: 8dc3f0ab6f55fe55fa9fd75e56f26f015be0d577b669b308758e7fe07b6c406d
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/shortname/output.golden
+++ b/install/installer/cmd/testdata/render/shortname/output.golden
@@ -3941,6 +3941,22 @@ data:
                   "*"
                 ],
                 "defaultValue": ""
+              },
+              {
+                "name": "extensionType",
+                "allowValues": [
+                  "critical",
+                  "normal",
+                  "unknown"
+                ],
+                "defaultValue": "unknown"
+              },
+              {
+                "name": "errorCode",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
               }
             ]
           },
@@ -4505,6 +4521,15 @@ data:
                   "*"
                 ],
                 "defaultValue": ""
+              },
+              {
+                "name": "extensionType",
+                "allowValues": [
+                  "critical",
+                  "normal",
+                  "unknown"
+                ],
+                "defaultValue": "unknown"
               }
             ],
             "buckets": [
@@ -8814,7 +8839,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: a15b2b182f09debb86b167e728add4f9d341bc9706bc4e330e1d4a5c9d4deee9
+        gitpod.io/checksum_config: 8dc3f0ab6f55fe55fa9fd75e56f26f015be0d577b669b308758e7fe07b6c406d
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -3953,6 +3953,22 @@ data:
                   "*"
                 ],
                 "defaultValue": ""
+              },
+              {
+                "name": "extensionType",
+                "allowValues": [
+                  "critical",
+                  "normal",
+                  "unknown"
+                ],
+                "defaultValue": "unknown"
+              },
+              {
+                "name": "errorCode",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
               }
             ]
           },
@@ -4517,6 +4533,15 @@ data:
                   "*"
                 ],
                 "defaultValue": ""
+              },
+              {
+                "name": "extensionType",
+                "allowValues": [
+                  "critical",
+                  "normal",
+                  "unknown"
+                ],
+                "defaultValue": "unknown"
               }
             ],
             "buckets": [
@@ -8826,7 +8851,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: a15b2b182f09debb86b167e728add4f9d341bc9706bc4e330e1d4a5c9d4deee9
+        gitpod.io/checksum_config: 8dc3f0ab6f55fe55fa9fd75e56f26f015be0d577b669b308758e7fe07b6c406d
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
+++ b/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
@@ -4274,6 +4274,22 @@ data:
                   "*"
                 ],
                 "defaultValue": ""
+              },
+              {
+                "name": "extensionType",
+                "allowValues": [
+                  "critical",
+                  "normal",
+                  "unknown"
+                ],
+                "defaultValue": "unknown"
+              },
+              {
+                "name": "errorCode",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
               }
             ]
           },
@@ -4838,6 +4854,15 @@ data:
                   "*"
                 ],
                 "defaultValue": ""
+              },
+              {
+                "name": "extensionType",
+                "allowValues": [
+                  "critical",
+                  "normal",
+                  "unknown"
+                ],
+                "defaultValue": "unknown"
               }
             ],
             "buckets": [
@@ -9258,7 +9283,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: a15b2b182f09debb86b167e728add4f9d341bc9706bc4e330e1d4a5c9d4deee9
+        gitpod.io/checksum_config: 8dc3f0ab6f55fe55fa9fd75e56f26f015be0d577b669b308758e7fe07b6c406d
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
+++ b/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
@@ -3944,6 +3944,22 @@ data:
                   "*"
                 ],
                 "defaultValue": ""
+              },
+              {
+                "name": "extensionType",
+                "allowValues": [
+                  "critical",
+                  "normal",
+                  "unknown"
+                ],
+                "defaultValue": "unknown"
+              },
+              {
+                "name": "errorCode",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
               }
             ]
           },
@@ -4508,6 +4524,15 @@ data:
                   "*"
                 ],
                 "defaultValue": ""
+              },
+              {
+                "name": "extensionType",
+                "allowValues": [
+                  "critical",
+                  "normal",
+                  "unknown"
+                ],
+                "defaultValue": "unknown"
               }
             ],
             "buckets": [
@@ -8817,7 +8842,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: a15b2b182f09debb86b167e728add4f9d341bc9706bc4e330e1d4a5c9d4deee9
+        gitpod.io/checksum_config: 8dc3f0ab6f55fe55fa9fd75e56f26f015be0d577b669b308758e7fe07b6c406d
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/pkg/components/ide-metrics/configmap.go
+++ b/install/installer/pkg/components/ide-metrics/configmap.go
@@ -155,7 +155,16 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 					Name:        "galleryHost",
 					AllowValues: []string{"*"},
 				},
-				// TODO(ak) errorCode - we should analyze error codes collect in analytics and categotize them here
+				{
+					Name:         "extensionType",
+					AllowValues:  []string{"critical", "normal", "unknown"},
+					DefaultValue: "unknown",
+				},
+				{
+					// TODO(ak) errorCode - we should analyze error codes collect in analytics and categotize them here
+					Name:        "errorCode",
+					AllowValues: []string{"*"},
+				},
 			},
 		},
 		{
@@ -198,6 +207,11 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 				{
 					Name:        "galleryHost",
 					AllowValues: []string{"*"},
+				},
+				{
+					Name:         "extensionType",
+					AllowValues:  []string{"critical", "normal", "unknown"},
+					DefaultValue: "unknown",
 				},
 			},
 			Buckets: []float64{0.1, 0.5, 1, 5, 10, 15, 30},


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Add extension type for vscode gallery metrics
- Related PR https://github.com/gitpod-io/openvscode-server/pull/465

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
- Open workspace with **latest code** in preview env
- Open this PR with Gitpod
```shell
# get ide metrics pod name
kubectl get pods | grep ide-metrics

# port forward
kubectl port-forward pods/<pod_name> 9500:9500
```
- Open 9500 in the browser
- Search with `gitpod_vscode_extension_gallery_operation_total` should contains label `extensionType`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
