### PR TITLE
Fail gracefully when executed from main

### DIFF
--- a/dev/BUILD.yaml
+++ b/dev/BUILD.yaml
@@ -31,12 +31,4 @@ packages:
 scripts:
   - name: preview
     description: Build Gitpod, create a preview environment, and deploy to it
-    script: |
-      export TF_INPUT=0
-      export TF_IN_AUTOMATION=true
-      source "preview/workflow/lib/ensure-gcloud-auth.sh"
-      ensure_gcloud_auth
-      leeway run dev/preview:create-preview
-      leeway run dev/preview:build
-      previewctl install-context
-      leeway run dev/preview:deploy-gitpod
+    script: ./preview/workflow/preview/preview.sh

--- a/dev/preview/workflow/lib/git.sh
+++ b/dev/preview/workflow/lib/git.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# this script is meant to be sourced
+
+function git:branch-name {
+    git rev-parse --abbrev-ref HEAD
+}
+
+function git:is-on-main {
+    if [[ "$(git:branch-name)" == "main" ]]
+    then return 0
+    else return 1
+    fi
+}

--- a/dev/preview/workflow/preview/preview.sh
+++ b/dev/preview/workflow/preview/preview.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# shellcheck disable=1091
+
+set -euo pipefail
+
+ROOT="$(realpath "$(dirname "$0")")/../../../../"
+
+source "${ROOT}/dev/preview/workflow/lib/ensure-gcloud-auth.sh"
+source "${ROOT}/dev/preview/workflow/lib/common.sh"
+source "${ROOT}/dev/preview/workflow/lib/git.sh"
+
+# Don't prompt user before terraform apply
+export TF_INPUT=0
+export TF_IN_AUTOMATION=true
+
+if git:is-on-main; then
+    log_error "We don't support running dev:preview from the main branch. Please switch to another branch."
+    exit 1
+fi
+
+ensure_gcloud_auth
+
+leeway run dev/preview:create-preview
+leeway run dev/preview:build
+previewctl install-context
+leeway run dev/preview:deploy-gitpod


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This PR ensures that `leeway run dev:preview` fails gracefully when executed from the main branch.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/14729

## How to test
<!-- Provide steps to test this PR -->

```sh
# That it still works on branches
git checkout mads/no-dev-preview-on-main
leeway run dev:preview

# That it fails on main
git checkout main
git merge mads/no-dev-preview-on-main
leeway run dev:preview
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

N/A

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
