### PR TITLE
[JetBrains] Refresh files before updating Maven projects

### DIFF
--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/optional/GitpodForceUpdateMavenProjectsActivity.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/optional/GitpodForceUpdateMavenProjectsActivity.kt
@@ -7,16 +7,17 @@ package io.gitpod.jetbrains.remote.optional
 import com.intellij.openapi.diagnostic.thisLogger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.startup.StartupActivity
+import com.intellij.openapi.vfs.VirtualFileManager
+import com.intellij.util.application
 import org.jetbrains.idea.maven.project.MavenProjectsManager
 
 class GitpodForceUpdateMavenProjectsActivity : StartupActivity.RequiredForSmartMode {
     override fun runActivity(project: Project) {
-        val mavenProjectManager = MavenProjectsManager.getInstance(project)
-
-        if (!mavenProjectManager.isMavenizedProject) return
-
-        mavenProjectManager.forceUpdateAllProjectsOrFindAllAvailablePomFiles()
-
-        thisLogger().warn("gitpod: Forced the update of Maven Project.")
+        application.invokeLater {
+            VirtualFileManager.getInstance().asyncRefresh {
+                MavenProjectsManager.getInstance(project).forceUpdateAllProjectsOrFindAllAvailablePomFiles()
+                thisLogger().warn("gitpod: Forced the update of Maven projects.")
+            }
+        }
     }
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Currently, when we open a prebuilt branch that has `.idea/runConfigurations` folder but doesn't have a `.idea/misc.xml` [[1](https://github.com/Gitpod-Samples/spring-petclinic/tree/update-idea-folder)] on JetBrains IDE v2022.3 (EAP), it loads like this:

<img width="1467" alt="image" src="https://user-images.githubusercontent.com/418083/203357524-e856e533-ec8c-423b-8e21-70902b3e52e0.png">

The file `.idea/misc.xml` pre-defines which JDK to use, and Maven depends on the info about JDK. When the repository doesn't have this file, Maven doesn't know which JDK to use until we finish setting it up to work correctly. Due to race condition, it happens that the `forceUpdateAllProjectsOrFindAllAvailablePomFiles()` is called before the JDK is appropriately setup [[1](https://github.com/gitpod-io/gitpod/blob/edff61c347adbd1c12e861b68a91eda545980353/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/GitpodProjectManager.kt#L86)] and the file system is refreshed. So  So the PR ensures the Maven will only run after the file system is up to date.

Note: Non-prebuilt workspaces don't suffer from this issue.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
- https://github.com/Gitpod-Samples/spring-petclinic/pull/71

## How to test
<!-- Provide steps to test this PR -->
1. Select IntelliJ IDEA EAP as your Editor at https://gitpod.io/preferences
2. Open https://gitpod.io/#https://github.com/Gitpod-Samples/spring-petclinic/tree/update-idea-folder (which has a prebuild ready)
3. Confirm the file explorer doesn't show correctly (like the image in the PR description)
4. Select IntelliJ IDEA EAP as your Editor at https://jetbrains-ef0e60b7eb.preview.gitpod-dev.com/preferences
5. Prebuild and open the same branch on the Preview Environment of this PR:  https://jetbrains-ef0e60b7eb.preview.gitpod-dev.com/#prebuild/https://github.com/Gitpod-Samples/spring-petclinic/tree/update-idea-folder
6. Confirm there's no issue. "Maven" tab should already be there (in the right-side bar), and the file explorer should display correctly. Also, confirm if Run Configurations run fine when clicking the Play or Debug button on the top bar.

<img width="1320" alt="image" src="https://user-images.githubusercontent.com/418083/203380565-e7114e20-2695-4165-aac9-030fb2ad6f13.png">

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
