### PR TITLE
Truncate branch name on prebuilds page

### DIFF
--- a/components/dashboard/src/projects/Prebuilds.tsx
+++ b/components/dashboard/src/projects/Prebuilds.tsx
@@ -266,16 +266,18 @@ export default function (props: { project?: Project; isAdminDashboard?: boolean 
                                         </div>
                                     </ItemField>
                                     <ItemField className="flex w-3/12">
-                                        <a href={p.info.changeUrl} className="cursor-pointer">
-                                            <div className="flex space-x-2 truncate">
-                                                <span
-                                                    className="font-medium text-gray-500 dark:text-gray-50 truncate"
-                                                    title={p.info.branch}
-                                                >
-                                                    {p.info.branch}
-                                                </span>
-                                            </div>
-                                        </a>
+                                        <div className="truncate">
+                                            <a href={p.info.changeUrl} className="cursor-pointer">
+                                                <div className="flex space-x-2 truncate">
+                                                    <span
+                                                        className="font-medium text-gray-500 dark:text-gray-50 truncate"
+                                                        title={p.info.branch}
+                                                    >
+                                                        {p.info.branch}
+                                                    </span>
+                                                </div>
+                                            </a>
+                                        </div>
                                         <span className="flex-grow" />
                                     </ItemField>
                                 </Item>


### PR DESCRIPTION
## Description

This will truncate the branch name on the prebuilds page.

## How to test
1. Create a team and a project
2. Trigger a prebuild with a branch using a long branch name
3. Go to the prebuilds page and notice the branch name truncating

## Screenshots

| BEFORE | AFTER |
|-|-|
| <img width="1440" alt="prebuilds-list-before" src="https://user-images.githubusercontent.com/120486/203317482-89294270-8ffd-4346-9c29-9f044a7d4057.png"> | <img width="1440" alt="prebuilds-list-after" src="https://user-images.githubusercontent.com/120486/203317489-ac9132e6-f3e7-4d55-b40b-4b9e794680c5.png"> |

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Truncate branch name on prebuilds page
```

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
