### PR TITLE
[ide-service] only add warm task when workspace type is prebuild

### DIFF
--- a/components/ide-service/pkg/server/server.go
+++ b/components/ide-service/pkg/server/server.go
@@ -356,7 +356,7 @@ func (s *IDEServiceServer) ResolveWorkspaceConfig(ctx context.Context, req *api.
 	}
 
 	jbGW, ok := ideConfig.IdeOptions.Clients["jetbrains-gateway"]
-	if ok {
+	if req.Type == api.WorkspaceType_PREBUILD && ok {
 		warmUpTask := ""
 		for _, alias := range jbGW.DesktopIDEs {
 			prebuilds := getPrebuilds(wsConfig, alias)

--- a/components/ide-service/pkg/server/testdata/resolve_ws_config_regular_with_intellij_config.golden
+++ b/components/ide-service/pkg/server/testdata/resolve_ws_config_regular_with_intellij_config.golden
@@ -1,0 +1,17 @@
+{
+    "Resp": {
+        "envvars": [
+            {
+                "name": "GITPOD_IDE_ALIAS",
+                "value": "intellij"
+            }
+        ],
+        "supervisor_image": "eu.gcr.io/gitpod-core-dev/build/supervisor:commit-ff38b98b7dde4929159bcaeec68d178898dc2139",
+        "web_image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-d6329814c2aa34c414574fd0d1301447d6fe82c9",
+        "ide_image_layers": [
+            "eu.gcr.io/gitpod-core-dev/build/ide/intellij:commit-9a6c79a91b2b1f583d5bcb7f9f1ef54ee977e0df",
+            "eu.gcr.io/gitpod-core-dev/build/ide/jb-backend-plugin:commit-b38092639d1783a1957894ddd4f492b3cdc9794a"
+        ]
+    },
+    "Err": ""
+}

--- a/components/ide-service/pkg/server/testdata/resolve_ws_config_regular_with_intellij_config.json
+++ b/components/ide-service/pkg/server/testdata/resolve_ws_config_regular_with_intellij_config.json
@@ -1,0 +1,6 @@
+{
+  "type": 0,
+  "context": "{\"isFile\":false,\"path\":\"\",\"title\":\"gitpod-io/empty \",\"revision\":\"\",\"repository\":{\"cloneUrl\":\"https://github.com/gitpod-io/empty.git\",\"host\":\"github.com\",\"name\":\"empty\",\"owner\":\"gitpod-io\",\"private\":false},\"normalizedContextURL\":\"https://github.com/gitpod-io/empty\",\"checkoutLocation\":\"empty\"}",
+  "ide_settings": "{\"settingVersion\":\"2.0\",\"defaultIde\":\"intellij\",\"useLatestVersion\":false}",
+  "workspace_config": "{\"tasks\":[{\"init\":\"echo 'init script'\",\"command\":\"echo 'start script'\"}],\"jetbrains\":{\"intellij\":{\"prebuilds\":{\"version\":\"both\"}}},\"_origin\":\"repo\",\"image\":\"docker.io/gitpod/workspace-full:latest\",\"vscode\":{\"extensions\":[]}}"
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
[ide-service] only add warm task when workspace type is prebuild

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
