### PR TITLE
[installer] manually set `allowPrivilegeEscalation` to false

### DIFF
--- a/install/installer/cmd/testdata/render/aws-setup/output.golden
+++ b/install/installer/cmd/testdata/render/aws-setup/output.golden
@@ -7295,6 +7295,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -7410,6 +7411,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 1000
         volumeMounts:
@@ -7445,6 +7447,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -7659,6 +7662,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -7683,6 +7687,8 @@ spec:
               - --shutdown
         name: node-labeler
         resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
       dnsPolicy: ClusterFirst
       enableServiceLinks: false
       hostPID: true
@@ -8071,6 +8077,8 @@ spec:
             requests:
               cpu: 1m
               memory: 150Mi
+          securityContext:
+            allowPrivilegeEscalation: false
           volumeMounts:
             - mountPath: /config
               name: config
@@ -8089,6 +8097,8 @@ spec:
             requests:
               cpu: 1m
               memory: 150Mi
+          securityContext:
+            allowPrivilegeEscalation: false
           volumeMounts:
             - mountPath: /config
               name: config
@@ -8113,6 +8123,7 @@ spec:
               cpu: 1m
               memory: 30Mi
           securityContext:
+            allowPrivilegeEscalation: false
             runAsGroup: 65532
             runAsNonRoot: true
             runAsUser: 65532
@@ -8264,6 +8275,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -8387,6 +8399,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -8479,6 +8492,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
       dnsPolicy: ClusterFirst
       enableServiceLinks: false
@@ -8625,6 +8639,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -8665,6 +8680,7 @@ spec:
         name: database-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       restartPolicy: Always
@@ -8754,6 +8770,7 @@ spec:
             cpu: 100m
             memory: 128Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /config
@@ -8778,6 +8795,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -8867,6 +8885,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
       dnsPolicy: ClusterFirst
       enableServiceLinks: false
@@ -8954,6 +8973,7 @@ spec:
             cpu: 100m
             memory: 128Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /config
@@ -8981,6 +9001,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -9073,6 +9094,7 @@ spec:
             cpu: 100m
             memory: 200Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 33333
         volumeMounts:
@@ -9104,6 +9126,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -9256,6 +9279,7 @@ spec:
             cpu: 100m
             memory: 200Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /etc/caddy/vhosts
@@ -9414,6 +9438,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /config.json
@@ -9439,6 +9464,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -9479,6 +9505,7 @@ spec:
         name: database-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       restartPolicy: Always
@@ -9735,6 +9762,7 @@ spec:
             cpu: 200m
             memory: 200Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
         volumeMounts:
@@ -9769,6 +9797,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -9808,6 +9837,7 @@ spec:
         name: database-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       - args:
@@ -9843,6 +9873,7 @@ spec:
         name: msgbus-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       priorityClassName: system-node-critical
@@ -9939,6 +9970,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /config
@@ -9975,6 +10007,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -10124,6 +10157,7 @@ spec:
             cpu: 100m
             memory: 64Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
         volumeMounts:
@@ -10152,6 +10186,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -10192,6 +10227,7 @@ spec:
         name: database-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       - args:
@@ -10227,6 +10263,7 @@ spec:
         name: msgbus-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       priorityClassName: system-node-critical
@@ -10335,6 +10372,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /config
@@ -10364,6 +10402,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -10455,6 +10494,8 @@ spec:
         imagePullPolicy: IfNotPresent
         name: dbinit-session
         resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /db-init-scripts
           name: db-init-scripts
@@ -10494,6 +10535,7 @@ spec:
         name: database-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       restartPolicy: Never
@@ -10584,6 +10626,8 @@ spec:
         imagePullPolicy: IfNotPresent
         name: migrations
         resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
       enableServiceLinks: false
       initContainers:
       - args:
@@ -10619,6 +10663,7 @@ spec:
         name: database-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       restartPolicy: Never
@@ -10671,6 +10716,8 @@ spec:
             imagePullPolicy: IfNotPresent
             name: gitpod-telemetry
             resources: {}
+            securityContext:
+              allowPrivilegeEscalation: false
           enableServiceLinks: false
           initContainers:
           - args:
@@ -10706,6 +10753,7 @@ spec:
             name: database-waiter
             resources: {}
             securityContext:
+              allowPrivilegeEscalation: false
               privileged: false
               runAsUser: 31001
           restartPolicy: OnFailure

--- a/install/installer/cmd/testdata/render/azure-setup/output.golden
+++ b/install/installer/cmd/testdata/render/azure-setup/output.golden
@@ -7140,6 +7140,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -7255,6 +7256,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 1000
         volumeMounts:
@@ -7290,6 +7292,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -7501,6 +7504,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -7525,6 +7529,8 @@ spec:
               - --shutdown
         name: node-labeler
         resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
       dnsPolicy: ClusterFirst
       enableServiceLinks: false
       hostPID: true
@@ -7910,6 +7916,8 @@ spec:
             requests:
               cpu: 1m
               memory: 150Mi
+          securityContext:
+            allowPrivilegeEscalation: false
           volumeMounts:
             - mountPath: /config
               name: config
@@ -7928,6 +7936,8 @@ spec:
             requests:
               cpu: 1m
               memory: 150Mi
+          securityContext:
+            allowPrivilegeEscalation: false
           volumeMounts:
             - mountPath: /config
               name: config
@@ -7952,6 +7962,7 @@ spec:
               cpu: 1m
               memory: 30Mi
           securityContext:
+            allowPrivilegeEscalation: false
             runAsGroup: 65532
             runAsNonRoot: true
             runAsUser: 65532
@@ -8103,6 +8114,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -8223,6 +8235,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -8312,6 +8325,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
       dnsPolicy: ClusterFirst
       enableServiceLinks: false
@@ -8458,6 +8472,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -8498,6 +8513,7 @@ spec:
         name: database-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       restartPolicy: Always
@@ -8587,6 +8603,7 @@ spec:
             cpu: 100m
             memory: 128Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /config
@@ -8611,6 +8628,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -8700,6 +8718,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
       dnsPolicy: ClusterFirst
       enableServiceLinks: false
@@ -8787,6 +8806,7 @@ spec:
             cpu: 100m
             memory: 128Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /config
@@ -8814,6 +8834,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -8906,6 +8927,7 @@ spec:
             cpu: 100m
             memory: 200Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 33333
         volumeMounts:
@@ -8937,6 +8959,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -9215,6 +9238,7 @@ spec:
             cpu: 100m
             memory: 200Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /etc/caddy/vhosts
@@ -9363,6 +9387,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /config.json
@@ -9388,6 +9413,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -9428,6 +9454,7 @@ spec:
         name: database-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       restartPolicy: Always
@@ -9586,6 +9613,7 @@ spec:
             cpu: 200m
             memory: 200Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
         volumeMounts:
@@ -9620,6 +9648,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -9659,6 +9688,7 @@ spec:
         name: database-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       - args:
@@ -9694,6 +9724,7 @@ spec:
         name: msgbus-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       priorityClassName: system-node-critical
@@ -9790,6 +9821,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /config
@@ -9823,6 +9855,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -9969,6 +10002,7 @@ spec:
             cpu: 100m
             memory: 64Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
         volumeMounts:
@@ -9997,6 +10031,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -10037,6 +10072,7 @@ spec:
         name: database-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       - args:
@@ -10072,6 +10108,7 @@ spec:
         name: msgbus-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       priorityClassName: system-node-critical
@@ -10180,6 +10217,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /config
@@ -10209,6 +10247,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -10300,6 +10339,8 @@ spec:
         imagePullPolicy: IfNotPresent
         name: dbinit-session
         resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /db-init-scripts
           name: db-init-scripts
@@ -10339,6 +10380,7 @@ spec:
         name: database-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       restartPolicy: Never
@@ -10429,6 +10471,8 @@ spec:
         imagePullPolicy: IfNotPresent
         name: migrations
         resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
       enableServiceLinks: false
       initContainers:
       - args:
@@ -10464,6 +10508,7 @@ spec:
         name: database-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       restartPolicy: Never
@@ -10516,6 +10561,8 @@ spec:
             imagePullPolicy: IfNotPresent
             name: gitpod-telemetry
             resources: {}
+            securityContext:
+              allowPrivilegeEscalation: false
           enableServiceLinks: false
           initContainers:
           - args:
@@ -10551,6 +10598,7 @@ spec:
             name: database-waiter
             resources: {}
             securityContext:
+              allowPrivilegeEscalation: false
               privileged: false
               runAsUser: 31001
           restartPolicy: OnFailure

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -8426,6 +8426,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -8550,6 +8551,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 1000
         volumeMounts:
@@ -8585,6 +8587,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -8805,6 +8808,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -8829,6 +8833,8 @@ spec:
               - --shutdown
         name: node-labeler
         resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
       dnsPolicy: ClusterFirst
       enableServiceLinks: false
       hostPID: true
@@ -9382,6 +9388,8 @@ spec:
             requests:
               cpu: 1m
               memory: 150Mi
+          securityContext:
+            allowPrivilegeEscalation: false
           volumeMounts:
             - mountPath: /config
               name: config
@@ -9400,6 +9408,8 @@ spec:
             requests:
               cpu: 1m
               memory: 150Mi
+          securityContext:
+            allowPrivilegeEscalation: false
           volumeMounts:
             - mountPath: /config
               name: config
@@ -9424,6 +9434,7 @@ spec:
               cpu: 1m
               memory: 30Mi
           securityContext:
