### PR TITLE
[installer] Use the right go mod path

### DIFF
--- a/install/installer/go.mod
+++ b/install/installer/go.mod
@@ -1,4 +1,4 @@
-module github.com/gitpod-io/gitpod/installer
+module github.com/gitpod-io/gitpod/install/installer
 
 go 1.19
 


### PR DESCRIPTION


## Description
<!-- Describe your changes in detail -->

This PR updates the `go.mod` file of the installer to be the right folder path.

With this fix, Go module imports should work that are outside of mono repo.

Signed-off-by: Tarun Pothulapati <tarun@gitpod.io>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
