### PR TITLE
[ubp] add chargebee cost center on cancellation

### DIFF
--- a/components/ee/payment-endpoint/BUILD.yaml
+++ b/components/ee/payment-endpoint/BUILD.yaml
@@ -10,6 +10,7 @@ packages:
     deps:
       - components/gitpod-db:lib
       - components/gitpod-protocol:lib
+      - components/usage-api/typescript:lib
     config:
       packaging: offline-mirror
       yarnLock: ${coreYarnLockBase}/../yarn.lock
@@ -24,6 +25,7 @@ packages:
     deps:
       - components/gitpod-db:lib
       - components/gitpod-protocol:lib
+      - components/usage-api/typescript:lib
       - :dbtest
     config:
       packaging: library
@@ -54,6 +56,7 @@ packages:
       - components/gitpod-db:dbtest-init
       - components/gitpod-db:lib
       - components/gitpod-protocol:lib
+      - components/usage-api/typescript:lib
     config:
       packaging: library
       yarnLock: ${coreYarnLockBase}/../yarn.lock

--- a/components/ee/payment-endpoint/package.json
+++ b/components/ee/payment-endpoint/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "@gitpod/gitpod-db": "0.1.5",
     "@gitpod/gitpod-protocol": "0.1.5",
+    "@gitpod/usage-api": "0.1.5",
     "@octokit/rest": "18.5.6",
     "@octokit/webhooks": "9.17.0",
     "body-parser": "^1.19.2",

--- a/components/ee/payment-endpoint/src/chargebee/subscription-handler.ts
+++ b/components/ee/payment-endpoint/src/chargebee/subscription-handler.ts
@@ -4,30 +4,30 @@
  * See License.enterprise.txt in the project root folder.
  */
 
-import { inject, injectable } from 'inversify';
+import { inject, injectable } from "inversify";
 
-import { SubscriptionService } from '../accounting/subscription-service';
-import { AccountingDB } from '@gitpod/gitpod-db/lib/accounting-db';
-import { log, LogContext } from '@gitpod/gitpod-protocol/lib/util/logging';
-import { SubscriptionMapperFactory } from './subscription-mapper';
-import { Plans } from '@gitpod/gitpod-protocol/lib/plans';
-import { Chargebee as chargebee } from './chargebee-types';
-import { EventHandler } from './chargebee-event-handler';
-import { UpgradeHelper } from './upgrade-helper';
+import { SubscriptionService } from "../accounting/subscription-service";
+import { AccountingDB } from "@gitpod/gitpod-db/lib/accounting-db";
+import { log, LogContext } from "@gitpod/gitpod-protocol/lib/util/logging";
+import { SubscriptionMapper } from "./subscription-mapper";
+import { Plans } from "@gitpod/gitpod-protocol/lib/plans";
+import { Chargebee as chargebee } from "./chargebee-types";
+import { EventHandler } from "./chargebee-event-handler";
+import { UpgradeHelper } from "./upgrade-helper";
 import { formatDate } from "@gitpod/gitpod-protocol/lib/util/date-time";