+            allowPrivilegeEscalation: false
             runAsGroup: 65532
             runAsNonRoot: true
             runAsUser: 65532
@@ -9584,6 +9595,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -9713,6 +9725,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -9812,6 +9825,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
       dnsPolicy: ClusterFirst
       enableServiceLinks: false
@@ -9967,6 +9981,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -10007,6 +10022,7 @@ spec:
         name: database-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       restartPolicy: Always
@@ -10105,6 +10121,7 @@ spec:
             cpu: 100m
             memory: 128Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /config
@@ -10129,6 +10146,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -10228,6 +10246,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
       dnsPolicy: ClusterFirst
       enableServiceLinks: false
@@ -10324,6 +10343,7 @@ spec:
             cpu: 100m
             memory: 128Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /config
@@ -10351,6 +10371,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -10452,6 +10473,7 @@ spec:
             cpu: 100m
             memory: 200Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 33333
         volumeMounts:
@@ -10483,6 +10505,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -10755,6 +10778,7 @@ spec:
             cpu: 100m
             memory: 200Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /etc/caddy/vhosts
@@ -10922,6 +10946,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /config.json
@@ -10947,6 +10972,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -10987,6 +11013,7 @@ spec:
         name: database-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       restartPolicy: Always
@@ -11243,6 +11270,7 @@ spec:
             cpu: 200m
             memory: 200Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
         volumeMounts:
@@ -11277,6 +11305,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -11316,6 +11345,7 @@ spec:
         name: database-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       - args:
@@ -11351,6 +11381,7 @@ spec:
         name: msgbus-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       priorityClassName: system-node-critical
@@ -11456,6 +11487,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /config
@@ -11489,6 +11521,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -11644,6 +11677,7 @@ spec:
             cpu: 100m
             memory: 64Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
         volumeMounts:
@@ -11672,6 +11706,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -11712,6 +11747,7 @@ spec:
         name: database-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       - args:
@@ -11747,6 +11783,7 @@ spec:
         name: msgbus-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       priorityClassName: system-node-critical
@@ -11864,6 +11901,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /config
@@ -11893,6 +11931,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -12011,6 +12050,8 @@ spec:
         imagePullPolicy: IfNotPresent
         name: migrations
         resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
       enableServiceLinks: false
       initContainers:
       - args:
@@ -12046,6 +12087,7 @@ spec:
         name: database-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       restartPolicy: Never
@@ -12098,6 +12140,8 @@ spec:
             imagePullPolicy: IfNotPresent
             name: gitpod-telemetry
             resources: {}
+            securityContext:
+              allowPrivilegeEscalation: false
           enableServiceLinks: false
           initContainers:
           - args:
@@ -12133,6 +12177,7 @@ spec:
             name: database-waiter
             resources: {}
             securityContext:
+              allowPrivilegeEscalation: false
               privileged: false
               runAsUser: 31001
           restartPolicy: OnFailure

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -7422,6 +7422,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -7537,6 +7538,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 1000
         volumeMounts:
@@ -7572,6 +7574,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -7783,6 +7786,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -7807,6 +7811,8 @@ spec:
               - --shutdown
         name: node-labeler
         resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
       dnsPolicy: ClusterFirst
       enableServiceLinks: false
       hostPID: true
@@ -8351,6 +8357,8 @@ spec:
             requests:
               cpu: 1m
               memory: 150Mi
+          securityContext:
+            allowPrivilegeEscalation: false
           volumeMounts:
             - mountPath: /config
               name: config
@@ -8369,6 +8377,8 @@ spec:
             requests:
               cpu: 1m
               memory: 150Mi
+          securityContext:
+            allowPrivilegeEscalation: false
           volumeMounts:
             - mountPath: /config
               name: config
@@ -8393,6 +8403,7 @@ spec:
               cpu: 1m
               memory: 30Mi
           securityContext:
+            allowPrivilegeEscalation: false
             runAsGroup: 65532
             runAsNonRoot: true
             runAsUser: 65532
@@ -8544,6 +8555,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -8664,6 +8676,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -8753,6 +8766,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
       dnsPolicy: ClusterFirst
       enableServiceLinks: false
@@ -8899,6 +8913,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -8939,6 +8954,7 @@ spec:
         name: database-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       restartPolicy: Always
@@ -9028,6 +9044,7 @@ spec:
             cpu: 100m
             memory: 128Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /config
@@ -9052,6 +9069,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -9141,6 +9159,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
       dnsPolicy: ClusterFirst
       enableServiceLinks: false
@@ -9228,6 +9247,7 @@ spec:
             cpu: 100m
             memory: 128Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /config
@@ -9255,6 +9275,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -9347,6 +9368,7 @@ spec:
             cpu: 100m
             memory: 200Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 33333
         volumeMounts:
@@ -9378,6 +9400,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -9641,6 +9664,7 @@ spec:
             cpu: 100m
             memory: 200Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /etc/caddy/vhosts
@@ -9789,6 +9813,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /config.json
@@ -9814,6 +9839,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -9854,6 +9880,7 @@ spec:
         name: database-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       restartPolicy: Always
@@ -10012,6 +10039,7 @@ spec:
             cpu: 200m
             memory: 200Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
         volumeMounts:
@@ -10046,6 +10074,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -10085,6 +10114,7 @@ spec:
         name: database-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       - args:
@@ -10120,6 +10150,7 @@ spec:
         name: msgbus-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       priorityClassName: system-node-critical
@@ -10216,6 +10247,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /config
@@ -10249,6 +10281,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -10395,6 +10428,7 @@ spec:
             cpu: 100m
             memory: 64Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
         volumeMounts:
@@ -10423,6 +10457,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -10463,6 +10498,7 @@ spec:
         name: database-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       - args:
@@ -10498,6 +10534,7 @@ spec:
         name: msgbus-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       priorityClassName: system-node-critical
@@ -10606,6 +10643,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /config
@@ -10635,6 +10673,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -10743,6 +10782,8 @@ spec:
         imagePullPolicy: IfNotPresent
         name: migrations
         resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
       enableServiceLinks: false
       initContainers:
       - args:
@@ -10778,6 +10819,7 @@ spec:
         name: database-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       restartPolicy: Never
@@ -10830,6 +10872,8 @@ spec:
             imagePullPolicy: IfNotPresent
             name: gitpod-telemetry
             resources: {}
+            securityContext:
+              allowPrivilegeEscalation: false
           enableServiceLinks: false
           initContainers:
           - args:
@@ -10865,6 +10909,7 @@ spec:
             name: database-waiter
             resources: {}
             securityContext:
+              allowPrivilegeEscalation: false
               privileged: false
               runAsUser: 31001
           restartPolicy: OnFailure

--- a/install/installer/cmd/testdata/render/gcp-setup/output.golden
+++ b/install/installer/cmd/testdata/render/gcp-setup/output.golden
@@ -7114,6 +7114,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -7229,6 +7230,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 1000
         volumeMounts:
@@ -7264,6 +7266,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -7478,6 +7481,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -7502,6 +7506,8 @@ spec:
               - --shutdown
         name: node-labeler
         resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
       dnsPolicy: ClusterFirst
       enableServiceLinks: false
       hostPID: true
@@ -7890,6 +7896,8 @@ spec:
             requests:
               cpu: 1m
               memory: 150Mi
+          securityContext:
+            allowPrivilegeEscalation: false
           volumeMounts:
             - mountPath: /config
               name: config
@@ -7908,6 +7916,8 @@ spec:
             requests:
               cpu: 1m
               memory: 150Mi
+          securityContext:
+            allowPrivilegeEscalation: false
           volumeMounts:
             - mountPath: /config
               name: config
@@ -7932,6 +7942,7 @@ spec:
               cpu: 1m
               memory: 30Mi
           securityContext:
+            allowPrivilegeEscalation: false
             runAsGroup: 65532
             runAsNonRoot: true
             runAsUser: 65532
@@ -8083,6 +8094,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -8149,6 +8161,7 @@ spec:
         - containerPort: 3306
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsNonRoot: false
         volumeMounts:
@@ -8275,6 +8288,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -8367,6 +8381,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
       dnsPolicy: ClusterFirst
       enableServiceLinks: false
@@ -8507,6 +8522,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -8541,6 +8557,7 @@ spec:
         name: database-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       restartPolicy: Always
@@ -8630,6 +8647,7 @@ spec:
             cpu: 100m
             memory: 128Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /config
@@ -8654,6 +8672,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -8743,6 +8762,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
       dnsPolicy: ClusterFirst
       enableServiceLinks: false
@@ -8830,6 +8850,7 @@ spec:
             cpu: 100m
             memory: 128Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /config
@@ -8857,6 +8878,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -8949,6 +8971,7 @@ spec:
             cpu: 100m
             memory: 200Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 33333
         volumeMounts:
@@ -8980,6 +9003,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -9132,6 +9156,7 @@ spec:
             cpu: 100m
             memory: 200Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /etc/caddy/vhosts
@@ -9274,6 +9299,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /config.json
@@ -9299,6 +9325,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -9333,6 +9360,7 @@ spec:
         name: database-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       restartPolicy: Always
@@ -9485,6 +9513,7 @@ spec:
             cpu: 200m
             memory: 200Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
         volumeMounts:
@@ -9519,6 +9548,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -9552,6 +9582,7 @@ spec:
         name: database-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       - args:
@@ -9587,6 +9618,7 @@ spec:
         name: msgbus-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       priorityClassName: system-node-critical
@@ -9683,6 +9715,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /config
@@ -9719,6 +9752,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -9862,6 +9896,7 @@ spec:
             cpu: 100m
             memory: 64Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
         volumeMounts:
