### PR TITLE
Improve ports respond in supervisor

### DIFF
--- a/components/gitpod-protocol/go/gitpod-service.go
+++ b/components/gitpod-protocol/go/gitpod-service.go
@@ -1951,7 +1951,6 @@ type PortConfig struct {
 	Visibility  string  `json:"visibility,omitempty"`
 	Description string  `json:"description,omitempty"`
 	Name        string  `json:"name,omitempty"`
-	Sort        uint32  `json:"sort,omitempty"`
 }
 
 // TaskConfig is the TaskConfig message type

--- a/components/supervisor/pkg/ports/ports-config.go
+++ b/components/supervisor/pkg/ports/ports-config.go
@@ -16,6 +16,8 @@ import (
 	"github.com/gitpod-io/gitpod/supervisor/pkg/config"
 )
 
+const NON_CONFIGED_BASIC_SCORE = 100000
+
 // RangeConfig is a port range config.
 type RangeConfig struct {
 	gitpod.PortsItems
@@ -190,7 +192,7 @@ func parseWorkspaceConfigs(ports []*gitpod.PortConfig) (portConfigs map[uint32]*
 			portConfigs[port] = &SortConfig{
 				PortConfig: *config,
 				// We don't care about workspace configs but instance config
-				Sort: 0,
+				Sort: NON_CONFIGED_BASIC_SCORE - 1,
 			}
 		}
 	}

