### PR TITLE
ready-probe-labeler: Add periodic monitoring

### DIFF
--- a/dev/ready-probe-labeler/main.go
+++ b/dev/ready-probe-labeler/main.go
@@ -68,16 +68,17 @@ func main() {
 		log.Fatalf("Unexpected error: %v", err)
 	}
 
+	start := time.Now()
+
 	if opts.Shutdown {
 		err = updateLabel(opts.Label, false, nodeName, client)
 		if err != nil {
 			log.Fatalf("Unexpected error removing node label: %v", err)
 		}
+		log.WithField("node", nodeName).WithField("time", time.Since(start).Seconds()).Info("node label updated")
 
 		return
 	}
-
-	start := time.Now()
 
 	err = waitForURLToBeReachable(opts.ProbeURL, opts.Timeout)
 	if err != nil {

--- a/install/installer/cmd/testdata/render/README.md
+++ b/install/installer/cmd/testdata/render/README.md
@@ -11,6 +11,7 @@ These are not unit tests in the strict sense. We do not have an expectated outco
 For most developers, the requirement will be to update the golden files when they write something that changes the output in some way. That is as simple as running:
 
 ```shell
+make deps
 make generateRenderTests
 ```
 

--- a/install/installer/cmd/testdata/render/aws-setup/output.golden
+++ b/install/installer/cmd/testdata/render/aws-setup/output.golden
@@ -7282,6 +7282,7 @@ spec:
         - /app/ready-probe-labeler
         - --label=gitpod.io/registry-facade_ready_ns_default
         - --probe-url=http://localhost:8086/ready
+        - --with-monitor
         env:
         - name: NODENAME
           valueFrom:

--- a/install/installer/cmd/testdata/render/azure-setup/output.golden
+++ b/install/installer/cmd/testdata/render/azure-setup/output.golden
@@ -7127,6 +7127,7 @@ spec:
         - /app/ready-probe-labeler
         - --label=gitpod.io/registry-facade_ready_ns_default
         - --probe-url=http://localhost:8086/ready
+        - --with-monitor
         env:
         - name: NODENAME
           valueFrom:

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -8388,6 +8388,7 @@ spec:
         - /app/ready-probe-labeler
         - --label=gitpod.io/registry-facade_ready_ns_default
         - --probe-url=http://localhost:8086/ready
+        - --with-monitor
         env:
         - name: NODENAME
           valueFrom:

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -7409,6 +7409,7 @@ spec:
         - /app/ready-probe-labeler
         - --label=gitpod.io/registry-facade_ready_ns_default
         - --probe-url=http://localhost:8086/ready
+        - --with-monitor
         env:
         - name: NODENAME
           valueFrom:

--- a/install/installer/cmd/testdata/render/gcp-setup/output.golden
+++ b/install/installer/cmd/testdata/render/gcp-setup/output.golden
@@ -7101,6 +7101,7 @@ spec:
         - /app/ready-probe-labeler
         - --label=gitpod.io/registry-facade_ready_ns_default
         - --probe-url=http://localhost:8086/ready
+        - --with-monitor
         env:
         - name: NODENAME
           valueFrom:

--- a/install/installer/cmd/testdata/render/http-proxy/output.golden
+++ b/install/installer/cmd/testdata/render/http-proxy/output.golden
@@ -7852,6 +7852,7 @@ spec:
         - /app/ready-probe-labeler
         - --label=gitpod.io/registry-facade_ready_ns_default
         - --probe-url=http://localhost:8086/ready
+        - --with-monitor
         env:
         - name: NODENAME
           valueFrom:

--- a/install/installer/cmd/testdata/render/insecure-s3-setup/output.golden
+++ b/install/installer/cmd/testdata/render/insecure-s3-setup/output.golden
@@ -7559,6 +7559,7 @@ spec:
         - /app/ready-probe-labeler
         - --label=gitpod.io/registry-facade_ready_ns_default
         - --probe-url=http://localhost:8086/ready
+        - --with-monitor
         env:
         - name: NODENAME
           valueFrom:

--- a/install/installer/cmd/testdata/render/kind-workspace/output.golden
+++ b/install/installer/cmd/testdata/render/kind-workspace/output.golden
@@ -3078,6 +3078,7 @@ spec:
         - /app/ready-probe-labeler
         - --label=gitpod.io/registry-facade_ready_ns_default
         - --probe-url=http://localhost:8086/ready
+        - --with-monitor
         env:
         - name: NODENAME
           valueFrom:

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -7689,6 +7689,7 @@ spec:
         - /app/ready-probe-labeler
         - --label=gitpod.io/registry-facade_ready_ns_default
         - --probe-url=http://localhost:8086/ready
+        - --with-monitor
         env:
         - name: NODENAME
           valueFrom:

--- a/install/installer/cmd/testdata/render/shortname/output.golden
+++ b/install/installer/cmd/testdata/render/shortname/output.golden
@@ -7689,6 +7689,7 @@ spec:
         - /app/ready-probe-labeler
         - --label=gitpod.io/registry-facade_ready_ns_default
         - --probe-url=http://localhost:8086/ready
+        - --with-monitor
         env:
         - name: NODENAME
           valueFrom:

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -7701,6 +7701,7 @@ spec:
         - /app/ready-probe-labeler
         - --label=gitpod.io/registry-facade_ready_ns_default
         - --probe-url=http://localhost:8086/ready
+        - --with-monitor
         env:
         - name: NODENAME
           valueFrom:

--- a/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
+++ b/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
@@ -8133,6 +8133,7 @@ spec:
         - /app/ready-probe-labeler
         - --label=gitpod.io/registry-facade_ready_ns_default
         - --probe-url=http://localhost:8086/ready
+        - --with-monitor
         env:
         - name: NODENAME
           valueFrom:

--- a/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
+++ b/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
@@ -7691,6 +7691,7 @@ spec:
         - /app/ready-probe-labeler
         - --label=gitpod.io/registry-facade_ready_ns_default
         - --probe-url=http://localhost:8086/ready
+        - --with-monitor
         env:
         - name: NODENAME
           valueFrom:

--- a/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
+++ b/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
@@ -7692,6 +7692,7 @@ spec:
         - /app/ready-probe-labeler
         - --label=gitpod.io/registry-facade_ready_ns_default
         - --probe-url=http://localhost:8086/ready
+        - --with-monitor
         env:
         - name: NODENAME
           valueFrom:

--- a/install/installer/pkg/components/registry-facade/daemonset.go
+++ b/install/installer/pkg/components/registry-facade/daemonset.go
@@ -304,6 +304,7 @@ func daemonset(ctx *common.RenderContext) ([]runtime.Object, error) {
 								"/app/ready-probe-labeler",
 								fmt.Sprintf("--label=gitpod.io/registry-facade_ready_ns_%v", ctx.Namespace),
 								fmt.Sprintf(`--probe-url=http://localhost:%v/ready`, ReadinessPort),
+								`--with-monitor`,
 							},
 							Env: common.CustomizeEnvvar(ctx, Component, common.MergeEnv(
 								common.NodeNameEnv(ctx),


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

When only the container of the registry-facade was broken the ready-nobel of the node was not disappearing. Periodically checking url will delete the label.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/13915

## How to test
<!-- Provide steps to test this PR -->

Please check this video more detail https://github.com/gitpod-io/gitpod/issues/13915#issuecomment-1330012196

I'd like to check them for reviewer
1. Node label, `gitpod.io/registry-facade_ready_ns_default` disappears when deleting a registry-facade **container** and turn on when registry-facade come back
2. Node label, `gitpod.io/registry-facade_ready_ns_default` disappears when deleting a registry-facade **pod** and turn on when registry-facade come back

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Do not land workspaces on the node with broken registry-facade
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
