### PR TITLE
[dashboard] Use Public API when fetching team members

### DIFF
--- a/components/dashboard/src/teams/TeamSettings.tsx
+++ b/components/dashboard/src/teams/TeamSettings.tsx
@@ -11,7 +11,7 @@ import { Redirect, useLocation } from "react-router";
 import ConfirmationModal from "../components/ConfirmationModal";
 import { PageWithSubMenu } from "../components/PageWithSubMenu";
 import { FeatureFlagContext } from "../contexts/FeatureFlagContext";
-import { teamsService } from "../service/public-api";
+import { publicApiTeamMembersToProtocol, teamsService } from "../service/public-api";
 import { getGitpodService, gitpodHostUrl } from "../service/service";
 import { UserContext } from "../user-context";
 import { getCurrentTeam, TeamsContext } from "./teams-context";
@@ -51,7 +51,12 @@ export default function TeamSettings() {
     useEffect(() => {
         (async () => {
             if (!team) return;
-            const members = await getGitpodService().server.getTeamMembers(team.id);
+            const members = usePublicApiTeamsService
+                ? await publicApiTeamMembersToProtocol(
+                      (await teamsService.getTeam({ teamId: team!.id })).team?.members || [],
+                  )
+                : await getGitpodService().server.getTeamMembers(team.id);
+
             const currentUserInTeam = members.find((member) => member.userId === user?.id);
             setIsUserOwner(currentUserInTeam?.role === "owner");
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Fetches team members from Public API.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
Preview, load the following:
* New Project
* Team Settings
* Billing Account Selector
* UBP

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