@@ -9890,6 +9925,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -9924,6 +9960,7 @@ spec:
         name: database-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       - args:
@@ -9959,6 +9996,7 @@ spec:
         name: msgbus-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       priorityClassName: system-node-critical
@@ -10067,6 +10105,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /config
@@ -10096,6 +10135,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -10181,6 +10221,8 @@ spec:
         imagePullPolicy: IfNotPresent
         name: dbinit-session
         resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /db-init-scripts
           name: db-init-scripts
@@ -10214,6 +10256,7 @@ spec:
         name: database-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       restartPolicy: Never
@@ -10298,6 +10341,8 @@ spec:
         imagePullPolicy: IfNotPresent
         name: migrations
         resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
       enableServiceLinks: false
       initContainers:
       - args:
@@ -10327,6 +10372,7 @@ spec:
         name: database-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       restartPolicy: Never
@@ -10379,6 +10425,8 @@ spec:
             imagePullPolicy: IfNotPresent
             name: gitpod-telemetry
             resources: {}
+            securityContext:
+              allowPrivilegeEscalation: false
           enableServiceLinks: false
           initContainers:
           - args:
@@ -10408,6 +10456,7 @@ spec:
             name: database-waiter
             resources: {}
             securityContext:
+              allowPrivilegeEscalation: false
               privileged: false
               runAsUser: 31001
           restartPolicy: OnFailure

--- a/install/installer/cmd/testdata/render/http-proxy/output.golden
+++ b/install/installer/cmd/testdata/render/http-proxy/output.golden
@@ -7785,6 +7785,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -7940,6 +7941,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 1000
         volumeMounts:
@@ -8015,6 +8017,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -8387,6 +8390,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -8451,6 +8455,8 @@ spec:
               - --shutdown
         name: node-labeler
         resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
       dnsPolicy: ClusterFirst
       enableServiceLinks: false
       hostPID: true
@@ -9076,6 +9082,8 @@ spec:
             requests:
               cpu: 1m
               memory: 150Mi
+          securityContext:
+            allowPrivilegeEscalation: false
           volumeMounts:
             - mountPath: /config
               name: config
@@ -9094,6 +9102,8 @@ spec:
             requests:
               cpu: 1m
               memory: 150Mi
+          securityContext:
+            allowPrivilegeEscalation: false
           volumeMounts:
             - mountPath: /config
               name: config
@@ -9158,6 +9168,7 @@ spec:
               cpu: 1m
               memory: 30Mi
           securityContext:
+            allowPrivilegeEscalation: false
             runAsGroup: 65532
             runAsNonRoot: true
             runAsUser: 65532
@@ -9389,6 +9400,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -9589,6 +9601,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -9718,6 +9731,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
       dnsPolicy: ClusterFirst
       enableServiceLinks: false
@@ -9944,6 +9958,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -10024,6 +10039,7 @@ spec:
         name: database-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       restartPolicy: Always
@@ -10153,6 +10169,7 @@ spec:
             cpu: 100m
             memory: 128Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /config
@@ -10217,6 +10234,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -10346,6 +10364,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
       dnsPolicy: ClusterFirst
       enableServiceLinks: false
@@ -10473,6 +10492,7 @@ spec:
             cpu: 100m
             memory: 128Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /config
@@ -10540,6 +10560,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -10672,6 +10693,7 @@ spec:
             cpu: 100m
             memory: 200Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 33333
         volumeMounts:
@@ -10743,6 +10765,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -11087,6 +11110,7 @@ spec:
             cpu: 100m
             memory: 200Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /etc/caddy/vhosts
@@ -11285,6 +11309,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /config.json
@@ -11350,6 +11375,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -11430,6 +11456,7 @@ spec:
         name: database-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       restartPolicy: Always
@@ -11715,6 +11742,7 @@ spec:
             cpu: 200m
             memory: 200Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
         volumeMounts:
@@ -11789,6 +11817,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -11868,6 +11897,7 @@ spec:
         name: database-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       - args:
@@ -11943,6 +11973,7 @@ spec:
         name: msgbus-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       priorityClassName: system-node-critical
@@ -12079,6 +12110,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /config
@@ -12152,6 +12184,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -12338,6 +12371,7 @@ spec:
             cpu: 100m
             memory: 64Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
         volumeMounts:
@@ -12406,6 +12440,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -12486,6 +12521,7 @@ spec:
         name: database-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       - args:
@@ -12561,6 +12597,7 @@ spec:
         name: msgbus-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       priorityClassName: system-node-critical
@@ -12709,6 +12746,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /config
@@ -12778,6 +12816,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -12926,6 +12965,8 @@ spec:
         imagePullPolicy: IfNotPresent
         name: migrations
         resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
       enableServiceLinks: false
       initContainers:
       - args:
@@ -13001,6 +13042,7 @@ spec:
         name: database-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       restartPolicy: Never
@@ -13053,6 +13095,8 @@ spec:
             imagePullPolicy: IfNotPresent
             name: gitpod-telemetry
             resources: {}
+            securityContext:
+              allowPrivilegeEscalation: false
           enableServiceLinks: false
           initContainers:
           - args:
@@ -13128,6 +13172,7 @@ spec:
             name: database-waiter
             resources: {}
             securityContext:
+              allowPrivilegeEscalation: false
               privileged: false
               runAsUser: 31001
           restartPolicy: OnFailure

--- a/install/installer/cmd/testdata/render/insecure-s3-setup/output.golden
+++ b/install/installer/cmd/testdata/render/insecure-s3-setup/output.golden
@@ -7572,6 +7572,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -7687,6 +7688,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 1000
         volumeMounts:
@@ -7722,6 +7724,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -7936,6 +7939,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -7960,6 +7964,8 @@ spec:
               - --shutdown
         name: node-labeler
         resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
       dnsPolicy: ClusterFirst
       enableServiceLinks: false
       hostPID: true
@@ -8507,6 +8513,8 @@ spec:
             requests:
               cpu: 1m
               memory: 150Mi
+          securityContext:
+            allowPrivilegeEscalation: false
           volumeMounts:
             - mountPath: /config
               name: config
@@ -8525,6 +8533,8 @@ spec:
             requests:
               cpu: 1m
               memory: 150Mi
+          securityContext:
+            allowPrivilegeEscalation: false
           volumeMounts:
             - mountPath: /config
               name: config
@@ -8549,6 +8559,7 @@ spec:
               cpu: 1m
               memory: 30Mi
           securityContext:
+            allowPrivilegeEscalation: false
             runAsGroup: 65532
             runAsNonRoot: true
             runAsUser: 65532
@@ -8700,6 +8711,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -8823,6 +8835,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -8915,6 +8928,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
       dnsPolicy: ClusterFirst
       enableServiceLinks: false
@@ -9061,6 +9075,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -9101,6 +9116,7 @@ spec:
         name: database-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       restartPolicy: Always
@@ -9190,6 +9206,7 @@ spec:
             cpu: 100m
             memory: 128Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /config
@@ -9214,6 +9231,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -9303,6 +9321,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
       dnsPolicy: ClusterFirst
       enableServiceLinks: false
@@ -9390,6 +9409,7 @@ spec:
             cpu: 100m
             memory: 128Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /config
@@ -9417,6 +9437,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -9509,6 +9530,7 @@ spec:
             cpu: 100m
             memory: 200Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 33333
         volumeMounts:
@@ -9540,6 +9562,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -9692,6 +9715,7 @@ spec:
             cpu: 100m
             memory: 200Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /etc/caddy/vhosts
@@ -9850,6 +9874,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /config.json
@@ -9875,6 +9900,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -9915,6 +9941,7 @@ spec:
         name: database-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       restartPolicy: Always
@@ -10158,6 +10185,7 @@ spec:
             cpu: 200m
             memory: 200Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
         volumeMounts:
@@ -10192,6 +10220,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -10231,6 +10260,7 @@ spec:
         name: database-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       - args:
@@ -10266,6 +10296,7 @@ spec:
         name: msgbus-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       priorityClassName: system-node-critical
@@ -10362,6 +10393,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /config
@@ -10398,6 +10430,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -10547,6 +10580,7 @@ spec:
             cpu: 100m
             memory: 64Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
         volumeMounts:
@@ -10575,6 +10609,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -10615,6 +10650,7 @@ spec:
         name: database-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       - args:
@@ -10650,6 +10686,7 @@ spec:
         name: msgbus-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       priorityClassName: system-node-critical
@@ -10758,6 +10795,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /config
@@ -10787,6 +10825,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -10895,6 +10934,8 @@ spec:
         imagePullPolicy: IfNotPresent
         name: migrations
         resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
       enableServiceLinks: false
       initContainers:
       - args:
@@ -10930,6 +10971,7 @@ spec:
         name: database-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       restartPolicy: Never
@@ -10982,6 +11024,8 @@ spec:
             imagePullPolicy: IfNotPresent
             name: gitpod-telemetry
             resources: {}
+            securityContext:
+              allowPrivilegeEscalation: false
           enableServiceLinks: false
           initContainers:
           - args:
@@ -11017,6 +11061,7 @@ spec:
             name: database-waiter
             resources: {}
             securityContext:
+              allowPrivilegeEscalation: false
               privileged: false
               runAsUser: 31001
           restartPolicy: OnFailure

--- a/install/installer/cmd/testdata/render/kind-ide/output.golden
+++ b/install/installer/cmd/testdata/render/kind-ide/output.golden
@@ -3045,6 +3045,8 @@ spec:
             requests:
               cpu: 1m
               memory: 150Mi