--- a/components/supervisor/pkg/ports/ports-config_test.go
+++ b/components/supervisor/pkg/ports/ports-config_test.go
@@ -89,7 +89,7 @@ func TestPortsConfig(t *testing.T) {
 			Expectation: &PortConfigTestExpectations{
 				InstanceRangeConfigs: []*RangeConfig{
 					{
-						PortsItems: &gitpod.PortsItems{
+						PortsItems: gitpod.PortsItems{
 							Port:        "9229-9339",
 							OnOpen:      "ignore",
 							Visibility:  "public",
@@ -136,7 +136,7 @@ func TestPortsConfig(t *testing.T) {
 				t.Fatal(err)
 			case change := <-updates:
 				for _, config := range change.workspaceConfigs {
-					actual.WorkspaceConfigs = append(actual.WorkspaceConfigs, config)
+					actual.WorkspaceConfigs = append(actual.WorkspaceConfigs, &config.PortConfig)
 				}
 			}
 
@@ -150,7 +150,7 @@ func TestPortsConfig(t *testing.T) {
 				case change := <-updates:
 					actual.InstanceRangeConfigs = change.instanceRangeConfigs
 					for _, config := range change.instancePortConfigs {
-						actual.InstancePortConfigs = append(actual.InstancePortConfigs, config)
+						actual.InstancePortConfigs = append(actual.InstancePortConfigs, &config.PortConfig)
 					}
 				}
 			}

--- a/components/supervisor/pkg/ports/ports.go
+++ b/components/supervisor/pkg/ports/ports.go
@@ -291,7 +291,7 @@ func (pm *Manager) updateState(ctx context.Context, exposed []ExposedPort, serve
 	stateChanged := !reflect.DeepEqual(newState, pm.state)
 	pm.state = newState
 
-	if !stateChanged {
+	if !stateChanged && configured == nil {
 		return
 	}
 

--- a/components/supervisor/pkg/ports/ports.go
+++ b/components/supervisor/pkg/ports/ports.go
@@ -748,8 +748,8 @@ func (pm *Manager) getStatus() []*api.PortsStatus {
 	}
 	sort.SliceStable(res, func(i, j int) bool {
 		// Max number of port 65536
-		score1 := 100000 + res[i].LocalPort
-		score2 := 100000 + res[j].LocalPort
+		score1 := NON_CONFIGED_BASIC_SCORE + res[i].LocalPort
+		score2 := NON_CONFIGED_BASIC_SCORE + res[j].LocalPort
 		if c, _, ok := pm.configs.Get(res[i].LocalPort); ok {
 			score1 = c.Sort
 		}

--- a/components/supervisor/pkg/ports/ports_test.go
+++ b/components/supervisor/pkg/ports/ports_test.go
@@ -63,8 +63,8 @@ func TestPortsUpdateState(t *testing.T) {
 				[]*api.PortsStatus{{LocalPort: 8080, Served: true, OnOpen: api.PortsStatus_notify_private}},
 				[]*api.PortsStatus{{LocalPort: 8080, Served: true, OnOpen: api.PortsStatus_notify_private, Exposed: &api.ExposedPortInfo{OnExposed: api.OnPortExposedAction_notify_private, Visibility: api.PortVisibility_private, Url: "foobar"}}},
 				[]*api.PortsStatus{{LocalPort: 8080, Served: true, OnOpen: api.PortsStatus_notify_private, Exposed: &api.ExposedPortInfo{OnExposed: api.OnPortExposedAction_notify_private, Visibility: api.PortVisibility_private, Url: "foobar"}}, {LocalPort: 60000, Served: true}},
-				[]*api.PortsStatus{{LocalPort: 60000, Served: true}},
-				{},
+				[]*api.PortsStatus{{LocalPort: 8080, Served: false, OnOpen: api.PortsStatus_notify_private, Exposed: &api.ExposedPortInfo{OnExposed: api.OnPortExposedAction_notify_private, Visibility: api.PortVisibility_private, Url: "foobar"}}, {LocalPort: 60000, Served: true}},
+				[]*api.PortsStatus{{LocalPort: 8080, Served: false, OnOpen: api.PortsStatus_notify_private, Exposed: &api.ExposedPortInfo{OnExposed: api.OnPortExposedAction_notify_private, Visibility: api.PortVisibility_private, Url: "foobar"}}},
 			},
 		},
 		{

--- a/components/supervisor/pkg/ports/ports_test.go
+++ b/components/supervisor/pkg/ports/ports_test.go
@@ -25,8 +25,7 @@ func TestPortsUpdateState(t *testing.T) {
 	type ExposureExpectation []ExposedPort
 	type UpdateExpectation [][]*api.PortsStatus
 	type ConfigChange struct {
-		workspace []*gitpod.PortConfig
-		instance  []*gitpod.PortsItems
+		instance []*gitpod.PortsItems
 	}
 	type Change struct {
 		Config      *ConfigChange
@@ -110,47 +109,6 @@ func TestPortsUpdateState(t *testing.T) {
 			ExpectedUpdates:  UpdateExpectation{{}},
 		},
 		{
-			Desc: "serving configured workspace port",
-			Changes: []Change{
-				{Config: &ConfigChange{
-					workspace: []*gitpod.PortConfig{
-						{Port: 8080, OnOpen: "open-browser"},
-						{Port: 9229, OnOpen: "ignore", Visibility: "private"},
-					},
-				}},
-				{
-					Exposed: []ExposedPort{
-						{LocalPort: 8080, Public: true, URL: "8080-foobar"},
-						{LocalPort: 9229, Public: false, URL: "9229-foobar"},
-					},
-				},
-				{
-					Served: []ServedPort{
-						{net.IPv4zero, 8080, false},
-						{net.IPv4(127, 0, 0, 1), 9229, true},
-					},
-				},
-			},
-			ExpectedExposure: []ExposedPort{
-				{LocalPort: 8080},
-				{LocalPort: 9229},
-			},
-			ExpectedUpdates: UpdateExpectation{
-				{},
-				[]*api.PortsStatus{
-					{LocalPort: 8080, OnOpen: api.PortsStatus_open_browser},
-					{LocalPort: 9229, OnOpen: api.PortsStatus_ignore}},
-				[]*api.PortsStatus{
-					{LocalPort: 8080, OnOpen: api.PortsStatus_open_browser, Exposed: &api.ExposedPortInfo{Visibility: api.PortVisibility_public, Url: "8080-foobar", OnExposed: api.OnPortExposedAction_open_browser}},
-					{LocalPort: 9229, OnOpen: api.PortsStatus_ignore, Exposed: &api.ExposedPortInfo{Visibility: api.PortVisibility_private, Url: "9229-foobar", OnExposed: api.OnPortExposedAction_ignore}},
-				},
-				[]*api.PortsStatus{
-					{LocalPort: 8080, Served: true, OnOpen: api.PortsStatus_open_browser, Exposed: &api.ExposedPortInfo{Visibility: api.PortVisibility_public, Url: "8080-foobar", OnExposed: api.OnPortExposedAction_open_browser}},
-					{LocalPort: 9229, Served: true, OnOpen: api.PortsStatus_ignore, Exposed: &api.ExposedPortInfo{Visibility: api.PortVisibility_private, Url: "9229-foobar", OnExposed: api.OnPortExposedAction_ignore}},
-				},
-			},
-		},
-		{
 			Desc: "serving port from the configured port range",
 			Changes: []Change{
 				{Config: &ConfigChange{
@@ -182,7 +140,7 @@ func TestPortsUpdateState(t *testing.T) {
 			Desc: "auto expose configured ports",
 			Changes: []Change{
 				{
-					Config: &ConfigChange{workspace: []*gitpod.PortConfig{
+					Config: &ConfigChange{instance: []*gitpod.PortsItems{
 						{Port: 8080, Visibility: "private"},
 					}},
 				},
@@ -244,7 +202,7 @@ func TestPortsUpdateState(t *testing.T) {
 			Desc: "served between auto exposing configured and exposed update",
 			Changes: []Change{
 				{
-					Config: &ConfigChange{workspace: []*gitpod.PortConfig{
+					Config: &ConfigChange{instance: []*gitpod.PortsItems{
 						{Port: 8080, Visibility: "private"},
 					}},
 				},
@@ -451,7 +409,7 @@ func TestPortsUpdateState(t *testing.T) {
 			Desc: "port status has description set as soon as the port gets exposed, if there was a description configured",
 			Changes: []Change{
 				{
-					Config: &ConfigChange{workspace: []*gitpod.PortConfig{
+					Config: &ConfigChange{instance: []*gitpod.PortsItems{
 						{Port: 8080, Visibility: "private", Description: "Development server"},
 					}},
 				},
@@ -476,7 +434,7 @@ func TestPortsUpdateState(t *testing.T) {
 			Desc: "port status has the name attribute set as soon as the port gets exposed, if there was a name configured in Gitpod's Workspace",
 			Changes: []Change{
 				{
-					Config: &ConfigChange{workspace: []*gitpod.PortConfig{
+					Config: &ConfigChange{instance: []*gitpod.PortsItems{
 						{Port: 3000, Visibility: "private", Name: "react"},
 					}},
 				},
@@ -582,9 +540,6 @@ func TestPortsUpdateState(t *testing.T) {
 			Changes: []Change{
 				{
 					Config: &ConfigChange{
-						workspace: []*gitpod.PortConfig{
-							{Port: 3000, Visibility: "private", Name: "react"},
-						},
 						instance: []*gitpod.PortsItems{
 							{Port: 3001, Visibility: "private", Name: "react"},
 							{Port: 3000, Visibility: "private", Name: "react"},
@@ -593,9 +548,6 @@ func TestPortsUpdateState(t *testing.T) {
 				},
 				{
 					Config: &ConfigChange{
-						workspace: []*gitpod.PortConfig{
-							{Port: 3000, Visibility: "private", Name: "react"},
-						},
 						instance: []*gitpod.PortsItems{
 							{Port: 3003, Visibility: "private", Name: "react"},
 							{Port: 3001, Visibility: "private", Name: "react"},
@@ -612,9 +564,6 @@ func TestPortsUpdateState(t *testing.T) {
 				},
 				{
 					Config: &ConfigChange{
-						workspace: []*gitpod.PortConfig{
-							{Port: 3000, Visibility: "private", Name: "react"},
-						},
 						instance: []*gitpod.PortsItems{
 							{Port: 3003, Visibility: "private", Name: "react"},
 							{Port: 3000, Visibility: "private", Name: "react"},
@@ -623,9 +572,6 @@ func TestPortsUpdateState(t *testing.T) {
 				},
 				{
 					Config: &ConfigChange{
-						workspace: []*gitpod.PortConfig{
-							{Port: 3000, Visibility: "private", Name: "react"},
-						},
 						instance: []*gitpod.PortsItems{
 							{Port: "3001-3005", Visibility: "private", Name: "react"},
 							{Port: 3003, Visibility: "private", Name: "react"},
@@ -738,7 +684,6 @@ func TestPortsUpdateState(t *testing.T) {
 				for _, c := range test.Changes {
 					if c.Config != nil {
 						change := &Configs{}
-						change.workspaceConfigs = parseWorkspaceConfigs(c.Config.workspace)
 						portConfigs, rangeConfigs := parseInstanceConfigs(c.Config.instance)
 						change.instancePortConfigs = portConfigs
 						change.instanceRangeConfigs = rangeConfigs


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

- Localify struct of ports sort - move sort property exists in supervisor only to address https://github.com/gitpod-io/gitpod/pull/13788#discussion_r1001082758
- Don't filter not served ports
- Add test cases for issue https://github.com/gitpod-io/gitpod/issues/14248 in case of regression
- Disable workspace config ports

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/14248

## How to test
<!-- Provide steps to test this PR -->
- Follow PR https://github.com/gitpod-io/gitpod/pull/13788
- And check if functions of ports working

**Disable workspace config ports**

- Open workspace with ports already defined in .gitpod.yml
- Change order after workspace started
- Check if order align only with current `.gitpod.yml`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Show not-served ports in gp-cli `ports` command, browser Ports view and desktop ExposedPorts view
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
