### PR TITLE
[server] Rate-limit Prebuilds per user

### DIFF
--- a/components/gitpod-db/src/workspace-db.ts
+++ b/components/gitpod-db/src/workspace-db.ts
@@ -188,7 +188,8 @@ export interface WorkspaceDB {
     findPrebuildByWorkspaceID(wsid: string): Promise<PrebuiltWorkspace | undefined>;
     findPrebuildByID(pwsid: string): Promise<PrebuiltWorkspace | undefined>;
     countRunningPrebuilds(cloneURL: string): Promise<number>;
-    countUnabortedPrebuildsSince(cloneURL: string, date: Date): Promise<number>;
+    countUnabortedPrebuildsPerCloneURLSince(cloneURL: string, date: Date): Promise<number>;
+    countUnabortedPrebuildsPerUserSince(userId: string, date: Date): Promise<number>;
     findQueuedPrebuilds(cloneURL?: string): Promise<PrebuildWithWorkspace[]>;
     attachUpdatableToPrebuild(pwsid: string, update: PrebuiltWorkspaceUpdatable): Promise<void>;
     findUpdatablesForPrebuild(pwsid: string): Promise<PrebuiltWorkspaceUpdatable[]>;

--- a/components/server/src/config.ts
+++ b/components/server/src/config.ts
@@ -200,6 +200,11 @@ export interface ConfigSerialized {
     prebuildLimiter: { [cloneURL: string]: number } & { "*": number };
 
     /**
+     * Number of prebuilds that can be started in the last 1 minute by a given user.
+     */
+    prebuildPerUserRateLimit?: number;
+
+    /**
      * If a numeric value interpreted as days is set, repositories not beeing opened with Gitpod are
      * considered inactive.
      */

--- a/install/installer/cmd/testdata/render/aws-setup/output.golden
+++ b/install/installer/cmd/testdata/render/aws-setup/output.golden
@@ -4829,6 +4829,7 @@ data:
       "prebuildLimiter": {
         "*": 50
       },
+      "prebuildPerUserRateLimit": 50,
       "workspaceClasses": [
         {
           "id": "default",
@@ -9228,7 +9229,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 1f0b6fbd9d15fd9e16f57ce2b53f92f98f0b4974eb4a7d18d11515f58e7f2b9e
+        gitpod.io/checksum_config: aabaf93d962caa018ab0da0bfae7e52f1b6d5872ecc934fd963156be38fb04f7
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/azure-setup/output.golden
+++ b/install/installer/cmd/testdata/render/azure-setup/output.golden
@@ -4692,6 +4692,7 @@ data:
       "prebuildLimiter": {
         "*": 50
       },
+      "prebuildPerUserRateLimit": 50,
       "workspaceClasses": [
         {
           "id": "default",
@@ -9079,7 +9080,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 1f0b6fbd9d15fd9e16f57ce2b53f92f98f0b4974eb4a7d18d11515f58e7f2b9e
+        gitpod.io/checksum_config: aabaf93d962caa018ab0da0bfae7e52f1b6d5872ecc934fd963156be38fb04f7
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -5668,6 +5668,7 @@ data:
       "prebuildLimiter": {
         "*": 50
       },
+      "prebuildPerUserRateLimit": 50,
       "workspaceClasses": [
         {
           "id": "default",
@@ -10690,7 +10691,7 @@ spec:
     metadata:
       annotations:
         gitpod.io: hello
-        gitpod.io/checksum_config: c32f872cba6a4c88efcffff25c4a3d3f855ebc48440cea6f8dfc29017f7e6a59
+        gitpod.io/checksum_config: 95e7146de1f6a22fac503f5ea089691c354329057b2219da260b495211f4a98a
         hello: world
       creationTimestamp: null
       labels:

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -4879,6 +4879,7 @@ data:
       "prebuildLimiter": {
         "*": 50
       },
+      "prebuildPerUserRateLimit": 50,
       "workspaceClasses": [
         {
           "id": "default",
@@ -9505,7 +9506,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: d37fd059853d2ddaad2353a075ca1dd6db4ec495074d332ac4331543e8a551a1
+        gitpod.io/checksum_config: a129b279a175e3b37640d47cc1c1b9f8d05f65b0a02227d179580facfc13fe66
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/gcp-setup/output.golden
+++ b/install/installer/cmd/testdata/render/gcp-setup/output.golden
@@ -4653,6 +4653,7 @@ data:
       "prebuildLimiter": {
         "*": 50
       },
+      "prebuildPerUserRateLimit": 50,
       "workspaceClasses": [
         {
           "id": "default",
@@ -8996,7 +8997,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 17bfee13a5c7f847a74ec789bd130694b16d1da616636de68ae3f10d4b8aefc9
+        gitpod.io/checksum_config: 79856d9195f58a1e3d74b8194793870bd397dba7079fedf9858c45ac48be9be8
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/http-proxy/output.golden
+++ b/install/installer/cmd/testdata/render/http-proxy/output.golden
@@ -5102,6 +5102,7 @@ data:
       "prebuildLimiter": {
         "*": 50
       },
+      "prebuildPerUserRateLimit": 50,
       "workspaceClasses": [
         {
           "id": "default",
@@ -11046,7 +11047,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: d37fd059853d2ddaad2353a075ca1dd6db4ec495074d332ac4331543e8a551a1
+        gitpod.io/checksum_config: a129b279a175e3b37640d47cc1c1b9f8d05f65b0a02227d179580facfc13fe66
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/insecure-s3-setup/output.golden
+++ b/install/installer/cmd/testdata/render/insecure-s3-setup/output.golden
@@ -5013,6 +5013,7 @@ data:
       "prebuildLimiter": {
         "*": 50
       },
+      "prebuildPerUserRateLimit": 50,
       "workspaceClasses": [
         {
           "id": "default",
@@ -9651,7 +9652,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: d37fd059853d2ddaad2353a075ca1dd6db4ec495074d332ac4331543e8a551a1
+        gitpod.io/checksum_config: a129b279a175e3b37640d47cc1c1b9f8d05f65b0a02227d179580facfc13fe66
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -5099,6 +5099,7 @@ data:
       "prebuildLimiter": {
         "*": 50
       },
+      "prebuildPerUserRateLimit": 50,
       "workspaceClasses": [
         {
           "id": "default",
@@ -9880,7 +9881,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: d37fd059853d2ddaad2353a075ca1dd6db4ec495074d332ac4331543e8a551a1
+        gitpod.io/checksum_config: a129b279a175e3b37640d47cc1c1b9f8d05f65b0a02227d179580facfc13fe66
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/shortname/output.golden
+++ b/install/installer/cmd/testdata/render/shortname/output.golden
@@ -5099,6 +5099,7 @@ data:
       "prebuildLimiter": {
         "*": 50
       },
+      "prebuildPerUserRateLimit": 50,
       "workspaceClasses": [
         {
           "id": "default",
@@ -9880,7 +9881,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 7f8e54313c6865fd3677be50acaf9fb6f048d9065fbd3b619fc143049d2e910b
+        gitpod.io/checksum_config: 5ea7564a8236689455062646e65d6ab7578f4c8ece5411161e8a40e67be4297d
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -5111,6 +5111,7 @@ data:
       "prebuildLimiter": {
         "*": 50
       },
+      "prebuildPerUserRateLimit": 50,
       "workspaceClasses": [
         {
           "id": "default",
@@ -9892,7 +9893,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: d37fd059853d2ddaad2353a075ca1dd6db4ec495074d332ac4331543e8a551a1
+        gitpod.io/checksum_config: a129b279a175e3b37640d47cc1c1b9f8d05f65b0a02227d179580facfc13fe66
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
+++ b/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
@@ -5432,6 +5432,7 @@ data:
       "prebuildLimiter": {
         "*": 50
       },
+      "prebuildPerUserRateLimit": 50,
       "workspaceClasses": [
         {
           "id": "default",
@@ -10324,7 +10325,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: d37fd059853d2ddaad2353a075ca1dd6db4ec495074d332ac4331543e8a551a1
+        gitpod.io/checksum_config: a129b279a175e3b37640d47cc1c1b9f8d05f65b0a02227d179580facfc13fe66
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
+++ b/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
@@ -5102,6 +5102,7 @@ data:
       "prebuildLimiter": {
         "*": 50
       },
+      "prebuildPerUserRateLimit": 50,
       "workspaceClasses": [
         {
           "id": "default",
@@ -9883,7 +9884,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: d37fd059853d2ddaad2353a075ca1dd6db4ec495074d332ac4331543e8a551a1
+        gitpod.io/checksum_config: a129b279a175e3b37640d47cc1c1b9f8d05f65b0a02227d179580facfc13fe66
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/pkg/components/server/configmap.go
+++ b/install/installer/pkg/components/server/configmap.go
@@ -171,6 +171,14 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		return nil
 	})
 
+	prebuildPerUserRateLimit := 50
+	_ = ctx.WithExperimental(func(cfg *experimental.Config) error {
+		if cfg.WebApp != nil && cfg.WebApp.Server != nil && cfg.WebApp.Server.PrebuildPerUserRateLimit != nil {
+			prebuildPerUserRateLimit = *cfg.WebApp.Server.PrebuildPerUserRateLimit
+		}
+		return nil
+	})
+
 	// todo(sje): all these values are configurable
 	scfg := ConfigSerialized{
 		Version:               ctx.VersionManifest.Version,
@@ -258,6 +266,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 			// default limit for all cloneURLs
 			"*": 50,
 		},
+		PrebuildPerUserRateLimit:       prebuildPerUserRateLimit,
 		WorkspaceClasses:               workspaceClasses,
 		InactivityPeriodForReposInDays: inactivityPeriodForReposInDays,
 	}

--- a/install/installer/pkg/components/server/types.go
+++ b/install/installer/pkg/components/server/types.go
@@ -52,7 +52,9 @@ type ConfigSerialized struct {
 	CodeSync                   CodeSync                   `json:"codeSync"`
 	// PrebuildLimiter defines the number of prebuilds allowed for each cloneURL in a given 1 minute interval
 	// Key of "*" defines the default limit, unless there exists a cloneURL in the map which overrides it.
-	PrebuildLimiter                map[string]int   `json:"prebuildLimiter"`
+	PrebuildLimiter map[string]int `json:"prebuildLimiter"`
+	// PrebuildPerUserRateLimit defines the number of prebuilds allowed for each user in a given 1 minute interval
+	PrebuildPerUserRateLimit       int              `json:"prebuildPerUserRateLimit"`
 	WorkspaceClasses               []WorkspaceClass `json:"workspaceClasses"`
 	InactivityPeriodForReposInDays int              `json:"inactivityPeriodForReposInDays"`
 }

--- a/install/installer/pkg/config/v1/experimental/experimental.go
+++ b/install/installer/pkg/config/v1/experimental/experimental.go
@@ -241,6 +241,7 @@ type ServerConfig struct {
 	RunDbDeleter                      *bool             `json:"runDbDeleter"`
 	DisableWorkspaceGarbageCollection bool              `json:"disableWorkspaceGarbageCollection"`
 	InactivityPeriodForReposInDays    *int              `json:"inactivityPeriodForReposInDays"`
+	PrebuildPerUserRateLimit          *int              `json:"prebuildPerUserRateLimit"`
 
 	// @deprecated use containerRegistry.privateBaseImageAllowList instead
 	DefaultBaseImageRegistryWhiteList []string `json:"defaultBaseImageRegistryWhitelist"`


### PR DESCRIPTION
## Description
Does what it says on the tin. The limit is configurable, and defaults to 50/min.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #14791 

## How to test
- `leeway build components/gitpod-db:dbtest-init`
- `(cd components/gitpod-db && yarn db-test)`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Rate-limit Prebuilds per user
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
