### PR TITLE
Add GH Action to sync dashboards

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -1,0 +1,13 @@
+gitpod-io/monitoring-central:
+  - source: operations/observability/mixins/cross-teams/dashboards/
+    dest: charts/grafana/dashboards/general/
+  - source: operations/observability/mixins/IDE/dashboards/
+    dest: charts/grafana/dashboards/ide/
+  - source: operations/observability/mixins/meta/dashboards/
+    dest: charts/grafana/dashboards/webapp/
+  - source: operations/observability/mixins/platform/dashboards/
+    dest: charts/grafana/dashboards/platform/
+  - source: operations/observability/mixins/self-hosted/dashboards/
+    dest: charts/grafana/dashboards/deployment-operations-experience/
+  - source: operations/observability/mixins/workspace/dashboards/
+    dest: charts/grafana/dashboards/workspace/

--- a/.github/workflows/dashboard-sync.yml
+++ b/.github/workflows/dashboard-sync.yml
@@ -1,0 +1,23 @@
+name: Dashboard sync
+on:
+  push:
+    paths:
+      - operations/observability/mixins/cross-teams/dashboards/*
+      - operations/observability/mixins/IDE/dashboards/*
+      - operations/observability/mixins/meta/dashboards/*
+      - operations/observability/mixins/platform/dashboards/*
+      - operations/observability/mixins/self-hosted/dashboards/*
+      - operations/observability/mixins/workspace/dashboards/*
+    branches:
+      - main
+  workflow_dispatch:
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@master
+      - name: Run GitHub File Sync
+        uses: BetaHuhn/repo-file-sync-action@v1
+        with:
+          GH_PAT: ${{ secrets.ROBOQUAT_FSYNC_TOKEN }}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
To continue experiments with a monorepo for monitoring central, this Github Action will synchronize dashboards in gitpod-io/monitoring-central every time they change in gitpod-io/gitpod.

Docs for the action used can be seen here: https://github.com/marketplace/actions/repo-file-sync-action

## How to test
<!-- Provide steps to test this PR -->
Unfortunately, we need to merge it to main to be able to test 😓 

## Release Notes
-->
```release-note
NONE
```