### PR TITLE
[server] Add `api/feature-flags/slow-database` endpoint

### DIFF
--- a/components/server/src/container-module.ts
+++ b/components/server/src/container-module.ts
@@ -108,6 +108,7 @@ import {
 import { VerificationService } from "./auth/verification-service";
 import { WebhookEventGarbageCollector } from "./projects/webhook-event-garbage-collector";
 import { LivenessController } from "./liveness/liveness-controller";
+import { FeatureFlagController } from "./feature-flag/featureflag-controller";
 import { IDEServiceClient, IDEServiceDefinition } from "@gitpod/ide-service-api/lib/ide.pb";
 import { prometheusClientMiddleware } from "@gitpod/gitpod-protocol/lib/util/nice-grpc";
 import { UsageService, UsageServiceImpl } from "./user/usage-service";
@@ -221,6 +222,7 @@ export const productionContainerModule = new ContainerModule((bind, unbind, isBo
     bind(WorkspaceGarbageCollector).toSelf().inSingletonScope();
     bind(WorkspaceDownloadService).toSelf().inSingletonScope();
     bind(LivenessController).toSelf().inSingletonScope();
+    bind(FeatureFlagController).toSelf().inSingletonScope();
 
     bind(OneTimeSecretServer).toSelf().inSingletonScope();
 

--- a/components/server/src/feature-flag/featureflag-controller.ts
+++ b/components/server/src/feature-flag/featureflag-controller.ts
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { injectable, inject } from "inversify";
+import * as express from "express";
+import { Config } from "../config";
+import { getExperimentsClientForBackend } from "@gitpod/gitpod-protocol/lib/experiments/configcat-server";
+import { User } from "@gitpod/gitpod-protocol";
+import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
+
+@injectable()
+export class FeatureFlagController {
+    @inject(Config) protected readonly config: Config;
+
+    get apiRouter(): express.Router {
+        const router = express.Router();
+        this.addSlowDatabaseFeatureFlagHandler(router);
+        return router;
+    }
+
+    protected addSlowDatabaseFeatureFlagHandler(router: express.Router) {
+        router.get("/slow-database", async (req, res) => {
+            if (!User.is(req.user)) {
+                res.sendStatus(401);
+                return;
+            }
+
+            try {
+                const flagValue = await getExperimentsClientForBackend().getValueAsync("slow_database", false, {
+                    user: req.user,
+                });
+                res.setHeader("X-Gitpod-Slow-Database", flagValue.toString());
+                res.status(200);
+                res.end();
+            } catch (error) {
+                log.error(`failed to retrieve value of 'slow_database' feature flag: ${error.message}`);
+                res.status(500);
+                res.end();
+            }
+        });
+    }
+}

--- a/components/server/src/server.ts
+++ b/components/server/src/server.ts
@@ -50,6 +50,7 @@ import { WsConnectionHandler } from "./express/ws-connection-handler";
 import { InstallationAdminController } from "./installation-admin/installation-admin-controller";
 import { WebhookEventGarbageCollector } from "./projects/webhook-event-garbage-collector";
 import { LivenessController } from "./liveness/liveness-controller";
+import { FeatureFlagController } from "./feature-flag/featureflag-controller";
 
 @injectable()
 export class Server<C extends GitpodClient, S extends GitpodServer> {
@@ -67,6 +68,7 @@ export class Server<C extends GitpodClient, S extends GitpodServer> {
     @inject(LocalMessageBroker) protected readonly localMessageBroker: LocalMessageBroker;
     @inject(WorkspaceDownloadService) protected readonly workspaceDownloadService: WorkspaceDownloadService;
     @inject(LivenessController) protected readonly livenessController: LivenessController;
+    @inject(FeatureFlagController) protected readonly featureFlagController: FeatureFlagController;
     @inject(MonitoringEndpointsApp) protected readonly monitoringEndpointsApp: MonitoringEndpointsApp;
     @inject(CodeSyncService) private readonly codeSyncService: CodeSyncService;
     @inject(HeadlessLogController) protected readonly headlessLogController: HeadlessLogController;
@@ -306,6 +308,7 @@ export class Server<C extends GitpodClient, S extends GitpodServer> {
             res.send(this.config.version);
         });
         app.use(this.oauthController.oauthRouter);
+        app.use("/feature-flags", this.featureFlagController.apiRouter);
     }
 
     public async start(port: number) {


### PR DESCRIPTION
## Description
Add a server endpoint to test the value of the `slow_database` feature flag for the currently authenticated user.

The endpoint sets the `X-Gitpod-Slow-Database` header in the response to either `true` or `false` according to the value of the feature flag.

The intention is that this endpoint can be used by the Caddy proxy to 'pre-flight' requests to server, sending the actual request to either `server` or `slow-server` as needed.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of #9198 

## How to test

0. Log in to the preview environment.
1. Hit https://af-feature1eafc027eb.preview.gitpod-dev.com/api/feature-flags/slow-database and inspect the response headers. The `X-Gitpod-Slow-Database` header should be set to `false` as the feature flag is not enabled for you.
2. Change the targeting rule for the `slow_database` feature flag (non-production environment) to this (replacing the user id with your user id in the preview):
<img width="1907" alt="image" src="https://user-images.githubusercontent.com/8225907/203328354-8954e22d-5243-4645-a52a-4306df9a9f29.png">

3. Wait up to 3 minutes for the configcat client to refresh the feature flag values.
4. Hit https://af-feature1eafc027eb.preview.gitpod-dev.com/api/feature-flags/slow-database and inspect the response headers. The `X-Gitpod-Slow-Database` header should be set to `true`.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
