### PR TITLE
[observability] add alert for upstream down

### DIFF
--- a/operations/observability/mixins/IDE/rules/opensvx.yaml
+++ b/operations/observability/mixins/IDE/rules/opensvx.yaml
@@ -26,6 +26,18 @@ spec:
       expr: |
           sum(rate(gitpod_vscode_extension_gallery_query_total{status="failure",errorCode!="canceled"}[5m])) by(cluster) / sum(rate(gitpod_vscode_extension_gallery_query_total[5m])) by(cluster) > 0.01
 
+    - alert: GitpodOpenVSXUpstreamDown
+      labels:
+        severity: critical
+      for: 20m
+      annotations:
+        runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodOpenVSXUpstreamDown.md
+        summary: Open-VSX upstream is possibly down
+        description: Open-VSX upstream is possibly down.
+        dashboard_url: https://grafana.gitpod.io/d/WI_x6hN4k/openvsx-mirror?var-cluster=openvsx-mirror-us01&viewPanel=13
+      expr: |
+          sum(rate(http_client_requests_seconds_count{cluster="openvsx-mirror-us01",outcome!~"SUCCESS|REDIRECTION|CLIENT_ERROR"})[2m])/sum(rate(http_client_requests_seconds_count{cluster="openvsx-mirror-us01"})[2m]) > 0.01
+
     - alert: GitpodOpenVSXUnavailable
       labels:
         severity: warning


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Alert when using openvsx-mirror and upstream is down

See also [Grafana Explore](https://grafana.gitpod.io/explore?orgId=1&left=%7B%22datasource%22:%22P4169E866C3094E38%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22datasource%22:%7B%22type%22:%22prometheus%22,%22uid%22:%22P4169E866C3094E38%22%7D,%22editorMode%22:%22code%22,%22expr%22:%22sum%28rate%28http_client_requests_seconds_count%7Bcluster%3D%5C%22openvsx-mirror-us01%5C%22,outcome%21~%5C%22SUCCESS%7CREDIRECTION%7CCLIENT_ERROR%5C%22%7D%29%5B2m%5D%29%2Fsum%28rate%28http_client_requests_seconds_count%7Bcluster%3D%5C%22openvsx-mirror-us01%5C%22%7D%29%5B2m%5D%29%20%3E%200.01%22,%22legendFormat%22:%22__auto%22,%22range%22:true,%22instant%22:true%7D%5D,%22range%22:%7B%22from%22:%22now-1h%22,%22to%22:%22now%22%7D%7D)

- Runbooks PR https://github.com/gitpod-io/runbooks/pull/406

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
no need

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
