### PR TITLE
[dashboard] Extremely basic listing of Personal Access Tokens in the UI

### DIFF
--- a/components/dashboard/src/service/public-api.ts
+++ b/components/dashboard/src/service/public-api.ts
@@ -7,6 +7,7 @@
 import { createConnectTransport, createPromiseClient } from "@bufbuild/connect-web";
 import { Team as ProtocolTeam } from "@gitpod/gitpod-protocol/lib/teams-projects-protocol";
 import { TeamsService } from "@gitpod/public-api/lib/gitpod/experimental/v1/teams_connectweb";
+import { TokensService } from "@gitpod/public-api/lib/gitpod/experimental/v1/tokens_connectweb";
 import { Team } from "@gitpod/public-api/lib/gitpod/experimental/v1/teams_pb";
 import { TeamMemberInfo, TeamMemberRole } from "@gitpod/gitpod-protocol";
 import { TeamMember, TeamRole } from "@gitpod/public-api/lib/gitpod/experimental/v1/teams_pb";
@@ -17,6 +18,7 @@ const transport = createConnectTransport({
 });
 
 export const teamsService = createPromiseClient(TeamsService, transport);
+export const personalAccessTokensService = createPromiseClient(TokensService, transport);
 
 export function publicApiTeamToProtocol(team: Team): ProtocolTeam {
     return {

--- a/components/dashboard/src/settings/PersonalAccessTokens.tsx
+++ b/components/dashboard/src/settings/PersonalAccessTokens.tsx
@@ -4,9 +4,11 @@
  * See License-AGPL.txt in the project root for license information.
  */
 
-import { useContext } from "react";
+import { PersonalAccessToken } from "@gitpod/public-api/lib/gitpod/experimental/v1/tokens_pb";
+import { useContext, useEffect, useState } from "react";
 import { Redirect } from "react-router";
 import { FeatureFlagContext } from "../contexts/FeatureFlagContext";
+import { personalAccessTokensService } from "../service/public-api";
 import { PageWithSettingsSubMenu } from "./PageWithSettingsSubMenu";
 
 function PersonalAccessTokens() {
@@ -21,8 +23,34 @@ function PersonalAccessTokens() {
             <PageWithSettingsSubMenu
                 title="Preferences"
                 subtitle="Manage your Personal Access Tokens to access the Gitpod API."
-                children={undefined}
-            ></PageWithSettingsSubMenu>
+            >
+                <ListAccessTokensView />
+            </PageWithSettingsSubMenu>
+        </div>
+    );
+}
+
+function ListAccessTokensView() {
+    const [tokens, setTokens] = useState<PersonalAccessToken[]>([]);
+
+    useEffect(() => {
+        (async () => {
+            const response = await personalAccessTokensService.listPersonalAccessTokens({});
+            setTokens(response.tokens);
+        })();
+    }, []);
+
+    return (
+        <div>
+            <ul>
+                {tokens.map((t: PersonalAccessToken) => {
+                    return (
+                        <li>
+                            {t.id} - {t.name} - {t.value}
+                        </li>
+                    );
+                })}
+            </ul>
         </div>
     );
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Currently there are no tokens created yet, but this change will at least start making that request to Pub API so that we can validate everything works as expected early.

The change is behind a feature flag, so should be risk-free to include in prod.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
