### PR TITLE
[pat] Validate and enforce scopes for PATs

### DIFF
--- a/components/gitpod-db/go/dbtest/personal_access_token.go
+++ b/components/gitpod-db/go/dbtest/personal_access_token.go
@@ -26,7 +26,7 @@ func NewPersonalAccessToken(t *testing.T, record db.PersonalAccessToken) db.Pers
 		UserID:         uuid.New(),
 		Hash:           "some-secure-hash",
 		Name:           "some-name",
-		Scopes:         []string{"read", "write"},
+		Scopes:         []string{"resource:default", "function:*"},
 		ExpirationTime: now.Add(5 * time.Hour),
 		CreatedAt:      now,
 		LastModified:   now,


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Adds the missing piece to CreatePerosonalToken which validates scopes for the token.

We operate in one of two modes:
* Token has no scopes, and therefore no permission
* Token has access to all functions, and default resource. This gives the token the ability to do anything the user can.

Any other option is rejected.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
Unit tests

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
