### PR TITLE
[server, installer] Configure PAT signing key

### DIFF
--- a/dev/preview/workflow/preview/deploy-gitpod.sh
+++ b/dev/preview/workflow/preview/deploy-gitpod.sh
@@ -396,7 +396,7 @@ yq w -i "${INSTALLER_CONFIG_PATH}" experimental.webapp.proxy.configcat.baseUrl "
 yq w -i "${INSTALLER_CONFIG_PATH}" experimental.webapp.proxy.configcat.pollInterval "1m"
 
 #
-# configurePublicAPI
+# configure Personal Access Token signign key
 #
 yq w -i "${INSTALLER_CONFIG_PATH}" experimental.webapp.publicApi.personalAccessTokenSigningKeySecretName "personal-access-token-signing-key"
 

--- a/install/installer/cmd/testdata/render/aws-setup/output.golden
+++ b/install/installer/cmd/testdata/render/aws-setup/output.golden
@@ -4770,6 +4770,7 @@ data:
       "stripeSecretsFile": "/stripe-secret/apikeys",
       "stripeConfigFile": "",
       "enablePayment": false,
+      "patSigningKeyFile": "",
       "workspaceHeartbeat": {
         "intervalSeconds": 60,
         "timeoutSeconds": 300
@@ -9252,7 +9253,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: de38b07ebe2e745c59774ddd2d9028db11d63b18ffb37dc0e6dbd08eeb2e4cc4
+        gitpod.io/checksum_config: d6614af994531fe5c31ddff93c3f5c9ae4eacae9dc0bcb278d23cd44d0bc4b41
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/azure-setup/output.golden
+++ b/install/installer/cmd/testdata/render/azure-setup/output.golden
@@ -4633,6 +4633,7 @@ data:
       "stripeSecretsFile": "/stripe-secret/apikeys",
       "stripeConfigFile": "",
       "enablePayment": false,
+      "patSigningKeyFile": "",
       "workspaceHeartbeat": {
         "intervalSeconds": 60,
         "timeoutSeconds": 300
@@ -9103,7 +9104,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: de38b07ebe2e745c59774ddd2d9028db11d63b18ffb37dc0e6dbd08eeb2e4cc4
+        gitpod.io/checksum_config: d6614af994531fe5c31ddff93c3f5c9ae4eacae9dc0bcb278d23cd44d0bc4b41
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -5609,6 +5609,7 @@ data:
       "stripeSecretsFile": "/stripe-secret/apikeys",
       "stripeConfigFile": "",
       "enablePayment": false,
+      "patSigningKeyFile": "",
       "workspaceHeartbeat": {
         "intervalSeconds": 60,
         "timeoutSeconds": 300
@@ -10714,7 +10715,7 @@ spec:
     metadata:
       annotations:
         gitpod.io: hello
-        gitpod.io/checksum_config: 948db83a83779ff24f5a5f9eb7b00e684a5dfcecb3f933dac378dc3d20dad8e2
+        gitpod.io/checksum_config: 671903bbf173feb891de94d4380d0f3360b0e8b4c4b3aeac6d49b7544f5ee697
         hello: world
       creationTimestamp: null
       labels:

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -4820,6 +4820,7 @@ data:
       "stripeSecretsFile": "/stripe-secret/apikeys",
       "stripeConfigFile": "",
       "enablePayment": false,
+      "patSigningKeyFile": "",
       "workspaceHeartbeat": {
         "intervalSeconds": 60,
         "timeoutSeconds": 300
@@ -9529,7 +9530,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3d98dffb48bebba57afb1ffd2b059e4a1a95bb679d843bee0158e5d4b1814914
+        gitpod.io/checksum_config: a94779de77b43b080faf67667aa017f25fc963c43412f8438c49ace3a7b7af2a
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/gcp-setup/output.golden
+++ b/install/installer/cmd/testdata/render/gcp-setup/output.golden
@@ -4594,6 +4594,7 @@ data:
       "stripeSecretsFile": "/stripe-secret/apikeys",
       "stripeConfigFile": "",
       "enablePayment": false,
+      "patSigningKeyFile": "",
       "workspaceHeartbeat": {
         "intervalSeconds": 60,
         "timeoutSeconds": 300
@@ -9020,7 +9021,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 4a901771b5b3705a7421e896ee40c283adfb4544d9064cda701458972bcaec85
+        gitpod.io/checksum_config: fce060cf17c7827eebde2eb3483be41a293d2ad20607890b0e23bded75346d93
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/http-proxy/output.golden
+++ b/install/installer/cmd/testdata/render/http-proxy/output.golden
@@ -5043,6 +5043,7 @@ data:
       "stripeSecretsFile": "/stripe-secret/apikeys",
       "stripeConfigFile": "",
       "enablePayment": false,
+      "patSigningKeyFile": "",
       "workspaceHeartbeat": {
         "intervalSeconds": 60,
         "timeoutSeconds": 300
@@ -11070,7 +11071,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3d98dffb48bebba57afb1ffd2b059e4a1a95bb679d843bee0158e5d4b1814914
+        gitpod.io/checksum_config: a94779de77b43b080faf67667aa017f25fc963c43412f8438c49ace3a7b7af2a
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/insecure-s3-setup/output.golden
+++ b/install/installer/cmd/testdata/render/insecure-s3-setup/output.golden
@@ -4954,6 +4954,7 @@ data:
       "stripeSecretsFile": "/stripe-secret/apikeys",
       "stripeConfigFile": "",
       "enablePayment": false,
+      "patSigningKeyFile": "",
       "workspaceHeartbeat": {
         "intervalSeconds": 60,
         "timeoutSeconds": 300
@@ -9675,7 +9676,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3d98dffb48bebba57afb1ffd2b059e4a1a95bb679d843bee0158e5d4b1814914
+        gitpod.io/checksum_config: a94779de77b43b080faf67667aa017f25fc963c43412f8438c49ace3a7b7af2a
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/kind-meta/output.golden
+++ b/install/installer/cmd/testdata/render/kind-meta/output.golden
@@ -3920,6 +3920,7 @@ data:
       "stripeSecretsFile": "/stripe-secret/apikeys",
       "stripeConfigFile": "",
       "enablePayment": false,
+      "patSigningKeyFile": "",
       "workspaceHeartbeat": {
         "intervalSeconds": 60,
         "timeoutSeconds": 300
@@ -7109,7 +7110,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3d98dffb48bebba57afb1ffd2b059e4a1a95bb679d843bee0158e5d4b1814914
+        gitpod.io/checksum_config: a94779de77b43b080faf67667aa017f25fc963c43412f8438c49ace3a7b7af2a
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/kind-webapp/output.golden
+++ b/install/installer/cmd/testdata/render/kind-webapp/output.golden
@@ -2206,6 +2206,7 @@ data:
       "stripeSecretsFile": "/stripe-secret/apikeys",
       "stripeConfigFile": "",
       "enablePayment": false,
+      "patSigningKeyFile": "",
       "workspaceHeartbeat": {
         "intervalSeconds": 60,
         "timeoutSeconds": 300
@@ -4314,7 +4315,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3d98dffb48bebba57afb1ffd2b059e4a1a95bb679d843bee0158e5d4b1814914
+        gitpod.io/checksum_config: a94779de77b43b080faf67667aa017f25fc963c43412f8438c49ace3a7b7af2a
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -5040,6 +5040,7 @@ data:
       "stripeSecretsFile": "/stripe-secret/apikeys",
       "stripeConfigFile": "",
       "enablePayment": false,
+      "patSigningKeyFile": "",
       "workspaceHeartbeat": {
         "intervalSeconds": 60,
         "timeoutSeconds": 300
@@ -9904,7 +9905,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3d98dffb48bebba57afb1ffd2b059e4a1a95bb679d843bee0158e5d4b1814914
+        gitpod.io/checksum_config: a94779de77b43b080faf67667aa017f25fc963c43412f8438c49ace3a7b7af2a
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/shortname/output.golden
+++ b/install/installer/cmd/testdata/render/shortname/output.golden
@@ -5040,6 +5040,7 @@ data:
       "stripeSecretsFile": "/stripe-secret/apikeys",
       "stripeConfigFile": "",
       "enablePayment": false,
+      "patSigningKeyFile": "",
       "workspaceHeartbeat": {
         "intervalSeconds": 60,
         "timeoutSeconds": 300
@@ -9904,7 +9905,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 1534b219b70146b0a76b843cc45814f5f7ffd159c77f5756ac4421da21c9b614
+        gitpod.io/checksum_config: fb70098b8891802e254f67cb2cab3ff40389429d959e77d3733a7eeba60399e5
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -5052,6 +5052,7 @@ data:
       "stripeSecretsFile": "/stripe-secret/apikeys",
       "stripeConfigFile": "",
       "enablePayment": false,
+      "patSigningKeyFile": "",
       "workspaceHeartbeat": {
         "intervalSeconds": 60,
         "timeoutSeconds": 300
@@ -9916,7 +9917,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3d98dffb48bebba57afb1ffd2b059e4a1a95bb679d843bee0158e5d4b1814914
+        gitpod.io/checksum_config: a94779de77b43b080faf67667aa017f25fc963c43412f8438c49ace3a7b7af2a
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
+++ b/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
@@ -5373,6 +5373,7 @@ data:
       "stripeSecretsFile": "/stripe-secret/apikeys",
       "stripeConfigFile": "",
       "enablePayment": false,
+      "patSigningKeyFile": "",
       "workspaceHeartbeat": {
         "intervalSeconds": 60,
         "timeoutSeconds": 300
@@ -10348,7 +10349,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3d98dffb48bebba57afb1ffd2b059e4a1a95bb679d843bee0158e5d4b1814914
+        gitpod.io/checksum_config: a94779de77b43b080faf67667aa017f25fc963c43412f8438c49ace3a7b7af2a
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
+++ b/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
@@ -5042,6 +5042,7 @@ data:
       "stripeSecretsFile": "/stripe-secret/apikeys",
       "stripeConfigFile": "",
       "enablePayment": false,
+      "patSigningKeyFile": "",
       "workspaceHeartbeat": {
         "intervalSeconds": 60,
         "timeoutSeconds": 300
@@ -9894,7 +9895,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3d98dffb48bebba57afb1ffd2b059e4a1a95bb679d843bee0158e5d4b1814914
+        gitpod.io/checksum_config: a94779de77b43b080faf67667aa017f25fc963c43412f8438c49ace3a7b7af2a
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
+++ b/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
@@ -5043,6 +5043,7 @@ data:
       "stripeSecretsFile": "/stripe-secret/apikeys",
       "stripeConfigFile": "",
       "enablePayment": false,
+      "patSigningKeyFile": "",
       "workspaceHeartbeat": {
         "intervalSeconds": 60,
         "timeoutSeconds": 300
@@ -9907,7 +9908,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3d98dffb48bebba57afb1ffd2b059e4a1a95bb679d843bee0158e5d4b1814914
+        gitpod.io/checksum_config: a94779de77b43b080faf67667aa017f25fc963c43412f8438c49ace3a7b7af2a
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/pkg/components/server/constants.go
+++ b/install/installer/pkg/components/server/constants.go
@@ -9,17 +9,18 @@ import (
 )
 
 const (
-	Component             = common.ServerComponent
-	ContainerPort         = 3000
-	ContainerPortName     = "http"
-	authProviderFilePath  = "/gitpod/auth-providers"
-	licenseFilePath       = "/gitpod/license"
-	chargebeeMountPath    = "/chargebee"
-	stripeSecretMountPath = "/stripe-secret"
-	githubAppCertSecret   = "github-app-cert-secret"
-	InstallationAdminPort = common.ServerInstallationAdminPort
-	InstallationAdminName = "install-admin"
-	DebugPortName         = "debug"
-	DebugNodePortName     = "debugnode"
-	ServicePort           = 3000
+	Component                              = common.ServerComponent
+	ContainerPort                          = 3000
+	ContainerPortName                      = "http"
+	authProviderFilePath                   = "/gitpod/auth-providers"
+	licenseFilePath                        = "/gitpod/license"
+	chargebeeMountPath                     = "/chargebee"
+	stripeSecretMountPath                  = "/stripe-secret"
+	githubAppCertSecret                    = "github-app-cert-secret"
+	InstallationAdminPort                  = common.ServerInstallationAdminPort
+	InstallationAdminName                  = "install-admin"
+	DebugPortName                          = "debug"
+	DebugNodePortName                      = "debugnode"
+	ServicePort                            = 3000
+	personalAccessTokenSigningKeyMountPath = "/secrets/personal-access-token-signing-key"
 )

--- a/install/installer/pkg/components/server/deployment.go
+++ b/install/installer/pkg/components/server/deployment.go
@@ -292,6 +292,17 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 		return nil
 	})
 
+	_ = ctx.WithExperimental(func(cfg *experimental.Config) error {
+		volume, mount, _, ok := getPersonalAccessTokenSigningKey(cfg)
+		if !ok {
+			return nil
+		}
+
+		volumes = append(volumes, volume)
+		volumeMounts = append(volumeMounts, mount)
+		return nil
+	})
+
 	return []runtime.Object{
 		&appsv1.Deployment{
 			TypeMeta: common.TypeMetaDeployment,

--- a/install/installer/pkg/components/server/types.go
+++ b/install/installer/pkg/components/server/types.go
@@ -38,6 +38,7 @@ type ConfigSerialized struct {
 	StripeSecretsFile                 string   `json:"stripeSecretsFile"`
 	StripeConfigFile                  string   `json:"stripeConfigFile"`
 	EnablePayment                     bool     `json:"enablePayment"`
+	PATSigningKeyFile                 string   `json:"patSigningKeyFile"`
 
 	WorkspaceHeartbeat         WorkspaceHeartbeat         `json:"workspaceHeartbeat"`
 	WorkspaceDefaults          WorkspaceDefaults          `json:"workspaceDefaults"`


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Setup configuration to mount pat signing key to server, such that we can use the key to validate PAT signatures

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Part of https://github.com/gitpod-io/gitpod/issues/14912

## How to test
<!-- Provide steps to test this PR -->
1. Get preview k8s context
2. Get config map `kubectl get cm server-config -o yaml`
3. Observe it contains `"patSigningKeyFile": "/secrets/personal-access-token-signing-key",`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
