### PR TITLE
Prompt on preview create if branch is not in remote

### DIFF
--- a/dev/preview/workflow/preview/preview.sh
+++ b/dev/preview/workflow/preview/preview.sh
@@ -3,11 +3,13 @@
 
 set -euo pipefail
 
-ROOT="$(realpath "$(dirname "$0")")/../../../../"
+SCRIPT_PATH=$(realpath "$(dirname "$0")")
 
-source "${ROOT}/dev/preview/workflow/lib/ensure-gcloud-auth.sh"
-source "${ROOT}/dev/preview/workflow/lib/common.sh"
-source "${ROOT}/dev/preview/workflow/lib/git.sh"
+# shellcheck source=../lib/common.sh
+source "$(realpath "${SCRIPT_PATH}/../lib/common.sh")"
+
+import "ensure-gcloud-auth.sh"
+import "git.sh"
 
 # Don't prompt user before terraform apply
 export TF_INPUT=0
@@ -19,7 +21,8 @@ if git:is-on-main; then
 fi
 
 if ! git:branch-exists-remotely; then
-    log_warn "Your branch doesn't exist on GitHub. Your preview environment might get garbage collected at any time. To avoid this please push your branch."
+    log_warn "Your branch doesn't exist on GitHub. Your preview environment WILL get garbage collected after AT MOST 1h. To avoid this please push your branch."
+    ask "I've read 👆 and I understand the implications."
 fi
 
 ensure_gcloud_auth


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Prompt on preview create if branch is not in remote

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://gitpod.slack.com/archives/C032A46PWR0/p1669106126384279?thread_ts=1669105961.391109&cid=C032A46PWR0

## How to test
<!-- Provide steps to test this PR -->
```bash
 👾 /workspace/gitpod leeway run dev:preview           
WARN: Your branch doesn't exist on GitHub. Your preview environment WILL get garbage collected after AT MOST 1h. To avoid this please push your branch.
I've read 👆 and I understand the implications. [y/n]: n
Aborted
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
