### PR TITLE
[usage] handle no stopping but stopped time

### DIFF
--- a/components/gitpod-db/go/workspace_instance.go
+++ b/components/gitpod-db/go/workspace_instance.go
@@ -135,6 +135,7 @@ func queryWorkspaceInstanceForUsage(ctx context.Context, conn *gorm.DB) *gorm.DB
 			"wsi.usageAttributionId as usageAttributionId, "+
 			"wsi.startedTime as startedTime, "+
 			"wsi.stoppingTime as stoppingTime, "+
+			"wsi.stoppedTime as stoppedTime, "+
 			"ws.ownerId as ownerId, "+
 			"wsi.workspaceId as workspaceId, "+
 			"ws.ownerId as userId, "+
@@ -221,6 +222,7 @@ type WorkspaceInstanceForUsage struct {
 
 	StartedTime  VarcharTime `gorm:"column:startedTime;type:varchar;size:255;" json:"startedTime"`
 	StoppingTime VarcharTime `gorm:"column:stoppingTime;type:varchar;size:255;" json:"stoppingTime"`
+	StoppedTime  VarcharTime `gorm:"column:stoppedTime;type:varchar;size:255;" json:"stoppedTime"`
 }
 
 // WorkspaceRuntimeSeconds computes how long this WorkspaceInstance has been running.
@@ -231,6 +233,8 @@ func (i *WorkspaceInstanceForUsage) WorkspaceRuntimeSeconds(stopTimeIfInstanceIs
 
 	if i.StoppingTime.IsSet() {
 		stop = i.StoppingTime.Time()
+	} else if i.StoppedTime.IsSet() {
+		stop = i.StoppedTime.Time()
 	}
 
 	if stop.Before(start) {
@@ -239,8 +243,10 @@ func (i *WorkspaceInstanceForUsage) WorkspaceRuntimeSeconds(stopTimeIfInstanceIs
 			WithField("workspace_id", i.WorkspaceID).
 			WithField("started_time", TimeToISO8601(i.StartedTime.Time())).
 			WithField("started_time_set", i.StartedTime.IsSet()).
-			WithField("stopping_time_set", i.StartedTime.IsSet()).
-			WithField("stopping_time", TimeToISO8601(i.StartedTime.Time())).
+			WithField("stopping_time_set", i.StoppingTime.IsSet()).
+			WithField("stopping_time", TimeToISO8601(i.StoppingTime.Time())).
+			WithField("stopped_time_set", i.StoppedTime.IsSet()).
+			WithField("stopped_time", TimeToISO8601(i.StoppedTime.Time())).
 			WithField("stop_time_if_instance_still_running", stopTimeIfInstanceIsStillRunning).
 			Errorf("Instance %s had stop time before start time. Using startedTime as stop time.", i.ID)
 

--- a/components/usage/pkg/apiv1/pricer_test.go
+++ b/components/usage/pkg/apiv1/pricer_test.go
@@ -109,6 +109,16 @@ func TestWorkspaceInstanceForUsage_WorkspaceRuntimeSeconds(t *testing.T) {
 			StopTimeIfStillRunning: time.Date(2022, 9, 8, 11, 0, 0, 00, time.UTC),
 			ExpectedCredits:        0,
 		},
+		{
+			Name: "an errored instance that has no stopping time.",
+			Instance: &db.WorkspaceInstanceForUsage{
+				WorkspaceClass: db.WorkspaceClass_Default,
+				StartedTime:    db.NewVarCharTime(time.Date(2022, 9, 8, 12, 0, 0, 0, time.UTC)),
+				StoppedTime:    db.NewVarCharTime(time.Date(2022, 9, 8, 12, 0, 0, 0, time.UTC)),
+			},
+			StopTimeIfStillRunning: time.Date(2022, 9, 8, 11, 0, 0, 00, time.UTC),
+			ExpectedCredits:        0,
+		},
 	} {
 		t.Run(s.Name, func(t *testing.T) {
 			credits := DefaultWorkspacePricer.CreditsUsedByInstance(s.Instance, s.StopTimeIfStillRunning)

--- a/components/usage/pkg/apiv1/usage.go
+++ b/components/usage/pkg/apiv1/usage.go
@@ -368,14 +368,19 @@ func reconcileUsage(instances []db.WorkspaceInstanceForUsage, drafts []db.Usage,
 const usageDescriptionFromController = "Usage collected by automated system."
 
 func newUsageFromInstance(instance db.WorkspaceInstanceForUsage, pricer *WorkspacePricer, now time.Time) (db.Usage, error) {
+	stopTime := instance.StoppingTime
+	if !stopTime.IsSet() {
+		stopTime = instance.StoppedTime
+	}
+
 	draft := true
-	if instance.StoppingTime.IsSet() {
+	if stopTime.IsSet() {
 		draft = false
 	}
 
 	effectiveTime := now
-	if instance.StoppingTime.IsSet() {
-		effectiveTime = instance.StoppingTime.Time()
+	if stopTime.IsSet() {
+		effectiveTime = stopTime.Time()
 	}
 
 	usage := db.Usage{


### PR DESCRIPTION
## Description
We have three workspace instances in prod that don't have a stoppingTime but a stoppedTime. I think falling back to stoppedTime in case stoppingTime is not set makes sense (after all they never were in a stopping phase, because they errored) and also makes the component more robust.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
