### PR TITLE
Update beta label on teams, projects, and usage

### DIFF
--- a/components/dashboard/src/components/UsageView.tsx
+++ b/components/dashboard/src/components/UsageView.tsx
@@ -268,22 +268,17 @@ function UsageView({ attributionId }: UsageViewProps) {
                                             </div>
                                         </div>
                                         <div className="flex flex-col truncate mt-8 text-sm">
-                                            <div className="text-gray-400 dark:text-gray-500">
-                                                This feature is in{" "}
+                                            <div className="text-gray-400 dark:text-gray-500 text-sm text-left">
+                                                <strong>Usage</strong> feature is in{" "}
                                                 <PillLabel
                                                     type="warn"
                                                     className="font-semibold mt-2 ml-0 py-0.5 px-1 self-center"
                                                 >
-                                                    <span className="text-xs">Early Access</span>
+                                                    <a href="https://www.gitpod.io/docs/references/gitpod-releases">
+                                                        <span className="text-xs">Early Access</span>
+                                                    </a>
                                                 </PillLabel>
                                                 <br />
-                                                <a
-                                                    href="https://www.gitpod.io/docs/references/gitpod-releases"
-                                                    className="gp-link"
-                                                >
-                                                    Learn more
-                                                </a>
-                                                &nbsp;·&nbsp;
                                                 <a
                                                     href="https://github.com/gitpod-io/gitpod/issues/12636"
                                                     className="gp-link"

--- a/components/dashboard/src/projects/NewProject.tsx
+++ b/components/dashboard/src/projects/NewProject.tsx
@@ -29,6 +29,7 @@ import {
 } from "../service/public-api";
 import { FeatureFlagContext } from "../contexts/FeatureFlagContext";
 import { ConnectError } from "@bufbuild/connect-web";
+import PillLabel from "../components/PillLabel";
 
 export default function NewProject() {
     const location = useLocation();
@@ -481,17 +482,18 @@ export default function NewProject() {
                         </div>
                     </div>
                 )}
-                <p className="text-center w-full mt-12 text-gray-500">
-                    <strong>Teams &amp; Projects</strong> are currently in Beta.{" "}
-                    <a
-                        href="https://github.com/gitpod-io/gitpod/issues/5095"
-                        target="gitpod-feedback-issue"
-                        rel="noopener"
-                        className="gp-link"
-                    >
+                <div className="text-gray-400 dark:text-gray-500 text-sm mt-24 text-left">
+                    <strong>Projects</strong> feature is in{" "}
+                    <PillLabel type="warn" className="font-semibold mt-2 ml-0 py-0.5 px-1 self-center">
+                        <a href="https://www.gitpod.io/docs/references/gitpod-releases">
+                            <span className="text-xs">BETA</span>
+                        </a>
+                    </PillLabel>
+                    &nbsp;&middot;&nbsp;
+                    <a href="https://github.com/gitpod-io/gitpod/issues/5095" className="gp-link">
                         Send feedback
                     </a>
-                </p>
+                </div>
             </>
         );
 

--- a/components/dashboard/src/teams/NewTeam.tsx
+++ b/components/dashboard/src/teams/NewTeam.tsx
@@ -11,6 +11,7 @@ import { TeamsContext } from "./teams-context";
 import { publicApiTeamsToProtocol, publicApiTeamToProtocol, teamsService } from "../service/public-api";
 import { FeatureFlagContext } from "../contexts/FeatureFlagContext";
 import { ConnectError } from "@bufbuild/connect-web";
+import PillLabel from "../components/PillLabel";
 
 export default function () {
     const { setTeams } = useContext(TeamsContext);
@@ -87,17 +88,18 @@ export default function () {
                 </div>
             </form>
 
-            <p className="text-center w-full mt-12 text-gray-500">
-                <strong>Teams &amp; Projects</strong> are currently in Beta.{" "}
-                <a
-                    href="https://github.com/gitpod-io/gitpod/issues/5095"
-                    target="gitpod-feedback-issue"
-                    rel="noopener"
-                    className="gp-link"
-                >
+            <div className="text-gray-400 dark:text-gray-500 text-sm mt-24 text-left">
+                <strong>Teams</strong> feature is in{" "}
+                <PillLabel type="warn" className="font-semibold mt-2 ml-0 py-0.5 px-1 self-center">
+                    <a href="https://www.gitpod.io/docs/references/gitpod-releases">
+                        <span className="text-xs">BETA</span>
+                    </a>
+                </PillLabel>
+                &nbsp;&middot;&nbsp;
+                <a href="https://github.com/gitpod-io/gitpod/issues/5095" className="gp-link">
                     Send feedback
                 </a>
-            </p>
+            </div>
         </div>
     );
 }


### PR DESCRIPTION
## Description

Minor style changes for the beta notice for Teams & Projects, following the style used for Usage.

This will also:
1. Include a hyperlink to the **[Gitpod Releases](https://www.gitpod.io/docs/help/public-roadmap/release-cycle)** page directly on the beta pill component.
2. Update the beta notice on the usage page to follow the same pattern.

| BEFORE | AFTER |
|-|-|
| <img width="446" alt="teams-before" src="https://user-images.githubusercontent.com/120486/204368089-d2cb139c-8fe3-42db-8289-edb9d290d44e.png"> | <img width="446" alt="teams-after" src="https://user-images.githubusercontent.com/120486/204368093-e4402b81-c19d-49ed-bae6-2b125193608e.png"> |
| <img width="463" alt="projects-before" src="https://user-images.githubusercontent.com/120486/204368100-761aaec0-f8f0-44e9-8043-1b195c70dc3a.png"> | <img width="463" alt="projects-after" src="https://user-images.githubusercontent.com/120486/204368103-5e1ad074-2402-4429-a06f-ae5b10c87942.png"> |
| ![usage-before](https://user-images.githubusercontent.com/120486/204369644-3dc7f2dd-2e17-403c-872f-da130f5fcd3b.png) | ![usage-after](https://user-images.githubusercontent.com/120486/204369649-aa634e66-3d58-4672-95b8-4285b07c2256.png) | 

## How to test
Notice the style changes for the `beta` notice for Teams & Projects, following the style used for Usage, at the footer of the `/teams/new` and `/new` pages.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Update beta label on teams, projects, and usage
```

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
