### PR TITLE
[public-api] Create Personal Access Token implementation

### DIFF
--- a/components/gitpod-db/go/dbtest/personal_access_token.go
+++ b/components/gitpod-db/go/dbtest/personal_access_token.go
@@ -82,7 +82,7 @@ func CreatePersonalAccessTokenRecords(t *testing.T, conn *gorm.DB, entries ...db
 		records = append(records, record)
 		ids = append(ids, record.ID.String())
 
-		_, err := db.CreateToken(context.Background(), conn, tokenEntry)
+		_, err := db.CreatePersonalAccessToken(context.Background(), conn, tokenEntry)
 		require.NoError(t, err)
 	}
 

--- a/components/gitpod-db/go/personal_access_token.go
+++ b/components/gitpod-db/go/personal_access_token.go
@@ -49,7 +49,7 @@ func GetToken(ctx context.Context, conn *gorm.DB, id uuid.UUID) (PersonalAccessT
 	return token, nil
 }
 
-func CreateToken(ctx context.Context, conn *gorm.DB, req PersonalAccessToken) (PersonalAccessToken, error) {
+func CreatePersonalAccessToken(ctx context.Context, conn *gorm.DB, req PersonalAccessToken) (PersonalAccessToken, error) {
 	if req.UserID == uuid.Nil {
 		return PersonalAccessToken{}, fmt.Errorf("Invalid or empty userID")
 	}
@@ -63,6 +63,7 @@ func CreateToken(ctx context.Context, conn *gorm.DB, req PersonalAccessToken) (P
 		return PersonalAccessToken{}, fmt.Errorf("Expiration time required")
 	}
 
+	now := time.Now().UTC()
 	token := PersonalAccessToken{
 		ID:             req.ID,
 		UserID:         req.UserID,
@@ -71,13 +72,13 @@ func CreateToken(ctx context.Context, conn *gorm.DB, req PersonalAccessToken) (P
 		Description:    req.Description,
 		Scopes:         req.Scopes,
 		ExpirationTime: req.ExpirationTime,
-		CreatedAt:      time.Now().UTC(),
-		LastModified:   time.Now().UTC(),
+		CreatedAt:      now,
+		LastModified:   now,
 	}
 
 	tx := conn.WithContext(ctx).Create(req)
 	if tx.Error != nil {
-		return PersonalAccessToken{}, fmt.Errorf("Failed to create token for user %s", req.UserID)
+		return PersonalAccessToken{}, fmt.Errorf("Failed to create personal access token for user %s", req.UserID)
 	}
 
 	return token, nil

--- a/components/gitpod-db/go/personal_access_token_test.go
+++ b/components/gitpod-db/go/personal_access_token_test.go
@@ -54,7 +54,7 @@ func TestPersonalAccessToken_Create(t *testing.T) {
 		LastModified:   time.Now(),
 	}
 
-	result, err := db.CreateToken(context.Background(), conn, request)
+	result, err := db.CreatePersonalAccessToken(context.Background(), conn, request)
 	require.NoError(t, err)
 
 	require.Equal(t, request.ID, result.ID)

--- a/components/public-api-server/go.mod
+++ b/components/public-api-server/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/spf13/cobra v1.4.0
 	github.com/stretchr/testify v1.8.1
 	github.com/stripe/stripe-go/v72 v72.122.0
+	golang.org/x/crypto v0.0.0-20220214200702-86341886e292
 	google.golang.org/grpc v1.50.1
 	google.golang.org/protobuf v1.28.1
 	gorm.io/gorm v1.24.1

--- a/components/public-api-server/pkg/auth/personal_access_token.go
+++ b/components/public-api-server/pkg/auth/personal_access_token.go
@@ -12,6 +12,8 @@ import (
 	"fmt"
 	"math/big"
 	"strings"
+
+	"golang.org/x/crypto/bcrypt"
 )
 
 const PersonalAccessTokenPrefix = "gitpod_pat_"
@@ -40,6 +42,16 @@ func (t *PersonalAccessToken) String() string {
 
 func (t *PersonalAccessToken) Value() string {
 	return t.value
+}
+
+func (t *PersonalAccessToken) ValueHash() (string, error) {
+	const bcryptCost = 16
+	hash, err := bcrypt.GenerateFromPassword([]byte(t.value), bcryptCost)
+	if err != nil {
+		return "", fmt.Errorf("failed to generate personal access token value hash: %w", err)
+	}
+
+	return string(hash), nil
 }
 
 func GeneratePersonalAccessToken(signer Signer) (PersonalAccessToken, error) {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Implements creation of Personal Access Tokens API

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Part of https://github.com/gitpod-io/gitpod/issues/14602

## How to test
<!-- Provide steps to test this PR -->
unit tests

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
