### PR TITLE
Update access tokens menu order

### DIFF
--- a/components/dashboard/src/settings/settings-menu.ts
+++ b/components/dashboard/src/settings/settings-menu.ts
@@ -35,18 +35,6 @@ export default function getSettingsMenu(params: {
             link: [settingsPathNotifications],
         },
         ...renderBillingMenuEntries(params.userBillingMode),
-        ...(params.enablePersonalAccessTokens
-            ? [
-                  {
-                      title: "Access Tokens",
-                      link: [
-                          settingsPathPersonalAccessTokens,
-                          settingsPathPersonalAccessTokenCreate,
-                          settingsPathPersonalAccessTokenEdit,
-                      ],
-                  },
-              ]
-            : []),
         {
             title: "Variables",
             link: [settingsPathVariables],
@@ -59,6 +47,18 @@ export default function getSettingsMenu(params: {
             title: "Integrations",
             link: [settingsPathIntegrations, "/access-control"],
         },
+        ...(params.enablePersonalAccessTokens
+            ? [
+                  {
+                      title: "Access Tokens",
+                      link: [
+                          settingsPathPersonalAccessTokens,
+                          settingsPathPersonalAccessTokenCreate,
+                          settingsPathPersonalAccessTokenEdit,
+                      ],
+                  },
+              ]
+            : []),
         {
             title: "Preferences",
             link: [settingsPathPreferences],


### PR DESCRIPTION
## Description

Following up from https://github.com/gitpod-io/gitpod/pull/14881#discussion_r1030208822, this will move update the access tokens menu order.

Cc @easyCZ because https://github.com/gitpod-io/gitpod/pull/14881

> | BEFORE | AFTER |
> |-|-|
> | <img width="340" alt="sidebar-before" src="https://user-images.githubusercontent.com/120486/203512776-f5268d61-52a7-45f5-b048-e11fb8e36154.png"> | <img width="340" alt="sidebar-after" src="https://user-images.githubusercontent.com/120486/203512793-d1006544-5a48-4f07-b4ac-20007d2777c0.png"> |

## How to test
1. Go to user settings.
2. Notice the _Access Tokens_ menu order.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Update access tokens menu order
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
