### PR TITLE
[codehelper] replace product.json only

### DIFF
--- a/components/ide/code/startup.sh
+++ b/components/ide/code/startup.sh
@@ -32,9 +32,5 @@ export USER=gitpod
 # shellcheck disable=SC1090,SC1091
 [ -s ~/.nvm/nvm-lazy.sh ] && source /home/gitpod/.nvm/nvm-lazy.sh
 
-# Replace OpenVSX URL
-grep -rl open-vsx.org /ide | xargs sed -i "s|https://open-vsx.org|$VSX_REGISTRY_URL|g"
-grep -rl "{{extensionsGalleryItemUrl}}\|{{trustedDomain}}" /ide | xargs sed -i "s|{{extensionsGalleryItemUrl}}|https://open-vsx.org/vscode/item|g;s|{{trustedDomain}}|https://open-vsx.org|g"
-
 cd /ide || exit
 exec /ide/codehelper "$@"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Replace `product.json` only for browser code frontend to save duration of ide ready

See also [internal chat](https://gitpod.slack.com/archives/C01KGM9BH54/p1668876572304729?thread_ts=1668748433.738219&cid=C01KGM9BH54)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
- Open workspace in prev env with latest code
- Check if everything related to extension gallery is working well
  - extension search / install all to with our openvsx-proxy
  - extension detail page click to vote star and marketplace will jump to open-vsx.org without ask to trust URL

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
