### PR TITLE
Add previewctl to code workspace

### DIFF
--- a/gitpod-ws.code-workspace
+++ b/gitpod-ws.code-workspace
@@ -30,6 +30,7 @@
         { "path": "dev/gpctl" },
         { "path": "dev/gp-gcloud" },
         { "path": "dev/loadgen" },
+        { "path": "dev/preview/previewctl" },
         { "path": "install/installer" },
         { "path": "install/preview" },
         { "path": "dev/ready-probe-labeler" },


### PR DESCRIPTION
## Description

This adds previewctl to the VSCode workspace file. This means all the go tooling will now work as well as it does with all our other Go "modules".

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
No issue but was going to work on previewctl so thought I'd get this in first.

## How to test
<!-- Provide steps to test this PR -->

Open a workspace. Go to definition etc. should work now.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
