### PR TITLE
[usage] reduce possibility for races in ResetUsage

### DIFF
--- a/components/usage/pkg/apiv1/usage.go
+++ b/components/usage/pkg/apiv1/usage.go
@@ -250,7 +250,7 @@ func (s *UsageService) ResetUsage(ctx context.Context, req *v1.ResetUsageRequest
 
 	var errors []error
 	for _, cc := range costCentersToUpdate {
-		_, err = s.costCenterManager.ResetUsage(ctx, cc)
+		_, err = s.costCenterManager.ResetUsage(ctx, cc.ID)
 		if err != nil {
 			errors = append(errors, err)
 		}


### PR DESCRIPTION
## Description
Fetch the cost center from db immediately before deciding to resetting the usage. So that the time window in which a parallel resetting for the same cost center could happen is minimized.

We saw eight cases in Nopvember where thsi happened. But teh likely hood was very high due to:
- no resetting scheduler was active (so every cost center was outdated at some point)
- we fetch the cost center first and do quite some computation before inserting the update.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #14973

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
