### PR TITLE
[proxy] Pre-flight server authentication related endpoints to add additional latency

### DIFF
--- a/components/proxy/conf/Caddyfile
+++ b/components/proxy/conf/Caddyfile
@@ -314,7 +314,25 @@ https://{$GITPOD_DOMAIN} {
 	handle @to_server {
 		import compression
 
-		reverse_proxy server.{$KUBE_NAMESPACE}.{$KUBE_DOMAIN}:3000 {
+		forward_auth server.{$KUBE_NAMESPACE}.{$KUBE_DOMAIN}:3000 {
+			uri /feature-flags/slow-database
+			copy_headers X-Gitpod-Slow-Database
+		}
+
+		@slow {
+			header X-Gitpod-Slow-Database "true"
+		}
+
+		@fast {
+			not header X-Gitpod-Slow-Database "true"
+		}
+
+		reverse_proxy @fast server.{$KUBE_NAMESPACE}.{$KUBE_DOMAIN}:3000 {
+			import upstream_headers
+			import upstream_connection
+		}
+
+		reverse_proxy @slow slow-server.{$KUBE_NAMESPACE}.{$KUBE_DOMAIN}:3000 {
 			import upstream_headers
 			import upstream_connection
 		}


### PR DESCRIPTION
## Description

Pre-flight requests to `server` `/auth/*` endpoints in order to decide whether to send the actual request to `server` or `slow-server` depending on the value of the `slow_database` feature flag.

This change will affect requests to following paths on `server`:  `/auth/github/callback /auth /auth/* /apps /apps/*`

The pre-flight approach taken here is the same as we use for other `api/*` endpoints (https://github.com/gitpod-io/gitpod/pull/14897) and websocket connections (https://github.com/gitpod-io/gitpod/pull/15035).

## Related Issue(s)
Part of #9198 and https://github.com/gitpod-io/gitpod/issues/14965

## How to test

1. Open the preview environment and start a workspace.
2. Take the instance id of the running workspace from the application db.
3. Hit  https://af-add-lat37f4cc0217.preview.gitpod-dev.com/api/auth/workspace-cookie/your-instance-id
4. Enable the `slow_database` feature flag for your user id in the preview.
5. Wait up to 3 minutes for the configcat client to fetch the updated feature flag.
6. Hit  https://af-add-lat37f4cc0217.preview.gitpod-dev.com/api/auth/workspace-cookie/your-instance-id and observe that the endpoint now has additional latency.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-slow-database
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
