### PR TITLE
[public-api] Implement list personal access tokens

### DIFF
--- a/components/gitpod-db/go/dbtest/personal_access_token.go
+++ b/components/gitpod-db/go/dbtest/personal_access_token.go
@@ -1,0 +1,96 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package dbtest
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	db "github.com/gitpod-io/gitpod/components/gitpod-db/go"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+func NewPersonalAccessToken(t *testing.T, record db.PersonalAccessToken) db.PersonalAccessToken {
+	t.Helper()
+
+	now := time.Now().UTC().Round(time.Millisecond)
+	tokenID := uuid.New()
+
+	result := db.PersonalAccessToken{
+		ID:             tokenID,
+		UserID:         uuid.New(),
+		Hash:           "some-secure-hash",
+		Name:           "some-name",
+		Description:    "some-description",
+		Scopes:         []string{"read", "write"},
+		ExpirationTime: now.Add(5 * time.Hour),
+		CreatedAt:      now,
+		LastModified:   now,
+	}
+
+	if record.ID != uuid.Nil {
+		result.ID = record.ID
+	}
+
+	if record.UserID != uuid.Nil {
+		result.UserID = record.UserID
+	}
+
+	if record.Hash != "" {
+		result.Hash = record.Hash
+	}
+
+	if record.Name != "" {
+		result.Name = record.Name
+	}
+
+	if record.Description != "" {
+		result.Description = record.Description
+	}
+
+	if len(record.Scopes) == 0 {
+		result.Scopes = record.Scopes
+	}
+
+	if !record.ExpirationTime.IsZero() {
+		result.ExpirationTime = record.ExpirationTime
+	}
+
+	if !record.CreatedAt.IsZero() {
+		result.CreatedAt = record.CreatedAt
+	}
+
+	if !record.LastModified.IsZero() {
+		result.LastModified = record.LastModified
+	}
+
+	return result
+}
+
+func CreatePersonalAccessTokenRecords(t *testing.T, conn *gorm.DB, entries ...db.PersonalAccessToken) []db.PersonalAccessToken {
+	t.Helper()
+
+	var records []db.PersonalAccessToken
+	var ids []string
+	for _, tokenEntry := range entries {
+		record := NewPersonalAccessToken(t, tokenEntry)
+		records = append(records, record)
+		ids = append(ids, record.ID.String())
+
+		_, err := db.CreateToken(context.Background(), conn, tokenEntry)
+		require.NoError(t, err)
+	}
+
+	t.Cleanup(func() {
+		if len(ids) > 0 {
+			require.NoError(t, conn.Where(ids).Delete(&db.PersonalAccessToken{}).Error)
+		}
+	})
+
+	return records
+}

--- a/components/gitpod-db/go/pagination.go
+++ b/components/gitpod-db/go/pagination.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package db
+
+import (
+	"gorm.io/gorm"
+)
+
+type Pagination struct {
+	Page     int
+	PageSize int
+}
+
+func Paginate(pagination Pagination) func(*gorm.DB) *gorm.DB {
+	return func(conn *gorm.DB) *gorm.DB {
+		page := 1
+		if pagination.Page > 0 {
+			page = pagination.Page
+		}
+
+		pageSize := 25
+		if pagination.PageSize >= 0 {
+			pageSize = pagination.PageSize
+		}
+
+		offset := (page - 1) * pageSize
+		return conn.Offset(offset).Limit(pageSize)
+	}
+}
+
+type PaginatedResult[T any] struct {
+	Results []T
+	Total   int64
+}

