### PR TITLE
[common] Improve log time accuracy

### DIFF
--- a/components/common-go/log/log.go
+++ b/components/common-go/log/log.go
@@ -127,10 +127,14 @@ func Init(service, version string, json, verbose bool) {
 					funcName := s[len(s)-1]
 					return funcName, fmt.Sprintf("%s:%d", path.Base(f.File), f.Line)
 				},
+				TimestampFormat: time.RFC3339Nano,
 			},
 		})
 	} else {
-		Log.Logger.SetFormatter(&logrus.TextFormatter{})
+		Log.Logger.SetFormatter(&logrus.TextFormatter{
+			TimestampFormat: time.RFC3339Nano,
+			FullTimestamp:   true,
+		})
 	}
 
 	// update default log level


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
[common] Improve log time accuracy

Before our log time accuracy is second, it will cause random order in gcp error (same second), this PR up time accuracy to nano sec.

<img width="764" alt="image" src="https://user-images.githubusercontent.com/8299500/204460932-a5252088-f3a1-4fb9-936c-dcd91bd92b09.png">


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
1. open this PR in gitpod.io
2. cd `components/supervisor/`
3. run `go run . run`
4. it will print an error, and the time should be nano sec.
|  before | after  |
|---|---|
|  <img width="775" alt="image" src="https://user-images.githubusercontent.com/8299500/204461286-3abc1f5f-cb72-4bc4-8e87-b7ee6ce3c135.png"> | <img width="756" alt="image" src="https://user-images.githubusercontent.com/8299500/204461248-3920d4db-c4d9-458b-9c2d-db8adb4a1458.png">  |

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
