### PR TITLE
Set LEEWAY_CACHE_DIR and LEEWAY_BUILD_DIR

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
-image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-leeway-v0.7.1.0
+image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-hartmann-don-t-store-leeway-15060.0
 workspaceLocation: gitpod/gitpod-ws.code-workspace
 checkoutLocation: gitpod
 ports:

--- a/.werft/aks-installer-tests.yaml
+++ b/.werft/aks-installer-tests.yaml
@@ -65,7 +65,7 @@ pod:
       secretName: self-hosted-github-oauth
   containers:
   - name: nightly-test
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-leeway-v0.7.1.0
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-hartmann-don-t-store-leeway-15060.0
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/build.yaml
+++ b/.werft/build.yaml
@@ -70,7 +70,7 @@ pod:
     - name: MYSQL_TCP_PORT
       value: 23306
   - name: build
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-leeway-v0.7.1.0
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-hartmann-don-t-store-leeway-15060.0
     workingDir: /workspace
     imagePullPolicy: IfNotPresent
     resources:

--- a/.werft/cleanup-installer-tests.yaml
+++ b/.werft/cleanup-installer-tests.yaml
@@ -25,7 +25,7 @@ pod:
       secretName: aks-credentials
   containers:
   - name: nightly-test
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-leeway-v0.7.1.0
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-hartmann-don-t-store-leeway-15060.0
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/debug.yaml
+++ b/.werft/debug.yaml
@@ -54,7 +54,7 @@ pod:
     - name: MYSQL_TCP_PORT
       value: 23306
   - name: build
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-leeway-v0.7.1.0
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-hartmann-don-t-store-leeway-15060.0
     workingDir: /workspace
     imagePullPolicy: IfNotPresent
     volumeMounts:

--- a/.werft/eks-installer-tests.yaml
+++ b/.werft/eks-installer-tests.yaml
@@ -65,7 +65,7 @@ pod:
       secretName: self-hosted-github-oauth
   containers:
   - name: nightly-test
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-leeway-v0.7.1.0
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-hartmann-don-t-store-leeway-15060.0
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/gke-installer-tests.yaml
+++ b/.werft/gke-installer-tests.yaml
@@ -65,7 +65,7 @@ pod:
         secretName: self-hosted-github-oauth
   containers:
     - name: nightly-test
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-leeway-v0.7.1.0
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-hartmann-don-t-store-leeway-15060.0
       workingDir: /workspace
       imagePullPolicy: Always
       volumeMounts:

--- a/.werft/ide-integration-tests-startup.yaml
+++ b/.werft/ide-integration-tests-startup.yaml
@@ -17,7 +17,7 @@ pod:
         secretName: github-token-gitpod-bot
   containers:
     - name: gcloud
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-leeway-v0.7.1.0
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-hartmann-don-t-store-leeway-15060.0
       workingDir: /workspace
       imagePullPolicy: IfNotPresent
       env:

--- a/.werft/k3s-installer-tests.yaml
+++ b/.werft/k3s-installer-tests.yaml
@@ -65,7 +65,7 @@ pod:
       secretName: self-hosted-github-oauth
   containers:
   - name: nightly-test
-    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-leeway-v0.7.1.0
+    image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-hartmann-don-t-store-leeway-15060.0
     workingDir: /workspace
     imagePullPolicy: Always
     volumeMounts:

--- a/.werft/platform-delete-preview-environment.yaml
+++ b/.werft/platform-delete-preview-environment.yaml
@@ -25,7 +25,7 @@ pod:
         secretName: harvester-vm-ssh-keys
   containers:
     - name: build
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-leeway-v0.7.1.0
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-hartmann-don-t-store-leeway-15060.0
       workingDir: /workspace
       imagePullPolicy: IfNotPresent
       volumeMounts:

--- a/.werft/platform-delete-preview-environments-cron.yaml
+++ b/.werft/platform-delete-preview-environments-cron.yaml
@@ -29,7 +29,7 @@ pod:
         secretName: github-token-gitpod-bot
   containers:
     - name: build
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-leeway-v0.7.1.0
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-hartmann-don-t-store-leeway-15060.0
       workingDir: /workspace
       imagePullPolicy: IfNotPresent
       volumeMounts:

