### PR TITLE
[pat] Apply on-update property to _lastModified column, remove from expirationTime

### DIFF
--- a/components/gitpod-db/src/typeorm/migration/1669888999897-PersonalAccessTokenFixLastModifiedAutoUpdate.ts
+++ b/components/gitpod-db/src/typeorm/migration/1669888999897-PersonalAccessTokenFixLastModifiedAutoUpdate.ts
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+const TABLE_NAME = "d_b_personal_access_token";
+
+export class PersonalAccessTokenFixLastModifiedAutoUpdate1669888999897 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE ${TABLE_NAME} MODIFY expirationTime timestamp(6) NOT NULL`);
+        await queryRunner.query(
+            `ALTER TABLE ${TABLE_NAME} MODIFY _lastModified timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) on update CURRENT_TIMESTAMP(6)`,
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {}
+}


### PR DESCRIPTION


## Description
<!-- Describe your changes in detail -->

In https://github.com/gitpod-io/gitpod/pull/15015#discussion_r1036347016, we've identified that the table has the on-update extra property on the wrong column. This migraiton moves it to the `_lastModified` column, and removes it from teh `expirationTime` column

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
CI runs the migrations on a local DB, tests in the public api use those migrations to run unit tests

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
