### PR TITLE
[protocol] Set `requestTimeoutMs` in configcat client

### DIFF
--- a/components/gitpod-protocol/src/experiments/configcat-server.ts
+++ b/components/gitpod-protocol/src/experiments/configcat-server.ts
@@ -32,6 +32,7 @@ export function getExperimentsClientForBackend(): Client {
 
     const configCatClient = configcat.createClient(sdkKey, {
         pollIntervalSeconds: 3 * 60, // 3 minutes
+        requestTimeoutMs: 2000,
         logger: configcat.createConsoleLogger(LogLevel.Error),
         maxInitWaitTimeSeconds: 0,
     });


### PR DESCRIPTION
## Description

Set a timeout value when constructing the configcat client.

See:

https://configcat.com/docs/sdk-reference/js/#auto-polling-default

## Related Issue(s)
Relates to https://github.com/gitpod-io/gitpod/pull/14856#discussion_r1030153466

## How to test

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