+          securityContext:
+            allowPrivilegeEscalation: false
           volumeMounts:
             - mountPath: /config
               name: config
@@ -3063,6 +3065,8 @@ spec:
             requests:
               cpu: 1m
               memory: 150Mi
+          securityContext:
+            allowPrivilegeEscalation: false
           volumeMounts:
             - mountPath: /config
               name: config
@@ -3087,6 +3091,7 @@ spec:
               cpu: 1m
               memory: 30Mi
           securityContext:
+            allowPrivilegeEscalation: false
             runAsGroup: 65532
             runAsNonRoot: true
             runAsUser: 65532
@@ -3238,6 +3243,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -3333,6 +3339,7 @@ spec:
             cpu: 100m
             memory: 128Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /config
@@ -3357,6 +3364,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -3446,6 +3454,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
       dnsPolicy: ClusterFirst
       enableServiceLinks: false
@@ -3533,6 +3542,7 @@ spec:
             cpu: 100m
             memory: 128Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /config
@@ -3560,6 +3570,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -3708,6 +3719,8 @@ spec:
             imagePullPolicy: IfNotPresent
             name: gitpod-telemetry
             resources: {}
+            securityContext:
+              allowPrivilegeEscalation: false
           enableServiceLinks: false
           initContainers:
           - args:
@@ -3743,6 +3756,7 @@ spec:
             name: database-waiter
             resources: {}
             securityContext:
+              allowPrivilegeEscalation: false
               privileged: false
               runAsUser: 31001
           restartPolicy: OnFailure

--- a/install/installer/cmd/testdata/render/kind-meta/output.golden
+++ b/install/installer/cmd/testdata/render/kind-meta/output.golden
@@ -5982,6 +5982,8 @@ spec:
             requests:
               cpu: 1m
               memory: 150Mi
+          securityContext:
+            allowPrivilegeEscalation: false
           volumeMounts:
             - mountPath: /config
               name: config
@@ -6000,6 +6002,8 @@ spec:
             requests:
               cpu: 1m
               memory: 150Mi
+          securityContext:
+            allowPrivilegeEscalation: false
           volumeMounts:
             - mountPath: /config
               name: config
@@ -6024,6 +6028,7 @@ spec:
               cpu: 1m
               memory: 30Mi
           securityContext:
+            allowPrivilegeEscalation: false
             runAsGroup: 65532
             runAsNonRoot: true
             runAsUser: 65532
@@ -6175,6 +6180,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -6295,6 +6301,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -6384,6 +6391,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
       dnsPolicy: ClusterFirst
       enableServiceLinks: false
@@ -6530,6 +6538,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -6570,6 +6579,7 @@ spec:
         name: database-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       restartPolicy: Always
@@ -6659,6 +6669,7 @@ spec:
             cpu: 100m
             memory: 128Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /config
@@ -6683,6 +6694,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -6772,6 +6784,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
       dnsPolicy: ClusterFirst
       enableServiceLinks: false
@@ -6859,6 +6872,7 @@ spec:
             cpu: 100m
             memory: 128Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /config
@@ -6886,6 +6900,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -7126,6 +7141,7 @@ spec:
             cpu: 100m
             memory: 200Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /etc/caddy/vhosts
@@ -7284,6 +7300,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /config.json
@@ -7309,6 +7326,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -7349,6 +7367,7 @@ spec:
         name: database-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       restartPolicy: Always
@@ -7592,6 +7611,7 @@ spec:
             cpu: 200m
             memory: 200Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
         volumeMounts:
@@ -7626,6 +7646,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -7665,6 +7686,7 @@ spec:
         name: database-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       - args:
@@ -7700,6 +7722,7 @@ spec:
         name: msgbus-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       priorityClassName: system-node-critical
@@ -7842,6 +7865,7 @@ spec:
             cpu: 100m
             memory: 64Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
         volumeMounts:
@@ -7870,6 +7894,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -7910,6 +7935,7 @@ spec:
         name: database-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       - args:
@@ -7945,6 +7971,7 @@ spec:
         name: msgbus-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       priorityClassName: system-node-critical
@@ -8039,6 +8066,8 @@ spec:
         imagePullPolicy: IfNotPresent
         name: migrations
         resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
       enableServiceLinks: false
       initContainers:
       - args:
@@ -8074,6 +8103,7 @@ spec:
         name: database-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       restartPolicy: Never
@@ -8126,6 +8156,8 @@ spec:
             imagePullPolicy: IfNotPresent
             name: gitpod-telemetry
             resources: {}
+            securityContext:
+              allowPrivilegeEscalation: false
           enableServiceLinks: false
           initContainers:
           - args:
@@ -8161,6 +8193,7 @@ spec:
             name: database-waiter
             resources: {}
             securityContext:
+              allowPrivilegeEscalation: false
               privileged: false
               runAsUser: 31001
           restartPolicy: OnFailure

--- a/install/installer/cmd/testdata/render/kind-webapp/output.golden
+++ b/install/installer/cmd/testdata/render/kind-webapp/output.golden
@@ -3822,6 +3822,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -3911,6 +3912,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
       dnsPolicy: ClusterFirst
       enableServiceLinks: false
@@ -4057,6 +4059,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -4097,6 +4100,7 @@ spec:
         name: database-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       restartPolicy: Always
@@ -4330,6 +4334,7 @@ spec:
             cpu: 100m
             memory: 200Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /etc/caddy/vhosts
@@ -4488,6 +4493,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /config.json
@@ -4513,6 +4519,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -4553,6 +4560,7 @@ spec:
         name: database-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       restartPolicy: Always
@@ -4796,6 +4804,7 @@ spec:
             cpu: 200m
             memory: 200Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
         volumeMounts:
@@ -4830,6 +4839,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -4869,6 +4879,7 @@ spec:
         name: database-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       - args:
@@ -4904,6 +4915,7 @@ spec:
         name: msgbus-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       priorityClassName: system-node-critical
@@ -5046,6 +5058,7 @@ spec:
             cpu: 100m
             memory: 64Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
         volumeMounts:
@@ -5074,6 +5087,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -5114,6 +5128,7 @@ spec:
         name: database-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       - args:
@@ -5149,6 +5164,7 @@ spec:
         name: msgbus-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       priorityClassName: system-node-critical
@@ -5243,6 +5259,8 @@ spec:
         imagePullPolicy: IfNotPresent
         name: migrations
         resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
       enableServiceLinks: false
       initContainers:
       - args:
@@ -5278,6 +5296,7 @@ spec:
         name: database-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       restartPolicy: Never
@@ -5330,6 +5349,8 @@ spec:
             imagePullPolicy: IfNotPresent
             name: gitpod-telemetry
             resources: {}
+            securityContext:
+              allowPrivilegeEscalation: false
           enableServiceLinks: false
           initContainers:
           - args:
@@ -5365,6 +5386,7 @@ spec:
             name: database-waiter
             resources: {}
             securityContext:
+              allowPrivilegeEscalation: false
               privileged: false
               runAsUser: 31001
           restartPolicy: OnFailure

--- a/install/installer/cmd/testdata/render/kind-workspace/output.golden
+++ b/install/installer/cmd/testdata/render/kind-workspace/output.golden
@@ -2923,6 +2923,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -3038,6 +3039,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 1000
         volumeMounts:
@@ -3073,6 +3075,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -3284,6 +3287,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -3308,6 +3312,8 @@ spec:
               - --shutdown
         name: node-labeler
         resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
       dnsPolicy: ClusterFirst
       enableServiceLinks: false
       hostPID: true
@@ -3499,6 +3505,7 @@ spec:
             cpu: 100m
             memory: 200Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 33333
         volumeMounts:
@@ -3530,6 +3537,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -3732,6 +3740,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /config
@@ -3765,6 +3774,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -3882,6 +3892,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /config
@@ -3911,6 +3922,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -7702,6 +7702,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -7817,6 +7818,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 1000
         volumeMounts:
@@ -7852,6 +7854,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -8063,6 +8066,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -8087,6 +8091,8 @@ spec:
               - --shutdown
         name: node-labeler
         resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
       dnsPolicy: ClusterFirst
       enableServiceLinks: false
       hostPID: true
@@ -8631,6 +8637,8 @@ spec:
             requests:
               cpu: 1m
               memory: 150Mi
+          securityContext:
+            allowPrivilegeEscalation: false
           volumeMounts:
             - mountPath: /config
               name: config
@@ -8649,6 +8657,8 @@ spec:
             requests:
               cpu: 1m
               memory: 150Mi
+          securityContext:
+            allowPrivilegeEscalation: false
           volumeMounts:
             - mountPath: /config
               name: config
@@ -8673,6 +8683,7 @@ spec:
               cpu: 1m
               memory: 30Mi
           securityContext:
+            allowPrivilegeEscalation: false
             runAsGroup: 65532
             runAsNonRoot: true
             runAsUser: 65532
@@ -8824,6 +8835,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -8944,6 +8956,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -9033,6 +9046,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
       dnsPolicy: ClusterFirst
       enableServiceLinks: false
@@ -9179,6 +9193,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -9219,6 +9234,7 @@ spec:
         name: database-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       restartPolicy: Always
@@ -9308,6 +9324,7 @@ spec:
             cpu: 100m
             memory: 128Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /config
@@ -9332,6 +9349,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -9421,6 +9439,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
       dnsPolicy: ClusterFirst
       enableServiceLinks: false
