### PR TITLE
[installer] Don't mount ws-manager-client-tls in meta/webapp deployments

### DIFF
--- a/install/installer/cmd/testdata/render/kind-meta/output.golden
+++ b/install/installer/cmd/testdata/render/kind-meta/output.golden
@@ -4293,23 +4293,7 @@ data:
   ws-manager-bridge.json: |-
     {
       "installation": "default",
-      "staticBridges": [
-        {
-          "name": "default",
-          "url": "dns:///ws-manager:8080",
-          "tls": {
-            "ca": "/ws-manager-client-tls-certs/ca.crt",
-            "crt": "/ws-manager-client-tls-certs/tls.crt",
-            "key": "/ws-manager-client-tls-certs/tls.key"
-          },
-          "state": "available",
-          "maxScore": 100,
-          "score": 50,
-          "govern": true,
-          "admissionConstraints": null,
-          "applicationCluster": "default"
-        }
-      ],
+      "staticBridges": [],
       "clusterService": {
         "port": 8080,
         "host": "localhost"
@@ -7565,7 +7549,7 @@ spec:
         - name: SHLVL
           value: "1"
         - name: WSMAN_CFG_MANAGERS
-          value: WwogIHsKICAgICJuYW1lIjogImRlZmF1bHQiLAogICAgInVybCI6ICJkbnM6Ly8vd3MtbWFuYWdlcjo4MDgwIiwKICAgICJ0bHMiOiB7CiAgICAgICJjYSI6ICIvd3MtbWFuYWdlci1jbGllbnQtdGxzLWNlcnRzL2NhLmNydCIsCiAgICAgICJjcnQiOiAiL3dzLW1hbmFnZXItY2xpZW50LXRscy1jZXJ0cy90bHMuY3J0IiwKICAgICAgImtleSI6ICIvd3MtbWFuYWdlci1jbGllbnQtdGxzLWNlcnRzL3Rscy5rZXkiCiAgICB9LAogICAgInN0YXRlIjogImF2YWlsYWJsZSIsCiAgICAibWF4U2NvcmUiOiAxMDAsCiAgICAic2NvcmUiOiA1MCwKICAgICJnb3Zlcm4iOiB0cnVlLAogICAgImFkbWlzc2lvbkNvbnN0cmFpbnRzIjogbnVsbCwKICAgICJhcHBsaWNhdGlvbkNsdXN0ZXIiOiAiZGVmYXVsdCIKICB9Cl0=
+          value: W10=
         image: eu.gcr.io/gitpod-core-dev/build/server:test
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -7600,9 +7584,6 @@ spec:
           readOnly: true
         - mountPath: /ide-config
           name: ide-config
-          readOnly: true
-        - mountPath: /ws-manager-client-tls-certs
-          name: ws-manager-client-tls-certs
           readOnly: true
         - mountPath: /twilio-config
           name: twilio-secret-volume
@@ -7711,9 +7692,6 @@ spec:
       - configMap:
           name: server-ide-config
         name: ide-config
-      - name: ws-manager-client-tls-certs
-        secret:
-          secretName: ws-manager-client-tls
       - name: twilio-secret-volume
         secret:
           optional: true
@@ -7744,7 +7722,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: c0a3088b82fda02787165a99308e1e0cd9f919c7ba88828f2c98734c22d14c64
+        gitpod.io/checksum_config: 7ceeb2c87fcc68e5af1699d595d3fdd09d02513bc1a1194290bfeaf7f1435693
       creationTimestamp: null
       labels:
         app: gitpod
@@ -7847,9 +7825,6 @@ spec:
         volumeMounts:
         - mountPath: /config
           name: config
-          readOnly: true
-        - mountPath: /ws-manager-client-tls-certs
-          name: ws-manager-client-tls-certs
           readOnly: true
       - args:
         - --logtostderr
@@ -7955,9 +7930,6 @@ spec:
       - configMap:
           name: ws-manager-bridge-config
         name: config
-      - name: ws-manager-client-tls-certs
-        secret:
-          secretName: ws-manager-client-tls
 status: {}
 ---
 # batch/v1/Job migrations

--- a/install/installer/cmd/testdata/render/kind-webapp/output.golden
+++ b/install/installer/cmd/testdata/render/kind-webapp/output.golden
@@ -2423,23 +2423,7 @@ data:
   ws-manager-bridge.json: |-
     {
       "installation": "default",
-      "staticBridges": [
-        {
-          "name": "default",
-          "url": "dns:///ws-manager:8080",
-          "tls": {
-            "ca": "/ws-manager-client-tls-certs/ca.crt",
-            "crt": "/ws-manager-client-tls-certs/tls.crt",
-            "key": "/ws-manager-client-tls-certs/tls.key"
-          },
-          "state": "available",
-          "maxScore": 100,
-          "score": 50,
-          "govern": true,
-          "admissionConstraints": null,
-          "applicationCluster": "default"
-        }
-      ],
+      "staticBridges": [],
       "clusterService": {
         "port": 8080,
         "host": "localhost"
@@ -4769,7 +4753,7 @@ spec:
         - name: SHLVL
           value: "1"
         - name: WSMAN_CFG_MANAGERS
-          value: WwogIHsKICAgICJuYW1lIjogImRlZmF1bHQiLAogICAgInVybCI6ICJkbnM6Ly8vd3MtbWFuYWdlcjo4MDgwIiwKICAgICJ0bHMiOiB7CiAgICAgICJjYSI6ICIvd3MtbWFuYWdlci1jbGllbnQtdGxzLWNlcnRzL2NhLmNydCIsCiAgICAgICJjcnQiOiAiL3dzLW1hbmFnZXItY2xpZW50LXRscy1jZXJ0cy90bHMuY3J0IiwKICAgICAgImtleSI6ICIvd3MtbWFuYWdlci1jbGllbnQtdGxzLWNlcnRzL3Rscy5rZXkiCiAgICB9LAogICAgInN0YXRlIjogImF2YWlsYWJsZSIsCiAgICAibWF4U2NvcmUiOiAxMDAsCiAgICAic2NvcmUiOiA1MCwKICAgICJnb3Zlcm4iOiB0cnVlLAogICAgImFkbWlzc2lvbkNvbnN0cmFpbnRzIjogbnVsbCwKICAgICJhcHBsaWNhdGlvbkNsdXN0ZXIiOiAiZGVmYXVsdCIKICB9Cl0=
+          value: W10=
         image: eu.gcr.io/gitpod-core-dev/build/server:test
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -4804,9 +4788,6 @@ spec:
           readOnly: true
         - mountPath: /ide-config
           name: ide-config
-          readOnly: true
-        - mountPath: /ws-manager-client-tls-certs
-          name: ws-manager-client-tls-certs
           readOnly: true
         - mountPath: /twilio-config
           name: twilio-secret-volume
@@ -4915,9 +4896,6 @@ spec:
       - configMap:
           name: server-ide-config
         name: ide-config
-      - name: ws-manager-client-tls-certs
-        secret:
-          secretName: ws-manager-client-tls
       - name: twilio-secret-volume
         secret:
           optional: true
@@ -4948,7 +4926,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: c0a3088b82fda02787165a99308e1e0cd9f919c7ba88828f2c98734c22d14c64
+        gitpod.io/checksum_config: 7ceeb2c87fcc68e5af1699d595d3fdd09d02513bc1a1194290bfeaf7f1435693
       creationTimestamp: null
       labels:
         app: gitpod
@@ -5051,9 +5029,6 @@ spec:
         volumeMounts:
         - mountPath: /config
           name: config
-          readOnly: true
-        - mountPath: /ws-manager-client-tls-certs
-          name: ws-manager-client-tls-certs
           readOnly: true
       - args:
         - --logtostderr
@@ -5159,9 +5134,6 @@ spec:
       - configMap:
           name: ws-manager-bridge-config
         name: config
-      - name: ws-manager-client-tls-certs
-        secret:
-          secretName: ws-manager-client-tls
 status: {}
 ---
 # batch/v1/Job migrations

--- a/install/installer/pkg/components/ws-manager-bridge/configmap.go
+++ b/install/installer/pkg/components/ws-manager-bridge/configmap.go
@@ -32,7 +32,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 			StoppingPhaseSeconds:  3600,
 		},
 		EmulatePreparingIntervalSeconds: 10,
-		StaticBridges:                   WSManagerList(ctx),
+		StaticBridges:                   InClusterWSManagerList(ctx),
 		ClusterSyncIntervalSeconds:      60,
 	}
 

--- a/install/installer/pkg/components/ws-manager-bridge/objects.go
+++ b/install/installer/pkg/components/ws-manager-bridge/objects.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 	wsmanager "github.com/gitpod-io/gitpod/installer/pkg/components/ws-manager"
+	"github.com/gitpod-io/gitpod/installer/pkg/config/v1"
 	"github.com/gitpod-io/gitpod/installer/pkg/config/v1/experimental"
 )
 
@@ -19,34 +20,44 @@ var Objects = common.CompositeRenderFunc(
 	common.DefaultServiceAccount(Component),
 )
 
-func WSManagerList(ctx *common.RenderContext) []WorkspaceCluster {
-	skipSelf := false
+// InClusterWSManagerList returns the list of ws-manager's available in the same cluster
+func InClusterWSManagerList(ctx *common.RenderContext) []WorkspaceCluster {
+	// WebApp and Meta deployments don't ship their own ws-manager
+	if ctx.Config.Kind == config.InstallationMeta || ctx.Config.Kind == config.InstallationWebApp {
+		return []WorkspaceCluster{}
+	}
+
+	// Registering a local cluster ws-manager only makes sense when we actually deploy one,
+	// (ie when we are doing a full self hosted installation rather than a SaaS install to gitpod.io).
+	//
+	// CW: eventually webapp will deploy with Kind:Meta or even Kind:WebApp at which point the
+	//     skipSelf exception is no longer needed.
+	var skipSelf bool
 	_ = ctx.WithExperimental(func(cfg *experimental.Config) error {
 		if cfg.WebApp != nil && cfg.WebApp.WorkspaceManagerBridge != nil {
 			skipSelf = cfg.WebApp.WorkspaceManagerBridge.SkipSelf
 		}
 		return nil
 	})
-
-	// Registering a local cluster ws-manager only makes sense when we actually deploy one,
-	// (ie when we are doing a full self hosted installation rather than a SaaS install to gitpod.io).
 	if skipSelf {
 		return []WorkspaceCluster{}
 	}
 
-	return []WorkspaceCluster{{
-		Name: ctx.Config.Metadata.InstallationShortname,
-		URL:  fmt.Sprintf("dns:///%s:%d", wsmanager.Component, wsmanager.RPCPort),
-		TLS: WorkspaceClusterTLS{
-			Authority:   "/ws-manager-client-tls-certs/ca.crt",
-			Certificate: "/ws-manager-client-tls-certs/tls.crt",
-			Key:         "/ws-manager-client-tls-certs/tls.key",
+	return []WorkspaceCluster{
+		{
+			Name: ctx.Config.Metadata.InstallationShortname,
+			URL:  fmt.Sprintf("dns:///%s:%d", wsmanager.Component, wsmanager.RPCPort),
+			TLS: WorkspaceClusterTLS{
+				Authority:   "/ws-manager-client-tls-certs/ca.crt",
+				Certificate: "/ws-manager-client-tls-certs/tls.crt",
+				Key:         "/ws-manager-client-tls-certs/tls.key",
+			},
+			State:                WorkspaceClusterStateAvailable,
+			MaxScore:             100,
+			Score:                50,
+			Govern:               true,
+			AdmissionConstraints: nil,
+			ApplicationCluster:   ctx.Config.Metadata.InstallationShortname,
 		},
-		State:                WorkspaceClusterStateAvailable,
-		MaxScore:             100,
-		Score:                50,
-		Govern:               true,
-		AdmissionConstraints: nil,
-		ApplicationCluster:   ctx.Config.Metadata.InstallationShortname,
-	}}
+	}
 }

--- a/install/installer/pkg/components/ws-manager-bridge/objects_test.go
+++ b/install/installer/pkg/components/ws-manager-bridge/objects_test.go
@@ -26,7 +26,7 @@ func TestWorkspaceManagerList_WhenSkipSelfIsSet(t *testing.T) {
 	for _, testCase := range testCases {
 		ctx := renderContextWithConfig(t, testCase.SkipSelf)
 
-		wsclusters := WSManagerList(ctx)
+		wsclusters := InClusterWSManagerList(ctx)
 		if testCase.ExpectWorkspaceClusters {
 			require.NotEmptyf(t, wsclusters, "expected to render workspace clusters when skipSelf=%v", testCase.SkipSelf)
 		} else {


### PR DESCRIPTION
## Description
This PR removes the `ws-manager-client-tls` mounts from WebApp/Meta deployments. Their presence causes issues in dedicated deployments where we run pure meta installations.

This PR is stacked on #15132  to facilitate its use before merging.

## How to test
See installer fixture tests.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
