### PR TITLE
[server] BillingMode: Make sure that users&teams with a Stripe subscr…

### DIFF
--- a/components/server/ee/src/billing/billing-mode.spec.db.ts
+++ b/components/server/ee/src/billing/billing-mode.spec.db.ts
@@ -487,6 +487,32 @@ class BillingModeSpec {
                     paid: true,
                 },
             },
+            // rollback: make sure users/teams with Stripe subscription stay UBP
+            {
+                name: "team: stripe paid, w/o UBP",
+                subject: team(),
+                config: {
+                    enablePayment: true,
+                    usageBasedPricingEnabled: false,
+                    stripeSubscription: stripeSubscription(),
+                },
+                expectation: {
+                    mode: "usage-based",
+                    paid: true,
+                },
+            },
+            {
+                name: "user: stripe paid, w/o UBP",
+                subject: user(),
+                config: {
+                    enablePayment: true,
+                    usageBasedPricingEnabled: false,
+                    stripeSubscription: stripeSubscription(),
+                },
+                expectation: {
+                    mode: "usage-based",
+                },
+            },
         ];
 
         const onlyTest = tests.find((t) => t.only);


### PR DESCRIPTION
…iption always stay "usage-based", no matter the Feature-Flag status

## Description
This PR ensures that [these new test cases ](https://github.com/gitpod-io/gitpod/blob/73029f3a5a282b6443634a7da2ac6f88af1af7e9/components/server/ee/src/billing/billing-mode.spec.db.ts#L490-L515) work:
 - user with active Stripe subscription but without UBP-feature-flag: stays UBP
 - team with active Stripe subscription but without UBP-feature-flag: stays UBP

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #14652 

## How to test

### Unit (DB) tests
- `leeway build components/gitpod-db:dbtest-init`
- `(cd components/server && yarn db-test)`


### Manual
 - create a team containing `Gitpod-...`
   - sign up for a **personal** Stripe subscription
 - leave said team (this only works in dev that way. It's weird, but the quickest to test)
 - check that you can still access the UBP billing config :heavy_check_mark: (verify with your admin page)
 - cancel the Stripe subscription
 - note how you're BillingMode "chargebee" again :heavy_check_mark: (verify with your admin page)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
