### PR TITLE
Fix workspace integration test suite and reduce log verbosity

### DIFF
--- a/test/pkg/integration/workspace.go
+++ b/test/pkg/integration/workspace.go
@@ -129,7 +129,6 @@ func LaunchWorkspaceDirectly(t *testing.T, ctx context.Context, api *ComponentAP
 		return nil, nil, err
 	}
 
-	t.Log("obtaining a lock to create a workspace")
 	parallelLimiter <- struct{}{}
 	defer func() {
 		if err != nil && stopWs == nil {
@@ -137,7 +136,6 @@ func LaunchWorkspaceDirectly(t *testing.T, ctx context.Context, api *ComponentAP
 			<-parallelLimiter
 		}
 	}()
-	t.Log("got the lock of parallelLimiter")
 
 	var workspaceImage string
 	if options.BaseImage != "" {
@@ -337,12 +335,10 @@ func LaunchWorkspaceFromContextURL(t *testing.T, ctx context.Context, contextURL
 		}
 	}()
 
-	t.Log("prepare for a connection with gitpod server")
 	server, err := api.GitpodServer(append(defaultServerOpts, serverOpts...)...)
 	if err != nil {
 		return nil, nil, xerrors.Errorf("cannot start server: %w", err)
 	}
-	t.Log("established a connection with gitpod server")
 
 	cctx, ccancel := context.WithTimeout(context.Background(), perCallTimeout)
 	defer ccancel()
@@ -426,7 +422,6 @@ func stopWsF(t *testing.T, instanceID string, workspaceID string, api *Component
 			if already {
 				return
 			} else {
-				t.Log("unlock the parallelLimiter")
 				<-parallelLimiter
 			}
 			already = true

--- a/test/tests/components/ws-daemon/cpu_burst_test.go
+++ b/test/tests/components/ws-daemon/cpu_burst_test.go
@@ -26,8 +26,8 @@ import (
 type DaemonConfig struct {
 	CpuLimitConfig struct {
 		Enabled    bool  `json:"enabled"`
-		Limit      int64 `json:"limit,string"`
-		BurstLimit int64 `json:"burstLimit,string"`
+		Limit      int64 `json:"limit"`
+		BurstLimit int64 `json:"burstLimit"`
 	} `json:"cpuLimit"`
 }
 


### PR DESCRIPTION
## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```


## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-integration-tests=workspace
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
