### PR TITLE
Update workspace download menu style

### DIFF
--- a/components/dashboard/src/workspaces/WorkspaceEntry.tsx
+++ b/components/dashboard/src/workspaces/WorkspaceEntry.tsx
@@ -88,7 +88,7 @@ export function WorkspaceEntry({ desc, model, isAdmin, stopWorkspace }: Props) {
         title: "Download",
         customContent: (
             <div className="">
-                <span className="block text-gray-300">Download</span>
+                <span className="block text-gray-300 dark:text-gray-500">Download</span>
                 <span className="text-gray-400">
                     Deprecated.{" "}
                     <a


### PR DESCRIPTION
## Description

Following up from https://github.com/gitpod-io/gitpod/pull/14393. this will fix the workspace download menu style so that the menu option looks disabled when using dark theme.

## How to test
1. Open a new workspace
2. Go to the workspaces list
3. Click on the more actions button
4. Notice the _Download_ option looks disabled

## Screenshots

| BEFORE | AFTER |
|-|-|
| ![dropdown-before](https://user-images.githubusercontent.com/120486/202030741-56a6b3dd-f658-45c4-8d1b-9d606e527748.png) | ![dropdown-after](https://user-images.githubusercontent.com/120486/202030752-4d19767c-837e-4d4b-a60a-37f400f577b9.png) |

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Update workspace download menu style
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