@@ -9508,6 +9527,7 @@ spec:
             cpu: 100m
             memory: 128Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /config
@@ -9535,6 +9555,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -9627,6 +9648,7 @@ spec:
             cpu: 100m
             memory: 200Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 33333
         volumeMounts:
@@ -9658,6 +9680,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -9921,6 +9944,7 @@ spec:
             cpu: 100m
             memory: 200Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /etc/caddy/vhosts
@@ -10079,6 +10103,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /config.json
@@ -10104,6 +10129,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -10144,6 +10170,7 @@ spec:
         name: database-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       restartPolicy: Always
@@ -10387,6 +10414,7 @@ spec:
             cpu: 200m
             memory: 200Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
         volumeMounts:
@@ -10421,6 +10449,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -10460,6 +10489,7 @@ spec:
         name: database-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       - args:
@@ -10495,6 +10525,7 @@ spec:
         name: msgbus-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       priorityClassName: system-node-critical
@@ -10591,6 +10622,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /config
@@ -10624,6 +10656,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -10770,6 +10803,7 @@ spec:
             cpu: 100m
             memory: 64Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
         volumeMounts:
@@ -10798,6 +10832,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -10838,6 +10873,7 @@ spec:
         name: database-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       - args:
@@ -10873,6 +10909,7 @@ spec:
         name: msgbus-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       priorityClassName: system-node-critical
@@ -10981,6 +11018,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /config
@@ -11010,6 +11048,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -11118,6 +11157,8 @@ spec:
         imagePullPolicy: IfNotPresent
         name: migrations
         resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
       enableServiceLinks: false
       initContainers:
       - args:
@@ -11153,6 +11194,7 @@ spec:
         name: database-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       restartPolicy: Never
@@ -11205,6 +11247,8 @@ spec:
             imagePullPolicy: IfNotPresent
             name: gitpod-telemetry
             resources: {}
+            securityContext:
+              allowPrivilegeEscalation: false
           enableServiceLinks: false
           initContainers:
           - args:
@@ -11240,6 +11284,7 @@ spec:
             name: database-waiter
             resources: {}
             securityContext:
+              allowPrivilegeEscalation: false
               privileged: false
               runAsUser: 31001
           restartPolicy: OnFailure

--- a/install/installer/cmd/testdata/render/shortname/output.golden
+++ b/install/installer/cmd/testdata/render/shortname/output.golden
@@ -7702,6 +7702,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -7817,6 +7818,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 1000
         volumeMounts:
@@ -7852,6 +7854,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -8063,6 +8066,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -8087,6 +8091,8 @@ spec:
               - --shutdown
         name: node-labeler
         resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
       dnsPolicy: ClusterFirst
       enableServiceLinks: false
       hostPID: true
@@ -8631,6 +8637,8 @@ spec:
             requests:
               cpu: 1m
               memory: 150Mi
+          securityContext:
+            allowPrivilegeEscalation: false
           volumeMounts:
             - mountPath: /config
               name: config
@@ -8649,6 +8657,8 @@ spec:
             requests:
               cpu: 1m
               memory: 150Mi
+          securityContext:
+            allowPrivilegeEscalation: false
           volumeMounts:
             - mountPath: /config
               name: config
@@ -8673,6 +8683,7 @@ spec:
               cpu: 1m
               memory: 30Mi
           securityContext:
+            allowPrivilegeEscalation: false
             runAsGroup: 65532
             runAsNonRoot: true
             runAsUser: 65532
@@ -8824,6 +8835,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -8944,6 +8956,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -9033,6 +9046,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
       dnsPolicy: ClusterFirst
       enableServiceLinks: false
@@ -9179,6 +9193,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -9219,6 +9234,7 @@ spec:
         name: database-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       restartPolicy: Always
@@ -9308,6 +9324,7 @@ spec:
             cpu: 100m
             memory: 128Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /config
@@ -9332,6 +9349,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -9421,6 +9439,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
       dnsPolicy: ClusterFirst
       enableServiceLinks: false
@@ -9508,6 +9527,7 @@ spec:
             cpu: 100m
             memory: 128Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /config
@@ -9535,6 +9555,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -9627,6 +9648,7 @@ spec:
             cpu: 100m
             memory: 200Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 33333
         volumeMounts:
@@ -9658,6 +9680,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -9921,6 +9944,7 @@ spec:
             cpu: 100m
             memory: 200Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /etc/caddy/vhosts
@@ -10079,6 +10103,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /config.json
@@ -10104,6 +10129,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -10144,6 +10170,7 @@ spec:
         name: database-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       restartPolicy: Always
@@ -10387,6 +10414,7 @@ spec:
             cpu: 200m
             memory: 200Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
         volumeMounts:
@@ -10421,6 +10449,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -10460,6 +10489,7 @@ spec:
         name: database-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       - args:
@@ -10495,6 +10525,7 @@ spec:
         name: msgbus-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       priorityClassName: system-node-critical
@@ -10591,6 +10622,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /config
@@ -10624,6 +10656,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -10770,6 +10803,7 @@ spec:
             cpu: 100m
             memory: 64Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
         volumeMounts:
@@ -10798,6 +10832,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -10838,6 +10873,7 @@ spec:
         name: database-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       - args:
@@ -10873,6 +10909,7 @@ spec:
         name: msgbus-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       priorityClassName: system-node-critical
@@ -10981,6 +11018,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /config
@@ -11010,6 +11048,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -11118,6 +11157,8 @@ spec:
         imagePullPolicy: IfNotPresent
         name: migrations
         resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
       enableServiceLinks: false
       initContainers:
       - args:
@@ -11153,6 +11194,7 @@ spec:
         name: database-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       restartPolicy: Never
@@ -11205,6 +11247,8 @@ spec:
             imagePullPolicy: IfNotPresent
             name: gitpod-telemetry
             resources: {}
+            securityContext:
+              allowPrivilegeEscalation: false
           enableServiceLinks: false
           initContainers:
           - args:
@@ -11240,6 +11284,7 @@ spec:
             name: database-waiter
             resources: {}
             securityContext:
+              allowPrivilegeEscalation: false
               privileged: false
               runAsUser: 31001
           restartPolicy: OnFailure

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -7714,6 +7714,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -7829,6 +7830,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 1000
         volumeMounts:
@@ -7864,6 +7866,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -8075,6 +8078,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -8099,6 +8103,8 @@ spec:
               - --shutdown
         name: node-labeler
         resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
       dnsPolicy: ClusterFirst
       enableServiceLinks: false
       hostPID: true
@@ -8643,6 +8649,8 @@ spec:
             requests:
               cpu: 1m
               memory: 150Mi
+          securityContext:
+            allowPrivilegeEscalation: false
           volumeMounts:
             - mountPath: /config
               name: config
@@ -8661,6 +8669,8 @@ spec:
             requests:
               cpu: 1m
               memory: 150Mi
+          securityContext:
+            allowPrivilegeEscalation: false
           volumeMounts:
             - mountPath: /config
               name: config
@@ -8685,6 +8695,7 @@ spec:
               cpu: 1m
               memory: 30Mi
           securityContext:
+            allowPrivilegeEscalation: false
             runAsGroup: 65532
             runAsNonRoot: true
             runAsUser: 65532
@@ -8836,6 +8847,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -8956,6 +8968,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -9045,6 +9058,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
       dnsPolicy: ClusterFirst
       enableServiceLinks: false
@@ -9191,6 +9205,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -9231,6 +9246,7 @@ spec:
         name: database-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       restartPolicy: Always
@@ -9320,6 +9336,7 @@ spec:
             cpu: 100m
             memory: 128Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /config
@@ -9344,6 +9361,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -9433,6 +9451,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
       dnsPolicy: ClusterFirst
       enableServiceLinks: false
@@ -9520,6 +9539,7 @@ spec:
             cpu: 100m
             memory: 128Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /config
@@ -9547,6 +9567,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -9639,6 +9660,7 @@ spec:
             cpu: 100m
             memory: 200Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 33333
         volumeMounts:
@@ -9670,6 +9692,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -9933,6 +9956,7 @@ spec:
             cpu: 100m
             memory: 200Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /etc/caddy/vhosts
@@ -10091,6 +10115,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /config.json
@@ -10116,6 +10141,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -10156,6 +10182,7 @@ spec:
         name: database-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       restartPolicy: Always
@@ -10399,6 +10426,7 @@ spec:
             cpu: 200m
             memory: 200Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
         volumeMounts:
@@ -10433,6 +10461,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -10472,6 +10501,7 @@ spec:
         name: database-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       - args:
@@ -10507,6 +10537,7 @@ spec:
         name: msgbus-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       priorityClassName: system-node-critical
@@ -10603,6 +10634,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /config
@@ -10636,6 +10668,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -10782,6 +10815,7 @@ spec:
             cpu: 100m
             memory: 64Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
         volumeMounts:
@@ -10810,6 +10844,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -10850,6 +10885,7 @@ spec:
         name: database-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       - args:
@@ -10885,6 +10921,7 @@ spec:
         name: msgbus-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       priorityClassName: system-node-critical
@@ -10993,6 +11030,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /config
@@ -11022,6 +11060,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -11130,6 +11169,8 @@ spec:
         imagePullPolicy: IfNotPresent
         name: migrations
         resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
       enableServiceLinks: false
       initContainers:
       - args:
@@ -11165,6 +11206,7 @@ spec:
         name: database-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       restartPolicy: Never
@@ -11217,6 +11259,8 @@ spec:
             imagePullPolicy: IfNotPresent
             name: gitpod-telemetry
             resources: {}
