### PR TITLE
[ubp] allow usage of team without stripe sub

### DIFF
--- a/components/dashboard/src/components/UsageBasedBillingConfig.tsx
+++ b/components/dashboard/src/components/UsageBasedBillingConfig.tsx
@@ -185,7 +185,7 @@ export default function UsageBasedBillingConfig({ attributionId }: Props) {
     }, [attributionId, billingCycleFrom]);
 
     const showSpinner = !attributionId || isLoadingStripeSubscription || !!pendingStripeSubscription;
-    const showBalance = !showSpinner && !(AttributionId.parse(attributionId)?.kind === "team" && !stripeSubscriptionId);
+    const showBalance = !showSpinner;
     const showUpgradeTeam =
         !showSpinner && AttributionId.parse(attributionId)?.kind === "team" && !stripeSubscriptionId;
     const showUpgradeUser =

--- a/components/server/src/user/user-service.ts
+++ b/components/server/src/user/user-service.ts
@@ -210,12 +210,6 @@ export class UserService {
                     "You're no longer a member of the selected billing team.",
                 );
             }
-            if (await this.isUnbilledTeam(attribution)) {
-                throw new ResponseError(
-                    ErrorCodes.INVALID_COST_CENTER,
-                    "The billing team you've selected does not have billing enabled.",
-                );
-            }
         }
         if (attribution.kind === "user") {
             if (user.id !== attribution.userId) {
@@ -258,11 +252,7 @@ export class UserService {
             } else {
                 attributionId = AttributionId.create(user);
             }
-            if (
-                !!attributionId &&
-                (await this.hasCredits(attributionId)) &&
-                !(await this.isUnbilledTeam(attributionId))
-            ) {
+            if (!!attributionId && (await this.hasCredits(attributionId))) {
                 return attributionId;
             }
         }
@@ -315,14 +305,6 @@ export class UserService {
     protected async hasCredits(attributionId: AttributionId): Promise<boolean> {
         const response = await this.usageService.getCurrentBalance(attributionId);
         return response.usedCredits < response.usageLimit;
-    }
-
-    protected async isUnbilledTeam(attributionId: AttributionId): Promise<boolean> {
-        if (attributionId.kind !== "team") {
-            return false;
-        }
-        const billingStrategy = await this.usageService.getCurrentBillingStategy(attributionId);
-        return billingStrategy !== CostCenter_BillingStrategy.BILLING_STRATEGY_STRIPE;
     }
 
     async setUsageAttribution(user: User, usageAttributionId: string): Promise<void> {


### PR DESCRIPTION
## Description
This change removes the requirement for a team to have an active stripe subscription in order to see their balance and start workspaces. 

It only depends on whether they have credits available. This change allows to grant a spending limit and/or credits to teams that are still on the internal `other` strategy.

<img width="850" alt="Screenshot 2022-12-05 at 16 00 17" src="https://user-images.githubusercontent.com/372735/205669294-91751197-ec52-4399-bbb1-3ec19828eb94.png">

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #15137

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-payment
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
