### PR TITLE
Change personal access tokens URL path

### DIFF
--- a/components/dashboard/src/Menu.tsx
+++ b/components/dashboard/src/Menu.tsx
@@ -114,7 +114,7 @@ export default function Menu() {
         "keys",
         "integrations",
         "preferences",
-        "personal-tokens",
+        "tokens",
     ]);
     const isAdminUI = inResource(window.location.pathname, ["admin"]);
 

--- a/components/dashboard/src/settings/settings.routes.ts
+++ b/components/dashboard/src/settings/settings.routes.ts
@@ -19,8 +19,8 @@ export const settingsPathTeamsJoin = [settingsPathTeams, "join"].join("/");
 export const settingsPathTeamsNew = [settingsPathTeams, "new"].join("/");
 
 export const settingsPathVariables = "/variables";
-export const settingsPathPersonalAccessTokens = "/personal-tokens";
-export const settingsPathPersonalAccessTokenCreate = "/personal-tokens/create";
-export const settingsPathPersonalAccessTokenEdit = "/personal-tokens/edit";
+export const settingsPathPersonalAccessTokens = "/tokens";
+export const settingsPathPersonalAccessTokenCreate = "/tokens/create";
+export const settingsPathPersonalAccessTokenEdit = "/tokens/edit";
 
 export const settingsPathSSHKeys = "/keys";


### PR DESCRIPTION
## Description

This will change the personal access tokens URL path from **/personal-tokens** to **/tokens**, for brevity and following the pattern used for environment variables, see **/variables**.

## How to test
1. Go to user settings
2. Open access tokens
3. Notice the new URL path (/tokens)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
