### PR TITLE
singleton SupervisorServiceClient

### DIFF
--- a/components/supervisor/frontend/src/ide/supervisor-service-client.ts
+++ b/components/supervisor/frontend/src/ide/supervisor-service-client.ts
@@ -4,23 +4,32 @@
  * See License-AGPL.txt in the project root for license information.
  */
 
-import { SupervisorStatusResponse, IDEStatusResponse, ContentStatusResponse } from '@gitpod/supervisor-api-grpc/lib/status_pb'
-import { GitpodServiceClient } from './gitpod-service-client';
-import { GitpodHostUrl } from '@gitpod/gitpod-protocol/lib/util/gitpod-host-url';
+import {
+    SupervisorStatusResponse,
+    IDEStatusResponse,
+    ContentStatusResponse,
+} from "@gitpod/supervisor-api-grpc/lib/status_pb";
+import { GitpodServiceClient } from "./gitpod-service-client";
+import { GitpodHostUrl } from "@gitpod/gitpod-protocol/lib/util/gitpod-host-url";
 
 export class SupervisorServiceClient {
-    readonly supervisorReady = this.checkReady('supervisor');
-    readonly ideReady = this.supervisorReady.then(() => this.checkReady('ide'))
-    readonly contentReady = Promise.all([
-        this.supervisorReady,
-        this.gitpodServiceClient.auth
-    ]).then(() => this.checkReady('content'));
+    private static _instance: SupervisorServiceClient | undefined;
+    static get(gitpodServiceClient: GitpodServiceClient): SupervisorServiceClient {
+        if (!SupervisorServiceClient._instance) {
+            SupervisorServiceClient._instance = new SupervisorServiceClient(gitpodServiceClient);
+        }
+        return SupervisorServiceClient._instance;
+    }
 
-    constructor(
-        private readonly gitpodServiceClient: GitpodServiceClient
-    ) { }
+    readonly supervisorReady = this.checkReady("supervisor");
+    readonly ideReady = this.supervisorReady.then(() => this.checkReady("ide"));
+    readonly contentReady = Promise.all([this.supervisorReady, this.gitpodServiceClient.auth]).then(() =>
+        this.checkReady("content"),
+    );
 
-    private async checkReady(kind: 'content' | 'ide' | 'supervisor', delay?: boolean): Promise<any> {
+    private constructor(private readonly gitpodServiceClient: GitpodServiceClient) {}
+
+    private async checkReady(kind: "content" | "ide" | "supervisor", delay?: boolean): Promise<any> {
         if (delay) {
             await new Promise((resolve) => setTimeout(resolve, 1000));
         }
@@ -31,37 +40,40 @@ export class SupervisorServiceClient {
         }
         try {
             const supervisorStatusPath = "_supervisor/v1/status/" + kind + wait;
-            const wsSupervisurStatusUrl = GitpodHostUrl.fromWorkspaceUrl(window.location.href)
-                .with(url => {
-                    let pathname = url.pathname;
-                    if (pathname === "") {
-                        pathname = "/";
-                    }
-                    pathname += supervisorStatusPath;
+            const wsSupervisurStatusUrl = GitpodHostUrl.fromWorkspaceUrl(window.location.href).with((url) => {
+                let pathname = url.pathname;
+                if (pathname === "") {
+                    pathname = "/";
+                }
+                pathname += supervisorStatusPath;
 
-                    return {
-                        pathname
-                    };
-                });
-            const response = await fetch(wsSupervisurStatusUrl.toString(), { credentials: 'include' });
+                return {
+                    pathname,
+                };
+            });
+            const response = await fetch(wsSupervisurStatusUrl.toString(), { credentials: "include" });
             let result;
             if (response.ok) {
                 result = await response.json();
-                if (kind === 'supervisor' && (result as SupervisorStatusResponse.AsObject).ok) {
+                if (kind === "supervisor" && (result as SupervisorStatusResponse.AsObject).ok) {
                     return;
                 }
-                if (kind === 'content' && (result as ContentStatusResponse.AsObject).available) {
+                if (kind === "content" && (result as ContentStatusResponse.AsObject).available) {
                     return;
                 }
-                if (kind === 'ide' && (result as IDEStatusResponse.AsObject).ok) {
+                if (kind === "ide" && (result as IDEStatusResponse.AsObject).ok) {
                     return result;
                 }
             }
-            console.debug(`failed to check whether ${kind} is ready, trying again...`, response.status, response.statusText, JSON.stringify(result, undefined, 2));
+            console.debug(
+                `failed to check whether ${kind} is ready, trying again...`,
+                response.status,
+                response.statusText,
+                JSON.stringify(result, undefined, 2),
+            );
         } catch (e) {
             console.debug(`failed to check whether ${kind} is ready, trying again...`, e);
         }
         return this.checkReady(kind, true);
     }
-
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Makes sure that supervisor-frontend only check for ide and content readiness once.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
fix #14782

## How to test
<!-- Provide steps to test this PR -->

- Open a new window with devtools.
- In this window start a workspace with IntelliJ and check that both VS Code and IntelliJ can be opened.
- Check in devtool that we send only successful request for ide and content readiness.


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