+            securityContext:
+              allowPrivilegeEscalation: false
           enableServiceLinks: false
           initContainers:
           - args:
@@ -11252,6 +11296,7 @@ spec:
             name: database-waiter
             resources: {}
             securityContext:
+              allowPrivilegeEscalation: false
               privileged: false
               runAsUser: 31001
           restartPolicy: OnFailure

--- a/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
+++ b/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
@@ -8146,6 +8146,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -8261,6 +8262,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 1000
         volumeMounts:
@@ -8296,6 +8298,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -8507,6 +8510,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -8531,6 +8535,8 @@ spec:
               - --shutdown
         name: node-labeler
         resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
       dnsPolicy: ClusterFirst
       enableServiceLinks: false
       hostPID: true
@@ -9075,6 +9081,8 @@ spec:
             requests:
               cpu: 1m
               memory: 150Mi
+          securityContext:
+            allowPrivilegeEscalation: false
           volumeMounts:
             - mountPath: /config
               name: config
@@ -9093,6 +9101,8 @@ spec:
             requests:
               cpu: 1m
               memory: 150Mi
+          securityContext:
+            allowPrivilegeEscalation: false
           volumeMounts:
             - mountPath: /config
               name: config
@@ -9117,6 +9127,7 @@ spec:
               cpu: 1m
               memory: 30Mi
           securityContext:
+            allowPrivilegeEscalation: false
             runAsGroup: 65532
             runAsNonRoot: true
             runAsUser: 65532
@@ -9268,6 +9279,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -9388,6 +9400,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -9477,6 +9490,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
       dnsPolicy: ClusterFirst
       enableServiceLinks: false
@@ -9623,6 +9637,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -9663,6 +9678,7 @@ spec:
         name: database-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       restartPolicy: Always
@@ -9752,6 +9768,7 @@ spec:
             cpu: 100m
             memory: 128Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /config
@@ -9776,6 +9793,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -9865,6 +9883,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
       dnsPolicy: ClusterFirst
       enableServiceLinks: false
@@ -9952,6 +9971,7 @@ spec:
             cpu: 100m
             memory: 128Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /config
@@ -9979,6 +9999,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -10071,6 +10092,7 @@ spec:
             cpu: 100m
             memory: 200Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 33333
         volumeMounts:
@@ -10102,6 +10124,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -10365,6 +10388,7 @@ spec:
             cpu: 100m
             memory: 200Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /etc/caddy/vhosts
@@ -10523,6 +10547,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /config.json
@@ -10548,6 +10573,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -10588,6 +10614,7 @@ spec:
         name: database-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       restartPolicy: Always
@@ -10831,6 +10858,7 @@ spec:
             cpu: 200m
             memory: 200Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
         volumeMounts:
@@ -10865,6 +10893,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -10904,6 +10933,7 @@ spec:
         name: database-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       - args:
@@ -10939,6 +10969,7 @@ spec:
         name: msgbus-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       priorityClassName: system-node-critical
@@ -11035,6 +11066,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /config
@@ -11068,6 +11100,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -11214,6 +11247,7 @@ spec:
             cpu: 100m
             memory: 64Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
         volumeMounts:
@@ -11242,6 +11276,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -11282,6 +11317,7 @@ spec:
         name: database-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       - args:
@@ -11317,6 +11353,7 @@ spec:
         name: msgbus-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       priorityClassName: system-node-critical
@@ -11425,6 +11462,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /config
@@ -11454,6 +11492,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -11562,6 +11601,8 @@ spec:
         imagePullPolicy: IfNotPresent
         name: migrations
         resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
       enableServiceLinks: false
       initContainers:
       - args:
@@ -11597,6 +11638,7 @@ spec:
         name: database-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       restartPolicy: Never
@@ -11649,6 +11691,8 @@ spec:
             imagePullPolicy: IfNotPresent
             name: gitpod-telemetry
             resources: {}
+            securityContext:
+              allowPrivilegeEscalation: false
           enableServiceLinks: false
           initContainers:
           - args:
@@ -11684,6 +11728,7 @@ spec:
             name: database-waiter
             resources: {}
             securityContext:
+              allowPrivilegeEscalation: false
               privileged: false
               runAsUser: 31001
           restartPolicy: OnFailure

--- a/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
+++ b/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
@@ -7704,6 +7704,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -7819,6 +7820,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 1000
         volumeMounts:
@@ -7854,6 +7856,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -8065,6 +8068,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -8089,6 +8093,8 @@ spec:
               - --shutdown
         name: node-labeler
         resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
       dnsPolicy: ClusterFirst
       enableServiceLinks: false
       hostPID: true
@@ -8633,6 +8639,8 @@ spec:
             requests:
               cpu: 1m
               memory: 150Mi
+          securityContext:
+            allowPrivilegeEscalation: false
           volumeMounts:
             - mountPath: /config
               name: config
@@ -8651,6 +8659,8 @@ spec:
             requests:
               cpu: 1m
               memory: 150Mi
+          securityContext:
+            allowPrivilegeEscalation: false
           volumeMounts:
             - mountPath: /config
               name: config
@@ -8675,6 +8685,7 @@ spec:
               cpu: 1m
               memory: 30Mi
           securityContext:
+            allowPrivilegeEscalation: false
             runAsGroup: 65532
             runAsNonRoot: true
             runAsUser: 65532
@@ -8814,6 +8825,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -8934,6 +8946,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -9023,6 +9036,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
       dnsPolicy: ClusterFirst
       enableServiceLinks: false
@@ -9169,6 +9183,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -9209,6 +9224,7 @@ spec:
         name: database-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       restartPolicy: Always
@@ -9298,6 +9314,7 @@ spec:
             cpu: 100m
             memory: 128Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /config
@@ -9322,6 +9339,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -9411,6 +9429,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
       dnsPolicy: ClusterFirst
       enableServiceLinks: false
@@ -9498,6 +9517,7 @@ spec:
             cpu: 100m
             memory: 128Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /config
@@ -9525,6 +9545,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -9617,6 +9638,7 @@ spec:
             cpu: 100m
             memory: 200Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 33333
         volumeMounts:
@@ -9648,6 +9670,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -9911,6 +9934,7 @@ spec:
             cpu: 100m
             memory: 200Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /etc/caddy/vhosts
@@ -10069,6 +10093,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /config.json
@@ -10094,6 +10119,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -10134,6 +10160,7 @@ spec:
         name: database-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       restartPolicy: Always
@@ -10377,6 +10404,7 @@ spec:
             cpu: 200m
             memory: 200Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
         volumeMounts:
@@ -10411,6 +10439,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -10450,6 +10479,7 @@ spec:
         name: database-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       - args:
@@ -10485,6 +10515,7 @@ spec:
         name: msgbus-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       priorityClassName: system-node-critical
@@ -10581,6 +10612,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /config
@@ -10614,6 +10646,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -10760,6 +10793,7 @@ spec:
             cpu: 100m
             memory: 64Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
         volumeMounts:
@@ -10788,6 +10822,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -10828,6 +10863,7 @@ spec:
         name: database-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       - args:
@@ -10863,6 +10899,7 @@ spec:
         name: msgbus-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       priorityClassName: system-node-critical
@@ -10971,6 +11008,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /config
@@ -11000,6 +11038,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -11108,6 +11147,8 @@ spec:
         imagePullPolicy: IfNotPresent
         name: migrations
         resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
       enableServiceLinks: false
       initContainers:
       - args:
@@ -11143,6 +11184,7 @@ spec:
         name: database-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       restartPolicy: Never
@@ -11195,6 +11237,8 @@ spec:
             imagePullPolicy: IfNotPresent
             name: gitpod-telemetry
             resources: {}
+            securityContext:
+              allowPrivilegeEscalation: false
           enableServiceLinks: false
           initContainers:
           - args:
@@ -11230,6 +11274,7 @@ spec:
             name: database-waiter
             resources: {}
             securityContext:
+              allowPrivilegeEscalation: false
               privileged: false
               runAsUser: 31001
           restartPolicy: OnFailure

--- a/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
+++ b/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
@@ -7705,6 +7705,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -7820,6 +7821,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 1000
         volumeMounts:
@@ -7855,6 +7857,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -8066,6 +8069,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -8090,6 +8094,8 @@ spec:
               - --shutdown
         name: node-labeler
         resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
       dnsPolicy: ClusterFirst
       enableServiceLinks: false
       hostPID: true
@@ -8634,6 +8640,8 @@ spec:
             requests:
               cpu: 1m
               memory: 150Mi
+          securityContext:
+            allowPrivilegeEscalation: false
           volumeMounts:
             - mountPath: /config
               name: config
@@ -8652,6 +8660,8 @@ spec:
             requests:
               cpu: 1m
               memory: 150Mi
+          securityContext:
+            allowPrivilegeEscalation: false
           volumeMounts:
             - mountPath: /config
               name: config
@@ -8676,6 +8686,7 @@ spec:
               cpu: 1m
               memory: 30Mi
           securityContext:
+            allowPrivilegeEscalation: false
             runAsGroup: 65532
             runAsNonRoot: true
             runAsUser: 65532
@@ -8827,6 +8838,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -8947,6 +8959,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -9036,6 +9049,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
       dnsPolicy: ClusterFirst
       enableServiceLinks: false
@@ -9182,6 +9196,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -9222,6 +9237,7 @@ spec:
         name: database-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       restartPolicy: Always
@@ -9311,6 +9327,7 @@ spec:
             cpu: 100m
             memory: 128Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /config
