### PR TITLE
[configcat] Set UserID as a custom attribute on configcat user data

### DIFF
--- a/components/common-go/experiments/configcat.go
+++ b/components/common-go/experiments/configcat.go
@@ -14,6 +14,7 @@ import (
 )
 
 const (
+	userIDAttribute         = "user_id"
 	projectIDAttribute      = "project_id"
 	teamIDAttribute         = "team_id"
 	teamNameAttribute       = "team_name"
@@ -55,6 +56,10 @@ func (c *configCatClient) GetStringValue(_ context.Context, experimentName strin
 
 func attributesToUser(attributes Attributes) *configcat.UserData {
 	custom := make(map[string]string)
+
+	if attributes.UserID != "" {
+		custom[userIDAttribute] = attributes.UserID
+	}
 
 	if attributes.TeamID != "" {
 		custom[teamIDAttribute] = attributes.TeamID


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This change normalizes the behaviour between our NodeJS client, and the Golang one. We set the UserID on both the User Identifier property, but also the custom attribute, to avoid unexpected surprises for feature flag operators

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
