### PR TITLE
[db] Create d_b_personal_access_token

### DIFF
--- a/components/gitpod-db/src/typeorm/migration/1668531007092-CreatePersonalAccessTokenTable.ts
+++ b/components/gitpod-db/src/typeorm/migration/1668531007092-CreatePersonalAccessTokenTable.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { tableExists } from "./helper/helper";
+
+export class CreatePersonalAccessTokenTable1668531007092 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        if (!(await tableExists(queryRunner, "d_b_personal_access_token"))) {
+            await queryRunner.query(
+                "CREATE TABLE IF NOT EXISTS `d_b_personal_access_token` (`id` varchar(255) NOT NULL, `userId` varchar(255) NOT NULL, `hash` varchar(255) NOT NULL, `name` varchar(255) NOT NULL, `description` text DEFAULT NULL, `scopes` text NOT NULL, `expirationTime` timestamp(6) NOT NULL, `createdAt` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), `_lastModified` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), `deleted` tinyint(4) NOT NULL DEFAULT '0', PRIMARY KEY (id))",
+            );
+            await queryRunner.query("CREATE INDEX `ind_userId` ON `d_b_personal_access_token` (userId)");
+            await queryRunner.query("CREATE INDEX `ind_hash` ON `d_b_personal_access_token` (hash)");
+            await queryRunner.query("CREATE INDEX `ind_lastModified` ON `d_b_personal_access_token` (_lastModified)");
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        if (await tableExists(queryRunner, "d_b_personal_access_token")) {
+            await queryRunner.query("DROP TABLE `d_b_personal_access_token`");
+        }
+    }
+}


### PR DESCRIPTION
## Description
Creates `d_b_personal_access_token` with the following schema
-- | field | type
-- | -- | --
primary key | id | varchar
idx | user_id | varchar
idx | hash | varchar
  | name | varchar
  | description | text
  | scopes | text
  | expiration_time | timestamp
  | created_at | timestamp
idx | last_modified | timestamp
  | deleted | boolean

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of #14602

## How to test
1. Connect to the preview environment DB[[1](https://www.notion.so/gitpod/Accessing-the-database-242e9fa0fef642128380a10d800d3b99#cd03b2615336429aa11833c44bf4745c)] 
2. `describe d_b_personal_access_token;`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
