### PR TITLE
Fix grammar in PersonalAccessTokens.tsx

### DIFF
--- a/components/dashboard/src/settings/PersonalAccessTokens.tsx
+++ b/components/dashboard/src/settings/PersonalAccessTokens.tsx
@@ -603,7 +603,7 @@ function ListAccessTokensView() {
                         <div className="bg-gray-100 dark:bg-gray-800 rounded-xl w-full py-28 flex flex-col items-center">
                             <h3 className="text-center pb-3 text-gray-500 dark:text-gray-400">No Access Tokens</h3>
                             <p className="text-center pb-6 text-gray-500 text-base w-96">
-                                Generate a access token for applications that need access to the Gitpod API.{" "}
+                                Generate an access token for applications that need access to the Gitpod API.{" "}
                             </p>
                             <Link to={settingsPathPersonalAccessTokenCreate}>
                                 <button>New Access Token</button>


### PR DESCRIPTION
`Generate an access token` 

Fixes #15140

## How to test
see /tokens in preview

```release-note
NONE
```

## Werft options:
- [x] /werft with-preview
