### PR TITLE
Auto remove GCP_ADC_FILE

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -34,6 +34,14 @@ ports:
   - port: 8022
     onOpen: ignore
 tasks:
+  - name: Remove GCP_ADC_FILE
+    command: |
+      if [[ -n "${GCP_ADC_FILE}" ]]; then
+        echo "$GCP_ADC_FILE" > "/home/gitpod/.config/gcloud/application_default_credentials.json"
+        yes | gcloud auth application-default revoke
+        gp env -u GCP_ADC_FILE
+      fi
+      exit 0
   # This task takes care of configuring your workspace so it can manage and interact
   # with preview environments.
   - name: Preview environment configuration


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Since https://github.com/gitpod-io/gitpod/pull/14893 has been merged we are no longer using GCP_ADC_FILE. Now we want to get revoke the credentials for everyone and remove the environment variable.

This PR extends `.gitpod.yml` so this happens automatically.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

Part of https://github.com/gitpod-io/security/issues/79

## How to test
<!-- Provide steps to test this PR -->

1. Go to https://gitpod.io/variables and see your GCP_ADC_FILE environment variable
2. Open a workspace off this branch
3. Refresh https://gitpod.io/variables
4. Open a new workspace (to verify it handles it well when the environment variable isn't set) 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

N/A

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
