### PR TITLE
[db] Define PersonalAccessToken model for TypeORM

### DIFF
--- a/components/gitpod-db/src/container-module.ts
+++ b/components/gitpod-db/src/container-module.ts
@@ -35,6 +35,7 @@ import { PeriodicDbDeleter } from "./periodic-deleter";
 import { TermsAcceptanceDB } from "./terms-acceptance-db";
 import { TermsAcceptanceDBImpl } from "./typeorm/terms-acceptance-db-impl";
 import { CodeSyncResourceDB } from "./typeorm/code-sync-resource-db";
+
 import { WorkspaceClusterDBImpl } from "./typeorm/workspace-cluster-db-impl";
 import { WorkspaceClusterDB } from "./workspace-cluster-db";
 import { AuthCodeRepositoryDB } from "./typeorm/auth-code-repository-db";
@@ -54,6 +55,7 @@ import { TeamDB } from "./team-db";
 import { TeamDBImpl } from "./typeorm/team-db-impl";
 import { ProjectDB } from "./project-db";
 import { ProjectDBImpl } from "./typeorm/project-db-impl";
+import { PersonalAccessTokenDB } from "./personal-access-token-db";
 import { EntityManager } from "typeorm";
 import { OssAllowListDB } from "./oss-allowlist-db";
 import { OssAllowListDBImpl } from "./typeorm/oss-allowlist-db-impl";
@@ -65,6 +67,7 @@ import { TypeORMBlockedRepositoryDBImpl } from "./typeorm/blocked-repository-db-
 import { BlockedRepositoryDB } from "./blocked-repository-db";
 import { WebhookEventDB } from "./webhook-event-db";
 import { WebhookEventDBImpl } from "./typeorm/webhook-event-db-impl";
+import { PersonalAccessTokenDBImpl } from "./typeorm/personal-access-token-db-impl";
 
 // THE DB container module that contains all DB implementations
 export const dbContainerModule = new ContainerModule((bind, unbind, isBound, rebind) => {
@@ -141,6 +144,9 @@ export const dbContainerModule = new ContainerModule((bind, unbind, isBound, reb
     bind(ProjectDB).toService(ProjectDBImpl);
     bind(WebhookEventDBImpl).toSelf().inSingletonScope();
     bind(WebhookEventDB).toService(WebhookEventDBImpl);
+
+    bind(PersonalAccessTokenDBImpl).toSelf().inSingletonScope();
+    bind(PersonalAccessTokenDB).toService(PersonalAccessTokenDBImpl);
 
     // com concerns
     bind(AccountingDB).to(TypeORMAccountingDBImpl).inSingletonScope();

--- a/components/gitpod-db/src/index.ts
+++ b/components/gitpod-db/src/index.ts
@@ -40,3 +40,5 @@ export * from "./team-db";
 export * from "./installation-admin-db";
 export * from "./webhook-event-db";
 export * from "./typeorm/metrics";
+export * from "./personal-access-token-db";
+export * from "./typeorm/entity/db-personal-access-token";

--- a/components/gitpod-db/src/personal-access-token-db.ts
+++ b/components/gitpod-db/src/personal-access-token-db.ts
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+ * Licensed under the Gitpod Enterprise Source Code License,
+ * See License.enterprise.txt in the project root folder.
+ */
+
+import { DBPersonalAccessToken } from "./typeorm/entity/db-personal-access-token";
+
+export const PersonalAccessTokenDB = Symbol("PersonalAccessTokenDB");
+export interface PersonalAccessTokenDB {
+    getByHash(hash: string): Promise<DBPersonalAccessToken>;
+}

--- a/components/gitpod-db/src/typeorm/entity/db-personal-access-token.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-personal-access-token.ts
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2020 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { Entity, Column, PrimaryColumn } from "typeorm";
+
+import { TypeORM } from "../typeorm";
+
+@Entity()
+// PersonalAccessToken defines the DB model.
+// It is primarily created by the Public API, when a user requests a token.
+// We define it in the TypeORM model such that we can support authentication from server.
+// We only use the model definition on Server to perform Reads, never writes to ensure the write path is consistent.
+// on DB but not Typeorm: @Index("ind_lastModified", ["_lastModified"])   // DBSync
+export class DBPersonalAccessToken {
+    @PrimaryColumn(TypeORM.UUID_COLUMN_TYPE)
+    id: string;
+
+    @Column("varchar")
+    userId: string;
+
+    @Column("varchar")
+    hash: string;
+
+    @Column("varchar")
+    name: string;
+
+    @Column({
+        type: "text",
+        transformer: {
+            to(value: any): any {
+                if (!Array.isArray(value)) {
+                    throw new Error(`Unknown scopes type when serializing ${value}`);
+                }
+
+                return value.join(",");
+            },
+            from(value: any): any {
+                if (typeof value !== "string") {
+                    throw new Error(`Unknown scope value ${value}`);
+                }
+
+                if (!value) {
+                    return [];
+                }
+
+                return value.split(",");
+            },
+        },
+    })
+    scopes: string[];
+
+    @Column("datetime")
+    expirationTime: Date;
+
+    @Column("datetime")
+    createdAt: Date;
+
+    @Column()
+    deleted?: boolean;
+}

--- a/components/gitpod-db/src/typeorm/personal-access-token-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/personal-access-token-db-impl.ts
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { inject, injectable } from "inversify";
+import { TypeORM } from "./typeorm";
+import { Repository } from "typeorm";
+import { PersonalAccessTokenDB } from "../personal-access-token-db";
+import { DBPersonalAccessToken } from "./entity/db-personal-access-token";
+
+@injectable()
+export class PersonalAccessTokenDBImpl implements PersonalAccessTokenDB {
+    @inject(TypeORM) typeORM: TypeORM;
+
+    protected async getEntityManager() {
+        return (await this.typeORM.getConnection()).manager;
+    }
+
+    protected async getRepo(): Promise<Repository<DBPersonalAccessToken>> {
+        return (await this.getEntityManager()).getRepository<DBPersonalAccessToken>(DBPersonalAccessToken);
+    }
+
+    public async getByHash(hash: string): Promise<DBPersonalAccessToken> {
+        throw new Error("unimplemented");
+    }
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Adds DB model into server to read PATs.

This is needed to be able to authenticate, and authorize, requests containing the PAT

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Part of https://github.com/gitpod-io/gitpod/issues/14912

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
