### PR TITLE
[dashboard] StartWorkspace: Map "Go to Dashboard" to /workspaces (again)

### DIFF
--- a/components/dashboard/src/start/StartWorkspace.tsx
+++ b/components/dashboard/src/start/StartWorkspace.tsx
@@ -536,7 +536,7 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
                                         },
                                         {
                                             title: "Go to Dashboard",
-                                            href: gitpodHostUrl.asDashboard().toString(),
+                                            href: gitpodHostUrl.asWorkspacePage().toString(),
                                             target: "_parent",
                                         },
                                     ]}
@@ -611,7 +611,7 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
                             </div>
                         </div>
                         <div className="mt-10 flex justify-center">
-                            <a target="_parent" href={gitpodHostUrl.asDashboard().toString()}>
+                            <a target="_parent" href={gitpodHostUrl.asWorkspacePage().toString()}>
                                 <button className="secondary">Go to Dashboard</button>
                             </a>
                         </div>
@@ -656,7 +656,7 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
                         </div>
                         <PendingChangesDropdown workspaceInstance={this.state.workspaceInstance} />
                         <div className="mt-10 justify-center flex space-x-2">
-                            <a target="_parent" href={gitpodHostUrl.asDashboard().toString()}>
+                            <a target="_parent" href={gitpodHostUrl.asWorkspacePage().toString()}>
                                 <button className="secondary">Go to Dashboard</button>
                             </a>
                             <a


### PR DESCRIPTION
## Description
In the past, the "Go to Dashboard" buttons on the "StartWorkspace" page always sent you to `/workspace`. This solved use-cases like "stop and delete workspace".
Because we recently changed the default page of the SPA to your current project (?), this is no longer the case, and when hitting that button, users are sent to the teams "Project Overview" page. This does not feel sensible, as there is no action for users to perform on that page that would make sense in that context.

This PR makes the mapping "Go to Dashboard" -> `/workspaces` explicit to restore the old behavior.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
fix 'Go to Dashboard' buttons on StartWorkspace
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
