### PR TITLE
Parallelise dev:preview and deploy monitoring satellite automatically

### DIFF
--- a/dev/preview/workflow/preview/preview.sh
+++ b/dev/preview/workflow/preview/preview.sh
@@ -29,7 +29,6 @@ fi
 leeway run dev/preview:configure-workspace
 ensure_gcloud_auth
 
-leeway run dev/preview:create-preview
-leeway run dev/preview:build
+leeway run dev/preview:create-preview dev/preview:build
 previewctl install-context --gcp-service-account "${PREVIEW_ENV_DEV_SA_KEY_PATH}" --timeout 10m
-leeway run dev/preview:deploy-gitpod
+leeway run dev/preview:deploy-gitpod dev/preview:deploy-monitoring-satellite


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Run `dev/preview:create-preview` and `dev/preview:build` in parallel. Add `dev/preview:deploy-monitoring-satellite` and run it in parallel with `dev/preview:deploy-gitpod`

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/14707
Fixes https://github.com/gitpod-io/gitpod/issues/14704

## How to test
<!-- Provide steps to test this PR -->

`leeway run dev:preview` should still work, but scripts should run in parallel where possible.

```sh
leeway run dev:preview
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
