### PR TITLE
[dashboard] fix condition for workspace classes

### DIFF
--- a/components/dashboard/src/projects/ProjectSettings.tsx
+++ b/components/dashboard/src/projects/ProjectSettings.tsx
@@ -158,14 +158,15 @@ export default function () {
                     </div>
                 </div>
             </div>
-
+            {BillingMode.canSetWorkspaceClass(teamBillingMode) && (
+                <SelectWorkspaceClass
+                    workspaceClass={project.settings?.workspaceClasses?.regular}
+                    enabled={BillingMode.canSetWorkspaceClass(teamBillingMode)}
+                    setWorkspaceClass={setWorkspaceClass}
+                />
+            )}
             {showPersistentVolumeClaimUI && (
                 <>
-                    <SelectWorkspaceClass
-                        workspaceClass={project.settings?.workspaceClasses?.regular}
-                        enabled={BillingMode.canSetWorkspaceClass(teamBillingMode)}
-                        setWorkspaceClass={setWorkspaceClass}
-                    />
                     {!BillingMode.canSetWorkspaceClass(teamBillingMode) && <h3 className="mt-12">Workspaces</h3>}
                     <CheckBox
                         title={


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Fix the condition for when to show the select workspace class setting on projects

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #14800

## How to test
<!-- Provide steps to test this PR -->
Create a project starting with "Gitpod" and verify that the setting is visible.
Create a project not starting with "Gitpod" and verify that the setting is not visible.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-payment
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
