### PR TITLE
Disable running prebuilds without a project

### DIFF
--- a/components/dashboard/src/start/CreateWorkspace.tsx
+++ b/components/dashboard/src/start/CreateWorkspace.tsx
@@ -207,6 +207,15 @@ export default class CreateWorkspace extends React.Component<CreateWorkspaceProp
                     phase = StartPhase.Stopped;
                     statusMessage = <UsageLimitReachedModal hints={this.state?.error?.data} />;
                     break;
+                case ErrorCodes.PROJECT_REQUIRED:
+                    statusMessage = (
+                        <p className="text-base text-gitpod-red w-96">
+                            <a className="gp-link" href="https://www.gitpod.io/docs/configure/projects">
+                                Learn more about projects
+                            </a>
+                        </p>
+                    );
+                    break;
                 default:
                     statusMessage = (
                         <p className="text-base text-gitpod-red w-96">

--- a/components/gitpod-protocol/src/context-url.spec.ts
+++ b/components/gitpod-protocol/src/context-url.spec.ts
@@ -41,24 +41,6 @@ export class ContextUrlTest {
         expect(actual?.pathname).to.equal("/gitpod-io/gitpod-test-repo.git");
     }
 
-    @test public parseContextUrl_withPrebuild() {
-        const actual = ContextURL.getNormalizedURL({
-            contextURL: "prebuild/https://github.com/gitpod-io/gitpod-test-repo",
-            context: {},
-        } as WsContextUrl);
-        expect(actual?.host).to.equal("github.com");
-        expect(actual?.pathname).to.equal("/gitpod-io/gitpod-test-repo");
-    }
-
-    @test public parseContextUrl_withPrebuild_withoutSchema() {
-        const actual = ContextURL.getNormalizedURL({
-            contextURL: "prebuild/github.com/gitpod-io/gitpod-test-repo",
-            context: {},
-        } as WsContextUrl);
-        expect(actual?.host).to.equal("github.com");
-        expect(actual?.pathname).to.equal("/gitpod-io/gitpod-test-repo");
-    }
-
     @test public parseContextUrl_badUrl() {
         const actual = ContextURL.getNormalizedURL({ contextURL: "[Object object]", context: {} } as WsContextUrl);
         expect(actual).to.be.undefined;

--- a/components/gitpod-protocol/src/context-url.ts
+++ b/components/gitpod-protocol/src/context-url.ts
@@ -15,7 +15,6 @@ import { Workspace } from ".";
  * TODO(gpl) See if we can get this into `server` code to remove the burden from clients
  */
 export namespace ContextURL {
-    export const INCREMENTAL_PREBUILD_PREFIX = "incremental-prebuild";
     export const PREBUILD_PREFIX = "prebuild";
     export const IMAGEBUILD_PREFIX = "imagebuild";
     export const SNAPSHOT_PREFIX = "snapshot";
@@ -91,7 +90,6 @@ export namespace ContextURL {
         const firstSegment = segments[0];
         if (
             firstSegment === PREBUILD_PREFIX ||
-            firstSegment === INCREMENTAL_PREBUILD_PREFIX ||
             firstSegment === IMAGEBUILD_PREFIX ||
             firstSegment === SNAPSHOT_PREFIX ||
             firstSegment.startsWith(REFERRER_PREFIX)

--- a/components/gitpod-protocol/src/messaging/error.ts
+++ b/components/gitpod-protocol/src/messaging/error.ts
@@ -35,6 +35,9 @@ export namespace ErrorCodes {
     // 430 Repository not whitelisted (custom status code)
     export const REPOSITORY_NOT_WHITELISTED = 430;
 
+    // 440 Prebuilds now always require a project (custom status code)
+    export const PROJECT_REQUIRED = 440;
+
     // 450 Payment error
     export const PAYMENT_ERROR = 450;
 

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -1127,7 +1127,7 @@ export interface WithCommitHistory {
 
 export interface StartPrebuildContext extends WorkspaceContext, WithCommitHistory {
     actual: WorkspaceContext;
-    project?: Project;
+    project: Project;
     branch?: string;
 }
 

--- a/components/server/ee/src/prebuilds/prebuild-manager.ts
+++ b/components/server/ee/src/prebuilds/prebuild-manager.ts
@@ -126,6 +126,11 @@ export class PrebuildManager {
             if (user.blocked) {
                 throw new Error(`Blocked users cannot start prebuilds (${user.name})`);
             }
+            if (!project) {
+                throw new Error(
+                    `Running prebuilds without a project is no longer supported. Please add '${cloneURL}' as a project in a Gitpod team.`,
+                );
+            }
             const existingPB = await this.findNonFailedPrebuiltWorkspace({ span }, cloneURL, commitSHAIdentifier);
 
             // If the existing prebuild is failed, it will be retriggered in the afterwards

--- a/components/server/ee/src/prebuilds/prebuild-manager.ts
+++ b/components/server/ee/src/prebuilds/prebuild-manager.ts
@@ -35,6 +35,8 @@ import { StopWorkspacePolicy } from "@gitpod/ws-manager/lib";
 import { error } from "console";
 import { IncrementalPrebuildsService } from "./incremental-prebuilds-service";
 import { PrebuildRateLimiterConfig } from "../../../src/workspace/prebuild-rate-limiter";
+import { ResponseError } from "vscode-ws-jsonrpc";
+import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
 
 export class WorkspaceRunningError extends Error {
     constructor(msg: string, public instance: WorkspaceInstance) {
@@ -124,10 +126,11 @@ export class PrebuildManager {
 
         try {
             if (user.blocked) {
-                throw new Error(`Blocked users cannot start prebuilds (${user.name})`);
+                throw new ResponseError(ErrorCodes.USER_BLOCKED, `Blocked users cannot start prebuilds (${user.name})`);
             }
             if (!project) {
-                throw new Error(
+                throw new ResponseError(
+                    ErrorCodes.PROJECT_REQUIRED,
                     `Running prebuilds without a project is no longer supported. Please add '${cloneURL}' as a project in a Gitpod team.`,
                 );
             }

--- a/components/server/ee/src/prebuilds/start-prebuild-context-parser.ts
+++ b/components/server/ee/src/prebuilds/start-prebuild-context-parser.ts
@@ -5,7 +5,9 @@
  */
 
 import { User, WorkspaceContext, ContextURL } from "@gitpod/gitpod-protocol";
+import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
 import { injectable } from "inversify";
+import { ResponseError } from "vscode-ws-jsonrpc";
 import { IPrefixContextParser } from "../../../src/workspace/context-parser";
 
 @injectable()
@@ -19,7 +21,8 @@ export class StartPrebuildContextParser implements IPrefixContextParser {
     }
 
     public async handle(user: User, prefix: string, context: WorkspaceContext): Promise<WorkspaceContext> {
-        throw new Error(
+        throw new ResponseError(
+            ErrorCodes.PROJECT_REQUIRED,
             `Running prebuilds without a project is no longer supported. Please add your repository as a project in a Gitpod team.`,
         );
     }

--- a/components/server/ee/src/prebuilds/start-prebuild-context-parser.ts
+++ b/components/server/ee/src/prebuilds/start-prebuild-context-parser.ts
@@ -4,7 +4,7 @@
  * See License.enterprise.txt in the project root folder.
  */
 
-import { User, WorkspaceContext, StartPrebuildContext, IssueContext, ContextURL } from "@gitpod/gitpod-protocol";
+import { User, WorkspaceContext, ContextURL } from "@gitpod/gitpod-protocol";
 import { injectable } from "inversify";
 import { IPrefixContextParser } from "../../../src/workspace/context-parser";
 
@@ -19,14 +19,8 @@ export class StartPrebuildContextParser implements IPrefixContextParser {
     }
 
     public async handle(user: User, prefix: string, context: WorkspaceContext): Promise<WorkspaceContext> {
-        if (IssueContext.is(context)) {
-            throw new Error("cannot start prebuilds on an issue context");
-        }
-
-        const result: StartPrebuildContext = {
-            title: `Prebuild of "${context.title}"`,
-            actual: context,
-        };
-        return result;
+        throw new Error(
+            `Running prebuilds without a project is no longer supported. Please add your repository as a project in a Gitpod team.`,
+        );
     }
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Throw an error when attempting to start a prebuild on a repository without a corresponding project.

Also _(reviving https://github.com/gitpod-io/gitpod/pull/15024)_ disable the deprecated `#prebuild/` context URL prefix, because it doesn't know about projects (and thus ignores any project details, settings, or safeguards).

The supported ways to start a prebuild are:
- Creating a Project
- Pushing commits to a Project branch
- Clicking on a `Run Prebuild` button in the UI

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/9898 https://github.com/gitpod-io/gitpod/issues/4353

## How to test
<!-- Provide steps to test this PR -->

1. Should build
2. Using the deprecated `#prebuild/` URL prefix should no longer work

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Disable running prebuilds without a project + disable the deprecated '#prebuild/' URL prefix
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
