### PR TITLE
[dashboard] Adjust Chargebee plan end-of-life notification text

### DIFF
--- a/components/dashboard/src/settings/Plans.tsx
+++ b/components/dashboard/src/settings/Plans.tsx
@@ -636,14 +636,16 @@ export default function () {
             <PageWithSettingsSubMenu title="Plans" subtitle="Manage account usage and billing.">
                 {isUsageBasedBillingEnabled && (
                     <Alert type="message" className="mb-4">
-                        Your account has been enabled for usage-based billing. Discover faster workspace classes and
-                        only pay for what you actually use.{" "}
-                        <a className="gp-link" href="https://www.gitpod.io/docs/configure/billing/usage-based-billing">
-                            Learn more
+                        To access{" "}
+                        <a className="gp-link" href="https://www.gitpod.io/docs/configure/workspaces/workspace-classes">
+                            large workspaces
+                        </a>{" "}
+                        and{" "}
+                        <a className="gp-link" href="https://www.gitpod.io/docs/configure/billing/pay-as-you-go">
+                            pay-as-you-go
                         </a>
-                        <br />
-                        <br />
-                        The old monthly plans are deprecated and will be cancelled by End of March 2023.
+                        , first cancel your existing plan. Existing plans will keep working until the end of March,
+                        2023.
                     </Alert>
                 )}
                 <div className="w-full text-center">

--- a/components/dashboard/src/settings/Teams.tsx
+++ b/components/dashboard/src/settings/Teams.tsx
@@ -456,14 +456,15 @@ function AllTeams() {
         <div>
             {isUsageBasedBillingEnabled && (
                 <Alert type="message" className="mb-4">
-                    Your account has been enabled for usage-based billing. Discover faster workspace classes and only
-                    pay for what you actually use.{" "}
-                    <a className="gp-link" href="https://www.gitpod.io/docs/configure/billing/usage-based-billing">
-                        Learn more
+                    To access{" "}
+                    <a className="gp-link" href="https://www.gitpod.io/docs/configure/workspaces/workspace-classes">
+                        large workspaces
+                    </a>{" "}
+                    and{" "}
+                    <a className="gp-link" href="https://www.gitpod.io/docs/configure/billing/pay-as-you-go">
+                        pay-as-you-go
                     </a>
-                    <br />
-                    <br />
-                    The old monthly plans are deprecated and will be cancelled by End of March 2023.
+                    , first cancel your existing plan. Existing plans will keep working until the end of March, 2023.
                 </Alert>
             )}
             <div className="flex flex-row">


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Adjust Chargebee plan end-of-life notification text. Follow-up to https://github.com/gitpod-io/gitpod/pull/15092.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/15173

## How to test
<!-- Provide steps to test this PR -->

1. Create a team called "Gitpod [Something]" to enable UBP
2. Open the `/plans` and `/teams` pages to view the notification

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
