### PR TITLE
[pat] API allows update which does not change any data

### DIFF
--- a/components/gitpod-db/go/personal_access_token.go
+++ b/components/gitpod-db/go/personal_access_token.go
@@ -235,10 +235,6 @@ func UpdatePersonalAccessTokenForUser(ctx context.Context, conn *gorm.DB, opts U
 		return PersonalAccessToken{}, fmt.Errorf("failed to update personal access token: %w", tx.Error)
 	}
 
-	if tx.RowsAffected == 0 {
-		return PersonalAccessToken{}, fmt.Errorf("token (ID: %s) for user (ID: %s) does not exist: %w", opts.TokenID, opts.UserID, ErrorNotFound)
-	}
-
 	return GetPersonalAccessTokenForUser(ctx, conn, opts.TokenID, opts.UserID)
 }
 

--- a/components/gitpod-db/go/personal_access_token_test.go
+++ b/components/gitpod-db/go/personal_access_token_test.go
@@ -285,6 +285,24 @@ func TestUpdatePersonalAccessTokenForUser(t *testing.T) {
 		require.ErrorIs(t, err, db.ErrorNotFound)
 	})
 
+	t.Run("no modified field completes gracefully", func(t *testing.T) {
+		conn := dbtest.ConnectForTests(t)
+		name := "first"
+
+		created := dbtest.CreatePersonalAccessTokenRecords(t, conn, dbtest.NewPersonalAccessToken(t, db.PersonalAccessToken{
+			Name: name,
+		}))[0]
+
+		udpated, err := db.UpdatePersonalAccessTokenForUser(context.Background(), conn, db.UpdatePersonalAccessTokenOpts{
+			TokenID: created.ID,
+			UserID:  created.UserID,
+			Name:    &name,
+		})
+		require.NoError(t, err)
+		require.Equal(t, name, udpated.Name)
+		require.Len(t, udpated.Scopes, 0)
+	})
+
 	t.Run("no update when all options are nil", func(t *testing.T) {
 		conn := dbtest.ConnectForTests(t)
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

MySQL would return 0 RowsModified when the updated values already match. Here, we solve it by not checking for the udpated rows and instead rely on the Get to return the not found.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/15105

## How to test
<!-- Provide steps to test this PR -->
Unit regression tests + 

1. Preview
2. Create PAT
3. Click edit PAT
4. Make no changes to it, press click Update
5. There's no Error.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
