### PR TITLE
[server] Validate PAT signature

### DIFF
--- a/components/server/src/config.ts
+++ b/components/server/src/config.ts
@@ -311,7 +311,7 @@ export namespace ConfigFile {
         let patSigningKey = "";
         if (config.patSigningKeyFile) {
             try {
-                patSigningKey = fs.readFileSync(filePathTelepresenceAware(config.patSigningKeyFile), "utf-8");
+                patSigningKey = fs.readFileSync(filePathTelepresenceAware(config.patSigningKeyFile), "utf-8").trim();
             } catch (error) {
                 log.error("Could not load Personal Access Token signing key", error);
             }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Uses PAT signing key to validate tokens

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Depends on https://github.com/gitpod-io/gitpod/pull/15037
* Part of https://github.com/gitpod-io/gitpod/issues/14912

## How to test
<!-- Provide steps to test this PR -->

1. Preview
2. Create PAT
3. Execute the following:
```bash
curl 'https://api.mp-server-3b46e8956e.preview.gitpod-dev.com/gitpod.experimental.v1.TokensService/ListPersonalAccessTokens' \
  -H 'accept: application/json' \
  -H 'content-type: application/json' \
  -H 'Authorization: Bearer <PAT>' \
  --data-raw '{}'
```
4. Try changing the token a bit to ensure it fails to validate

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
