### PR TITLE
Update copy-to-clipboard button text case

### DIFF
--- a/components/dashboard/src/settings/PersonalAccessTokens.tsx
+++ b/components/dashboard/src/settings/PersonalAccessTokens.tsx
@@ -444,7 +444,7 @@ function ListAccessTokensView() {
                                     Make sure to copy your personal access token — you won't be able to access it again.
                                 </div>
                                 <button className="secondary" onClick={handleCopyToken}>
-                                    Copy Token To Clipboard
+                                    Copy Token to Clipboard
                                 </button>
                             </div>
                         </div>


### PR DESCRIPTION
## Description

Minor change to update copy-to-clipboard button text case in the personal access tokens settings.

## How to test
1. Go to /personal-tokens
2. Create a new token
3. Notice that the copy-to-clipboard button is using proper title case

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