@@ -9335,6 +9352,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -9424,6 +9442,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
       dnsPolicy: ClusterFirst
       enableServiceLinks: false
@@ -9511,6 +9530,7 @@ spec:
             cpu: 100m
             memory: 128Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /config
@@ -9538,6 +9558,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -9630,6 +9651,7 @@ spec:
             cpu: 100m
             memory: 200Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 33333
         volumeMounts:
@@ -9661,6 +9683,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -9924,6 +9947,7 @@ spec:
             cpu: 100m
             memory: 200Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /etc/caddy/vhosts
@@ -10082,6 +10106,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /config.json
@@ -10107,6 +10132,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -10147,6 +10173,7 @@ spec:
         name: database-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       restartPolicy: Always
@@ -10390,6 +10417,7 @@ spec:
             cpu: 200m
             memory: 200Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
         volumeMounts:
@@ -10424,6 +10452,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -10463,6 +10492,7 @@ spec:
         name: database-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       - args:
@@ -10498,6 +10528,7 @@ spec:
         name: msgbus-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       priorityClassName: system-node-critical
@@ -10594,6 +10625,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /config
@@ -10627,6 +10659,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -10773,6 +10806,7 @@ spec:
             cpu: 100m
             memory: 64Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
         volumeMounts:
@@ -10801,6 +10835,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -10841,6 +10876,7 @@ spec:
         name: database-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       - args:
@@ -10876,6 +10912,7 @@ spec:
         name: msgbus-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       priorityClassName: system-node-critical
@@ -10984,6 +11021,7 @@ spec:
             cpu: 100m
             memory: 32Mi
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
         volumeMounts:
         - mountPath: /config
@@ -11013,6 +11051,7 @@ spec:
             cpu: 1m
             memory: 30Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -11121,6 +11160,8 @@ spec:
         imagePullPolicy: IfNotPresent
         name: migrations
         resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
       enableServiceLinks: false
       initContainers:
       - args:
@@ -11156,6 +11197,7 @@ spec:
         name: database-waiter
         resources: {}
         securityContext:
+          allowPrivilegeEscalation: false
           privileged: false
           runAsUser: 31001
       restartPolicy: Never
@@ -11208,6 +11250,8 @@ spec:
             imagePullPolicy: IfNotPresent
             name: gitpod-telemetry
             resources: {}
+            securityContext:
+              allowPrivilegeEscalation: false
           enableServiceLinks: false
           initContainers:
           - args:
@@ -11243,6 +11287,7 @@ spec:
             name: database-waiter
             resources: {}
             securityContext:
+              allowPrivilegeEscalation: false
               privileged: false
               runAsUser: 31001
           restartPolicy: OnFailure

--- a/install/installer/pkg/common/common.go
+++ b/install/installer/pkg/common/common.go
@@ -414,8 +414,9 @@ func DatabaseWaiterContainer(ctx *RenderContext) *corev1.Container {
 			"database",
 		},
 		SecurityContext: &corev1.SecurityContext{
-			Privileged: pointer.Bool(false),
-			RunAsUser:  pointer.Int64(31001),
+			Privileged:               pointer.Bool(false),
+			AllowPrivilegeEscalation: pointer.Bool(false),
+			RunAsUser:                pointer.Int64(31001),
 		},
 		Env: MergeEnv(
 			DatabaseEnv(&ctx.Config),
@@ -433,8 +434,9 @@ func MessageBusWaiterContainer(ctx *RenderContext) *corev1.Container {
 			"messagebus",
 		},
 		SecurityContext: &corev1.SecurityContext{
-			Privileged: pointer.Bool(false),
-			RunAsUser:  pointer.Int64(31001),
+			Privileged:               pointer.Bool(false),
+			AllowPrivilegeEscalation: pointer.Bool(false),
+			RunAsUser:                pointer.Int64(31001),
 		},
 		Env: MergeEnv(
 			MessageBusEnv(&ctx.Config),
@@ -478,9 +480,10 @@ func KubeRBACProxyContainerWithConfig(ctx *RenderContext) *corev1.Container {
 		}},
 		TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 		SecurityContext: &corev1.SecurityContext{
-			RunAsUser:    pointer.Int64(65532),
-			RunAsGroup:   pointer.Int64(65532),
-			RunAsNonRoot: pointer.Bool(true),
+			AllowPrivilegeEscalation: pointer.Bool(false),
+			RunAsUser:                pointer.Int64(65532),
+			RunAsGroup:               pointer.Int64(65532),
+			RunAsNonRoot:             pointer.Bool(true),
 		},
 	}
 }

