### PR TITLE
[IDE] use sh instead of bash for ide startup

### DIFF
--- a/components/ide/code-desktop/startup.sh
+++ b/components/ide/code-desktop/startup.sh
@@ -1,12 +1,12 @@
-#!/bin/bash -li
+#!/bin/sh
 # Copyright (c) 2021 Gitpod GmbH. All rights reserved.
 # Licensed under the GNU Affero General Public License (AGPL).
 # See License-AGPL.txt in the project root for license information.
 
-set -euo pipefail
+set -euo
 
 # kill background jobs when the script exits
-trap "jobs -p | xargs -r kill" SIGINT SIGTERM EXIT
+trap "jobs -p | xargs -r kill" INT TERM EXIT
 
 /ide-desktop/status "$1" "$2" "$3"
 

--- a/components/ide/code/startup.sh
+++ b/components/ide/code/startup.sh
@@ -1,36 +1,6 @@
-#!/bin/bash -li
+#!/bin/sh
 # Copyright (c) 2020 Gitpod GmbH. All rights reserved.
-# Licensed under the GNU Affero General Public License (AGPL).
-# See License-AGPL.txt in the project root for license information.
-
-
- # DO NOT REMOVE THE SPACES AT THE BEGINNING OF THESE LINES
- # The spaces at the beginning of the line prevent those lines from being added to
- # the bash history.
- set +o history
- history -c
- truncate -s 0 "$HISTFILE"
-
-# This is the main entrypoint to workspace container in Gitpod. It is called (and controlled) by the supervisor
-# container root process.
-# To mimic a regular login shell on a local computer we execute this with "bash -li" (interactive login shell):
-#  - login (-l): triggers sourcing of ~/.profile and similar files
-#  - interactive (-i): triggers sourcing of ~/.bashrc (and similar). This is necessary because Theia sub-processes
-#    started from non-interactive shells rely some values that we (and others) tend to place into .bashrc
-#    (exmaples: language servers, other language tools)
-# Reference: https://www.gnu.org/software/bash/manual/html_node/Bash-Startup-Files.html#Bash-Startup-Files
-
-export SHELL=/bin/bash
 export USER=gitpod
-
-# TODO ENVVAR CLEANUP: This stays here until we moved it to a central location, ideally workspace-full
-# (+ compatibility period)
-# Also to mitigate compatibility issues let's try to source recently added configuration explicitly
-[ -d "/home/gitpod/.sdkman" ] && [ -z "$SDKMAN_DIR" ] && export SDKMAN_DIR="/home/gitpod/.sdkman"
-# shellcheck disable=SC1090,SC1091
-[ -s /home/gitpod/.sdkman/bin/sdkman-init.sh ] && [ -z "$SDKMAN_VERSION" ] && source "/home/gitpod/.sdkman/bin/sdkman-init.sh"
-# shellcheck disable=SC1090,SC1091
-[ -s ~/.nvm/nvm-lazy.sh ] && source /home/gitpod/.nvm/nvm-lazy.sh
 
 cd /ide || exit
 exec /ide/codehelper "$@"

--- a/components/ide/jetbrains/image/startup.sh
+++ b/components/ide/jetbrains/image/startup.sh
@@ -1,12 +1,12 @@
-#!/bin/bash
+#!/bin/sh
 # Copyright (c) 2021 Gitpod GmbH. All rights reserved.
 # Licensed under the GNU Affero General Public License (AGPL).
 # See License-AGPL.txt in the project root for license information.
 
-set -euo pipefail
+set -euo
 
 # kill background jobs when the script exits
-trap "jobs -p | xargs -r kill" SIGINT SIGTERM EXIT
+trap "jobs -p | xargs -r kill" INT TERM EXIT
 
 # instead put them into /ide-desktop/backend/bin/idea64.vmoptions
 # otherwise JB will complain to a user on each startup


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
[IDE] use sh instead of bash for ide startup

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
