### PR TITLE
[ws-manager] Remove wait from probes

### DIFF
--- a/components/ws-manager/pkg/manager/probe.go
+++ b/components/ws-manager/pkg/manager/probe.go
@@ -42,7 +42,7 @@ type WorkspaceReadyProbe struct {
 
 // NewWorkspaceReadyProbe creates a new workspace probe
 func NewWorkspaceReadyProbe(workspaceID string, workspaceURL url.URL) WorkspaceReadyProbe {
-	workspaceURL.Path += "/_supervisor/v1/status/ide/wait/true"
+	workspaceURL.Path += "/_supervisor/v1/status/ide"
 	readyURL := workspaceURL.String()
 
 	return WorkspaceReadyProbe{

--- a/test/pkg/integration/integration.go
+++ b/test/pkg/integration/integration.go
@@ -308,7 +308,7 @@ func Instrument(component ComponentType, agentName string, namespace string, kub
 	closer = append(closer, func() error {
 		if res != nil {
 			err := res.Call(MethodTestAgentShutdown, new(TestAgentShutdownRequest), new(TestAgentShutdownResponse))
-			if err != nil && strings.Contains(err.Error(), "connection is shut down") {
+			if err != nil && (strings.Contains(err.Error(), "connection is shut down") || strings.Contains(err.Error(), "the client connection is closing")) {
 				return nil
 			}
 

--- a/test/tests/components/ws-daemon/cpu_burst_test.go
+++ b/test/tests/components/ws-daemon/cpu_burst_test.go
@@ -26,8 +26,8 @@ import (
 type DaemonConfig struct {
 	CpuLimitConfig struct {
 		Enabled    bool  `json:"enabled"`
-		Limit      int64 `json:"limit,string"`
-		BurstLimit int64 `json:"burstLimit,string"`
+		Limit      int64 `json:"limit"`
+		BurstLimit int64 `json:"burstLimit"`
 	} `json:"cpuLimit"`
 }
 


### PR DESCRIPTION
## Description

Partially reverts https://github.com/gitpod-io/gitpod/pull/13828 to not wait in probe

## Release Notes
```release-note
NONE
```

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-integration-tests=workspace
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
