### PR TITLE
[pat] Reduce bcrypt cost to 10

### DIFF
--- a/components/public-api-server/pkg/auth/personal_access_token.go
+++ b/components/public-api-server/pkg/auth/personal_access_token.go
@@ -45,7 +45,7 @@ func (t *PersonalAccessToken) Value() string {
 }
 
 func (t *PersonalAccessToken) ValueHash() (string, error) {
-	const bcryptCost = 16
+	const bcryptCost = 10
 	hash, err := bcrypt.GenerateFromPassword([]byte(t.value), bcryptCost)
 	if err != nil {
 		return "", fmt.Errorf("failed to generate personal access token value hash: %w", err)


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

At cost 16, we're taking 4.5 secs on average to compute the hash. At cost 10, we're taking on average 100ms which is acceptable.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
