### PR TITLE
Log a warning if branch isn't pushed

### DIFF
--- a/dev/preview/workflow/lib/common.sh
+++ b/dev/preview/workflow/lib/common.sh
@@ -27,12 +27,18 @@ function import() {
 BLUE='\033[0;34m'
 RED='\033[0;31m'
 GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
 # NC=no color
 NC='\033[0m'
 
 function log_error() {
   local text=$1
   echo -e "${RED}ERROR: ${NC}${text}" 1>&2
+}
+
+function log_warn() {
+  local text="$1"
+  echo -e "${YELLOW}WARN: ${NC}${text}"
 }
 
 function log_success() {

--- a/dev/preview/workflow/lib/git.sh
+++ b/dev/preview/workflow/lib/git.sh
@@ -12,3 +12,7 @@ function git:is-on-main {
     else return 1
     fi
 }
+
+function git:branch-exists-remotely {
+    git ls-remote --exit-code --heads origin "$(git:branch-name)" > /dev/null
+}

--- a/dev/preview/workflow/preview/preview.sh
+++ b/dev/preview/workflow/preview/preview.sh
@@ -18,6 +18,10 @@ if git:is-on-main; then
     exit 1
 fi
 
+if ! git:branch-exists-remotely; then
+    log_warn "Your branch doesn't exist on GitHub. Your preview environment might get garbage collected at any time. To avoid this please push your branch."
+fi
+
 ensure_gcloud_auth
 
 leeway run dev/preview:create-preview


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Log a warning if the active branch doesn't exist on GitHub.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/14734

## How to test
<!-- Provide steps to test this PR -->

```
$ leeway run dev:preview
WARN: Your branch doesn't exist on GitHub. Your preview environment might get garbage collected at any time. To avoid this please push your branch.

$ git push -u origin mads/log-warnning-when-branch-isnt-pushed
$ leeway run dev:preview
# No warnings
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
