### PR TITLE
Label JetBrains IDE images with their versions

### DIFF
--- a/.github/workflows/jetbrains-auto-update-template.yml
+++ b/.github/workflows/jetbrains-auto-update-template.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.19'
+          go-version: "1.19"
       - name: Download leeway
         run: cd /usr/local/bin && curl -fsSL https://github.com/gitpod-io/leeway/releases/download/v0.4.1/leeway_0.4.1_Linux_x86_64.tar.gz | tar xz
       - name: Download golangci-lint
@@ -52,18 +52,21 @@ jobs:
         run: |
           curl -sL "https://data.services.jetbrains.com/products/releases?code=${{ inputs.productCode }}&type=eap,rc,release&platform=linux" > releases.json
           IDE_VERSION=$(cat releases.json | jq -r -c 'first(.${{ inputs.productCode }}[] | select(.build | contains("${{ steps.platform-version.outputs.result }}")) | .build)')
+          IDE_BACKEND_VERSION=$(cat releases.json | jq -r '.${{ inputs.productCode }}[0].version')
           rm releases.json
           echo "::set-output name=result::$IDE_VERSION"
+          echo "::set-output name=ideBackendVersion::$IDE_BACKEND_VERSION"
           echo $IDE_VERSION
+          echo $IDE_BACKEND_VERSION
       - name: Leeway build
         if: ${{ steps.ide-version.outputs.result }}
         env:
-          LEEWAY_MAX_PROVENANCE_BUNDLE_SIZE: '8388608'
+          LEEWAY_MAX_PROVENANCE_BUNDLE_SIZE: "8388608"
         run: |
           gcloud auth configure-docker --quiet
           export LEEWAY_WORKSPACE_ROOT=$(pwd)
           cd components/ide/jetbrains/image
-          leeway build -Dversion=latest -DimageRepoBase=eu.gcr.io/gitpod-core-dev/build -DbuildNumber=${{ steps.ide-version.outputs.result }} .:${{ inputs.productId }}-latest
+          leeway build -Dversion=latest -DimageRepoBase=eu.gcr.io/gitpod-core-dev/build -DbuildNumber=${{ steps.ide-version.outputs.result }} .:${{ inputs.productId }}-latest -DjbBackendVersion=${{ steps.ide-version.outputs.ideBackendVersion }}
       - name: Get previous job's status
         id: lastrun
         uses: filiptronicek/get-last-job-status@main

--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -19,6 +19,7 @@ defaultArgs:
   webstormDownloadUrl: "https://download.jetbrains.com/webstorm/WebStorm-2022.2.3.tar.gz"
   riderDownloadUrl: "https://download.jetbrains.com/rider/JetBrains.Rider-2022.2.4.tar.gz"
   clionDownloadUrl: "https://download.jetbrains.com/cpp/CLion-2022.2.4.tar.gz"
+  jbBackendVersion: "latest"
   REPLICATED_API_TOKEN: ""
   REPLICATED_APP: ""
 provenance:

--- a/components/ide/jetbrains/image/BUILD.js
+++ b/components/ide/jetbrains/image/BUILD.js
@@ -37,6 +37,16 @@ const ideConfigs = [
     },
 ];
 
+const getIDEVersion = function (qualifier, url) {
+    if (qualifier == "latest") {
+        return args.jbBackendVersion;
+    } else {
+        // https://download.jetbrains.com/idea/ideaIU-2022.2.4.tar.gz
+        const str = url.split("-");
+        return str[str.length - 1].replace(".tar.gz", "");
+    }
+};
+
 const packages = [];
 const generateIDEBuildPackage = function (ideConfig, qualifier) {
     let name = ideConfig.name + (qualifier === "stable" ? "" : "-" + qualifier);
@@ -55,6 +65,7 @@ const generateIDEBuildPackage = function (ideConfig, qualifier) {
                 JETBRAINS_DOWNLOAD_QUALIFIER: name,
                 SUPERVISOR_IDE_CONFIG: `supervisor-ide-config_${ideConfig.name}.json`,
                 JETBRAINS_BACKEND_QUALIFIER: qualifier,
+                JETBRAINS_BACKEND_VERSION: getIDEVersion(qualifier, args[`${ideConfig.name}DownloadUrl`]),
             },
             image: [],
         },

--- a/components/ide/jetbrains/image/leeway.Dockerfile
+++ b/components/ide/jetbrains/image/leeway.Dockerfile
@@ -10,6 +10,7 @@ RUN mkdir /ide-desktop
 FROM scratch
 ARG JETBRAINS_DOWNLOAD_QUALIFIER
 ARG JETBRAINS_BACKEND_QUALIFIER
+ARG JETBRAINS_BACKEND_VERSION
 ARG SUPERVISOR_IDE_CONFIG
 # ensures right permissions for /ide-desktop
 COPY --from=base_builder --chown=33333:33333 /ide-desktop/ /ide-desktop/
@@ -30,3 +31,5 @@ ENV GITPOD_ENV_SET_GP_OPEN_EDITOR "$GITPOD_ENV_SET_EDITOR"
 ENV GITPOD_ENV_SET_GIT_EDITOR "$GITPOD_ENV_SET_EDITOR --wait"
 ENV GITPOD_ENV_SET_GP_PREVIEW_BROWSER "/ide-desktop/bin/idea-cli preview"
 ENV GITPOD_ENV_SET_GP_EXTERNAL_BROWSER "/ide-desktop/bin/idea-cli preview"
+
+LABEL "io.gitpod.ide.version"=$JETBRAINS_BACKEND_VERSION


### PR DESCRIPTION
## Description

Implements https://github.com/gitpod-io/gitpod/pull/14055 for the JetBrains Backend images with the difference being we don't label the images with `io.gitpod.ide.commit`, because we don't have access to that.

## How to test



## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