--- a/components/gitpod-db/go/personal_access_token_test.go
+++ b/components/gitpod-db/go/personal_access_token_test.go
@@ -6,6 +6,7 @@ package db_test
 
 import (
 	"context"
+	"strconv"
 	"testing"
 	"time"
 
@@ -57,4 +58,86 @@ func TestPersonalAccessToken_Create(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, request.ID, result.ID)
+}
+
+func TestListPersonalAccessTokensForUser(t *testing.T) {
+	ctx := context.Background()
+	conn := dbtest.ConnectForTests(t)
+	pagination := db.Pagination{
+		Page:     1,
+		PageSize: 10,
+	}
+
+	userA := uuid.New()
+	userB := uuid.New()
+
+	now := time.Now().UTC()
+
+	dbtest.CreatePersonalAccessTokenRecords(t, conn,
+		dbtest.NewPersonalAccessToken(t, db.PersonalAccessToken{
+			UserID:    userA,
+			CreatedAt: now.Add(-1 * time.Minute),
+		}),
+		dbtest.NewPersonalAccessToken(t, db.PersonalAccessToken{
+			UserID:    userA,
+			CreatedAt: now,
+		}),
+		dbtest.NewPersonalAccessToken(t, db.PersonalAccessToken{
+			UserID: userB,
+		}),
+	)
+
+	tokensForUserA, err := db.ListPersonalAccessTokensForUser(ctx, conn, userA, pagination)
+	require.NoError(t, err)
+	require.Len(t, tokensForUserA.Results, 2)
+
+	tokensForUserB, err := db.ListPersonalAccessTokensForUser(ctx, conn, userB, pagination)
+	require.NoError(t, err)
+	require.Len(t, tokensForUserB.Results, 1)
+
+	tokensForUserWithNoData, err := db.ListPersonalAccessTokensForUser(ctx, conn, uuid.New(), pagination)
+	require.NoError(t, err)
+	require.Len(t, tokensForUserWithNoData.Results, 0)
+}
+
+func TestListPersonalAccessTokensForUser_PaginateThroughResults(t *testing.T) {
+	ctx := context.Background()
+	conn := dbtest.ConnectForTests(t).Debug()
+
+	userA := uuid.New()
+
+	total := 11
+	var toCreate []db.PersonalAccessToken
+	for i := 0; i < total; i++ {
+		toCreate = append(toCreate, dbtest.NewPersonalAccessToken(t, db.PersonalAccessToken{
+			UserID: userA,
+			Name:   strconv.Itoa(i),
+		}))
+	}
+
+	dbtest.CreatePersonalAccessTokenRecords(t, conn, toCreate...)
+
+	batch1, err := db.ListPersonalAccessTokensForUser(ctx, conn, userA, db.Pagination{
+		Page:     1,
+		PageSize: 5,
+	})
+	require.NoError(t, err)
+	require.Len(t, batch1.Results, 5)
+	require.EqualValues(t, batch1.Total, total)
+
+	batch2, err := db.ListPersonalAccessTokensForUser(ctx, conn, userA, db.Pagination{
+		Page:     2,
+		PageSize: 5,
+	})
+	require.NoError(t, err)
+	require.Len(t, batch2.Results, 5)
+	require.EqualValues(t, batch2.Total, total)
+
+	batch3, err := db.ListPersonalAccessTokensForUser(ctx, conn, userA, db.Pagination{
+		Page:     3,
+		PageSize: 5,
+	})
+	require.NoError(t, err)
+	require.Len(t, batch3.Results, 1)
+	require.EqualValues(t, batch3.Total, total)
 }

--- a/components/public-api-server/BUILD.yaml
+++ b/components/public-api-server/BUILD.yaml
@@ -11,6 +11,7 @@ packages:
       - components/usage-api/go:lib
       - components/gitpod-protocol/go:lib
       - components/gitpod-db/go:lib
+      - components/gitpod-db/go:init-testdb
     env:
       - CGO_ENABLED=0
       - GOOS=linux

--- a/components/public-api-server/pkg/apiv1/pagination.go
+++ b/components/public-api-server/pkg/apiv1/pagination.go
@@ -1,0 +1,38 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package apiv1
+
+import (
+	db "github.com/gitpod-io/gitpod/components/gitpod-db/go"
+	v1 "github.com/gitpod-io/gitpod/components/public-api/go/experimental/v1"
+)
+
+func validatePagination(p *v1.Pagination) *v1.Pagination {
+	pagination := &v1.Pagination{
+		PageSize: 25,
+		Page:     1,
+	}
+
+	if p == nil {
+		return pagination
+	}
+
+	if p.Page > 0 {
+		pagination.Page = p.Page
+	}
+	if p.PageSize > 0 && p.PageSize <= 100 {
+		pagination.PageSize = p.PageSize
+	}
+
+	return pagination
+}
+
+func paginationToDB(p *v1.Pagination) db.Pagination {
+	validated := validatePagination(p)
+	return db.Pagination{
+		Page:     int(validated.GetPage()),
+		PageSize: int(validated.GetPageSize()),
+	}
+}

