### PR TITLE
[tests] Stop running self-hosted tests daily

### DIFF
--- a/.werft/aks-installer-tests.yaml
+++ b/.werft/aks-installer-tests.yaml
@@ -174,5 +174,5 @@ pod:
           npx ts-node .werft/installer-tests.ts "STANDARD_AKS_TEST"
 
 # The bit below makes this a cron job
-plugins:
-  cron: "15 3 * * *"
+# plugins:
+#   cron: "15 3 * * *"

--- a/.werft/eks-installer-tests.yaml
+++ b/.werft/eks-installer-tests.yaml
@@ -173,5 +173,5 @@ pod:
           npx ts-node .werft/installer-tests.ts "STANDARD_EKS_TEST"
 
 # The bit below makes this a cron job
-plugins:
-  cron: "15 3 * * *"
+# plugins:
+#   cron: "15 3 * * *"

--- a/.werft/gke-installer-tests.yaml
+++ b/.werft/gke-installer-tests.yaml
@@ -158,5 +158,5 @@ pod:
           npm config set update-notifier false
           npx ts-node .werft/installer-tests.ts "STANDARD_GKE_TEST"
 # The bit below makes this a cron job
-plugins:
-  cron: "15 4 * * *"
+# plugins:
+#   cron: "15 4 * * *"

--- a/.werft/k3s-installer-tests.yaml
+++ b/.werft/k3s-installer-tests.yaml
@@ -161,5 +161,5 @@ pod:
         npm config set update-notifier false
         npx ts-node .werft/installer-tests.ts "STANDARD_K3S_TEST"
 # The bit below makes this a cron job
-plugins:
-  cron: "15 3 * * *"
+# plugins:
+#   cron: "15 3 * * *"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
The intent of this change is to reduce noise in Slack for each product team's `job` channel. 

Why?
* Self-hosted test automation runs is generally only needed once a month, as part of our self-hosted release process. 
* Teams have generic test suites that run tests for their components as part of separate jobs. [[1](https://github.com/gitpod-io/gitpod/blob/116ea559bc0979227467c9e30c717e786c2bee97/.werft/workspace-run-integration-tests.yaml#L74-L75)][[2](https://github.com/gitpod-io/gitpod/blob/116ea559bc0979227467c9e30c717e786c2bee97/.werft/ide-integration-tests-startup.yaml#L67-L68)]

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes # n/a

## How to test
<!-- Provide steps to test this PR -->
After this is merged, the self-hosted tests won't run on a schedule, and `job` Slack channels will have less threads. The tests can still be run manually, and will output to Slack.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
