### PR TITLE
Update StuckOnStopping alert

### DIFF
--- a/operations/observability/mixins/workspace/rules/central/workspaces.yaml
+++ b/operations/observability/mixins/workspace/rules/central/workspaces.yaml
@@ -34,12 +34,12 @@ spec:
       for: 30m
       annotations:
         runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWorkspaceStuckOnStopping.md
-        summary: 5 or more workspaces are stuck on stopping in cluster {{ $labels.cluster }}.
+        summary: 15 or more workspaces are stuck on stopping in cluster {{ $labels.cluster }}.
         description: '{{ printf "%.2f" $value }} {{ $labels.workspace_type }} workspaces are stuck on stopping for more than 20 minutes.'
       expr: |
         sum(
           gitpod_ws_manager_workspace_phase_total{type="REGULAR", phase="STOPPING", cluster!~"ephemeral.*"}
-        ) without(phase) > 5
+        ) without(phase) > 15
 
     - alert: GitpodWorkspaceHighFailureRate
       labels:


### PR DESCRIPTION
## Description
With the number of workspaces we are running now this alert fires too often without anything being amiss.

## Related Issue(s)
n.a.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
