### PR TITLE
[supervisor] give 1s window between content and tasks for IDE startup

### DIFF
--- a/components/supervisor/pkg/supervisor/tasks_test.go
+++ b/components/supervisor/pkg/supervisor/tasks_test.go
@@ -224,7 +224,7 @@ func TestTaskManager(t *testing.T) {
 						GitpodTasks:    gitpodTasks,
 						GitpodHeadless: strconv.FormatBool(test.Headless),
 					},
-				}, terminalService, contentState, &reporter)
+				}, terminalService, contentState, &reporter, nil, nil)
 			)
 			taskManager.storeLocation = storeLocation
 			contentState.MarkContentReady(test.Source)


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

We suspect that competition for resources between tasks and IDE starting at the same time can delay IDE startup.
Since IDE startup is fast we try to delay start of tasks for max 1s to give an opportunity for IDE to start.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

Check that a workspace can start with tasks, VS Code Browser and IntelliJ IDEA. (test for regressions)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
