### PR TITLE
[installer] Add `slow-server` to network policy ingress rules

### DIFF
--- a/install/installer/cmd/testdata/render/aws-setup/output.golden
+++ b/install/installer/cmd/testdata/render/aws-setup/output.golden
@@ -158,6 +158,9 @@ spec:
               component: server
         - podSelector:
             matchLabels:
+              component: slow-server
+        - podSelector:
+            matchLabels:
               component: ws-manager
   podSelector:
     matchLabels:

--- a/install/installer/cmd/testdata/render/azure-setup/output.golden
+++ b/install/installer/cmd/testdata/render/azure-setup/output.golden
@@ -158,6 +158,9 @@ spec:
               component: server
         - podSelector:
             matchLabels:
+              component: slow-server
+        - podSelector:
+            matchLabels:
               component: ws-manager
   podSelector:
     matchLabels:

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -158,6 +158,9 @@ spec:
               component: server
         - podSelector:
             matchLabels:
+              component: slow-server
+        - podSelector:
+            matchLabels:
               component: ws-manager
   podSelector:
     matchLabels:

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -158,6 +158,9 @@ spec:
               component: server
         - podSelector:
             matchLabels:
+              component: slow-server
+        - podSelector:
+            matchLabels:
               component: ws-manager
   podSelector:
     matchLabels:

--- a/install/installer/cmd/testdata/render/gcp-setup/output.golden
+++ b/install/installer/cmd/testdata/render/gcp-setup/output.golden
@@ -158,6 +158,9 @@ spec:
               component: server
         - podSelector:
             matchLabels:
+              component: slow-server
+        - podSelector:
+            matchLabels:
               component: ws-manager
   podSelector:
     matchLabels:

--- a/install/installer/cmd/testdata/render/http-proxy/output.golden
+++ b/install/installer/cmd/testdata/render/http-proxy/output.golden
@@ -158,6 +158,9 @@ spec:
               component: server
         - podSelector:
             matchLabels:
+              component: slow-server
+        - podSelector:
+            matchLabels:
               component: ws-manager
   podSelector:
     matchLabels:

--- a/install/installer/cmd/testdata/render/insecure-s3-setup/output.golden
+++ b/install/installer/cmd/testdata/render/insecure-s3-setup/output.golden
@@ -158,6 +158,9 @@ spec:
               component: server
         - podSelector:
             matchLabels:
+              component: slow-server
+        - podSelector:
+            matchLabels:
               component: ws-manager
   podSelector:
     matchLabels:

--- a/install/installer/cmd/testdata/render/kind-workspace/output.golden
+++ b/install/installer/cmd/testdata/render/kind-workspace/output.golden
@@ -36,6 +36,9 @@ spec:
               component: server
         - podSelector:
             matchLabels:
+              component: slow-server
+        - podSelector:
+            matchLabels:
               component: ws-manager
   podSelector:
     matchLabels:

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -158,6 +158,9 @@ spec:
               component: server
         - podSelector:
             matchLabels:
+              component: slow-server
+        - podSelector:
+            matchLabels:
               component: ws-manager
   podSelector:
     matchLabels:

--- a/install/installer/cmd/testdata/render/shortname/output.golden
+++ b/install/installer/cmd/testdata/render/shortname/output.golden
@@ -158,6 +158,9 @@ spec:
               component: server
         - podSelector:
             matchLabels:
+              component: slow-server
+        - podSelector:
+            matchLabels:
               component: ws-manager
   podSelector:
     matchLabels:

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -158,6 +158,9 @@ spec:
               component: server
         - podSelector:
             matchLabels:
+              component: slow-server
+        - podSelector:
+            matchLabels:
               component: ws-manager
   podSelector:
     matchLabels:

--- a/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
+++ b/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
@@ -158,6 +158,9 @@ spec:
               component: server
         - podSelector:
             matchLabels:
+              component: slow-server
+        - podSelector:
+            matchLabels:
               component: ws-manager
   podSelector:
     matchLabels:

--- a/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
+++ b/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
@@ -158,6 +158,9 @@ spec:
               component: server
         - podSelector:
             matchLabels:
+              component: slow-server
+        - podSelector:
+            matchLabels:
               component: ws-manager
   podSelector:
     matchLabels:

--- a/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
+++ b/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
@@ -158,6 +158,9 @@ spec:
               component: server
         - podSelector:
             matchLabels:
+              component: slow-server
+        - podSelector:
+            matchLabels:
               component: ws-manager
   podSelector:
     matchLabels:

--- a/install/installer/pkg/common/constants.go
+++ b/install/installer/pkg/common/constants.go
@@ -38,6 +38,7 @@ const (
 	RegistryFacadeServicePort   = 20000
 	RegistryFacadeTLSCertSecret = "builtin-registry-facade-cert"
 	ServerComponent             = "server"
+	SlowServerComponent         = "slow-server"
 	ServerInstallationAdminPort = 9000
 	SystemNodeCritical          = "system-node-critical"
 	PublicApiComponent          = "public-api-server"

--- a/install/installer/pkg/components/image-builder-mk3/networkpolicy.go
+++ b/install/installer/pkg/components/image-builder-mk3/networkpolicy.go
@@ -40,6 +40,13 @@ func networkpolicy(ctx *common.RenderContext) ([]runtime.Object, error) {
 							{
 								PodSelector: &metav1.LabelSelector{
 									MatchLabels: map[string]string{
+										"component": common.SlowServerComponent,
+									},
+								},
+							},
+							{
+								PodSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
 										"component": common.WSManagerComponent,
 									},
 								},

--- a/install/installer/pkg/components/usage/networkpolicy.go
+++ b/install/installer/pkg/components/usage/networkpolicy.go
@@ -45,6 +45,13 @@ func networkpolicy(ctx *common.RenderContext) ([]runtime.Object, error) {
 							{
 								PodSelector: &metav1.LabelSelector{
 									MatchLabels: map[string]string{
+										"component": common.SlowServerComponent,
+									},
+								},
+							},
+							{
+								PodSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
 										"component": common.PublicApiComponent,
 									},
 								},


### PR DESCRIPTION
## Description

As part of #9198, a deployment called `slow-server` was added, identical to `server` but with a higher latency connection to the database.

This PR adds the `slow-server` component to the `image-builder-mk3` and `usage` component network policy ingress rules, so that ingress to those two components works for `slow-server` just as it does for the `server` component.

This means that workspace startup works correctly for workspaces started by `slow-server`.

## Related Issue(s)

Fixes https://github.com/gitpod-io/gitpod/issues/15027

## How to test

1. Log into the preview environment.
2. Update the configcat targeting rule for the `slow_database` (non-production) feature flag for your user id.
3. Wait for 3 minutes for configcat to pull the new config or until `/api/feature-flags/slow-database` starts setting `X-Gitpod-Slow-Database: true` in the response headers.
4. Start a workspace.

The workspace start should be slower than usual, but should complete successfully.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-slow-database
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
