### PR TITLE
Update usage period date format

### DIFF
--- a/components/dashboard/src/components/UsageBasedBillingConfig.tsx
+++ b/components/dashboard/src/components/UsageBasedBillingConfig.tsx
@@ -256,15 +256,13 @@ export default function UsageBasedBillingConfig({ attributionId }: Props) {
                             <div className="flex-grow">
                                 <div className="uppercase text-sm text-gray-400 dark:text-gray-500">Current Period</div>
                                 <div className="text-sm font-medium text-gray-500 dark:text-gray-400">
-                                    <span className="font-semibold">{`${billingCycleFrom.format("MMMM YYYY")}`}</span> (
                                     <span title={billingCycleFrom.toDate().toUTCString().replace("GMT", "UTC")}>
-                                        {billingCycleFrom.format("MMM D")}
+                                        {billingCycleFrom.format("MMM D, YYYY")}
                                     </span>{" "}
-                                    -{" "}
+                                    &ndash;{" "}
                                     <span title={billingCycleTo.toDate().toUTCString().replace("GMT", "UTC")}>
-                                        {billingCycleTo.format("MMM D")}
+                                        {billingCycleTo.format("MMM D, YYYY")}
                                     </span>
-                                    )
                                 </div>
                             </div>
                             <div>


### PR DESCRIPTION
## Description

Following up from https://github.com/gitpod-io/gitpod/pull/14705, this will :a: update the usage period date format, moving away from the fixed month-based named period, and :b: use a more appropriate dash punctuation mark ([En Dash](https://en.wiktionary.org/wiki/en_dash)) for separating the date range.

## How to test

1. Enable UBP flag. //TODO: We definitely need a link to describe how to enable a feature flag.
2. Go to `/billing`
3. Notice the difference in current period date format

## Screenshots 

| BEFORE | AFTER |
|-|-|
| <img width="609" alt="billing-before" src="https://user-images.githubusercontent.com/120486/203112420-363e3db4-cff3-442f-9f30-73b583e69a6f.png"> | <img width="609" alt="billing-after" src="https://user-images.githubusercontent.com/120486/203112425-11042bd5-ac12-4eac-86a9-68fcaae920e2.png"> |

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Update usage period date format
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
