### PR TITLE
Fix Stripe automatic tax support

### DIFF
--- a/components/usage/pkg/stripe/stripe.go
+++ b/components/usage/pkg/stripe/stripe.go
@@ -234,6 +234,7 @@ func (c *Client) GetCustomer(ctx context.Context, customerID string) (customer *
 	customer, err = c.sc.Customers.Get(customerID, &stripe.CustomerParams{
 		Params: stripe.Params{
 			Context: ctx,
+			Expand:  []*string{stripe.String("tax")},
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

When we create a new subscription, we check whether the customer supports "automatic tax".

This information is present in a `tax` section that needs to be expanded when retrieving a customer:

https://github.com/gitpod-io/gitpod/blob/b1161a50943463e7547f212991c327e238f51bf2/components/server/ee/src/user/stripe-service.ts#L126

Unfortunately, when we ported this code to Go, we lost the expansion of the customer `tax` section, so we no longer enable automatic tax even when it's supported:

https://github.com/gitpod-io/gitpod/blob/2cf5dc7451899aa1f7da920c14cafa83387ff21e/components/usage/pkg/apiv1/billing.go#L193

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

1. Create a subscription from an automatic tax supported location (e.g. any EU country)
2. In the Stripe dashboard, your new subscription should have automatic tax enabled

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
