### PR TITLE
[pat] Harden Personal Access Token name validation

### DIFF
--- a/components/public-api-server/pkg/apiv1/tokens_test.go
+++ b/components/public-api-server/pkg/apiv1/tokens_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -72,6 +73,21 @@ func TestTokensService_CreatePersonalAccessTokenWithoutFeatureFlag(t *testing.T)
 			Token: &v1.PersonalAccessToken{},
 		}))
 		require.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+	})
+
+	t.Run("invalid argument when name does not match required regex", func(t *testing.T) {
+		_, _, client := setupTokensService(t, withTokenFeatureDisabled)
+
+		names := []string{"a", "ab", strings.Repeat("a", 64), "!#$!%"}
+
+		for _, name := range names {
+			_, err := client.CreatePersonalAccessToken(context.Background(), connect.NewRequest(&v1.CreatePersonalAccessTokenRequest{
+				Token: &v1.PersonalAccessToken{
+					Name: name,
+				},
+			}))
+			require.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+		}
 	})
 
 	t.Run("invalid argument when expiration time is unspecified", func(t *testing.T) {

--- a/components/public-api/gitpod/experimental/v1/tokens.proto
+++ b/components/public-api/gitpod/experimental/v1/tokens.proto
@@ -19,7 +19,8 @@ message PersonalAccessToken {
     // Read only.
     string value = 2;
 
-    // name is the name of the token for humans, set by the user
+    // name is the name of the token for humans, set by the user.
+    // Must match regexp ^[a-zA-Z0-9-_ ]{3,63}$
     string name = 3;
 
     // expiration_time is the time when the token expires

--- a/components/public-api/go/experimental/v1/tokens.pb.go
+++ b/components/public-api/go/experimental/v1/tokens.pb.go
@@ -39,7 +39,8 @@ type PersonalAccessToken struct {
 	// The value property is only populated when the PersonalAccessToken is first created, and never again.
 	// Read only.
 	Value string `protobuf:"bytes,2,opt,name=value,proto3" json:"value,omitempty"`
-	// name is the name of the token for humans, set by the user
+	// name is the name of the token for humans, set by the user.
+	// Must match regexp ^[a-zA-Z0-9-_ ]{3,63}$
 	Name string `protobuf:"bytes,3,opt,name=name,proto3" json:"name,omitempty"`
 	// expiration_time is the time when the token expires
 	// Read only.

--- a/components/public-api/typescript/src/gitpod/experimental/v1/tokens_pb.ts
+++ b/components/public-api/typescript/src/gitpod/experimental/v1/tokens_pb.ts
@@ -37,7 +37,8 @@ export class PersonalAccessToken extends Message<PersonalAccessToken> {
   value = "";
 
   /**
-   * name is the name of the token for humans, set by the user
+   * name is the name of the token for humans, set by the user.
+   * Must match regexp ^[a-zA-Z0-9-_ ]{3,63}$
    *
    * @generated from field: string name = 3;
    */


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Hardens Personal Access Token name validation. See regex for allowed format.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
Unit tests

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
