### PR TITLE
Replace usage-based with pay-as-you-go in billing pages

### DIFF
--- a/components/dashboard/src/components/UsageBasedBillingConfig.tsx
+++ b/components/dashboard/src/components/UsageBasedBillingConfig.tsx
@@ -211,7 +211,7 @@ export default function UsageBasedBillingConfig({ attributionId }: Props) {
 
     return (
         <div className="mb-16">
-            <h2 className="text-gray-500">Manage usage-based billing, usage limit, and payment method.</h2>
+            <h2 className="text-gray-500">Manage pay-as-you-go billing.</h2>
             <div className="max-w-xl flex flex-col">
                 {errorMessage && (
                     <Alert className="max-w-xl mt-2" closable={false} showIcon={true} type="error">

--- a/components/dashboard/src/settings/Billing.tsx
+++ b/components/dashboard/src/settings/Billing.tsx
@@ -19,7 +19,7 @@ export default function Billing() {
             <div>
                 <h3>Default Billing Account</h3>
                 <BillingAccountSelector />
-                <h3 className="mt-12">Personal Plan</h3>
+                <h3 className="mt-12">Personal Billing</h3>
                 <UsageBasedBillingConfig
                     attributionId={user && AttributionId.render({ kind: "user", userId: user.id })}
                 />

--- a/components/dashboard/src/teams/TeamUsageBasedBilling.tsx
+++ b/components/dashboard/src/teams/TeamUsageBasedBilling.tsx
@@ -33,7 +33,7 @@ export default function TeamUsageBasedBilling() {
 
     return (
         <>
-            <h3>Usage-Based Billing</h3>
+            <h3>Team Billing</h3>
             <UsageBasedBillingConfig attributionId={team && AttributionId.render({ kind: "team", teamId: team.id })} />
         </>
     );


### PR DESCRIPTION
Tiny PR with tweaks to the user and team billing pages, to replace "usage-based" with "pay-as-you-go".  

Fixes #14475

### How to test
Check that there is no mention of "Usage-based" in user and team billing settings. 

### Release Notes
```release-note
Replace "usage-based" with "pay-as-you-go" in user and team billing pages.
```

### Documentation
https://github.com/gitpod-io/website/issues/3004

### Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-payment
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
