### PR TITLE
[dashboard] Rename Personal Access Tokens settings entry to Access Tokens

### DIFF
--- a/components/dashboard/src/App.tsx
+++ b/components/dashboard/src/App.tsx
@@ -401,9 +401,9 @@ function App() {
                     <Route path={settingsPathNotifications} exact component={Notifications} />
                     <Route path={settingsPathBilling} exact component={Billing} />
                     <Route path={settingsPathPlans} exact component={Plans} />
-                    <Route path={settingsPathPersonalAccessTokens} exact component={PersonalAccessTokens} />
                     <Route path={settingsPathVariables} exact component={EnvironmentVariables} />
                     <Route path={settingsPathSSHKeys} exact component={SSHKeys} />
+                    <Route path={settingsPathPersonalAccessTokens} exact component={PersonalAccessTokens} />
                     <Route path={settingsPathPreferences} exact component={Preferences} />
                     <Route path={projectsPathInstallGitHubApp} exact component={InstallGitHubApp} />
                     <Route path="/from-referrer" exact component={FromReferrer} />

--- a/components/dashboard/src/settings/PersonalAccessTokens.tsx
+++ b/components/dashboard/src/settings/PersonalAccessTokens.tsx
@@ -20,10 +20,7 @@ function PersonalAccessTokens() {
 
     return (
         <div>
-            <PageWithSettingsSubMenu
-                title="Preferences"
-                subtitle="Manage your Personal Access Tokens to access the Gitpod API."
-            >
+            <PageWithSettingsSubMenu title="Access Tokens" subtitle="Manage your personal access tokens.">
                 <ListAccessTokensView />
             </PageWithSettingsSubMenu>
         </div>

--- a/components/dashboard/src/settings/settings-menu.ts
+++ b/components/dashboard/src/settings/settings-menu.ts
@@ -36,7 +36,7 @@ export default function getSettingsMenu(params: {
         ...(params.enablePersonalAccessTokens
             ? [
                   {
-                      title: "Personal Access Tokens",
+                      title: "Access Tokens",
                       link: [settingsPathPersonalAccessTokens],
                   },
               ]


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Changes name as per designs

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
