### PR TITLE
[db] Drop description column from d_b_personal_access_token

### DIFF
--- a/components/gitpod-db/src/typeorm/migration/1669237520073-PersonalAccessTokenRemoveDescriptionColumn.ts
+++ b/components/gitpod-db/src/typeorm/migration/1669237520073-PersonalAccessTokenRemoveDescriptionColumn.ts
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { columnExists } from "./helper/helper";
+
+const TABLE_NAME = "d_b_personal_access_token";
+const COLUMN_NAME = "description";
+
+export class PersonalAccessTokenRemoveDescriptionColumn1669237520073 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        if (await columnExists(queryRunner, TABLE_NAME, COLUMN_NAME)) {
+            await queryRunner.query(`ALTER TABLE ${TABLE_NAME} DROP COLUMN ${COLUMN_NAME}`);
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {}
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Removes description column `d_b_personal_access_token` table

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Depends on https://github.com/gitpod-io/gitpod/pull/14901
* Fixes https://github.com/gitpod-io/gitpod/issues/14900

## How to test
<!-- Provide steps to test this PR -->
Unit tests execute migrations, CI passes

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold depends on https://github.com/gitpod-io/gitpod/pull/14901