### PR TITLE
[proxy] Add latency to all websocket connections to server

### DIFF
--- a/components/proxy/conf/Caddyfile
+++ b/components/proxy/conf/Caddyfile
@@ -210,12 +210,21 @@ https://{$GITPOD_DOMAIN} {
 	handle @backend_wss {
 		gitpod.sec_websocket_key
 
+		forward_auth server.{$KUBE_NAMESPACE}.{$KUBE_DOMAIN}:3000 {
+			uri /feature-flags/slow-database
+
+			header_up -Connection
+			header_up -Upgrade
+
+			copy_headers X-Gitpod-Slow-Database
+		}
+
 		@slow {
-			header "Sec-WebSocket-Protocol" "slow-database"
+			header X-Gitpod-Slow-Database "true"
 		}
 
 		@fast {
-			not header "Sec-WebSocket-Protocol" "slow-database"
+			not header X-Gitpod-Slow-Database "true"
 		}
 
 		uri strip_prefix /api


### PR DESCRIPTION
## Description

In https://github.com/gitpod-io/gitpod/pull/14778 and https://github.com/gitpod-io/gitpod/pull/14752, latency was added to websocket connections to `server` from the dashboard by testing the value of the `slow_database` feature flag on the client side and setting an appropriate header during the websocket connection upgrade handshake.

This approach works for connections to `server` from the dashboard but not for other websocket connections to `server`.

This PR moves the evaluation of the feature flag from the dashboard client to `proxy`, using a 'pre-flight' check just like the one added in https://github.com/gitpod-io/gitpod/issues/14960 for regular HTTP requests to `server` `/api*` requests.

The client side code to check the value of the feature flag will be removed by https://github.com/gitpod-io/gitpod/pull/15035.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of #9198 

Closes https://github.com/gitpod-io/gitpod/issues/14964

## How to test

When the `slow_database` feature flag is enabled for your user id in the preview environment, websocket connections from dashboard are still subject to extra latency.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-slow-database 
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
