### PR TITLE
Increase timeout for cpu limit test

### DIFF
--- a/test/tests/components/ws-daemon/cpu_burst_test.go
+++ b/test/tests/components/ws-daemon/cpu_burst_test.go
@@ -90,7 +90,7 @@ func TestCpuBurst(t *testing.T) {
 
 		containerId := getWorkspaceContainerId(&pod)
 		var resp daemon.GetWorkspaceResourcesResponse
-		for i := 0; i < 6; i++ {
+		for i := 0; i < 10; i++ {
 			err = daemonClient.Call("DaemonAgent.GetWorkspaceResources", daemon.GetWorkspaceResourcesRequest{
 				ContainerId: containerId,
 			}, &resp)


### PR DESCRIPTION
## Description
Increase timeout for cpu limit test until we can analyze the flakiness

## Related Issue(s)
n.a.

## How to test
```
go test -run ^TestCpuBurst$ github.com/gitpod-io/gitpod/test/tests/components/ws-manager -count=1 -namespace=default -kubeconfig=/home/gitpod/.kube/config -v -timeout=20m
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
