### PR TITLE
allow to layout multiple JB product layers in the same image

### DIFF
--- a/.github/workflows/jetbrains-auto-update-template.yml
+++ b/.github/workflows/jetbrains-auto-update-template.yml
@@ -41,32 +41,25 @@ jobs:
         uses: google-github-actions/setup-gcloud@v0
         with:
           project_id: ${{ secrets.projectId }}
-      - name: Get Platform Version from JetBrains EAP Backend Plugin
-        id: platform-version
-        run: |
-          PLATFORM_VERSION=$(cat ./components/ide/jetbrains/backend-plugin/gradle-latest.properties | grep platformVersion= | sed 's/platformVersion=//' | sed 's/-EAP-CANDIDATE-SNAPSHOT//')
-          echo "::set-output name=result::$PLATFORM_VERSION"
-          echo $PLATFORM_VERSION
       - name: Find IDE version to download
         id: ide-version
         run: |
-          curl -sL "https://data.services.jetbrains.com/products/releases?code=${{ inputs.productCode }}&type=eap,rc,release&platform=linux" > releases.json
-          IDE_VERSION=$(cat releases.json | jq -r -c 'first(.${{ inputs.productCode }}[] | select(.build | contains("${{ steps.platform-version.outputs.result }}")) | .build)')
-          IDE_BACKEND_VERSION=$(cat releases.json | jq -r '.${{ inputs.productCode }}[0].version')
-          rm releases.json
-          echo "::set-output name=result::$IDE_VERSION"
-          echo "::set-output name=ideBackendVersion::$IDE_BACKEND_VERSION"
-          echo $IDE_VERSION
-          echo $IDE_BACKEND_VERSION
+          IDE_VERSIONS_JSON=$(bash ./components/ide/jetbrains/image/resolve-latest-ide-version.sh ${{ inputs.productCode }})
+          IDE_BUILD_VERSION=$(echo "$IDE_VERSIONS_JSON" | jq -r .IDE_BUILD_VERSION)
+          IDE_VERSION=$(echo "$IDE_VERSIONS_JSON" | jq -r .IDE_VERSION)
+          echo "IDE_BUILD_VERSION: $IDE_BUILD_VERSION"
+          echo "IDE_VERSION: $IDE_VERSION"
+          echo "::set-output name=ideBuildVersion::$IDE_BUILD_VERSION"
+          echo "::set-output name=ideVersion::$IDE_VERSION"
       - name: Leeway build
-        if: ${{ steps.ide-version.outputs.result }}
+        if: ${{ steps.ide-version.outputs.ideBuildVersion }}
         env:
           LEEWAY_MAX_PROVENANCE_BUNDLE_SIZE: "8388608"
         run: |
           gcloud auth configure-docker --quiet
           export LEEWAY_WORKSPACE_ROOT=$(pwd)
           cd components/ide/jetbrains/image
-          leeway build -Dversion=latest -DimageRepoBase=eu.gcr.io/gitpod-core-dev/build -DbuildNumber=${{ steps.ide-version.outputs.result }} .:${{ inputs.productId }}-latest -DjbBackendVersion=${{ steps.ide-version.outputs.ideBackendVersion }}
+          leeway build -Dversion=latest -DimageRepoBase=eu.gcr.io/gitpod-core-dev/build -DbuildNumber=${{ steps.ide-version.outputs.ideBuildVersion }} .:${{ inputs.productId }}-latest -DjbBackendVersion=${{ steps.ide-version.outputs.ideVersion }}
       - name: Get previous job's status
         id: lastrun
         uses: filiptronicek/get-last-job-status@main

--- a/components/ide/jetbrains/backend-plugin/leeway.Dockerfile
+++ b/components/ide/jetbrains/backend-plugin/leeway.Dockerfile
@@ -11,4 +11,7 @@ FROM scratch
 ARG JETBRAINS_BACKEND_QUALIFIER
 # ensures right permissions for /ide-desktop-plugins
 COPY --from=base_builder --chown=33333:33333 /ide-desktop-plugins/ /ide-desktop-plugins/
