### PR TITLE
Update spacing in token regeneration modal

### DIFF
--- a/components/dashboard/src/settings/PersonalAccessTokens.tsx
+++ b/components/dashboard/src/settings/PersonalAccessTokens.tsx
@@ -148,7 +148,7 @@ function ShowTokenModal(props: TokenModalProps) {
                     Expires on {dayjs(props.token.expirationTime!.toDate()).format("MMM D, YYYY")}
                 </div>
             </div>
-            <>
+            <div className="mt-4">
                 {props.showDateSelector && (
                     <DateSelector
                         title="Expiration Date"
@@ -165,7 +165,7 @@ function ShowTokenModal(props: TokenModalProps) {
                         }
                     />
                 )}
-            </>
+            </div>
         </Modal>
     );
 }


### PR DESCRIPTION
## Description

This will update spacing between elements in the token regeneration modal, following the proposal in https://github.com/gitpod-io/gitpod/issues/15104#issuecomment-1333805855.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/15104

## How to test
1. Create a new access token
2. Go to the access tokens list
3. Click on more actions to regenerate a token or regenerate via the token edit page
4. Notice the spacing in the modal

From https://github.com/gitpod-io/gitpod/issues/15104#issuecomment-1333805855:

> | BEFORE | AFTER |
> |-|-|
> | <img width="536" alt="modal-before" src="https://user-images.githubusercontent.com/120486/205071027-2aca7750-c54e-44c1-840e-85925521b9ea.png"> | <img width="536" alt="modal-after" src="https://user-images.githubusercontent.com/120486/205071034-2c70d4d0-20b3-499b-814f-9e05c67eb7a6.png"> |

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Update spacing in token regeneration modal
```

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
