### PR TITLE
[pat] Do not list deleted PATs

### DIFF
--- a/components/gitpod-db/go/personal_access_token.go
+++ b/components/gitpod-db/go/personal_access_token.go
@@ -169,6 +169,7 @@ func ListPersonalAccessTokensForUser(ctx context.Context, conn *gorm.DB, userID 
 		WithContext(ctx).
 		Table((&PersonalAccessToken{}).TableName()).
 		Where("userId = ?", userID).
+		Where("deleted = ?", 0).
 		Count(&count)
 	if tx.Error != nil {
 		return nil, fmt.Errorf("failed to count total number of personal access tokens for user %s: %w", userID.String(), tx.Error)


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Currently with 1 deleted token, we'd return { Results: [], Total: 1 }. This fixes that.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
