### PR TITLE
[installer] Have `slow-server` take replica count and resource limits from `server`

### DIFF
--- a/install/installer/pkg/components/slowserver/deployment.go
+++ b/install/installer/pkg/components/slowserver/deployment.go
@@ -334,7 +334,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 			},
 			Spec: appsv1.DeploymentSpec{
 				Selector: &metav1.LabelSelector{MatchLabels: common.DefaultLabels(Component)},
-				Replicas: common.Replicas(ctx, Component),
+				Replicas: common.Replicas(ctx, common.ServerComponent),
 				Strategy: common.DeploymentStrategy,
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{

--- a/install/installer/pkg/components/slowserver/deployment.go
+++ b/install/installer/pkg/components/slowserver/deployment.go
@@ -390,7 +390,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 							Name:            Component,
 							Image:           ctx.ImageName(ctx.Config.Repository, common.ServerComponent, ctx.VersionManifest.Components.Server.Version),
 							ImagePullPolicy: corev1.PullIfNotPresent,
-							Resources: common.ResourceRequirements(ctx, Component, Component, corev1.ResourceRequirements{
+							Resources: common.ResourceRequirements(ctx, common.ServerComponent, common.ServerComponent, corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
 									"cpu":    resource.MustParse("200m"),
 									"memory": resource.MustParse("200Mi"),


### PR DESCRIPTION
## Description

https://github.com/gitpod-io/gitpod/pull/14671 added a new `slow-server` deployment for experimenting with high-latency database connections.

This PR makes a couple of small changes to the `slow-server` deployment:

* Uses the same replica count as defined for the `server` deployment.
* Uses the same resources as defined for the `server` deployment.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of #9198 

## How to test

Installer unit tests.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-slow-database
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
