### PR TITLE
[proxy] Extract common request matchers to a snippet

### DIFF
--- a/components/proxy/conf/Caddyfile
+++ b/components/proxy/conf/Caddyfile
@@ -128,6 +128,16 @@
 	}
 }
 
+(slow_fast_matchers) {
+	@slow {
+		header X-Gitpod-Slow-Database "true"
+	}
+
+	@fast {
+		not header X-Gitpod-Slow-Database "true"
+	}
+}
+
 # Kubernetes health-check
 :8003 {
 	respond /live 200
@@ -223,13 +233,7 @@ https://{$GITPOD_DOMAIN} {
 			copy_headers X-Gitpod-Slow-Database
 		}
 
-		@slow {
-			header X-Gitpod-Slow-Database "true"
-		}
-
-		@fast {
-			not header X-Gitpod-Slow-Database "true"
-		}
+		import slow_fast_matchers
 
 		uri strip_prefix /api
 
@@ -255,13 +259,7 @@ https://{$GITPOD_DOMAIN} {
 			copy_headers X-Gitpod-Slow-Database
 		}
 
-		@slow {
-			header X-Gitpod-Slow-Database "true"
-		}
-
-		@fast {
-			not header X-Gitpod-Slow-Database "true"
-		}
+		import slow_fast_matchers
 
 		uri strip_prefix /api
 
@@ -319,13 +317,7 @@ https://{$GITPOD_DOMAIN} {
 			copy_headers X-Gitpod-Slow-Database
 		}
 
-		@slow {
-			header X-Gitpod-Slow-Database "true"
-		}
-
-		@fast {
-			not header X-Gitpod-Slow-Database "true"
-		}
+		import slow_fast_matchers
 
 		reverse_proxy @fast server.{$KUBE_NAMESPACE}.{$KUBE_DOMAIN}:3000 {
 			import upstream_headers


### PR DESCRIPTION
## Description

Extract some request matchers that are duplicated between different `handle` blocks into a snippet.

## Related Issue(s)
Part of #9198 

## How to test

Existing behaviour with request to pre-flights based on  the `slow_database` feature flag is preserved.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-slow-database
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
