### PR TITLE
[installer] Configure personal access token signing key

### DIFF
--- a/components/public-api/go/config/config.go
+++ b/components/public-api/go/config/config.go
@@ -14,5 +14,8 @@ type Configuration struct {
 	// StripeWebhookSigningSecretPath is a filepath to a secret used to validate incoming webhooks from Stripe
 	StripeWebhookSigningSecretPath string `json:"stripeWebhookSigningSecretPath"`
 
+	// Path to file which contains personal access token singing key
+	PersonalAccessTokenSigningKeyPath string `json:"personalAccessTokenSigningKeyPath"`
+
 	Server *baseserver.Configuration `json:"server,omitempty"`
 }

--- a/install/installer/cmd/testdata/render/aws-setup/output.golden
+++ b/install/installer/cmd/testdata/render/aws-setup/output.golden
@@ -2557,7 +2557,7 @@ data:
     kind: Deployment
     metadata:
       annotations:
-        gitpod.io/checksum_config: 2d64dca8ac18437c4ba1d80fd2112af408f1e5fb2ca0294f422f03bcbad647bb
+        gitpod.io/checksum_config: 74ab9c5d2ac7f57832d1df15f9764c3abfc450f45beb9a31d8aefb9bcf1aaea8
       creationTimestamp: null
       labels:
         app: gitpod
@@ -4607,6 +4607,7 @@ data:
       "gitpodServiceUrl": "wss://gitpod.example.com",
       "billingServiceAddress": "usage.default.svc.cluster.local:9001",
       "stripeWebhookSigningSecretPath": "",
