### PR TITLE
test: disable PVC integration test

### DIFF
--- a/test/tests/workspace/contexts_test.go
+++ b/test/tests/workspace/contexts_test.go
@@ -114,7 +114,7 @@ func runContextTests(t *testing.T, tests []ContextTest) {
 				FF   string
 			}{
 				{Name: "classic"},
-				{Name: "pvc", FF: "persistent_volume_claim"},
+				// {Name: "pvc", FF: "persistent_volume_claim"},
 			}
 
 			for _, ff := range ffs {

--- a/test/tests/workspace/git_hooks_test.go
+++ b/test/tests/workspace/git_hooks_test.go
@@ -48,7 +48,7 @@ func TestGitHooks(t *testing.T) {
 				FF   string
 			}{
 				{Name: "classic"},
-				{Name: "pvc", FF: "persistent_volume_claim"},
+				// {Name: "pvc", FF: "persistent_volume_claim"},
 			}
 
 			for _, ff := range ffs {

--- a/test/tests/workspace/git_test.go
+++ b/test/tests/workspace/git_test.go
@@ -136,7 +136,7 @@ func TestGitActions(t *testing.T) {
 				FF   string
 			}{
 				{Name: "classic"},
-				{Name: "pvc", FF: "persistent_volume_claim"},
+				// {Name: "pvc", FF: "persistent_volume_claim"},
 			}
 
 			for _, ff := range ffs {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Disble PVC integration test

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
#7901

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
