### PR TITLE
[configcat] Log at error level only in Golang client

### DIFF
--- a/components/common-go/experiments/configcat.go
+++ b/components/common-go/experiments/configcat.go
@@ -90,5 +90,5 @@ type configCatLogger struct {
 }
 
 func (l *configCatLogger) GetLevel() configcat.LogLevel {
-	return l.Level
+	return configcat.LogLevelError
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

To remove the [following logs](https://console.cloud.google.com/logs/query;query=jsonPayload.message%3D%22fetching%20from%20https:%2F%2Fcdn-global.configcat.com%22;timeRange=PT3H;cursorTimestamp=2022-11-30T13:32:54.517479136Z?authuser=0&project=gitpod-191109)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
