### PR TITLE
Add retry option to install-context

### DIFF
--- a/dev/preview/previewctl/BUILD.yaml
+++ b/dev/preview/previewctl/BUILD.yaml
@@ -17,8 +17,12 @@ scripts:
     script: |
       set -euo pipefail
 
-      source="$(which previewctl)"
       destination="/workspace/bin/previewctl"
+      # Leeway puts the dependencies at the end of the PATH which means that /workspace/bin takes precedence
+      # on the path. So for `which previewctl` to return the previewctl Leeway just build (/tmp/build/.../previewctl)
+      # we have to delete /workspace/bin/previewctl first.
+      rm -f "$destination"
+      source="$(which previewctl)"
 
       mkdir -p /workspace/bin
 

--- a/dev/preview/workflow/preview/preview.sh
+++ b/dev/preview/workflow/preview/preview.sh
@@ -29,5 +29,5 @@ ensure_gcloud_auth
 
 leeway run dev/preview:create-preview
 leeway run dev/preview:build
-previewctl install-context
+previewctl install-context --retry 30
 leeway run dev/preview:deploy-gitpod


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Adds a `--retry <count>` flag to `previewctl install-context` and uses it in `leeway run dev:preview`. 

Also fixed one bug when using `leeway run dev/preview/previewctl:install` multiple times.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/14759

## How to test
<!-- Provide steps to test this PR -->

```sh
leeway run dev:preview
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

N/A

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