+      "personalAccessTokenSigningKeyPath": "",
       "server": {
         "services": {
           "grpc": {
@@ -8922,7 +8923,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    gitpod.io/checksum_config: 2d64dca8ac18437c4ba1d80fd2112af408f1e5fb2ca0294f422f03bcbad647bb
+    gitpod.io/checksum_config: 74ab9c5d2ac7f57832d1df15f9764c3abfc450f45beb9a31d8aefb9bcf1aaea8
   creationTimestamp: null
   labels:
     app: gitpod

--- a/install/installer/cmd/testdata/render/azure-setup/output.golden
+++ b/install/installer/cmd/testdata/render/azure-setup/output.golden
@@ -2474,7 +2474,7 @@ data:
     kind: Deployment
     metadata:
       annotations:
-        gitpod.io/checksum_config: 2d64dca8ac18437c4ba1d80fd2112af408f1e5fb2ca0294f422f03bcbad647bb
+        gitpod.io/checksum_config: 74ab9c5d2ac7f57832d1df15f9764c3abfc450f45beb9a31d8aefb9bcf1aaea8
       creationTimestamp: null
       labels:
         app: gitpod
@@ -4507,6 +4507,7 @@ data:
       "gitpodServiceUrl": "wss://gitpod.example.com",
       "billingServiceAddress": "usage.default.svc.cluster.local:9001",
       "stripeWebhookSigningSecretPath": "",
+      "personalAccessTokenSigningKeyPath": "",
       "server": {
         "services": {
           "grpc": {
@@ -8871,7 +8872,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    gitpod.io/checksum_config: 2d64dca8ac18437c4ba1d80fd2112af408f1e5fb2ca0294f422f03bcbad647bb
+    gitpod.io/checksum_config: 74ab9c5d2ac7f57832d1df15f9764c3abfc450f45beb9a31d8aefb9bcf1aaea8
   creationTimestamp: null
   labels:
     app: gitpod

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -3041,7 +3041,7 @@ data:
     metadata:
       annotations:
         gitpod.io: hello
-        gitpod.io/checksum_config: cdfc28fc7531a2a524d1a6ada588bb7a547a34a2236ce588de015b4a3915eadb
+        gitpod.io/checksum_config: c8ec0a4694c7ee3ab1dc716c894e528f605270c05c212ec9b4d7a28ba100ac8e
         hello: world
       creationTimestamp: null
       labels:
@@ -5436,6 +5436,7 @@ data:
       "gitpodServiceUrl": "wss://gitpod.example.com",
       "billingServiceAddress": "usage.default.svc.cluster.local:9001",
       "stripeWebhookSigningSecretPath": "",
+      "personalAccessTokenSigningKeyPath": "",
       "server": {
         "services": {
           "grpc": {
@@ -10379,7 +10380,7 @@ kind: Deployment
 metadata:
   annotations:
     gitpod.io: hello
-    gitpod.io/checksum_config: cdfc28fc7531a2a524d1a6ada588bb7a547a34a2236ce588de015b4a3915eadb
+    gitpod.io/checksum_config: c8ec0a4694c7ee3ab1dc716c894e528f605270c05c212ec9b4d7a28ba100ac8e
     hello: world
   creationTimestamp: null
   labels:

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -2551,7 +2551,7 @@ data:
     kind: Deployment
     metadata:
       annotations:
-        gitpod.io/checksum_config: 2d64dca8ac18437c4ba1d80fd2112af408f1e5fb2ca0294f422f03bcbad647bb
+        gitpod.io/checksum_config: 74ab9c5d2ac7f57832d1df15f9764c3abfc450f45beb9a31d8aefb9bcf1aaea8
       creationTimestamp: null
       labels:
         app: gitpod
@@ -4694,6 +4694,7 @@ data:
       "gitpodServiceUrl": "wss://gitpod.example.com",
       "billingServiceAddress": "usage.default.svc.cluster.local:9001",
       "stripeWebhookSigningSecretPath": "",
+      "personalAccessTokenSigningKeyPath": "",
       "server": {
         "services": {
           "grpc": {
@@ -9297,7 +9298,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    gitpod.io/checksum_config: 2d64dca8ac18437c4ba1d80fd2112af408f1e5fb2ca0294f422f03bcbad647bb
+    gitpod.io/checksum_config: 74ab9c5d2ac7f57832d1df15f9764c3abfc450f45beb9a31d8aefb9bcf1aaea8
   creationTimestamp: null
   labels:
     app: gitpod

--- a/install/installer/cmd/testdata/render/gcp-setup/output.golden
+++ b/install/installer/cmd/testdata/render/gcp-setup/output.golden
@@ -2493,7 +2493,7 @@ data:
     kind: Deployment
     metadata:
       annotations:
-        gitpod.io/checksum_config: 2d64dca8ac18437c4ba1d80fd2112af408f1e5fb2ca0294f422f03bcbad647bb
+        gitpod.io/checksum_config: 74ab9c5d2ac7f57832d1df15f9764c3abfc450f45beb9a31d8aefb9bcf1aaea8
       creationTimestamp: null
       labels:
         app: gitpod
@@ -4468,6 +4468,7 @@ data:
       "gitpodServiceUrl": "wss://gitpod.example.com",
       "billingServiceAddress": "usage.default.svc.cluster.local:9001",
       "stripeWebhookSigningSecretPath": "",
+      "personalAccessTokenSigningKeyPath": "",
       "server": {
         "services": {
           "grpc": {
@@ -8800,7 +8801,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    gitpod.io/checksum_config: 2d64dca8ac18437c4ba1d80fd2112af408f1e5fb2ca0294f422f03bcbad647bb
+    gitpod.io/checksum_config: 74ab9c5d2ac7f57832d1df15f9764c3abfc450f45beb9a31d8aefb9bcf1aaea8
   creationTimestamp: null
   labels:
     app: gitpod

--- a/install/installer/cmd/testdata/render/http-proxy/output.golden
+++ b/install/installer/cmd/testdata/render/http-proxy/output.golden
@@ -2660,7 +2660,7 @@ data:
     kind: Deployment
     metadata:
       annotations:
-        gitpod.io/checksum_config: 2d64dca8ac18437c4ba1d80fd2112af408f1e5fb2ca0294f422f03bcbad647bb
+        gitpod.io/checksum_config: 74ab9c5d2ac7f57832d1df15f9764c3abfc450f45beb9a31d8aefb9bcf1aaea8
       creationTimestamp: null
       labels:
         app: gitpod
@@ -4880,6 +4880,7 @@ data:
       "gitpodServiceUrl": "wss://gitpod.example.com",
       "billingServiceAddress": "usage.default.svc.cluster.local:9001",
       "stripeWebhookSigningSecretPath": "",
+      "personalAccessTokenSigningKeyPath": "",
       "server": {
         "services": {
           "grpc": {
@@ -10633,7 +10634,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    gitpod.io/checksum_config: 2d64dca8ac18437c4ba1d80fd2112af408f1e5fb2ca0294f422f03bcbad647bb
+    gitpod.io/checksum_config: 74ab9c5d2ac7f57832d1df15f9764c3abfc450f45beb9a31d8aefb9bcf1aaea8
   creationTimestamp: null
   labels:
     app: gitpod

--- a/install/installer/cmd/testdata/render/insecure-s3-setup/output.golden
+++ b/install/installer/cmd/testdata/render/insecure-s3-setup/output.golden
@@ -2631,7 +2631,7 @@ data:
     kind: Deployment
     metadata:
       annotations:
-        gitpod.io/checksum_config: 2d64dca8ac18437c4ba1d80fd2112af408f1e5fb2ca0294f422f03bcbad647bb
+        gitpod.io/checksum_config: 74ab9c5d2ac7f57832d1df15f9764c3abfc450f45beb9a31d8aefb9bcf1aaea8
       creationTimestamp: null
       labels:
         app: gitpod
@@ -4791,6 +4791,7 @@ data:
       "gitpodServiceUrl": "wss://gitpod.example.com",
       "billingServiceAddress": "usage.default.svc.cluster.local:9001",
       "stripeWebhookSigningSecretPath": "",
+      "personalAccessTokenSigningKeyPath": "",
       "server": {
         "services": {
           "grpc": {
@@ -9358,7 +9359,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    gitpod.io/checksum_config: 2d64dca8ac18437c4ba1d80fd2112af408f1e5fb2ca0294f422f03bcbad647bb
+    gitpod.io/checksum_config: 74ab9c5d2ac7f57832d1df15f9764c3abfc450f45beb9a31d8aefb9bcf1aaea8
   creationTimestamp: null
   labels:
     app: gitpod

--- a/install/installer/cmd/testdata/render/kind-meta/output.golden
+++ b/install/installer/cmd/testdata/render/kind-meta/output.golden
@@ -2208,7 +2208,7 @@ data:
     kind: Deployment
     metadata:
       annotations:
-        gitpod.io/checksum_config: 2d64dca8ac18437c4ba1d80fd2112af408f1e5fb2ca0294f422f03bcbad647bb
+        gitpod.io/checksum_config: 74ab9c5d2ac7f57832d1df15f9764c3abfc450f45beb9a31d8aefb9bcf1aaea8
       creationTimestamp: null
       labels:
         app: gitpod
@@ -3809,6 +3809,7 @@ data:
       "gitpodServiceUrl": "wss://gitpod.example.com",
       "billingServiceAddress": "usage.default.svc.cluster.local:9001",
       "stripeWebhookSigningSecretPath": "",
+      "personalAccessTokenSigningKeyPath": "",
       "server": {
         "services": {
           "grpc": {
@@ -6792,7 +6793,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    gitpod.io/checksum_config: 2d64dca8ac18437c4ba1d80fd2112af408f1e5fb2ca0294f422f03bcbad647bb
+    gitpod.io/checksum_config: 74ab9c5d2ac7f57832d1df15f9764c3abfc450f45beb9a31d8aefb9bcf1aaea8
   creationTimestamp: null
   labels:
     app: gitpod

--- a/install/installer/cmd/testdata/render/kind-webapp/output.golden
+++ b/install/installer/cmd/testdata/render/kind-webapp/output.golden
@@ -1587,7 +1587,7 @@ data:
     kind: Deployment
     metadata:
       annotations:
-        gitpod.io/checksum_config: 2d64dca8ac18437c4ba1d80fd2112af408f1e5fb2ca0294f422f03bcbad647bb
+        gitpod.io/checksum_config: 74ab9c5d2ac7f57832d1df15f9764c3abfc450f45beb9a31d8aefb9bcf1aaea8
       creationTimestamp: null
       labels:
         app: gitpod
@@ -2118,6 +2118,7 @@ data:
       "gitpodServiceUrl": "wss://gitpod.example.com",
       "billingServiceAddress": "usage.default.svc.cluster.local:9001",
       "stripeWebhookSigningSecretPath": "",
+      "personalAccessTokenSigningKeyPath": "",
       "server": {
         "services": {
           "grpc": {
@@ -4020,7 +4021,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    gitpod.io/checksum_config: 2d64dca8ac18437c4ba1d80fd2112af408f1e5fb2ca0294f422f03bcbad647bb
+    gitpod.io/checksum_config: 74ab9c5d2ac7f57832d1df15f9764c3abfc450f45beb9a31d8aefb9bcf1aaea8
   creationTimestamp: null
   labels:
     app: gitpod

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -2657,7 +2657,7 @@ data:
     kind: Deployment
     metadata:
       annotations:
-        gitpod.io/checksum_config: 2d64dca8ac18437c4ba1d80fd2112af408f1e5fb2ca0294f422f03bcbad647bb
+        gitpod.io/checksum_config: 74ab9c5d2ac7f57832d1df15f9764c3abfc450f45beb9a31d8aefb9bcf1aaea8
       creationTimestamp: null
       labels:
         app: gitpod
@@ -4877,6 +4877,7 @@ data:
       "gitpodServiceUrl": "wss://gitpod.example.com",
       "billingServiceAddress": "usage.default.svc.cluster.local:9001",
       "stripeWebhookSigningSecretPath": "",
+      "personalAccessTokenSigningKeyPath": "",
       "server": {
         "services": {
           "grpc": {
@@ -9587,7 +9588,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    gitpod.io/checksum_config: 2d64dca8ac18437c4ba1d80fd2112af408f1e5fb2ca0294f422f03bcbad647bb
+    gitpod.io/checksum_config: 74ab9c5d2ac7f57832d1df15f9764c3abfc450f45beb9a31d8aefb9bcf1aaea8
   creationTimestamp: null
   labels:
     app: gitpod

--- a/install/installer/cmd/testdata/render/shortname/output.golden
+++ b/install/installer/cmd/testdata/render/shortname/output.golden
@@ -2657,7 +2657,7 @@ data:
     kind: Deployment
     metadata:
       annotations:
-        gitpod.io/checksum_config: 2d64dca8ac18437c4ba1d80fd2112af408f1e5fb2ca0294f422f03bcbad647bb
+        gitpod.io/checksum_config: 74ab9c5d2ac7f57832d1df15f9764c3abfc450f45beb9a31d8aefb9bcf1aaea8
       creationTimestamp: null
       labels:
         app: gitpod
@@ -4877,6 +4877,7 @@ data:
       "gitpodServiceUrl": "wss://gitpod.example.com",
       "billingServiceAddress": "usage.default.svc.cluster.local:9001",
       "stripeWebhookSigningSecretPath": "",
+      "personalAccessTokenSigningKeyPath": "",
       "server": {
         "services": {
           "grpc": {
@@ -9587,7 +9588,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    gitpod.io/checksum_config: 2d64dca8ac18437c4ba1d80fd2112af408f1e5fb2ca0294f422f03bcbad647bb
+    gitpod.io/checksum_config: 74ab9c5d2ac7f57832d1df15f9764c3abfc450f45beb9a31d8aefb9bcf1aaea8
   creationTimestamp: null
   labels:
     app: gitpod

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -2669,7 +2669,7 @@ data:
     kind: Deployment
     metadata:
       annotations:
-        gitpod.io/checksum_config: 2d64dca8ac18437c4ba1d80fd2112af408f1e5fb2ca0294f422f03bcbad647bb
+        gitpod.io/checksum_config: 74ab9c5d2ac7f57832d1df15f9764c3abfc450f45beb9a31d8aefb9bcf1aaea8
       creationTimestamp: null
       labels:
         app: gitpod
@@ -4889,6 +4889,7 @@ data:
       "gitpodServiceUrl": "wss://gitpod.example.com",
       "billingServiceAddress": "usage.default.svc.cluster.local:9001",
       "stripeWebhookSigningSecretPath": "",
+      "personalAccessTokenSigningKeyPath": "",
       "server": {
         "services": {
           "grpc": {
@@ -9599,7 +9600,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    gitpod.io/checksum_config: 2d64dca8ac18437c4ba1d80fd2112af408f1e5fb2ca0294f422f03bcbad647bb
+    gitpod.io/checksum_config: 74ab9c5d2ac7f57832d1df15f9764c3abfc450f45beb9a31d8aefb9bcf1aaea8
   creationTimestamp: null
   labels:
     app: gitpod

--- a/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
+++ b/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
@@ -2945,7 +2945,7 @@ data:
     kind: Deployment
     metadata:
       annotations:
-        gitpod.io/checksum_config: 2d64dca8ac18437c4ba1d80fd2112af408f1e5fb2ca0294f422f03bcbad647bb
+        gitpod.io/checksum_config: 74ab9c5d2ac7f57832d1df15f9764c3abfc450f45beb9a31d8aefb9bcf1aaea8
       creationTimestamp: null
       labels:
         app: gitpod
@@ -5210,6 +5210,7 @@ data:
       "gitpodServiceUrl": "wss://gitpod.example.com",
       "billingServiceAddress": "usage.default.svc.cluster.local:9001",
       "stripeWebhookSigningSecretPath": "",
+      "personalAccessTokenSigningKeyPath": "",
       "server": {
         "services": {
           "grpc": {
@@ -10031,7 +10032,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    gitpod.io/checksum_config: 2d64dca8ac18437c4ba1d80fd2112af408f1e5fb2ca0294f422f03bcbad647bb
+    gitpod.io/checksum_config: 74ab9c5d2ac7f57832d1df15f9764c3abfc450f45beb9a31d8aefb9bcf1aaea8
   creationTimestamp: null
   labels:
     app: gitpod

--- a/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
+++ b/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
@@ -2659,7 +2659,7 @@ data:
     kind: Deployment
     metadata:
       annotations:
-        gitpod.io/checksum_config: 2d64dca8ac18437c4ba1d80fd2112af408f1e5fb2ca0294f422f03bcbad647bb
+        gitpod.io/checksum_config: 74ab9c5d2ac7f57832d1df15f9764c3abfc450f45beb9a31d8aefb9bcf1aaea8
       creationTimestamp: null
       labels:
         app: gitpod
@@ -4879,6 +4879,7 @@ data:
       "gitpodServiceUrl": "wss://gitpod.example.com",
       "billingServiceAddress": "usage.default.svc.cluster.local:9001",
       "stripeWebhookSigningSecretPath": "",
+      "personalAccessTokenSigningKeyPath": "",
       "server": {
         "services": {
           "grpc": {
@@ -9577,7 +9578,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    gitpod.io/checksum_config: 2d64dca8ac18437c4ba1d80fd2112af408f1e5fb2ca0294f422f03bcbad647bb
+    gitpod.io/checksum_config: 74ab9c5d2ac7f57832d1df15f9764c3abfc450f45beb9a31d8aefb9bcf1aaea8
   creationTimestamp: null
   labels:
     app: gitpod

--- a/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
+++ b/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
@@ -2660,7 +2660,7 @@ data:
     kind: Deployment
     metadata:
       annotations:
-        gitpod.io/checksum_config: 2d64dca8ac18437c4ba1d80fd2112af408f1e5fb2ca0294f422f03bcbad647bb
+        gitpod.io/checksum_config: 74ab9c5d2ac7f57832d1df15f9764c3abfc450f45beb9a31d8aefb9bcf1aaea8
       creationTimestamp: null
       labels:
         app: gitpod
@@ -4880,6 +4880,7 @@ data:
       "gitpodServiceUrl": "wss://gitpod.example.com",
       "billingServiceAddress": "usage.default.svc.cluster.local:9001",
       "stripeWebhookSigningSecretPath": "",
+      "personalAccessTokenSigningKeyPath": "",
       "server": {
         "services": {
           "grpc": {
@@ -9590,7 +9591,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    gitpod.io/checksum_config: 2d64dca8ac18437c4ba1d80fd2112af408f1e5fb2ca0294f422f03bcbad647bb
+    gitpod.io/checksum_config: 74ab9c5d2ac7f57832d1df15f9764c3abfc450f45beb9a31d8aefb9bcf1aaea8
   creationTimestamp: null
   labels:
     app: gitpod

--- a/install/installer/pkg/components/public-api-server/configmap_test.go
+++ b/install/installer/pkg/components/public-api-server/configmap_test.go
@@ -30,10 +30,17 @@ func TestConfigMap(t *testing.T) {
 		return nil
 	})
 
+	var personalAccessTokenSigningKeyPath string
+	_ = ctx.WithExperimental(func(ucfg *experimental.Config) error {
+		_, _, personalAccessTokenSigningKeyPath, _ = getPersonalAccessTokenSigningKey(ucfg)
+		return nil
+	})
+
 	expectedConfiguration := config.Configuration{
-		GitpodServiceURL:               "wss://test.domain.everything.awesome.is",
-		BillingServiceAddress:          fmt.Sprintf("usage.%s.svc.cluster.local:9001", ctx.Namespace),
-		StripeWebhookSigningSecretPath: stripeSecretPath,
+		GitpodServiceURL:                  "wss://test.domain.everything.awesome.is",
+		BillingServiceAddress:             fmt.Sprintf("usage.%s.svc.cluster.local:9001", ctx.Namespace),
+		StripeWebhookSigningSecretPath:    stripeSecretPath,
+		PersonalAccessTokenSigningKeyPath: personalAccessTokenSigningKeyPath,
 		Server: &baseserver.Configuration{
 			Services: baseserver.ServicesConfiguration{
 				GRPC: &baseserver.ServerConfiguration{

--- a/install/installer/pkg/components/public-api-server/constants.go
+++ b/install/installer/pkg/components/public-api-server/constants.go
@@ -14,5 +14,6 @@ const (
 	HTTPServicePort   = 9002
 	HTTPPortName      = "http"
 
-	stripeSecretMountPath = "/secrets/stripe-webhook-secret"
+	stripeSecretMountPath                  = "/secrets/stripe-webhook-secret"
+	personalAccessTokenSigningKeyMountPath = "/secrets/personal-access-token-signing-key"
 )

--- a/install/installer/pkg/components/public-api-server/deployment.go
+++ b/install/installer/pkg/components/public-api-server/deployment.go
@@ -64,6 +64,17 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 		return nil
 	})
 
+	_ = ctx.WithExperimental(func(cfg *experimental.Config) error {
+		volume, mount, _, ok := getPersonalAccessTokenSigningKey(cfg)
+		if !ok {
+			return nil
+		}
+
+		volumes = append(volumes, volume)
+		volumeMounts = append(volumeMounts, mount)
+		return nil
+	})
+
 	labels := common.CustomizeLabel(ctx, Component, common.TypeMetaDeployment)
 	return []runtime.Object{
 		&appsv1.Deployment{

--- a/install/installer/pkg/components/public-api-server/deployment_test.go
+++ b/install/installer/pkg/components/public-api-server/deployment_test.go
@@ -64,5 +64,14 @@ func TestDeployment_ServerArguments(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name: "personal-access-token-signing-key",
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: "personal-access-token-signing-key",
+					Optional:   pointer.Bool(true),
+				},
+			},
+		},
 	}, dpl.Spec.Template.Spec.Volumes, "must bind config as a volume")
 }

--- a/install/installer/pkg/components/public-api-server/objects_test.go
+++ b/install/installer/pkg/components/public-api-server/objects_test.go
@@ -28,7 +28,8 @@ func renderContextWithPublicAPI(t *testing.T) *common.RenderContext {
 		Experimental: &experimental.Config{
 			WebApp: &experimental.WebAppConfig{
 				PublicAPI: &experimental.PublicAPIConfig{
-					StripeSecretName: "stripe-webhook-secret",
+					StripeSecretName:                        "stripe-webhook-secret",
+					PersonalAccessTokenSigningKeySecretName: "personal-access-token-signing-key",
 				},
 			},
 		},

--- a/install/installer/pkg/config/v1/experimental/experimental.go
+++ b/install/installer/pkg/config/v1/experimental/experimental.go
@@ -264,6 +264,9 @@ type ConfigcatProxyConfig struct {
 type PublicAPIConfig struct {
 	// Name of the kubernetes secret to use for Stripe secrets
 	StripeSecretName string `json:"stripeSecretName"`
+
+	// Name of the kubernetes secret to use for signature of Personal Access Tokens
+	PersonalAccessTokenSigningKeySecretName string `json:"personalAccessTokenSigningKeySecretName"`
 }
 
 type UsageConfig struct {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Adds config to Public API to load a secret reference to Personal Access Token signing key. 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
CI

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
