### PR TITLE
[observability] merge all ide kind for ide startup time

### DIFF
--- a/operations/observability/mixins/IDE/dashboards/components/ide-startup-time.json
+++ b/operations/observability/mixins/IDE/dashboards/components/ide-startup-time.json
@@ -42,8 +42,6 @@
       },
       "id": 14,
       "panels": [],
-      "repeat": "kind",
-      "repeatDirection": "h",
       "targets": [
         {
           "datasource": {
@@ -53,7 +51,7 @@
           "refId": "A"
         }
       ],
-      "title": "IDE Startup time: ${kind} ",
+      "title": "IDE Startup time",
       "type": "row"
     },
     {
@@ -235,7 +233,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(1, sum by(le) (rate(supervisor_ide_ready_duration_total_bucket{kind=~\"${kind}\", cluster=~\"${cluster}\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(1, sum by(le) (rate(supervisor_ide_ready_duration_total_bucket{kind=~\"${kind}\", cluster=~\"${cluster}\"}[$__interval])))",
           "hide": false,
           "legendFormat": "max",
           "range": true,
@@ -247,7 +245,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum by(le) (rate(supervisor_ide_ready_duration_total_bucket{kind=~\"${kind}\", cluster=~\"${cluster}\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.99, sum by(le) (rate(supervisor_ide_ready_duration_total_bucket{kind=~\"${kind}\", cluster=~\"${cluster}\"}[$__interval])))",
           "hide": false,
           "legendFormat": "0.99",
           "range": true,
@@ -259,7 +257,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum by(le) (rate(supervisor_ide_ready_duration_total_bucket{kind=~\"${kind}\", cluster=~\"${cluster}\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.95, sum by(le) (rate(supervisor_ide_ready_duration_total_bucket{kind=~\"${kind}\", cluster=~\"${cluster}\"}[$__interval])))",
           "hide": false,
           "legendFormat": "0.95",
           "range": true,
@@ -271,7 +269,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.8, sum by(le) (rate(supervisor_ide_ready_duration_total_bucket{kind=~\"${kind}\", cluster=~\"${cluster}\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.8, sum by(le) (rate(supervisor_ide_ready_duration_total_bucket{kind=~\"${kind}\", cluster=~\"${cluster}\"}[$__interval])))",
           "hide": false,
           "legendFormat": "0.8",
           "range": true,
@@ -283,7 +281,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.5, sum by(le) (rate(supervisor_ide_ready_duration_total_bucket{kind=~\"${kind}\", cluster=~\"${cluster}\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.5, sum by(le) (rate(supervisor_ide_ready_duration_total_bucket{kind=~\"${kind}\", cluster=~\"${cluster}\"}[$__interval])))",
           "hide": false,
           "legendFormat": "median",
           "range": true,
@@ -372,14 +370,14 @@
           "unit": "s"
         }
       },
-      "pluginVersion": "9.2.4",
+      "pluginVersion": "9.2.6",
       "targets": [
         {
           "datasource": {
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "sum(increase(supervisor_ide_ready_duration_total_bucket{kind=~\"${kind}\"}[$__rate_interval])) by (le)",
+          "expr": "sum(increase(supervisor_ide_ready_duration_total_bucket{kind=~\"${kind}\"}[$__interval])) by (le)",
           "format": "heatmap",
           "intervalFactor": 2,
           "legendFormat": "{{le}}",
@@ -434,7 +432,7 @@
       },
       "gridPos": {
         "h": 11,
-        "w": 24,
+        "w": 12,
         "x": 0,
         "y": 28
       },
@@ -483,7 +481,7 @@
           "unit": "s"
         }
       },
-      "pluginVersion": "9.2.4",
+      "pluginVersion": "9.2.6",
       "repeat": "cluster",
       "repeatDirection": "h",
       "targets": [
@@ -492,7 +490,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "sum(increase(supervisor_ide_ready_duration_total_bucket{kind=~\"${kind}\", cluster=~\"${cluster}\"}[$__rate_interval])) by (le)",
+          "expr": "sum(increase(supervisor_ide_ready_duration_total_bucket{kind=~\"${kind}\", cluster=~\"${cluster}\"}[$__interval])) by (le)",
           "format": "heatmap",
           "intervalFactor": 2,
           "legendFormat": "{{le}}",
@@ -573,7 +571,7 @@
       },
       {
         "current": {
-          "selected": false,
+          "selected": true,
           "text": "All",
           "value": "$__all"
         },


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
[observability] merge all ide kind for ide startup time

This PR also change `__rate_interval` to `__interval`, this allows for more accurate

| before | after |
|---|---|
| ![image](https://user-images.githubusercontent.com/8299500/204754458-55ce1746-2a74-4467-b874-f6b327181346.png) |  ![image](https://user-images.githubusercontent.com/8299500/204754679-6ead3af5-b750-49de-ac46-b51a8c53af64.png) |

<img width="955" alt="image" src="https://user-images.githubusercontent.com/8299500/204754937-817d2298-05fe-497e-806a-84e5e50c195c.png">

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
