### PR TITLE
Refresh files after selecting the JDK

### DIFF
--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/optional/GitpodForceUpdateMavenProjectsActivity.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/optional/GitpodForceUpdateMavenProjectsActivity.kt
@@ -11,12 +11,7 @@ import org.jetbrains.idea.maven.project.MavenProjectsManager
 
 class GitpodForceUpdateMavenProjectsActivity : StartupActivity.RequiredForSmartMode {
     override fun runActivity(project: Project) {
-        val mavenProjectManager = MavenProjectsManager.getInstance(project)
-
-        if (!mavenProjectManager.isMavenizedProject) return
-
-        mavenProjectManager.forceUpdateAllProjectsOrFindAllAvailablePomFiles()
-
-        thisLogger().warn("gitpod: Forced the update of Maven Project.")
+        MavenProjectsManager.getInstance(project).forceUpdateAllProjectsOrFindAllAvailablePomFiles()
+        thisLogger().warn("gitpod: Forced the update of Maven projects.")
     }
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Currently, when we open a prebuilt branch that has `.idea/runConfigurations` folder but doesn't have a `.idea/misc.xml` [[1](https://github.com/Gitpod-Samples/spring-petclinic/tree/update-idea-folder)], it loads like this:

| Stable | EAP |
| --- | --- |
| <img width="1476" alt="image" src="https://user-images.githubusercontent.com/418083/203356797-dc8694c7-3f5b-47b5-a883-c054a870e717.png"> | <img width="1467" alt="image" src="https://user-images.githubusercontent.com/418083/203357524-e856e533-ec8c-423b-8e21-70902b3e52e0.png"> |

Changes in this PR intend to refresh files after the JDK is selected.

Note: Non-prebuilt workspaces don't suffer from this issue.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
--

## How to test
<!-- Provide steps to test this PR -->
1. Select IntelliJ IDEA as your Editor
2. Open branch https://github.com/Gitpod-Samples/spring-petclinic/tree/update-idea-folder (which as a prebuild ready)
3. Confirm the file explorer doesn't show correctly (like the image in the PR description)
4. Prebuild and open the same branch on the Preview Environment of this PR:  https://felladrin-4e4a564c7a.preview.gitpod-dev.com/#prebuild/https://github.com/Gitpod-Samples/spring-petclinic/tree/update-idea-folder
5. Confirm there's no issue. "Maven" tab should already be there (in the right-side bar) and the file explorer should display correctly.

<img width="1320" alt="image" src="https://user-images.githubusercontent.com/418083/203380565-e7114e20-2695-4165-aac9-030fb2ad6f13.png">


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
