### PR TITLE
[server] Change response codes returned from `api/feature-flags/slow-database` endpoint

### DIFF
--- a/components/server/src/feature-flag/featureflag-controller.ts
+++ b/components/server/src/feature-flag/featureflag-controller.ts
@@ -24,6 +24,7 @@ export class FeatureFlagController {
     protected addSlowDatabaseFeatureFlagHandler(router: express.Router) {
         router.get("/slow-database", async (req, res) => {
             if (!User.is(req.user)) {
+                res.setHeader("X-Gitpod-Slow-Database", "false");
                 res.sendStatus(200);
                 return;
             }
@@ -37,6 +38,7 @@ export class FeatureFlagController {
                 res.end();
             } catch (error) {
                 log.error(`failed to retrieve value of 'slow_database' feature flag: ${error.message}`);
+                res.setHeader("X-Gitpod-Slow-Database", "false");
                 res.status(200);
                 res.end();
             }

--- a/components/server/src/feature-flag/featureflag-controller.ts
+++ b/components/server/src/feature-flag/featureflag-controller.ts
@@ -24,7 +24,7 @@ export class FeatureFlagController {
     protected addSlowDatabaseFeatureFlagHandler(router: express.Router) {
         router.get("/slow-database", async (req, res) => {
             if (!User.is(req.user)) {
-                res.sendStatus(401);
+                res.sendStatus(200);
                 return;
             }
 
@@ -37,7 +37,7 @@ export class FeatureFlagController {
                 res.end();
             } catch (error) {
                 log.error(`failed to retrieve value of 'slow_database' feature flag: ${error.message}`);
-                res.status(500);
+                res.status(200);
                 res.end();
             }
         });

--- a/components/server/src/feature-flag/featureflag-controller.ts
+++ b/components/server/src/feature-flag/featureflag-controller.ts
@@ -23,22 +23,20 @@ export class FeatureFlagController {
 
     protected addSlowDatabaseFeatureFlagHandler(router: express.Router) {
         router.get("/slow-database", async (req, res) => {
-            if (!User.is(req.user)) {
-                res.setHeader("X-Gitpod-Slow-Database", "false");
-                res.sendStatus(200);
-                return;
-            }
-
             try {
+                if (!User.is(req.user)) {
+                    res.setHeader("X-Gitpod-Slow-Database", "false");
+                    return;
+                }
+
                 const flagValue = await getExperimentsClientForBackend().getValueAsync("slow_database", false, {
                     user: req.user,
                 });
                 res.setHeader("X-Gitpod-Slow-Database", flagValue.toString());
-                res.status(200);
-                res.end();
             } catch (error) {
                 log.error(`failed to retrieve value of 'slow_database' feature flag: ${error.message}`);
                 res.setHeader("X-Gitpod-Slow-Database", "false");
+            } finally {
                 res.status(200);
                 res.end();
             }


### PR DESCRIPTION
## Description

Make the `api/feature-flags/slow-database` return code `200` and set the `X-Gitpod-Slow-Database` header consistently.

We don't need to distinguish between response codes for the reverse proxy 'pre-flight' added in #14897  and in fact having the endpoint return non-success codes is actively unhelpful when using the Caddy [forward_auth](https://caddyserver.com/docs/caddyfile/directives/forward_auth) directive.

See https://github.com/gitpod-io/gitpod/pull/14897#discussion_r1030654402 for more context. 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of #9198 

## How to test

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
