### PR TITLE
Update beta label on access  tokens

### DIFF
--- a/components/dashboard/src/settings/PersonalAccessTokens.tsx
+++ b/components/dashboard/src/settings/PersonalAccessTokens.tsx
@@ -150,7 +150,7 @@ function ListAccessTokensView() {
                 <div>
                     <h3>
                         Access Tokens{" "}
-                        <PillLabel type="warn" className="font-semibold self-center">
+                        <PillLabel type="warn" className="font-semibold self-center py-0.5 px-1.5">
                             <a href="https://www.gitpod.io/docs/references/gitpod-releases">
                                 <span className="text-xs">BETA</span>
                             </a>


### PR DESCRIPTION
## Description

Follow up from https://github.com/gitpod-io/gitpod/pull/15201.

See also relevant discussion in https://github.com/gitpod-io/gitpod/pull/15201#issuecomment-1341137103 and follow-up issue to improve the label component in https://github.com/gitpod-io/gitpod/issues/15218.

| BEFORE | AFTER |
|-|-|
| <img width="311" alt="label-before" src="https://user-images.githubusercontent.com/120486/206210389-8c436caa-1db9-4767-bfaa-7274d0f53dbb.png"> | <img width="311" alt="label-after" src="https://user-images.githubusercontent.com/120486/206210410-d0b5d770-d550-4050-9c66-c7455fd12783.png"> |

## How to test
1. Go to /tokens
2. Notice the label visual update

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
