### PR TITLE
Always allow running new prebuilds, regardless of any previous prebuild state

### DIFF
--- a/components/dashboard/src/projects/Prebuild.tsx
+++ b/components/dashboard/src/projects/Prebuild.tsx
@@ -156,39 +156,42 @@ export default function () {
             <Header title={renderTitle()} subtitle={renderSubtitle()} />
             <div className="app-container mt-8">
                 <PrebuildLogs workspaceId={prebuild?.info?.buildWorkspaceId}>
-                    {["aborted", "timeout", "failed"].includes(prebuild?.status || "") || !!prebuild?.error ? (
-                        <button
-                            className="flex items-center space-x-2"
-                            disabled={isRerunningPrebuild}
-                            onClick={rerunPrebuild}
-                        >
-                            {isRerunningPrebuild && (
-                                <img className="h-4 w-4 animate-spin filter brightness-150" src={Spinner} />
-                            )}
-                            <span>Rerun Prebuild ({prebuild?.info.branch})</span>
-                        </button>
-                    ) : ["building", "queued"].includes(prebuild?.status || "") ? (
+                    {["building", "queued"].includes(prebuild?.status || "") ? (
                         <button
                             className="danger flex items-center space-x-2"
                             disabled={isCancellingPrebuild}
                             onClick={cancelPrebuild}
                         >
                             {isCancellingPrebuild && (
-                                <img className="h-4 w-4 animate-spin filter brightness-150" src={Spinner} />
+                                <img alt="" className="h-4 w-4 animate-spin filter brightness-150" src={Spinner} />
                             )}
                             <span>Cancel Prebuild</span>
                         </button>
-                    ) : prebuild?.status === "available" ? (
-                        <a
-                            className="my-auto"
-                            href={gitpodHostUrl
-                                .withContext(`open-prebuild/${prebuild?.info.id}/${prebuild?.info.changeUrl}`)
-                                .toString()}
-                        >
-                            <button>New Workspace (with this prebuild)</button>
-                        </a>
                     ) : (
-                        <button disabled={true}>New Workspace (with this prebuild)</button>
+                        <>
+                            <button
+                                className="secondary flex items-center space-x-2"
+                                disabled={isRerunningPrebuild}
+                                onClick={rerunPrebuild}
+                            >
+                                {isRerunningPrebuild && (
+                                    <img alt="" className="h-4 w-4 animate-spin filter brightness-150" src={Spinner} />
+                                )}
+                                <span>Rerun Prebuild ({prebuild?.info.branch})</span>
+                            </button>
+                            {prebuild?.status === "available" ? (
+                                <a
+                                    className="my-auto"
+                                    href={gitpodHostUrl
+                                        .withContext(`open-prebuild/${prebuild?.info.id}/${prebuild?.info.changeUrl}`)
+                                        .toString()}
+                                >
+                                    <button>New Workspace (with this prebuild)</button>
+                                </a>
+                            ) : (
+                                <button disabled={true}>New Workspace (with this prebuild)</button>
+                            )}
+                        </>
                     )}
                 </PrebuildLogs>
             </div>

--- a/components/dashboard/src/projects/Project.tsx
+++ b/components/dashboard/src/projects/Project.tsx
@@ -388,20 +388,7 @@ export default function () {
                                                 <ItemFieldContextMenu
                                                     className="py-0.5"
                                                     menuEntries={
-                                                        !prebuild ||
-                                                        prebuild.status === "aborted" ||
-                                                        prebuild.status === "failed" ||
-                                                        prebuild.status === "timeout" ||
-                                                        !!prebuild.error
-                                                            ? [
-                                                                  {
-                                                                      title: `${prebuild ? "Rerun" : "Run"} Prebuild (${
-                                                                          branch.name
-                                                                      })`,
-                                                                      onClick: () => triggerPrebuild(branch),
-                                                                  },
-                                                              ]
-                                                            : prebuild.status === "building"
+                                                        prebuild?.status === "queued" || prebuild?.status === "building"
                                                             ? [
                                                                   {
                                                                       title: "Cancel Prebuild",
@@ -411,7 +398,14 @@ export default function () {
                                                                           prebuild && cancelPrebuild(prebuild.info.id),
                                                                   },
                                                               ]
-                                                            : []
+                                                            : [
+                                                                  {
+                                                                      title: `${prebuild ? "Rerun" : "Run"} Prebuild (${
+                                                                          branch.name
+                                                                      })`,
+                                                                      onClick: () => triggerPrebuild(branch),
+                                                                  },
+                                                              ]
                                                     }
                                                 />
                                             </ItemField>


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Make the 'Run Prebuild' button actually do what it says 100% of the time.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/15144

## How to test
<!-- Provide steps to test this PR -->

1. Create a Team
2. Create a Project (this runs a first prebuild)
3. When the prebuild has finished successfully, try to re-trigger the prebuild -- this should always work (i.e. it should always start a new prebuild, and not redirect you to an older successful prebuild)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Always allow running new prebuilds, regardless of any previous prebuild state
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
