### PR TITLE
[installer] Set latency and jitter values for Toxiproxy mysql proxy

### DIFF
--- a/install/installer/pkg/components/toxiproxy/deployment.go
+++ b/install/installer/pkg/components/toxiproxy/deployment.go
@@ -106,10 +106,13 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 						}, {
 							Name:  "toxic-config",
 							Image: ctx.ImageName(ctx.Config.Repository, ConfigComponent, ctx.VersionManifest.Components.ToxicConfig.Version),
+							// latency and jitter values taken from:
+							// https://geekflare.com/google-cloud-latency/
+							// using the values for the latency between europe-west1 (Belgium) and us-west1 (Oregon)
 							Args: []string{
 								fmt.Sprintf("--proxy=%s", proxyName),
-								"--latency=1000",
-								"--jitter=250",
+								"--latency=280",
+								"--jitter=25",
 								"--wait=true",
 							},
 						},


### PR DESCRIPTION
## Description

Set these to more realistic values for simulating a connection to a US west coast database.

## Related Issue(s)
Part of #9198 

Closes https://github.com/gitpod-io/gitpod/issues/14958

## How to test

## Release Notes
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
