### PR TITLE
[public-api] Use personal access token signing key

### DIFF
--- a/components/public-api-server/pkg/apiv1/tokens.go
+++ b/components/public-api-server/pkg/apiv1/tokens.go
@@ -24,11 +24,12 @@ import (
 	"gorm.io/gorm"
 )
 
-func NewTokensService(connPool proxy.ServerConnectionPool, expClient experiments.Client, dbConn *gorm.DB) *TokensService {
+func NewTokensService(connPool proxy.ServerConnectionPool, expClient experiments.Client, dbConn *gorm.DB, signer auth.Signer) *TokensService {
 	return &TokensService{
 		connectionPool: connPool,
 		expClient:      expClient,
 		dbConn:         dbConn,
+		signer:         signer,
 	}
 }
 
@@ -36,6 +37,7 @@ type TokensService struct {
 	connectionPool proxy.ServerConnectionPool
 	expClient      experiments.Client
 	dbConn         *gorm.DB
+	signer         auth.Signer
 
 	v1connect.UnimplementedTokensServiceHandler
 }

--- a/components/public-api-server/pkg/apiv1/tokens_test.go
+++ b/components/public-api-server/pkg/apiv1/tokens_test.go
@@ -370,13 +370,14 @@ func setupTokensService(t *testing.T, expClient experiments.Client) (*protocol.M
 	t.Helper()
 
 	dbConn := dbtest.ConnectForTests(t)
+	signer := auth.NewHS256Signer([]byte("my-secret"))
 
 	ctrl := gomock.NewController(t)
 	t.Cleanup(ctrl.Finish)
 
 	serverMock := protocol.NewMockAPIInterface(ctrl)
 
-	svc := NewTokensService(&FakeServerConnPool{api: serverMock}, expClient, dbConn)
+	svc := NewTokensService(&FakeServerConnPool{api: serverMock}, expClient, dbConn, signer)
 
 	_, handler := v1connect.NewTokensServiceHandler(svc, connect.WithInterceptors(auth.NewServerInterceptor()))
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Creates a signer and uses the Personal Access Token signing key in Public API.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Depends on https://github.com/gitpod-io/gitpod/pull/14823

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold for dependency on https://github.com/gitpod-io/gitpod/pull/14823