### PR TITLE
Use Leeway version v0.7.1

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
-image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-remove-adc.9
+image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-leeway-v0.7.1.0
 workspaceLocation: gitpod/gitpod-ws.code-workspace
 checkoutLocation: gitpod
 ports:

--- a/.werft/aks-installer-tests.yaml
+++ b/.werft/aks-installer-tests.yaml
@@ -65,7 +65,7 @@ pod:
       secretName: self-hosted-github-oauth
   containers:
   - name: nightly-test
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-remove-adc.9
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-leeway-v0.7.1.0
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/build.yaml
+++ b/.werft/build.yaml
@@ -70,7 +70,7 @@ pod:
     - name: MYSQL_TCP_PORT
       value: 23306
   - name: build
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-remove-adc.9
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-leeway-v0.7.1.0
     workingDir: /workspace
     imagePullPolicy: IfNotPresent
     resources:

--- a/.werft/cleanup-installer-tests.yaml
+++ b/.werft/cleanup-installer-tests.yaml
@@ -25,7 +25,7 @@ pod:
       secretName: aks-credentials
   containers:
   - name: nightly-test
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-remove-adc.9
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-leeway-v0.7.1.0
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/debug.yaml
+++ b/.werft/debug.yaml
@@ -54,7 +54,7 @@ pod:
     - name: MYSQL_TCP_PORT
       value: 23306
   - name: build
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-remove-adc.9
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-leeway-v0.7.1.0
     workingDir: /workspace
     imagePullPolicy: IfNotPresent
     volumeMounts:

--- a/.werft/eks-installer-tests.yaml
+++ b/.werft/eks-installer-tests.yaml
@@ -65,7 +65,7 @@ pod:
       secretName: self-hosted-github-oauth
   containers:
   - name: nightly-test
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-remove-adc.9
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-leeway-v0.7.1.0
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/gke-installer-tests.yaml
+++ b/.werft/gke-installer-tests.yaml
@@ -65,7 +65,7 @@ pod:
         secretName: self-hosted-github-oauth
   containers:
     - name: nightly-test
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-remove-adc.9
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-leeway-v0.7.1.0
       workingDir: /workspace
       imagePullPolicy: Always
       volumeMounts:

--- a/.werft/ide-integration-tests-startup.yaml
+++ b/.werft/ide-integration-tests-startup.yaml
@@ -17,7 +17,7 @@ pod:
         secretName: github-token-gitpod-bot
   containers:
     - name: gcloud
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-remove-adc.9
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-leeway-v0.7.1.0
       workingDir: /workspace
       imagePullPolicy: IfNotPresent
       env:

--- a/.werft/k3s-installer-tests.yaml
+++ b/.werft/k3s-installer-tests.yaml
@@ -65,7 +65,7 @@ pod:
       secretName: self-hosted-github-oauth
   containers:
   - name: nightly-test
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-remove-adc.9
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-leeway-v0.7.1.0
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/platform-delete-preview-environment.yaml
+++ b/.werft/platform-delete-preview-environment.yaml
@@ -25,7 +25,7 @@ pod:
         secretName: harvester-vm-ssh-keys
   containers:
     - name: build
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-remove-adc.9
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-leeway-v0.7.1.0
       workingDir: /workspace
       imagePullPolicy: IfNotPresent
       volumeMounts:

--- a/.werft/platform-delete-preview-environments-cron.yaml
+++ b/.werft/platform-delete-preview-environments-cron.yaml
@@ -29,7 +29,7 @@ pod:
         secretName: github-token-gitpod-bot
   containers:
     - name: build
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-remove-adc.9
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-leeway-v0.7.1.0
       workingDir: /workspace
       imagePullPolicy: IfNotPresent
       volumeMounts:

--- a/.werft/platform-trigger-artificial-job.yaml
+++ b/.werft/platform-trigger-artificial-job.yaml
@@ -24,7 +24,7 @@ pod:
         secretName: github-token-gitpod-bot
   containers:
     - name: build
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-remove-adc.9
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-leeway-v0.7.1.0
       workingDir: /workspace
       imagePullPolicy: IfNotPresent
       volumeMounts:

--- a/.werft/platform-trigger-werft-cleanup.yaml
+++ b/.werft/platform-trigger-werft-cleanup.yaml
@@ -22,7 +22,7 @@ pod:
         secretName: gcp-sa-gitpod-dev-deployer
   containers:
     - name: build
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-remove-adc.9
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-leeway-v0.7.1.0
       workingDir: /workspace
       imagePullPolicy: IfNotPresent
       volumeMounts:

--- a/.werft/workspace-run-integration-tests.yaml
+++ b/.werft/workspace-run-integration-tests.yaml
@@ -22,7 +22,7 @@ pod:
         secretName: github-token-gitpod-bot
   containers:
     - name: gcloud
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-remove-adc.9
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-leeway-v0.7.1.0
       workingDir: /workspace
       imagePullPolicy: IfNotPresent
       env:

--- a/dev/image/Dockerfile
+++ b/dev/image/Dockerfile
@@ -57,8 +57,9 @@ RUN cd /usr/bin && curl -fsSL https://github.com/cert-manager/cert-manager/relea
 RUN cd /usr/bin && curl -fsSL https://github.com/praetorian-inc/gokart/releases/download/v0.4.0/gokart_0.4.0_linux_x86_64.tar.gz | tar xzv --no-anchored gokart
 
 # leeway
+ARG LEEWAY_VERSION=0.7.1
 ENV LEEWAY_MAX_PROVENANCE_BUNDLE_SIZE=8388608
-RUN cd /usr/bin && curl -fsSL https://github.com/gitpod-io/leeway/releases/download/v0.5.2/leeway_0.5.2_Linux_x86_64.tar.gz | tar xz
+RUN cd /usr/bin && curl -fsSL https://github.com/gitpod-io/leeway/releases/download/v${LEEWAY_VERSION}/leeway_${LEEWAY_VERSION}_Linux_x86_64.tar.gz | tar xz
 
 # evans (gRPC client)
 RUN cd /usr/bin && curl -fsSL https://github.com/ktr0731/evans/releases/download/v0.10.6/evans_linux_amd64.tar.gz | tar xz evans


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Bumps Leeway to version 0.7.1. The previous version was 0.5.2 so this includes quite a few changes. Most of them is about cleaning up unused features and code, but some notable changes are:

1. in [0.6.0](https://github.com/gitpod-io/leeway/releases/tag/v0.6.0) we "Log go mod download only when verbose" which will drastically reduce the logs you see in Werft (@sagor999 you'll like this I think as you created the [original report of this issue](https://github.com/gitpod-io/leeway/issues/107) - and thanks to @csweichel for making the fix in Leeway)
2. In [0.7.1](https://github.com/gitpod-io/leeway/releases/tag/v0.7.1) Enable running Leeways scripts in parallel. This is needed for https://github.com/gitpod-io/gitpod/issues/14707 and https://github.com/gitpod-io/gitpod/issues/14704

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of https://github.com/gitpod-io/gitpod/issues/14707
Part of https://github.com/gitpod-io/gitpod/issues/14704
Fixes https://github.com/gitpod-io/leeway/issues/107

## How to test
<!-- Provide steps to test this PR -->

I created a preview environment and ran the workspace integration tests against it to validate that the preview environment seems healthy enough ☺️

```
werft job run github -a with-preview=true -a with-integration-tests=workspace
```

And a quick check from a workspace to see that I did indeed upgrade Leeway

```
leeway version
0.7.1-7858d75
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
