### PR TITLE
Add logging for code startup perf issues

### DIFF
--- a/components/supervisor/pkg/supervisor/supervisor.go
+++ b/components/supervisor/pkg/supervisor/supervisor.go
@@ -812,6 +812,7 @@ func launchIDE(cfg *Config, ideConfig *IDEConfig, cmd *exec.Cmd, ideStopped chan
 		runtime.LockOSThread()
 		defer runtime.UnlockOSThread()
 
+		log.Info("start launchIDE")
 		err := cmd.Start()
 		if err != nil {
 			if s == func() *ideStatus { i := statusNeverRan; return &i }() {
@@ -1037,7 +1038,8 @@ func runIDEReadinessProbe(cfg *Config, ideConfig *IDEConfig, ide IDEKind) (deskt
 			break
 		}
 
-		log.WithField("ide", ide.String()).Infof("IDE readiness took %.3f seconds", time.Since(t0).Seconds())
+		duration := time.Since(t0).Seconds()
+		log.WithField("ide", ide.String()).WithField("duration", duration).Infof("IDE readiness took %.3f seconds", duration)
 
 		if ide != DesktopIDE {
 			return

--- a/install/installer/cmd/testdata/render/aws-setup/output.golden
+++ b/install/installer/cmd/testdata/render/aws-setup/output.golden
@@ -3426,7 +3426,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-0c67a475297ba36557b193e772f3d0e129c11cd7",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-7faac86f8121d3099a81f5adb1ac9804ffc8c23a",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {
@@ -4875,7 +4875,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-0c67a475297ba36557b193e772f3d0e129c11cd7",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-7faac86f8121d3099a81f5adb1ac9804ffc8c23a",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/azure-setup/output.golden
+++ b/install/installer/cmd/testdata/render/azure-setup/output.golden
@@ -3343,7 +3343,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-0c67a475297ba36557b193e772f3d0e129c11cd7",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-7faac86f8121d3099a81f5adb1ac9804ffc8c23a",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {
@@ -4738,7 +4738,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-0c67a475297ba36557b193e772f3d0e129c11cd7",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-7faac86f8121d3099a81f5adb1ac9804ffc8c23a",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -4179,7 +4179,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-0c67a475297ba36557b193e772f3d0e129c11cd7",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-7faac86f8121d3099a81f5adb1ac9804ffc8c23a",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {
@@ -5719,7 +5719,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-0c67a475297ba36557b193e772f3d0e129c11cd7",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-7faac86f8121d3099a81f5adb1ac9804ffc8c23a",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -3484,7 +3484,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-0c67a475297ba36557b193e772f3d0e129c11cd7",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-7faac86f8121d3099a81f5adb1ac9804ffc8c23a",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {
@@ -4925,7 +4925,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-0c67a475297ba36557b193e772f3d0e129c11cd7",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-7faac86f8121d3099a81f5adb1ac9804ffc8c23a",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/gcp-setup/output.golden
+++ b/install/installer/cmd/testdata/render/gcp-setup/output.golden
@@ -3314,7 +3314,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-0c67a475297ba36557b193e772f3d0e129c11cd7",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-7faac86f8121d3099a81f5adb1ac9804ffc8c23a",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {
@@ -4699,7 +4699,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-0c67a475297ba36557b193e772f3d0e129c11cd7",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-7faac86f8121d3099a81f5adb1ac9804ffc8c23a",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/http-proxy/output.golden
+++ b/install/installer/cmd/testdata/render/http-proxy/output.golden
@@ -3653,7 +3653,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-0c67a475297ba36557b193e772f3d0e129c11cd7",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-7faac86f8121d3099a81f5adb1ac9804ffc8c23a",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {
@@ -5148,7 +5148,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-0c67a475297ba36557b193e772f3d0e129c11cd7",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-7faac86f8121d3099a81f5adb1ac9804ffc8c23a",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/insecure-s3-setup/output.golden
+++ b/install/installer/cmd/testdata/render/insecure-s3-setup/output.golden
@@ -3564,7 +3564,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-0c67a475297ba36557b193e772f3d0e129c11cd7",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-7faac86f8121d3099a81f5adb1ac9804ffc8c23a",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {
@@ -5059,7 +5059,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-0c67a475297ba36557b193e772f3d0e129c11cd7",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-7faac86f8121d3099a81f5adb1ac9804ffc8c23a",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -3650,7 +3650,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-0c67a475297ba36557b193e772f3d0e129c11cd7",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-7faac86f8121d3099a81f5adb1ac9804ffc8c23a",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {
@@ -5145,7 +5145,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-0c67a475297ba36557b193e772f3d0e129c11cd7",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-7faac86f8121d3099a81f5adb1ac9804ffc8c23a",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/shortname/output.golden
+++ b/install/installer/cmd/testdata/render/shortname/output.golden
@@ -3650,7 +3650,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-0c67a475297ba36557b193e772f3d0e129c11cd7",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-7faac86f8121d3099a81f5adb1ac9804ffc8c23a",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {
@@ -5145,7 +5145,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-0c67a475297ba36557b193e772f3d0e129c11cd7",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-7faac86f8121d3099a81f5adb1ac9804ffc8c23a",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -3662,7 +3662,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-0c67a475297ba36557b193e772f3d0e129c11cd7",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-7faac86f8121d3099a81f5adb1ac9804ffc8c23a",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {
@@ -5157,7 +5157,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-0c67a475297ba36557b193e772f3d0e129c11cd7",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-7faac86f8121d3099a81f5adb1ac9804ffc8c23a",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
+++ b/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
@@ -3983,7 +3983,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-0c67a475297ba36557b193e772f3d0e129c11cd7",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-7faac86f8121d3099a81f5adb1ac9804ffc8c23a",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {
@@ -5478,7 +5478,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-0c67a475297ba36557b193e772f3d0e129c11cd7",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-7faac86f8121d3099a81f5adb1ac9804ffc8c23a",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
+++ b/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
@@ -3653,7 +3653,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-0c67a475297ba36557b193e772f3d0e129c11cd7",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-7faac86f8121d3099a81f5adb1ac9804ffc8c23a",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {
@@ -5148,7 +5148,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-0c67a475297ba36557b193e772f3d0e129c11cd7",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-7faac86f8121d3099a81f5adb1ac9804ffc8c23a",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/pkg/components/workspace/ide/constants.go
+++ b/install/installer/pkg/components/workspace/ide/constants.go
@@ -6,7 +6,7 @@ package ide
 
 const (
 	CodeIDEImage                = "ide/code"
-	CodeIDEImageStableVersion   = "commit-0c67a475297ba36557b193e772f3d0e129c11cd7" // stable version that will be updated manually on demand
+	CodeIDEImageStableVersion   = "commit-7faac86f8121d3099a81f5adb1ac9804ffc8c23a" // stable version that will be updated manually on demand
 	CodeDesktopIDEImage         = "ide/code-desktop"
 	CodeDesktopInsidersIDEImage = "ide/code-desktop-insiders"
 	IntelliJDesktopIDEImage     = "ide/intellij"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Add logging for IDE startup (code browser)

See also [[internal chat]](https://gitpod.slack.com/archives/C01KGM9BH54/p1668757178295269?thread_ts=1668748433.738219&cid=C01KGM9BH54)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
- Start workspace in prev env with latest code
- Check workspace log, should contains `phase start`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
