### PR TITLE
[content-service] Prevent permission denied during content init

### DIFF
--- a/components/content-service/pkg/archive/tar.go
+++ b/components/content-service/pkg/archive/tar.go
@@ -111,7 +111,6 @@ func ExtractTarbal(ctx context.Context, src io.Reader, dst string, opts ...TarOp
 		"tar",
 		"--extract",
 		"--preserve-permissions",
-		"--xattrs", "--xattrs-include=security.capability",
 	)
 	tarcmd.Dir = dst
 	tarcmd.Stdin = teeReader


### PR DESCRIPTION
## Description
For details see https://github.com/gitpod-io/gitpod/issues/11183

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/11183

## How to test
1. Run these tests :point_down: 
- Open a workspace. In the terminal execute:
```
touch basic
sudo touch root-file
touch executable-file
chmod +x executable-file
touch suid-file
chmod 2555 suid-file
mkdir suid-directory
chmod g+s suid-directory
```
- Check the output of `ls -lat`, should be similar to
```
drwxr-x--- 8 gitpod gitpod 4096 Apr 28 17:31 .
-r-xr-sr-x 1 gitpod gitpod    0 Apr 28 17:31 suid-file
drwxr-sr-x 2 gitpod gitpod    6 Apr 28 17:31 suid-directory
-rwxr-xr-x 1 gitpod gitpod    0 Apr 28 17:30 executable-file
-rw-r--r-- 1 root   root      0 Apr 28 17:30 root-file
-rw-r--r-- 1 gitpod gitpod    0 Apr 28 17:30 basic
```
- Stop and open the workspace
- Open a terminal and run `ls -lat`
- Compare the outputs

2. Assert the [steps to recreate here](https://github.com/gitpod-io/gitpod/issues/3174) do not fail

3. Open this repository: https://github.com/Furisto/gitpod-repro/tree/content-init-11183
   - Wait for the workspace and Supertokens to be started
   - Stop the workspace and wait for it to be stopped
   - Open and start workspace -> There should be no error


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Fixed an issue where a stopped workspace could not be restarted
```

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-integration-tests=workspace
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
