### PR TITLE
[pat] Remove Personal from Access Tokens UI

### DIFF
--- a/components/dashboard/src/settings/PersonalAccessTokens.tsx
+++ b/components/dashboard/src/settings/PersonalAccessTokens.tsx
@@ -268,7 +268,7 @@ export function PersonalAccessTokenCreateView() {
                 </>
                 <div className="max-w-md mb-6">
                     <div className="flex flex-col mb-4">
-                        <h3>{editTokenID ? "Edit" : "New"} Personal Access Token</h3>
+                        <h3>{editTokenID ? "Edit" : "New"} Access Token</h3>
                         {editTokenID ? (
                             <>
                                 <h2 className="text-gray-500 dark:text-gray-400 dark:text-gray-400">
@@ -338,7 +338,7 @@ export function PersonalAccessTokenCreateView() {
                             </button>
                         </Link>
                     )}
-                    <button onClick={handleConfirm}>{editTokenID ? "Update" : "Create"} Personal Access Token</button>
+                    <button onClick={handleConfirm}>{editTokenID ? "Update" : "Create"} Access Token</button>
                 </div>
             </PageWithSettingsSubMenu>
         </div>
@@ -387,7 +387,7 @@ function ListAccessTokensView() {
         <>
             <div className="flex items-center sm:justify-between mb-4">
                 <div>
-                    <h3>Personal Access Tokens</h3>
+                    <h3>Access Tokens</h3>
                     <h2 className="text-gray-500">Create or regenerate access tokens.</h2>
                 </div>
                 {tokens.length > 0 && (


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

* Follow up to https://github.com/gitpod-io/gitpod/pull/15015#issuecomment-1333698377

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Relates to https://github.com/gitpod-io/gitpod/issues/15002

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