--- a/install/installer/pkg/components/dashboard/deployment.go
+++ b/install/installer/pkg/components/dashboard/deployment.go
@@ -62,7 +62,8 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 								Name:          PortName,
 							}},
 							SecurityContext: &corev1.SecurityContext{
-								Privileged: pointer.Bool(false),
+								Privileged:               pointer.Bool(false),
+								AllowPrivilegeEscalation: pointer.Bool(false),
 							},
 							Env: common.CustomizeEnvvar(ctx, Component, common.MergeEnv(
 								common.DefaultEnv(&ctx.Config),

--- a/install/installer/pkg/components/database/cloudsql/deployment.go
+++ b/install/installer/pkg/components/database/cloudsql/deployment.go
@@ -67,8 +67,9 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 						Containers: []corev1.Container{{
 							Name: "cloud-sql-proxy",
 							SecurityContext: &corev1.SecurityContext{
-								Privileged:   pointer.Bool(false),
-								RunAsNonRoot: pointer.Bool(false),
+								Privileged:               pointer.Bool(false),
+								RunAsNonRoot:             pointer.Bool(false),
+								AllowPrivilegeEscalation: pointer.Bool(false),
 							},
 							Image: ctx.ImageName(ImageRepo, ImageName, ImageVersion),
 							Command: []string{

--- a/install/installer/pkg/components/database/init/job.go
+++ b/install/installer/pkg/components/database/init/job.go
@@ -58,6 +58,9 @@ func job(ctx *common.RenderContext) ([]runtime.Object, error) {
 						Env: common.MergeEnv(
 							common.DatabaseEnv(&ctx.Config),
 						),
+						SecurityContext: &corev1.SecurityContext{
+							AllowPrivilegeEscalation: pointer.Bool(false),
+						},
 						Command: []string{
 							"sh",
 							"-c",

--- a/install/installer/pkg/components/gitpod/cronjob.go
+++ b/install/installer/pkg/components/gitpod/cronjob.go
@@ -68,6 +68,9 @@ func cronjob(ctx *common.RenderContext) ([]runtime.Object, error) {
 										Args: []string{
 											"send",
 										},
+										SecurityContext: &v1.SecurityContext{
+											AllowPrivilegeEscalation: pointer.Bool(false),
+										},
 										Env: []v1.EnvVar{
 											{
 												Name:  "GITPOD_INSTALLATION_VERSION",

--- a/install/installer/pkg/components/ide-metrics/deployment.go
+++ b/install/installer/pkg/components/ide-metrics/deployment.go
@@ -108,7 +108,8 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 								Name:          PortName,
 							}},
 							SecurityContext: &corev1.SecurityContext{
-								Privileged: pointer.Bool(false),
+								Privileged:               pointer.Bool(false),
+								AllowPrivilegeEscalation: pointer.Bool(false),
 							},
 							Env:          env,
 							VolumeMounts: volumeMounts,

--- a/install/installer/pkg/components/ide-proxy/deployment.go
+++ b/install/installer/pkg/components/ide-proxy/deployment.go
@@ -62,7 +62,8 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 								Name:          PortName,
 							}},
 							SecurityContext: &corev1.SecurityContext{
-								Privileged: pointer.Bool(false),
+								Privileged:               pointer.Bool(false),
+								AllowPrivilegeEscalation: pointer.Bool(false),
 							},
 							Env: common.CustomizeEnvvar(ctx, Component, common.MergeEnv(
 								common.DefaultEnv(&ctx.Config),

--- a/install/installer/pkg/components/ide-service/deployment.go
+++ b/install/installer/pkg/components/ide-service/deployment.go
@@ -73,7 +73,8 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 								Name:          GRPCPortName,
 							}},
 							SecurityContext: &corev1.SecurityContext{
-								Privileged: pointer.Bool(false),
+								Privileged:               pointer.Bool(false),
+								AllowPrivilegeEscalation: pointer.Bool(false),
 							},
 							Env: common.CustomizeEnvvar(ctx, Component, common.MergeEnv(
 								common.DefaultEnv(&ctx.Config),

--- a/install/installer/pkg/components/image-builder-mk3/deployment.go
+++ b/install/installer/pkg/components/image-builder-mk3/deployment.go
@@ -167,8 +167,9 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 							Name:          RPCPortName,
 						}},
 						SecurityContext: &corev1.SecurityContext{
-							Privileged: pointer.Bool(false),
-							RunAsUser:  pointer.Int64(33333),
+							Privileged:               pointer.Bool(false),
+							AllowPrivilegeEscalation: pointer.Bool(false),
+							RunAsUser:                pointer.Int64(33333),
 						},
 						VolumeMounts: volumeMounts,
 					},

--- a/install/installer/pkg/components/migrations/job.go
+++ b/install/installer/pkg/components/migrations/job.go
@@ -48,6 +48,9 @@ func job(ctx *common.RenderContext) ([]runtime.Object, error) {
 							common.DatabaseEnv(&ctx.Config),
 							common.DefaultEnv(&ctx.Config),
 						)),
+						SecurityContext: &corev1.SecurityContext{
+							AllowPrivilegeEscalation: pointer.Bool(false),
+						},
 						Command: []string{
 							"sh",
 							"-c",

--- a/install/installer/pkg/components/openvsx-proxy/statefulset.go
+++ b/install/installer/pkg/components/openvsx-proxy/statefulset.go
@@ -112,6 +112,9 @@ func statefulset(ctx *common.RenderContext) ([]runtime.Object, error) {
 								},
 							},
 						},
+						SecurityContext: &v1.SecurityContext{
+							AllowPrivilegeEscalation: pointer.Bool(false),
+						},
 						ImagePullPolicy: v1.PullIfNotPresent,
 						Resources: common.ResourceRequirements(ctx, Component, Component, v1.ResourceRequirements{
 							Requests: v1.ResourceList{
@@ -149,6 +152,9 @@ func statefulset(ctx *common.RenderContext) ([]runtime.Object, error) {
 						Ports: []v1.ContainerPort{{
 							ContainerPort: 6379,
 						}},
+						SecurityContext: &v1.SecurityContext{
+							AllowPrivilegeEscalation: pointer.Bool(false),
+						},
 						Resources: common.ResourceRequirements(ctx, Component, redisContainerName, v1.ResourceRequirements{
 							Requests: v1.ResourceList{
 								"cpu":    resource.MustParse("1m"),

--- a/install/installer/pkg/components/proxy/deployment.go
+++ b/install/installer/pkg/components/proxy/deployment.go
@@ -156,6 +156,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 						RestartPolicy:                 "Always",
 						TerminationGracePeriodSeconds: pointer.Int64(30),
 						SecurityContext: &corev1.PodSecurityContext{
+
 							RunAsNonRoot: pointer.Bool(false),
 						},
 						Volumes: volumes,
@@ -228,7 +229,8 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 								Protocol:      *common.TCPProtocol,
 							}, prometheusPort},
 							SecurityContext: &corev1.SecurityContext{
-								Privileged: pointer.Bool(false),
+								Privileged:               pointer.Bool(false),
+								AllowPrivilegeEscalation: pointer.Bool(false),
 							},
 							ReadinessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{

--- a/install/installer/pkg/components/public-api-server/deployment.go
+++ b/install/installer/pkg/components/public-api-server/deployment.go
@@ -131,7 +131,8 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 									},
 								},
 								SecurityContext: &corev1.SecurityContext{
-									Privileged: pointer.Bool(false),
+									Privileged:               pointer.Bool(false),
+									AllowPrivilegeEscalation: pointer.Bool(false),
 								},
 								Env: common.CustomizeEnvvar(ctx, Component, common.MergeEnv(
 									common.DefaultEnv(&ctx.Config),

--- a/install/installer/pkg/components/registry-facade/daemonset.go
+++ b/install/installer/pkg/components/registry-facade/daemonset.go
@@ -230,8 +230,9 @@ func daemonset(ctx *common.RenderContext) ([]runtime.Object, error) {
 							HostPort:      ServicePort,
 						}},
 						SecurityContext: &corev1.SecurityContext{
-							Privileged: pointer.Bool(false),
-							RunAsUser:  pointer.Int64(1000),
+							Privileged:               pointer.Bool(false),
+							AllowPrivilegeEscalation: pointer.Bool(false),
+							RunAsUser:                pointer.Int64(1000),
 						},
 						Env: common.CustomizeEnvvar(ctx, Component, common.MergeEnv(
 							common.DefaultEnv(&ctx.Config),

--- a/install/installer/pkg/components/server/deployment.go
+++ b/install/installer/pkg/components/server/deployment.go
@@ -391,8 +391,9 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 								FailureThreshold:    6,
 							},
 							SecurityContext: &corev1.SecurityContext{
-								Privileged: pointer.Bool(false),
-								RunAsUser:  pointer.Int64(31001),
+								Privileged:               pointer.Bool(false),
+								AllowPrivilegeEscalation: pointer.Bool(false),
+								RunAsUser:                pointer.Int64(31001),
 							},
 							Ports: []corev1.ContainerPort{{
 								Name:          ContainerPortName,

--- a/install/installer/pkg/components/slowserver/deployment.go
+++ b/install/installer/pkg/components/slowserver/deployment.go
@@ -411,8 +411,9 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 								FailureThreshold:    6,
 							},
 							SecurityContext: &corev1.SecurityContext{
-								Privileged: pointer.Bool(false),
-								RunAsUser:  pointer.Int64(31001),
+								Privileged:               pointer.Bool(false),
+								AllowPrivilegeEscalation: pointer.Bool(false),
+								RunAsUser:                pointer.Int64(31001),
 							},
 							Ports: []corev1.ContainerPort{{
 								Name:          ContainerPortName,

--- a/install/installer/pkg/components/toxiproxy/deployment.go
+++ b/install/installer/pkg/components/toxiproxy/deployment.go
@@ -99,7 +99,8 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 								ContainerPort: HttpContainerPort,
 							}},
 							SecurityContext: &corev1.SecurityContext{
-								Privileged: pointer.Bool(false),
+								Privileged:               pointer.Bool(false),
+								AllowPrivilegeEscalation: pointer.Bool(false),
 							},
 							Env:          common.CustomizeEnvvar(ctx, Component, common.MergeEnv(common.DefaultEnv(&ctx.Config))),
 							VolumeMounts: volumeMounts,
@@ -114,6 +115,9 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 								"--latency=280",
 								"--jitter=25",
 								"--wait=true",
+							},
+							SecurityContext: &corev1.SecurityContext{
+								AllowPrivilegeEscalation: pointer.Bool(false),
 							},
 						},
 							*common.KubeRBACProxyContainerWithConfig(ctx),

--- a/install/installer/pkg/components/usage/deployment.go
+++ b/install/installer/pkg/components/usage/deployment.go
@@ -114,7 +114,8 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 							}),
 							Ports: []corev1.ContainerPort{},
 							SecurityContext: &corev1.SecurityContext{
-								Privileged: pointer.Bool(false),
+								Privileged:               pointer.Bool(false),
+								AllowPrivilegeEscalation: pointer.Bool(false),
 							},
 							Env: common.CustomizeEnvvar(ctx, Component, common.MergeEnv(
 								common.DefaultEnv(&ctx.Config),

--- a/install/installer/pkg/components/ws-daemon/daemonset.go
+++ b/install/installer/pkg/components/ws-daemon/daemonset.go
@@ -290,6 +290,9 @@ fi
 					common.ProxyEnv(&ctx.Config),
 				)),
 				ImagePullPolicy: corev1.PullIfNotPresent,
+				SecurityContext: &corev1.SecurityContext{
+					AllowPrivilegeEscalation: pointer.Bool(false),
+				},
 				Lifecycle: &corev1.Lifecycle{
 					PreStop: &corev1.LifecycleHandler{
 						Exec: &corev1.ExecAction{

--- a/install/installer/pkg/components/ws-manager-bridge/deployment.go
+++ b/install/installer/pkg/components/ws-manager-bridge/deployment.go
@@ -122,8 +122,9 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 								},
 							}),
 							SecurityContext: &corev1.SecurityContext{
-								Privileged: pointer.Bool(false),
-								RunAsUser:  pointer.Int64(31001),
+								Privileged:               pointer.Bool(false),
+								RunAsUser:                pointer.Int64(31001),
+								AllowPrivilegeEscalation: pointer.Bool(false),
 							},
 							Env: common.CustomizeEnvvar(ctx, Component, common.MergeEnv(
 								common.DefaultEnv(&ctx.Config),

--- a/install/installer/pkg/components/ws-manager/deployment.go
+++ b/install/installer/pkg/components/ws-manager/deployment.go
@@ -50,7 +50,8 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 				},
 			},
 			SecurityContext: &corev1.SecurityContext{
-				Privileged: pointer.Bool(false),
+				Privileged:               pointer.Bool(false),
+				AllowPrivilegeEscalation: pointer.Bool(false),
 			},
 			Env: common.CustomizeEnvvar(ctx, Component, common.MergeEnv(
 				common.DefaultEnv(&ctx.Config),

--- a/install/installer/pkg/components/ws-proxy/deployment.go
+++ b/install/installer/pkg/components/ws-proxy/deployment.go
@@ -114,7 +114,8 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 				ContainerPort: baseserver.BuiltinMetricsPort,
 			}},
 			SecurityContext: &corev1.SecurityContext{
-				Privileged: pointer.Bool(false),
+				Privileged:               pointer.Bool(false),
+				AllowPrivilegeEscalation: pointer.Bool(false),
 			},
 			Env: common.CustomizeEnvvar(ctx, Component, common.MergeEnv(
 				common.DefaultEnv(&ctx.Config),


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This PR manually sets the `allowPrivilegeEscalation` container config to false where
we don't need extra capabilities. Though this **does not effect anything** yet, 
This is needed as not setting this explicitely could mean that it could still be `true`
based on some other settings.

This also helps us future proof on any behaviour changes around this.

This skips the following components as they need privilege access:
- `agent-smith` component container
- `ws-daemon` Component container
- `shiftfs` container

Signed-off-by: Tarun Pothulapati <tarun@gitpod.io>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of https://github.com/gitpod-io/security/issues/70

## How to test
<!-- Provide steps to test this PR -->

Tested that workspaces start correctly through [a preview environment](https://tar-disall94b71aa516.preview.gitpod-dev.com/workspaces)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[installer] manually set `allowPrivilegeEscalation` to false
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
