### PR TITLE
[server] Print more details on auth error

### DIFF
--- a/components/gitpod-db/src/typeorm/auth-code-repository-db.ts
+++ b/components/gitpod-db/src/typeorm/auth-code-repository-db.ts
@@ -18,6 +18,7 @@ import { inject, injectable } from "inversify";
 import { EntityManager, Repository } from "typeorm";
 import { DBOAuthAuthCodeEntry } from "./entity/db-oauth-auth-code";
 import { TypeORM } from "./typeorm";
+import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 
 const expiryInFuture = new DateInterval("5m");
 
@@ -66,7 +67,12 @@ export class AuthCodeRepositoryDB implements OAuthAuthCodeRepository {
             authCode.id = uuidv4();
             await authCodeRepo.save(authCode);
         } catch (error) {
-            console.error("Error while persisting an DBOAuthAuthCodeEntry.", error, { error });
+            log.error(
+                { userId: authCode.user?.id || "<not-set>" },
+                "Error while persisting an DBOAuthAuthCodeEntry.",
+                error,
+                { expiresAt: authCode.expiresAt, clientId: authCode.client.id },
+            );
         }
     }
     public async isRevoked(authCodeCode: string): Promise<boolean> {


### PR DESCRIPTION
## Description

This PR seeks to gain more insight into #14464 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Context: #14464 

## How to test
- see that the build works

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
