### PR TITLE
[dashboard] Remove client side eval of `slow_database` flag

### DIFF
--- a/components/dashboard/src/App.tsx
+++ b/components/dashboard/src/App.tsx
@@ -12,7 +12,7 @@ import { Login } from "./Login";
 import { UserContext } from "./user-context";
 import { getSelectedTeamSlug, TeamsContext } from "./teams/teams-context";
 import { ThemeContext } from "./theme-context";
-import { getGitpodService, initGitPodService } from "./service/service";
+import { getGitpodService } from "./service/service";
 import { shouldSeeWhatsNew, WhatsNew } from "./whatsnew/WhatsNew";
 import gitpodIcon from "./icons/gitpod.svg";
 import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
@@ -162,17 +162,13 @@ function App() {
     const { user, setUser, refreshUserBillingMode } = useContext(UserContext);
     const { teams, setTeams } = useContext(TeamsContext);
     const { setIsDark } = useContext(ThemeContext);
-    const { usePublicApiTeamsService, useSlowDatabase } = useContext(FeatureFlagContext);
+    const { usePublicApiTeamsService } = useContext(FeatureFlagContext);
 
     const [loading, setLoading] = useState<boolean>(true);
     const [isWhatsNewShown, setWhatsNewShown] = useState(false);
     const [showUserIdePreference, setShowUserIdePreference] = useState(false);
     const [isSetupRequired, setSetupRequired] = useState(false);
     const history = useHistory();
-
-    useEffect(() => {
-        initGitPodService(useSlowDatabase);
-    }, [useSlowDatabase]);
 
     useEffect(() => {
         (async () => {

--- a/components/dashboard/src/contexts/FeatureFlagContext.tsx
+++ b/components/dashboard/src/contexts/FeatureFlagContext.tsx
@@ -21,14 +21,12 @@ const FeatureFlagContext = createContext<{
     showUseLastSuccessfulPrebuild: boolean;
     usePublicApiTeamsService: boolean;
     enablePersonalAccessTokens: boolean;
-    useSlowDatabase: boolean;
 }>({
     showPersistentVolumeClaimUI: false,
     showUsageView: false,
     showUseLastSuccessfulPrebuild: false,
     usePublicApiTeamsService: false,
     enablePersonalAccessTokens: false,
-    useSlowDatabase: false,
 });
 
 const FeatureFlagContextProvider: React.FC = ({ children }) => {
@@ -42,7 +40,6 @@ const FeatureFlagContextProvider: React.FC = ({ children }) => {
     const [showUseLastSuccessfulPrebuild, setShowUseLastSuccessfulPrebuild] = useState<boolean>(false);
     const [usePublicApiTeamsService, setUsePublicApiTeamsService] = useState<boolean>(false);
     const [enablePersonalAccessTokens, setPersonalAccessTokensEnabled] = useState<boolean>(false);
-    const [useSlowDatabase, setUseSlowDatabase] = useState<boolean>(false);
 
     useEffect(() => {
         if (!user) return;
@@ -53,7 +50,6 @@ const FeatureFlagContextProvider: React.FC = ({ children }) => {
                 showUseLastSuccessfulPrebuild: { defaultValue: false, setter: setShowUseLastSuccessfulPrebuild },
                 publicApiExperimentalTeamsService: { defaultValue: false, setter: setUsePublicApiTeamsService },
                 personalAccessTokensEnabled: { defaultValue: false, setter: setPersonalAccessTokensEnabled },
-                slow_database: { defaultValue: false, setter: setUseSlowDatabase },
             };
 
             for (const [flagName, config] of Object.entries(featureFlags)) {
@@ -98,7 +94,6 @@ const FeatureFlagContextProvider: React.FC = ({ children }) => {
                 showUseLastSuccessfulPrebuild,
                 usePublicApiTeamsService,
                 enablePersonalAccessTokens,
-                useSlowDatabase,
             }}
         >
             {children}

--- a/components/dashboard/src/service/service.tsx
+++ b/components/dashboard/src/service/service.tsx
@@ -19,7 +19,7 @@ import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 
 export const gitpodHostUrl = new GitpodHostUrl(window.location.toString());
 
-function createGitpodService<C extends GitpodClient, S extends GitpodServer>(useSlowDatabase: boolean = false) {
+function createGitpodService<C extends GitpodClient, S extends GitpodServer>() {
     if (window.top !== window.self && process.env.NODE_ENV === "production") {
         const connection = createWindowMessageConnection("gitpodServer", window.parent, "*");
         const factory = new JsonRpcProxyFactory<S>();
@@ -48,7 +48,6 @@ function createGitpodService<C extends GitpodClient, S extends GitpodServer>(use
         onListening: (socket) => {
             onReconnect = () => socket.reconnect();
         },
-        subProtocol: useSlowDatabase ? "slow-database" : undefined,
     });
 
     return new GitpodServiceImpl<C, S>(proxy, { onReconnect });
@@ -65,13 +64,4 @@ function getGitpodService(): GitpodService {
     return service;
 }
 
-function initGitPodService(useSlowDatabase: boolean) {
-    const w = window as any;
-    const _gp = w._gp || (w._gp = {});
-    if (window.location.search.includes("service=mock")) {
-        _gp.gitpodService = require("./service-mock").gitpodServiceMock;
-    }
-    _gp.gitpodService = createGitpodService(useSlowDatabase);
-}
-
-export { getGitpodService, initGitPodService };
+export { getGitpodService };

--- a/components/gitpod-protocol/src/messaging/browser/connection.ts
+++ b/components/gitpod-protocol/src/messaging/browser/connection.ts
@@ -16,7 +16,6 @@ import ReconnectingWebSocket, { Event } from "reconnecting-websocket";
 export interface WebSocketOptions {
     onerror?: (event: Event) => void;
     onListening?: (socket: ReconnectingWebSocket) => void;
-    subProtocol?: string;
 }
 
 export class WebSocketConnectionProvider {
@@ -63,7 +62,7 @@ export class WebSocketConnectionProvider {
      */
     listen(handler: ConnectionHandler, eventHandler: ConnectionEventHandler, options?: WebSocketOptions): WebSocket {
         const url = handler.path;
-        const webSocket = this.createWebSocket(url, options);
+        const webSocket = this.createWebSocket(url);
 
         const logger = this.createLogger();
         if (options && options.onerror) {
@@ -87,8 +86,8 @@ export class WebSocketConnectionProvider {
     /**
      * Creates a web socket for the given url
      */
-    createWebSocket(url: string, options?: WebSocketOptions): WebSocket {
-        return new ReconnectingWebSocket(url, options?.subProtocol, {
+    createWebSocket(url: string): WebSocket {
+        return new ReconnectingWebSocket(url, undefined, {
             maxReconnectionDelay: 10000,
             minReconnectionDelay: 1000,
             reconnectionDelayGrowFactor: 1.3,


### PR DESCRIPTION
## Description

Reverts https://github.com/gitpod-io/gitpod/pull/14752.

The logic of checking the feature flag has moved (in https://github.com/gitpod-io/gitpod/pull/15035) to the backend (`proxy`) so we don't need this logic on the dashboard anymore.

## Related Issue(s)

Part of #9198 and https://github.com/gitpod-io/gitpod/issues/14964.

## How to test

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
