### PR TITLE
[dashboard/protocol] Pass `slow-database` `Sec-WebSocket-Protocol` header to websocket connections from dashboard

### DIFF
--- a/components/dashboard/src/App.tsx
+++ b/components/dashboard/src/App.tsx
@@ -12,7 +12,7 @@ import { Login } from "./Login";
 import { UserContext } from "./user-context";
 import { getSelectedTeamSlug, TeamsContext } from "./teams/teams-context";
 import { ThemeContext } from "./theme-context";
-import { getGitpodService } from "./service/service";
+import { getGitpodService, initGitPodService } from "./service/service";
 import { shouldSeeWhatsNew, WhatsNew } from "./whatsnew/WhatsNew";
 import gitpodIcon from "./icons/gitpod.svg";
 import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
@@ -159,13 +159,17 @@ function App() {
     const { user, setUser, refreshUserBillingMode } = useContext(UserContext);
     const { teams, setTeams } = useContext(TeamsContext);
     const { setIsDark } = useContext(ThemeContext);
-    const { usePublicApiTeamsService } = useContext(FeatureFlagContext);
+    const { usePublicApiTeamsService, useSlowDatabase } = useContext(FeatureFlagContext);
 
     const [loading, setLoading] = useState<boolean>(true);
     const [isWhatsNewShown, setWhatsNewShown] = useState(false);
     const [showUserIdePreference, setShowUserIdePreference] = useState(false);
     const [isSetupRequired, setSetupRequired] = useState(false);
     const history = useHistory();
+
+    useEffect(() => {
+        initGitPodService(useSlowDatabase);
+    }, [useSlowDatabase]);
 
     useEffect(() => {
         (async () => {

--- a/components/dashboard/src/contexts/FeatureFlagContext.tsx
+++ b/components/dashboard/src/contexts/FeatureFlagContext.tsx
@@ -21,12 +21,14 @@ const FeatureFlagContext = createContext<{
     showUseLastSuccessfulPrebuild: boolean;
     usePublicApiTeamsService: boolean;
     enablePersonalAccessTokens: boolean;
+    useSlowDatabase: boolean;
 }>({
     showPersistentVolumeClaimUI: false,
     showUsageView: false,
     showUseLastSuccessfulPrebuild: false,
     usePublicApiTeamsService: false,
     enablePersonalAccessTokens: false,
+    useSlowDatabase: false,
 });
 
 const FeatureFlagContextProvider: React.FC = ({ children }) => {
@@ -40,6 +42,7 @@ const FeatureFlagContextProvider: React.FC = ({ children }) => {
     const [showUseLastSuccessfulPrebuild, setShowUseLastSuccessfulPrebuild] = useState<boolean>(false);
     const [usePublicApiTeamsService, setUsePublicApiTeamsService] = useState<boolean>(false);
     const [enablePersonalAccessTokens, setPersonalAccessTokensEnabled] = useState<boolean>(false);
+    const [useSlowDatabase, setUseSlowDatabase] = useState<boolean>(false);
 
     useEffect(() => {
         if (!user) return;
@@ -50,6 +53,7 @@ const FeatureFlagContextProvider: React.FC = ({ children }) => {
                 showUseLastSuccessfulPrebuild: { defaultValue: false, setter: setShowUseLastSuccessfulPrebuild },
                 publicApiExperimentalTeamsService: { defaultValue: false, setter: setUsePublicApiTeamsService },
                 personalAccessTokensEnabled: { defaultValue: false, setter: setPersonalAccessTokensEnabled },
+                useSlowDatabase: { defaultValue: false, setter: setUseSlowDatabase },
             };
             for (const [flagName, config] of Object.entries(featureFlags)) {
                 if (teams) {
@@ -88,6 +92,7 @@ const FeatureFlagContextProvider: React.FC = ({ children }) => {
                 showUseLastSuccessfulPrebuild,
                 usePublicApiTeamsService,
                 enablePersonalAccessTokens,
+                useSlowDatabase,
             }}
         >
             {children}

--- a/components/dashboard/src/contexts/FeatureFlagContext.tsx
+++ b/components/dashboard/src/contexts/FeatureFlagContext.tsx
@@ -53,7 +53,7 @@ const FeatureFlagContextProvider: React.FC = ({ children }) => {
                 showUseLastSuccessfulPrebuild: { defaultValue: false, setter: setShowUseLastSuccessfulPrebuild },
                 publicApiExperimentalTeamsService: { defaultValue: false, setter: setUsePublicApiTeamsService },
                 personalAccessTokensEnabled: { defaultValue: false, setter: setPersonalAccessTokensEnabled },
-                useSlowDatabase: { defaultValue: false, setter: setUseSlowDatabase },
+                slow_database: { defaultValue: false, setter: setUseSlowDatabase },
             };
             for (const [flagName, config] of Object.entries(featureFlags)) {
                 if (teams) {

--- a/components/dashboard/src/service/service.tsx
+++ b/components/dashboard/src/service/service.tsx
@@ -19,7 +19,7 @@ import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 
 export const gitpodHostUrl = new GitpodHostUrl(window.location.toString());
 
-function createGitpodService<C extends GitpodClient, S extends GitpodServer>() {
+function createGitpodService<C extends GitpodClient, S extends GitpodServer>(useSlowDatabase: boolean = false) {
     if (window.top !== window.self && process.env.NODE_ENV === "production") {
         const connection = createWindowMessageConnection("gitpodServer", window.parent, "*");
         const factory = new JsonRpcProxyFactory<S>();
@@ -48,6 +48,7 @@ function createGitpodService<C extends GitpodClient, S extends GitpodServer>() {
         onListening: (socket) => {
             onReconnect = () => socket.reconnect();
         },
+        subProtocol: useSlowDatabase ? "slow-database" : undefined,
     });
 
     return new GitpodServiceImpl<C, S>(proxy, { onReconnect });
@@ -64,4 +65,13 @@ function getGitpodService(): GitpodService {
     return service;
 }
 
-export { getGitpodService };
+function initGitPodService(useSlowDatabase: boolean) {
+    const w = window as any;
+    const _gp = w._gp || (w._gp = {});
+    if (window.location.search.includes("service=mock")) {
+        _gp.gitpodService = require("./service-mock").gitpodServiceMock;
+    }
+    _gp.gitpodService = createGitpodService(useSlowDatabase);
+}
+
+export { getGitpodService, initGitPodService };

--- a/components/gitpod-protocol/src/messaging/browser/connection.ts
+++ b/components/gitpod-protocol/src/messaging/browser/connection.ts
@@ -16,6 +16,7 @@ import ReconnectingWebSocket, { Event } from "reconnecting-websocket";
 export interface WebSocketOptions {
     onerror?: (event: Event) => void;
     onListening?: (socket: ReconnectingWebSocket) => void;
+    subProtocol?: string;
 }
 
 export class WebSocketConnectionProvider {
@@ -62,7 +63,7 @@ export class WebSocketConnectionProvider {
      */
     listen(handler: ConnectionHandler, eventHandler: ConnectionEventHandler, options?: WebSocketOptions): WebSocket {
         const url = handler.path;
-        const webSocket = this.createWebSocket(url);
+        const webSocket = this.createWebSocket(url, options);
 
         const logger = this.createLogger();
         if (options && options.onerror) {
@@ -86,8 +87,8 @@ export class WebSocketConnectionProvider {
     /**
      * Creates a web socket for the given url
      */
-    createWebSocket(url: string): WebSocket {
-        return new ReconnectingWebSocket(url, undefined, {
+    createWebSocket(url: string, options?: WebSocketOptions): WebSocket {
+        return new ReconnectingWebSocket(url, options?.subProtocol, {
             maxReconnectionDelay: 10000,
             minReconnectionDelay: 1000,
             reconnectionDelayGrowFactor: 1.3,


### PR DESCRIPTION
## Description

Allow websocket connections from the dashboard to the server to specify a [Sec-WebSocket-Protocol](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-WebSocket-Protocol) header indicating whether the connection should use a high-latency database connection, according to the value of a feature flag.

At a high level, the architecture looks like this:

![ws](https://user-images.githubusercontent.com/8225907/203027373-d8c30052-098e-4e17-a476-590232b92649.svg)

Together with the dependency #14778 which handles the proxying of websocket upgrade requests to the `slow-server` backend based on the presence of the `Sec-WebSocket-Protocol` header, this PR gives us a means to roll out higher-latency dashboard to server websocket connections to selected internal users.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of #9198 

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-slow-database
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
