### PR TITLE
PoC: Parallelism through ephemeral packages

### DIFF
--- a/dev/preview/BUILD.yaml
+++ b/dev/preview/BUILD.yaml
@@ -7,6 +7,53 @@ packages:
     config:
       commands:
         - ["echo", "done"]
+
+  #
+  # The following ephemeral packages are used to control parallelism
+  #
+
+  - name: parallel-create-and-build
+    type: generic
+    ephemeral: true
+    deps:
+    - :create-preview
+    - :build
+
+  - name: parallel-deploy-all
+    type: generic
+    ephemeral: true
+    deps:
+    - :deploy-gitpod
+    - :deploy-monitoring-satellite
+
+  - name: "create-preview"
+    type: "generic"
+    ephemeral: true
+    config:
+      commands:
+        - ["leeway", "run", "dev/preview:create-preview"]
+
+  - name: "build"
+    type: "generic"
+    ephemeral: true
+    config:
+      commands:
+        - ["leeway", "run", "dev/preview:build"]
+
+  - name: "deploy-gitpod"
+    type: "generic"
+    ephemeral: true
+    config:
+      commands:
+        - ["leeway", "run", "dev/preview:deploy-gitpod"]
+
+  - name: "deploy-monitoring-satellite"
+    type: "generic"
+    ephemeral: true
+    config:
+      commands:
+        - ["leeway", "run", "dev/preview:deploy-monitoring-satellite"]
+
 scripts:
   - name: build
     description: Build all packages needed to deploy Gitpod to preview environments

--- a/dev/preview/workflow/preview/preview.sh
+++ b/dev/preview/workflow/preview/preview.sh
@@ -27,7 +27,6 @@ fi
 
 ensure_gcloud_auth
 
-leeway run dev/preview:create-preview
-leeway run dev/preview:build
+leeway build dev/preview:parallel-create-and-build
 previewctl install-context
-leeway run dev/preview:deploy-gitpod
+leeway build dev/preview:parallel-deploy-all


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

**This is a PoC and not meant to be merged. It's a prototype. It's a lot of YAML.**

PoC for the approach titled "Leeway Package" in [Run installs in parallel: preview envs](https://www.notion.so/gitpod/Run-installs-in-parallel-preview-envs-654ceb1934bf4979a249a3ddc2a6b890).

Alternative approach discussed in https://github.com/gitpod-io/leeway/issues/136

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/14707

## How to test
<!-- Provide steps to test this PR -->

```
leeway run dev:preview
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
