### PR TITLE
Increase scrape interval to decrease datapoints per minute

### DIFF
--- a/operations/observability/mixins/self-hosted/rules/argocd/servicemonitor.yaml
+++ b/operations/observability/mixins/self-hosted/rules/argocd/servicemonitor.yaml
@@ -15,6 +15,7 @@ spec:
       app.kubernetes.io/name: argocd-metrics
   endpoints:
   - port: metrics
+    interval: 60s
     relabelings:
       - action: drop
         regex: (argocd_git_request_duration_seconds_count|argocd_git_request_duration_seconds_sum|argocd_redis_request_duration_seconds_bucket|argocd_redis_request_duration_bucket|argocd_repo_pending_request_total|argocd_cluster_info|argocd_cluster_cache_age_seconds|argocd_cluster_connection_status|argocd_app_reconcile_sum|argocd_redis_request_duration_seconds_count|argocd_kubectl_exec_total|argocd_redis_request_duration_seconds_sum|argocd_redis_request_duration_count|argocd_redis_request_duration_sum|)
@@ -38,6 +39,7 @@ spec:
       app.kubernetes.io/name: argocd-server-metrics
   endpoints:
   - port: metrics
+    interval: 60s
     relabelings:
       - action: drop
         regex: (argocd_git_request_duration_seconds_count|argocd_git_request_duration_seconds_sum|argocd_redis_request_duration_seconds_bucket|argocd_redis_request_duration_bucket|argocd_repo_pending_request_total|argocd_cluster_info|argocd_cluster_cache_age_seconds|argocd_cluster_connection_status|argocd_app_reconcile_sum|argocd_redis_request_duration_seconds_count|argocd_kubectl_exec_total|argocd_redis_request_duration_seconds_sum|argocd_redis_request_duration_count|argocd_redis_request_duration_sum|)
@@ -61,6 +63,7 @@ spec:
       app.kubernetes.io/name: argocd-repo-server
   endpoints:
   - port: metrics
+    interval: 60s
     relabelings:
       - action: drop
         regex: (argocd_git_request_duration_seconds_count|argocd_git_request_duration_seconds_sum|argocd_redis_request_duration_seconds_bucket|argocd_redis_request_duration_bucket|argocd_repo_pending_request_total|argocd_cluster_info|argocd_cluster_cache_age_seconds|argocd_cluster_connection_status|argocd_app_reconcile_sum|argocd_redis_request_duration_seconds_count|argocd_kubectl_exec_total|argocd_redis_request_duration_seconds_sum|argocd_redis_request_duration_count|argocd_redis_request_duration_sum|)
@@ -84,6 +87,7 @@ spec:
       app.kubernetes.io/name: argocd-applicationset-controller
   endpoints:
   - port: metrics
+    interval: 60s
     relabelings:
       - action: drop
         regex: (argocd_git_request_duration_seconds_count|argocd_git_request_duration_seconds_sum|argocd_redis_request_duration_seconds_bucket|argocd_redis_request_duration_bucket|argocd_repo_pending_request_total|argocd_cluster_info|argocd_cluster_cache_age_seconds|argocd_cluster_connection_status|argocd_app_reconcile_sum|argocd_redis_request_duration_seconds_count|argocd_kubectl_exec_total|argocd_redis_request_duration_seconds_sum|argocd_redis_request_duration_count|argocd_redis_request_duration_sum|)

--- a/operations/observability/mixins/self-hosted/rules/pyrra/servicemonitor.yaml
+++ b/operations/observability/mixins/self-hosted/rules/pyrra/servicemonitor.yaml
@@ -13,3 +13,4 @@ spec:
       port: metrics
   endpoints:
   - port: metrics
+    interval: 60s


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Following [the RFC](https://www.notion.so/gitpod/Monitoring-central-Migration-to-Grafana-Cloud-6c29eb19a8c445aa84d680ba1c68bc66#febbbbc524a14614b7cd9c45e1af3bdc), we can decrease metric costs by reducing the frequency that we scrape metrics endpoints.

This PR updates all our ServiceMonitors that are imported by different monitoring-satellites to 60s.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
