### PR TITLE
[dashboard] consistent pay wall

### DIFF
--- a/components/dashboard/src/components/UsageLimitReachedModal.tsx
+++ b/components/dashboard/src/components/UsageLimitReachedModal.tsx
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { Team } from "@gitpod/gitpod-protocol";
+import { AttributionId } from "@gitpod/gitpod-protocol/lib/attribution";
+import { useContext, useEffect, useState } from "react";
+import { gitpodHostUrl } from "../service/service";
+import { TeamsContext } from "../teams/teams-context";
+import Alert from "./Alert";
+import Modal from "./Modal";
+
+export function UsageLimitReachedModal(p: { hints: any }) {
+    const { teams } = useContext(TeamsContext);
+    // const [attributionId, setAttributionId] = useState<AttributionId | undefined>();
+    const [attributedTeam, setAttributedTeam] = useState<Team | undefined>();
+
+    useEffect(() => {
+        const attributionId: AttributionId | undefined = p.hints && p.hints.attributionId;
+        if (attributionId) {
+            // setAttributionId(attributionId);
+            if (attributionId.kind === "team") {
+                const team = teams?.find((t) => t.id === attributionId.teamId);
+                setAttributedTeam(team);
+            }
+        }
+    }, []);
+
+    const attributedTeamName = attributedTeam?.name;
+    return (
+        <Modal visible={true} closeable={false} onClose={() => {}}>
+            <h3 className="flex">
+                <span className="flex-grow">Usage Limit Reached</span>
+            </h3>
+            <div className="border-t border-b border-gray-200 dark:border-gray-800 mt-4 -mx-6 px-6 py-6">
+                <Alert type="error" className="app-container rounded-md">
+                    You have reached the <strong>usage limit</strong> of your billing account.
+                </Alert>
+                <p className="mt-3 text-base text-gray-600 dark:text-gray-300">
+                    {"Contact a team owner "}
+                    {attributedTeamName && (
+                        <>
+                            of <strong>{attributedTeamName} </strong>
+                        </>
+                    )}
+                    to increase the usage limit, or change your <a href="/billing">billing settings</a>.
+                </p>
+            </div>
+            <div className="flex justify-end mt-6 space-x-2">
+                <a href={gitpodHostUrl.asBilling().toString()}>
+                    <button className="secondary">Go to Billing</button>
+                </a>
+            </div>
+        </Modal>
+    );
+}

--- a/components/dashboard/src/start/CreateWorkspace.tsx
+++ b/components/dashboard/src/start/CreateWorkspace.tsx
@@ -10,7 +10,6 @@ import {
     RunningWorkspacePrebuildStarting,
     ContextURL,
     DisposableCollection,
-    Team,
     GitpodServer,
 } from "@gitpod/gitpod-protocol";
 import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
@@ -26,10 +25,8 @@ import PrebuildLogs from "../components/PrebuildLogs";
 import FeedbackComponent from "../feedback-form/FeedbackComponent";
 import { isGitpodIo } from "../utils";
 import { BillingAccountSelector } from "../components/BillingAccountSelector";
-import { AttributionId } from "@gitpod/gitpod-protocol/lib/attribution";
-import { TeamsContext } from "../teams/teams-context";
-import Alert from "../components/Alert";
 import { FeatureFlagContext } from "../contexts/FeatureFlagContext";
+import { UsageLimitReachedModal } from "../components/UsageLimitReachedModal";
 
 export interface CreateWorkspaceProps {
     contextUrl: string;
@@ -378,50 +375,6 @@ function LimitReachedOutOfHours() {
                 for your workspaces.
             </p>
         </LimitReachedModal>
-    );
-}
-function UsageLimitReachedModal(p: { hints: any }) {
-    const { teams } = useContext(TeamsContext);
-    // const [attributionId, setAttributionId] = useState<AttributionId | undefined>();
-    const [attributedTeam, setAttributedTeam] = useState<Team | undefined>();
-
-    useEffect(() => {
-        const attributionId: AttributionId | undefined = p.hints && p.hints.attributionId;
-        if (attributionId) {
-            // setAttributionId(attributionId);
-            if (attributionId.kind === "team") {
-                const team = teams?.find((t) => t.id === attributionId.teamId);
-                setAttributedTeam(team);
-            }
-        }
-    }, []);
-
-    const attributedTeamName = attributedTeam?.name;
-    return (
-        <Modal visible={true} closeable={false} onClose={() => {}}>
-            <h3 className="flex">
-                <span className="flex-grow">Usage Limit Reached</span>
-            </h3>
-            <div className="border-t border-b border-gray-200 dark:border-gray-800 mt-4 -mx-6 px-6 py-6">
-                <Alert type="error" className="app-container rounded-md">
-                    You have reached the <strong>usage limit</strong> of your billing account.
-                </Alert>
-                <p className="mt-3 text-base text-gray-600 dark:text-gray-300">
-                    {"Contact a team owner "}
-                    {attributedTeamName && (
-                        <>
-                            of <strong>{attributedTeamName} </strong>
-                        </>
-                    )}
-                    to increase the usage limit, or change your <a href="/billing">billing settings</a>.
-                </p>
-            </div>
-            <div className="flex justify-end mt-6 space-x-2">
-                <a href={gitpodHostUrl.asDashboard().toString()}>
-                    <button className="secondary">Go to Dashboard</button>
-                </a>
-            </div>
-        </Modal>
     );
 }
 

--- a/components/dashboard/src/start/StartPage.tsx
+++ b/components/dashboard/src/start/StartPage.tsx
@@ -7,6 +7,7 @@
 import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
 import { useEffect } from "react";
 import Alert from "../components/Alert";
+import { UsageLimitReachedModal } from "../components/UsageLimitReachedModal";
 import gitpodIconUA from "../icons/gitpod.svg";
 import { gitpodHostUrl } from "../service/service";
 import { VerifyModal } from "./VerifyModal";
@@ -109,6 +110,9 @@ export function StartPage(props: StartPageProps) {
                     <ProgressBar phase={phase} error={!!error} />
                 )}
                 {error && error.code === ErrorCodes.NEEDS_VERIFICATION && <VerifyModal />}
+                {error && error.code === ErrorCodes.PAYMENT_SPENDING_LIMIT_REACHED && (
+                    <UsageLimitReachedModal hints={error?.data} />
+                )}
                 {error && <StartError error={error} />}
                 {props.children}
                 {props.showLatestIdeWarning && (

--- a/components/gitpod-protocol/src/util/gitpod-host-url.ts
+++ b/components/gitpod-protocol/src/util/gitpod-host-url.ts
@@ -93,6 +93,10 @@ export class GitpodHostUrl {
         return this.with((url) => ({ pathname: "/" }));
     }
 
+    asBilling(): GitpodHostUrl {
+        return this.with((url) => ({ pathname: "/billing" }));
+    }
+
     asLogin(): GitpodHostUrl {
         return this.with((url) => ({ pathname: "/login" }));
     }


### PR DESCRIPTION
## Description
Generalizes the pay wall on start and create ws and changes the link to point to /billing

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #15188

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-payment
- [x] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
