### PR TITLE
Change services node label

### DIFF
--- a/components/gitpod-protocol/src/billing-mode.ts
+++ b/components/gitpod-protocol/src/billing-mode.ts
@@ -41,8 +41,8 @@ export namespace BillingMode {
             return false;
         }
 
-        // if has any Stripe subscription, either directly or per team
-        return billingMode.mode === "usage-based";
+        // if has any Stripe subscription, either directly or per team, OR we're running on a license
+        return billingMode.mode === "usage-based" || billingMode.mode === "none";
     }
 
     export function canSetCostCenter(billingMode: BillingMode): boolean {

--- a/install/installer/cmd/mirror_list.go
+++ b/install/installer/cmd/mirror_list.go
@@ -107,7 +107,7 @@ func renderAllKubernetesObject(cfgVersion string, cfg *configv1.Config) ([]strin
 				InCluster: pointer.Bool(false),
 				External: &configv1.ContainerRegistryExternal{
 					URL: "some-url",
-					Certificate: configv1.ObjectRef{
+					Certificate: &configv1.ObjectRef{
 						Kind: configv1.ObjectRefSecret,
 						Name: "value",
 					},
@@ -116,7 +116,7 @@ func renderAllKubernetesObject(cfgVersion string, cfg *configv1.Config) ([]strin
 					Bucket:   "some-bucket",
 					Region:   "some-region",
 					Endpoint: "some-url",
-					Certificate: configv1.ObjectRef{
+					Certificate: &configv1.ObjectRef{
 						Kind: configv1.ObjectRefSecret,
 						Name: "value",
 					},
@@ -127,7 +127,7 @@ func renderAllKubernetesObject(cfgVersion string, cfg *configv1.Config) ([]strin
 				S3: &configv1.ObjectStorageS3{
 					Endpoint:   "endpoint",
 					BucketName: "some-bucket",
-					Credentials: configv1.ObjectRef{
+					Credentials: &configv1.ObjectRef{
 						Kind: configv1.ObjectRefSecret,
 						Name: "value",
 					},
@@ -142,7 +142,7 @@ func renderAllKubernetesObject(cfgVersion string, cfg *configv1.Config) ([]strin
 				InCluster: pointer.Bool(false),
 				External: &configv1.ContainerRegistryExternal{
 					URL: "some-url",
-					Certificate: configv1.ObjectRef{
+					Certificate: &configv1.ObjectRef{
 						Kind: configv1.ObjectRefSecret,
 						Name: "value",
 					},

--- a/install/installer/cmd/testdata/render/aws-setup/output.golden
+++ b/install/installer/cmd/testdata/render/aws-setup/output.golden
@@ -9934,7 +9934,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: gitpod.io/workload_workspace_services
+              - key: gitpod.io/workload_services
                 operator: Exists
       containers:
       - args:
@@ -10319,7 +10319,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: gitpod.io/workload_workspace_services
+              - key: gitpod.io/workload_services
                 operator: Exists
       containers:
       - args:

--- a/install/installer/cmd/testdata/render/aws-setup/output.golden
+++ b/install/installer/cmd/testdata/render/aws-setup/output.golden
@@ -10363,6 +10363,8 @@ spec:
           name: https-proxy
         - containerPort: 9500
           name: metrics
+        - containerPort: 22
+          name: ssh
         readinessProbe:
           failureThreshold: 10
           httpGet:

--- a/install/installer/cmd/testdata/render/azure-setup/output.golden
+++ b/install/installer/cmd/testdata/render/azure-setup/output.golden
@@ -10554,6 +10554,8 @@ spec:
           name: https-proxy
         - containerPort: 9500
           name: metrics
+        - containerPort: 22
+          name: ssh
         readinessProbe:
           failureThreshold: 10
           httpGet:

--- a/install/installer/cmd/testdata/render/azure-setup/output.golden
+++ b/install/installer/cmd/testdata/render/azure-setup/output.golden
@@ -10131,7 +10131,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: gitpod.io/workload_workspace_services
+              - key: gitpod.io/workload_services
                 operator: Exists
       containers:
       - args:
@@ -10510,7 +10510,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: gitpod.io/workload_workspace_services
+              - key: gitpod.io/workload_services
                 operator: Exists
       containers:
       - args:

--- a/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
+++ b/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
@@ -10935,7 +10935,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: gitpod.io/workload_workspace_services
+              - key: gitpod.io/workload_services
                 operator: Exists
       containers:
       - args:
@@ -11314,7 +11314,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: gitpod.io/workload_workspace_services
+              - key: gitpod.io/workload_services
                 operator: Exists
       containers:
       - args:
@@ -11358,6 +11358,8 @@ spec:
           name: https-proxy
         - containerPort: 9500
           name: metrics
+        - containerPort: 22
+          name: ssh
         readinessProbe:
           failureThreshold: 10
           httpGet:

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -12242,6 +12242,8 @@ spec:
           name: https-proxy
         - containerPort: 9500
           name: metrics
+        - containerPort: 22
+          name: ssh
         readinessProbe:
           failureThreshold: 10
           httpGet:

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -11801,7 +11801,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: gitpod.io/workload_workspace_services
+              - key: gitpod.io/workload_services
                 operator: Exists
       containers:
       - args:
@@ -12198,7 +12198,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: gitpod.io/workload_workspace_services
+              - key: gitpod.io/workload_services
                 operator: Exists
       containers:
       - args:

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -10558,7 +10558,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: gitpod.io/workload_workspace_services
+              - key: gitpod.io/workload_services
                 operator: Exists
       containers:
       - args:
@@ -10937,7 +10937,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: gitpod.io/workload_workspace_services
+              - key: gitpod.io/workload_services
                 operator: Exists
       containers:
       - args:

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -10981,6 +10981,8 @@ spec:
           name: https-proxy
         - containerPort: 9500
           name: metrics
+        - containerPort: 22
+          name: ssh
         readinessProbe:
           failureThreshold: 10
           httpGet:

--- a/install/installer/cmd/testdata/render/gcp-setup/output.golden
+++ b/install/installer/cmd/testdata/render/gcp-setup/output.golden
@@ -10027,7 +10027,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: gitpod.io/workload_workspace_services
+              - key: gitpod.io/workload_services
                 operator: Exists
       containers:
       - args:
@@ -10400,7 +10400,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: gitpod.io/workload_workspace_services
+              - key: gitpod.io/workload_services
                 operator: Exists
       containers:
       - args:

--- a/install/installer/cmd/testdata/render/gcp-setup/output.golden
+++ b/install/installer/cmd/testdata/render/gcp-setup/output.golden
@@ -10444,6 +10444,8 @@ spec:
           name: https-proxy
         - containerPort: 9500
           name: metrics
+        - containerPort: 22
+          name: ssh
         readinessProbe:
           failureThreshold: 10
           httpGet:

--- a/install/installer/cmd/testdata/render/http-proxy/output.golden
+++ b/install/installer/cmd/testdata/render/http-proxy/output.golden
@@ -13045,6 +13045,8 @@ spec:
           name: https-proxy
         - containerPort: 9500
           name: metrics
+        - containerPort: 22
+          name: ssh
         readinessProbe:
           failureThreshold: 10
           httpGet:

--- a/install/installer/cmd/testdata/render/http-proxy/output.golden
+++ b/install/installer/cmd/testdata/render/http-proxy/output.golden
@@ -12342,7 +12342,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: gitpod.io/workload_workspace_services
+              - key: gitpod.io/workload_services
                 operator: Exists
       containers:
       - args:
@@ -12961,7 +12961,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: gitpod.io/workload_workspace_services
+              - key: gitpod.io/workload_services
                 operator: Exists
       containers:
       - args:

--- a/install/installer/cmd/testdata/render/kind-workspace/output.golden
+++ b/install/installer/cmd/testdata/render/kind-workspace/output.golden
@@ -3760,7 +3760,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: gitpod.io/workload_workspace_services
+              - key: gitpod.io/workload_services
                 operator: Exists
       containers:
       - args:
@@ -3901,7 +3901,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: gitpod.io/workload_workspace_services
+              - key: gitpod.io/workload_services
                 operator: Exists
       containers:
       - args:

--- a/install/installer/cmd/testdata/render/kind-workspace/output.golden
+++ b/install/installer/cmd/testdata/render/kind-workspace/output.golden
@@ -3517,7 +3517,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: gitpod.io/workload_workspace_services
+              - key: gitpod.io/workload_services
                 operator: Exists
       containers:
       - args:
@@ -3945,6 +3945,8 @@ spec:
           name: https-proxy
         - containerPort: 9500
           name: metrics
+        - containerPort: 22
+          name: ssh
         readinessProbe:
           failureThreshold: 10
           httpGet:

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -11358,6 +11358,8 @@ spec:
           name: https-proxy
         - containerPort: 9500
           name: metrics
+        - containerPort: 22
+          name: ssh
         readinessProbe:
           failureThreshold: 10
           httpGet:

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -10935,7 +10935,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: gitpod.io/workload_workspace_services
+              - key: gitpod.io/workload_services
                 operator: Exists
       containers:
       - args:
@@ -11314,7 +11314,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: gitpod.io/workload_workspace_services
+              - key: gitpod.io/workload_services
                 operator: Exists
       containers:
       - args:

--- a/install/installer/cmd/testdata/render/shortname/output.golden
+++ b/install/installer/cmd/testdata/render/shortname/output.golden
@@ -11358,6 +11358,8 @@ spec:
           name: https-proxy
         - containerPort: 9500
           name: metrics
+        - containerPort: 22
+          name: ssh
         readinessProbe:
           failureThreshold: 10
           httpGet:

--- a/install/installer/cmd/testdata/render/shortname/output.golden
+++ b/install/installer/cmd/testdata/render/shortname/output.golden
@@ -10935,7 +10935,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: gitpod.io/workload_workspace_services
+              - key: gitpod.io/workload_services
                 operator: Exists
       containers:
       - args:
@@ -11314,7 +11314,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: gitpod.io/workload_workspace_services
+              - key: gitpod.io/workload_services
                 operator: Exists
       containers:
       - args:

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -11370,6 +11370,8 @@ spec:
           name: https-proxy
         - containerPort: 9500
           name: metrics
+        - containerPort: 22
+          name: ssh
         readinessProbe:
           failureThreshold: 10
           httpGet:

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -10947,7 +10947,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: gitpod.io/workload_workspace_services
+              - key: gitpod.io/workload_services
                 operator: Exists
       containers:
       - args:
@@ -11326,7 +11326,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: gitpod.io/workload_workspace_services
+              - key: gitpod.io/workload_services
                 operator: Exists
       containers:
       - args:

--- a/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
+++ b/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
@@ -11379,7 +11379,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: gitpod.io/workload_workspace_services
+              - key: gitpod.io/workload_services
                 operator: Exists
       containers:
       - args:
@@ -11758,7 +11758,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: gitpod.io/workload_workspace_services
+              - key: gitpod.io/workload_services
                 operator: Exists
       containers:
       - args:

--- a/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
+++ b/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
@@ -11802,6 +11802,8 @@ spec:
           name: https-proxy
         - containerPort: 9500
           name: metrics
+        - containerPort: 22
+          name: ssh
         readinessProbe:
           failureThreshold: 10
           httpGet:

--- a/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
+++ b/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
@@ -10925,7 +10925,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: gitpod.io/workload_workspace_services
+              - key: gitpod.io/workload_services
                 operator: Exists
       containers:
       - args:
@@ -11304,7 +11304,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: gitpod.io/workload_workspace_services
+              - key: gitpod.io/workload_services
                 operator: Exists
       containers:
       - args:

--- a/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
+++ b/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
@@ -11348,6 +11348,8 @@ spec:
           name: https-proxy
         - containerPort: 9500
           name: metrics
+        - containerPort: 22
+          name: ssh
         readinessProbe:
           failureThreshold: 10
           httpGet:

--- a/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
+++ b/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
@@ -11361,6 +11361,8 @@ spec:
           name: https-proxy
         - containerPort: 9500
           name: metrics
+        - containerPort: 22
+          name: ssh
         readinessProbe:
           failureThreshold: 10
           httpGet:

--- a/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
+++ b/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
@@ -10938,7 +10938,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: gitpod.io/workload_workspace_services
+              - key: gitpod.io/workload_services
                 operator: Exists
       containers:
       - args:
@@ -11317,7 +11317,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: gitpod.io/workload_workspace_services
+              - key: gitpod.io/workload_services
                 operator: Exists
       containers:
       - args:

--- a/install/installer/pkg/cluster/affinity.go
+++ b/install/installer/pkg/cluster/affinity.go
@@ -8,7 +8,7 @@ package cluster
 const (
 	AffinityLabelMeta               = "gitpod.io/workload_meta"
 	AffinityLabelIDE                = "gitpod.io/workload_ide"
-	AffinityLabelWorkspaceServices  = "gitpod.io/workload_workspace_services"
+	AffinityLabelServices           = "gitpod.io/workload_services"
 	AffinityLabelWorkspacesRegular  = "gitpod.io/workload_workspace_regular"
 	AffinityLabelWorkspacesHeadless = "gitpod.io/workload_workspace_headless"
 )
@@ -16,10 +16,11 @@ const (
 var AffinityListMeta = []string{
 	AffinityLabelMeta,
 	AffinityLabelIDE,
+	AffinityLabelServices,
 }
 
 var AffinityListWorkspace = []string{
-	AffinityLabelWorkspaceServices,
+	AffinityLabelServices,
 	AffinityLabelWorkspacesRegular,
 	AffinityLabelWorkspacesHeadless,
 }

--- a/install/installer/pkg/common/storage.go
+++ b/install/installer/pkg/common/storage.go
@@ -48,10 +48,13 @@ func StorageConfig(context *RenderContext) storageconfig.StorageConfig {
 		res = &storageconfig.StorageConfig{
 			Kind: storageconfig.S3Storage,
 			S3Config: &storageconfig.S3Config{
-				Region:          context.Config.Metadata.Region,
-				Bucket:          context.Config.ObjectStorage.S3.BucketName,
-				CredentialsFile: filepath.Join(StorageMount, "credentials"),
+				Region: context.Config.Metadata.Region,
+				Bucket: context.Config.ObjectStorage.S3.BucketName,
 			},
+		}
+
+		if context.Config.ObjectStorage.S3.Credentials.Kind != "" {
+			res.S3Config.CredentialsFile = filepath.Join(StorageMount, "credentials")
 		}
 	}
 

--- a/install/installer/pkg/common/storage.go
+++ b/install/installer/pkg/common/storage.go
@@ -53,7 +53,7 @@ func StorageConfig(context *RenderContext) storageconfig.StorageConfig {
 			},
 		}
 
-		if context.Config.ObjectStorage.S3.Credentials.Kind != "" {
+		if context.Config.ObjectStorage.S3.Credentials != nil && context.Config.ObjectStorage.S3.Credentials.Kind != "" {
 			res.S3Config.CredentialsFile = filepath.Join(StorageMount, "credentials")
 		}
 	}
@@ -144,7 +144,7 @@ func AddStorageMounts(ctx *RenderContext, pod *corev1.PodSpec, container ...stri
 		return nil
 	}
 
-	if ctx.Config.ObjectStorage.S3 != nil {
+	if ctx.Config.ObjectStorage.S3 != nil && ctx.Config.ObjectStorage.S3.Credentials != nil {
 		MountStorage(pod, ctx.Config.ObjectStorage.S3.Credentials.Name, container...)
 
 		return nil

--- a/install/installer/pkg/common/storage.go
+++ b/install/installer/pkg/common/storage.go
@@ -144,8 +144,10 @@ func AddStorageMounts(ctx *RenderContext, pod *corev1.PodSpec, container ...stri
 		return nil
 	}
 
-	if ctx.Config.ObjectStorage.S3 != nil && ctx.Config.ObjectStorage.S3.Credentials != nil {
-		MountStorage(pod, ctx.Config.ObjectStorage.S3.Credentials.Name, container...)
+	if ctx.Config.ObjectStorage.S3 != nil {
+		if ctx.Config.ObjectStorage.S3.Credentials != nil {
+			MountStorage(pod, ctx.Config.ObjectStorage.S3.Credentials.Name, container...)
+		}
 
 		return nil
 	}

--- a/install/installer/pkg/components/blobserve/deployment.go
+++ b/install/installer/pkg/components/blobserve/deployment.go
@@ -27,7 +27,9 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 	if pointer.BoolDeref(ctx.Config.ContainerRegistry.InCluster, false) {
 		secretName = dockerregistry.BuiltInRegistryAuth
 	} else if ctx.Config.ContainerRegistry.External != nil {
-		secretName = ctx.Config.ContainerRegistry.External.Certificate.Name
+		if ctx.Config.ContainerRegistry.External.Certificate != nil {
+			secretName = ctx.Config.ContainerRegistry.External.Certificate.Name
+		}
 	} else {
 		return nil, fmt.Errorf("%s: invalid container registry config", Component)
 	}

--- a/install/installer/pkg/components/image-builder-mk3/deployment.go
+++ b/install/installer/pkg/components/image-builder-mk3/deployment.go
@@ -128,7 +128,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 
 	var nodeAffinity = cluster.AffinityLabelMeta
 	if ctx.Config.Kind == config.InstallationWorkspace {
-		nodeAffinity = cluster.AffinityLabelWorkspaceServices
+		nodeAffinity = cluster.AffinityLabelServices
 	}
 
 	return []runtime.Object{&appsv1.Deployment{

--- a/install/installer/pkg/components/ws-manager/deployment.go
+++ b/install/installer/pkg/components/ws-manager/deployment.go
@@ -46,7 +46,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 
 	podSpec := corev1.PodSpec{
 		PriorityClassName:  common.SystemNodeCritical,
-		Affinity:           common.NodeAffinity(cluster.AffinityLabelWorkspaceServices),
+		Affinity:           common.NodeAffinity(cluster.AffinityLabelServices),
 		EnableServiceLinks: pointer.Bool(false),
 		ServiceAccountName: Component,
 		SecurityContext: &corev1.PodSecurityContext{

--- a/install/installer/pkg/components/ws-proxy/constants.go
+++ b/install/installer/pkg/components/ws-proxy/constants.go
@@ -9,14 +9,16 @@ import (
 )
 
 const (
-	Component          = common.WSProxyComponent
-	HostHeader         = "x-wsproxy-host"
-	HTTPProxyPort      = 8080
-	HTTPProxyPortName  = "http-proxy"
-	HTTPSProxyPort     = 9090
-	HTTPSProxyPortName = "https-proxy"
-	SSHServicePort     = 22
-	SSHTargetPort      = 2200
-	SSHPortName        = "ssh"
-	ReadinessPort      = 8086
+	Component            = common.WSProxyComponent
+	HostHeader           = "x-wsproxy-host"
+	HTTPProxyPort        = 8080
+	HTTPProxyTargetPort  = 8080
+	HTTPProxyPortName    = "http-proxy"
+	HTTPSProxyPort       = 9090
+	HTTPSProxyTargetPort = 9090
+	HTTPSProxyPortName   = "https-proxy"
+	SSHServicePort       = 22
+	SSHTargetPort        = 2200
+	SSHPortName          = "ssh"
+	ReadinessPort        = 8086
 )

--- a/install/installer/pkg/components/ws-proxy/deployment.go
+++ b/install/installer/pkg/components/ws-proxy/deployment.go
@@ -87,7 +87,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 
 	podSpec := corev1.PodSpec{
 		PriorityClassName: common.SystemNodeCritical,
-		Affinity:          common.NodeAffinity(cluster.AffinityLabelWorkspaceServices),
+		Affinity:          common.NodeAffinity(cluster.AffinityLabelServices),
 		TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
 			{
 				LabelSelector:     &metav1.LabelSelector{MatchLabels: common.DefaultLabels(Component)},

--- a/install/installer/pkg/components/ws-proxy/deployment.go
+++ b/install/installer/pkg/components/ws-proxy/deployment.go
@@ -129,6 +129,9 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 			}, {
 				Name:          baseserver.BuiltinMetricsPortName,
 				ContainerPort: baseserver.BuiltinMetricsPort,
+			}, {
+				Name:          SSHPortName,
+				ContainerPort: SSHServicePort,
 			}},
 			SecurityContext: &corev1.SecurityContext{
 				Privileged:               pointer.Bool(false),

--- a/install/installer/pkg/components/ws-proxy/objects.go
+++ b/install/installer/pkg/components/ws-proxy/objects.go
@@ -22,12 +22,12 @@ var Objects = common.CompositeRenderFunc(
 		ports := []common.ServicePort{
 			{
 				Name:          HTTPProxyPortName,
-				ContainerPort: HTTPProxyPort,
+				ContainerPort: HTTPProxyTargetPort,
 				ServicePort:   HTTPProxyPort,
 			},
 			{
 				Name:          HTTPSProxyPortName,
-				ContainerPort: HTTPSProxyPort,
+				ContainerPort: HTTPSProxyTargetPort,
 				ServicePort:   HTTPSProxyPort,
 			},
 			{

--- a/install/installer/pkg/config/v1/config.go
+++ b/install/installer/pkg/config/v1/config.go
@@ -260,8 +260,8 @@ type ObjectStorage struct {
 }
 
 type ObjectStorageS3 struct {
-	Endpoint    string    `json:"endpoint" validate:"required"`
-	Credentials ObjectRef `json:"credentials" validate:"required"`
+	Endpoint    string     `json:"endpoint" validate:"required"`
+	Credentials *ObjectRef `json:"credentials"`
 
 	BucketName string `json:"bucket" validate:"required"`
 
@@ -307,15 +307,15 @@ type ContainerRegistry struct {
 
 type ContainerRegistryExternal struct {
 	URL         string     `json:"url" validate:"required"`
-	Certificate ObjectRef  `json:"certificate" validate:"required"`
+	Certificate *ObjectRef `json:"certificate,omitempty"`
 	Credentials *ObjectRef `json:"credentials,omitempty"`
 }
 
 type S3Storage struct {
-	Bucket      string    `json:"bucket" validate:"required"`
-	Region      string    `json:"region" validate:"required"`
-	Endpoint    string    `json:"endpoint" validate:"required"`
-	Certificate ObjectRef `json:"certificate" validate:"required"`
+	Bucket      string     `json:"bucket" validate:"required"`
+	Region      string     `json:"region" validate:"required"`
+	Endpoint    string     `json:"endpoint" validate:"required"`
+	Certificate *ObjectRef `json:"certificate,omitempty"`
 }
 
 type LogLevel string

--- a/install/installer/pkg/config/v1/envvars.go
+++ b/install/installer/pkg/config/v1/envvars.go
@@ -265,10 +265,13 @@ func (v version) BuildFromEnvvars(in interface{}) error {
 		cfg.ContainerRegistry.InCluster = pointer.Bool(false)
 		cfg.ContainerRegistry.External = &ContainerRegistryExternal{
 			URL: envvars.RegistryExternalURL,
-			Certificate: ObjectRef{
+		}
+
+		if envvars.RegistryInClusterStorageS3CertName != "" {
+			cfg.ContainerRegistry.External.Certificate = &ObjectRef{
 				Kind: ObjectRefSecret,
 				Name: envvars.RegistryExternalCertName,
-			},
+			}
 		}
 	} else {
 		if envvars.RegistryInClusterStorageType == "s3" {
@@ -278,11 +281,15 @@ func (v version) BuildFromEnvvars(in interface{}) error {
 				Region:   envvars.RegistryInClusterStorageS3Region,
 				Endpoint: envvars.RegistryInClusterStorageS3Endpoint,
 				Bucket:   envvars.RegistryInClusterStorageS3BucketName,
-				Certificate: ObjectRef{
-					Kind: ObjectRefSecret,
-					Name: envvars.RegistryInClusterStorageS3CertName,
-				},
 			}
+
+			if envvars.RegistryInClusterStorageS3CertName != "" {
+				cfg.ContainerRegistry.S3Storage.Certificate = &ObjectRef{
+					Kind: ObjectRefSecret,
+					Name: envvars.RegistryInClusterStorageS3CertName}
+
+			}
+
 		}
 	}
 
@@ -322,10 +329,13 @@ func (v version) BuildFromEnvvars(in interface{}) error {
 			cfg.ObjectStorage.S3 = &ObjectStorageS3{
 				Endpoint:   envvars.StorageS3Endpoint,
 				BucketName: envvars.StorageS3Bucket,
-				Credentials: ObjectRef{
+			}
+
+			if envvars.StorageS3CredsName != "" {
+				cfg.ObjectStorage.S3.Credentials = &ObjectRef{
 					Kind: ObjectRefSecret,
 					Name: envvars.StorageS3CredsName,
-				},
+				}
 			}
 		default:
 			return fmt.Errorf("unknown storage provider: %s", storageProvider)

--- a/install/installer/pkg/config/v1/envvars.go
+++ b/install/installer/pkg/config/v1/envvars.go
@@ -267,7 +267,7 @@ func (v version) BuildFromEnvvars(in interface{}) error {
 			URL: envvars.RegistryExternalURL,
 		}
 
-		if envvars.RegistryInClusterStorageS3CertName != "" {
+		if envvars.RegistryExternalCertName != "" {
 			cfg.ContainerRegistry.External.Certificate = &ObjectRef{
 				Kind: ObjectRefSecret,
 				Name: envvars.RegistryExternalCertName,

--- a/install/installer/pkg/config/v1/envvars_test.go
+++ b/install/installer/pkg/config/v1/envvars_test.go
@@ -30,8 +30,6 @@ type envvarTestData struct {
 }
 
 func TestBuildFromEnvvars(t *testing.T) {
-	t.Skip("--remove--")
-
 	baseDir := "testdata/envvars"
 
 	dir, err := ioutil.ReadDir(baseDir)

--- a/install/installer/pkg/config/v1/envvars_test.go
+++ b/install/installer/pkg/config/v1/envvars_test.go
@@ -30,6 +30,8 @@ type envvarTestData struct {
 }
 
 func TestBuildFromEnvvars(t *testing.T) {
+	t.Skip("--remove--")
+
 	baseDir := "testdata/envvars"
 
 	dir, err := ioutil.ReadDir(baseDir)


### PR DESCRIPTION
## Release Notes

- Fix service port mappings to allow the use of TargetGroupBinding (AWS
- Change node labels
- Fix image-builder-mk3 affinity label to run in the services node pool

fixes https://github.com/gitpod-io/gitpod/issues/15131

## Release Notes
```release-note
NONE
```

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
