### PR TITLE
[JetBrains] Auto-update also the Stable Gateway Plugin

### DIFF
--- a/.github/workflows/jetbrains-update-plugin-platform-template.yml
+++ b/.github/workflows/jetbrains-update-plugin-platform-template.yml
@@ -70,7 +70,7 @@ jobs:
                   git diff
             - name: Create Pull Request for Gateway Plugin
               id: create-gateway-pr
-              if: ${{ inputs.pluginId == 'gateway-plugin' && steps.latest-version.outputs.result != steps.current-version.outputs.result }}
+              if: ${{ contains(inputs.pluginId, 'gateway-plugin') && steps.latest-version.outputs.result != steps.current-version.outputs.result }}
               uses: peter-evans/create-pull-request@v4
               with:
                   title: "[JetBrains] Update Platform Version from ${{ inputs.pluginName }}"
@@ -79,7 +79,7 @@ jobs:
                       This PR updates the Platform Version from ${{ inputs.pluginName }} to the latest version.
 
                       ## How to test
-                      1. Ensure you have the [latest JetBrains Gateway](https://www.jetbrains.com/remote-development/gateway/) installed.
+                      1. Ensure you have the Gateway installed from [JetBrains Toolbox App](https://www.jetbrains.com/toolbox-app/) and have it up-to-date.
                       2. Download the plugin build related to this branch in [Dev Versions](https://plugins.jetbrains.com/plugin/18438-gitpod-gateway/versions/dev), and [install it on the Gateway](https://www.jetbrains.com/help/idea/managing-plugins.html#install_plugin_from_disk).
                       3. Create a new workspace from the Gateway (it's ok to use the pre-selected IDE and Repository) and confirm if JetBrains Client can connect to it.
 
@@ -101,14 +101,14 @@ jobs:
                   token: ${{ secrets.roboquatRepoPat }}
                   committer: Robo Quat <roboquat@gitpod.io>
                   author: Robo Quat <roboquat@gitpod.io>
-            - name: Approve Pull Request for Gateway Plugin
-              if: ${{ steps.create-gateway-pr.outputs.pull-request-number }}
+            - name: Approve Pull Request for Gateway Plugin (EAP)
+              if: ${{ inputs.pluginId == 'latest-gateway-plugin' && steps.create-gateway-pr.outputs.pull-request-number }}
               uses: hmarr/auto-approve-action@v3
               with:
                   pull-request-number: ${{ steps.create-gateway-pr.outputs.pull-request-number }}
             - name: Create Pull Request for Backend Plugin
               id: create-backend-pr
-              if: ${{ inputs.pluginId == 'backend-plugin' && steps.latest-version.outputs.result != steps.current-version.outputs.result }}
+              if: ${{ contains(inputs.pluginId, 'backend-plugin') && steps.latest-version.outputs.result != steps.current-version.outputs.result }}
               uses: peter-evans/create-pull-request@v4
               with:
                   title: "[JetBrains] Update Platform Version from ${{ inputs.pluginName }}"

--- a/.github/workflows/jetbrains-update-plugin-platform.yml
+++ b/.github/workflows/jetbrains-update-plugin-platform.yml
@@ -5,23 +5,33 @@ on:
         # At 11:00 on every day-of-week from Monday through Friday.
         - cron: "0 11 * * 1-5"
 jobs:
-    update-backend-plugin-platform:
+    update-latest-backend-plugin:
         uses: ./.github/workflows/jetbrains-update-plugin-platform-template.yml
         with:
-            pluginName: JetBrains Backend Plugin
-            pluginId: backend-plugin
+            pluginName: JetBrains Backend Plugin (EAP)
+            pluginId: latest-backend-plugin
             xpath: "(/html/body/table[preceding::h2/text()='com.jetbrains.intellij.idea'][1]/tbody/tr/td[contains(text(),'-EAP-CANDIDATE-SNAPSHOT') and starts-with(text(),'MAJOR_VERSION_PLACEHOLDER')]/text())[1]"
             gradlePropertiesPath: components/ide/jetbrains/backend-plugin/gradle-latest.properties
         secrets:
             slackWebhook: ${{ secrets.IDE_SLACK_WEBHOOK }}
             roboquatRepoPat: ${{ secrets.ROBOQUAT_REPO_PAT }}
-    update-gateway-plugin-platform:
+    update-latest-gateway-plugin:
         uses: ./.github/workflows/jetbrains-update-plugin-platform-template.yml
         with:
-            pluginName: JetBrains Gateway Plugin
-            pluginId: gateway-plugin
+            pluginName: JetBrains Gateway Plugin (EAP)
+            pluginId: latest-gateway-plugin
             xpath: "(/html/body/table[preceding::h2/text()='com.jetbrains.gateway'][1]/tbody/tr/td[contains(text(),'-CUSTOM-SNAPSHOT') and starts-with(text(),'MAJOR_VERSION_PLACEHOLDER') and not(contains(text(),'-NIGHTLY'))]/text())[1]"
             gradlePropertiesPath: components/ide/jetbrains/gateway-plugin/gradle-latest.properties
+        secrets:
+            slackWebhook: ${{ secrets.IDE_SLACK_WEBHOOK }}
+            roboquatRepoPat: ${{ secrets.ROBOQUAT_REPO_PAT }}
+    update-stable-gateway-plugin:
+        uses: ./.github/workflows/jetbrains-update-plugin-platform-template.yml
+        with:
+            pluginName: JetBrains Gateway Plugin (Stable)
+            pluginId: stable-gateway-plugin
+            xpath: "(/html/body/table[preceding::h2/text()='com.jetbrains.gateway'][1]/tbody/tr/td[contains(text(),'-CUSTOM-SNAPSHOT') and starts-with(text(),'MAJOR_VERSION_PLACEHOLDER') and not(contains(text(),'-NIGHTLY'))]/text())[1]"
+            gradlePropertiesPath: components/ide/jetbrains/gateway-plugin/gradle-stable.properties
         secrets:
             slackWebhook: ${{ secrets.IDE_SLACK_WEBHOOK }}
             roboquatRepoPat: ${{ secrets.ROBOQUAT_REPO_PAT }}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Auto-update also the Stable Gateway Plugin.

References:
- [GitHub Actions Expressions: contains](https://docs.github.com/en/actions/learn-github-actions/expressions#contains)



## Related Issue(s)
<!-- List the issue(s) this PR solves -->
- https://github.com/gitpod-io/gitpod/issues/13654

## How to test
<!-- Provide steps to test this PR -->
I've already run in, and you can see the results here: https://github.com/gitpod-io/gitpod/actions/runs/3480056231
The action created this PR: https://github.com/gitpod-io/gitpod/pull/14745 (note it didn't target the main branch, as it was a test.)
<img width="572" alt="image" src="https://user-images.githubusercontent.com/418083/202204088-5822d311-d391-4bc8-91d9-8969b03aac61.png">

It was tested with the following steps:

1. Accessed https://github.com/gitpod-io/gitpod/actions/workflows/jetbrains-update-plugin-platform.yml
2. Ran the workflow targeting branch `felladrin/auto-update-stable-gateway-plugin`
    <img width="362" alt="image" src="https://user-images.githubusercontent.com/418083/202200765-0685091b-e40f-4037-9156-8be1516b6ec8.png">

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```