### PR TITLE
preview delete cron use previewctl list stale

### DIFF
--- a/.werft/jobs/build/deploy-to-preview-environment.ts
+++ b/.werft/jobs/build/deploy-to-preview-environment.ts
@@ -72,8 +72,8 @@ export async function deployToPreviewEnvironment(werft: Werft, jobConfig: JobCon
     VM.waitForVMReadiness({ name: destname, timeoutSeconds: 60 * 10, slice: vmSlices.VM_READINESS });
     werft.done(vmSlices.VM_READINESS);
 
-    werft.log(vmSlices.KUBECONFIG, "Copying k3s kubeconfig");
-    VM.copyk3sKubeconfigShell({ name: destname, timeoutMS: 1000 * 60 * 6, slice: vmSlices.KUBECONFIG });
+    werft.log(vmSlices.KUBECONFIG, "Installing preview context");
+    await VM.installPreviewContext({ name: destname, slice: vmSlices.KUBECONFIG });
     werft.done(vmSlices.KUBECONFIG);
 
     werft.phase(phases.DEPLOY, "Deploying Gitpod and Observability Stack");

--- a/.werft/jobs/build/prepare.ts
+++ b/.werft/jobs/build/prepare.ts
@@ -24,7 +24,7 @@ export async function prepare(werft: Werft, config: JobConfig) {
         werft.log(prepareSlices.CONFIGURE_CORE_DEV, prepareSlices.CONFIGURE_CORE_DEV);
         activateCoreDevServiceAccount();
         configureDocker();
-        installPreviewCTL();
+        await installPreviewCTL();
         configureStaticClustersAccess();
         configureGlobalKubernetesContext();
         werft.done(prepareSlices.CONFIGURE_CORE_DEV);
@@ -69,8 +69,15 @@ function configureGlobalKubernetesContext() {
     }
 }
 
-function installPreviewCTL() {
-    exec(`leeway run dev/preview/previewctl:install`, {slice: "Install previewctl", dontCheckRc: false})
+export async function installPreviewCTL() {
+    try {
+        await execStream(`leeway build dev/preview/previewctl:install -Dversion=$(date +%F_T%H-%M-%S) --dont-test`, {
+            slice: "Install previewctl",
+            dontCheckRc: false
+        })
+    }catch (e) {
+        throw new Error("Failed to install previewctl.");
+    }
 }
 
 function configureStaticClustersAccess() {

--- a/.werft/platform-delete-preview-environment.ts
+++ b/.werft/platform-delete-preview-environment.ts
@@ -1,14 +1,7 @@
-import { Werft } from "./util/werft";
+import {Werft} from "./util/werft";
 import * as Tracing from "./observability/tracing";
-import { HarvesterPreviewEnvironment, PreviewEnvironment } from "./util/preview";
-import { SpanStatusCode } from "@opentelemetry/api";
-import { exec } from "./util/shell";
-import {
-    CORE_DEV_KUBECONFIG_PATH,
-    GCLOUD_SERVICE_ACCOUNT_PATH,
-    GLOBAL_KUBECONFIG_PATH,
-    HARVESTER_KUBECONFIG_PATH
-} from "./jobs/build/const";
+import {configureGlobalKubernetesContext, HarvesterPreviewEnvironment} from "./util/preview";
+import {SpanStatusCode} from "@opentelemetry/api";
 import * as fs from "fs";
 
 // Will be set once tracing has been initialized
@@ -23,9 +16,6 @@ const DRY_RUN = annotations["dry-run"] in annotations || false;
 
 const SLICES = {
     VALIDATE_CONFIGURATION: "Validating configuration",
-    CONFIGURE_K8S: "Configuring k8s access.",
-    CONFIGURE_ACCESS: "Configuring access to relevant resources",
-    INSTALL_HARVESTER_KUBECONFIG: "Install Harvester kubeconfig",
     DELETING_PREVIEW: `Deleting preview environment: ${previewName}`,
 };
 
@@ -59,56 +49,19 @@ async function deletePreviewEnvironment() {
     }
     werft.done(SLICES.VALIDATE_CONFIGURATION);
 
-    werft.phase("Configure access");
-    try {
-        exec(`gcloud auth activate-service-account --key-file "${GCLOUD_SERVICE_ACCOUNT_PATH}"`, {
-            slice: SLICES.CONFIGURE_ACCESS,
-        });
-        exec(
-            `KUBECONFIG=${CORE_DEV_KUBECONFIG_PATH} gcloud container clusters get-credentials core-dev --zone europe-west1-b --project gitpod-core-dev`,
-            { slice: SLICES.CONFIGURE_ACCESS },
-        );
-        werft.done(SLICES.CONFIGURE_ACCESS);
-    } catch (err) {
-        werft.fail(SLICES.CONFIGURE_ACCESS, err);
-    }
-
-    werft.phase("Install Harvester kubeconfig");
-    try {
-        exec(`cp /mnt/secrets/harvester-kubeconfig/harvester-kubeconfig.yml ${HARVESTER_KUBECONFIG_PATH}`, {
-            slice: SLICES.INSTALL_HARVESTER_KUBECONFIG,
-        });
-        werft.done(SLICES.INSTALL_HARVESTER_KUBECONFIG);
-    } catch (err) {
-        werft.fail(SLICES.INSTALL_HARVESTER_KUBECONFIG, err);
-    }
-
-    configureGlobalKubernetesContext()
+    await configureGlobalKubernetesContext(werft)
 
     const preview = new HarvesterPreviewEnvironment(werft, previewName);
     if (DRY_RUN) {
         werft.log(SLICES.DELETING_PREVIEW, `Would have deleted preview ${preview.name}`);
     } else {
-        removePreviewEnvironment(preview);
-    }
-}
-
-function configureGlobalKubernetesContext() {
-    exec(`leeway run dev/preview/previewctl:install`, {slice: "Install previewctl", dontCheckRc: false})
-    const rc = exec(`KUBECONFIG=${GLOBAL_KUBECONFIG_PATH} previewctl get-credentials --gcp-service-account=${GCLOUD_SERVICE_ACCOUNT_PATH}`, { slice: SLICES.CONFIGURE_K8S }).code;
-
-    if (rc != 0) {
-        throw new Error("Failed to configure global kubernetes context.");
-    }
-}
-
-async function removePreviewEnvironment(previewEnvironment: PreviewEnvironment) {
-    werft.log(SLICES.DELETING_PREVIEW, `Starting deletion of all resources related to ${previewEnvironment.name}`);
-    try {
-        // We're running these promises sequentially to make it easier to read the log output.
-        await previewEnvironment.delete();
-        werft.done(SLICES.DELETING_PREVIEW);
-    } catch (e) {
-        werft.failSlice(SLICES.DELETING_PREVIEW, e);
+        werft.log(SLICES.DELETING_PREVIEW, `Starting deletion of all resources related to ${preview.name}`);
+        try {
+            // We're running these promises sequentially to make it easier to read the log output.
+            await preview.delete();
+            werft.done(SLICES.DELETING_PREVIEW);
+        } catch (e) {
+            werft.failSlice(SLICES.DELETING_PREVIEW, e);
+        }
     }
 }

--- a/.werft/platform-delete-preview-environments-cron.ts
+++ b/.werft/platform-delete-preview-environments-cron.ts
@@ -1,13 +1,16 @@
 import {Werft} from "./util/werft";
 import * as Tracing from "./observability/tracing";
 import {SpanStatusCode} from "@opentelemetry/api";
-import {exec} from "./util/shell";
-import {CORE_DEV_KUBECONFIG_PATH, HARVESTER_KUBECONFIG_PATH} from "./jobs/build/const";
-import {HarvesterPreviewEnvironment, PreviewEnvironment} from "./util/preview";
+import {exec, execStream} from "./util/shell";
+import {configureGlobalKubernetesContext, HarvesterPreviewEnvironment, PreviewEnvironment} from "./util/preview";
+import {GCLOUD_SERVICE_ACCOUNT_PATH} from "./jobs/build/const";
+import * as fs from "fs";
 
+const context: any = JSON.parse(fs.readFileSync("context.json").toString());
+const annotations = context.Annotations || {};
 // for testing purposes
 // if set to 'true' it shows only previews that would be deleted
-const DRY_RUN = false;
+const DRY_RUN = annotations["dry-run"] in annotations || false;
 
 const SLICES = {
     CONFIGURE_ACCESS: "Configuring access to relevant resources",
@@ -43,171 +46,63 @@ Tracing.initialize()
         werft.endAllSpans();
     });
 
-async function getAllPreviewEnvironments(slice: string): Promise<PreviewEnvironment[]> {
-    const harvesterPreviewEnvironments = exec(
-        `kubectl --kubeconfig ${HARVESTER_KUBECONFIG_PATH} get ns -o=custom-columns=:metadata.name | grep preview-`,
-        { slice, silent: true, async: false },
+async function getStalePreviewEnvironments(slice: string): Promise<PreviewEnvironment[]> {
+    await execStream(
+        `GOOGLE_APPLICATION_CREDENTIALS=${GCLOUD_SERVICE_ACCOUNT_PATH} \
+                   previewctl list stale --private-key-path=/workspace/.ssh/id_rsa_harvester_vm > /tmp/stale`,
+        {slice: slice},
     )
+
+    const harvesterPreviewEnvironments = exec(`cat /tmp/stale`)
         .stdout.trim()
         .split("\n")
-        .map((namespace) => new HarvesterPreviewEnvironment(werft, namespace.trim()));
+        .map((name) => new HarvesterPreviewEnvironment(werft, "preview-" + name.trim()));
 
     werft.currentPhaseSpan.setAttributes({
-        "preview_environments.counts.harvester": harvesterPreviewEnvironments.length,
+        "preview_environments.counts.stale.harvester": harvesterPreviewEnvironments.length,
     });
 
-    // We never want to delete the environment for the main branch.
-    return harvesterPreviewEnvironments.filter((preview: PreviewEnvironment) => preview.name != "main");
+    return harvesterPreviewEnvironments;
 }
 
 async function deletePreviewEnvironments() {
-    werft.phase("Configure access");
-    try {
-        const GCLOUD_SERVICE_ACCOUNT_PATH = "/mnt/secrets/gcp-sa/service-account.json";
-        exec(`gcloud auth activate-service-account --key-file "${GCLOUD_SERVICE_ACCOUNT_PATH}"`, {
-            slice: SLICES.CONFIGURE_ACCESS,
-        });
-        exec(
-            `KUBECONFIG=${CORE_DEV_KUBECONFIG_PATH} gcloud container clusters get-credentials core-dev --zone europe-west1-b --project gitpod-core-dev`,
-            { slice: SLICES.CONFIGURE_ACCESS },
-        );
-        werft.done(SLICES.CONFIGURE_ACCESS);
-    } catch (err) {
-        werft.fail(SLICES.CONFIGURE_ACCESS, err);
-    }
+    await configureGlobalKubernetesContext(werft)
 
-    werft.phase("Install Harvester kubeconfig");
+    werft.phase("Fetching stale preview environments");
+    let stalePreviews: PreviewEnvironment[];
     try {
-        exec(`cp /mnt/secrets/harvester-kubeconfig/harvester-kubeconfig.yml ${HARVESTER_KUBECONFIG_PATH}`, {
-            slice: SLICES.INSTALL_HARVESTER_KUBECONFIG,
-        });
-        werft.done(SLICES.INSTALL_HARVESTER_KUBECONFIG);
-    } catch (err) {
-        werft.fail(SLICES.INSTALL_HARVESTER_KUBECONFIG, err);
-    }
-
-    werft.phase("Fetching preview environments");
-    let previews: PreviewEnvironment[];
-    try {
-        previews = await getAllPreviewEnvironments(SLICES.FETCHING_PREVIEW_ENVIRONMENTS);
-        previews.forEach((preview: PreviewEnvironment) =>
+        stalePreviews = await getStalePreviewEnvironments(SLICES.FETCHING_PREVIEW_ENVIRONMENTS);
+        stalePreviews.forEach((preview: PreviewEnvironment) =>
             werft.log(SLICES.FETCHING_PREVIEW_ENVIRONMENTS, `${preview.name} (${preview.namespace})`),
         );
-        werft.log(SLICES.FETCHING_PREVIEW_ENVIRONMENTS, `Found ${previews.length} preview environments`);
+        werft.log(SLICES.FETCHING_PREVIEW_ENVIRONMENTS, `Found ${stalePreviews.length} stale preview environments`);
         werft.done(SLICES.FETCHING_PREVIEW_ENVIRONMENTS);
     } catch (err) {
         werft.fail(SLICES.FETCHING_PREVIEW_ENVIRONMENTS, err);
     }
 
-    werft.phase("Fetching branches");
-    const branches = getAllBranches();
-    werft.log(SLICES.FETCHING_BRANCHES, `Found ${branches.length} branches`);
-
     werft.phase("Determining which preview environments are stale");
 
-    const previewsToDelete = await determineStalePreviewEnvironments({
-        branches: branches,
-        previews: previews,
-    });
-
-    if (previewsToDelete.length == 0) {
+    if (stalePreviews.length == 0) {
         werft.log(SLICES.DETERMINING_STALE_PREVIEW_ENVIRONMENTS, "No stale preview environments.");
         werft.done(SLICES.DETERMINING_STALE_PREVIEW_ENVIRONMENTS);
         return;
     } else {
         werft.log(
             SLICES.DETERMINING_STALE_PREVIEW_ENVIRONMENTS,
-            `Found ${previewsToDelete.length} stale preview environments`,
+            `Found ${stalePreviews.length} stale preview environments`,
         );
         werft.done(SLICES.DETERMINING_STALE_PREVIEW_ENVIRONMENTS);
     }
 
     try {
         const promises: Promise<any>[] = [];
-        previewsToDelete.forEach((preview) => promises.push(removePreviewEnvironment(preview)));
+        stalePreviews.forEach((preview) => promises.push(removePreviewEnvironment(preview)));
         await Promise.all(promises);
         werft.done(SLICES.DELETING_PREVIEW_ENVIRONMNETS);
     } catch (err) {
         werft.fail(SLICES.DELETING_PREVIEW_ENVIRONMNETS, err);
     }
-}
-
-/**
- * Determines if preview environemnts are stale and should be deleted
- *
- * As we don't have a mapping from preview environnment -> Git branch we have to
- * go about this in a bit of a backwards way.
- *
- * Based on the active git branches we compute a set of "expected" preview environments
- * and then use that to compare with the "live" preview environemnts to decide which
- * ones to keep
- */
-async function determineStalePreviewEnvironments(options: {
-    previews: PreviewEnvironment[];
-    branches: string[];
-}): Promise<PreviewEnvironment[]> {
-    const { branches, previews } = options;
-
-    // The set of namespaces that we would expect based on the open branches.
-    // This contains both the core-dev and the harvester namespaces as we only use this set for
-    // testing membership in situations where we don't care if the preview environment is based on
-    // core-dev or harvester.
-    const previewNamespaceBasedOnBranches = new Set(
-        branches.flatMap((branch) => [HarvesterPreviewEnvironment.expectedNamespaceFromBranch(branch)]),
-    );
-
-    // The set of namespaces where the underlying branch is considered stale
-    // This contains both core-dev and harvester namespaces, see above.
-    werft.log(SLICES.CHECKING_FOR_STALE_BRANCHES, `Checking commit activity on ${branches.length} branches`);
-    const previewNamespaceBasedOnStaleBranches = new Set(
-        branches
-            .filter((branch) => {
-                const lastCommit = exec(`git log origin/${branch} --since=$(date +%Y-%m-%d -d "2 days ago")`, {
-                    silent: true,
-                });
-                const hasRecentCommits = lastCommit.length > 1;
-                werft.log(SLICES.CHECKING_FOR_STALE_BRANCHES, `${branch} has-recent-commits=${hasRecentCommits}`);
-                return !hasRecentCommits;
-            })
-            .flatMap((branch: string) => [HarvesterPreviewEnvironment.expectedNamespaceFromBranch(branch)]),
-    );
-    werft.done(SLICES.CHECKING_FOR_STALE_BRANCHES);
-
-    werft.log(SLICES.CHECKING_FOR_DB_ACTIVITY, `Checking ${previews.length} preview environments for DB activity`);
-    const previewNamespacesWithNoDBActivity = new Set(
-        previews
-            .filter((preview) => !preview.isActive(SLICES.CHECKING_FOR_DB_ACTIVITY))
-            .map((preview) => preview.namespace),
-    );
-
-    werft.done(SLICES.CHECKING_FOR_DB_ACTIVITY);
-
-    return previews.filter((preview: PreviewEnvironment) => {
-        if (!previewNamespaceBasedOnBranches.has(preview.namespace)) {
-            werft.log(
-                SLICES.DETERMINING_STALE_PREVIEW_ENVIRONMENTS,
-                `Considering ${preview.name} (${preview.namespace}) stale due to missing branch`,
-            );
-            return true;
-        }
-
-        if (
-            previewNamespaceBasedOnStaleBranches.has(preview.namespace) &&
-            previewNamespacesWithNoDBActivity.has(preview.namespace)
-        ) {
-            werft.log(
-                SLICES.DETERMINING_STALE_PREVIEW_ENVIRONMENTS,
-                `Considering ${preview.name} (${preview.namespace}) stale due to no recent commit and DB activity`,
-            );
-            return true;
-        }
-
-        werft.log(
-            SLICES.DETERMINING_STALE_PREVIEW_ENVIRONMENTS,
-            `Considering ${preview.name} (${preview.namespace}) active`,
-        );
-        return false;
-    });
 }
 
 async function removePreviewEnvironment(previewEnvironment: PreviewEnvironment) {
@@ -224,12 +119,4 @@ async function removePreviewEnvironment(previewEnvironment: PreviewEnvironment) 
     } catch (e) {
         werft.failSlice(sliceID, e);
     }
-}
-
-function getAllBranches(): string[] {
-    return exec(
-        `git branch -r | grep -v '\\->' | sed "s,\\x1B\\[[0-9;]*[a-zA-Z],,g" | while read remote; do echo "\${remote#origin/}"; done`,
-    )
-        .stdout.trim()
-        .split("\n");
 }

--- a/.werft/platform-delete-preview-environments-cron.yaml
+++ b/.werft/platform-delete-preview-environments-cron.yaml
@@ -83,6 +83,7 @@ pod:
           git config --global user.email roboquat@gitpod.io
 
           (cd .werft && yarn install && mv node_modules ..) | werft log slice prep
+          printf '{{ toJson . }}' > context.json
 
           npx ts-node .werft/platform-delete-preview-environments-cron.ts
 plugins:

--- a/.werft/util/preview.ts
+++ b/.werft/util/preview.ts
@@ -1,8 +1,15 @@
-import { createHash } from "crypto";
-import { PREVIEW_K3S_KUBECONFIG_PATH } from "../jobs/build/const";
+import {createHash} from "crypto";
 import * as VM from "../vm/vm";
-import { exec } from "./shell";
-import { Werft } from "./werft";
+import {exec} from "./shell";
+import {Werft} from "./werft";
+import {installPreviewCTL} from "../jobs/build/prepare";
+import {GCLOUD_SERVICE_ACCOUNT_PATH, GLOBAL_KUBECONFIG_PATH} from "../jobs/build/const";
+
+const SLICES = {
+    CONFIGURE_GCP_ACCESS: "Activating service account",
+    CONFIGURE_K8S_ACCESS: "Installing dev/harvester contexts account",
+    INSTALL_PREVIEWCTL: "Install previewctl",
+};
 
 /**
  * Based on the current branch name this will compute the name of the associated
@@ -50,147 +57,39 @@ export class HarvesterPreviewEnvironment {
 
     werft: Werft;
 
-    // The namespace in the k3s cluster where all resources are (default)
-    k3sNamespace: string = "default";
-
     constructor(werft: Werft, namespace: string) {
         this.werft = werft;
         this.namespace = namespace;
         this.name = namespace;
-        if (this.namespace.startsWith(HarvesterPreviewEnvironment.namespacePrefix)){
+        if (this.namespace.startsWith(HarvesterPreviewEnvironment.namespacePrefix)) {
             this.name = namespace.slice(HarvesterPreviewEnvironment.namespacePrefix.length);
         }
     }
 
     async delete(): Promise<void> {
-        VM.deleteVM({ name: this.name });
+        await VM.destroyPreview({name: this.name});
+    }
+}
+
+export async function configureGlobalKubernetesContext(werft: Werft) {
+    werft.phase("Configure access");
+    try {
+        exec(`gcloud auth activate-service-account --key-file "${GCLOUD_SERVICE_ACCOUNT_PATH}"`, {
+            slice: SLICES.CONFIGURE_GCP_ACCESS,
+        });
+        werft.done(SLICES.CONFIGURE_GCP_ACCESS);
+    } catch (err) {
+        werft.fail(SLICES.CONFIGURE_GCP_ACCESS, err);
     }
 
-    /**
-     * Checks whether a preview environment is active based on the db activity.
-     *
-     * It errs on the side of caution, so in case of connection issues etc. it will consider the
-     * preview environment active.
-     */
-    isActive(sliceID: string): boolean {
-        try {
-            try {
-                VM.get({ name: this.name });
-            } catch (e) {
-                if (e instanceof VM.NotFoundError) {
-                    this.werft.log(
-                        sliceID,
-                        `${this.name} - is-active=false - The VM doesn't exist, deleting the environment`,
-                    );
-                    return false;
-                }
-                this.werft.log(
-                    sliceID,
-                    `${this.name} - is-active=true - Unexpected error trying to get the VM. Marking env as active: ${e.message}`,
-                );
-                return true;
-            }
+    await installPreviewCTL()
 
-            VM.copyk3sKubeconfigShell({ name: this.name, timeoutMS: 1000 * 60 * 3, slice: sliceID });
-            const kubectclCmd = `KUBECONFIG=${PREVIEW_K3S_KUBECONFIG_PATH} kubectl --insecure-skip-tls-verify`;
+    const rc = exec(`KUBECONFIG=${GLOBAL_KUBECONFIG_PATH} previewctl get-credentials --gcp-service-account=${GCLOUD_SERVICE_ACCOUNT_PATH}`, {
+        slice: SLICES.CONFIGURE_K8S_ACCESS
+    }).code;
 
-            this.werft.log(sliceID, `${this.name} (${this.k3sNamespace}) - Checking status of the MySQL pod`);
-            const statusDB = exec(
-                `${kubectclCmd} get pods mysql-0 -n ${this.k3sNamespace} -o jsonpath='{.status.phase}'`,
-                { slice: sliceID, dontCheckRc: true },
-            );
-            const statusDbContainer = exec(
-                `${kubectclCmd} get pods mysql-0 -n ${this.k3sNamespace} -o jsonpath='{.status.containerStatuses.*.ready}'`,
-                { slice: sliceID, dontCheckRc: true },
-            );
-
-            if (statusDB.code != 0 || statusDB != "Running" || statusDbContainer == "false") {
-                this.werft.log(
-                    sliceID,
-                    `${this.name} (${this.k3sNamespace}) - is-active=false - The database is not reachable, assuming env is not active`,
-                );
-                VM.stopKubectlPortForwards();
-                exec(`rm ${PREVIEW_K3S_KUBECONFIG_PATH}`, { silent: true, slice: sliceID });
-                return false;
-            }
-
-            const dbPassword = exec(
-                `${kubectclCmd} get secret db-password -n ${this.k3sNamespace} -o jsonpath='{.data.mysql-root-password}' | base64 -d`,
-                { silent: true },
-            ).stdout.trim();
-
-            // MySQL runs in the preview env cluster that is not reachable form the job's pod, so we have to port forward
-            exec(`${kubectclCmd} -n ${this.k3sNamespace} port-forward svc/mysql 33061:3306`, {
-                async: true,
-                silent: true,
-                slice: sliceID,
-                dontCheckRc: true,
-            });
-            exec("sleep 5", { silent: true, slice: sliceID });
-
-            // Using MYSQL_PWD instead of a flag for the pwd suppresses "[Warning] Using a password on the command line interface can be insecure."
-            const dbConn = `MYSQL_PWD=${dbPassword} mysql --host=127.0.0.1 --port=33061 --user=root --database=gitpod -s -N`;
-            const active = this.isDbActive(dbConn, sliceID);
-
-            // clean after ourselves, as we'll be running this for quite a few environments
-            VM.stopKubectlPortForwards();
-            exec(`rm ${PREVIEW_K3S_KUBECONFIG_PATH}`, { silent: true, slice: sliceID });
-
-            return active;
-        } catch (err) {
-            // cleanup in case of an error
-            VM.stopKubectlPortForwards();
-            exec(`rm ${PREVIEW_K3S_KUBECONFIG_PATH}`, { silent: true, slice: sliceID });
-            this.werft.log(
-                sliceID,
-                `${this.name} (${this.k3sNamespace}) - is-active=true - Unable to check DB activity, assuming env is active`,
-            );
-            return true;
-        }
-    }
-
-    /**
-     * Determines if the db of a preview environment is active
-     * by looking if there were relevant entries in the workspace and user tables in the last 48h
-     *
-     */
-    private isDbActive(dbConn: string, sliceID: string): boolean {
-        const timeout = 48;
-        let isActive = false;
-
-        const queries = {
-            d_b_workspace_instance: `SELECT TIMESTAMPDIFF(HOUR, creationTime, NOW()) FROM d_b_workspace_instance WHERE creationTime > DATE_SUB(NOW(), INTERVAL '${timeout}' HOUR) ORDER BY creationTime DESC LIMIT 1`,
-            "d_b_user-created": `SELECT TIMESTAMPDIFF(HOUR, creationDate, NOW()) FROM d_b_user WHERE creationDate > DATE_SUB(NOW(), INTERVAL '${timeout}' HOUR) ORDER BY creationDate DESC LIMIT 1`,
-            "d_b_user-modified": `SELECT TIMESTAMPDIFF(HOUR, _lastModified, NOW()) FROM d_b_user WHERE _lastModified > DATE_SUB(NOW(), INTERVAL '${timeout}' HOUR) ORDER BY _lastModified DESC LIMIT 1`,
-            d_b_workspace_instance_user: `SELECT TIMESTAMPDIFF(HOUR, lastSeen, NOW()) FROM d_b_workspace_instance_user WHERE lastSeen > DATE_SUB(NOW(), INTERVAL '${timeout}' HOUR) ORDER BY lastSeen DESC LIMIT 1`,
-        };
-
-        const result = {};
-        // let logLine = `Last Activity (hours ago):`
-        for (const [key, query] of Object.entries(queries)) {
-            // explicitly set to null, so we get an output in the logs for those queries
-            result[key] = null;
-            const queryResult = exec(`${dbConn} --execute="${query}"`, { silent: true, slice: sliceID });
-            if (queryResult.length > 0) {
-                result[key] = queryResult.stdout.trim();
-                isActive = true;
-            }
-        }
-
-        const logLines = Object.entries(result).map((kv) => `${kv.join(":")}`);
-        const logLine = `Last Activity (hours ago): ${logLines.join(",")}`;
-
-        this.werft.log(sliceID, `${this.name} (${this.namespace}) - is-active=${isActive} ${logLine}`);
-
-        return isActive;
-    }
-
-    /**
-     * Given a branch name it will return the expected namespace of the preview environment
-     */
-    static expectedNamespaceFromBranch(branch: string): string {
-        const previewName = previewNameFromBranchName(branch);
-        return `${HarvesterPreviewEnvironment.namespacePrefix}${previewName}`;
+    if (rc != 0) {
+        throw new Error("Failed to configure global kubernetes context.");
     }
 }
 

--- a/.werft/vm/vm.ts
+++ b/.werft/vm/vm.ts
@@ -1,27 +1,18 @@
-import {
-    GCLOUD_SERVICE_ACCOUNT_PATH,
-    GLOBAL_KUBECONFIG_PATH,
-    HARVESTER_KUBECONFIG_PATH,
-    PREVIEW_K3S_KUBECONFIG_PATH
-} from "../jobs/build/const";
+import {GCLOUD_SERVICE_ACCOUNT_PATH, HARVESTER_KUBECONFIG_PATH, PREVIEW_K3S_KUBECONFIG_PATH} from "../jobs/build/const";
 import {exec, execStream} from "../util/shell";
-import { getGlobalWerftInstance } from "../util/werft";
-
-import * as shell from "shelljs";
+import {getGlobalWerftInstance} from "../util/werft";
 
 /**
  * Remove all VM resources - Namespace+VM+Proxy svc on Harvester, LB+SVC on DEV
  */
-export async function deleteVM(options: { name: string }) {
+export async function destroyPreview(options: { name: string }) {
     const werft = getGlobalWerftInstance();
 
     try {
-        await execStream(`DESTROY=true \
+        await execStream(`TF_VAR_preview_name=${options.name} \
                                     GOOGLE_APPLICATION_CREDENTIALS=${GCLOUD_SERVICE_ACCOUNT_PATH} \
                                     GOOGLE_BACKEND_CREDENTIALS=${GCLOUD_SERVICE_ACCOUNT_PATH} \
-                                    TF_VAR_kubeconfig_path=${GLOBAL_KUBECONFIG_PATH} \
-                                    TF_VAR_preview_name=${options.name} \
-                                    ./dev/preview/workflow/preview/deploy-harvester.sh`,
+                                    leeway run dev/preview:delete-preview`,
             {slice: "Deleting VM."})
     } catch (err) {
         werft.currentPhaseSpan.setAttribute("preview.deleted_vm", false);
@@ -45,42 +36,6 @@ export function vmExists(options: { name: string }) {
     return status.code == 0;
 }
 
-export class NotFoundError extends Error {
-    constructor(message: string) {
-        super(message);
-        this.name = "NotFoundError";
-    }
-}
-
-export class KubectlError extends Error {
-    constructor(message: string) {
-        super(message);
-        this.name = "KubectlError";
-    }
-}
-
-export function get(options: { name: string }): shell.ShellString {
-    const namespace = `preview-${options.name}`;
-    const vmErrNotFound = `Error from server (NotFound): virtualmachineinstances.kubevirt.io "${this.name}" not found`;
-    const namespaceErrNotFound = `Error from server (NotFound): namespaces "${namespace}" not found`;
-    const vm = exec(`kubectl --kubeconfig ${HARVESTER_KUBECONFIG_PATH} -n ${namespace} get vmi ${options.name}`, {
-        dontCheckRc: true,
-        silent: true,
-    });
-
-    if (vm.code != 0) {
-        switch (vm.stderr) {
-            case vmErrNotFound:
-            case namespaceErrNotFound:
-                throw new NotFoundError("The VM or Namespace doesn't exist");
-            default:
-                throw new KubectlError(vm.stderr);
-        }
-    }
-
-    return vm;
-}
-
 /**
  * Wait until the VM Instance reaches the Running status.
  * If the VM Instance doesn't reach Running before the timeoutMS it will throw an Error.
@@ -92,7 +47,7 @@ export function waitForVMReadiness(options: { name: string; timeoutSeconds: numb
     const startTime = Date.now();
     const ready = exec(
         `kubectl --kubeconfig ${HARVESTER_KUBECONFIG_PATH} -n ${namespace} wait --for=condition=ready --timeout=${options.timeoutSeconds}s pod -l kubevirt.io=virt-launcher -l harvesterhci.io/vmName=${options.name}`,
-        { dontCheckRc: true, silent: true },
+        {dontCheckRc: true, silent: true},
     );
 
     if (ready.code == 0) {
@@ -108,34 +63,26 @@ export function waitForVMReadiness(options: { name: string; timeoutSeconds: numb
 }
 
 /**
- * Copies the k3s kubeconfig out of the VM and places it at `path`
+ * Installs the preview environment's context
  * If it doesn't manage to do so before the timeout it will throw an Error
  */
-export function copyk3sKubeconfigShell(options: { name: string; timeoutMS: number; slice: string }) {
-    const werft = getGlobalWerftInstance();
-    const startTime = Date.now();
-    while (true) {
-        const status = exec(
-            `VM_NAME=${options.name} \
-                      K3S_KUBECONFIG_PATH=${PREVIEW_K3S_KUBECONFIG_PATH} \
-                      GCLOUD_SERVICE_ACCOUNT_PATH=${GCLOUD_SERVICE_ACCOUNT_PATH} \
-                      ./dev/preview/install-k3s-kubeconfig.sh`,
-            { dontCheckRc: true, slice: options.slice },
+export async function installPreviewContext(options: { name: string; slice: string }) {
+    try {
+        await execStream(
+            `previewctl install-context --branch=${options.name} --timeout=10m`,
+            {slice: options.slice},
         );
 
-        if (status.code == 0) {
-            return;
-        }
+        exec(
+            `kubectl --context=${options.name} config view --minify --flatten > ${PREVIEW_K3S_KUBECONFIG_PATH}`,
+            {dontCheckRc: true, slice: options.slice},
+        )
 
-        const elapsedTimeMs = Date.now() - startTime;
-        if (elapsedTimeMs > options.timeoutMS) {
-            throw new Error(
-                `Wasn't able to copy out the kubeconfig before the timeout. Exit code ${status.code}. Stderr: ${status.stderr}. Stdout: ${status.stdout}`,
-            );
-        }
-
-        werft.log(options.slice, `Wasn't able to copy out kubeconfig yet. Sleeping 10 seconds`);
-        exec("sleep 10", { silent: true, slice: options.slice });
+        return;
+    } catch (e) {
+        throw new Error(
+            `Wasn't able to copy out the kubeconfig before the timeout. `,
+        );
     }
 }
 

--- a/dev/preview/previewctl/BUILD.yaml
+++ b/dev/preview/previewctl/BUILD.yaml
@@ -11,6 +11,17 @@ packages:
       - components/common-go:lib
     config:
       packaging: app
+  - name: "install"
+    type: "generic"
+    argdeps:
+      - version
+    deps:
+      - :cli
+    config:
+      commands:
+        - [ "sh", "-c", "mkdir -p /workspace/bin && sudo mv dev-preview-previewctl--cli/previewctl /workspace/bin/previewctl" ]
+        - [ "sh", "-c", "if ! $(grep 'previewctl completion bash' ~/.bashrc > /dev/null); then previewctl completion bash >> ~/.bashrc; fi" ]
+
 scripts:
   - name: install
     description: Build and install previewctl into the current environment

--- a/dev/preview/previewctl/cmd/workspaces.go
+++ b/dev/preview/previewctl/cmd/workspaces.go
@@ -17,7 +17,9 @@ import (
 )
 
 type listWorkspaceOpts struct {
-	TFDir   string
+	TFDir             string
+	sshPrivateKeyPath string
+
 	logger  *logrus.Logger
 	timeout time.Duration
 }

--- a/dev/preview/previewctl/pkg/preview/status.go
+++ b/dev/preview/previewctl/pkg/preview/status.go
@@ -38,10 +38,10 @@ func (c *Config) GetStatus(ctx context.Context) (Status, error) {
 		"preview": c.name,
 	})
 
-	// If the VM got created in the last 20 mins, always assume it's active
+	// If the VM got created in the last 120 mins, always assume it's active
 	// clock skew can go to hell
 	c.ensureVMICreationTime()
-	if c.vmiCreationTime.After(time.Now().Add(-20 * time.Minute)) {
+	if c.vmiCreationTime.After(time.Now().Add(-120 * time.Minute)) {
 		logEntry.WithFields(log.Fields{
 			"created": c.vmiCreationTime,
 		}).Debug("VM created in the past 20 mins, assuming active")

--- a/dev/preview/workflow/preview/configure-workspace.sh
+++ b/dev/preview/workflow/preview/configure-workspace.sh
@@ -13,8 +13,8 @@ if { [[ "${auth}" != "(unset)" ]] || [ -n "${auth:-}" ]; } && [ -f "${PREVIEW_EN
   exit 0
 fi
 
-if [[ -z "${PREVIEW_ENV_DEV_SA_KEY:-}" ]]; then
-  log_warn "PREVIEW_ENV_DEV_SA_KEY is not set. Skipping workspace setup."
+if [[ -z "${PREVIEW_ENV_DEV_SA_KEY:-}" ]] || [[ -z "${PREVIEW_ENV_DEV_SA_KEY_PATH:-}" ]]; then
+  log_warn "Neither PREVIEW_ENV_DEV_SA_KEY, nor PREVIEW_ENV_DEV_SA_KEY_PATH is set. Skipping workspace setup."
   exit 0
 fi
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Part 3 in https://github.com/gitpod-io/ops/issues/5226

Updates the werft jobs to use `previewctl list stale`

https://werft.gitpod-dev.com/job/gitpod-custom-aa-prev-clean-up-refactor-werft.5

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/ops/issues/5226

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
