### PR TITLE
Build less package when deploying gitpod from local 

### DIFF
--- a/dev/preview/BUILD.yaml
+++ b/dev/preview/BUILD.yaml
@@ -2,11 +2,14 @@ packages:
   - name: "deploy-dependencies"
     type: "generic"
     deps:
-      - install/installer:docker
-      - components:docker-versions
+      - install/installer:raw-app
+      - components:all-docker
+      - dev/version-manifest:app
     config:
       commands:
-        - ["echo", "done"]
+        - [ "sh", "-c", "sudo mv install-installer--raw-app/installer /usr/local/bin" ]
+        - [ "sh", "-c", "cat components--all-docker/versions.yaml > /tmp/versions.yaml" ]
+
 scripts:
   - name: build
     description: Build all packages needed to deploy Gitpod to preview environments

--- a/dev/preview/workflow/preview/preview.sh
+++ b/dev/preview/workflow/preview/preview.sh
@@ -27,6 +27,7 @@ fi
 
 ensure_gcloud_auth
 
+leeway run dev/preview:get-credentials
 leeway run dev/preview:create-preview
 leeway run dev/preview:build
 previewctl install-context --retry 30


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
* Reduce the dependencies required when deploying in preview envs
* Build the installer and use the binary, instead of relying on pushing it to docker
* Use local `versions.yaml`, instead of relying on docker-versions

<details>
<summary>Before</summary>

```
leeway build dev/preview:deploy-dependencies --dont-test -Dversion=test   

59.40s user 
12.35s system 96% cpu 
1:14.59 total


🔧  build                      components/gitpod-db/go:init-testdb                                    (version b72dd9c3c1de3fb4d09693fce5dd31ae91030225)
🔧  build                      components/gitpod-db:dbtest-init                                       (version 53913f13103e6b342b40c47311f04de838af412c)
🔧  build                      components/ws-manager:app                                              (version d8c147554d732e2c8afcaf26f2405519bbf260c7)
🔧  build                      components/ws-manager:docker                                           (version c5da76cff90d87d1211726f04c56d79b64156e6c)
🔧  build                      components:all-docker                                                  (version 444b0caae30acf3cea2e4d45e80668b27fe06289)
🔧  build                      components:docker-versions                                             (version f9b0afbaa9b6da35c6cfe8c2b48ddb403e79f617)
🔧  build                      dev/preview:deploy-dependencies                                        (version 7eae120fd77a5f9fd3607b286ddccfab0fd54bf9)
🔧  build                      install/installer:app                                                  (version 15a7c2d54ccbda9767818fb9bdc6096f68f9d353)
🔧  build                      install/installer:docker                                               (version 7d8c7e61437def47d24a7e058c6d65745f542e5f)

[components/ws-manager:app] package build succeded (13.21s)
[components/ws-manager:docker] package build succeded (20.83s)
[components:all-docker] package build succeded (1.56s)
[install/installer:app] package build succeded (4.98s)
[install/installer:docker] package build succeded (22.03s)
[components:docker-versions] package build succeded (11.70s)
[dev/preview:deploy-dependencies] package build succeded (3.12s)
```
</details>

<details>
<summary>After</summary>

```bash
leeway build dev/preview:deploy-dependencies --dont-test -Dversion=test   

49.98s user 
12.71s system 104% cpu 
59.844 total


🔧  build                         components/gitpod-db/go:init-testdb                                    (version b72dd9c3c1de3fb4d09693fce5dd31ae91030225)
🔧  build                         components/gitpod-db:dbtest-init                                       (version 53913f13103e6b342b40c47311f04de838af412c)
🔧  build                         components/ws-manager:app                                              (version 9341e9722c646b7a1883f645dd1ad473a0c80dd2)
🔧  build                         components/ws-manager:docker                                           (version 5cfa734fa8107f23db12751101a87834b3272082)
🔧  build                         components:all-docker                                                  (version d45f16189049cb4d3efbdbd0b45bab5638086182)
🔧  build                         dev/preview:deploy-dependencies                                        (version 11c5cab9528cea562f937e9be0d228cbeff04766)


[components/ws-manager:app] package build succeded (13.39s)
[components/ws-manager:docker] package build succeded (25.39s)
[components:all-docker] package build succeded (2.00s)
[dev/preview:deploy-dependencies] package build succeded (3.76s)
```
</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/14701

## How to test
<!-- Provide steps to test this PR -->

```bash
leeway run dev:preview
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
