### PR TITLE
ws-daemon: Enhause the traces for DisposeWorkspace

### DIFF
--- a/components/ws-daemon/pkg/content/service.go
+++ b/components/ws-daemon/pkg/content/service.go
@@ -383,6 +383,7 @@ func (s *WorkspaceService) DisposeWorkspace(ctx context.Context, req *api.Dispos
 		return resp, nil
 	}
 
+	span.SetTag("backupLogs", req.BackupLogs)
 	if req.BackupLogs {
 		if sess.RemoteStorageDisabled {
 			return nil, status.Errorf(codes.FailedPrecondition, "workspace has no remote storage")
@@ -396,6 +397,7 @@ func (s *WorkspaceService) DisposeWorkspace(ctx context.Context, req *api.Dispos
 		}
 	}
 
+	span.SetTag("backup", req.Backup)
 	if req.Backup {
 		if sess.RemoteStorageDisabled {
 			return nil, status.Errorf(codes.FailedPrecondition, "workspace has no remote storage")
@@ -450,7 +452,7 @@ func (s *WorkspaceService) uploadWorkspaceContent(ctx context.Context, sess *ses
 	span, ctx := opentracing.StartSpanFromContext(ctx, "uploadWorkspaceContent")
 	span.SetTag("workspace", sess.WorkspaceID)
 	span.SetTag("instance", sess.InstanceID)
-	span.SetTag("backup", backupName)
+	span.SetTag("backupName", backupName)
 	span.SetTag("manifest", mfName)
 	span.SetTag("full", sess.FullWorkspaceBackup)
 	span.SetTag("pvc", sess.PersistentVolumeClaim)


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Add the necessary information.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

Investigation for https://github.com/gitpod-io/gitpod/issues/15049

## How to test
<!-- Provide steps to test this PR -->

Works fine

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
