### PR TITLE
test: support namespace overwrites from env var

### DIFF
--- a/test/run.sh
+++ b/test/run.sh
@@ -55,7 +55,7 @@ esac
 
 args=()
 args+=( "-kubeconfig=${KUBECONFIG:-/home/gitpod/.kube/config}" )
-args+=( "-namespace=default" )
+args+=( "-namespace=${NAMESPACE:-default}" )
 args+=( "-timeout=60m" )
 args+=( "-p=2" )
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Support namespace overwrites from env var.

The self-hosted env which installed the gitpod components into the `gitpod` namespace rather than `default` namespace.
Provide a way to overwrite the namespace variable from env var.

After that, we could run the integration test against the workspace test by
```console
export NAMESPACE=gitpod
./run.sh workspace
```

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
