### PR TITLE
add grpc_client_handling_seconds metrics for nice-grpc

### DIFF
--- a/components/gitpod-protocol/src/messaging/client-call-metrics.ts
+++ b/components/gitpod-protocol/src/messaging/client-call-metrics.ts
@@ -14,6 +14,7 @@ export class PrometheusClientCallMetrics implements IClientCallMetrics {
     readonly sentCounter: prometheusClient.Counter<string>;
     readonly receivedCounter: prometheusClient.Counter<string>;
     readonly handledCounter: prometheusClient.Counter<string>;
+    readonly handledSecondsHistogram: prometheusClient.Histogram<string>;
 
     constructor() {
         this.startedCounter = new prometheusClient.Counter({
@@ -37,6 +38,12 @@ export class PrometheusClientCallMetrics implements IClientCallMetrics {
         this.handledCounter = new prometheusClient.Counter({
             name: "grpc_client_handled_total",
             help: "Total number of RPCs completed by the client, regardless of success or failure.",
+            labelNames: ["grpc_service", "grpc_method", "grpc_type", "grpc_code"],
+            registers: [prometheusClient.register],
+        });
+        this.handledSecondsHistogram = new prometheusClient.Histogram({
+            name: "grpc_client_handling_seconds",
+            help: "Histogram of response latency (seconds) of the gRPC until it is finished by the application.",
             labelNames: ["grpc_service", "grpc_method", "grpc_type", "grpc_code"],
             registers: [prometheusClient.register],
         });
@@ -72,6 +79,16 @@ export class PrometheusClientCallMetrics implements IClientCallMetrics {
             grpc_method: labels.method,
             grpc_type: labels.type,
             grpc_code: labels.code,
+        });
+    }
+
+    startHandleTimer(
+        labels: IGrpcCallMetricsLabelsWithCode,
+    ): (labels?: Partial<Record<string, string | number>> | undefined) => number {
+        return this.handledSecondsHistogram.startTimer({
+            grpc_service: labels.service,
+            grpc_method: labels.method,
+            grpc_type: labels.type,
         });
     }
 }

--- a/components/gitpod-protocol/src/util/grpc.ts
+++ b/components/gitpod-protocol/src/util/grpc.ts
@@ -36,6 +36,9 @@ export interface IClientCallMetrics {
     sent(labels: IGrpcCallMetricsLabels): void;
     received(labels: IGrpcCallMetricsLabels): void;
     handled(labels: IGrpcCallMetricsLabelsWithCode): void;
+    startHandleTimer(
+        labels: IGrpcCallMetricsLabels,
+    ): (labels?: Partial<Record<string, string | number>> | undefined) => number;
 }
 
 export function getGrpcMethodType(requestStream: boolean, responseStream: boolean): GrpcMethodType {

--- a/components/gitpod-protocol/src/util/nice-grpc.ts
+++ b/components/gitpod-protocol/src/util/nice-grpc.ts
@@ -49,6 +49,8 @@ export function prometheusClientMiddleware(metrics: IClientCallMetrics): ClientM
 
         metrics.started(labels);
 
+        const stopTimer = metrics.startHandleTimer(labels);
+
         let settled = false;
         let status: Status = Status.OK;
 
@@ -87,6 +89,7 @@ export function prometheusClientMiddleware(metrics: IClientCallMetrics): ClientM
             if (!settled) {
                 status = Status.CANCELLED;
             }
+            stopTimer({ grpc_code: Status[status] });
             metrics.handled({ ...labels, code: Status[status] });
         }
     };


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
add grpc_client_handling_seconds metrics for nice-grpc

<img width="1577" alt="image" src="https://user-images.githubusercontent.com/8299500/206378689-379dd9d5-171f-41b4-b37a-e6af19d18f94.png">


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
1. start a workspace from this branch in gitpod.io
2. run `./dev/preview/portforward-monitoring-satellite.sh -c harvester`
3. go to grafana, using explore query `grpc_client_handling_seconds_bucket{grpc_service="ide_service_api.IDEService"}`
4. you should see some metrics

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
