### PR TITLE
[usage] make increment billing cycle more robust

### DIFF
--- a/components/gitpod-db/go/cost_center.go
+++ b/components/gitpod-db/go/cost_center.go
@@ -138,7 +138,8 @@ func (c *CostCenterManager) IncrementBillingCycle(ctx context.Context, attributi
 	}
 	now := time.Now().UTC()
 	if cc.NextBillingTime.Time().After(now) {
-		return CostCenter{}, status.Errorf(codes.FailedPrecondition, "cannot increment billing cycle before next billing time")
+		log.Infof("Cost center %s is not yet expired. Skipping increment.", attributionId)
+		return cc, nil
 	}
 	billingCycleStart := NewVarCharTime(now)
 	if cc.NextBillingTime.IsSet() {

--- a/components/usage/pkg/apiv1/billing.go
+++ b/components/usage/pkg/apiv1/billing.go
@@ -299,12 +299,13 @@ func (s *BillingService) FinalizeInvoice(ctx context.Context, in *v1.FinalizeInv
 		logger.WithError(err).Errorf("Failed to insert Invoice usage record into the db.")
 		return nil, status.Errorf(codes.Internal, "Failed to insert Invoice into usage records.")
 	}
+	logger.WithField("usage_id", usage.ID).Infof("Inserted usage record into database for %f credits against %s attribution", usage.CreditCents.ToCredits(), usage.AttributionID)
+
 	_, err = s.ccManager.IncrementBillingCycle(ctx, usage.AttributionID)
 	if err != nil {
+		// we are just logging at this point, so that we don't see the event again as the usage has been recorded.
 		logger.WithError(err).Errorf("Failed to increment billing cycle.")
-		return nil, status.Errorf(codes.Internal, "Failed to increment billing cycle.")
 	}
-	logger.WithField("usage_id", usage.ID).Infof("Inserted usage record into database for %f credits against %s attribution", usage.CreditCents.ToCredits(), usage.AttributionID)
 	return &v1.FinalizeInvoiceResponse{}, nil
 }
 


### PR DESCRIPTION
## Description
We receive finalize invoice events also before a cost center is expired. For instance when a user first subscribes but also when a user cancels their plan. The `IncrementBillingCycle` method should just skip in such cases, also we should not return an error once the usage has been recorded in the DB.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #15203

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
