### PR TITLE
test: disable the PVC integration test

### DIFF
--- a/test/tests/components/ws-manager/content_test.go
+++ b/test/tests/components/ws-manager/content_test.go
@@ -39,20 +39,22 @@ func TestBackup(t *testing.T) {
 					WorkspaceRoot:    "/workspace/empty",
 					CheckoutLocation: "empty",
 				},
-				{
-					Name:             "pvc",
-					ContextURL:       "https://github.com/gitpod-io/empty",
-					WorkspaceRoot:    "/workspace/empty",
-					CheckoutLocation: "empty",
-					FF:               []wsmanapi.WorkspaceFeatureFlag{wsmanapi.WorkspaceFeatureFlag_PERSISTENT_VOLUME_CLAIM},
-				},
-				{
-					Name:             "pvc-non-gitpodified",
-					ContextURL:       "https://github.com/gitpod-io/non-gitpodified-repo",
-					WorkspaceRoot:    "/workspace/non-gitpodified-repo",
-					CheckoutLocation: "non-gitpodified-repo",
-					FF:               []wsmanapi.WorkspaceFeatureFlag{wsmanapi.WorkspaceFeatureFlag_PERSISTENT_VOLUME_CLAIM},
-				},
+				/*
+					{
+						Name:             "pvc",
+						ContextURL:       "https://github.com/gitpod-io/empty",
+						WorkspaceRoot:    "/workspace/empty",
+						CheckoutLocation: "empty",
+						FF:               []wsmanapi.WorkspaceFeatureFlag{wsmanapi.WorkspaceFeatureFlag_PERSISTENT_VOLUME_CLAIM},
+					},
+					{
+						Name:             "pvc-non-gitpodified",
+						ContextURL:       "https://github.com/gitpod-io/non-gitpodified-repo",
+						WorkspaceRoot:    "/workspace/non-gitpodified-repo",
+						CheckoutLocation: "non-gitpodified-repo",
+						FF:               []wsmanapi.WorkspaceFeatureFlag{wsmanapi.WorkspaceFeatureFlag_PERSISTENT_VOLUME_CLAIM},
+					},
+				*/
 			}
 			for _, test := range tests {
 				t.Run(test.Name, func(t *testing.T) {
@@ -203,6 +205,7 @@ func TestBackup(t *testing.T) {
 }
 
 // TestExistingWorkspaceEnablePVC tests enable PVC feature flag on the existing workspace
+/*
 func TestExistingWorkspaceEnablePVC(t *testing.T) {
 	f := features.New("backup").
 		WithLabel("component", "ws-manager").
@@ -356,6 +359,7 @@ func TestExistingWorkspaceEnablePVC(t *testing.T) {
 
 	testEnv.Test(t, f)
 }
+*/
 
 // TestMissingBackup ensures workspaces fail if they should have a backup but don't have one
 func TestMissingBackup(t *testing.T) {
@@ -399,7 +403,7 @@ func TestMissingBackup(t *testing.T) {
 			}{
 				{Name: "classic"},
 				{Name: "fwb", FF: []wsmanapi.WorkspaceFeatureFlag{wsmanapi.WorkspaceFeatureFlag_FULL_WORKSPACE_BACKUP}},
-				{Name: "pvc", FF: []wsmanapi.WorkspaceFeatureFlag{wsmanapi.WorkspaceFeatureFlag_PERSISTENT_VOLUME_CLAIM}},
+				// {Name: "pvc", FF: []wsmanapi.WorkspaceFeatureFlag{wsmanapi.WorkspaceFeatureFlag_PERSISTENT_VOLUME_CLAIM}},
 			}
 			for _, test := range tests {
 				t.Run(test.Name+"_backup_init", func(t *testing.T) {

--- a/test/tests/components/ws-manager/prebuild_test.go
+++ b/test/tests/components/ws-manager/prebuild_test.go
@@ -51,16 +51,18 @@ func TestPrebuildWorkspaceTaskSuccess(t *testing.T) {
 						{Init: "echo \"some output\" > someFile; sleep 10; exit 0;"},
 					},
 				},
-				{
-					Name:             "pvc",
-					ContextURL:       "https://github.com/gitpod-io/empty",
-					CheckoutLocation: "empty",
-					WorkspaceRoot:    "/workspace/empty",
-					Task: []gitpod.TasksItems{
-						{Init: "echo \"some output\" > someFile; sleep 10; exit 0;"},
+				/*
+					{
+						Name:             "pvc",
+						ContextURL:       "https://github.com/gitpod-io/empty",
+						CheckoutLocation: "empty",
+						WorkspaceRoot:    "/workspace/empty",
+						Task: []gitpod.TasksItems{
+							{Init: "echo \"some output\" > someFile; sleep 10; exit 0;"},
+						},
+						FF: []wsmanapi.WorkspaceFeatureFlag{wsmanapi.WorkspaceFeatureFlag_PERSISTENT_VOLUME_CLAIM},
 					},
-					FF: []wsmanapi.WorkspaceFeatureFlag{wsmanapi.WorkspaceFeatureFlag_PERSISTENT_VOLUME_CLAIM},
-				},
+				*/
 			}
 			for _, test := range tests {
 				t.Run(test.Name, func(t *testing.T) {
@@ -235,13 +237,15 @@ func TestOpenWorkspaceFromPrebuildSerialOnly(t *testing.T) {
 					CheckoutLocation: "empty",
 					WorkspaceRoot:    "/workspace/empty",
 				},
-				{
-					Name:             "pvc",
-					ContextURL:       "https://github.com/gitpod-io/empty",
-					CheckoutLocation: "empty",
-					WorkspaceRoot:    "/workspace/empty",
-					FF:               []wsmanapi.WorkspaceFeatureFlag{wsmanapi.WorkspaceFeatureFlag_PERSISTENT_VOLUME_CLAIM},
-				},
+				/*
+					{
+						Name:             "pvc",
+						ContextURL:       "https://github.com/gitpod-io/empty",
+						CheckoutLocation: "empty",
+						WorkspaceRoot:    "/workspace/empty",
+						FF:               []wsmanapi.WorkspaceFeatureFlag{wsmanapi.WorkspaceFeatureFlag_PERSISTENT_VOLUME_CLAIM},
+					},
+				*/
 			}
 
 			for _, test := range tests {
@@ -676,6 +680,7 @@ func TestOpenWorkspaceFromOutdatedPrebuild(t *testing.T) {
 // - create a prebuild with large workspace class (30Gi disk) separately
 // - create the workspace from prebuild with small workspace class (20Gi disk) separately
 // - make sure the workspace can't start
+/*
 func TestPrebuildAndRegularWorkspaceDifferentWorkspaceClass(t *testing.T) {
 	f := features.New("prebuild").
 		WithLabel("component", "ws-manager").
@@ -843,6 +848,7 @@ func TestPrebuildAndRegularWorkspaceDifferentWorkspaceClass(t *testing.T) {
 
 	testEnv.Test(t, f)
 }
+*/
 
 // checkSnapshot checks the volume snapshot information is valid or not
 func checkSnapshot(t *testing.T, vsInfo *wsmanapi.VolumeSnapshotInfo, isPVCEnable bool) {

--- a/test/tests/components/ws-manager/tasks_test.go
+++ b/test/tests/components/ws-manager/tasks_test.go
@@ -40,16 +40,18 @@ func TestRegularWorkspaceTasks(t *testing.T) {
 			},
 			LookForFile: []string{"init-ran", "before-ran", "command-ran"},
 		},
-		{
-			Name: "pvc",
-			Task: []gitpod.TasksItems{
-				{Init: fmt.Sprintf("touch %s/init-ran; exit", wsLoc)},
-				{Before: fmt.Sprintf("touch %s/before-ran; exit", wsLoc)},
-				{Command: fmt.Sprintf("touch %s/command-ran; exit", wsLoc)},
+		/*
+			{
+				Name: "pvc",
+				Task: []gitpod.TasksItems{
+					{Init: fmt.Sprintf("touch %s/init-ran; exit", wsLoc)},
+					{Before: fmt.Sprintf("touch %s/before-ran; exit", wsLoc)},
+					{Command: fmt.Sprintf("touch %s/command-ran; exit", wsLoc)},
+				},
+				LookForFile: []string{"init-ran", "before-ran", "command-ran"},
+				FF:          []wsmanapi.WorkspaceFeatureFlag{wsmanapi.WorkspaceFeatureFlag_PERSISTENT_VOLUME_CLAIM},
 			},
-			LookForFile: []string{"init-ran", "before-ran", "command-ran"},
-			FF:          []wsmanapi.WorkspaceFeatureFlag{wsmanapi.WorkspaceFeatureFlag_PERSISTENT_VOLUME_CLAIM},
-		},
+		*/
 	}
 
 	f := features.New("ws-manager").


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Disable the PVC integration test because we stop proceeding with the PVC feature now.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
#7901

## How to test
<!-- Provide steps to test this PR -->

Run the workspace integration test.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-integration-tests=workspace
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
