### PR TITLE
[JetBrains] Fail build on error

### DIFF
--- a/components/ide/jetbrains/backend-plugin/build.sh
+++ b/components/ide/jetbrains/backend-plugin/build.sh
@@ -3,6 +3,8 @@
 # Licensed under the GNU Affero General Public License (AGPL).
 # See License-AGPL.txt in the project root for license information.
 
+set -e
+
 if [ "${NO_VERIFY_JB_PLUGIN}" == "true" ]; then
     echo "build.sh: skip verify plugin step"
 else


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Fail build if any of script steps are ended with error.

PR initially created at https://github.com/gitpod-io/gitpod/pull/14530, but moved here due to the necessity of a rebase for Werft Build to succeed.

## How to test
<!-- Provide steps to test this PR -->
Just check if Werft Build succeeds.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Post-merge actions
- Close https://github.com/gitpod-io/gitpod/pull/14530 as complete.

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
