### PR TITLE
[dashboard] display professional OS

### DIFF
--- a/components/dashboard/src/components/UsageBasedBillingConfig.tsx
+++ b/components/dashboard/src/components/UsageBasedBillingConfig.tsx
@@ -298,7 +298,7 @@ export default function UsageBasedBillingConfig({ attributionId }: Props) {
                     <div className="flex flex-col mt-4 p-4 rounded-xl bg-gray-50 dark:bg-gray-800">
                         <div className="uppercase text-sm text-gray-400 dark:text-gray-500">Current Plan</div>
                         <div className="mt-1 text-xl font-semibold flex-grow text-gray-600 dark:text-gray-400">
-                            {usageLimit > 500 ? "Professional Open Source" : "Free"}
+                            {usageLimit > 500 ? "Open Source" : "Free"}
                         </div>
                         <div className="mt-4 flex space-x-1 text-gray-400 dark:text-gray-500">
                             <Check className="m-0.5 w-5 h-5 text-orange-500" />

--- a/components/dashboard/src/components/UsageBasedBillingConfig.tsx
+++ b/components/dashboard/src/components/UsageBasedBillingConfig.tsx
@@ -298,14 +298,14 @@ export default function UsageBasedBillingConfig({ attributionId }: Props) {
                     <div className="flex flex-col mt-4 p-4 rounded-xl bg-gray-50 dark:bg-gray-800">
                         <div className="uppercase text-sm text-gray-400 dark:text-gray-500">Current Plan</div>
                         <div className="mt-1 text-xl font-semibold flex-grow text-gray-600 dark:text-gray-400">
-                            Free
+                            {usageLimit > 500 ? "Professional Open Source" : "Free"}
                         </div>
                         <div className="mt-4 flex space-x-1 text-gray-400 dark:text-gray-500">
                             <Check className="m-0.5 w-5 h-5 text-orange-500" />
                             <div className="flex flex-col">
-                                <span className="font-bold text-gray-500 dark:text-gray-400">500 credits</span>
+                                <span className="font-bold text-gray-500 dark:text-gray-400">{usageLimit} credits</span>
                                 <span>
-                                    50 hours of Standard workspace usage.{" "}
+                                    {usageLimit / 10} hours of Standard workspace usage.{" "}
                                     <a
                                         className="gp-link"
                                         href="https://www.gitpod.io/docs/configure/billing/usage-based-billing"


### PR DESCRIPTION
## Description
This is the minimal change that displays free accounts with more than 500 credits as "Professional Open Source" plans.
We don't really have a great place to store such information explicitly atm and I don'T think it is worth introducing something at this point (we can do later).

This PR does not include any automatic updates for existing professional open-source users. Will do this in a follow up PR.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
See #14819 

## How to test
<!-- Provide steps to test this PR -->
Increase the usage limit (> 500) using the admin dashboard and verify that under billing the user is shown to be on the "Professional Open Source" Plan.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-payment
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
