### PR TITLE
Update email notifications settings

### DIFF
--- a/components/dashboard/src/settings/Notifications.tsx
+++ b/components/dashboard/src/settings/Notifications.tsx
@@ -81,13 +81,7 @@ export default function Notifications() {
     return (
         <div>
             <PageWithSettingsSubMenu title="Notifications" subtitle="Choose when to be notified.">
-                <h3>Email Notification Preferences</h3>
-                <CheckBox
-                    title="Account Notifications [required]"
-                    desc="Receive essential emails about changes to your account"
-                    checked={true}
-                    disabled={true}
-                />
+                <h3>Email Notifications</h3>
                 <CheckBox
                     title="Onboarding guide"
                     desc="In the first weeks after you sign up, we'll guide you through the product, so you can get the most out of it"


### PR DESCRIPTION
## Description

Remove the always disabled option for account notifications.

## How to test
1. Create an account
2. Go to notifications settings
3. Notice the disabled account notifications option is missing

## Screenshots

| BEFORE | AFTER |
|-|-|
| <img width="660" alt="notifications-before" src="https://user-images.githubusercontent.com/120486/202202873-e18986e8-c7ff-48e5-afa4-91bf9ece1249.png"> | <img width="660" alt="notifications-after" src="https://user-images.githubusercontent.com/120486/202202877-49cb43a9-574c-4fdb-bf60-97d63a741a47.png"> |

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Update email notifications settings
```

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
