### PR TITLE
Don't include previewctl in dev image

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
-image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-leeway-v0.5.2.0
+image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-dont-include-previewctl-in-image.12
 workspaceLocation: gitpod/gitpod-ws.code-workspace
 checkoutLocation: gitpod
 ports:
@@ -34,14 +34,12 @@ ports:
   - port: 8022
     onOpen: ignore
 tasks:
-  - name: Install Preview Environment kube-context
+  - name: Preview environment configuration
+    init: |
+      leeway run dev/preview/previewctl:install
     command: |
+      previewctl get-credentials
       previewctl install-context --watch
-      exit
-  - name: Add Harvester kubeconfig
-    command: |
-      ./dev/preview/util/download-and-merge-harvester-kubeconfig.sh
-      exit 0
   - name: Installer dependencies
     init: |
       (cd install/installer && make deps)

--- a/.werft/aks-installer-tests.yaml
+++ b/.werft/aks-installer-tests.yaml
@@ -65,7 +65,7 @@ pod:
       secretName: self-hosted-github-oauth
   containers:
   - name: nightly-test
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-leeway-v0.5.2.0
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-dont-include-previewctl-in-image.12
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/build.yaml
+++ b/.werft/build.yaml
@@ -70,7 +70,7 @@ pod:
     - name: MYSQL_TCP_PORT
       value: 23306
   - name: build
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-leeway-v0.5.2.0
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-dont-include-previewctl-in-image.12
     workingDir: /workspace
     imagePullPolicy: IfNotPresent
     resources:

--- a/.werft/cleanup-installer-tests.yaml
+++ b/.werft/cleanup-installer-tests.yaml
@@ -25,7 +25,7 @@ pod:
       secretName: aks-credentials
   containers:
   - name: nightly-test
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-leeway-v0.5.2.0
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-dont-include-previewctl-in-image.12
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/debug.yaml
+++ b/.werft/debug.yaml
@@ -54,7 +54,7 @@ pod:
     - name: MYSQL_TCP_PORT
       value: 23306
   - name: build
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-leeway-v0.5.2.0
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-dont-include-previewctl-in-image.12
     workingDir: /workspace
     imagePullPolicy: IfNotPresent
     volumeMounts:

--- a/.werft/eks-installer-tests.yaml
+++ b/.werft/eks-installer-tests.yaml
@@ -65,7 +65,7 @@ pod:
       secretName: self-hosted-github-oauth
   containers:
   - name: nightly-test
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-leeway-v0.5.2.0
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-dont-include-previewctl-in-image.12
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/gke-installer-tests.yaml
+++ b/.werft/gke-installer-tests.yaml
@@ -65,7 +65,7 @@ pod:
         secretName: self-hosted-github-oauth
   containers:
     - name: nightly-test
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-leeway-v0.5.2.0
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-dont-include-previewctl-in-image.12
       workingDir: /workspace
       imagePullPolicy: Always
       volumeMounts:

--- a/.werft/ide-integration-tests-startup.yaml
+++ b/.werft/ide-integration-tests-startup.yaml
@@ -17,7 +17,7 @@ pod:
         secretName: github-token-gitpod-bot
   containers:
     - name: gcloud
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-leeway-v0.5.2.0
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-dont-include-previewctl-in-image.12
       workingDir: /workspace
       imagePullPolicy: IfNotPresent
       env:

