### PR TITLE
[werft] add public api token service support for preview environment

### DIFF
--- a/.werft/jobs/build/installer/post-process.sh
+++ b/.werft/jobs/build/installer/post-process.sh
@@ -40,6 +40,13 @@ if [[ -f "/tmp/payment" ]] ; then
    printf \\n'---'\\n >> k8s.yaml
    cat "/tmp/payment" >> k8s.yaml
 fi
+# if public-api is configured: Append the YAML objects
+if [[ -f "/tmp/public-api" ]] ; then
+   echo "found /tmp/public-api, appending to k8s.yaml now"
+   # do not make any assumptions about new lines
+   printf \\n'---'\\n >> k8s.yaml
+   cat "/tmp/public-api" >> k8s.yaml
+fi
 
 # count YAML like lines in the k8s manifest file
 MATCHES="$(grep -c -- --- k8s.yaml)"

--- a/.werft/jobs/build/public-api/personal-access-token-signing-key.yaml
+++ b/.werft/jobs/build/public-api/personal-access-token-signing-key.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+data:
+  personal-access-token-signing-key: Zm9vCg==
+kind: Secret
+metadata:
+  name: personal-access-token-signing-key
+  namespace: default
+type: Opaque

--- a/dev/preview/workflow/preview/deploy-gitpod.sh
+++ b/dev/preview/workflow/preview/deploy-gitpod.sh
@@ -384,6 +384,11 @@ yq w -i "${INSTALLER_CONFIG_PATH}" experimental.webapp.proxy.configcat.baseUrl "
 yq w -i "${INSTALLER_CONFIG_PATH}" experimental.webapp.proxy.configcat.pollInterval "1m"
 
 #
+# configurePublicAPI
+#
+yq w -i "${INSTALLER_CONFIG_PATH}" experimental.webapp.publicApi.personalAccessTokenSigningKeySecretName "personal-access-token-signing-key"
+
+#
 # configureDefaultTemplate
 #
 yq w -i "${INSTALLER_CONFIG_PATH}" 'workspace.templates.default.spec.containers[+].name' "workspace"
@@ -490,6 +495,16 @@ for manifest in "$ROOT"/.werft/jobs/build/payment/*.yaml; do
 done
 
 #
+# configurePublicAPI
+#
+
+rm -f /tmp/public-api
+for manifest in "$ROOT"/.werft/jobs/build/public-api/*.yaml; do
+  cat "$manifest" >> /tmp/public-api
+  echo "---" >> /tmp/public-api
+done
+
+#
 # Run post-process script
 #
 
@@ -501,6 +516,7 @@ WITH_VM=true "$ROOT/.werft/jobs/build/installer/post-process.sh" "${PREVIEW_NAME
 rm -f /tmp/payment
 rm -f /tmp/defaultFeatureFlags
 rm -f /tmp/license
+rm -f /tmp/public-api
 
 # ===============
 # Install


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
[werft] add public api token service support for preview environment

This PR add post-process setp to werft job , it will automatic inject a signing-key into preview environment

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
1. open this PR in gitpod.io, and run `werft run github -a with-preview=1` [see this job](https://werft.gitpod-dev.com/job/gitpod-build-hw-preview-pat.4)
2. open preview environment to check token service is configure.
<img width="1190" alt="image" src="https://user-images.githubusercontent.com/20944364/203730764-b63d14fe-c64c-4cfd-8ee1-ba644d9d403f.png">

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