-import { getUpdatedAt } from './chargebee-subscription-helper';
-import { UserPaidSubscription } from '@gitpod/gitpod-protocol/lib/accounting-protocol';
-import { DBSubscriptionAdditionalData } from '@gitpod/gitpod-db/lib/typeorm/entity/db-subscription';
+import { getUpdatedAt } from "./chargebee-subscription-helper";
+import { UserPaidSubscription } from "@gitpod/gitpod-protocol/lib/accounting-protocol";
+import { DBSubscriptionAdditionalData } from "@gitpod/gitpod-db/lib/typeorm/entity/db-subscription";
 
 @injectable()
 export class SubscriptionHandler implements EventHandler<chargebee.SubscriptionEventV2> {
     @inject(SubscriptionService) protected readonly subscriptionService: SubscriptionService;
     @inject(AccountingDB) protected readonly db: AccountingDB;
-    @inject(SubscriptionMapperFactory) protected readonly mapperFactory: SubscriptionMapperFactory;
+    @inject(SubscriptionMapper) protected readonly mapper: SubscriptionMapper;
     @inject(UpgradeHelper) protected readonly upgradeHelper: UpgradeHelper;
 
     canHandle(event: chargebee.Event<any>): boolean {
-        if (event.event_type.startsWith('subscription')) {
+        if (event.event_type.startsWith("subscription")) {
             const evt = event as chargebee.Event<chargebee.SubscriptionEventV2>;
             const plan = Plans.getById(evt.content.subscription.plan_id);
             return !!plan && !plan.team;
@@ -44,16 +44,16 @@ export class SubscriptionHandler implements EventHandler<chargebee.SubscriptionE
         log.debug(logContext, `Start SubscriptionHandler.handleSingleEvent`, { eventType });
         try {
             if (!event.content.subscription) {
-                log.error(logContext, 'Ignoring event, because it does not contain a subscription', event);
+                log.error(logContext, "Ignoring event, because it does not contain a subscription", event);
             } else {
                 try {
                     await this.storeAdditionalData(event.content.subscription, event.content.invoice);
-                } catch(err) {
-                    log.error(logContext, 'Failed to store additional subscription data', event);
+                } catch (err) {
+                    log.error(logContext, "Failed to store additional subscription data", event);
                 }
             }
 
-            if (event.event_type === 'subscription_changed') {
+            if (event.event_type === "subscription_changed") {
                 await this.checkAndChargeForUpgrade(userId, chargebeeSubscription);
             }
 
@@ -70,11 +70,12 @@ export class SubscriptionHandler implements EventHandler<chargebee.SubscriptionE
         const paymentReference = subscription.id;
         const coupons = subscription.coupons;
         const mrr = subscription.mrr || 0;
-        const nextBilling = subscription.next_billing_at && new Date(subscription.next_billing_at * 1000).toISOString() || '';
-        let lastInvoice = '';
+        const nextBilling =
+            (subscription.next_billing_at && new Date(subscription.next_billing_at * 1000).toISOString()) || "";
+        let lastInvoice = "";
         let lastInvoiceAmount: number = 0;
         if (invoice) {
-            lastInvoice = invoice.date && new Date(invoice.date * 1000).toISOString() || '';
+            lastInvoice = (invoice.date && new Date(invoice.date * 1000).toISOString()) || "";
             lastInvoiceAmount = invoice.total || 0;
         }
 
@@ -84,7 +85,7 @@ export class SubscriptionHandler implements EventHandler<chargebee.SubscriptionE
             mrr,
             lastInvoice,
             lastInvoiceAmount,
-            nextBilling
+            nextBilling,
         };
         await this.db.storeSubscriptionAdditionalData(data);
     }
@@ -100,18 +101,28 @@ export class SubscriptionHandler implements EventHandler<chargebee.SubscriptionE
     protected async checkAndChargeForUpgrade(userId: string, chargebeeSubscription: chargebee.Subscription) {
         const gitpodSubscriptions = await this.db.findSubscriptionForUserByPaymentRef(userId, chargebeeSubscription.id);
         if (gitpodSubscriptions.length === 0) {
-            throw new Error(`Expected existing Gitpod subscription for PaymentRef ${chargebeeSubscription.id} and user ${userId}, found none.`);
+            throw new Error(
+                `Expected existing Gitpod subscription for PaymentRef ${chargebeeSubscription.id} and user ${userId}, found none.`,
+            );
         }
-        const currentGitpodSubscription = gitpodSubscriptions[0];   // Ordered by startDate DESC
+        const currentGitpodSubscription = gitpodSubscriptions[0]; // Ordered by startDate DESC
         const oldPlan = Plans.getById(currentGitpodSubscription.planId)!;
         const newPlan = Plans.getById(chargebeeSubscription.plan_id)!;
 
         if (newPlan.pricePerMonth > oldPlan.pricePerMonth) {
             // Upgrade: Charge for it!
-            const diffInCents = (newPlan.pricePerMonth * 100) - (oldPlan.pricePerMonth * 100);
+            const diffInCents = newPlan.pricePerMonth * 100 - oldPlan.pricePerMonth * 100;
             const upgradeTimestamp = getUpdatedAt(chargebeeSubscription);
-            const description = `Difference on Upgrade from '${oldPlan.name}' to '${newPlan.name}' (${formatDate(upgradeTimestamp)})`;
-            await this.upgradeHelper.chargeForUpgrade(userId, chargebeeSubscription.id, diffInCents, description, upgradeTimestamp);
+            const description = `Difference on Upgrade from '${oldPlan.name}' to '${newPlan.name}' (${formatDate(
+                upgradeTimestamp,
+            )})`;
+            await this.upgradeHelper.chargeForUpgrade(
+                userId,
+                chargebeeSubscription.id,
+                diffInCents,
+                description,
+                upgradeTimestamp,
+            );
         }
     }
 
@@ -123,14 +134,13 @@ export class SubscriptionHandler implements EventHandler<chargebee.SubscriptionE
     protected async mapToGitpodSubscription(userId: string, event: chargebee.Event<chargebee.SubscriptionEventV2>) {
         await this.db.transaction(async (db) => {
             const subscriptions = await db.findAllSubscriptionsForUser(userId);
-            const userPaidSubscriptions = subscriptions.filter(s => UserPaidSubscription.is(s));
+            const userPaidSubscriptions = subscriptions.filter((s) => UserPaidSubscription.is(s));
 
-            const mapper = this.mapperFactory.newMapper();
-            const delta = mapper.map(userPaidSubscriptions, event).getResult();
+            const delta = this.mapper.map(userPaidSubscriptions, event).getResult();
 
             await Promise.all([
-                ...delta.updates.map(s => db.storeSubscription(s)),
-                ...delta.inserts.map(s => db.newSubscription(s))
+                ...delta.updates.map((s) => db.storeSubscription(s)),
+                ...delta.inserts.map((s) => db.newSubscription(s)),
             ]);
         });
     }

--- a/components/ee/payment-endpoint/src/chargebee/subscription-mapper.spec.ts
+++ b/components/ee/payment-endpoint/src/chargebee/subscription-mapper.spec.ts
@@ -4,259 +4,282 @@
  * See License.enterprise.txt in the project root folder.
  */
 
-import * as chai from 'chai';
+import * as chai from "chai";
 const expect = chai.expect;
-import { suite, test } from 'mocha-typescript';
-import * as fs from 'fs';
-import * as path from 'path';
+import { suite, test } from "mocha-typescript";
+import * as fs from "fs";
+import * as path from "path";
 
-import { Chargebee as chargebee } from './chargebee-types';
-import { testContainer } from '@gitpod/gitpod-db/lib/test-container';
-import { Subscription } from '@gitpod/gitpod-protocol/lib/accounting-protocol';
+import { Chargebee as chargebee } from "./chargebee-types";
+import { testContainer } from "@gitpod/gitpod-db/lib/test-container";
+import { Subscription } from "@gitpod/gitpod-protocol/lib/accounting-protocol";
 
-import { SubscriptionMapperFactory, SubscriptionMapper } from './subscription-mapper';
-import { Plans, ABSOLUTE_MAX_USAGE } from '@gitpod/gitpod-protocol/lib/plans';
+import { SubscriptionMapper } from "./subscription-mapper";
+import { Plans, ABSOLUTE_MAX_USAGE } from "@gitpod/gitpod-protocol/lib/plans";
+import {
+    CostCenter_BillingStrategy,
+    DeepPartial,
+    GetCostCenterRequest,
+    GetCostCenterResponse,
+    SetCostCenterRequest,
+    SetCostCenterResponse,
+    UsageServiceDefinition,
+} from "@gitpod/usage-api/lib/usage/v1/usage.pb";
 
-@suite class SubscriptionMapperSpec {
-
-    mapperFactory = testContainer.get<SubscriptionMapperFactory>(SubscriptionMapperFactory);
-    mapper: SubscriptionMapper;
-
-    async before() {
-        this.mapper = this.mapperFactory.newMapper();
-    }
+@suite
+class SubscriptionMapperSpec {
+    mapper = testContainer.get<SubscriptionMapper>(SubscriptionMapper);
 
     @test async first_basic() {
         const userCreatedDate = new Date("2018-11-24T04:05:48.000Z").toISOString();
-        const events = loadFromFolder<chargebee.SubscriptionEventV2>('first_basic');
+        const events = loadFromFolder<chargebee.SubscriptionEventV2>("first_basic");
 
         let subscriptions: Subscription[] = [];
 
-        const basicCreated = events.get('basic-created')!;
+        const basicCreated = events.get("basic-created")!;
         const model = this.mapper.map(filterFree(subscriptions), basicCreated);
         subscriptions = model.mergedWithFreeSubscriptions(userCreatedDate);
 
-        expect(filterIrrelevantFields(subscriptions)).to.deep.equal([{
-            userId: '68b75ca3-df45-4fde-8665-9f9f3d749d55',
-            startDate: "2018-11-29T12:01:09.000Z",
-            amount: 100,
-            planId: "basic-usd",
-            paymentReference: "Hr55127RAn4dqQ1e7x"
-        },
-        {
-            userId: '68b75ca3-df45-4fde-8665-9f9f3d749d55',
-            startDate: "2018-11-24T04:05:48.000Z",
-            endDate: "2018-11-29T12:01:09.000Z",
-            amount: 100,
-            planId: "free",
-            cancellationDate: '2018-11-29T12:01:09.000Z'
-        }]);
+        expect(filterIrrelevantFields(subscriptions)).to.deep.equal([
+            {
+                userId: "68b75ca3-df45-4fde-8665-9f9f3d749d55",
+                startDate: "2018-11-29T12:01:09.000Z",
+                amount: 100,
+                planId: "basic-usd",
+                paymentReference: "Hr55127RAn4dqQ1e7x",
+            },
+            {
+                userId: "68b75ca3-df45-4fde-8665-9f9f3d749d55",
+                startDate: "2018-11-24T04:05:48.000Z",
+                endDate: "2018-11-29T12:01:09.000Z",
+                amount: 100,
+                planId: "free",
+                cancellationDate: "2018-11-29T12:01:09.000Z",
+            },
+        ]);
     }
 
     @test async full_cycle() {
         const userCreatedDate = new Date("2018-11-20T15:25:48.000Z").toISOString();
-        const events = loadFromFolder<chargebee.SubscriptionEventV2>('full_cycle');
+        const events = loadFromFolder<chargebee.SubscriptionEventV2>("full_cycle");
 
         let subscriptions: Subscription[] = [];
 
-        const basicCreated = events.get('basic-created')!;
+        const basicCreated = events.get("basic-created")!;
         let model = this.mapper.map(filterFree(subscriptions), basicCreated);
         subscriptions = model.mergedWithFreeSubscriptions(userCreatedDate);
 
-        expect(filterIrrelevantFields(subscriptions), 'basic-created').to.deep.equal([{
-            userId: '31376076-3362-4faa-9012-01ee684b73ff',
-            startDate: '2018-11-27T15:25:48.000Z',
-            planId: 'basic-usd',
-            amount: 100,
-            paymentReference: 'Hr5511ERAcD8VHCmF'
-        },
-        {
-            userId: '31376076-3362-4faa-9012-01ee684b73ff',
-            planId: 'free',
-            amount: 100,
-            startDate: '2018-11-20T15:25:48.000Z',
-            endDate: '2018-11-27T15:25:48.000Z',
-            cancellationDate: '2018-11-27T15:25:48.000Z'
-        }]);
+        expect(filterIrrelevantFields(subscriptions), "basic-created").to.deep.equal([
+            {
+                userId: "31376076-3362-4faa-9012-01ee684b73ff",
+                startDate: "2018-11-27T15:25:48.000Z",
+                planId: "basic-usd",
+                amount: 100,
+                paymentReference: "Hr5511ERAcD8VHCmF",
+            },
+            {
+                userId: "31376076-3362-4faa-9012-01ee684b73ff",
+                planId: "free",
+                amount: 100,
+                startDate: "2018-11-20T15:25:48.000Z",
+                endDate: "2018-11-27T15:25:48.000Z",
+                cancellationDate: "2018-11-27T15:25:48.000Z",
+            },
+        ]);
 
-        const upgradeToPro = events.get('upgrade-to-pro')!;
+        const upgradeToPro = events.get("upgrade-to-pro")!;
         model = this.mapper.map(filterFree(subscriptions), upgradeToPro);
         subscriptions = model.mergedWithFreeSubscriptions(userCreatedDate);
 
-        expect(filterIrrelevantFields(subscriptions), 'upgrade-to-pro').to.deep.equal([{
-            userId: '31376076-3362-4faa-9012-01ee684b73ff',
-            startDate: '2018-11-27T15:25:48.000Z',
-            planId: 'professional-usd',
-            amount: ABSOLUTE_MAX_USAGE,
-            paymentReference: 'Hr5511ERAcD8VHCmF'
-        },
-        {
-            userId: '31376076-3362-4faa-9012-01ee684b73ff',
-            planId: 'free',
-            amount: 100,
-            startDate: '2018-11-20T15:25:48.000Z',
-            endDate: '2018-11-27T15:25:48.000Z',
-            cancellationDate: '2018-11-27T15:25:48.000Z'
-        }]);
+        expect(filterIrrelevantFields(subscriptions), "upgrade-to-pro").to.deep.equal([
+            {
+                userId: "31376076-3362-4faa-9012-01ee684b73ff",
+                startDate: "2018-11-27T15:25:48.000Z",
+                planId: "professional-usd",
+                amount: ABSOLUTE_MAX_USAGE,
+                paymentReference: "Hr5511ERAcD8VHCmF",
+            },
+            {
+                userId: "31376076-3362-4faa-9012-01ee684b73ff",
+                planId: "free",
+                amount: 100,
+                startDate: "2018-11-20T15:25:48.000Z",
+                endDate: "2018-11-27T15:25:48.000Z",
+                cancellationDate: "2018-11-27T15:25:48.000Z",
+            },
+        ]);
 
-        const proCancelled = events.get('pro-cancelled')!;
+        const proCancelled = events.get("pro-cancelled")!;
         model = this.mapper.map(filterFree(subscriptions), proCancelled);
         subscriptions = model.mergedWithFreeSubscriptions(userCreatedDate);
 
-        expect(filterIrrelevantFields(subscriptions), 'pro-cancelled').to.deep.equal([{
-            userId: '31376076-3362-4faa-9012-01ee684b73ff',
-            startDate: '2018-12-27T15:25:48.000Z',
-            planId: 'free',
-            amount: 100
-        },
-        {
-            userId: '31376076-3362-4faa-9012-01ee684b73ff',
-            startDate: '2018-11-27T15:25:48.000Z',
-            planId: 'professional-usd',
-            amount: ABSOLUTE_MAX_USAGE,
-            paymentReference: 'Hr5511ERAcD8VHCmF',
-            endDate: '2018-12-27T15:25:48.000Z',
-            cancellationDate: '2018-11-27T15:56:23.000Z'
-        },
-        {
-            userId: '31376076-3362-4faa-9012-01ee684b73ff',
-            planId: 'free',
-            amount: 100,
-            startDate: '2018-11-20T15:25:48.000Z',
-            endDate: '2018-11-27T15:25:48.000Z',
-            cancellationDate: '2018-11-27T15:25:48.000Z'
-        }]);
+        expect(filterIrrelevantFields(subscriptions), "pro-cancelled").to.deep.equal([
+            {
+                userId: "31376076-3362-4faa-9012-01ee684b73ff",
+                startDate: "2018-12-27T15:25:48.000Z",
+                planId: "free",
+                amount: 100,
+            },
+            {
+                userId: "31376076-3362-4faa-9012-01ee684b73ff",
+                startDate: "2018-11-27T15:25:48.000Z",
+                planId: "professional-usd",
+                amount: ABSOLUTE_MAX_USAGE,
+                paymentReference: "Hr5511ERAcD8VHCmF",
+                endDate: "2018-12-27T15:25:48.000Z",
+                cancellationDate: "2018-11-27T15:56:23.000Z",
+            },
+            {
+                userId: "31376076-3362-4faa-9012-01ee684b73ff",
+                planId: "free",
+                amount: 100,
+                startDate: "2018-11-20T15:25:48.000Z",
+                endDate: "2018-11-27T15:25:48.000Z",
+                cancellationDate: "2018-11-27T15:25:48.000Z",
+            },
+        ]);
 
-        const proReactivated = events.get('pro-reactivated')!;
+        const proReactivated = events.get("pro-reactivated")!;
         model = this.mapper.map(filterFree(subscriptions), proReactivated);
         subscriptions = model.mergedWithFreeSubscriptions(userCreatedDate);
 
-        expect(filterIrrelevantFields(subscriptions), 'pro-reactivated').to.deep.equal([{
-            amount: ABSOLUTE_MAX_USAGE,
-            paymentReference: 'Hr5511ERAcD8VHCmF',
-            planId: 'professional-usd',
-            startDate: '2018-11-27T15:25:48.000Z',
-            userId: '31376076-3362-4faa-9012-01ee684b73ff'
-        },
-        {
-            userId: '31376076-3362-4faa-9012-01ee684b73ff',
-            startDate: '2018-11-27T15:25:48.000Z',
-            planId: 'professional-usd',
-            amount: ABSOLUTE_MAX_USAGE,
-            paymentReference: 'Hr5511ERAcD8VHCmF',
-            endDate: '2018-12-27T15:25:48.000Z',
-            cancellationDate: '2018-11-27T15:56:23.000Z'
-        },
-        {
-            userId: '31376076-3362-4faa-9012-01ee684b73ff',
-            planId: 'free',
-            amount: 100,
-            startDate: '2018-11-20T15:25:48.000Z',
-            endDate: '2018-11-27T15:25:48.000Z',
-            cancellationDate: '2018-11-27T15:25:48.000Z'
-        }]);
+        expect(filterIrrelevantFields(subscriptions), "pro-reactivated").to.deep.equal([
+            {
+                amount: ABSOLUTE_MAX_USAGE,
+                paymentReference: "Hr5511ERAcD8VHCmF",
+                planId: "professional-usd",
+                startDate: "2018-11-27T15:25:48.000Z",
+                userId: "31376076-3362-4faa-9012-01ee684b73ff",
+            },
+            {
+                userId: "31376076-3362-4faa-9012-01ee684b73ff",
+                startDate: "2018-11-27T15:25:48.000Z",
+                planId: "professional-usd",
+                amount: ABSOLUTE_MAX_USAGE,
+                paymentReference: "Hr5511ERAcD8VHCmF",
+                endDate: "2018-12-27T15:25:48.000Z",
+                cancellationDate: "2018-11-27T15:56:23.000Z",
+            },
+            {
+                userId: "31376076-3362-4faa-9012-01ee684b73ff",
+                planId: "free",
+                amount: 100,
+                startDate: "2018-11-20T15:25:48.000Z",
+                endDate: "2018-11-27T15:25:48.000Z",
+                cancellationDate: "2018-11-27T15:25:48.000Z",
+            },
+        ]);
 
-        const downgradeToBasic = events.get('downgrade-to-basic')!;
+        const downgradeToBasic = events.get("downgrade-to-basic")!;
         model = this.mapper.map(filterFree(subscriptions), downgradeToBasic);
         subscriptions = model.mergedWithFreeSubscriptions(userCreatedDate);
 
-        expect(filterIrrelevantFields(subscriptions), 'downgrade-to-basic').to.deep.equal([{
-            amount: ABSOLUTE_MAX_USAGE,
-            paymentReference: 'Hr5511ERAcD8VHCmF',
-            planId: 'professional-usd',
-            startDate: '2018-11-27T15:25:48.000Z',
-            userId: '31376076-3362-4faa-9012-01ee684b73ff'
-        },
-        {
-            userId: '31376076-3362-4faa-9012-01ee684b73ff',
-            startDate: '2018-11-27T15:25:48.000Z',
-            planId: 'professional-usd',
-            amount: ABSOLUTE_MAX_USAGE,
-            paymentReference: 'Hr5511ERAcD8VHCmF',
-            endDate: '2018-12-27T15:25:48.000Z',
-            cancellationDate: '2018-11-27T15:56:23.000Z'
-        },
-        {
-            userId: '31376076-3362-4faa-9012-01ee684b73ff',
-            planId: 'free',
-            amount: 100,
-            startDate: '2018-11-20T15:25:48.000Z',
-            endDate: '2018-11-27T15:25:48.000Z',
-            cancellationDate: '2018-11-27T15:25:48.000Z'
-        }]);
+        expect(filterIrrelevantFields(subscriptions), "downgrade-to-basic").to.deep.equal([
+            {
+                amount: ABSOLUTE_MAX_USAGE,
+                paymentReference: "Hr5511ERAcD8VHCmF",
+                planId: "professional-usd",
+                startDate: "2018-11-27T15:25:48.000Z",
+                userId: "31376076-3362-4faa-9012-01ee684b73ff",
+            },
+            {
+                userId: "31376076-3362-4faa-9012-01ee684b73ff",
+                startDate: "2018-11-27T15:25:48.000Z",
+                planId: "professional-usd",
+                amount: ABSOLUTE_MAX_USAGE,
+                paymentReference: "Hr5511ERAcD8VHCmF",
+                endDate: "2018-12-27T15:25:48.000Z",
+                cancellationDate: "2018-11-27T15:56:23.000Z",
+            },
+            {
+                userId: "31376076-3362-4faa-9012-01ee684b73ff",
+                planId: "free",
+                amount: 100,
+                startDate: "2018-11-20T15:25:48.000Z",
+                endDate: "2018-11-27T15:25:48.000Z",
+                cancellationDate: "2018-11-27T15:25:48.000Z",
+            },
+        ]);
     }
-
 
     @test async downgrade_unlimited_to_professional_new() {
         const userCreatedDate = new Date("2018-11-20T15:25:48.000Z").toISOString();
-        const events = loadFromFolder<chargebee.SubscriptionEventV2>('downgrade_unlimited_to_professional_new');
+        const events = loadFromFolder<chargebee.SubscriptionEventV2>("downgrade_unlimited_to_professional_new");
 
         let subscriptions: Subscription[] = [
-        {
-            userId: '643ac637-74ae-4f82-9a86-c8527eb1e496',
-            startDate: "2018-11-20T15:25:48.000Z",
-            endDate: "2019-04-07T13:17:58.000Z",
-            cancellationDate: '2019-04-07T13:17:58.000Z',
-            amount: 100,
-            uid: '7f76687f-8b09-482b-b059-5779e51c3a44',
-            planId: "free"
-        },
-        {
-            userId: '643ac637-74ae-4f82-9a86-c8527eb1e496',
-            startDate: '2019-04-07T13:17:58.000Z',
-            amount: 5952,
-            uid: '7f76687f-8b09-482b-b059-5779e51c3a22',
-            planId: 'professional-eur',
-            paymentReference: '1mkVvmiRMxfTZj1JGs',
-            paymentData: {
-                downgradeDate: "2020-01-07T13:17:58.000Z"
-            }
-        }];
+            {
+                userId: "643ac637-74ae-4f82-9a86-c8527eb1e496",
+                startDate: "2018-11-20T15:25:48.000Z",
+                endDate: "2019-04-07T13:17:58.000Z",
+                cancellationDate: "2019-04-07T13:17:58.000Z",
+                amount: 100,
+                uid: "7f76687f-8b09-482b-b059-5779e51c3a44",
+                planId: "free",
+            },
+            {
+                userId: "643ac637-74ae-4f82-9a86-c8527eb1e496",
+                startDate: "2019-04-07T13:17:58.000Z",
+                amount: 5952,
+                uid: "7f76687f-8b09-482b-b059-5779e51c3a22",
+                planId: "professional-eur",
+                paymentReference: "1mkVvmiRMxfTZj1JGs",
+                paymentData: {
+                    downgradeDate: "2020-01-07T13:17:58.000Z",
+                },
+            },
+        ];
 
-        const basicCreated = events.get('downgrade-change-actual')!;
+        const basicCreated = events.get("downgrade-change-actual")!;
         let model = this.mapper.map(filterFree(subscriptions), basicCreated);
         subscriptions = model.mergedWithFreeSubscriptions(userCreatedDate);
 
-        expect(filterIrrelevantFields(subscriptions), 'downgrade-change-actual').to.deep.equal([
-        {
-            userId: '643ac637-74ae-4f82-9a86-c8527eb1e496',
-            startDate: '2020-01-07T13:17:58.000Z',
-            amount: 11904,
-            planId: 'professional-new-eur',
-            paymentReference: '1mkVvmiRMxfTZj1JGs'
-        },
-        {
-            userId: '643ac637-74ae-4f82-9a86-c8527eb1e496',
-            startDate: '2019-04-07T13:17:58.000Z',
-            endDate: '2020-01-07T13:17:58.000Z',
-            cancellationDate: '2020-01-07T13:17:58.000Z',
-            amount: 5952,
-            planId: 'professional-eur',
-            paymentReference: '1mkVvmiRMxfTZj1JGs',
-            paymentData: {
-                downgradeDate: "2020-01-07T13:17:58.000Z"
-            }
-        },
-        {
-            userId: '643ac637-74ae-4f82-9a86-c8527eb1e496',
-            startDate: "2018-11-20T15:25:48.000Z",
-            endDate: "2019-04-07T13:17:58.000Z",
-            amount: 100,
-            planId: "free",
-            cancellationDate: '2019-04-07T13:17:58.000Z'
-        }]);
+        expect(filterIrrelevantFields(subscriptions), "downgrade-change-actual").to.deep.equal([
+            {
+                userId: "643ac637-74ae-4f82-9a86-c8527eb1e496",
+                startDate: "2020-01-07T13:17:58.000Z",
+                amount: 11904,
+                planId: "professional-new-eur",
+                paymentReference: "1mkVvmiRMxfTZj1JGs",
+            },
+            {
+                userId: "643ac637-74ae-4f82-9a86-c8527eb1e496",
+                startDate: "2019-04-07T13:17:58.000Z",
+                endDate: "2020-01-07T13:17:58.000Z",
+                cancellationDate: "2020-01-07T13:17:58.000Z",
+                amount: 5952,
+                planId: "professional-eur",
+                paymentReference: "1mkVvmiRMxfTZj1JGs",
+                paymentData: {
+                    downgradeDate: "2020-01-07T13:17:58.000Z",
+                },
+            },
+            {
+                userId: "643ac637-74ae-4f82-9a86-c8527eb1e496",
+                startDate: "2018-11-20T15:25:48.000Z",
+                endDate: "2019-04-07T13:17:58.000Z",
+                amount: 100,
+                planId: "free",
+                cancellationDate: "2019-04-07T13:17:58.000Z",
+            },
+        ]);
     }
 }
 
 const filterFree = (subscriptions: Subscription[]): Subscription[] => {
-    return subscriptions.filter(s =>
-        s.planId !== Plans.FREE.chargebeeId
-        && s.planId !== Plans.FREE_50.chargebeeId
-        && s.planId !== Plans.FREE_OPEN_SOURCE.chargebeeId);
+    return subscriptions.filter(
+        (s) =>
+            s.planId !== Plans.FREE.chargebeeId &&
+            s.planId !== Plans.FREE_50.chargebeeId &&
+            s.planId !== Plans.FREE_OPEN_SOURCE.chargebeeId,
+    );
 };
 
 const filterIrrelevantFields = (subscriptions: Subscription[]): Subscription[] => {
-    return subscriptions.map(s => { const r = { ...s }; delete (r as any).uid; return r; });
+    return subscriptions.map((s) => {
+        const r = { ...s };
+        delete (r as any).uid;
+        return r;
+    });
 };
 
 /**
@@ -267,13 +290,13 @@ const filterIrrelevantFields = (subscriptions: Subscription[]): Subscription[] =
  */
 const loadFromFolder = <T>(testname: string): Map<string, chargebee.Event<T>> => {
     const events: Map<string, chargebee.Event<T>> = new Map();
-    const testBasePath = path.join(__dirname, '../../test/fixtures/', testname);
+    const testBasePath = path.join(__dirname, "../../test/fixtures/", testname);
     const files = fs.readdirSync(testBasePath).sort();
     for (const file of files) {
         const content = fs.readFileSync(path.join(testBasePath, file));
-        const fileParts = file.split('.');
+        const fileParts = file.split(".");
         if (fileParts.length < 2) {
-            throw new Error('Expected file name of the format <number>.<name>.[...]');
+            throw new Error("Expected file name of the format <number>.<name>.[...]");
         }
         const name = fileParts[1];
         events.set(name, JSON.parse(content.toString()));
@@ -281,11 +304,24 @@ const loadFromFolder = <T>(testname: string): Map<string, chargebee.Event<T>> =>
     return events;
 };
 
-testContainer.bind(SubscriptionMapperFactory).toDynamicValue(ctx => {
-    return {
-        newMapper: () => {
-            return new SubscriptionMapper();
-        }
-    };
-}).inSingletonScope();
+testContainer.bind(UsageServiceDefinition.name).toConstantValue(<any>{
+    async getCostCenter(request: DeepPartial<GetCostCenterRequest>): Promise<GetCostCenterResponse> {
+        return {
+            costCenter: {
+                attributionId: "user:foo",
+                billingCycleStart: new Date(),
+                billingStrategy: CostCenter_BillingStrategy.BILLING_STRATEGY_OTHER,
+                spendingLimit: 500,
+                nextBillingTime: new Date(),
+            },
+        };
+    },
+    /** SetCostCenter stores the given cost center */
+    async setCostCenter(request: DeepPartial<SetCostCenterRequest>): Promise<SetCostCenterResponse> {
+        return {
+            costCenter: request!.costCenter as any,
+        };
+    },
+});
+testContainer.bind(SubscriptionMapper).toSelf().inSingletonScope();
 module.exports = new SubscriptionMapperSpec();

--- a/components/ee/payment-endpoint/src/config.ts
+++ b/components/ee/payment-endpoint/src/config.ts
@@ -5,22 +5,23 @@
  */
 
 import { injectable } from "inversify";
-import * as fs from 'fs';
+import * as fs from "fs";
 
-import { AbstractComponentEnv, getEnvVar, filePathTelepresenceAware } from '@gitpod/gitpod-protocol/lib/env';
+import { AbstractComponentEnv, getEnvVar, filePathTelepresenceAware } from "@gitpod/gitpod-protocol/lib/env";
 import { parseOptions } from "./chargebee/chargebee-provider";
 
 @injectable()
 export class Config extends AbstractComponentEnv {
-    readonly chargebeeProviderOptions = parseOptions(fs.readFileSync(filePathTelepresenceAware('/chargebee/providerOptions')).toString());
+    readonly chargebeeProviderOptions = parseOptions(
+        fs.readFileSync(filePathTelepresenceAware("/chargebee/providerOptions")).toString(),
+    );
 
     readonly chargebeeWebhook = this.parseChargebeeWebhook();
     protected parseChargebeeWebhook(): ChargebeeWebhook {
-        const envVar = getEnvVar('CHARGEBEE_WEBHOOK');
+        const envVar = getEnvVar("CHARGEBEE_WEBHOOK");
         const obj = JSON.parse(envVar) as ChargebeeWebhook;
-        if (!('user' in obj &&
-                'password' in obj)) {
-            throw new Error('Unable to parse chargebee webhook config from string: ' + envVar);
+        if (!("user" in obj && "password" in obj)) {
+            throw new Error("Unable to parse chargebee webhook config from string: " + envVar);
         }
         return obj;
     }
@@ -36,8 +37,11 @@ export GITPOD_GITHUB_APP_MKT_NAME=gitpod-draft-development-app
     readonly githubAppAppID: number = process.env.GITPOD_GITHUB_APP_ID ? parseInt(process.env.GITPOD_GITHUB_APP_ID) : 0;
     readonly githubAppWebhookSecret: string = process.env.GITPOD_GITHUB_APP_WEBHOOK_SECRET || "unknown";
     readonly githubAppCertPath: string = process.env.GITPOD_GITHUB_APP_CERT_PATH || "unknown";
+    readonly usageServiceAddr: string = process.env.GITPOD_USAGE_SERVICE_ADDR || "usage.default.svc.cluster.local:9001";
 
-    readonly maxTeamSlotsOnCreation: number = !!process.env.TS_MAX_SLOTS_ON_CREATION ? parseInt(process.env.TS_MAX_SLOTS_ON_CREATION) : 1000;
+    readonly maxTeamSlotsOnCreation: number = !!process.env.TS_MAX_SLOTS_ON_CREATION
+        ? parseInt(process.env.TS_MAX_SLOTS_ON_CREATION)
+        : 1000;
 }
 
 export interface ChargebeeWebhook {

--- a/components/ee/payment-endpoint/src/container-module.ts
+++ b/components/ee/payment-endpoint/src/container-module.ts
@@ -12,7 +12,7 @@ import { SubscriptionService } from "./accounting/subscription-service";
 import { Config } from "./config";
 import { Server } from "./server";
 import { SubscriptionHandler } from "./chargebee/subscription-handler";
-import { SubscriptionMapperFactory, SubscriptionMapper } from "./chargebee/subscription-mapper";
+import { SubscriptionMapper } from "./chargebee/subscription-mapper";
 import { TeamSubscriptionHandler } from "./chargebee/team-subscription-handler";
 import { CompositeEventHandler, EventHandler } from "./chargebee/chargebee-event-handler";
 import { UpgradeHelper } from "./chargebee/upgrade-helper";
@@ -23,22 +23,17 @@ import { AccountServiceImpl } from "./accounting/account-service-impl";
 import { GithubEndpointController } from "./github/endpoint-controller";
 import { GithubSubscriptionMapper } from "./github/subscription-mapper";
 import { GithubSubscriptionReconciler } from "./github/subscription-reconciler";
-
+import { UsageServiceClient, UsageServiceDefinition } from "@gitpod/usage-api/lib/usage/v1/usage.pb";
+import { createChannel, createClient } from "nice-grpc";
+import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 
 export const productionContainerModule = new ContainerModule((bind, unbind, isBound, rebind) => {
-
     bind(Config).toSelf().inSingletonScope();
     bind(Server).toSelf().inSingletonScope();
 
     bind(EndpointController).toSelf().inSingletonScope();
     bind(SubscriptionHandler).toSelf().inSingletonScope();
-    bind(SubscriptionMapperFactory).toDynamicValue(ctx => {
-        return {
-            newMapper: () => {
-                return new SubscriptionMapper();
-            }
-        };
-    });
+    bind(SubscriptionMapper).toSelf().inSingletonScope();
     bind(TeamSubscriptionHandler).toSelf().inSingletonScope();
 
     bind(CompositeEventHandler).toSelf().inSingletonScope();
@@ -51,14 +46,23 @@ export const productionContainerModule = new ContainerModule((bind, unbind, isBo
     bind(AccountService).to(AccountServiceImpl).inSingletonScope();
 
     bind(ChargebeeProvider).toSelf().inSingletonScope();
-    bind(ChargebeeProviderOptions).toDynamicValue(ctx => {
-        const config = ctx.container.get(Config);
-        return config.chargebeeProviderOptions;
-    }).inSingletonScope();
+    bind(ChargebeeProviderOptions)
+        .toDynamicValue((ctx) => {
+            const config = ctx.container.get(Config);
+            return config.chargebeeProviderOptions;
+        })
+        .inSingletonScope();
     bind(UpgradeHelper).toSelf().inSingletonScope();
 
     bind(GithubEndpointController).toSelf().inSingletonScope();
     bind(GithubSubscriptionMapper).toSelf().inSingletonScope();
     bind(GithubSubscriptionReconciler).toSelf().inSingletonScope();
 
+    bind<UsageServiceClient>(UsageServiceDefinition.name)
+        .toDynamicValue((ctx) => {
+            const config = ctx.container.get<Config>(Config);
+            log.info("Connecting to usage service at", { addr: config.usageServiceAddr });
+            return createClient(UsageServiceDefinition, createChannel(config.usageServiceAddr));
+        })
+        .inSingletonScope();
 });

--- a/components/usage/pkg/apiv1/usage.go
+++ b/components/usage/pkg/apiv1/usage.go
@@ -234,6 +234,7 @@ func (s *UsageService) SetCostCenter(ctx context.Context, in *v1.SetCostCenterRe
 		ID:              attrID,
 		SpendingLimit:   in.CostCenter.SpendingLimit,
 		BillingStrategy: convertBillingStrategyToDB(in.CostCenter.BillingStrategy),
+		NextBillingTime: db.NewVarCharTime(in.CostCenter.NextBillingTime.AsTime()),
 	}
 	result, err := s.costCenterManager.UpdateCostCenter(ctx, costCenter)
 	if err != nil {

--- a/components/usage/pkg/apiv1/usage_test.go
+++ b/components/usage/pkg/apiv1/usage_test.go
@@ -245,7 +245,14 @@ func TestGetAndSetCostCenter(t *testing.T) {
 		{
 			AttributionId:   string(db.NewTeamAttributionID(uuid.New().String())),
 			SpendingLimit:   0,
+			NextBillingTime: timestamppb.New(time.Now().Add(12 * time.Hour)),
 			BillingStrategy: v1.CostCenter_BILLING_STRATEGY_OTHER,
+		},
+		{
+			AttributionId:   string(db.NewTeamAttributionID(uuid.New().String())),
+			SpendingLimit:   3000,
+			NextBillingTime: timestamppb.New(time.Now().Add(12 * time.Hour)),
+			BillingStrategy: v1.CostCenter_BILLING_STRATEGY_CHARGEBEE_CANCELLATION,
 		},
 	}
 
@@ -259,6 +266,11 @@ func TestGetAndSetCostCenter(t *testing.T) {
 
 		require.Equal(t, costCenter.SpendingLimit, retrieved.CostCenter.SpendingLimit)
 		require.Equal(t, costCenter.BillingStrategy, retrieved.CostCenter.BillingStrategy)
+		if costCenter.BillingStrategy == v1.CostCenter_BILLING_STRATEGY_CHARGEBEE_CANCELLATION {
+			require.Equal(t, costCenter.NextBillingTime.String(), retrieved.CostCenter.NextBillingTime.String())
+		} else {
+			require.NotEqual(t, costCenter.NextBillingTime, retrieved.CostCenter.NextBillingTime)
+		}
 	}
 }
 

--- a/install/installer/pkg/common/constants.go
+++ b/install/installer/pkg/common/constants.go
@@ -40,6 +40,7 @@ const (
 	ServerComponent             = "server"
 	ServerInstallationAdminPort = 9000
 	SystemNodeCritical          = "system-node-critical"
+	PaymentEndpointComponent    = "payment-endpoint"
 	PublicApiComponent          = "public-api-server"
 	WSManagerComponent          = "ws-manager"
 	WSManagerBridgeComponent    = "ws-manager-bridge"

--- a/install/installer/pkg/components/usage/networkpolicy.go
+++ b/install/installer/pkg/components/usage/networkpolicy.go
@@ -49,6 +49,13 @@ func networkpolicy(ctx *common.RenderContext) ([]runtime.Object, error) {
 									},
 								},
 							},
+							{
+								PodSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										"component": common.PaymentEndpointComponent,
+									},
+								},
+							},
 						},
 					},
 				},


### PR DESCRIPTION
## Description
Create a chargebee cost center when the plan gets cancelled. This is so that our usage component treats any accumulated usage as covered and resets to a fresh UBP free plan at the endDate.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #15055

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
