### PR TITLE
[proxy] Proxy websocket traffic to `slow-server` deployment according to `Sec-WebSocket-Protocol` header

### DIFF
--- a/components/proxy/conf/Caddyfile
+++ b/components/proxy/conf/Caddyfile
@@ -12,15 +12,15 @@
 
 	# configure plugin order
 	# https://caddyserver.com/docs/caddyfile/directives#directive-order
-	order gitpod.cors_origin            before header
-	order gitpod.workspace_download     before redir
-	order gitpod.headless_log_download	before rewrite
-	order gitpod.configcat	            before rewrite
-	order gitpod.sec_websocket_key      before header
+	order gitpod.cors_origin before header
+	order gitpod.workspace_download before redir
+	order gitpod.headless_log_download before rewrite
+	order gitpod.configcat before rewrite
+	order gitpod.sec_websocket_key before header
 
 	servers {
-        protocols h1 h2 h2c
-    }
+		protocols h1 h2 h2c
+	}
 }
 
 (compression) {
@@ -31,15 +31,15 @@
 (security_headers) {
 	header {
 		# enable HSTS
-		Strict-Transport-Security  max-age=31536000
+		Strict-Transport-Security max-age=31536000
 		# disable clients from sniffing the media type
-		X-Content-Type-Options     nosniff
+		X-Content-Type-Options nosniff
 		# Define valid parents that may embed a page
-		Content-Security-Policy    "frame-ancestors 'self' https://*.{$GITPOD_DOMAIN} https://{$GITPOD_DOMAIN}"
+		Content-Security-Policy "frame-ancestors 'self' https://*.{$GITPOD_DOMAIN} https://{$GITPOD_DOMAIN}"
 		# keep referrer data off of HTTP connections
-		Referrer-Policy            no-referrer-when-downgrade
+		Referrer-Policy no-referrer-when-downgrade
 		# Enable cross-site filter (XSS) and tell browser to block detected attacks
-		X-XSS-Protection           "1; mode=block"
+		X-XSS-Protection "1; mode=block"
 
 		defer # delay changes
 	}
@@ -143,10 +143,10 @@
 
 # public-api
 api.{$GITPOD_DOMAIN} {
-    log {
-        level DEBUG
-        output stdout
-    }
+	log {
+		level DEBUG
+		output stdout
+	}
 
 	gitpod.cors_origin {
 		allowed_origins https://{$GITPOD_DOMAIN}
@@ -154,7 +154,6 @@ api.{$GITPOD_DOMAIN} {
 
 	reverse_proxy public-api-server.{$KUBE_NAMESPACE}.{$KUBE_DOMAIN}:9002
 }
-
 
 # always redirect to HTTPS
 http:// {
@@ -206,15 +205,15 @@ https://{$GITPOD_DOMAIN} {
 	}
 
 	@backend_wss {
-			path /api/gitpod
+		path /api/gitpod
 	}
 	handle @backend_wss {
-			gitpod.sec_websocket_key
+		gitpod.sec_websocket_key
 
-			uri strip_prefix /api
-			reverse_proxy server.{$KUBE_NAMESPACE}.{$KUBE_DOMAIN}:3000 {
-					import upstream_headers
-			}
+		uri strip_prefix /api
+		reverse_proxy server.{$KUBE_NAMESPACE}.{$KUBE_DOMAIN}:3000 {
+			import upstream_headers
+		}
 	}
 
 	@backend path /api/* /headless-logs/*
@@ -309,7 +308,7 @@ https://*.*.{$GITPOD_DOMAIN} {
 			import workspace_transport
 			import upstream_headers
 
-			header_up X-WSProxy-Host       {http.request.host}
+			header_up X-WSProxy-Host {http.request.host}
 		}
 	}
 
@@ -320,19 +319,19 @@ https://*.*.{$GITPOD_DOMAIN} {
 			import upstream_headers
 
 			header_up X-Gitpod-WorkspaceId {re.host.workspaceID}
-			header_up X-Gitpod-Port        {re.host.workspacePort}
-			header_up X-WSProxy-Host       {http.request.host}
+			header_up X-Gitpod-Port {re.host.workspacePort}
+			header_up X-WSProxy-Host {http.request.host}
 		}
 	}
 
-	@workspace 	header_regexp host Host ^(?P<workspaceID>[a-z0-9][0-9a-z\-]+).ws(?P<location>-[a-z0-9]+)?.{$GITPOD_DOMAIN}
+	@workspace header_regexp host Host ^(?P<workspaceID>[a-z0-9][0-9a-z\-]+).ws(?P<location>-[a-z0-9]+)?.{$GITPOD_DOMAIN}
 	handle @workspace {
 		reverse_proxy https://ws-proxy.{$KUBE_NAMESPACE}.{$KUBE_DOMAIN}:9090 {
 			import workspace_transport
 			import upstream_headers
 
 			header_up X-Gitpod-WorkspaceId {re.host.workspaceID}
-			header_up X-WSProxy-Host       {http.request.host}
+			header_up X-WSProxy-Host {http.request.host}
 		}
 	}
 

--- a/components/proxy/conf/Caddyfile
+++ b/components/proxy/conf/Caddyfile
@@ -210,8 +210,21 @@ https://{$GITPOD_DOMAIN} {
 	handle @backend_wss {
 		gitpod.sec_websocket_key
 
+		@slow {
+			header "Sec-WebSocket-Protocol" "slow-database"
+		}
+
+		@fast {
+			not header "Sec-WebSocket-Protocol" "slow-database"
+		}
+
 		uri strip_prefix /api
-		reverse_proxy server.{$KUBE_NAMESPACE}.{$KUBE_DOMAIN}:3000 {
+
+		reverse_proxy @fast server.{$KUBE_NAMESPACE}.{$KUBE_DOMAIN}:3000 {
+			import upstream_headers
+		}
+
+		reverse_proxy @slow slow-server.{$KUBE_NAMESPACE}.{$KUBE_DOMAIN}:3000 {
 			import upstream_headers
 		}
 	}


### PR DESCRIPTION
## Description

As part of #9198 we want to send a subset of websocket traffic from the dashboard to an instance of `server` that runs with a higher latency connection to the Gitpod database.

This PR changes the `proxy` `Caddyfile` to reverse proxy traffic to the new `slow-server` deployment depending on the value of the `Sec-WebSocket-Protocol` header that is sent by the browser websocket client during the websocket connection handshake.

https://github.com/gitpod-io/gitpod/pull/14752 demonstrates an approach that allows to selectively set the value of this header for some users, based on the value of a feature flag.

## Related Issue(s)

Part of #9198 

## How to test

In the browser console, establish a new websocket connection to the Gitpod JSON RPC API:

```js
const sock = new WebSocket('wss://af-use-slofc5943d8fc.preview.gitpod-dev.com/api/gitpod', 'slow-database')
```

The network tab should show a new websocket connection with these headers sent during the handshake:

<img width="482" alt="image" src="https://user-images.githubusercontent.com/8225907/202576423-804acec4-fd07-41bc-ae38-ce48b24ce709.png">

Sending and receiving through the new connection should now incur higher than usual latency:

```js
const msg = JSON.stringify({"jsonrpc":"2.0","id":12,"method":"getWorkspaces","params":{"limit":50}})
sock.send(msg)
```

the network tab shows a gap of ~1s between message send and response.

Tailing the logs of pods in the `slow-server` deployment reveals that they are handling websocket traffic.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-slow-database
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
