### PR TITLE
[installer-tests] fix upgrade test behavior to not delete on failure

### DIFF
--- a/.werft/jobs/build/self-hosted-upgrade-tests.ts
+++ b/.werft/jobs/build/self-hosted-upgrade-tests.ts
@@ -56,13 +56,14 @@ export async function triggerUpgradeTests(werft: Werft, config: JobConfig, usern
 
         werft.phase(upgradeConfig.phase, upgradeConfig.description);
 
-        annotation = `${annotation} -a updateGitHubStatus=gitpod-io/gitpod -a subdomain=${subdomain}-${upgradeConfig.cloud} -a deps=external`
+        annotation = `${annotation} -a updateGitHubStatus=gitpod-io/gitpod \
+                        -a subdomain=${subdomain}-${upgradeConfig.cloud} -a deps=external -a deleteOnFail=false`
 
         const testFile: string = `.werft/${phase}-installer-tests.yaml`;
 
         try {
             const ret = exec(
-                `werft run --remote-job-path ${testFile} ${annotation} github`,
+                `werft run --remote-job-path ${testFile} ${annotation} -a deleteOnFail=false github`,
                 {
                     slice: upgradeConfig.phase,
                 },
@@ -124,7 +125,7 @@ export async function triggerSelfHostedPreview(werft: Werft, config: JobConfig, 
 
     werft.phase("self-hosted-preview", `Create self-hosted preview in ${cluster}`);
 
-    annotation = `${annotation} -a cluster=${cluster} -a updateGitHubStatus=gitpod-io/gitpod -a subdomain=${subdomain}`
+    annotation = `${annotation} -a cluster=${cluster} -a updateGitHubStatus=gitpod-io/gitpod -a subdomain=${subdomain} -a deleteOnFail=false`
 
     const testFile: string = `.werft/${cluster}-installer-tests.yaml`;
 

--- a/install/infra/modules/tools/external-dns/main.tf
+++ b/install/infra/modules/tools/external-dns/main.tf
@@ -1,7 +1,7 @@
-variable settings {}
-variable domain_name { default = "test"}
-variable kubeconfig { default = "conf"}
-variable txt_owner_id { default = "nightly-test" }
+variable "settings" {}
+variable "domain_name" { default = "test" }
+variable "kubeconfig" { default = "conf" }
+variable "txt_owner_id" { default = "nightly-test" }
 
 provider "helm" {
   kubernetes {
@@ -12,7 +12,7 @@ provider "helm" {
 # External DNS Deployment using Helm
 resource "helm_release" "external_dns" {
   name             = "external-dns"
-  repository       = "https://charts.bitnami.com"
+  repository       = "https://charts.bitnami.com/bitnami"
   chart            = "external-dns"
   namespace        = "external-dns"
   create_namespace = true
@@ -22,14 +22,14 @@ resource "helm_release" "external_dns" {
     value = var.domain_name
   }
   set {
-    name = "txt-owner-id"
+    name  = "txt-owner-id"
     value = var.txt_owner_id
   }
 
   dynamic "set" {
     for_each = var.settings
     content {
-      name = set.value["name"]
+      name  = set.value["name"]
       value = set.value["value"]
     }
   }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This is a small PR that sets the flag `deleteOnFail` to the upgrade tests. This avoids the from scratch recreation if any failure occurs during the release tests.

I am also sneaking in a small change to the external-dns charts. It turns out that external-dns setup is failing everyday due to the wrong chart source. This fixes the issue.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
From your workspace, run:
```
werft run github -j .werft/build.yaml -a with-sh-preview=true
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
