### PR TITLE
[obs] improve workspace alerts

### DIFF
--- a/operations/observability/mixins/workspace/rules/central/nodes.yaml
+++ b/operations/observability/mixins/workspace/rules/central/nodes.yaml
@@ -29,7 +29,7 @@ spec:
       labels:
         severity: warning
         team: workspace
-      for: 20m
+      for: 60m
       annotations:
         runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWorkspaceNodeHighNormalizedLoadAverage.md
         summary: Workspace node's normalized load average is higher than 10 for more than 20 minutes. Check for abuse.

--- a/operations/observability/mixins/workspace/rules/central/nodes.yaml
+++ b/operations/observability/mixins/workspace/rules/central/nodes.yaml
@@ -32,7 +32,7 @@ spec:
       for: 60m
       annotations:
         runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWorkspaceNodeHighNormalizedLoadAverage.md
-        summary: Workspace node's normalized load average is higher than 10 for more than 20 minutes. Check for abuse.
+        summary: Workspace node's normalized load average is higher than 10 for more than 60 minutes. Check for abuse.
         description: Node {{ $labels.node }} in {{ $labels.cluster }} is reporting {{ printf "%.2f" $value }}% normalized load average. Normalized load average is current load average divided by number of CPU cores of the node.
       expr: nodepool:node_load1:normalized{nodepool=~".*workspace.*", cluster!~"ephemeral.*"} > 10
 

--- a/operations/observability/mixins/workspace/rules/central/workspaces.yaml
+++ b/operations/observability/mixins/workspace/rules/central/workspaces.yaml
@@ -14,19 +14,17 @@ spec:
 
   - name: workspace-alerts
     rules:
-    - alert: GitpodWorkspaceStuckOnStarting
+    - alert: GitpodWorkspaceStuckOnStopped
       labels:
         severity: warning
         team: workspace
       for: 20m
       annotations:
-        runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWorkspaceStuckOnStarting.md
-        summary: 5 or more workspaces are stuck on starting in cluster {{ $labels.cluster }}.
-        description: '{{ printf "%.2f" $value }} regular workspaces are stuck on starting for more than 20 minutes. Current status: {{ $labels.reason }}'
+        runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodWorkspaceStuckOnStopped.md
+        summary: Workspaces are stuck in STOPPED phase on cluster {{ $labels.cluster }}.
+        description: '{{ printf "%.2f" $value }} regular workspaces are stuck on stopped for more than 20 minutes. Current status: {{ $labels.reason }}'
       expr: |
-        count(
-          kube_pod_container_status_waiting_reason{cluster!~"ephemeral.*"} * on(pod) group_left kube_pod_labels{component="workspace", workspace_type="regular"}
-        ) by (reason, cluster) > 5
+        sum(gitpod_ws_manager_workspace_phase_total{phase="STOPPED", cluster!~"ephemeral.*"}) > 5
 
     - alert: GitpodWorkspaceStuckOnStopping
       labels:

--- a/operations/observability/mixins/workspace/rules/central/workspaces.yaml
+++ b/operations/observability/mixins/workspace/rules/central/workspaces.yaml
@@ -90,3 +90,26 @@ spec:
         description: workspace pods are terminating for too long in cluster {{ $labels.cluster }}.
       expr: |
         sum(time() - kube_pod_deletion_timestamp{namespace="default", pod=~"^ws-.*", cluster!~"ephemeral.*"}) by (pod) > 24 * 60 * 60
+
+    - alert: GitpodImagebuildSuccessRate
+      labels:
+        severity: warning
+        team: workspace
+      annotations:
+        runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodImagebuildSuccessRate.md
+        summary: imagebuild success rate is low in cluster {{ $labels.cluster }}.
+        description: imagebuild are failing at too high of a rate in cluster {{ $labels.cluster }}.
+      expr: |
+        (1 - (sum(rate(gitpod_image_builder_builds_done_total{success="false", cluster!~"ephemeral.*"}[4h])) / sum(rate(gitpod_image_builder_builds_done_total{cluster!~"ephemeral.*"}[4h])))) < 0.75
+
+    - alert: GitpodImagebuildSuccessFailing
+      labels:
+        severity: critical
+        team: workspace
+      for: 3h
+      annotations:
+        runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodImagebuildSuccessRate.md
+        summary: imagebuild success rate is failing in cluster {{ $labels.cluster }}.
+        description: imagebuild are failing at too high of a rate in cluster {{ $labels.cluster }}.
+      expr: |
+        (1 - (sum(rate(gitpod_image_builder_builds_done_total{success="false", cluster!~"ephemeral.*"}[4h])) / sum(rate(gitpod_image_builder_builds_done_total{cluster!~"ephemeral.*"}[4h])))) < 0.50


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
1. add image build alerts
2. simplify alerts for stopped regular workspaces
3. reduce frequency of normalized load average alerts, to make them actionable in  [#team-workspace-alerts](https://gitpod.slack.com/archives/C03QZ1NH517)

To recap, warnings should go to [#team-workspace-alerts](https://gitpod.slack.com/archives/C03QZ1NH517), and criticals should trigger pager duty. Critical alerts must also have a related runbook, Warnings do not.

## Related PR

The runbook for the critical alert: https://github.com/gitpod-io/runbooks/pull/408 <-- must be approved and merged before removing this PR's hold.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes # n/a

## How to test
<!-- Provide steps to test this PR -->
1. [Observe how this would have triggered for EU this week, but, not US](https://grafana.gitpod.io/explore?orgId=1&left=%7B%22datasource%22:%22P4169E866C3094E38%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22datasource%22:%7B%22type%22:%22prometheus%22,%22uid%22:%22P4169E866C3094E38%22%7D,%22editorMode%22:%22code%22,%22expr%22:%22%281%20-%20%28sum%20by%28cluster%29%20%28rate%28gitpod_image_builder_builds_done_total%7Bsuccess%3D%5C%22false%5C%22,%20cluster%21~%5C%22ephemeral.%2A%5C%22%7D%5B4h%5D%29%29%20%2F%20sum%20by%28cluster%29%20%28rate%28gitpod_image_builder_builds_done_total%7Bcluster%21~%5C%22ephemeral.%2A%5C%22%7D%5B4h%5D%29%29%29%29%20%3C%20.50%22,%22legendFormat%22:%22__auto%22,%22range%22:true,%22instant%22:true%7D%5D,%22range%22:%7B%22from%22:%221669537328726%22,%22to%22:%221669584955291%22%7D%7D). In other words, this image build success rate alert would have helped sooner detect [this incident](https://www.gitpodstatus.com/incidents/b5b2p2fhwv0j).
2. Observe [overview dashboard](https://grafana.gitpod.io/?orgId=1&var-datasource=VictoriaMetrics&var-cluster=eu77&var-cluster=us77&from=now-1h&to=now&refresh=1m), and how there are many workspaces with a STOPPED phase in Workspace Phases. The alert and query we use now to catch this is too complex.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
