### PR TITLE
[JetBrains] Fix Github Action to search for a Build Artifact when updating the Stable Backend Plugin SDK

### DIFF
--- a/components/ide/jetbrains/image/gha-update-image/index.js
+++ b/components/ide/jetbrains/image/gha-update-image/index.js
@@ -127,7 +127,7 @@ const IDEs = [
     const ideaArtifact = artifacts.find(
         (artifact) =>
             artifact.groupId === "com.jetbrains.intellij.idea" &&
-            artifact.artifactId === "ideaIU" &&
+            artifact.artifactId === "BUILD" &&
             artifact.version.startsWith(currentMajorVersion) &&
             artifact.version.endsWith("-EAP-CANDIDATE-SNAPSHOT"),
     );


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Fix Github Action to search for a Build Artifact when updating the Stable Backend Plugin SDK

Because in https://www.jetbrains.com/intellij-repository/snapshots they only list artifacts which _ID_ is _BUILD_.

| | |
| --- | --- |
| <img width="275" alt="image" src="https://user-images.githubusercontent.com/418083/202172526-82df0439-7697-4fa1-908a-18d8854d0816.png"> | <img width="417" alt="image" src="https://user-images.githubusercontent.com/418083/202172435-d353d6d1-74e5-4928-9f76-f345e36c45ba.png"> |

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
- Fixes https://github.com/gitpod-io/gitpod/issues/14676

## How to test
<!-- Provide steps to test this PR -->
Checkout the branch of this PR and run the script manually to see the results.

```
$ node index.js 
All IDEs are in the same major version: 2022.2
{
  majorVersion: '2022.2',
  currentPlatformVersion: '222.4459-EAP-CANDIDATE-SNAPSHOT',
  currentMajorVersion: '222',
  ideaArtifact: {
    groupId: 'com.jetbrains.intellij.idea',
    artifactId: 'BUILD',
    version: '222.4459-EAP-CANDIDATE-SNAPSHOT',
    classifier: '',
    packaging: 'txt',
    lastModified: '2022-11-16T11:09:13Z',
    lastModifiedUnixTimeMs: 1668596953000,
    eTag: '151b90d4b77474e40636adfe3f9707b7',
    content: '222.4459.16'
  }
}
File updated: /workspace/gitpod/WORKSPACE.yaml
File updated: /workspace/gitpod/components/ide/jetbrains/backend-plugin/gradle-stable.properties
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
