### PR TITLE
[JSON-RPC] don't pass non-JSON data

### DIFF
--- a/components/dashboard/src/components/UsageBasedBillingConfig.tsx
+++ b/components/dashboard/src/components/UsageBasedBillingConfig.tsx
@@ -52,11 +52,8 @@ export default function UsageBasedBillingConfig({ attributionId }: Props) {
         setStripeSubscriptionId(undefined);
         setIsLoadingStripeSubscription(true);
         try {
-            const [subscriptionId, costCenter] = await Promise.all([
-                getGitpodService().server.findStripeSubscriptionId(attributionId),
-                getGitpodService().server.getCostCenter(attributionId),
-            ]);
-            setStripeSubscriptionId(subscriptionId);
+            getGitpodService().server.findStripeSubscriptionId(attributionId).then(setStripeSubscriptionId);
+            const costCenter = await getGitpodService().server.getCostCenter(attributionId);
             setUsageLimit(costCenter?.spendingLimit);
             setBillingCycleFrom(dayjs(costCenter?.billingCycleStart || now.startOf("month")).utc(true));
             setBillingCycleTo(dayjs(costCenter?.nextBillingTime || now.endOf("month")).utc(true));

--- a/components/gitpod-protocol/BUILD.yaml
+++ b/components/gitpod-protocol/BUILD.yaml
@@ -5,7 +5,6 @@ packages:
       - :lib
       - components/gitpod-protocol/go:lib
       - components/gitpod-protocol/java:lib
-      - components/usage-api/typescript:lib
   - name: lib
     type: yarn
     srcs:
@@ -14,8 +13,6 @@ packages:
       - package.json
       - mocha.opts
       - "data/*.json"
-    deps:
-      - components/usage-api/typescript:lib
     config:
       packaging: library
       yarnLock: ${coreYarnLockBase}/yarn.lock

--- a/components/gitpod-protocol/package.json
+++ b/components/gitpod-protocol/package.json
@@ -41,7 +41,6 @@
         "watch": "leeway exec --package .:lib --transitive-dependencies --filter-type yarn --components --parallel -- tsc -w --preserveWatchOutput"
     },
     "dependencies": {
-        "@gitpod/usage-api": "0.1.5",
         "@types/react": "17.0.32",
         "abort-controller-x": "^0.4.0",
         "ajv": "^6.5.4",

--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -59,10 +59,9 @@ import {
 import { RemotePageMessage, RemoteTrackMessage, RemoteIdentifyMessage } from "./analytics";
 import { IDEServer } from "./ide-protocol";
 import { InstallationAdminSettings, TelemetryData } from "./installation-admin-protocol";
-import { ListUsageRequest, ListUsageResponse } from "./usage";
+import { ListUsageRequest, ListUsageResponse, CostCenterJSON } from "./usage";
 import { SupportedWorkspaceClass } from "./workspace-class";
 import { BillingMode } from "./billing-mode";
-import { CostCenter } from "@gitpod/usage-api/lib/usage/v1/usage.pb";
 
 export interface GitpodClient {
     onInstanceUpdate(instance: WorkspaceInstance): void;
@@ -281,7 +280,7 @@ export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, 
     createStripeCustomerIfNeeded(attributionId: string, currency: string): Promise<void>;
     subscribeToStripe(attributionId: string, setupIntentId: string, usageLimit: number): Promise<number | undefined>;
     getStripePortalUrl(attributionId: string): Promise<string>;
-    getCostCenter(attributionId: string): Promise<CostCenter | undefined>;
+    getCostCenter(attributionId: string): Promise<CostCenterJSON | undefined>;
     setUsageLimit(attributionId: string, usageLimit: number): Promise<void>;
 
     listUsage(req: ListUsageRequest): Promise<ListUsageResponse>;

--- a/components/gitpod-protocol/src/usage.ts
+++ b/components/gitpod-protocol/src/usage.ts
@@ -69,3 +69,17 @@ export interface InvoiceUsageData {
     startDate: string;
     endDate: string;
 }
+
+export interface CostCenterJSON {
+    attributionId: string;
+    spendingLimit: number;
+    billingStrategy: CostCenter_BillingStrategy;
+    nextBillingTime?: string;
+    billingCycleStart?: string;
+}
+
+export enum CostCenter_BillingStrategy {
+    BILLING_STRATEGY_STRIPE = "BILLING_STRATEGY_STRIPE",
+    BILLING_STRATEGY_OTHER = "BILLING_STRATEGY_OTHER",
+    UNRECOGNIZED = "UNRECOGNIZED",
+}

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -181,7 +181,7 @@ import { MessageBusIntegration } from "./messagebus-integration";
 import { AttributionId } from "@gitpod/gitpod-protocol/lib/attribution";
 import * as grpc from "@grpc/grpc-js";
 import { CachingBlobServiceClientProvider } from "../util/content-service-sugar";
-import { CostCenter } from "@gitpod/usage-api/lib/usage/v1/usage.pb";
+import { CostCenterJSON } from "@gitpod/gitpod-protocol/lib/usage";
 
 // shortcut
 export const traceWI = (ctx: TraceContext, wi: Omit<LogContext, "userId">) => TraceContext.setOWI(ctx, wi); // userId is already taken care of in WebsocketConnectionManager
@@ -3128,7 +3128,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         throw new ResponseError(ErrorCodes.SAAS_FEATURE, `Not implemented in this version`);
     }
 
-    async getCostCenter(ctx: TraceContext, attributionId: string): Promise<CostCenter | undefined> {
+    async getCostCenter(ctx: TraceContext, attributionId: string): Promise<CostCenterJSON | undefined> {
         throw new ResponseError(ErrorCodes.SAAS_FEATURE, `Not implemented in this version`);
     }
 


### PR DESCRIPTION
## Description
The JSON-RPC protocol cannot handle JavaScript Date. This PR translates them to an iso string

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #14743

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
