### PR TITLE
[usage] don't reset usage limit

### DIFF
--- a/components/gitpod-db/go/cost_center.go
+++ b/components/gitpod-db/go/cost_center.go
@@ -267,22 +267,6 @@ func (c *CostCenterManager) ResetUsage(ctx context.Context, cc CostCenter) (Cost
 		return CostCenter{}, fmt.Errorf("cannot reset usage for Billing Strategy %s for Cost Center ID: %s", cc.BillingStrategy, cc.ID)
 	}
 
-	entity, _ := cc.ID.Values()
-
-	// We do not carry over the spending limit from the existing CostCenter.
-	// At the moment, we don't have a use case for it. Getting the spending limit from configured values
-	// ensures that we progressively update the spending limit to configured values rather than having to
-	// perform bulk DB queries when the defaults do change.
-	var spendingLimit int32
-	switch entity {
-	case AttributionEntity_Team:
-		spendingLimit = c.cfg.ForTeams
-	case AttributionEntity_User:
-		spendingLimit = c.cfg.ForUsers
-	default:
-		return CostCenter{}, fmt.Errorf("cannot reset usage for unknown attribution entity ID: %s", cc.ID)
-	}
-
 	now := time.Now().UTC()
 
 	// Default to 1 month from now, if there's no nextBillingTime set on the record.
@@ -300,7 +284,7 @@ func (c *CostCenterManager) ResetUsage(ctx context.Context, cc CostCenter) (Cost
 	// All fields on the new cost center remain the same, except for BillingCycleStart, NextBillingTime, and CreationTime
 	newCostCenter := CostCenter{
 		ID:                cc.ID,
-		SpendingLimit:     spendingLimit,
+		SpendingLimit:     cc.SpendingLimit,
 		BillingStrategy:   cc.BillingStrategy,
 		BillingCycleStart: NewVarCharTime(now),
 		NextBillingTime:   NewVarCharTime(nextBillingTime),


### PR DESCRIPTION
## Description
We previously decided to always reset usage limit of cost centers to their configured defaults when running the free billing cycle renewal (billingStrategy: other). This was a simple way to clean up some legacy values in the DB.
This PR changes the code to keep whatever is configured, because we now can adjust the usage limit on these cost centers and don't want the usage component to revert those changes every month.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
