### PR TITLE
Drop unused ArgoCD Metrics

### DIFF
--- a/operations/observability/mixins/self-hosted/rules/argocd/servicemonitor.yaml
+++ b/operations/observability/mixins/self-hosted/rules/argocd/servicemonitor.yaml
@@ -15,6 +15,11 @@ spec:
       app.kubernetes.io/name: argocd-metrics
   endpoints:
   - port: metrics
+    relabelings:
+      - action: drop
+        regex: (argocd_git_request_duration_seconds_count|argocd_git_request_duration_seconds_sum|argocd_redis_request_duration_seconds_bucket|argocd_redis_request_duration_bucket|argocd_repo_pending_request_total|argocd_cluster_info|argocd_cluster_cache_age_seconds|argocd_cluster_connection_status|argocd_app_reconcile_sum|argocd_redis_request_duration_seconds_count|argocd_kubectl_exec_total|argocd_redis_request_duration_seconds_sum|argocd_redis_request_duration_count|argocd_redis_request_duration_sum|)
+        sourceLabels:
+          - "__name__"
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
@@ -33,6 +38,11 @@ spec:
       app.kubernetes.io/name: argocd-server-metrics
   endpoints:
   - port: metrics
+    relabelings:
+      - action: drop
+        regex: (argocd_git_request_duration_seconds_count|argocd_git_request_duration_seconds_sum|argocd_redis_request_duration_seconds_bucket|argocd_redis_request_duration_bucket|argocd_repo_pending_request_total|argocd_cluster_info|argocd_cluster_cache_age_seconds|argocd_cluster_connection_status|argocd_app_reconcile_sum|argocd_redis_request_duration_seconds_count|argocd_kubectl_exec_total|argocd_redis_request_duration_seconds_sum|argocd_redis_request_duration_count|argocd_redis_request_duration_sum|)
+        sourceLabels:
+          - "__name__"
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
@@ -51,6 +61,11 @@ spec:
       app.kubernetes.io/name: argocd-repo-server
   endpoints:
   - port: metrics
+    relabelings:
+      - action: drop
+        regex: (argocd_git_request_duration_seconds_count|argocd_git_request_duration_seconds_sum|argocd_redis_request_duration_seconds_bucket|argocd_redis_request_duration_bucket|argocd_repo_pending_request_total|argocd_cluster_info|argocd_cluster_cache_age_seconds|argocd_cluster_connection_status|argocd_app_reconcile_sum|argocd_redis_request_duration_seconds_count|argocd_kubectl_exec_total|argocd_redis_request_duration_seconds_sum|argocd_redis_request_duration_count|argocd_redis_request_duration_sum|)
+        sourceLabels:
+          - "__name__"
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
@@ -69,3 +84,8 @@ spec:
       app.kubernetes.io/name: argocd-applicationset-controller
   endpoints:
   - port: metrics
+    relabelings:
+      - action: drop
+        regex: (argocd_git_request_duration_seconds_count|argocd_git_request_duration_seconds_sum|argocd_redis_request_duration_seconds_bucket|argocd_redis_request_duration_bucket|argocd_repo_pending_request_total|argocd_cluster_info|argocd_cluster_cache_age_seconds|argocd_cluster_connection_status|argocd_app_reconcile_sum|argocd_redis_request_duration_seconds_count|argocd_kubectl_exec_total|argocd_redis_request_duration_seconds_sum|argocd_redis_request_duration_count|argocd_redis_request_duration_sum|)
+        sourceLabels:
+          - "__name__"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Similar to https://github.com/gitpod-io/ops/pull/6900, this PR updates the serviceMonitor that is imported to our cluster with ArgoCD so we drop all metrics that we don't need.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
