### PR TITLE
[proxy] Pre-flight requests to server /api/* endpoints

### DIFF
--- a/components/proxy/conf/Caddyfile
+++ b/components/proxy/conf/Caddyfile
@@ -235,10 +235,30 @@ https://{$GITPOD_DOMAIN} {
 			base_domain {$GITPOD_DOMAIN}
 		}
 
-		# note: no compression, as that breaks streaming for headless logs
+		forward_auth server.{$KUBE_NAMESPACE}.{$KUBE_DOMAIN}:3000 {
+			uri /feature-flags/slow-database
+			copy_headers X-Gitpod-Slow-Database
+		}
+
+		@slow {
+			header X-Gitpod-Slow-Database "true"
+		}
+
+		@fast {
+			not header X-Gitpod-Slow-Database "true"
+		}
 
 		uri strip_prefix /api
-		reverse_proxy server.{$KUBE_NAMESPACE}.{$KUBE_DOMAIN}:3000 {
+
+		reverse_proxy @fast server.{$KUBE_NAMESPACE}.{$KUBE_DOMAIN}:3000 {
+			import upstream_headers
+			import upstream_connection
+
+			# required for smooth streaming of terminal logs
+			flush_interval -1
+		}
+
+		reverse_proxy @slow slow-server.{$KUBE_NAMESPACE}.{$KUBE_DOMAIN}:3000 {
 			import upstream_headers
 			import upstream_connection
 


### PR DESCRIPTION
## Description

Before handling `server` `/api` requests, make a 'pre-flight' request to `/api/feature-flags/slow-database` (on `server`) and use the `X-Gitpod-Slow-Database` header in the response to decide where to send the actual request; either to the regular `server` service or the new `slow-server` service.

This allows us to use a feature flag to simulate the performance of these endpoints when they use a higher latency database connection.

## Related Issue(s)
Part of #9198 

Closes https://github.com/gitpod-io/gitpod/issues/14960.

## How to test

0. Log in to the preview environment.
1. Hit https://af-proxy-a5b2f4cfb56.preview.gitpod-dev.com/api/version and inspect the response timings. 
2. Change the targeting rule for the `slow_database` feature flag (non-production environment) to this (replacing the user id with your user id in the preview):
<img width="1907" alt="image" src="https://user-images.githubusercontent.com/8225907/203328354-8954e22d-5243-4645-a52a-4306df9a9f29.png">

3. Wait up to 3 minutes for the configcat client to refresh the feature flag values.
4. Hit https://af-proxy-a5b2f4cfb56.preview.gitpod-dev.com/api/version and inspect the response timings.

## Release Notes

```release-note
NONE
```

## Documentation

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-slow-database
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
