### PR TITLE
Add IDE versions to the dashboard

### DIFF
--- a/components/dashboard/src/settings/SelectIDE.tsx
+++ b/components/dashboard/src/settings/SelectIDE.tsx
@@ -75,12 +75,12 @@ export default function SelectIDE(props: SelectIDEProps) {
     const [ideOptions, setIdeOptions] = useState<IDEOptions | undefined>(undefined);
     useEffect(() => {
         (async () => {
-            const ideopts = await getGitpodService().server.getIDEOptions();
+            const ideOptions = await getGitpodService().server.getIDEOptions();
             // TODO: Compatible with ide-config not deployed, need revert after ide-config deployed
-            delete ideopts.options["code-latest"];
-            delete ideopts.options["code-desktop-insiders"];
+            delete ideOptions.options["code-latest"];
+            delete ideOptions.options["code-desktop-insiders"];
 
-            setIdeOptions(ideopts);
+            setIdeOptions(ideOptions);
         })();
     }, []);
 
@@ -95,8 +95,9 @@ export default function SelectIDE(props: SelectIDEProps) {
                             <div className={`my-4 gap-3 flex flex-wrap max-w-3xl`}>
                                 {allIdeOptions.map(([id, option]) => {
                                     const selected = defaultIde === id;
+                                    const version = useLatestVersion ? option.latestImageVersion : option.imageVersion;
                                     const onSelect = () => actuallySetDefaultIde(id);
-                                    return renderIdeOption(option, selected, onSelect);
+                                    return renderIdeOption(option, selected, version, onSelect);
                                 })}
                             </div>
                             {ideOptions.options[defaultIde]?.notes && (
@@ -176,20 +177,45 @@ function orderedIdeOptions(ideOptions: IDEOptions) {
         });
 }
 
-function renderIdeOption(option: IDEOption, selected: boolean, onSelect: () => void): JSX.Element {
+function renderIdeOption(
+    option: IDEOption,
+    selected: boolean,
+    version: IDEOption["imageVersion"],
+    onSelect: () => void,
+): JSX.Element {
     const label = option.type === "desktop" ? "" : option.type;
     const card = (
-        <SelectableCardSolid className="w-36 h-40" title={option.title} selected={selected} onClick={onSelect}>
+        <SelectableCardSolid className="w-36 h-44" title={option.title} selected={selected} onClick={onSelect}>
             <div className="flex justify-center mt-3">
                 <img className="w-16 filter-grayscale self-center" src={option.logo} alt="logo" />
             </div>
-            {label ? (
+            <div
+                className="mt-2 px-3 py-1 self-center"
+                style={{
+                    minHeight: "1.75rem",
+                }}
+            >
+                {label ? (
+                    <span
+                        className={`font-semibold text-sm ${
+                            selected ? "text-gray-100 dark:text-gray-600" : "text-gray-600 dark:text-gray-500"
+                        } uppercase`}
+                    >
+                        {label}
+                    </span>
+                ) : (
+                    <></>
+                )}
+            </div>
+
+            {version ? (
                 <div
-                    className={`font-semibold text-sm ${
+                    className={`font-semibold text-xs ${
                         selected ? "text-gray-100 dark:text-gray-600" : "text-gray-600 dark:text-gray-500"
-                    } uppercase mt-2 px-3 py-1 self-center`}
+                    } uppercase px-3 self-center`}
+                    title="The IDE's current version on Gitpod"
                 >
-                    {label}
+                    {version}
                 </div>
             ) : (
                 <></>

--- a/components/dashboard/src/settings/SelectIDE.tsx
+++ b/components/dashboard/src/settings/SelectIDE.tsx
@@ -75,12 +75,7 @@ export default function SelectIDE(props: SelectIDEProps) {
     const [ideOptions, setIdeOptions] = useState<IDEOptions | undefined>(undefined);
     useEffect(() => {
         (async () => {
-            const ideOptions = await getGitpodService().server.getIDEOptions();
-            // TODO: Compatible with ide-config not deployed, need revert after ide-config deployed
-            delete ideOptions.options["code-latest"];
-            delete ideOptions.options["code-desktop-insiders"];
-
-            setIdeOptions(ideOptions);
+            setIdeOptions(await getGitpodService().server.getIDEOptions());
         })();
     }, []);
 

--- a/components/gitpod-protocol/src/ide-protocol.ts
+++ b/components/gitpod-protocol/src/ide-protocol.ts
@@ -87,7 +87,7 @@ export interface IDEOption {
     label?: string;
 
     /**
-     * Notes to the IDE option that are renderd in the preferences when a user
+     * Notes to the IDE option that are rendered in the preferences when a user
      * chooses this IDE.
      */
     notes?: string[];
@@ -126,4 +126,14 @@ export interface IDEOption {
      * The latest plugin image ref for the latest IDE image, this image ref always resolve to digest.
      */
     pluginLatestImage?: string;
+
+    /**
+     * ImageVersion the semantic version of the IDE image.
+     */
+    imageVersion?: string;
+
+    /**
+     * LatestImageVersion the semantic version of the latest IDE image.
+     */
+    latestImageVersion?: string;
 }


### PR DESCRIPTION
## Description
This PR is simply adding versions below the icons of all IDEs in the IDE switcher component (used during on-boarding and always available in the user preferences). 

This is partially a lie because we don't associate VS Code Desktop with a version, but it holds true for the rest.
<img width="817" alt="image" src="https://user-images.githubusercontent.com/29888641/205440587-239444f4-c31c-40a8-a485-18a40d213c27.png">


It's a relatively easy win because we:
1. Already tag all newly-built IDE images with their version strings (https://github.com/gitpod-io/gitpod/pull/15082, https://github.com/gitpod-io/gitpod/pull/14055)
2. We already implemented the functionality in [`ide-service`](https://github.com/gitpod-io/gitpod/tree/main/components/ide-service) so that it returns the IDE versions along the IDE options (https://github.com/gitpod-io/gitpod/pull/15081)

With this we can do two things at once:
- keep our users informed what versions we use right from the Dashboard (good for checking new versions with bug fixes and features)
- makes it easier for us to check that our IDEs are at their correct versions when releasing them at IDE (the team).

## How to test

1. Go to the [preview environment](https://ft-add-idebd181cc38e.preview.gitpod-dev.com/workspaces) and sign in
2. You should be greeted with a modal with the IDEs and their versions, you can also visit the [user prefs](https://ft-add-idebd181cc38e.preview.gitpod-dev.com/preferences) to see it.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Added versions of all the suppoerted IDEs to the Preferences page
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
