### PR TITLE
[server] IAM: Report missing session info as client error

### DIFF
--- a/components/server/src/auth/authenticator.ts
+++ b/components/server/src/auth/authenticator.ts
@@ -114,7 +114,8 @@ export class Authenticator {
             return;
         }
         if (!req.session) {
-            increaseLoginCounter("failed", authProvider.info.host);
+            // The session is missing entirely: count as client error
+            increaseLoginCounter("failed_client", authProvider.info.host);
             log.info({}, `No session.`, { "login-flow": true });
             res.redirect(this.getSorryUrl(`No session found. Please refresh the browser.`));
             return;

--- a/components/server/src/auth/generic-auth-provider.ts
+++ b/components/server/src/auth/generic-auth-provider.ts
@@ -336,7 +336,8 @@ export class GenericAuthProvider implements AuthProvider {
 
         // assert additional infomation is attached to current session
         if (!authFlow) {
-            increaseLoginCounter("failed", this.host);
+            // The auth flow state info is missing in the session: count as client error
+            increaseLoginCounter("failed_client", this.host);
 
             log.error(cxt, `(${strategyName}) No session found during auth callback.`, { clientInfo });
             response.redirect(this.getSorryUrl(`Please allow Cookies in your browser and try to log in again.`));

--- a/components/server/src/prometheus-metrics.ts
+++ b/components/server/src/prometheus-metrics.ts
@@ -30,7 +30,15 @@ const loginCounter = new prometheusClient.Counter({
     labelNames: ["status", "auth_host"],
 });
 
-export function increaseLoginCounter(status: string, auth_host: string) {
+type LoginCounterStatus =
+    // The login attempt failed due to a system error (picked up by alerts)
+    | "failed"
+    // The login attempt succeeded
+    | "succeeded"
+    // The login attempt failed, because the client failed to provide complete session information, for instance.
+    | "failed_client";
+
+export function increaseLoginCounter(status: LoginCounterStatus, auth_host: string) {
     loginCounter.inc({
         status,
         auth_host,


### PR DESCRIPTION
## Description
The intention here is to make our reporting and alerting more precise, as mentioned in #15175 .

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #15175

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
