### PR TITLE
[dashboard] Fix CheckBox component style regression

### DIFF
--- a/components/dashboard/src/components/CheckBox.tsx
+++ b/components/dashboard/src/components/CheckBox.tsx
@@ -26,7 +26,7 @@ function CheckBox(props: {
     const checkboxId = `checkbox-${props.title}-${String(Math.random())}`;
 
     return (
-        <div className={"flex max-w-2xl" + className}>
+        <div className={"flex max-w-2xl " + className}>
             <input
                 className={
                     "h-4 w-4 focus:ring-0 mt-1 rounded cursor-pointer bg-transparent border-2 dark:filter-invert border-gray-800 dark:border-gray-900 focus:border-gray-900 dark:focus:border-gray-800 " +


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

We've recently introduced a `className` property in the `CheckBox` component, in order to allow for custom classes:

https://github.com/gitpod-io/gitpod/blob/dfc399b13c5b4f191037ae4ea3b7d36190c59eb6/components/dashboard/src/components/CheckBox.tsx#L29

Unfortunately, we didn't add a space between `max-w-2xl` and the `className` properties. This caused both `max-w-2xl` and `mt-4` classes to stop working in the default case.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

1. Look at any dashboard page that has checkboxes, e.g. `/notifications`
2. There should be some vertical spacing above each checkbox

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
