### PR TITLE
Revert removing the workspace download feature

### DIFF
--- a/components/dashboard/src/workspaces/WorkspaceEntry.tsx
+++ b/components/dashboard/src/workspaces/WorkspaceEntry.tsx
@@ -57,6 +57,11 @@ export function WorkspaceEntry({ desc, model, isAdmin, stopWorkspace }: Props) {
         pathname: "/start/",
         hash: "#" + ws.id,
     });
+    const downloadURL = new GitpodHostUrl(window.location.href)
+        .with({
+            pathname: `/workspace-download/get/${ws.id}`,
+        })
+        .toString();
     const menuEntries: ContextMenuEntry[] = [
         {
             title: "Open",
@@ -86,22 +91,8 @@ export function WorkspaceEntry({ desc, model, isAdmin, stopWorkspace }: Props) {
     }
     menuEntries.push({
         title: "Download",
-        customContent: (
-            <div className="">
-                <span className="block text-gray-300 dark:text-gray-500">Download</span>
-                <span className="text-gray-400">
-                    Deprecated.{" "}
-                    <a
-                        href="https://github.com/gitpod-io/gitpod/issues/7901"
-                        className="gp-link"
-                        target="_blank"
-                        rel="noreferrer"
-                    >
-                        Learn more
-                    </a>
-                </span>
-            </div>
-        ),
+        href: downloadURL,
+        download: `${ws.id}.tar`,
     });
     if (!isAdmin) {
         menuEntries.push(


### PR DESCRIPTION
## Description

This will restore the removed workspace download functionality.

See [relevant discussion](https://gitpod.slack.com/archives/C02EN94AEPL/p1668813874167919) (internal). Cc @kylos101 @atduarte @jldec 

## How to test
1. Open a new workspace
2. Stop the workspace
3. Go to the workspaces list
4. Notice the download menu in the workspace more actions dropdown exists
5. Download the stopped workspace

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Revert removing the workspace download feature
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
