### PR TITLE
[pat] Store hash as sha256 instead of bcrypt

### DIFF
--- a/components/public-api-server/go.mod
+++ b/components/public-api-server/go.mod
@@ -23,7 +23,6 @@ require (
 	github.com/spf13/cobra v1.4.0
 	github.com/stretchr/testify v1.8.1
 	github.com/stripe/stripe-go/v72 v72.122.0
-	golang.org/x/crypto v0.0.0-20220214200702-86341886e292
 	google.golang.org/grpc v1.50.1
 	google.golang.org/protobuf v1.28.1
 	gorm.io/gorm v1.24.1

--- a/components/public-api-server/pkg/apiv1/tokens.go
+++ b/components/public-api-server/pkg/apiv1/tokens.go
@@ -82,16 +82,10 @@ func (s *TokensService) CreatePersonalAccessToken(ctx context.Context, req *conn
 		return nil, connect.NewError(connect.CodeInternal, errors.New("Failed to generate personal access token."))
 	}
 
-	hash, err := pat.ValueHash()
-	if err != nil {
-		log.WithError(err).Errorf("Failed to generate personal access token value hash for user %s", userID.String())
-		return nil, connect.NewError(connect.CodeInternal, errors.New("Failed to compute personal access token hash."))
-	}
-
 	token, err := db.CreatePersonalAccessToken(ctx, s.dbConn, db.PersonalAccessToken{
 		ID:             uuid.New(),
 		UserID:         userID,
-		Hash:           hash,
+		Hash:           pat.ValueHash(),
 		Name:           name,
 		Scopes:         scopes,
 		ExpirationTime: expiry.AsTime().UTC(),
@@ -183,12 +177,7 @@ func (s *TokensService) RegeneratePersonalAccessToken(ctx context.Context, req *
 		return nil, connect.NewError(connect.CodeInternal, errors.New("Failed to regenerate personal access token."))
 	}
 
-	hash, err := pat.ValueHash()
-	if err != nil {
-		log.WithError(err).Errorf("Failed to regenerate personal access token value hash for user %s", userID.String())
-		return nil, connect.NewError(connect.CodeInternal, errors.New("Failed to compute personal access token hash."))
-	}
-
+	hash := pat.ValueHash()
 	token, err := db.UpdatePersonalAccessTokenHash(ctx, s.dbConn, tokenID, userID, hash, expiry.AsTime().UTC())
 	if err != nil {
 		log.WithError(err).Errorf("Failed to store personal access token for user %s", userID.String())

--- a/components/public-api-server/pkg/auth/personal_access_token.go
+++ b/components/public-api-server/pkg/auth/personal_access_token.go
@@ -6,14 +6,14 @@ package auth
 
 import (
 	"crypto/rand"
+	"crypto/sha256"
 	"crypto/subtle"
 	"encoding/base64"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"math/big"
 	"strings"
-
-	"golang.org/x/crypto/bcrypt"
 )
 
 const PersonalAccessTokenPrefix = "gitpod_pat_"
@@ -44,14 +44,10 @@ func (t *PersonalAccessToken) Value() string {
 	return t.value
 }
 
-func (t *PersonalAccessToken) ValueHash() (string, error) {
-	const bcryptCost = 10
-	hash, err := bcrypt.GenerateFromPassword([]byte(t.value), bcryptCost)
-	if err != nil {
-		return "", fmt.Errorf("failed to generate personal access token value hash: %w", err)
-	}
-
-	return string(hash), nil
+// ValueHash computes the SHA256 hash of the token value
+func (t *PersonalAccessToken) ValueHash() string {
+	hashed := sha256.Sum256([]byte(t.value))
+	return hex.EncodeToString(hashed[:])
 }
 
 func GeneratePersonalAccessToken(signer Signer) (PersonalAccessToken, error) {

--- a/components/public-api-server/pkg/auth/personal_access_token_test.go
+++ b/components/public-api-server/pkg/auth/personal_access_token_test.go
@@ -5,7 +5,9 @@
 package auth
 
 import (
+	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"fmt"
 	"regexp"
 	"testing"
@@ -18,6 +20,7 @@ func TestGeneratePersonalAccessToken(t *testing.T) {
 
 	pat, err := GeneratePersonalAccessToken(signer)
 	require.NoError(t, err)
+	fmt.Println(pat)
 
 	signature, err := signer.Sign([]byte(pat.value))
 	require.NoError(t, err)
@@ -35,6 +38,16 @@ func TestGeneratePersonalAccessToken(t *testing.T) {
 	parsed, err := ParsePersonalAccessToken(pat.String(), signer)
 	require.NoError(t, err)
 	require.Equal(t, pat, parsed)
+}
+
+func TestPersonalAccessToken_HashValue(t *testing.T) {
+	signer := NewHS256Signer([]byte("my-secret"))
+	pat, err := GeneratePersonalAccessToken(signer)
+	require.NoError(t, err)
+
+	h := sha256.Sum256([]byte(pat.value))
+
+	require.Equal(t, hex.EncodeToString(h[:]), pat.ValueHash(), "hash value must be hex sha-256 hash of value")
 }
 
 func TestParsePersonalAccessToken_Errors(t *testing.T) {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Originally wanted to use bcrypt, however bcrypt generated hashes also encode the salt with multiple rounds in the token. This means that a value, which is hashed by bcrypt does not hash to the same value the next time. As a result, we can't lookup that hashed value in the db.

Instead, we're hashing it with sha256, which is sufficient given we're also generating the token value so the seed itself is already random, and prevents rainbow table attacks.

As a follow up, I will deleteexisting tokens from the DB by setting `deleted` to true, and db-sync cleaning up.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
Unit

Preview
1. Generate a new token

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
