### PR TITLE
[installer]: document the config surface and guarantees

### DIFF
--- a/install/installer/README.md
+++ b/install/installer/README.md
@@ -13,3 +13,38 @@ The best way to get started with Gitpod is by using our recommended & default in
 > The installer is an internal tool and as such not expected to be used by those external to Gitpod. Instructions for how to use it can be found in the [docs](https://github.com/gitpod-io/gitpod/tree/main/install/installer/docs/overview.md) folder of this repo.
 
 [![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-908a85?logo=gitpod)](https://gitpod.io/from-referrer/)
+
+## Configuration expectations
+
+The [config](./pkg/config/) is the primary way that the installer can be interacted with. This guide details the expectations that users can have of the installer's configuration and the contract that it specifies.
+
+### Versioning
+
+The installer supports only one active version of the configuration at a given time.
+
+#### Expectations for a version
+
+The configuration for a version has the following expectations. If a constraint needs to be broken to support a new feature, this should trigger a new version of the configuration surface.
+
+1. new parameters may be introduced
+2. a parameter may have additional validation rules introduced
+3. no parameter may be removed or renamed
+4. sensitive data should always be included via a Kubernetes secret
+
+Prior to deployment, a user should run the installer's `validation config` and `validation cluster` commands to ensure that the configuration is correct and the cluster is in a state to accept the deployment.
+
+#### Introducing a new version
+
+> At this stage, this is largely hypothetical as it has not yet been necessary to go beyond `v1`. This should be treated as the plan if-and-when it becomes necessary.
+
+In the event that a [configuration expectation](#expectations-for-a-version) needs to be violated, a new version must be created. This should increment the `apiVersion` to the next integer (eg, from `v1` to `v2`), although this may change dependent upon the specific circumstances at the time.
+
+There is a `config migrate` command that exists to convert the old configuration YAML to the new format.
+
+#### Experimental config
+
+> tl;dr here be dragons
+
+As part of the configuration surface, there is an `experimental` feature. This is not designed to be used by the general public, but exists primarily for Gitpod-specific purposes or for those of our supported installations. The guarantees and expectations that exist for the main configuration surface do not exist for any parameter inside the `experimental` configuration and may be withdrawn or changed without notice.
+
+A parameter may be promoted from `experimental` to the main configuration. In general, the previous `experimental` parameter must be marked as deprecated and should retained in the current state for a minimum of 3 months. This is to ensure that no supported deployments have any breaking changes introduced.

--- a/install/installer/cmd/config_migrate.go
+++ b/install/installer/cmd/config_migrate.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
+package cmd
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// configMigrateCmd represents the config migration command
+var configMigrateCmd = &cobra.Command{
+	Use:   "migrate",
+	Short: "Migrate the configuration YAML to the currently supported version",
+	Args: func(cmd *cobra.Command, args []string) error {
+		// receive the target config version to migrate to
+		if len(args) != 1 {
+			return errors.New("new configuration version is required")
+		}
+
+		// @todo(sje): validate that the version is acceptable
+
+		return nil
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return fmt.Errorf("this command is a placeholder for when a new version is introduced")
+	},
+}
+
+func init() {
+	configCmd.AddCommand(configMigrateCmd)
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This documents a few linked things around the configuration surface:
1. document the guarantees
1. scaffold the `config migrate` command for future use

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #15121

## How to test
<!-- Provide steps to test this PR -->
Read the new docs and comment.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[installer]: document the config surface and guarantees
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