--- a/components/public-api-server/pkg/apiv1/pagination_test.go
+++ b/components/public-api-server/pkg/apiv1/pagination_test.go
@@ -1,0 +1,79 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+package apiv1
+
+import (
+	"testing"
+
+	v1 "github.com/gitpod-io/gitpod/components/public-api/go/experimental/v1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidatePagination(t *testing.T) {
+
+	t.Run("empty pagination defaults to page size 25, page 1", func(t *testing.T) {
+		require.Equal(t, &v1.Pagination{
+			PageSize: 25,
+			Page:     1,
+		}, validatePagination(nil))
+
+		require.Equal(t, &v1.Pagination{
+			PageSize: 25,
+			Page:     1,
+		}, validatePagination(&v1.Pagination{}))
+	})
+
+	t.Run("negative, or zero, page defaults to page 1", func(t *testing.T) {
+		require.Equal(t, &v1.Pagination{
+			PageSize: 25,
+			Page:     1,
+		}, validatePagination(&v1.Pagination{
+			Page: 0,
+		}))
+
+		require.Equal(t, &v1.Pagination{
+			PageSize: 25,
+			Page:     1,
+		}, validatePagination(&v1.Pagination{
+			Page: -1,
+		}))
+	})
+
+	t.Run("page size of 0, or below, defaults to 25", func(t *testing.T) {
+		require.Equal(t, &v1.Pagination{
+			PageSize: 25,
+			Page:     1,
+		}, validatePagination(&v1.Pagination{
+			PageSize: 0,
+		}))
+
+		require.Equal(t, &v1.Pagination{
+			PageSize: 25,
+			Page:     1,
+		}, validatePagination(&v1.Pagination{
+			PageSize: -1,
+		}))
+	})
+
+	t.Run("page size greater than 100 defaults to 25", func(t *testing.T) {
+		require.Equal(t, &v1.Pagination{
+			PageSize: 25,
+			Page:     1,
+		}, validatePagination(&v1.Pagination{
+			PageSize: 101,
+		}))
+	})
+
+	t.Run("valid page and page size is used", func(t *testing.T) {
+		require.Equal(t, &v1.Pagination{
+			PageSize: 77,
+			Page:     9,
+		}, validatePagination(&v1.Pagination{
+			PageSize: 77,
+			Page:     9,
+		}))
+	})
+
+}

--- a/components/usage/BUILD.yaml
+++ b/components/usage/BUILD.yaml
@@ -10,6 +10,7 @@ packages:
       - components/common-go:lib
       - components/usage-api/go:lib
       - components/content-service-api/go:lib
+      - components/gitpod-db/go:init-testdb
     env:
       - CGO_ENABLED=0
       - GOOS=linux
@@ -24,6 +25,7 @@ packages:
       - components/common-go:lib
       - components/usage-api/go:lib
       - components/content-service-api/go:lib
+      - components/gitpod-db/go:init-testdb
     srcs:
       - "**/*.go"
       - "go.mod"

--- a/gitpod-ws.code-workspace
+++ b/gitpod-ws.code-workspace
@@ -24,6 +24,7 @@
         { "path": "components/ws-manager" },
         { "path": "components/ws-proxy" },
         { "path": "components/public-api-server" },
+        { "path": "components/gitpod-db" },
         { "path": "test" },
         { "path": "dev/blowtorch" },
         { "path": "dev/changelog" },


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Implements ListPersonalAccessTokens.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Part of https://github.com/gitpod-io/gitpod/issues/14610
* Depends on https://github.com/gitpod-io/gitpod/pull/14835

## How to test
<!-- Provide steps to test this PR -->
Unit tests

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