+COPY --chown=33333:33333 components-ide-jetbrains-backend-plugin--plugin-${JETBRAINS_BACKEND_QUALIFIER}/build/gitpod-remote /ide-desktop-plugins/gitpod-remote-${JETBRAINS_BACKEND_QUALIFIER}/
+
+# added for backwards compatibility, can be removed in the future
 COPY --chown=33333:33333 components-ide-jetbrains-backend-plugin--plugin-${JETBRAINS_BACKEND_QUALIFIER}/build/gitpod-remote /ide-desktop-plugins/gitpod-remote/

--- a/components/ide/jetbrains/cli/cmd/root.go
+++ b/components/ide/jetbrains/cli/cmd/root.go
@@ -27,6 +27,7 @@ func Execute() {
 
 func getCliApiUrl() *url.URL {
 	var backendPort = 63342
+	// TODO look up under alias + qualifier, i.e. intellij or intellij-latest
 	if _, fileStatError := os.Stat("/ide-desktop/bin/idea-cli-dev"); !errors.Is(fileStatError, os.ErrNotExist) {
 		backendPort = backendPort + 1
 	}

--- a/components/ide/jetbrains/image/BUILD.js
+++ b/components/ide/jetbrains/image/BUILD.js
@@ -54,7 +54,7 @@ const generateIDEBuildPackage = function (ideConfig, qualifier) {
     let pkg = {
         name,
         type: "docker",
-        srcs: ["startup.sh", `supervisor-ide-config_${ideConfig.name}.json`],
+        srcs: ["startup.sh", `supervisor-ide-config_${name}.json`],
         deps: ["components/ide/jetbrains/image/status:app", `:download-${name}`, "components/ide/jetbrains/cli:app"],
         config: {
             dockerfile: "leeway.Dockerfile",
@@ -63,7 +63,7 @@ const generateIDEBuildPackage = function (ideConfig, qualifier) {
             },
             buildArgs: {
                 JETBRAINS_DOWNLOAD_QUALIFIER: name,
-                SUPERVISOR_IDE_CONFIG: `supervisor-ide-config_${ideConfig.name}.json`,
+                SUPERVISOR_IDE_CONFIG: `supervisor-ide-config_${name}.json`,
                 JETBRAINS_BACKEND_QUALIFIER: qualifier,
                 JETBRAINS_BACKEND_VERSION: getIDEVersion(qualifier, args[`${ideConfig.name}DownloadUrl`]),
             },

--- a/components/ide/jetbrains/image/create-supervisor-config.js
+++ b/components/ide/jetbrains/image/create-supervisor-config.js
@@ -1,0 +1,58 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License-AGPL.txt in the project root for license information.
+
+// @ts-check
+const fs = require("fs");
+
+const ideConfigs = [
+    {
+        name: "intellij",
+        displayName: "IntelliJ IDEA",
+    },
+    {
+        name: "goland",
+        displayName: "GoLand",
+    },
+    {
+        name: "pycharm",
+        displayName: "PyCharm",
+    },
+    {
+        name: "phpstorm",
+        displayName: "PhpStorm",
+    },
+    {
+        name: "rubymine",
+        displayName: "RubyMine",
+    },
+    {
+        name: "webstorm",
+        displayName: "WebStorm",
+    },
+    {
+        name: "rider",
+        displayName: "Rider",
+    },
+    {
+        name: "clion",
+        displayName: "CLion",
+    },
+];
+
+["stable", "latest"].forEach((qualifier) => {
+    ideConfigs.forEach((ideConfig) => {
+        const name = ideConfig.name + (qualifier === "stable" ? "" : "-" + qualifier);
+        const template = {
+            entrypoint: `/ide-desktop/${name}/status`,
+            entrypointArgs: ["{DESKTOPIDEPORT}", ideConfig.name, `Open in ${ideConfig.displayName}`],
+            readinessProbe: {
+                type: "http",
+                http: {
+                    path: "/status",
+                },
+            },
+        };
+        fs.writeFileSync(`supervisor-ide-config_${name}.json`, JSON.stringify(template, null, 2), "utf-8");
+    });
+});

--- a/components/ide/jetbrains/image/leeway.Dockerfile
+++ b/components/ide/jetbrains/image/leeway.Dockerfile
@@ -15,21 +15,21 @@ ARG SUPERVISOR_IDE_CONFIG
 # ensures right permissions for /ide-desktop
 COPY --from=base_builder --chown=33333:33333 /ide-desktop/ /ide-desktop/
 COPY --chown=33333:33333 ${SUPERVISOR_IDE_CONFIG} /ide-desktop/supervisor-ide-config.json
-COPY --chown=33333:33333 components-ide-jetbrains-image--download-${JETBRAINS_DOWNLOAD_QUALIFIER}/backend /ide-desktop/backend
-COPY --chown=33333:33333 components-ide-jetbrains-image-status--app/status /ide-desktop
+COPY --chown=33333:33333 components-ide-jetbrains-image--download-${JETBRAINS_DOWNLOAD_QUALIFIER}/backend /ide-desktop/${JETBRAINS_DOWNLOAD_QUALIFIER}/backend
+COPY --chown=33333:33333 components-ide-jetbrains-image-status--app/status /ide-desktop/${JETBRAINS_DOWNLOAD_QUALIFIER}
 
 ARG JETBRAINS_BACKEND_QUALIFIER
 ENV GITPOD_ENV_SET_JETBRAINS_BACKEND_QUALIFIER ${JETBRAINS_BACKEND_QUALIFIER}
 
-COPY --chown=33333:33333 components-ide-jetbrains-cli--app/cli /ide-desktop/bin/idea-cli
-ENV GITPOD_ENV_APPEND_PATH /ide-desktop/bin:
+COPY --chown=33333:33333 components-ide-jetbrains-cli--app/cli /ide-desktop/${JETBRAINS_DOWNLOAD_QUALIFIER}/bin/idea-cli
+ENV GITPOD_ENV_APPEND_PATH /ide-desktop/${JETBRAINS_DOWNLOAD_QUALIFIER}/bin:
 
 # editor config
-ENV GITPOD_ENV_SET_EDITOR "/ide-desktop/bin/idea-cli open"
+ENV GITPOD_ENV_SET_EDITOR "/ide-desktop/${JETBRAINS_DOWNLOAD_QUALIFIER}/bin/idea-cli open"
 ENV GITPOD_ENV_SET_VISUAL "$GITPOD_ENV_SET_EDITOR"
 ENV GITPOD_ENV_SET_GP_OPEN_EDITOR "$GITPOD_ENV_SET_EDITOR"
 ENV GITPOD_ENV_SET_GIT_EDITOR "$GITPOD_ENV_SET_EDITOR --wait"
-ENV GITPOD_ENV_SET_GP_PREVIEW_BROWSER "/ide-desktop/bin/idea-cli preview"
-ENV GITPOD_ENV_SET_GP_EXTERNAL_BROWSER "/ide-desktop/bin/idea-cli preview"
+ENV GITPOD_ENV_SET_GP_PREVIEW_BROWSER "/ide-desktop/${JETBRAINS_DOWNLOAD_QUALIFIER}/bin/idea-cli preview"
+ENV GITPOD_ENV_SET_GP_EXTERNAL_BROWSER "/ide-desktop/${JETBRAINS_DOWNLOAD_QUALIFIER}/bin/idea-cli preview"
 
 LABEL "io.gitpod.ide.version"=$JETBRAINS_BACKEND_VERSION

--- a/components/ide/jetbrains/image/resolve-latest-ide-version.sh
+++ b/components/ide/jetbrains/image/resolve-latest-ide-version.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+# Licensed under the GNU Affero General Public License (AGPL).
+# See License-AGPL.txt in the project root for license information.
+
+set -Eeuo pipefail
+
+ROOT_DIR="$(dirname "$0")/../../../.."
+PRODUCT_CODE=${1}
+TEMP_FILENAME=$(mktemp)
+PLUGIN_PLATFORM_VERSION=$(grep platformVersion= "$ROOT_DIR/components/ide/jetbrains/backend-plugin/gradle-latest.properties" | sed 's/platformVersion=//' | sed 's/-EAP-CANDIDATE-SNAPSHOT//') # Example: PLUGIN_PLATFORM_VERSION: 223.7571
+
+curl -sL "https://data.services.jetbrains.com/products/releases?code=$PRODUCT_CODE&type=eap,rc,release&platform=linux" > "$TEMP_FILENAME"
+IDE_BUILD_VERSION=$(jq -r -c "first(.${PRODUCT_CODE}[] | select(.build | contains(\"$PLUGIN_PLATFORM_VERSION\")) | .build)" < "$TEMP_FILENAME") # Example: IDE_BUILD_VERSION: 223.7571.176
+IDE_VERSION=$(jq -r ".${PRODUCT_CODE}[0].version" < "$TEMP_FILENAME") # Example: IDE_VERSION: 2022.3
+rm "$TEMP_FILENAME"
+
+echo "{\"IDE_BUILD_VERSION\": \"$IDE_BUILD_VERSION\", \"IDE_VERSION\": \"$IDE_VERSION\"}"

--- a/components/ide/jetbrains/image/supervisor-ide-config_clion-latest.json
+++ b/components/ide/jetbrains/image/supervisor-ide-config_clion-latest.json
@@ -1,5 +1,5 @@
 {
-  "entrypoint": "/ide-desktop/clion/status",
+  "entrypoint": "/ide-desktop/clion-latest/status",
   "entrypointArgs": [
     "{DESKTOPIDEPORT}",
     "clion",

--- a/components/ide/jetbrains/image/supervisor-ide-config_goland-latest.json
+++ b/components/ide/jetbrains/image/supervisor-ide-config_goland-latest.json
@@ -1,9 +1,9 @@
 {
-  "entrypoint": "/ide-desktop/clion/status",
+  "entrypoint": "/ide-desktop/goland-latest/status",
   "entrypointArgs": [
     "{DESKTOPIDEPORT}",
-    "clion",
-    "Open in CLion"
+    "goland",
+    "Open in GoLand"
   ],
   "readinessProbe": {
     "type": "http",

--- a/components/ide/jetbrains/image/supervisor-ide-config_goland.json
+++ b/components/ide/jetbrains/image/supervisor-ide-config_goland.json
@@ -1,10 +1,14 @@
 {
-    "entrypoint": "/ide-desktop/status",
-    "entrypointArgs": [ "{DESKTOPIDEPORT}", "goland", "Open in GoLand" ],
-    "readinessProbe": {
-        "type": "http",
-        "http": {
-            "path": "/status"
-        }
-      }
+  "entrypoint": "/ide-desktop/goland/status",
+  "entrypointArgs": [
+    "{DESKTOPIDEPORT}",
+    "goland",
+    "Open in GoLand"
+  ],
+  "readinessProbe": {
+    "type": "http",
+    "http": {
+      "path": "/status"
+    }
+  }
 }

--- a/components/ide/jetbrains/image/supervisor-ide-config_intellij-latest.json
+++ b/components/ide/jetbrains/image/supervisor-ide-config_intellij-latest.json
@@ -1,9 +1,9 @@
 {
-  "entrypoint": "/ide-desktop/clion/status",
+  "entrypoint": "/ide-desktop/intellij-latest/status",
   "entrypointArgs": [
     "{DESKTOPIDEPORT}",
-    "clion",
-    "Open in CLion"
+    "intellij",
+    "Open in IntelliJ IDEA"
   ],
   "readinessProbe": {
     "type": "http",

--- a/components/ide/jetbrains/image/supervisor-ide-config_intellij.json
+++ b/components/ide/jetbrains/image/supervisor-ide-config_intellij.json
@@ -1,10 +1,14 @@
 {
-    "entrypoint": "/ide-desktop/status",
-    "entrypointArgs": [ "{DESKTOPIDEPORT}", "intellij", "Open in IntelliJ IDEA" ],
-    "readinessProbe": {
-        "type": "http",
-        "http": {
-            "path": "/status"
-        }
-      }
+  "entrypoint": "/ide-desktop/intellij/status",
+  "entrypointArgs": [
+    "{DESKTOPIDEPORT}",
+    "intellij",
+    "Open in IntelliJ IDEA"
+  ],
+  "readinessProbe": {
+    "type": "http",
+    "http": {
+      "path": "/status"
+    }
+  }
 }

--- a/components/ide/jetbrains/image/supervisor-ide-config_phpstorm-latest.json
+++ b/components/ide/jetbrains/image/supervisor-ide-config_phpstorm-latest.json
@@ -1,9 +1,9 @@
 {
-  "entrypoint": "/ide-desktop/clion/status",
+  "entrypoint": "/ide-desktop/phpstorm-latest/status",
   "entrypointArgs": [
     "{DESKTOPIDEPORT}",
-    "clion",
-    "Open in CLion"
+    "phpstorm",
+    "Open in PhpStorm"
   ],
   "readinessProbe": {
     "type": "http",

--- a/components/ide/jetbrains/image/supervisor-ide-config_phpstorm.json
+++ b/components/ide/jetbrains/image/supervisor-ide-config_phpstorm.json
@@ -1,10 +1,14 @@
 {
-    "entrypoint": "/ide-desktop/status",
-    "entrypointArgs": [ "{DESKTOPIDEPORT}", "phpstorm", "Open in PhpStorm" ],
-    "readinessProbe": {
-        "type": "http",
-        "http": {
-            "path": "/status"
-        }
-      }
+  "entrypoint": "/ide-desktop/phpstorm/status",
+  "entrypointArgs": [
+    "{DESKTOPIDEPORT}",
+    "phpstorm",
+    "Open in PhpStorm"
+  ],
+  "readinessProbe": {
+    "type": "http",
+    "http": {
+      "path": "/status"
+    }
+  }
 }

--- a/components/ide/jetbrains/image/supervisor-ide-config_pycharm-latest.json
+++ b/components/ide/jetbrains/image/supervisor-ide-config_pycharm-latest.json
@@ -1,9 +1,9 @@
 {
-  "entrypoint": "/ide-desktop/clion/status",
+  "entrypoint": "/ide-desktop/pycharm-latest/status",
   "entrypointArgs": [
     "{DESKTOPIDEPORT}",
-    "clion",
-    "Open in CLion"
+    "pycharm",
+    "Open in PyCharm"
   ],
   "readinessProbe": {
     "type": "http",

--- a/components/ide/jetbrains/image/supervisor-ide-config_pycharm.json
+++ b/components/ide/jetbrains/image/supervisor-ide-config_pycharm.json
@@ -1,10 +1,14 @@
 {
-    "entrypoint": "/ide-desktop/status",
-    "entrypointArgs": [ "{DESKTOPIDEPORT}", "pycharm", "Open in PyCharm" ],
-    "readinessProbe": {
-        "type": "http",
-        "http": {
-            "path": "/status"
-        }
-      }
+  "entrypoint": "/ide-desktop/pycharm/status",
+  "entrypointArgs": [
+    "{DESKTOPIDEPORT}",
+    "pycharm",
+    "Open in PyCharm"
+  ],
+  "readinessProbe": {
+    "type": "http",
+    "http": {
+      "path": "/status"
+    }
+  }
 }

--- a/components/ide/jetbrains/image/supervisor-ide-config_rider-latest.json
+++ b/components/ide/jetbrains/image/supervisor-ide-config_rider-latest.json
@@ -1,9 +1,9 @@
 {
-  "entrypoint": "/ide-desktop/clion/status",
+  "entrypoint": "/ide-desktop/rider-latest/status",
   "entrypointArgs": [
     "{DESKTOPIDEPORT}",
-    "clion",
-    "Open in CLion"
+    "rider",
+    "Open in Rider"
   ],
   "readinessProbe": {
     "type": "http",

--- a/components/ide/jetbrains/image/supervisor-ide-config_rider.json
+++ b/components/ide/jetbrains/image/supervisor-ide-config_rider.json
@@ -1,10 +1,14 @@
 {
-    "entrypoint": "/ide-desktop/status",
-    "entrypointArgs": [ "{DESKTOPIDEPORT}", "rider", "Open in Rider" ],
-    "readinessProbe": {
-        "type": "http",
-        "http": {
-            "path": "/status"
-        }
-      }
+  "entrypoint": "/ide-desktop/rider/status",
+  "entrypointArgs": [
+    "{DESKTOPIDEPORT}",
+    "rider",
+    "Open in Rider"
+  ],
+  "readinessProbe": {
+    "type": "http",
+    "http": {
+      "path": "/status"
+    }
+  }
 }

--- a/components/ide/jetbrains/image/supervisor-ide-config_rubymine-latest.json
+++ b/components/ide/jetbrains/image/supervisor-ide-config_rubymine-latest.json
@@ -1,9 +1,9 @@
 {
-  "entrypoint": "/ide-desktop/clion/status",
+  "entrypoint": "/ide-desktop/rubymine-latest/status",
   "entrypointArgs": [
     "{DESKTOPIDEPORT}",
-    "clion",
-    "Open in CLion"
+    "rubymine",
+    "Open in RubyMine"
   ],
   "readinessProbe": {
     "type": "http",

--- a/components/ide/jetbrains/image/supervisor-ide-config_rubymine.json
+++ b/components/ide/jetbrains/image/supervisor-ide-config_rubymine.json
@@ -1,10 +1,14 @@
 {
-    "entrypoint": "/ide-desktop/status",
-    "entrypointArgs": [ "{DESKTOPIDEPORT}", "rubymine", "Open in RubyMine" ],
-    "readinessProbe": {
-        "type": "http",
-        "http": {
-            "path": "/status"
-        }
-      }
+  "entrypoint": "/ide-desktop/rubymine/status",
+  "entrypointArgs": [
+    "{DESKTOPIDEPORT}",
+    "rubymine",
+    "Open in RubyMine"
+  ],
+  "readinessProbe": {
+    "type": "http",
+    "http": {
+      "path": "/status"
+    }
+  }
 }

--- a/components/ide/jetbrains/image/supervisor-ide-config_webstorm-latest.json
+++ b/components/ide/jetbrains/image/supervisor-ide-config_webstorm-latest.json
@@ -1,9 +1,9 @@
 {
-  "entrypoint": "/ide-desktop/clion/status",
+  "entrypoint": "/ide-desktop/webstorm-latest/status",
   "entrypointArgs": [
     "{DESKTOPIDEPORT}",
-    "clion",
-    "Open in CLion"
+    "webstorm",
+    "Open in WebStorm"
   ],
   "readinessProbe": {
     "type": "http",

--- a/components/ide/jetbrains/image/supervisor-ide-config_webstorm.json
+++ b/components/ide/jetbrains/image/supervisor-ide-config_webstorm.json
@@ -1,10 +1,14 @@
 {
-    "entrypoint": "/ide-desktop/status",
-    "entrypointArgs": [ "{DESKTOPIDEPORT}", "webstorm", "Open in WebStorm" ],
-    "readinessProbe": {
-        "type": "http",
-        "http": {
-            "path": "/status"
-        }
-      }
+  "entrypoint": "/ide-desktop/webstorm/status",
+  "entrypointArgs": [
+    "{DESKTOPIDEPORT}",
+    "webstorm",
+    "Open in WebStorm"
+  ],
+  "readinessProbe": {
+    "type": "http",
+    "http": {
+      "path": "/status"
+    }
+  }
 }


### PR DESCRIPTION
## Description
This PR changes the file structure for JetBrains IDE images. The previous structure would allow only a single IDE to be stored, with the new approach we can layer multiple IDEs without risk of overriding each other.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related to https://github.com/gitpod-io/gitpod/issues/6740

## How to test
1. For *stable*, start a workspace for a couple of JB IDE and make sure they work as expected, including customizations done via the backend-plugin to the Backend Control Center, or custom actions are visible, meaning the plugin is loaded correctly.
2. For *latest*, TODO

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
