### PR TITLE
[server] don't fail on currency change

### DIFF
--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -2160,12 +2160,10 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
         if (customer) {
             // NOTE: this is a temporary workaround, as long as we're not automatically re-create the customer
             // entity on Stripe to support a switch of currencies, we're taking an exit here.
-            if (customer.currency !== currency) {
+            if (customer.currency && customer.currency !== currency) {
                 throw new ResponseError(
                     ErrorCodes.SUBSCRIPTION_ERROR,
-                    `Your previous subscription was in ${
-                        customer.currency || "unknown"
-                    }. If you'd like to change currencies, please contact our support.`,
+                    `Your previous subscription was in ${customer.currency}. If you'd like to change currencies, please contact our support.`,
                     { hint: "currency", oldValue: customer.currency, value: currency },
                 );
             }


### PR DESCRIPTION
## Description
If I had previsously signed up I cannot resubscribe because of this error. Let's have people reach out for currency changes.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #15211

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
