### PR TITLE
[dashboard] remove admin alter OSS plan

### DIFF
--- a/components/dashboard/src/admin/UserDetail.tsx
+++ b/components/dashboard/src/admin/UserDetail.tsx
@@ -44,9 +44,6 @@ export default function UserDetail(p: { user: User }) {
     const [editRoles, setEditRoles] = useState(false);
     const userRef = useRef(user);
 
-    const isProfessionalOpenSource =
-        accountStatement && accountStatement.subscriptions.some((s) => s.planId === Plans.FREE_OPEN_SOURCE.chargebeeId);
-
     const initialize = () => {
         setUser(user);
         getGitpodService()
@@ -193,25 +190,7 @@ export default function UserDetail(p: { user: User }) {
                     </Property>,
                 );
                 properties.push(
-                    <Property
-                        name="Plan"
-                        actions={
-                            accountStatement && [
-                                {
-                                    label: (isProfessionalOpenSource ? "Disable" : "Enable") + " Professional OSS",
-                                    onClick: async () => {
-                                        await getGitpodService().server.adminSetProfessionalOpenSource(
-                                            user.id,
-                                            !isProfessionalOpenSource,
-                                        );
-                                        setAccountStatement(
-                                            await getGitpodService().server.adminGetAccountStatement(user.id),
-                                        );
-                                    },
-                                },
-                            ]
-                        }
-                    >
+                    <Property name="Plan">
                         {accountStatement?.subscriptions
                             ? accountStatement.subscriptions
                                   .filter((s) => !s.deleted && Subscription.isActive(s, new Date().toISOString()))


### PR DESCRIPTION
## Description
Removes the possibility to change the professional open-source status.
This is because it would only take effect until UBP GA. In the future we can flxibly adjust the usage Limit.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #15095

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