--- a/.werft/jobs/build/prepare.ts
+++ b/.werft/jobs/build/prepare.ts
@@ -24,6 +24,7 @@ export async function prepare(werft: Werft, config: JobConfig) {
         werft.log(prepareSlices.CONFIGURE_CORE_DEV, prepareSlices.CONFIGURE_CORE_DEV);
         activateCoreDevServiceAccount();
         configureDocker();
+        installPreviewCTL();
         configureStaticClustersAccess();
         configureGlobalKubernetesContext();
         werft.done(prepareSlices.CONFIGURE_CORE_DEV);
@@ -66,6 +67,10 @@ function configureGlobalKubernetesContext() {
     if (rc != 0) {
         throw new Error("Failed to configure global kubernetes context.");
     }
+}
+
+function installPreviewCTL() {
+    exec(`leeway run dev/preview/previewctl:install`, {slice: "Install previewctl", dontCheckRc: false})
 }
 
 function configureStaticClustersAccess() {

--- a/.werft/k3s-installer-tests.yaml
+++ b/.werft/k3s-installer-tests.yaml
@@ -65,7 +65,7 @@ pod:
       secretName: self-hosted-github-oauth
   containers:
   - name: nightly-test
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-leeway-v0.5.2.0
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-dont-include-previewctl-in-image.12
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/platform-delete-preview-environment.ts
+++ b/.werft/platform-delete-preview-environment.ts
@@ -94,6 +94,7 @@ async function deletePreviewEnvironment() {
 }
 
 function configureGlobalKubernetesContext() {
+    exec(`leeway run dev/preview/previewctl:install`, {slice: "Install previewctl", dontCheckRc: false})
     const rc = exec(`KUBECONFIG=${GLOBAL_KUBECONFIG_PATH} previewctl get-credentials --gcp-service-account=${GCLOUD_SERVICE_ACCOUNT_PATH}`, { slice: SLICES.CONFIGURE_K8S }).code;
 
     if (rc != 0) {

--- a/.werft/platform-delete-preview-environment.yaml
+++ b/.werft/platform-delete-preview-environment.yaml
@@ -25,7 +25,7 @@ pod:
         secretName: harvester-vm-ssh-keys
   containers:
     - name: build
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-leeway-v0.5.2.0
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-dont-include-previewctl-in-image.12
       workingDir: /workspace
       imagePullPolicy: IfNotPresent
       volumeMounts:

--- a/.werft/platform-delete-preview-environments-cron.yaml
+++ b/.werft/platform-delete-preview-environments-cron.yaml
@@ -29,7 +29,7 @@ pod:
         secretName: github-token-gitpod-bot
   containers:
     - name: build
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-leeway-v0.5.2.0
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-dont-include-previewctl-in-image.12
       workingDir: /workspace
       imagePullPolicy: IfNotPresent
       volumeMounts:

--- a/.werft/platform-trigger-artificial-job.yaml
+++ b/.werft/platform-trigger-artificial-job.yaml
@@ -24,7 +24,7 @@ pod:
         secretName: github-token-gitpod-bot
   containers:
     - name: build
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-leeway-v0.5.2.0
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-dont-include-previewctl-in-image.12
       workingDir: /workspace
       imagePullPolicy: IfNotPresent
       volumeMounts:

--- a/.werft/platform-trigger-werft-cleanup.yaml
+++ b/.werft/platform-trigger-werft-cleanup.yaml
@@ -22,7 +22,7 @@ pod:
         secretName: gcp-sa-gitpod-dev-deployer
   containers:
     - name: build
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-leeway-v0.5.2.0
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-dont-include-previewctl-in-image.12
       workingDir: /workspace
       imagePullPolicy: IfNotPresent
       volumeMounts:

--- a/.werft/workspace-run-integration-tests.yaml
+++ b/.werft/workspace-run-integration-tests.yaml
@@ -22,7 +22,7 @@ pod:
         secretName: github-token-gitpod-bot
   containers:
     - name: gcloud
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-leeway-v0.5.2.0
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-dont-include-previewctl-in-image.12
       workingDir: /workspace
       imagePullPolicy: IfNotPresent
       env:

--- a/dev/BUILD.yaml
+++ b/dev/BUILD.yaml
@@ -10,14 +10,12 @@ packages:
       - dev/blowtorch:app
       - dev/gpctl:app
       - dev/loadgen:app
-      - dev/preview/previewctl:cli
       - dev/gp-gcloud:app
   - name: dev-utils
     type: docker
     deps:
       - dev/gpctl:app
       - dev/kubecdl:app
-      - dev/preview/previewctl:cli
       - dev/gp-gcloud:app
     argdeps:
       - imageRepoBase

--- a/dev/image/BUILD.yaml
+++ b/dev/image/BUILD.yaml
@@ -4,7 +4,6 @@ packages:
     deps:
       - dev/gpctl:app
       - dev/kubecdl:app
-      - dev/preview/previewctl:cli
     argdeps:
       - imageRepoBase
     srcs:

--- a/dev/image/Dockerfile
+++ b/dev/image/Dockerfile
@@ -4,7 +4,7 @@
 
 FROM gitpod/workspace-full:2022-11-09-13-54-49
 
-ENV TRIGGER_REBUILD 24
+ENV TRIGGER_REBUILD 25
 
 USER root
 
@@ -257,8 +257,9 @@ RUN brew install tmux tmuxinator
 
 # Copy our own tools
 ENV NEW_KUBECDL=1
-COPY dev-kubecdl--app/kubecdl dev-gpctl--app/gpctl dev-preview-previewctl--cli/previewctl /usr/bin/
+COPY dev-kubecdl--app/kubecdl dev-gpctl--app/gpctl /usr/bin/
 
 # Configure our tools' autocompletion
-RUN bash -c "echo . \<\(gpctl completion bash\) >> ~/.bashrc" && \
-    bash -c "echo . \<\(previewctl completion bash\) >> ~/.bashrc"
+RUN bash -c "echo . \<\(gpctl completion bash\) >> ~/.bashrc"
+
+ENV PATH=$PATH:/workspace/bin

--- a/dev/leeway.Dockerfile
+++ b/dev/leeway.Dockerfile
@@ -4,4 +4,4 @@
 
 FROM scratch
 
-COPY dev-gpctl--app/gpctl dev-kubecdl--app/kubecdl dev-preview-previewctl--cli/previewctl dev-gp-gcloud--app/gp-gcloud /app/
+COPY dev-gpctl--app/gpctl dev-kubecdl--app/kubecdl dev-gp-gcloud--app/gp-gcloud /app/

--- a/dev/preview/previewctl/BUILD.yaml
+++ b/dev/preview/previewctl/BUILD.yaml
@@ -9,4 +9,26 @@ packages:
       - CGO_ENABLED=0
     config:
       packaging: app
-      dontTest: false
+scripts:
+  - name: install
+    description: Build and install previewctl into the current environment
+    deps:
+    - :cli
+    script: |
+      set -euo pipefail
+
+      source="$(which previewctl)"
+      destination="/workspace/bin/previewctl"
+
+      mkdir -p /workspace/bin
+
+      echo "Installing $source into $destination"
+      cp "$source" "$destination"
+
+      if ! $(grep 'previewctl completion bash' ~/.bashrc > /dev/null)
+      then
+        echo "Adding bash completions to ~/.bashrc"
+        echo '. <(previewctl completion bash)' >> ~/.bashrc
+      else
+        echo "Bash completions already installed. Skipping."
+      fi


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This PR removes `previewctl` from the Dockerfile in favour of installing it in prebuilds through an `init` task.

`leeway run dev/preview/previewctl:install` will now build and copy the binary over to `/workspace/preview/bin`. `/workspace/bin` has been created and added to the $PATH.

This makes it much easier for us to iterate on `previewctl` as we won't have to rebuild the dev image and update all references to it (triggering review from every team) for every change we make.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/14149

## How to test
<!-- Provide steps to test this PR -->

That preview environments from Werft still works ([example](https://werft.gitpod-dev.com/job/gitpod-build-mads-dont-include-previewctl-in-image.14))

```
werft job run github -a with-preview=true
```

That `previewctl` is available in workspaces

```
which previewctl
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

N/A

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
