### PR TITLE
test: remove hardcode namespace

### DIFF
--- a/test/tests/components/ws-manager/dotfiles_test.go
+++ b/test/tests/components/ws-manager/dotfiles_test.go
@@ -72,7 +72,7 @@ func TestDotfiles(t *testing.T) {
 						"scope": ["function:getToken", "function:openPort", "function:getOpenPorts", "function:guessGitTokenScopes", "getWorkspace", "resource:token::*::get"],
 						"expiryDate": "2022-10-26T10:38:05.232Z",
 						"reuse": 4
-					}]`, tokenId, getHostUrl(ctx, t, cfg.Client())),
+					}]`, tokenId, getHostUrl(ctx, t, cfg.Client(), cfg.Namespace())),
 				},
 			)
 
@@ -129,9 +129,9 @@ func TestDotfiles(t *testing.T) {
 	testEnv.Test(t, f)
 }
 
-func getHostUrl(ctx context.Context, t *testing.T, k8sClient klient.Client) string {
+func getHostUrl(ctx context.Context, t *testing.T, k8sClient klient.Client, namespace string) string {
 	var configmap corev1.ConfigMap
-	if err := k8sClient.Resources().Get(ctx, "server-config", "default", &configmap); err != nil {
+	if err := k8sClient.Resources().Get(ctx, "server-config", namespace, &configmap); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

When running the integration test against self-hosted env, which default Gitpod components are in gitpod namespace rather than default namespace.
Remove the hardcode namespace in the integration test.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
