### PR TITLE
dev/preview:configure-workspace fix

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -46,7 +46,7 @@ tasks:
   # with preview environments.
   - name: Preview environment configuration
     init: leeway run dev/preview/previewctl:install
-    command: leeway run dev/preview:configure-workspace
+    command: INSTALL_CONTEXT=true leeway run dev/preview:configure-workspace
   - name: Installer dependencies
     init: |
       (cd install/installer && make deps)

--- a/dev/preview/workflow/preview/configure-workspace.sh
+++ b/dev/preview/workflow/preview/configure-workspace.sh
@@ -8,7 +8,7 @@ SCRIPT_PATH=$(realpath "$(dirname "$0")")
 source "$(realpath "${SCRIPT_PATH}/../lib/common.sh")"
 
 auth=$(gcloud config get-value account)
-if [[ "${auth}" != "(unset)" ]] || [ -n "${auth:-}" ]; then
+if { [[ "${auth}" != "(unset)" ]] || [ -n "${auth:-}" ]; } && [ -f "${PREVIEW_ENV_DEV_SA_KEY_PATH}" ]; then
   log_info "Access already configured"
   exit 0
 fi
@@ -24,5 +24,7 @@ gcloud auth activate-service-account --key-file "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
 log_info "Configuring access to kubernetes clusters"
 previewctl get-credentials --gcp-service-account "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
 
-log_info "Starting watch-loop to configure access to your preview environment"
-previewctl install-context --gcp-service-account "${PREVIEW_ENV_DEV_SA_KEY_PATH}" --watch
+if [[ -n "${INSTALL_CONTEXT:-}" ]]; then
+  log_info "Starting watch-loop to configure access to your preview environment"
+  previewctl install-context --gcp-service-account "${PREVIEW_ENV_DEV_SA_KEY_PATH}" --watch
+fi


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Fix a check in configure-workspace and add a flag for signalling installation of the context.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
