### PR TITLE
test: fix unmarshal string to int64 failed

### DIFF
--- a/.werft/jobs/build/installer/post-process.sh
+++ b/.werft/jobs/build/installer/post-process.sh
@@ -289,9 +289,9 @@ while [ "$documentIndex" -le "$DOCS" ]; do
       yq r /tmp/"$NAME"-"$KIND"-overrides.yaml 'data.[config.json]' \
       | jq ".service.address = $WS_DAEMON_PORT" \
       | jq ".daemon.cpulimit.enabled = true" \
-      | jq ".daemon.cpulimit.totalBandwidth = 12" \
-      | jq ".daemon.cpulimit.limit = 2" \
-      | jq ".daemon.cpulimit.burstLimit = 6" > /tmp/"$NAME"-"$KIND"-overrides.json
+      | jq ".daemon.cpulimit.totalBandwidth = \"12\"" \
+      | jq ".daemon.cpulimit.limit = \"2\"" \
+      | jq ".daemon.cpulimit.burstLimit = \"6\"" > /tmp/"$NAME"-"$KIND"-overrides.json
       # Give the port a colon prefix, ("5678" to ":5678")
       # jq would not have it, hence the usage of sed to do the transformation
       PORT_NUM_FORMAT_EXPR="s/\"address\": $WS_DAEMON_PORT/\"address\": \":$WS_DAEMON_PORT\"/"

--- a/test/tests/components/ws-daemon/cpu_burst_test.go
+++ b/test/tests/components/ws-daemon/cpu_burst_test.go
@@ -26,8 +26,8 @@ import (
 type DaemonConfig struct {
 	CpuLimitConfig struct {
 		Enabled    bool  `json:"enabled"`
-		Limit      int64 `json:"limit"`
-		BurstLimit int64 `json:"burstLimit"`
+		Limit      int64 `json:"limit,string"`
+		BurstLimit int64 `json:"burstLimit,string"`
 	} `json:"cpuLimit"`
 }
 

--- a/test/tests/components/ws-daemon/cpu_burst_test.go
+++ b/test/tests/components/ws-daemon/cpu_burst_test.go
@@ -106,7 +106,7 @@ func TestCpuBurst(t *testing.T) {
 		}
 
 		if resp.CpuQuota != daemonConfig.CpuLimitConfig.Limit {
-			t.Fatalf("expected cpu quota of %v, but was %v", daemonConfig.CpuLimitConfig.Limit, resp.CpuQuota)
+			t.Fatalf("expected cpu limit quota of %v, but was %v", daemonConfig.CpuLimitConfig.Limit, resp.CpuQuota)
 		}
 
 		workspaceClient, workspaceCloser, err := integration.Instrument(integration.ComponentWorkspace, "workspace", cfg.Namespace(), kubeconfig, cfg.Client(),
@@ -147,7 +147,7 @@ func TestCpuBurst(t *testing.T) {
 		}
 
 		if resp.CpuQuota != daemonConfig.CpuLimitConfig.BurstLimit {
-			t.Fatalf("expected cpu quota of %v, but was %v", daemonConfig.CpuLimitConfig.BurstLimit, resp.CpuQuota)
+			t.Fatalf("expected cpu burst limit quota of %v, but was %v", daemonConfig.CpuLimitConfig.BurstLimit, resp.CpuQuota)
 		}
 		return ctx
 	}).Feature()


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Partially revert the change of PR #14786.

Fix an error when running the integration test against the self-hosted environment.
`json: cannot unmarshal string into Go struct field .cpuLimit.limit of type int64`.

According to the [values](https://github.com/gitpod-io/ops/blob/2e6d65c4269da96c5eda85da5363586e3f41839f/deploy/workspace/installer-values.yaml#L49-L50), it's string based. So, quote the values in the preview environment.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/pull/14786/files#r1029984960

## How to test
<!-- Provide steps to test this PR -->

Run the integration test on the self-hosted environment.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-integration-tests=workspace
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
