### PR TITLE
[JetBrains] Run Auto JDK Service only for Stable IDE versions, as on EAP JDK is now automatically resolved

### DIFF
--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/stable/GitpodAutoJdkService.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/stable/GitpodAutoJdkService.kt
@@ -2,7 +2,7 @@
 // Licensed under the GNU Affero General Public License (AGPL).
 // See License-AGPL.txt in the project root for license information.
 
-package io.gitpod.jetbrains.remote
+package io.gitpod.jetbrains.remote.stable
 
 import com.intellij.ProjectTopics
 import com.intellij.openapi.diagnostic.thisLogger
@@ -25,7 +25,7 @@ import kotlinx.coroutines.launch
 import java.util.concurrent.CompletableFuture
 
 @Suppress("UnstableApiUsage", "OPT_IN_USAGE")
-class GitpodProjectManager(
+class GitpodAutoJdkService(
         private val project: Project
 ) {
 

--- a/components/ide/jetbrains/backend-plugin/src/main/resources-stable/META-INF/extensions.xml
+++ b/components/ide/jetbrains/backend-plugin/src/main/resources-stable/META-INF/extensions.xml
@@ -10,5 +10,6 @@
         <applicationService serviceInterface="io.gitpod.jetbrains.remote.GitpodCLIHelper" serviceImplementation="io.gitpod.jetbrains.remote.stable.GitpodCLIHelperImpl"/>
         <projectService serviceImplementation="io.gitpod.jetbrains.remote.stable.GitpodClientProjectGuestSessionTracker" client="guest" preload="true"/>
         <projectService serviceImplementation="io.gitpod.jetbrains.remote.stable.GitpodTerminalGuestService" client="guest" preload="true"/>
+        <projectService serviceImplementation="io.gitpod.jetbrains.remote.stable.GitpodAutoJdkService" preload="true"/>
     </extensions>
 </idea-plugin>

--- a/components/ide/jetbrains/backend-plugin/src/main/resources/META-INF/plugin.xml
+++ b/components/ide/jetbrains/backend-plugin/src/main/resources/META-INF/plugin.xml
@@ -28,7 +28,6 @@
         <applicationService serviceImplementation="io.gitpod.jetbrains.remote.GitpodManager" preload="true"/>
         <notificationGroup id="Gitpod Notifications" displayType="BALLOON" isLogByDefault="false"/>
         <httpRequestHandler implementation="io.gitpod.jetbrains.remote.GitpodCLIService"/>
-        <projectService serviceImplementation="io.gitpod.jetbrains.remote.GitpodProjectManager" preload="true"/>
         <gateway.customization.name
                 implementation="io.gitpod.jetbrains.remote.GitpodGatewayClientCustomizationProvider"/>
         <gateway.customization.performance id="gitpodMetricsControl" order="before cpuControl"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PR was intended to run the Auto JDK Service only for Stable IDE versions, as on EAP JDK [should be automatically resolved](https://youtrack.jetbrains.com/issue/IDEA-296866/Automatically-pick-the-Java-on-PATH-if-module-SDK-isnt-explicitly-set).
But as it was [confirmed not to work as expected](https://github.com/gitpod-io/gitpod/issues/14697#issuecomment-1318388488), this PR will be closed right away.
The only reason for creating this PR is to keep the changeset in the record.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
- https://github.com/gitpod-io/gitpod/issues/14697

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```