--- a/.werft/platform-trigger-artificial-job.yaml
+++ b/.werft/platform-trigger-artificial-job.yaml
@@ -24,7 +24,7 @@ pod:
         secretName: github-token-gitpod-bot
   containers:
     - name: build
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-leeway-v0.7.1.0
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-hartmann-don-t-store-leeway-15060.0
       workingDir: /workspace
       imagePullPolicy: IfNotPresent
       volumeMounts:

--- a/.werft/platform-trigger-werft-cleanup.yaml
+++ b/.werft/platform-trigger-werft-cleanup.yaml
@@ -22,7 +22,7 @@ pod:
         secretName: gcp-sa-gitpod-dev-deployer
   containers:
     - name: build
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-leeway-v0.7.1.0
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-hartmann-don-t-store-leeway-15060.0
       workingDir: /workspace
       imagePullPolicy: IfNotPresent
       volumeMounts:

--- a/.werft/workspace-run-integration-tests.yaml
+++ b/.werft/workspace-run-integration-tests.yaml
@@ -22,7 +22,7 @@ pod:
         secretName: github-token-gitpod-bot
   containers:
     - name: gcloud
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-leeway-v0.7.1.0
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-hartmann-don-t-store-leeway-15060.0
       workingDir: /workspace
       imagePullPolicy: IfNotPresent
       env:

--- a/dev/image/Dockerfile
+++ b/dev/image/Dockerfile
@@ -59,6 +59,10 @@ RUN cd /usr/bin && curl -fsSL https://github.com/praetorian-inc/gokart/releases/
 # leeway
 ARG LEEWAY_VERSION=0.7.1
 ENV LEEWAY_MAX_PROVENANCE_BUNDLE_SIZE=8388608
+ENV LEEWAY_WORKSPACE_ROOT=/workspace/gitpod
+ENV LEEWAY_REMOTE_CACHE_BUCKET=gitpod-core-leeway-cache-branch
+ENV LEEWAY_CACHE_DIR=/var/tmp/cache
+ENV LEEWAY_BUILD_DIR=/var/tmp/build
 RUN cd /usr/bin && curl -fsSL https://github.com/gitpod-io/leeway/releases/download/v${LEEWAY_VERSION}/leeway_${LEEWAY_VERSION}_Linux_x86_64.tar.gz | tar xz
 
 # evans (gRPC client)
@@ -170,9 +174,6 @@ ARG GCLOUD_CONFIG_DIR=/home/gitpod/.config/gcloud
 COPY --chown=gitpod gcloud-default-config $GCLOUD_CONFIG_DIR/configurations/config_default
 
 ENV DB_HOST=localhost
-
-ENV LEEWAY_WORKSPACE_ROOT=/workspace/gitpod
-ENV LEEWAY_REMOTE_CACHE_BUCKET=gitpod-core-leeway-cache-branch
 
 # awscliv2
 # See also: https://docs.aws.amazon.com/cli/latest/userguide/getting-started-version.html


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This moves the Leeway cache and build directory to `/var/tmp` - see https://github.com/gitpod-io/gitpod/issues/15060 for the reasoning behind this.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/15060

## How to test
<!-- Provide steps to test this PR -->

- [x]  `leeway run dev:preview`
- [ ] ❌ `leeway run dev:preview` after having changed `components/ide/jetbrains/image/status/main.go` as this trigger a rebuild of all the IDEs which would run out of disk before. ➡️ We still run out of disk space, but that's expected given that we're hitting the hard Gitpod limit "Evicted: Pod ephemeral local storage usage exceeds the total limit of containers 20Gi."
- [x] `werft job run github -a with-preview=true -a with-integration-tests=workspace` - job [here](https://werft.gitpod-dev.com/job/gitpod-build-mads-hartmann-don-t-store-leeway-15060.2)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
