### PR TITLE
Deprecate and remove "Cancel Prebuilds on Outdated Commits" feature

### DIFF
--- a/components/dashboard/src/projects/ProjectSettings.tsx
+++ b/components/dashboard/src/projects/ProjectSettings.tsx
@@ -97,12 +97,6 @@ export default function () {
                 onChange={({ target }) => updateProjectSettings({ useIncrementalPrebuilds: target.checked })}
             />
             <CheckBox
-                title={<span>Cancel Prebuilds on Outdated Commits </span>}
-                desc={<span>Cancel pending or running prebuilds on the same branch when new commits are pushed.</span>}
-                checked={!project.settings?.keepOutdatedPrebuildsRunning}
-                onChange={({ target }) => updateProjectSettings({ keepOutdatedPrebuildsRunning: !target.checked })}
-            />
-            <CheckBox
                 title={
                     <span>
                         Use Last Successful Prebuild{" "}
@@ -121,8 +115,6 @@ export default function () {
                 onChange={({ target }) =>
                     updateProjectSettings({
                         allowUsingPreviousPrebuilds: target.checked,
-                        // we are disabling prebuild cancellation when incremental workspaces are enabled
-                        keepOutdatedPrebuildsRunning: target.checked || project?.settings?.keepOutdatedPrebuildsRunning,
                     })
                 }
             />

--- a/components/gitpod-db/src/workspace-db.ts
+++ b/components/gitpod-db/src/workspace-db.ts
@@ -62,12 +62,6 @@ export interface PrebuildWithWorkspace {
     workspace: Workspace;
 }
 
-export interface PrebuildWithWorkspaceAndInstances {
-    prebuild: PrebuiltWorkspace;
-    workspace: Workspace;
-    instances: WorkspaceInstance[];
-}
-
 export type WorkspaceAndOwner = Pick<Workspace, "id" | "ownerId">;
 export type WorkspaceOwnerAndSoftDeleted = Pick<Workspace, "id" | "ownerId" | "softDeleted">;
 
@@ -180,10 +174,6 @@ export interface WorkspaceDB {
 
     storePrebuiltWorkspace(pws: PrebuiltWorkspace): Promise<PrebuiltWorkspace>;
     findPrebuiltWorkspaceByCommit(cloneURL: string, commit: string): Promise<PrebuiltWorkspace | undefined>;
-    findActivePrebuiltWorkspacesByBranch(
-        projectId: string,
-        branch: string,
-    ): Promise<PrebuildWithWorkspaceAndInstances[]>;
     findPrebuildsWithWorkpace(cloneURL: string): Promise<PrebuildWithWorkspace[]>;
     findPrebuildByWorkspaceID(wsid: string): Promise<PrebuiltWorkspace | undefined>;
     findPrebuildByID(pwsid: string): Promise<PrebuiltWorkspace | undefined>;

--- a/components/gitpod-protocol/src/teams-projects-protocol.ts
+++ b/components/gitpod-protocol/src/teams-projects-protocol.ts
@@ -16,7 +16,6 @@ export interface ProjectConfig {
 export interface ProjectSettings {
     useIncrementalPrebuilds?: boolean;
     usePersistentVolumeClaim?: boolean;
-    keepOutdatedPrebuildsRunning?: boolean;
     // whether new workspaces can start on older prebuilds and incrementally update
     allowUsingPreviousPrebuilds?: boolean;
     // how many commits in the commit history a prebuild is good (undefined and 0 means every commit is prebuilt)

--- a/components/public-api/gitpod/experimental/v1/projects.proto
+++ b/components/public-api/gitpod/experimental/v1/projects.proto
@@ -48,7 +48,8 @@ message ProjectSettings {
 
 message PrebuildSettings {
     bool enable_incremental_prebuilds = 1;
-    bool keep_outdated_prebuilds_running = 2;
+    // DEPRECATED bool keep_outdated_prebuilds_running = 2;
+    reserved 2;
     bool use_previous_prebuilds = 3;
     int32 prebuild_every_nth = 4;
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Deprecates and removes the "Cancel Prebuilds on Outdated Commits" feature.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/14949 https://github.com/gitpod-io/gitpod/issues/13874

## How to test
<!-- Provide steps to test this PR -->

1. Should build
2. Project Settings should no longer have "Cancel Prebuilds on Outdated Commits"

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
