### PR TITLE
[Analytics] adopt cookieless ID on dashboard and server

### DIFF
--- a/components/dashboard/src/Analytics.tsx
+++ b/components/dashboard/src/Analytics.tsx
@@ -173,7 +173,15 @@ export const identifyUser = async (traits: Traits) => {
     });
 };
 
-const getAnonymousId = (): string => {
+const getCookieConsent = () => {
+    return Cookies.get("gp-analytical") === "true";
+};
+
+const getAnonymousId = (): string | undefined => {
+    if (!getCookieConsent()) {
+        //we do not want to read or set the id cookie if we don't have consent
+        return;
+    }
     let anonymousId = Cookies.get("ajs_anonymous_id");
     if (anonymousId) {
         return anonymousId.replace(/^"(.+(?="$))"$/, "$1"); //strip enclosing double quotes before returning


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PR introduces cookieless tracking for the webapp and server. This is done so that users are identified consistently throughout the website and the webapp when [#2938](https://github.com/gitpod-io/website/pull/2938) on the website is merged. The following changes are introduced:

- users that expressed their consent to tracking on the website (which leads to the `gp-analytical` cookie to be set for the `.gitpod.io` domain) continue to be tracked with the anonymous ID that can be read from the `ajs_anonymous_id` cookie
- users that did not express consent to tracking are tracked through a cookieless ID that is created by hashing a combination of the user's IP, user agent, and today's date. If the IP or user agent are not available (might happen in preview environments as the IP `clientHeaderFields` is retrieved from the load balancer which does not exist in the preview environment if i understand it correctly), `unidentified-user` is used as anonymous ID in order to use these events in debugging in the warehouse

## How to test
<!-- Provide steps to test this PR -->

1. Clear your cookies for `ajs_anonymous_id` and `gp-analytical` if they exist
2. Spin up a preview environment and head over to the Debugger of [Segment's Staging Trusted Source](https://app.segment.com/gitpod/sources/staging_trusted/debugger)
3. Load a page of the preview environment without signing up and ensure that a page call is made with an anonymous ID that  contains a sequence of letters and digits (no hyphens as for UUIDs).
4. Set the `gp-analytical` to `true` and any value for the `ajs_anonymous_id` for the `.gitpod.io` (or any other domain that matches the preview environment). Load another page and ensure that a page call is made with the anonymous ID set in the cookie.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
- [x] /werft analytics=segment
