### PR TITLE
[code] switch download extension logic to vscode

### DIFF
--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -7,7 +7,7 @@ defaultArgs:
   publishToNPM: true
   publishToJBMarketplace: true
   localAppVersion: unknown
-  codeCommit: ceb45e4773645eb33a21902080ae4962a82e346f
+  codeCommit: 032f2b4b6d0686105c47a80ba72203dae8237a9c
   codeVersion: 1.73.1
   codeQuality: stable
   noVerifyJBPlugin: false

--- a/install/installer/cmd/testdata/render/aws-setup/output.golden
+++ b/install/installer/cmd/testdata/render/aws-setup/output.golden
@@ -3426,7 +3426,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-adf78e4cd7f0309b567a0c849bee9d473b37496a",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-7588b82c91ad977c97dbd51e64694981261c2aaf",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {
@@ -4899,7 +4899,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-adf78e4cd7f0309b567a0c849bee9d473b37496a",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-7588b82c91ad977c97dbd51e64694981261c2aaf",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/azure-setup/output.golden
+++ b/install/installer/cmd/testdata/render/azure-setup/output.golden
@@ -3343,7 +3343,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-adf78e4cd7f0309b567a0c849bee9d473b37496a",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-7588b82c91ad977c97dbd51e64694981261c2aaf",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {
@@ -4762,7 +4762,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-adf78e4cd7f0309b567a0c849bee9d473b37496a",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-7588b82c91ad977c97dbd51e64694981261c2aaf",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -4179,7 +4179,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-adf78e4cd7f0309b567a0c849bee9d473b37496a",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-7588b82c91ad977c97dbd51e64694981261c2aaf",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {
@@ -5743,7 +5743,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-adf78e4cd7f0309b567a0c849bee9d473b37496a",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-7588b82c91ad977c97dbd51e64694981261c2aaf",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -3484,7 +3484,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-adf78e4cd7f0309b567a0c849bee9d473b37496a",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-7588b82c91ad977c97dbd51e64694981261c2aaf",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {
@@ -4949,7 +4949,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-adf78e4cd7f0309b567a0c849bee9d473b37496a",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-7588b82c91ad977c97dbd51e64694981261c2aaf",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/gcp-setup/output.golden
+++ b/install/installer/cmd/testdata/render/gcp-setup/output.golden
@@ -3314,7 +3314,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-adf78e4cd7f0309b567a0c849bee9d473b37496a",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-7588b82c91ad977c97dbd51e64694981261c2aaf",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {
@@ -4723,7 +4723,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-adf78e4cd7f0309b567a0c849bee9d473b37496a",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-7588b82c91ad977c97dbd51e64694981261c2aaf",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/http-proxy/output.golden
+++ b/install/installer/cmd/testdata/render/http-proxy/output.golden
@@ -3653,7 +3653,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-adf78e4cd7f0309b567a0c849bee9d473b37496a",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-7588b82c91ad977c97dbd51e64694981261c2aaf",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {
@@ -5172,7 +5172,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-adf78e4cd7f0309b567a0c849bee9d473b37496a",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-7588b82c91ad977c97dbd51e64694981261c2aaf",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/insecure-s3-setup/output.golden
+++ b/install/installer/cmd/testdata/render/insecure-s3-setup/output.golden
@@ -3564,7 +3564,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-adf78e4cd7f0309b567a0c849bee9d473b37496a",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-7588b82c91ad977c97dbd51e64694981261c2aaf",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {
@@ -5083,7 +5083,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-adf78e4cd7f0309b567a0c849bee9d473b37496a",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-7588b82c91ad977c97dbd51e64694981261c2aaf",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/kind-ide/output.golden
+++ b/install/installer/cmd/testdata/render/kind-ide/output.golden
@@ -1273,7 +1273,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-adf78e4cd7f0309b567a0c849bee9d473b37496a",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-7588b82c91ad977c97dbd51e64694981261c2aaf",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {
@@ -2403,7 +2403,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-adf78e4cd7f0309b567a0c849bee9d473b37496a",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-7588b82c91ad977c97dbd51e64694981261c2aaf",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/kind-meta/output.golden
+++ b/install/installer/cmd/testdata/render/kind-meta/output.golden
@@ -2625,7 +2625,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-adf78e4cd7f0309b567a0c849bee9d473b37496a",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-7588b82c91ad977c97dbd51e64694981261c2aaf",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {
@@ -4049,7 +4049,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-adf78e4cd7f0309b567a0c849bee9d473b37496a",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-7588b82c91ad977c97dbd51e64694981261c2aaf",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -3650,7 +3650,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-adf78e4cd7f0309b567a0c849bee9d473b37496a",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-7588b82c91ad977c97dbd51e64694981261c2aaf",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {
@@ -5169,7 +5169,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-adf78e4cd7f0309b567a0c849bee9d473b37496a",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-7588b82c91ad977c97dbd51e64694981261c2aaf",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/shortname/output.golden
+++ b/install/installer/cmd/testdata/render/shortname/output.golden
@@ -3650,7 +3650,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-adf78e4cd7f0309b567a0c849bee9d473b37496a",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-7588b82c91ad977c97dbd51e64694981261c2aaf",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {
@@ -5169,7 +5169,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-adf78e4cd7f0309b567a0c849bee9d473b37496a",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-7588b82c91ad977c97dbd51e64694981261c2aaf",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -3662,7 +3662,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-adf78e4cd7f0309b567a0c849bee9d473b37496a",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-7588b82c91ad977c97dbd51e64694981261c2aaf",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {
@@ -5181,7 +5181,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-adf78e4cd7f0309b567a0c849bee9d473b37496a",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-7588b82c91ad977c97dbd51e64694981261c2aaf",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
+++ b/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
@@ -3983,7 +3983,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-adf78e4cd7f0309b567a0c849bee9d473b37496a",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-7588b82c91ad977c97dbd51e64694981261c2aaf",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {
@@ -5502,7 +5502,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-adf78e4cd7f0309b567a0c849bee9d473b37496a",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-7588b82c91ad977c97dbd51e64694981261c2aaf",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
+++ b/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
@@ -3652,7 +3652,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-adf78e4cd7f0309b567a0c849bee9d473b37496a",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-7588b82c91ad977c97dbd51e64694981261c2aaf",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {
@@ -5171,7 +5171,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-adf78e4cd7f0309b567a0c849bee9d473b37496a",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-7588b82c91ad977c97dbd51e64694981261c2aaf",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
+++ b/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
@@ -3653,7 +3653,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-adf78e4cd7f0309b567a0c849bee9d473b37496a",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-7588b82c91ad977c97dbd51e64694981261c2aaf",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {
@@ -5172,7 +5172,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-adf78e4cd7f0309b567a0c849bee9d473b37496a",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-7588b82c91ad977c97dbd51e64694981261c2aaf",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/pkg/components/workspace/ide/constants.go
+++ b/install/installer/pkg/components/workspace/ide/constants.go
@@ -6,7 +6,7 @@ package ide
 
 const (
 	CodeIDEImage                = "ide/code"
-	CodeIDEImageStableVersion   = "commit-adf78e4cd7f0309b567a0c849bee9d473b37496a" // stable version that will be updated manually on demand
+	CodeIDEImageStableVersion   = "commit-7588b82c91ad977c97dbd51e64694981261c2aaf" // stable version that will be updated manually on demand
 	CodeDesktopIDEImage         = "ide/code-desktop"
 	CodeDesktopInsidersIDEImage = "ide/code-desktop-insiders"
 	IntelliJDesktopIDEImage     = "ide/intellij"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
[code] switch download extension logic to vscode

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

Use https://github.com/iQQBot/test.test/tree/vsix repo start a workspace and restart extensions should be quickly available in both cases.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
