### PR TITLE
Add `storage-class` annotation for preview envs, and pass less vars to `create-preview`

### DIFF
--- a/.werft/jobs/build/job-config.ts
+++ b/.werft/jobs/build/job-config.ts
@@ -25,6 +25,7 @@ export interface JobConfig {
     publishToKots: boolean;
     replicatedChannel: string;
     storage: string;
+    storageClass: string;
     version: string;
     withContrib: boolean;
     withIntegrationTests: WithIntegrationTests;
@@ -105,6 +106,7 @@ export function jobConfig(werft: Werft, context: any): JobConfig {
     const recreatePreview = "recreate-preview" in buildConfig
     const recreateVm = mainBuild || "recreate-vm" in buildConfig;
     const withSlowDatabase = "with-slow-database" in buildConfig && !mainBuild;
+    const storageClass = buildConfig["storage-class"] || "";
 
     const analytics = parseAnalytics(werft, sliceId, buildConfig["analytics"])
     const withIntegrationTests = parseWithIntegrationTests(werft, sliceId, buildConfig["with-integration-tests"]);
@@ -164,6 +166,7 @@ export function jobConfig(werft: Werft, context: any): JobConfig {
         replicatedVersion,
         repository,
         storage,
+        storageClass,
         version,
         withContrib,
         withIntegrationTests,

--- a/.werft/jobs/build/prepare.ts
+++ b/.werft/jobs/build/prepare.ts
@@ -106,11 +106,13 @@ async function createVM(werft: Werft, config: JobConfig) {
         "GOOGLE_BACKEND_CREDENTIALS": GCLOUD_SERVICE_ACCOUNT_PATH,
         "GOOGLE_APPLICATION_CREDENTIALS": GCLOUD_SERVICE_ACCOUNT_PATH,
         "TF_VAR_cert_issuer": config.certIssuer,
-        "TF_VAR_kubeconfig_path": GLOBAL_KUBECONFIG_PATH,
         "TF_VAR_preview_name": config.previewEnvironment.destname,
         "TF_VAR_vm_cpu": `${cpu}`,
         "TF_VAR_vm_memory": `${memory}Gi`,
-        "TF_VAR_vm_storage_class": "longhorn-gitpod-k3s-202209251218-onereplica"
+    }
+
+    if (config.storageClass.length > 0){
+        environment["TF_VAR_vm_storage_class"] = config.storageClass
     }
 
     const variables = Object

--- a/dev/preview/BUILD.yaml
+++ b/dev/preview/BUILD.yaml
@@ -23,7 +23,7 @@ scripts:
       export TF_VAR_cert_issuer="${TF_VAR_cert_issuer:-zerossl-issuer-gitpod-core-dev}"
       export TF_VAR_dev_kube_path="${TF_VAR_dev_kube_path:-/home/gitpod/.kube/config}"
       export TF_VAR_dev_kube_context="${TF_VAR_dev_kube_context:-dev}"
-      export TF_VAR_harvester_kube_path="${TF_VAR_harvester_kube_path:-/home/gitpod/.kube/config}"
+      export TF_VAR_harvester_kube_path="${TF_VAR_harvester_kube_path:-$HOME/.kube/config}"
       export TF_VAR_harvester_kube_context="${TF_VAR_harvester_kube_context:-harvester}"
       export TF_VAR_preview_name="${TF_VAR_preview_name:-$(previewctl get-name)}"
       export TF_VAR_vm_cpu="${TF_VAR_vm_cpu:-6}"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
* Add `storage-class` annotation for preview envs
* Pass less vars to `dev/preview:create-preview` from werft

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
Run a job, passing the storage class
```bash
werft run github -a with-preview=true -a storage-class=longhorn-gitpod-k3s-202211180921-onereplica
```

Check the storage class:
```bash
k -n preview-aa-less-create-vars get pvc

NAME                                STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                                  AGE
aa-less-create-vars-storage-994p7   Bound    pvc-e432f615-706c-4df8-bddc-c2d5e3f7ceb6   30Gi       RWO            longhorn-onereplica                           4m12s
aa-less-create-vars-system-94xvs    Bound    pvc-f1975c4b-27ec-4140-bc49-0c3bcc664a07   200Gi      RWO            longhorn-gitpod-k3s-202211180921-onereplica   4m12s
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
