### PR TITLE
[pat] Fix expiration time auto-udpate

### DIFF
--- a/components/gitpod-db/src/typeorm/migration/1669892320740-PersonalAccessTokenFixExpirationTimeAutoUpdate.ts
+++ b/components/gitpod-db/src/typeorm/migration/1669892320740-PersonalAccessTokenFixExpirationTimeAutoUpdate.ts
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+const TABLE_NAME = "d_b_personal_access_token";
+
+export class PersonalAccessTokenFixExpirationTimeAutoUpdate1669892320740 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `ALTER TABLE ${TABLE_NAME} CHANGE expirationTime expirationTime timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6)`,
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {}
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Previous [PR](https://github.com/gitpod-io/gitpod/pull/15093/files) wouldn't fix it on a DB which already has existing data

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

1. On this PR, in a workspace `leeway build components/gitpod-db/go:init-testdb`
2. Connect to the local db `mysql -h 127.0.0.1 -P 23306 -u root -D gitpod --select-limit=200 --safe-updates -p`, `pw: test`
3. `mysql> show columns from d_b_personal_access_token;`
```
+----------------+--------------+------+-----+----------------------+--------------------------------+
| Field          | Type         | Null | Key | Default              | Extra                          |
+----------------+--------------+------+-----+----------------------+--------------------------------+
| id             | varchar(255) | NO   | PRI | NULL                 |                                |
| userId         | varchar(255) | NO   | MUL | NULL                 |                                |
| hash           | varchar(255) | NO   | MUL | NULL                 |                                |
| name           | varchar(255) | NO   |     | NULL                 |                                |
| scopes         | text         | NO   |     | NULL                 |                                |
| expirationTime | timestamp(6) | NO   |     | CURRENT_TIMESTAMP(6) |                                |
| createdAt      | timestamp(6) | NO   | MUL | CURRENT_TIMESTAMP(6) |                                |
| _lastModified  | timestamp(6) | NO   | MUL | CURRENT_TIMESTAMP(6) | on update CURRENT_TIMESTAMP(6) |
| deleted        | tinyint(4)   | NO   |     | 0                    |                                |
+----------------+--------------+------+-----+----------------------+--------------------------------+
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
