### PR TITLE
[go] clean up gen of go types

### DIFF
--- a/components/gitpod-protocol/go/gitpod-config-types.go
+++ b/components/gitpod-protocol/go/gitpod-config-types.go
@@ -6,32 +6,25 @@
 
 package protocol
 
-import (
-	"bytes"
-	"encoding/json"
-	"errors"
-	"fmt"
-)
-
 // AdditionalRepositoriesItems
 type AdditionalRepositoriesItems struct {
 
 	// Path to where the repository should be checked out relative to `/workspace`. Defaults to the simple repository name.
-	CheckoutLocation string `yaml:"checkoutLocation,omitempty"`
+	CheckoutLocation string `yaml:"checkoutLocation,omitempty" json:"checkoutLocation,omitempty"`
 
 	// The url of the git repository to clone. Supports any context URLs.
-	Url string `yaml:"url"`
+	Url string `yaml:"url" json:"url"`
 }
 
 // CoreDump Configure the default action of certain signals is to cause a process to terminate and produce a core dump file, a file containing an image of the process's memory at the time of termination. Disabled by default.
 type CoreDump struct {
-	Enabled bool `yaml:"enabled,omitempty"`
+	Enabled bool `yaml:"enabled,omitempty" json:"enabled,omitempty"`
 
 	// the hard limit acts as a ceiling for the soft limit. For more details please check https://man7.org/linux/man-pages/man2/getrlimit.2.html
-	HardLimit float64 `yaml:"hardLimit,omitempty"`
+	HardLimit float64 `yaml:"hardLimit,omitempty" json:"hardLimit,omitempty"`
 
 	// upper limit on the size of the core dump file that will be produced if it receives a core dump signal
-	SoftLimit float64 `yaml:"softLimit,omitempty"`
+	SoftLimit float64 `yaml:"softLimit,omitempty" json:"softLimit,omitempty"`
 }
 
 // Env Environment variables to set.
