### PR TITLE
[server, installer] Make PrebuildRateLimiter period configurable

### DIFF
--- a/components/server/src/config.ts
+++ b/components/server/src/config.ts
@@ -17,6 +17,7 @@ import * as yaml from "js-yaml";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 import { filePathTelepresenceAware } from "@gitpod/gitpod-protocol/lib/env";
 import { WorkspaceClasses, WorkspaceClassesConfig } from "./workspace/workspace-classes";
+import { PrebuildRateLimiters } from "./workspace/prebuild-rate-limiter";
 
 export const Config = Symbol("Config");
 export type Config = Omit<
@@ -200,10 +201,10 @@ export interface ConfigSerialized {
     enablePayment?: boolean;
 
     /**
-     * Number of prebuilds that can be started in the last 1 minute.
+     * Number of prebuilds that can be started in a given time period.
      * Key '*' specifies the default rate limit for a cloneURL, unless overriden by a specific cloneURL.
      */
-    prebuildLimiter: { [cloneURL: string]: number } & { "*": number };
+    prebuildLimiter: PrebuildRateLimiters;
 
     /**
      * If a numeric value interpreted as days is set, repositories not beeing opened with Gitpod are

--- a/components/server/src/workspace/prebuild-rate-limiter.ts
+++ b/components/server/src/workspace/prebuild-rate-limiter.ts
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+export type PrebuildRateLimiters = { [cloneURL: string]: PrebuildRateLimiterConfig } & {
+    "*": PrebuildRateLimiterConfig;
+};
+
+export type PrebuildRateLimiterConfig = {
+    // maximum number of requests per period
+    limit: number;
+
+    // time period which the limit is enforce against in seconds
+    period: number;
+};
+
+export namespace PrebuildRateLimiterConfig {
+    const DEFAULT_CONFIG: PrebuildRateLimiterConfig = {
+        limit: 50,
+        period: 50,
+    };
+
+    export function getConfigForCloneURL(
+        rateLimiters: PrebuildRateLimiters,
+        cloneURL: string,
+    ): PrebuildRateLimiterConfig {
+        // First we use any explicit overrides for a given cloneURL
+        let config = rateLimiters[cloneURL];
+        if (config) {
+            return config;
+        }
+
+        // Find if there is a default value set under the '*' key
+        config = rateLimiters["*"];
+        if (config) {
+            return config;
+        }
+
+        // Last resort default
+        return DEFAULT_CONFIG;
+    }
+}

--- a/install/installer/cmd/testdata/render/aws-setup/output.golden
+++ b/install/installer/cmd/testdata/render/aws-setup/output.golden
@@ -4853,7 +4853,10 @@ data:
         "resources": null
       },
       "prebuildLimiter": {
-        "*": 50
+        "*": {
+          "limit": 100,
+          "period": 600
+        }
       },
       "workspaceClasses": [
         {
@@ -9254,7 +9257,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: d6614af994531fe5c31ddff93c3f5c9ae4eacae9dc0bcb278d23cd44d0bc4b41
+        gitpod.io/checksum_config: b32c163fe13c4dd3dbabb7512d3fea34e61192c7b703a882669b339922630979
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/azure-setup/output.golden
+++ b/install/installer/cmd/testdata/render/azure-setup/output.golden
@@ -4716,7 +4716,10 @@ data:
         "resources": null
       },
       "prebuildLimiter": {
-        "*": 50
+        "*": {
+          "limit": 100,
+          "period": 600
+        }
       },
       "workspaceClasses": [
         {
@@ -9105,7 +9108,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: d6614af994531fe5c31ddff93c3f5c9ae4eacae9dc0bcb278d23cd44d0bc4b41
+        gitpod.io/checksum_config: b32c163fe13c4dd3dbabb7512d3fea34e61192c7b703a882669b339922630979
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -5692,7 +5692,10 @@ data:
         "resources": null
       },
       "prebuildLimiter": {
-        "*": 50
+        "*": {
+          "limit": 100,
+          "period": 600
+        }
       },
       "workspaceClasses": [
         {
@@ -10716,7 +10719,7 @@ spec:
     metadata:
       annotations:
         gitpod.io: hello
-        gitpod.io/checksum_config: 671903bbf173feb891de94d4380d0f3360b0e8b4c4b3aeac6d49b7544f5ee697
+        gitpod.io/checksum_config: b963c6af8760581ce8807544183b759ea2e40fc1a23232d1fc60df13e817c937
         hello: world
       creationTimestamp: null
       labels:

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -4903,7 +4903,10 @@ data:
         "resources": null
       },
       "prebuildLimiter": {
-        "*": 50
+        "*": {
+          "limit": 100,
+          "period": 600
+        }
       },
       "workspaceClasses": [
         {
@@ -9531,7 +9534,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: a94779de77b43b080faf67667aa017f25fc963c43412f8438c49ace3a7b7af2a
+        gitpod.io/checksum_config: a369165008e0cfac09c1b83051c9c686c06acf116907f80e46cf73b105f55719
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/gcp-setup/output.golden
+++ b/install/installer/cmd/testdata/render/gcp-setup/output.golden
@@ -4677,7 +4677,10 @@ data:
         "resources": null
       },
       "prebuildLimiter": {
-        "*": 50
+        "*": {
+          "limit": 100,
+          "period": 600
+        }
       },
       "workspaceClasses": [
         {
@@ -9022,7 +9025,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: fce060cf17c7827eebde2eb3483be41a293d2ad20607890b0e23bded75346d93
+        gitpod.io/checksum_config: 67d25bb8e71032ee17ede85e68359e908eb6b74de606d59d9a0ba9168bfccc38
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/http-proxy/output.golden
+++ b/install/installer/cmd/testdata/render/http-proxy/output.golden
@@ -5126,7 +5126,10 @@ data:
         "resources": null
       },
       "prebuildLimiter": {
-        "*": 50
+        "*": {
+          "limit": 100,
+          "period": 600
+        }
       },
       "workspaceClasses": [
         {
@@ -11072,7 +11075,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: a94779de77b43b080faf67667aa017f25fc963c43412f8438c49ace3a7b7af2a
+        gitpod.io/checksum_config: a369165008e0cfac09c1b83051c9c686c06acf116907f80e46cf73b105f55719
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/insecure-s3-setup/output.golden
+++ b/install/installer/cmd/testdata/render/insecure-s3-setup/output.golden
@@ -5037,7 +5037,10 @@ data:
         "resources": null
       },
       "prebuildLimiter": {
-        "*": 50
+        "*": {
+          "limit": 100,
+          "period": 600
+        }
       },
       "workspaceClasses": [
         {
@@ -9677,7 +9680,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: a94779de77b43b080faf67667aa017f25fc963c43412f8438c49ace3a7b7af2a
+        gitpod.io/checksum_config: a369165008e0cfac09c1b83051c9c686c06acf116907f80e46cf73b105f55719
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/kind-meta/output.golden
+++ b/install/installer/cmd/testdata/render/kind-meta/output.golden
@@ -4003,7 +4003,10 @@ data:
         "resources": null
       },
       "prebuildLimiter": {
-        "*": 50
+        "*": {
+          "limit": 100,
+          "period": 600
+        }
       },
       "workspaceClasses": [
         {
@@ -7111,7 +7114,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: a94779de77b43b080faf67667aa017f25fc963c43412f8438c49ace3a7b7af2a
+        gitpod.io/checksum_config: a369165008e0cfac09c1b83051c9c686c06acf116907f80e46cf73b105f55719
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/kind-webapp/output.golden
+++ b/install/installer/cmd/testdata/render/kind-webapp/output.golden
@@ -2288,7 +2288,10 @@ data:
         "resources": null
       },
       "prebuildLimiter": {
-        "*": 50
+        "*": {
+          "limit": 100,
+          "period": 600
+        }
       },
       "workspaceClasses": [
         {
@@ -4315,7 +4318,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: a94779de77b43b080faf67667aa017f25fc963c43412f8438c49ace3a7b7af2a
+        gitpod.io/checksum_config: a369165008e0cfac09c1b83051c9c686c06acf116907f80e46cf73b105f55719
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -5123,7 +5123,10 @@ data:
         "resources": null
       },
       "prebuildLimiter": {
-        "*": 50
+        "*": {
+          "limit": 100,
+          "period": 600
+        }
       },
       "workspaceClasses": [
         {
@@ -9906,7 +9909,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: a94779de77b43b080faf67667aa017f25fc963c43412f8438c49ace3a7b7af2a
+        gitpod.io/checksum_config: a369165008e0cfac09c1b83051c9c686c06acf116907f80e46cf73b105f55719
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/shortname/output.golden
+++ b/install/installer/cmd/testdata/render/shortname/output.golden
@@ -5123,7 +5123,10 @@ data:
         "resources": null
       },
       "prebuildLimiter": {
-        "*": 50
+        "*": {
+          "limit": 100,
+          "period": 600
+        }
       },
       "workspaceClasses": [
         {
@@ -9906,7 +9909,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: fb70098b8891802e254f67cb2cab3ff40389429d959e77d3733a7eeba60399e5
+        gitpod.io/checksum_config: 547d4ea1c8405743d18271c02b7eab2469c1eee1888ef5ceaeaff41fe4946333
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -5135,7 +5135,10 @@ data:
         "resources": null
       },
       "prebuildLimiter": {
-        "*": 50
+        "*": {
+          "limit": 100,
+          "period": 600
+        }
       },
       "workspaceClasses": [
         {
@@ -9918,7 +9921,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: a94779de77b43b080faf67667aa017f25fc963c43412f8438c49ace3a7b7af2a
+        gitpod.io/checksum_config: a369165008e0cfac09c1b83051c9c686c06acf116907f80e46cf73b105f55719
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
+++ b/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
@@ -5456,7 +5456,10 @@ data:
         "resources": null
       },
       "prebuildLimiter": {
-        "*": 50
+        "*": {
+          "limit": 100,
+          "period": 600
+        }
       },
       "workspaceClasses": [
         {
@@ -10350,7 +10353,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: a94779de77b43b080faf67667aa017f25fc963c43412f8438c49ace3a7b7af2a
+        gitpod.io/checksum_config: a369165008e0cfac09c1b83051c9c686c06acf116907f80e46cf73b105f55719
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
+++ b/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
@@ -5125,7 +5125,10 @@ data:
         "resources": null
       },
       "prebuildLimiter": {
-        "*": 50
+        "*": {
+          "limit": 100,
+          "period": 600
+        }
       },
       "workspaceClasses": [
         {
@@ -9896,7 +9899,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: a94779de77b43b080faf67667aa017f25fc963c43412f8438c49ace3a7b7af2a
+        gitpod.io/checksum_config: a369165008e0cfac09c1b83051c9c686c06acf116907f80e46cf73b105f55719
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
+++ b/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
@@ -5126,7 +5126,10 @@ data:
         "resources": null
       },
       "prebuildLimiter": {
-        "*": 50
+        "*": {
+          "limit": 100,
+          "period": 600
+        }
       },
       "workspaceClasses": [
         {
@@ -9909,7 +9912,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: a94779de77b43b080faf67667aa017f25fc963c43412f8438c49ace3a7b7af2a
+        gitpod.io/checksum_config: a369165008e0cfac09c1b83051c9c686c06acf116907f80e46cf73b105f55719
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/pkg/components/server/configmap.go
+++ b/install/installer/pkg/components/server/configmap.go
@@ -260,9 +260,12 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		ChargebeeProviderOptionsFile: fmt.Sprintf("%s/providerOptions", chargebeeMountPath),
 		StripeSecretsFile:            fmt.Sprintf("%s/apikeys", stripeSecretMountPath),
 		InsecureNoDomain:             false,
-		PrebuildLimiter: map[string]int{
+		PrebuildLimiter: PrebuildRateLimiters{
 			// default limit for all cloneURLs
-			"*": 50,
+			"*": PrebuildRateLimiterConfig{
+				Limit:  100,
+				Period: 600,
+			},
 		},
 		WorkspaceClasses:               workspaceClasses,
 		InactivityPeriodForReposInDays: inactivityPeriodForReposInDays,

--- a/install/installer/pkg/components/server/types.go
+++ b/install/installer/pkg/components/server/types.go
@@ -53,9 +53,9 @@ type ConfigSerialized struct {
 	CodeSync                   CodeSync                   `json:"codeSync"`
 	// PrebuildLimiter defines the number of prebuilds allowed for each cloneURL in a given 1 minute interval
 	// Key of "*" defines the default limit, unless there exists a cloneURL in the map which overrides it.
-	PrebuildLimiter                map[string]int   `json:"prebuildLimiter"`
-	WorkspaceClasses               []WorkspaceClass `json:"workspaceClasses"`
-	InactivityPeriodForReposInDays int              `json:"inactivityPeriodForReposInDays"`
+	PrebuildLimiter                PrebuildRateLimiters `json:"prebuildLimiter"`
+	WorkspaceClasses               []WorkspaceClass     `json:"workspaceClasses"`
+	InactivityPeriodForReposInDays int                  `json:"inactivityPeriodForReposInDays"`
 }
 type CodeSyncResources struct {
 	RevLimit int32 `json:"revLimit"`
@@ -157,3 +157,10 @@ type WorkspaceClassCategory string
 const (
 	GeneralPurpose WorkspaceClassCategory = "GENERAL PURPOSE"
 )
+
+type PrebuildRateLimiters = map[string]PrebuildRateLimiterConfig
+
+type PrebuildRateLimiterConfig struct {
+	Limit  uint32 `json:"limit"`
+	Period uint32 `json:"period"`
+}

--- a/install/installer/pkg/components/slowserver/configmap.go
+++ b/install/installer/pkg/components/slowserver/configmap.go
@@ -242,9 +242,12 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		StripeSecretsFile:            fmt.Sprintf("%s/apikeys", stripeSecretMountPath),
 		StripeConfigFile:             fmt.Sprintf("%s/config", stripeConfigMountPath),
 		InsecureNoDomain:             false,
-		PrebuildLimiter: map[string]int{
+		PrebuildLimiter: server.PrebuildRateLimiters{
 			// default limit for all cloneURLs
-			"*": 50,
+			"*": server.PrebuildRateLimiterConfig{
+				Limit:  100,
+				Period: 600,
+			},
 		},
 		WorkspaceClasses:               workspaceClasses,
 		InactivityPeriodForReposInDays: inactivityPeriodForReposInDays,


### PR DESCRIPTION
## Description


Effectively changes the rate limiter from being
```
Limit:  50,
Period: 60,
```
to be
```
Limit:  100,
Period: 600,
```

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #14791 

## How to test
- setup a project
- change the server ConfigMap to be set to `limit: 2`, and `kubectl rollout restart deployment/server`
- trigger 3 prebuilds on that project withing 5 minutes
- notice how the 3rd gets rejected (you can use the `...project/events` endpoint for that)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Make PrebuildRateLimiter more configurable
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
