### PR TITLE
[server] fix persist of DBOAuthAuthCodeEntry (part 2)

### DIFF
--- a/components/gitpod-db/src/typeorm/user-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/user-db-impl.ts
@@ -517,6 +517,10 @@ export class TypeORMUserDBImpl implements UserDB {
 
     // OAuthTokenRepository
     async issueToken(client: OAuthClient, scopes: OAuthScope[], user?: OAuthUser): Promise<OAuthToken> {
+        if (!user) {
+            // this would otherwise break persisting of an DBOAuthAuthCodeEntry in AuthCodeRepositoryDB
+            throw new Error("Cannot issue auth code for unknown user.");
+        }
         const expiry = tokenExpiryInFuture.getEndDate();
         return <OAuthToken>{
             accessToken: crypto.randomBytes(30).toString("hex"),


### PR DESCRIPTION
https://github.com/gitpod-io/gitpod/pull/14758 was not enough to fix https://github.com/gitpod-io/gitpod/issues/14464

I hope this PR catches the rest.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