@@ -42,1225 +35,191 @@ type Env struct {
 type Github struct {
 
 	// Set to true to enable workspace prebuilds, false to disable them. Defaults to true.
-	Prebuilds interface{} `yaml:"prebuilds,omitempty"`
+	Prebuilds interface{} `yaml:"prebuilds,omitempty" json:"prebuilds,omitempty"`
 }
 
 // GitpodConfig
 type GitpodConfig struct {
 
 	// List of additional repositories that are part of this project.
-	AdditionalRepositories []*AdditionalRepositoriesItems `yaml:"additionalRepositories,omitempty"`
+	AdditionalRepositories []*AdditionalRepositoriesItems `yaml:"additionalRepositories,omitempty" json:"additionalRepositories,omitempty"`
 
 	// Path to where the repository should be checked out relative to `/workspace`. Defaults to the simple repository name.
-	CheckoutLocation string `yaml:"checkoutLocation,omitempty"`
+	CheckoutLocation string `yaml:"checkoutLocation,omitempty" json:"checkoutLocation,omitempty"`
 
 	// Configure the default action of certain signals is to cause a process to terminate and produce a core dump file, a file containing an image of the process's memory at the time of termination. Disabled by default.
-	CoreDump *CoreDump `yaml:"coreDump,omitempty"`
+	CoreDump *CoreDump `yaml:"coreDump,omitempty" json:"coreDump,omitempty"`
 
 	// Experimental network configuration in workspaces (deprecated). Enabled by default
-	ExperimentalNetwork bool `yaml:"experimentalNetwork,omitempty"`
+	ExperimentalNetwork bool `yaml:"experimentalNetwork,omitempty" json:"experimentalNetwork,omitempty"`
 
 	// Git config values should be provided in pairs. E.g. `core.autocrlf: input`. See https://git-scm.com/docs/git-config#_values.
-	GitConfig map[string]string `yaml:"gitConfig,omitempty"`
+	GitConfig map[string]string `yaml:"gitConfig,omitempty" json:"gitConfig,omitempty"`
 
 	// Configures Gitpod's GitHub app
-	Github *Github `yaml:"github,omitempty"`
+	Github *Github `yaml:"github,omitempty" json:"github,omitempty"`
 
 	// The Docker image to run your workspace in.
-	Image interface{} `yaml:"image,omitempty"`
+	Image interface{} `yaml:"image,omitempty" json:"image,omitempty"`
 
 	// Configure JetBrains integration
-	Jetbrains *Jetbrains `yaml:"jetbrains,omitempty"`
+	Jetbrains *Jetbrains `yaml:"jetbrains,omitempty" json:"jetbrains,omitempty"`
 
 	// The main repository, containing the dev environment configuration.
-	MainConfiguration string `yaml:"mainConfiguration,omitempty"`
+	MainConfiguration string `yaml:"mainConfiguration,omitempty" json:"mainConfiguration,omitempty"`
 
 	// List of exposed ports.
-	Ports []*PortsItems `yaml:"ports,omitempty"`
+	Ports []*PortsItems `yaml:"ports,omitempty" json:"ports,omitempty"`
 
 	// List of tasks to run on start. Each task will open a terminal in the IDE.
-	Tasks []*TasksItems `yaml:"tasks,omitempty"`
+	Tasks []*TasksItems `yaml:"tasks,omitempty" json:"tasks,omitempty"`
 
 	// Configure VS Code integration
-	Vscode *Vscode `yaml:"vscode,omitempty"`
+	Vscode *Vscode `yaml:"vscode,omitempty" json:"vscode,omitempty"`
 
 	// Path to where the IDE's workspace should be opened. Supports vscode's `*.code-workspace` files.
-	WorkspaceLocation string `yaml:"workspaceLocation,omitempty"`
+	WorkspaceLocation string `yaml:"workspaceLocation,omitempty" json:"workspaceLocation,omitempty"`
 }
 
 // Image_object The Docker image to run your workspace in.
 type Image_object struct {
 
 	// Relative path to the context path (optional). Should only be set if you need to copy files into the image.
-	Context string `yaml:"context,omitempty"`
+	Context string `yaml:"context,omitempty" json:"context,omitempty"`
 
 	// Relative path to a docker file.
-	File string `yaml:"file"`
+	File string `yaml:"file" json:"file"`
 }
 
 // Jetbrains Configure JetBrains integration
 type Jetbrains struct {
 
 	// Configure CLion integration
-	Clion *JetbrainsProduct `yaml:"clion,omitempty"`
+	Clion *JetbrainsProduct `yaml:"clion,omitempty" json:"clion,omitempty"`
 
 	// Configure GoLand integration
-	Goland *JetbrainsProduct `yaml:"goland,omitempty"`
+	Goland *JetbrainsProduct `yaml:"goland,omitempty" json:"goland,omitempty"`
 
 	// Configure IntelliJ integration
-	Intellij *JetbrainsProduct `yaml:"intellij,omitempty"`
+	Intellij *JetbrainsProduct `yaml:"intellij,omitempty" json:"intellij,omitempty"`
 
 	// Configure PhpStorm integration
-	Phpstorm *JetbrainsProduct `yaml:"phpstorm,omitempty"`
+	Phpstorm *JetbrainsProduct `yaml:"phpstorm,omitempty" json:"phpstorm,omitempty"`
 
 	// List of plugins which should be installed for all JetBrains product for users of this workspace. From the JetBrains Marketplace page, find a page of the required plugin, select 'Versions' tab, click any version to copy pluginId (short name such as org.rust.lang) of the plugin you want to install.
-	Plugins []string `yaml:"plugins,omitempty"`
+	Plugins []string `yaml:"plugins,omitempty" json:"plugins,omitempty"`
 
 	// Configure PyCharm integration
-	Pycharm *JetbrainsProduct `yaml:"pycharm,omitempty"`
+	Pycharm *JetbrainsProduct `yaml:"pycharm,omitempty" json:"pycharm,omitempty"`
 
 	// Configure Rider integration
-	Rider *JetbrainsProduct `yaml:"rider,omitempty"`
+	Rider *JetbrainsProduct `yaml:"rider,omitempty" json:"rider,omitempty"`
 
 	// Configure RubyMine integration
-	Rubymine *JetbrainsProduct `yaml:"rubymine,omitempty"`
+	Rubymine *JetbrainsProduct `yaml:"rubymine,omitempty" json:"rubymine,omitempty"`
 
 	// Configure WebStorm integration
-	Webstorm *JetbrainsProduct `yaml:"webstorm,omitempty"`
+	Webstorm *JetbrainsProduct `yaml:"webstorm,omitempty" json:"webstorm,omitempty"`
 }
 
 // JetbrainsProduct
 type JetbrainsProduct struct {
 
 	// List of plugins which should be installed for users of this workspace. From the JetBrains Marketplace page, find a page of the required plugin, select 'Versions' tab, click any version to copy pluginId (short name such as org.rust.lang) of the plugin you want to install.
-	Plugins []string `yaml:"plugins,omitempty"`
+	Plugins []string `yaml:"plugins,omitempty" json:"plugins,omitempty"`
 
 	// Enable warming up of JetBrains backend in prebuilds.
-	Prebuilds *Prebuilds `yaml:"prebuilds,omitempty"`
+	Prebuilds *Prebuilds `yaml:"prebuilds,omitempty" json:"prebuilds,omitempty"`
 
 	// Configure JVM options, for instance '-Xmx=4096m'.
-	Vmoptions string `yaml:"vmoptions,omitempty"`
+	Vmoptions string `yaml:"vmoptions,omitempty" json:"vmoptions,omitempty"`
 }
 
 // PortsItems
 type PortsItems struct {
 
 	// A description to identify what is this port used for.
-	Description string `yaml:"description,omitempty"`
+	Description string `yaml:"description,omitempty" json:"description,omitempty"`
 
 	// Port name.
-	Name string `yaml:"name,omitempty"`
+	Name string `yaml:"name,omitempty" json:"name,omitempty"`
 
 	// What to do when a service on this port was detected. 'notify' (default) will show a notification asking the user what to do. 'open-browser' will open a new browser tab. 'open-preview' will open in the preview on the right of the IDE. 'ignore' will do nothing.
-	OnOpen string `yaml:"onOpen,omitempty"`
+	OnOpen string `yaml:"onOpen,omitempty" json:"onOpen,omitempty"`
 
 	// The port number (e.g. 1337) or range (e.g. 3000-3999) to expose.
-	Port interface{} `yaml:"port"`
+	Port interface{} `yaml:"port" json:"port"`
 
 	// The protocol to be used. (deprecated)
-	Protocol string `yaml:"protocol,omitempty"`
+	Protocol string `yaml:"protocol,omitempty" json:"protocol,omitempty"`
 
 	// Whether the port visibility should be private or public. 'private' (default) will only allow users with workspace access to access the port. 'public' will allow everyone with the port URL to access the port.
-	Visibility string `yaml:"visibility,omitempty"`
+	Visibility string `yaml:"visibility,omitempty" json:"visibility,omitempty"`
 }
 
 // Prebuilds Enable warming up of JetBrains backend in prebuilds.
 type Prebuilds struct {
 
 	// Whether only stable, latest or both versions should be warmed up. Default is stable only.
-	Version string `yaml:"version,omitempty"`
+	Version string `yaml:"version,omitempty" json:"version,omitempty"`
 }
 
 // Prebuilds_object Set to true to enable workspace prebuilds, false to disable them. Defaults to true.
 type Prebuilds_object struct {
 
 	// Add a Review in Gitpod badge to pull requests. Defaults to true.
-	AddBadge bool `yaml:"addBadge,omitempty"`
+	AddBadge bool `yaml:"addBadge,omitempty" json:"addBadge,omitempty"`
 
 	// Add a commit check to pull requests. Set to 'fail-on-error' if you want broken prebuilds to block merging. Defaults to true.
-	AddCheck interface{} `yaml:"addCheck,omitempty"`
+	AddCheck interface{} `yaml:"addCheck,omitempty" json:"addCheck,omitempty"`
 
 	// Add a label to a PR when it's prebuilt. Set to true to use the default label (prebuilt-in-gitpod) or set to a string to use a different label name. This is a beta feature and may be unreliable. Defaults to false.
-	AddLabel interface{} `yaml:"addLabel,omitempty"`
+	AddLabel interface{} `yaml:"addLabel,omitempty" json:"addLabel,omitempty"`
 
 	// Enable prebuilds for all branches. Defaults to false.
-	Branches bool `yaml:"branches,omitempty"`
+	Branches bool `yaml:"branches,omitempty" json:"branches,omitempty"`
 
 	// Enable prebuilds for the default branch (typically master). Defaults to true.
-	Master bool `yaml:"master,omitempty"`
+	Master bool `yaml:"master,omitempty" json:"master,omitempty"`
 
 	// Enable prebuilds for pull-requests from the original repo. Defaults to true.
-	PullRequests bool `yaml:"pullRequests,omitempty"`
+	PullRequests bool `yaml:"pullRequests,omitempty" json:"pullRequests,omitempty"`
 
 	// Enable prebuilds for pull-requests from any repo (e.g. from forks). Defaults to false.
-	PullRequestsFromForks bool `yaml:"pullRequestsFromForks,omitempty"`
+	PullRequestsFromForks bool `yaml:"pullRequestsFromForks,omitempty" json:"pullRequestsFromForks,omitempty"`
 }
 
 // TasksItems
 type TasksItems struct {
 
 	// A shell command to run before `init` and the main `command`. This command is executed on every start and is expected to terminate. If it fails, the following commands will not be executed.
-	Before string `yaml:"before,omitempty"`
+	Before string `yaml:"before,omitempty" json:"before,omitempty"`
 
 	// The main shell command to run after `before` and `init`. This command is executed last on every start and doesn't have to terminate.
-	Command string `yaml:"command,omitempty"`
+	Command string `yaml:"command,omitempty" json:"command,omitempty"`
 
 	// Environment variables to set.
-	Env *Env `yaml:"env,omitempty"`
+	Env *Env `yaml:"env,omitempty" json:"env,omitempty"`
 
 	// A shell command to run between `before` and the main `command`. This command is executed only on after initializing a workspace with a fresh clone, but not on restarts and snapshots. This command is expected to terminate. If it fails, the `command` property will not be executed.
-	Init string `yaml:"init,omitempty"`
+	Init string `yaml:"init,omitempty" json:"init,omitempty"`
 
 	// Name of the task. Shown on the tab of the opened terminal.
-	Name string `yaml:"name,omitempty"`
+	Name string `yaml:"name,omitempty" json:"name,omitempty"`
 
 	// The panel/area where to open the terminal. Default is 'bottom' panel.
-	OpenIn string `yaml:"openIn,omitempty"`
+	OpenIn string `yaml:"openIn,omitempty" json:"openIn,omitempty"`
 
 	// The opening mode. Default is 'tab-after'.
-	OpenMode string `yaml:"openMode,omitempty"`
+	OpenMode string `yaml:"openMode,omitempty" json:"openMode,omitempty"`
 
 	// A shell command to run after `before`. This command is executed only on during workspace prebuilds. This command is expected to terminate. If it fails, the workspace build fails.
-	Prebuild string `yaml:"prebuild,omitempty"`
+	Prebuild string `yaml:"prebuild,omitempty" json:"prebuild,omitempty"`
 }
 
 // Vscode Configure VS Code integration
 type Vscode struct {
 
 	// List of extensions which should be installed for users of this workspace. The identifier of an extension is always '${publisher}.${name}'. For example: 'vscode.csharp'.
-	Extensions []string `yaml:"extensions,omitempty"`
-}
-
-func (strct *AdditionalRepositoriesItems) MarshalJSON() ([]byte, error) {
-	buf := bytes.NewBuffer(make([]byte, 0))
-	buf.WriteString("{")
-	comma := false
-	// Marshal the "checkoutLocation" field
-	if comma {
-		buf.WriteString(",")
-	}
-	buf.WriteString("\"checkoutLocation\": ")
-	if tmp, err := json.Marshal(strct.CheckoutLocation); err != nil {
-		return nil, err
-	} else {
-		buf.Write(tmp)
-	}
-	comma = true
-	// "Url" field is required
-	// only required object types supported for marshal checking (for now)
-	// Marshal the "url" field
-	if comma {
-		buf.WriteString(",")
-	}
-	buf.WriteString("\"url\": ")
-	if tmp, err := json.Marshal(strct.Url); err != nil {
-		return nil, err
-	} else {
-		buf.Write(tmp)
-	}
-	comma = true
-
-	buf.WriteString("}")
-	rv := buf.Bytes()
-	return rv, nil
-}
-
-func (strct *AdditionalRepositoriesItems) UnmarshalJSON(b []byte) error {
-	urlReceived := false
-	var jsonMap map[string]json.RawMessage
-	if err := json.Unmarshal(b, &jsonMap); err != nil {
-		return err
-	}
-	// parse all the defined properties
-	for k, v := range jsonMap {
-		switch k {
-		case "checkoutLocation":
-			if err := json.Unmarshal([]byte(v), &strct.CheckoutLocation); err != nil {
-				return err
-			}
-		case "url":
-			if err := json.Unmarshal([]byte(v), &strct.Url); err != nil {
-				return err
-			}
-			urlReceived = true
-		default:
-			return fmt.Errorf("additional property not allowed: \"" + k + "\"")
-		}
-	}
-	// check if url (a required property) was received
-	if !urlReceived {
-		return errors.New("\"url\" is required but was not present")
-	}
-	return nil
-}
-
-func (strct *CoreDump) MarshalJSON() ([]byte, error) {
-	buf := bytes.NewBuffer(make([]byte, 0))
-	buf.WriteString("{")
-	comma := false
-	// Marshal the "enabled" field
-	if comma {
-		buf.WriteString(",")
-	}
-	buf.WriteString("\"enabled\": ")
-	if tmp, err := json.Marshal(strct.Enabled); err != nil {
-		return nil, err
-	} else {
-		buf.Write(tmp)
-	}
-	comma = true
-	// Marshal the "hardLimit" field
-	if comma {
-		buf.WriteString(",")
-	}
-	buf.WriteString("\"hardLimit\": ")
-	if tmp, err := json.Marshal(strct.HardLimit); err != nil {
-		return nil, err
-	} else {
-		buf.Write(tmp)
-	}
-	comma = true
-	// Marshal the "softLimit" field
-	if comma {
-		buf.WriteString(",")
-	}
-	buf.WriteString("\"softLimit\": ")
-	if tmp, err := json.Marshal(strct.SoftLimit); err != nil {
-		return nil, err
-	} else {
-		buf.Write(tmp)
-	}
-	comma = true
-
-	buf.WriteString("}")
-	rv := buf.Bytes()
-	return rv, nil
-}
-
-func (strct *CoreDump) UnmarshalJSON(b []byte) error {
-	var jsonMap map[string]json.RawMessage
-	if err := json.Unmarshal(b, &jsonMap); err != nil {
-		return err
-	}
-	// parse all the defined properties
-	for k, v := range jsonMap {
-		switch k {
-		case "enabled":
-			if err := json.Unmarshal([]byte(v), &strct.Enabled); err != nil {
-				return err
-			}
-		case "hardLimit":
-			if err := json.Unmarshal([]byte(v), &strct.HardLimit); err != nil {
-				return err
-			}
-		case "softLimit":
-			if err := json.Unmarshal([]byte(v), &strct.SoftLimit); err != nil {
-				return err
-			}
-		default:
-			return fmt.Errorf("additional property not allowed: \"" + k + "\"")
-		}
-	}
-	return nil
-}
-
-func (strct *Github) MarshalJSON() ([]byte, error) {
-	buf := bytes.NewBuffer(make([]byte, 0))
-	buf.WriteString("{")
-	comma := false
-	// Marshal the "prebuilds" field
-	if comma {
-		buf.WriteString(",")
-	}
-	buf.WriteString("\"prebuilds\": ")
-	if tmp, err := json.Marshal(strct.Prebuilds); err != nil {
-		return nil, err
-	} else {
-		buf.Write(tmp)
-	}
-	comma = true
-
-	buf.WriteString("}")
-	rv := buf.Bytes()
-	return rv, nil
-}
-
-func (strct *Github) UnmarshalJSON(b []byte) error {
-	var jsonMap map[string]json.RawMessage
-	if err := json.Unmarshal(b, &jsonMap); err != nil {
-		return err
-	}
-	// parse all the defined properties
-	for k, v := range jsonMap {
-		switch k {
-		case "prebuilds":
-			if err := json.Unmarshal([]byte(v), &strct.Prebuilds); err != nil {
-				return err
-			}
-		default:
-			return fmt.Errorf("additional property not allowed: \"" + k + "\"")
-		}
-	}
-	return nil
-}
-
-func (strct *GitpodConfig) MarshalJSON() ([]byte, error) {
-	buf := bytes.NewBuffer(make([]byte, 0))
-	buf.WriteString("{")
-	comma := false
-	// Marshal the "additionalRepositories" field
-	if comma {
-		buf.WriteString(",")
-	}
-	buf.WriteString("\"additionalRepositories\": ")
-	if tmp, err := json.Marshal(strct.AdditionalRepositories); err != nil {
-		return nil, err
-	} else {
-		buf.Write(tmp)
-	}
-	comma = true
-	// Marshal the "checkoutLocation" field
-	if comma {
-		buf.WriteString(",")
-	}
-	buf.WriteString("\"checkoutLocation\": ")
-	if tmp, err := json.Marshal(strct.CheckoutLocation); err != nil {
-		return nil, err
-	} else {
-		buf.Write(tmp)
-	}
-	comma = true
-	// Marshal the "coreDump" field
-	if comma {
-		buf.WriteString(",")
-	}
-	buf.WriteString("\"coreDump\": ")
-	if tmp, err := json.Marshal(strct.CoreDump); err != nil {
-		return nil, err
-	} else {
-		buf.Write(tmp)
-	}
-	comma = true
-	// Marshal the "experimentalNetwork" field
-	if comma {
-		buf.WriteString(",")
-	}
-	buf.WriteString("\"experimentalNetwork\": ")
-	if tmp, err := json.Marshal(strct.ExperimentalNetwork); err != nil {
-		return nil, err
-	} else {
-		buf.Write(tmp)
-	}
-	comma = true
-	// Marshal the "gitConfig" field
-	if comma {
-		buf.WriteString(",")
-	}
-	buf.WriteString("\"gitConfig\": ")
-	if tmp, err := json.Marshal(strct.GitConfig); err != nil {
-		return nil, err
-	} else {
-		buf.Write(tmp)
-	}
-	comma = true
-	// Marshal the "github" field
-	if comma {
-		buf.WriteString(",")
-	}
-	buf.WriteString("\"github\": ")
-	if tmp, err := json.Marshal(strct.Github); err != nil {
-		return nil, err
-	} else {
-		buf.Write(tmp)
-	}
-	comma = true
-	// Marshal the "image" field
-	if comma {
-		buf.WriteString(",")
-	}
-	buf.WriteString("\"image\": ")
-	if tmp, err := json.Marshal(strct.Image); err != nil {
-		return nil, err
-	} else {
-		buf.Write(tmp)
-	}
-	comma = true
-	// Marshal the "jetbrains" field
-	if comma {
-		buf.WriteString(",")
-	}
-	buf.WriteString("\"jetbrains\": ")
-	if tmp, err := json.Marshal(strct.Jetbrains); err != nil {
-		return nil, err
-	} else {
-		buf.Write(tmp)
-	}
-	comma = true
-	// Marshal the "mainConfiguration" field
-	if comma {
-		buf.WriteString(",")
-	}
-	buf.WriteString("\"mainConfiguration\": ")
-	if tmp, err := json.Marshal(strct.MainConfiguration); err != nil {
-		return nil, err
-	} else {
-		buf.Write(tmp)
-	}
-	comma = true
-	// Marshal the "ports" field
-	if comma {
-		buf.WriteString(",")
-	}
-	buf.WriteString("\"ports\": ")
-	if tmp, err := json.Marshal(strct.Ports); err != nil {
-		return nil, err
-	} else {
-		buf.Write(tmp)
-	}
-	comma = true
-	// Marshal the "tasks" field
-	if comma {
-		buf.WriteString(",")
-	}
-	buf.WriteString("\"tasks\": ")
-	if tmp, err := json.Marshal(strct.Tasks); err != nil {
-		return nil, err
-	} else {
-		buf.Write(tmp)
-	}
-	comma = true
-	// Marshal the "vscode" field
-	if comma {
-		buf.WriteString(",")
-	}
-	buf.WriteString("\"vscode\": ")
-	if tmp, err := json.Marshal(strct.Vscode); err != nil {
-		return nil, err
-	} else {
-		buf.Write(tmp)
-	}
-	comma = true
-	// Marshal the "workspaceLocation" field
-	if comma {
-		buf.WriteString(",")
-	}
-	buf.WriteString("\"workspaceLocation\": ")
-	if tmp, err := json.Marshal(strct.WorkspaceLocation); err != nil {
-		return nil, err
-	} else {
-		buf.Write(tmp)
-	}
-	comma = true
-
-	buf.WriteString("}")
-	rv := buf.Bytes()
-	return rv, nil
-}
-
-func (strct *GitpodConfig) UnmarshalJSON(b []byte) error {
-	var jsonMap map[string]json.RawMessage
-	if err := json.Unmarshal(b, &jsonMap); err != nil {
-		return err
-	}
-	// parse all the defined properties
-	for k, v := range jsonMap {
-		switch k {
-		case "additionalRepositories":
-			if err := json.Unmarshal([]byte(v), &strct.AdditionalRepositories); err != nil {
-				return err
-			}
-		case "checkoutLocation":
-			if err := json.Unmarshal([]byte(v), &strct.CheckoutLocation); err != nil {
-				return err
-			}
-		case "coreDump":
-			if err := json.Unmarshal([]byte(v), &strct.CoreDump); err != nil {
-				return err
-			}
-		case "experimentalNetwork":
-			if err := json.Unmarshal([]byte(v), &strct.ExperimentalNetwork); err != nil {
-				return err
-			}
-		case "gitConfig":
-			if err := json.Unmarshal([]byte(v), &strct.GitConfig); err != nil {
-				return err
-			}
-		case "github":
-			if err := json.Unmarshal([]byte(v), &strct.Github); err != nil {
-				return err
-			}
-		case "image":
-			if err := json.Unmarshal([]byte(v), &strct.Image); err != nil {
-				return err
-			}
-		case "jetbrains":
-			if err := json.Unmarshal([]byte(v), &strct.Jetbrains); err != nil {
-				return err
-			}
-		case "mainConfiguration":
-			if err := json.Unmarshal([]byte(v), &strct.MainConfiguration); err != nil {
-				return err
-			}
-		case "ports":
-			if err := json.Unmarshal([]byte(v), &strct.Ports); err != nil {
-				return err
-			}
-		case "tasks":
-			if err := json.Unmarshal([]byte(v), &strct.Tasks); err != nil {
-				return err
-			}
-		case "vscode":
-			if err := json.Unmarshal([]byte(v), &strct.Vscode); err != nil {
-				return err
-			}
-		case "workspaceLocation":
-			if err := json.Unmarshal([]byte(v), &strct.WorkspaceLocation); err != nil {
-				return err
-			}
-		default:
-			return fmt.Errorf("additional property not allowed: \"" + k + "\"")
-		}
-	}
-	return nil
-}
-
-func (strct *Image_object) MarshalJSON() ([]byte, error) {
-	buf := bytes.NewBuffer(make([]byte, 0))
-	buf.WriteString("{")
-	comma := false
-	// Marshal the "context" field
-	if comma {
-		buf.WriteString(",")
-	}
-	buf.WriteString("\"context\": ")
-	if tmp, err := json.Marshal(strct.Context); err != nil {
-		return nil, err
-	} else {
-		buf.Write(tmp)
-	}
-	comma = true
-	// "File" field is required
-	// only required object types supported for marshal checking (for now)
-	// Marshal the "file" field
-	if comma {
-		buf.WriteString(",")
-	}
-	buf.WriteString("\"file\": ")
-	if tmp, err := json.Marshal(strct.File); err != nil {
-		return nil, err
-	} else {
-		buf.Write(tmp)
-	}
-	comma = true
-
-	buf.WriteString("}")
-	rv := buf.Bytes()
-	return rv, nil
-}
-
-func (strct *Image_object) UnmarshalJSON(b []byte) error {
-	fileReceived := false
-	var jsonMap map[string]json.RawMessage
-	if err := json.Unmarshal(b, &jsonMap); err != nil {
-		return err
-	}
-	// parse all the defined properties
-	for k, v := range jsonMap {
-		switch k {
-		case "context":
-			if err := json.Unmarshal([]byte(v), &strct.Context); err != nil {
-				return err
-			}
-		case "file":
-			if err := json.Unmarshal([]byte(v), &strct.File); err != nil {
-				return err
-			}
-			fileReceived = true
-		default:
-			return fmt.Errorf("additional property not allowed: \"" + k + "\"")
-		}
-	}
-	// check if file (a required property) was received
-	if !fileReceived {
-		return errors.New("\"file\" is required but was not present")
-	}
-	return nil
-}
-
-func (strct *Jetbrains) MarshalJSON() ([]byte, error) {
-	buf := bytes.NewBuffer(make([]byte, 0))
-	buf.WriteString("{")
-	comma := false
-	// Marshal the "clion" field
-	if comma {
-		buf.WriteString(",")
-	}
-	buf.WriteString("\"clion\": ")
-	if tmp, err := json.Marshal(strct.Clion); err != nil {
-		return nil, err
-	} else {
-		buf.Write(tmp)
-	}
-	comma = true
-	// Marshal the "goland" field
-	if comma {
-		buf.WriteString(",")
-	}
-	buf.WriteString("\"goland\": ")
-	if tmp, err := json.Marshal(strct.Goland); err != nil {
-		return nil, err
-	} else {
-		buf.Write(tmp)
-	}
-	comma = true
-	// Marshal the "intellij" field
-	if comma {
-		buf.WriteString(",")
-	}
-	buf.WriteString("\"intellij\": ")
-	if tmp, err := json.Marshal(strct.Intellij); err != nil {
-		return nil, err
-	} else {
-		buf.Write(tmp)
-	}
-	comma = true
-	// Marshal the "phpstorm" field
-	if comma {
-		buf.WriteString(",")
-	}
-	buf.WriteString("\"phpstorm\": ")
-	if tmp, err := json.Marshal(strct.Phpstorm); err != nil {
-		return nil, err
-	} else {
-		buf.Write(tmp)
-	}
-	comma = true
-	// Marshal the "plugins" field
-	if comma {
-		buf.WriteString(",")
-	}
-	buf.WriteString("\"plugins\": ")
-	if tmp, err := json.Marshal(strct.Plugins); err != nil {
-		return nil, err
-	} else {
-		buf.Write(tmp)
-	}
-	comma = true
-	// Marshal the "pycharm" field
-	if comma {
-		buf.WriteString(",")
-	}
-	buf.WriteString("\"pycharm\": ")
-	if tmp, err := json.Marshal(strct.Pycharm); err != nil {
-		return nil, err
-	} else {
-		buf.Write(tmp)
-	}
-	comma = true
-	// Marshal the "rider" field
-	if comma {
-		buf.WriteString(",")
-	}
-	buf.WriteString("\"rider\": ")
-	if tmp, err := json.Marshal(strct.Rider); err != nil {
-		return nil, err
-	} else {
-		buf.Write(tmp)
-	}
-	comma = true
-	// Marshal the "rubymine" field
-	if comma {
-		buf.WriteString(",")
-	}
-	buf.WriteString("\"rubymine\": ")
-	if tmp, err := json.Marshal(strct.Rubymine); err != nil {
-		return nil, err
-	} else {
-		buf.Write(tmp)
-	}
-	comma = true
-	// Marshal the "webstorm" field
-	if comma {
-		buf.WriteString(",")
-	}
-	buf.WriteString("\"webstorm\": ")
-	if tmp, err := json.Marshal(strct.Webstorm); err != nil {
-		return nil, err
-	} else {
-		buf.Write(tmp)
-	}
-	comma = true
-
-	buf.WriteString("}")
-	rv := buf.Bytes()
-	return rv, nil
-}
-
-func (strct *Jetbrains) UnmarshalJSON(b []byte) error {
-	var jsonMap map[string]json.RawMessage
-	if err := json.Unmarshal(b, &jsonMap); err != nil {
-		return err
-	}
-	// parse all the defined properties
-	for k, v := range jsonMap {
-		switch k {
-		case "clion":
-			if err := json.Unmarshal([]byte(v), &strct.Clion); err != nil {
-				return err
-			}
-		case "goland":
-			if err := json.Unmarshal([]byte(v), &strct.Goland); err != nil {
-				return err
-			}
-		case "intellij":
-			if err := json.Unmarshal([]byte(v), &strct.Intellij); err != nil {
-				return err
-			}
-		case "phpstorm":
-			if err := json.Unmarshal([]byte(v), &strct.Phpstorm); err != nil {
-				return err
-			}
-		case "plugins":
-			if err := json.Unmarshal([]byte(v), &strct.Plugins); err != nil {
-				return err
-			}
-		case "pycharm":
-			if err := json.Unmarshal([]byte(v), &strct.Pycharm); err != nil {
-				return err
-			}
-		case "rider":
-			if err := json.Unmarshal([]byte(v), &strct.Rider); err != nil {
-				return err
-			}
-		case "rubymine":
-			if err := json.Unmarshal([]byte(v), &strct.Rubymine); err != nil {
-				return err
-			}
-		case "webstorm":
-			if err := json.Unmarshal([]byte(v), &strct.Webstorm); err != nil {
-				return err
-			}
-		default:
-			return fmt.Errorf("additional property not allowed: \"" + k + "\"")
-		}
-	}
-	return nil
-}
-
-func (strct *JetbrainsProduct) MarshalJSON() ([]byte, error) {
-	buf := bytes.NewBuffer(make([]byte, 0))
-	buf.WriteString("{")
-	comma := false
-	// Marshal the "plugins" field
-	if comma {
-		buf.WriteString(",")
-	}
-	buf.WriteString("\"plugins\": ")
-	if tmp, err := json.Marshal(strct.Plugins); err != nil {
-		return nil, err
-	} else {
-		buf.Write(tmp)
-	}
-	comma = true
-	// Marshal the "prebuilds" field
-	if comma {
-		buf.WriteString(",")
-	}
-	buf.WriteString("\"prebuilds\": ")
-	if tmp, err := json.Marshal(strct.Prebuilds); err != nil {
-		return nil, err
-	} else {
-		buf.Write(tmp)
-	}
-	comma = true
-	// Marshal the "vmoptions" field
-	if comma {
-		buf.WriteString(",")
-	}
-	buf.WriteString("\"vmoptions\": ")
-	if tmp, err := json.Marshal(strct.Vmoptions); err != nil {
-		return nil, err
-	} else {
-		buf.Write(tmp)
-	}
-	comma = true
-
-	buf.WriteString("}")
-	rv := buf.Bytes()
-	return rv, nil
-}
-
-func (strct *JetbrainsProduct) UnmarshalJSON(b []byte) error {
-	var jsonMap map[string]json.RawMessage
-	if err := json.Unmarshal(b, &jsonMap); err != nil {
-		return err
-	}
-	// parse all the defined properties
-	for k, v := range jsonMap {
-		switch k {
-		case "plugins":
-			if err := json.Unmarshal([]byte(v), &strct.Plugins); err != nil {
-				return err
-			}
-		case "prebuilds":
-			if err := json.Unmarshal([]byte(v), &strct.Prebuilds); err != nil {
-				return err
-			}
-		case "vmoptions":
-			if err := json.Unmarshal([]byte(v), &strct.Vmoptions); err != nil {
-				return err
-			}
-		default:
-			return fmt.Errorf("additional property not allowed: \"" + k + "\"")
-		}
-	}
-	return nil
-}
-
-func (strct *PortsItems) MarshalJSON() ([]byte, error) {
-	buf := bytes.NewBuffer(make([]byte, 0))
-	buf.WriteString("{")
-	comma := false
-	// Marshal the "description" field
-	if comma {
-		buf.WriteString(",")
-	}
-	buf.WriteString("\"description\": ")
-	if tmp, err := json.Marshal(strct.Description); err != nil {
-		return nil, err
-	} else {
-		buf.Write(tmp)
-	}
-	comma = true
-	// Marshal the "name" field
-	if comma {
-		buf.WriteString(",")
-	}
-	buf.WriteString("\"name\": ")
-	if tmp, err := json.Marshal(strct.Name); err != nil {
-		return nil, err
-	} else {
-		buf.Write(tmp)
-	}
-	comma = true
-	// Marshal the "onOpen" field
-	if comma {
-		buf.WriteString(",")
-	}
-	buf.WriteString("\"onOpen\": ")
-	if tmp, err := json.Marshal(strct.OnOpen); err != nil {
-		return nil, err
-	} else {
-		buf.Write(tmp)
-	}
-	comma = true
-	// "Port" field is required
-	// only required object types supported for marshal checking (for now)
-	// Marshal the "port" field
-	if comma {
-		buf.WriteString(",")
-	}
-	buf.WriteString("\"port\": ")
-	if tmp, err := json.Marshal(strct.Port); err != nil {
-		return nil, err
-	} else {
-		buf.Write(tmp)
-	}
-	comma = true
-	// Marshal the "protocol" field
-	if comma {
-		buf.WriteString(",")
-	}
-	buf.WriteString("\"protocol\": ")
-	if tmp, err := json.Marshal(strct.Protocol); err != nil {
-		return nil, err
-	} else {
-		buf.Write(tmp)
-	}
-	comma = true
-	// Marshal the "visibility" field
-	if comma {
-		buf.WriteString(",")
-	}
-	buf.WriteString("\"visibility\": ")
-	if tmp, err := json.Marshal(strct.Visibility); err != nil {
-		return nil, err
-	} else {
-		buf.Write(tmp)
-	}
-	comma = true
-
-	buf.WriteString("}")
-	rv := buf.Bytes()
-	return rv, nil
-}
-
-func (strct *PortsItems) UnmarshalJSON(b []byte) error {
-	portReceived := false
-	var jsonMap map[string]json.RawMessage
-	if err := json.Unmarshal(b, &jsonMap); err != nil {
-		return err
-	}
-	// parse all the defined properties
-	for k, v := range jsonMap {
-		switch k {
-		case "description":
-			if err := json.Unmarshal([]byte(v), &strct.Description); err != nil {
-				return err
-			}
-		case "name":
-			if err := json.Unmarshal([]byte(v), &strct.Name); err != nil {
-				return err
-			}
-		case "onOpen":
-			if err := json.Unmarshal([]byte(v), &strct.OnOpen); err != nil {
-				return err
-			}
-		case "port":
-			if err := json.Unmarshal([]byte(v), &strct.Port); err != nil {
-				return err
-			}
-			portReceived = true
-		case "protocol":
-			if err := json.Unmarshal([]byte(v), &strct.Protocol); err != nil {
-				return err
-			}
-		case "visibility":
-			if err := json.Unmarshal([]byte(v), &strct.Visibility); err != nil {
-				return err
-			}
-		default:
-			return fmt.Errorf("additional property not allowed: \"" + k + "\"")
-		}
-	}
-	// check if port (a required property) was received
-	if !portReceived {
-		return errors.New("\"port\" is required but was not present")
-	}
-	return nil
-}
-
-func (strct *Prebuilds) MarshalJSON() ([]byte, error) {
-	buf := bytes.NewBuffer(make([]byte, 0))
-	buf.WriteString("{")
-	comma := false
-	// Marshal the "version" field
-	if comma {
-		buf.WriteString(",")
-	}
-	buf.WriteString("\"version\": ")
-	if tmp, err := json.Marshal(strct.Version); err != nil {
-		return nil, err
-	} else {
-		buf.Write(tmp)
-	}
-	comma = true
-
-	buf.WriteString("}")
-	rv := buf.Bytes()
-	return rv, nil
-}
-
-func (strct *Prebuilds) UnmarshalJSON(b []byte) error {
-	var jsonMap map[string]json.RawMessage
-	if err := json.Unmarshal(b, &jsonMap); err != nil {
-		return err
-	}
-	// parse all the defined properties
-	for k, v := range jsonMap {
-		switch k {
-		case "version":
-			if err := json.Unmarshal([]byte(v), &strct.Version); err != nil {
-				return err
-			}
-		default:
-			return fmt.Errorf("additional property not allowed: \"" + k + "\"")
-		}
-	}
-	return nil
-}
-
-func (strct *TasksItems) MarshalJSON() ([]byte, error) {
-	buf := bytes.NewBuffer(make([]byte, 0))
-	buf.WriteString("{")
-	comma := false
-	// Marshal the "before" field
-	if comma {
-		buf.WriteString(",")
-	}
-	buf.WriteString("\"before\": ")
-	if tmp, err := json.Marshal(strct.Before); err != nil {
-		return nil, err
-	} else {
-		buf.Write(tmp)
-	}
-	comma = true
-	// Marshal the "command" field
-	if comma {
-		buf.WriteString(",")
-	}
-	buf.WriteString("\"command\": ")
-	if tmp, err := json.Marshal(strct.Command); err != nil {
-		return nil, err
-	} else {
-		buf.Write(tmp)
-	}
-	comma = true
-	// Marshal the "env" field
-	if comma {
-		buf.WriteString(",")
-	}
-	buf.WriteString("\"env\": ")
-	if tmp, err := json.Marshal(strct.Env); err != nil {
-		return nil, err
-	} else {
-		buf.Write(tmp)
-	}
-	comma = true
-	// Marshal the "init" field
-	if comma {
-		buf.WriteString(",")
-	}
-	buf.WriteString("\"init\": ")
-	if tmp, err := json.Marshal(strct.Init); err != nil {
-		return nil, err
-	} else {
-		buf.Write(tmp)
-	}
-	comma = true
-	// Marshal the "name" field
-	if comma {
-		buf.WriteString(",")
-	}
-	buf.WriteString("\"name\": ")
-	if tmp, err := json.Marshal(strct.Name); err != nil {
-		return nil, err
-	} else {
-		buf.Write(tmp)
-	}
-	comma = true
-	// Marshal the "openIn" field
-	if comma {
-		buf.WriteString(",")
-	}
-	buf.WriteString("\"openIn\": ")
-	if tmp, err := json.Marshal(strct.OpenIn); err != nil {
-		return nil, err
-	} else {
-		buf.Write(tmp)
-	}
-	comma = true
-	// Marshal the "openMode" field
-	if comma {
-		buf.WriteString(",")
-	}
-	buf.WriteString("\"openMode\": ")
-	if tmp, err := json.Marshal(strct.OpenMode); err != nil {
-		return nil, err
-	} else {
-		buf.Write(tmp)
-	}
-	comma = true
-	// Marshal the "prebuild" field
-	if comma {
-		buf.WriteString(",")
-	}
-	buf.WriteString("\"prebuild\": ")
-	if tmp, err := json.Marshal(strct.Prebuild); err != nil {
-		return nil, err
-	} else {
-		buf.Write(tmp)
-	}
-	comma = true
-
-	buf.WriteString("}")
-	rv := buf.Bytes()
-	return rv, nil
-}
-
-func (strct *TasksItems) UnmarshalJSON(b []byte) error {
-	var jsonMap map[string]json.RawMessage
-	if err := json.Unmarshal(b, &jsonMap); err != nil {
-		return err
-	}
-	// parse all the defined properties
-	for k, v := range jsonMap {
-		switch k {
-		case "before":
-			if err := json.Unmarshal([]byte(v), &strct.Before); err != nil {
-				return err
-			}
-		case "command":
-			if err := json.Unmarshal([]byte(v), &strct.Command); err != nil {
-				return err
-			}
-		case "env":
-			if err := json.Unmarshal([]byte(v), &strct.Env); err != nil {
-				return err
-			}
-		case "init":
-			if err := json.Unmarshal([]byte(v), &strct.Init); err != nil {
-				return err
-			}
-		case "name":
-			if err := json.Unmarshal([]byte(v), &strct.Name); err != nil {
-				return err
-			}
-		case "openIn":
-			if err := json.Unmarshal([]byte(v), &strct.OpenIn); err != nil {
-				return err
-			}
-		case "openMode":
-			if err := json.Unmarshal([]byte(v), &strct.OpenMode); err != nil {
-				return err
-			}
-		case "prebuild":
-			if err := json.Unmarshal([]byte(v), &strct.Prebuild); err != nil {
-				return err
-			}
-		default:
-			return fmt.Errorf("additional property not allowed: \"" + k + "\"")
-		}
-	}
-	return nil
-}
-
-func (strct *Vscode) MarshalJSON() ([]byte, error) {
-	buf := bytes.NewBuffer(make([]byte, 0))
-	buf.WriteString("{")
-	comma := false
-	// Marshal the "extensions" field
-	if comma {
-		buf.WriteString(",")
-	}
-	buf.WriteString("\"extensions\": ")
-	if tmp, err := json.Marshal(strct.Extensions); err != nil {
-		return nil, err
-	} else {
-		buf.Write(tmp)
-	}
-	comma = true
-
-	buf.WriteString("}")
-	rv := buf.Bytes()
-	return rv, nil
-}
-
-func (strct *Vscode) UnmarshalJSON(b []byte) error {
-	var jsonMap map[string]json.RawMessage
-	if err := json.Unmarshal(b, &jsonMap); err != nil {
-		return err
-	}
-	// parse all the defined properties
-	for k, v := range jsonMap {
-		switch k {
-		case "extensions":
-			if err := json.Unmarshal([]byte(v), &strct.Extensions); err != nil {
-				return err
-			}
-		default:
-			return fmt.Errorf("additional property not allowed: \"" + k + "\"")
-		}
-	}
-	return nil
+	Extensions []string `yaml:"extensions,omitempty" json:"extensions,omitempty"`
 }

--- a/components/gitpod-protocol/go/scripts/generate-config.sh
+++ b/components/gitpod-protocol/go/scripts/generate-config.sh
@@ -25,7 +25,11 @@ go install github.com/a-h/generate/...@latest
 
 schema-generate -p protocol "$CONFIG_PATH" > "$GITPOD_CONFIG_TYPE_PATH"
 
-sed -i 's/json:/yaml:/g' "$GITPOD_CONFIG_TYPE_PATH"
+# remove custom marshal logic to allow additional properties
+sed -i '/func /,$d' "$GITPOD_CONFIG_TYPE_PATH" #functions
+sed -i '5,10d' "$GITPOD_CONFIG_TYPE_PATH" #imports
+# support yaml and json
+sed -i -E 's/(json:)(".*")/yaml:\2 \1\2/g' "$GITPOD_CONFIG_TYPE_PATH"
 gofmt -w "$GITPOD_CONFIG_TYPE_PATH"
 
 if [ "${LEEWAY_BUILD-}" == "true" ]; then


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

In context of https://github.com/gitpod-io/gitpod/pull/15062 we need to pass config from server to ide-service.
But because of current code generator we cannot unmarshall it and marshall back additional tasks.
This PR simplifies code generated output that it has only types and rely on default go logic for marshalling.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related to https://github.com/gitpod-io/gitpod/issues/9189

## How to test
<!-- Provide steps to test this PR -->

Start a workspace with IntelliJ and VS Code with .gitpod.yml with extensions/plugins/ports and see whether UI respect it.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.NONE
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
