### PR TITLE
[proxy] Match `/api/v1` in the `@backend_wss` matcher

### DIFF
--- a/components/proxy/conf/Caddyfile
+++ b/components/proxy/conf/Caddyfile
@@ -205,7 +205,7 @@ https://{$GITPOD_DOMAIN} {
 	}
 
 	@backend_wss {
-		path /api/gitpod
+		path /api/gitpod /api/v1
 	}
 	handle @backend_wss {
 		gitpod.sec_websocket_key


### PR DESCRIPTION
## Description

Websocket `Upgrade` requests can hit either `/api/gitpod` (from `server`) or `/api/v1` (from the public API).

This matcher change ensures that websocket requests to `api/v1` are handled by the matcher block intended to handle websocket requests rather than the block for `api/*` requests.

Websocket `Upgrade` requests to `api/v1` worked without this change because the handler for `api/*` handled those requests correctly, but this won't be the case after https://github.com/gitpod-io/gitpod/pull/14897 (which makes changes to the `/api/*` handler) lands.

## Related Issue(s)
Part of #9198 

## How to test

The public API RPCs that delegate to `server` over the JSON-RPC API still work.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
