### PR TITLE
[pat] Change title from Personal Access Tokens to Access Tokens

### DIFF
--- a/components/dashboard/src/settings/PersonalAccessTokens.tsx
+++ b/components/dashboard/src/settings/PersonalAccessTokens.tsx
@@ -337,7 +337,7 @@ export function PersonalAccessTokenCreateView() {
                 <SpinnerOverlayLoader content="loading access token" loading={loading}>
                     <div className="mb-6">
                         <div className="flex flex-col mb-4">
-                            <h3>{isEditing ? "Edit" : "New"} Personal Access Token</h3>
+                            <h3>{isEditing ? "Edit" : "New"} Access Token</h3>
                             {isEditing ? (
                                 <h2 className="text-gray-500 dark:text-gray-400">
                                     Update token name, expiration date, permissions, or regenerate token.
@@ -410,7 +410,7 @@ export function PersonalAccessTokenCreateView() {
                             </Link>
                         )}
                         <button onClick={handleConfirm} disabled={isEditing && !editToken}>
-                            {isEditing ? "Update" : "Create"} Personal Access Token
+                            {isEditing ? "Update" : "Create"} Access Token
                         </button>
                     </div>
                 </SpinnerOverlayLoader>
@@ -601,11 +601,9 @@ function ListAccessTokensView() {
                 <>
                     {tokens.length === 0 ? (
                         <div className="bg-gray-100 dark:bg-gray-800 rounded-xl w-full py-28 flex flex-col items-center">
-                            <h3 className="text-center pb-3 text-gray-500 dark:text-gray-400">
-                                No Access Tokens (PAT)
-                            </h3>
+                            <h3 className="text-center pb-3 text-gray-500 dark:text-gray-400">No Access Tokens</h3>
                             <p className="text-center pb-6 text-gray-500 text-base w-96">
-                                Generate a access token (PAT) for applications that need access to the Gitpod API.{" "}
+                                Generate a access token for applications that need access to the Gitpod API.{" "}
                             </p>
                             <Link to={settingsPathPersonalAccessTokenCreate}>
                                 <button>New Access Token</button>
@@ -653,10 +651,10 @@ function ListAccessTokensView() {
             {modalData?.action === TokenAction.Delete && (
                 <ShowTokenModal
                     token={modalData.token}
-                    title="Delete Personal Access Token"
-                    description="Are you sure you want to delete this personal access token?"
+                    title="Delete Access Token"
+                    description="Are you sure you want to delete this access token?"
                     descriptionImportant="Any applications using this token will no longer be able to access the Gitpod API."
-                    actionDescription="Delete Personal Access Token"
+                    actionDescription="Delete Access Token"
                     onSave={() => handleDeleteToken(modalData.token.id)}
                     onClose={() => setModalData(undefined)}
                 />
@@ -665,7 +663,7 @@ function ListAccessTokensView() {
                 <ShowTokenModal
                     token={modalData.token}
                     title="Regenerate Token"
-                    description="Are you sure you want to regenerate this personal access token?"
+                    description="Are you sure you want to regenerate this access token?"
                     descriptionImportant="Any applications using this token will no longer be able to access the Gitpod API."
                     actionDescription="Regenerate Token"
                     showDateSelector

--- a/components/dashboard/src/settings/PersonalAccessTokens.tsx
+++ b/components/dashboard/src/settings/PersonalAccessTokens.tsx
@@ -50,7 +50,7 @@ const personalAccessTokenNameRegex = /^[a-zA-Z0-9-_ ]{3,63}$/;
 
 enum TokenAction {
     Create = "CREATED",
-    Regerenrate = "REGENERATED",
+    Regenerate = "REGENERATED",
     Delete = "DELETE",
 }
 
@@ -247,7 +247,7 @@ export function PersonalAccessTokenCreateView() {
                 id: tokenId,
                 expirationTime: Timestamp.fromDate(expirationDate),
             });
-            backToListView({ method: TokenAction.Regerenrate, data: resp.token! });
+            backToListView({ method: TokenAction.Regenerate, data: resp.token! });
         } catch (e) {
             setErrorMsg(e.message);
         }
@@ -522,7 +522,7 @@ function ListAccessTokensView() {
                 id: tokenId,
                 expirationTime: Timestamp.fromDate(expirationDate),
             });
-            setTokenInfo({ method: TokenAction.Regerenrate, data: resp.token! });
+            setTokenInfo({ method: TokenAction.Regenerate, data: resp.token! });
             loadTokens();
             setModalData(undefined);
         } catch (e) {
@@ -534,7 +534,7 @@ function ListAccessTokensView() {
         <>
             <div className="flex items-center sm:justify-between mb-4">
                 <div>
-                    <h3>Personal Access Tokens</h3>
+                    <h3>Access Tokens</h3>
                     <h2 className="text-gray-500">Create or regenerate access tokens.</h2>
                 </div>
                 {tokens.length > 0 && (
@@ -633,7 +633,7 @@ function ListAccessTokensView() {
                                             href: "",
                                             customFontStyle:
                                                 "text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-300",
-                                            onClick: () => setModalData({ token: t, action: TokenAction.Regerenrate }),
+                                            onClick: () => setModalData({ token: t, action: TokenAction.Regenerate }),
                                         },
                                         {
                                             title: "Delete",
@@ -661,7 +661,7 @@ function ListAccessTokensView() {
                     onClose={() => setModalData(undefined)}
                 />
             )}
-            {modalData?.action === TokenAction.Regerenrate && (
+            {modalData?.action === TokenAction.Regenerate && (
                 <ShowTokenModal
                     token={modalData.token}
                     title="Regenerate Token"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

From
<img width="339" alt="Screenshot 2022-12-02 at 10 42 38" src="https://user-images.githubusercontent.com/1419286/205263725-d98981a3-e538-4168-9c65-ac7d4a17fe0a.png">


To
<img width="318" alt="Screenshot 2022-12-02 at 10 42 49" src="https://user-images.githubusercontent.com/1419286/205263745-a4677342-7a0d-4f7c-a1e7-8555e433a2c7.png">


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
