### PR TITLE
[installer]: improve the comparison method for the golden files

### DIFF
--- a/install/installer/cmd/render_test.go
+++ b/install/installer/cmd/render_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 )
 
@@ -82,7 +83,9 @@ func TestRender(t *testing.T) {
 			}
 
 			// Compare
-			require.Equal(t, string(content), got)
+			if diff := cmp.Diff(string(content), got); diff != "" {
+				t.Errorf("non-matching golden file %s (-want +got):\n%s", testCase.Name, diff)
+			}
 		})
 	}
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Switch the golden files comparison to use `cmp.Diff` - this produces a more readable diff for golden files.

**Important** - this does not use the FixtureTest in `common-go/testing/fixtures.go` as suggested - that is designed around the config being a JSON file, whereas the Installer requires it to be YAML and is injected as a string that the Installer reads, not a struct. Whilst we could make this change, it's probably not massively useful to the `components` and would require a lot of changes which may introduce problem.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #12578

## How to test
<!-- Provide steps to test this PR -->
1. change an `output.golden` file (eg add "err" to the end of the file)
2. run `go test ./cmd/...`
3. read the failure diff
4. stash the change and rerun - should see no failure

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
