### PR TITLE
[pat] Check personal access tokens enabled feature flag against teams

### DIFF
--- a/components/public-api-server/pkg/apiv1/tokens_test.go
+++ b/components/public-api-server/pkg/apiv1/tokens_test.go
@@ -41,6 +41,8 @@ var (
 	}
 
 	signer = auth.NewHS256Signer([]byte("my-secret"))
+
+	teams = []*protocol.Team{newTeam(&protocol.Team{})}
 )
 
 func TestTokensService_CreatePersonalAccessTokenWithoutFeatureFlag(t *testing.T) {
@@ -50,6 +52,7 @@ func TestTokensService_CreatePersonalAccessTokenWithoutFeatureFlag(t *testing.T)
 		serverMock, _, client := setupTokensService(t, withTokenFeatureDisabled)
 
 		serverMock.EXPECT().GetLoggedInUser(gomock.Any()).Return(user, nil)
+		serverMock.EXPECT().GetTeams(gomock.Any()).Return(teams, nil)
 
 		_, err := client.CreatePersonalAccessToken(context.Background(), connect.NewRequest(&v1.CreatePersonalAccessTokenRequest{
 			Token: &v1.PersonalAccessToken{
@@ -211,6 +214,7 @@ func TestTokensService_GetPersonalAccessToken(t *testing.T) {
 		)
 
 		serverMock.EXPECT().GetLoggedInUser(gomock.Any()).Return(user, nil)
+		serverMock.EXPECT().GetTeams(gomock.Any()).Return(teams, nil)
 
 		_, err := client.GetPersonalAccessToken(context.Background(), connect.NewRequest(&v1.GetPersonalAccessTokenRequest{
 			Id: tokens[0].ID.String(),
@@ -228,6 +232,7 @@ func TestTokensService_ListPersonalAccessTokens(t *testing.T) {
 		serverMock, _, client := setupTokensService(t, withTokenFeatureDisabled)
 
 		serverMock.EXPECT().GetLoggedInUser(gomock.Any()).Return(user, nil)
+		serverMock.EXPECT().GetTeams(gomock.Any()).Return(teams, nil)
 
 		_, err := client.ListPersonalAccessTokens(context.Background(), connect.NewRequest(&v1.ListPersonalAccessTokensRequest{}))
 
@@ -337,6 +342,7 @@ func TestTokensService_RegeneratePersonalAccessToken(t *testing.T) {
 		serverMock, _, client := setupTokensService(t, withTokenFeatureDisabled)
 
 		serverMock.EXPECT().GetLoggedInUser(gomock.Any()).Return(user, nil)
+		serverMock.EXPECT().GetTeams(gomock.Any()).Return(teams, nil)
 
 		_, err := client.RegeneratePersonalAccessToken(context.Background(), connect.NewRequest(&v1.RegeneratePersonalAccessTokenRequest{
 			Id: uuid.New().String(),
@@ -384,6 +390,7 @@ func TestTokensService_UpdatePersonalAccessToken(t *testing.T) {
 		serverMock, _, client := setupTokensService(t, withTokenFeatureDisabled)
 
 		serverMock.EXPECT().GetLoggedInUser(gomock.Any()).Return(user, nil)
+		serverMock.EXPECT().GetTeams(gomock.Any()).Return(teams, nil)
 
 		_, err := client.UpdatePersonalAccessToken(context.Background(), connect.NewRequest(&v1.UpdatePersonalAccessTokenRequest{
 			Token: &v1.PersonalAccessToken{
@@ -437,6 +444,7 @@ func TestTokensService_DeletePersonalAccessToken(t *testing.T) {
 		serverMock, _, client := setupTokensService(t, withTokenFeatureDisabled)
 
 		serverMock.EXPECT().GetLoggedInUser(gomock.Any()).Return(user, nil)
+		serverMock.EXPECT().GetTeams(gomock.Any()).Return(teams, nil)
 
 		_, err := client.DeletePersonalAccessToken(context.Background(), connect.NewRequest(&v1.DeletePersonalAccessTokenRequest{
 			Id: uuid.New().String(),


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Retrieves teams for the current user to check if the feature flag is enabled for a whole team.

When fetching a team fails, we do not check against teams and continue as before.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
