### PR TITLE
migrate oss users to ubp

### DIFF
--- a/components/gitpod-db/src/typeorm/migration/1669370193752-MigrateToUBP.ts
+++ b/components/gitpod-db/src/typeorm/migration/1669370193752-MigrateToUBP.ts
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class MigrateToUBP1669370193752 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        // migrate OSS users, the group by and having clause makes sure that we only add open-source users that are not on other plans as well.
+        queryRunner.query(`
+            INSERT INTO d_b_cost_center
+                (id, spendingLimit, creationTime, billingStrategy, billingCycleStart, nextBillingTime)
+            SELECT
+                CONCAT('user:', userId),
+                1000,
+                DATE_FORMAT(now(), '%Y-%m-%dT%TZ'),
+                'other',
+                DATE_FORMAT(now(), '%Y-%m-%dT%TZ'),
+                DATE_FORMAT(DATE_ADD(now(),INTERVAL 1 month), '%Y-%m-%dT%TZ')
+            FROM d_b_subscription
+            WHERE
+                cancellationDate=''
+                AND endDate=''
+                AND deleted=0
+            GROUP BY userid
+            HAVING max(planId) = 'free-open-source'
+        `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {}
+}

--- a/components/gitpod-db/src/typeorm/migration/1669370193752-MigrateToUBP.ts
+++ b/components/gitpod-db/src/typeorm/migration/1669370193752-MigrateToUBP.ts
@@ -12,20 +12,20 @@ export class MigrateToUBP1669370193752 implements MigrationInterface {
         queryRunner.query(`
             INSERT INTO d_b_cost_center
                 (id, spendingLimit, creationTime, billingStrategy, billingCycleStart, nextBillingTime)
-            SELECT
-                CONCAT('user:', userId),
-                1000,
-                DATE_FORMAT(now(), '%Y-%m-%dT%TZ'),
-                'other',
-                DATE_FORMAT(now(), '%Y-%m-%dT%TZ'),
-                DATE_FORMAT(DATE_ADD(now(),INTERVAL 1 month), '%Y-%m-%dT%TZ')
-            FROM d_b_subscription
-            WHERE
-                cancellationDate=''
-                AND endDate=''
-                AND deleted=0
-            GROUP BY userid
-            HAVING max(planId) = 'free-open-source'
+                SELECT
+                    CONCAT('user:', userId),
+                    1000,
+                    DATE_FORMAT(now(), '%Y-%m-%dT%TZ'),
+                    'other',
+                    DATE_FORMAT(now(), '%Y-%m-%dT%TZ'),
+                    DATE_FORMAT(DATE_ADD(now(),INTERVAL 1 month), '%Y-%m-%dT%TZ')
+                FROM d_b_subscription
+                WHERE
+                    cancellationDate=''
+                    AND planId = 'free-open-source'
+                    AND endDate=''
+                    AND deleted=0
+                GROUP BY userid;
         `);
     }
 


### PR DESCRIPTION
## Description
This migration updates the cost centers for all users that have an active free-open-source plan and besides 'free' no other active plan. 
The update includes:
- start the billing cycle the moment the migration runs
- end the billing cycle one month later
- spendingLimit: 1000
- billingStrategy: other (so we finalize the invoice at the end of the period)

NOTE: I ran the SELECT part of the query against the production database. It returns 1247 entries and takes 10 sec.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #https://github.com/gitpod-io/gitpod/issues/14819

## How to test
<!-- Provide steps to test this PR -->
In the preview environment 
- create a user
- grant professional open source in admin dashboard
- manual execute the migration query against the DB
- create a 'Gitpod something' team so the user gets UBP activated
- verify the user has "open source" plan and 1000 credits in billing/admin

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-payment
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
