### PR TITLE
Remove beta and early access labels for Teams, Projects, and Billing

### DIFF
--- a/components/dashboard/src/components/UsageView.tsx
+++ b/components/dashboard/src/components/UsageView.tsx
@@ -23,7 +23,6 @@ import { ReactComponent as Spinner } from "../icons/Spinner.svg";
 import { ReactComponent as UsageIcon } from "../images/usage-default.svg";
 import { toRemoteURL } from "../projects/render-utils";
 import { WorkspaceType } from "@gitpod/gitpod-protocol";
-import PillLabel from "./PillLabel";
 import { SupportedWorkspaceClass } from "@gitpod/gitpod-protocol/lib/workspace-class";
 import DatePicker from "react-datepicker";
 import "react-datepicker/dist/react-datepicker.css";
@@ -265,26 +264,6 @@ function UsageView({ attributionId }: UsageViewProps) {
                                             <div className="flex text-lg text-gray-600 font-semibold">
                                                 <CreditsSvg className="my-auto mr-1" />
                                                 <span>{totalCreditsUsed.toLocaleString()} Credits</span>
-                                            </div>
-                                        </div>
-                                        <div className="flex flex-col truncate mt-8 text-sm">
-                                            <div className="text-gray-400 dark:text-gray-500 text-sm text-left">
-                                                <strong>Usage</strong> feature is in{" "}
-                                                <PillLabel
-                                                    type="warn"
-                                                    className="font-semibold mt-2 ml-0 py-0.5 px-1 self-center"
-                                                >
-                                                    <a href="https://www.gitpod.io/docs/references/gitpod-releases">
-                                                        <span className="text-xs">Early Access</span>
-                                                    </a>
-                                                </PillLabel>
-                                                <br />
-                                                <a
-                                                    href="https://github.com/gitpod-io/gitpod/issues/12636"
-                                                    className="gp-link"
-                                                >
-                                                    Send feedback
-                                                </a>
                                             </div>
                                         </div>
                                     </div>

--- a/components/dashboard/src/projects/NewProject.tsx
+++ b/components/dashboard/src/projects/NewProject.tsx
@@ -29,7 +29,6 @@ import {
 } from "../service/public-api";
 import { FeatureFlagContext } from "../contexts/FeatureFlagContext";
 import { ConnectError } from "@bufbuild/connect-web";
-import PillLabel from "../components/PillLabel";
 
 export default function NewProject() {
     const location = useLocation();
@@ -482,18 +481,6 @@ export default function NewProject() {
                         </div>
                     </div>
                 )}
-                <div className="text-gray-400 dark:text-gray-500 text-sm mt-24 text-left">
-                    <strong>Projects</strong> feature is in{" "}
-                    <PillLabel type="warn" className="font-semibold mt-2 ml-0 py-0.5 px-1 self-center">
-                        <a href="https://www.gitpod.io/docs/references/gitpod-releases">
-                            <span className="text-xs">BETA</span>
-                        </a>
-                    </PillLabel>
-                    &nbsp;&middot;&nbsp;
-                    <a href="https://github.com/gitpod-io/gitpod/issues/5095" className="gp-link">
-                        Send feedback
-                    </a>
-                </div>
             </>
         );
 

--- a/components/dashboard/src/teams/NewTeam.tsx
+++ b/components/dashboard/src/teams/NewTeam.tsx
@@ -11,7 +11,6 @@ import { TeamsContext } from "./teams-context";
 import { publicApiTeamsToProtocol, publicApiTeamToProtocol, teamsService } from "../service/public-api";
 import { FeatureFlagContext } from "../contexts/FeatureFlagContext";
 import { ConnectError } from "@bufbuild/connect-web";
-import PillLabel from "../components/PillLabel";
 
 export default function () {
     const { setTeams } = useContext(TeamsContext);
@@ -87,19 +86,6 @@ export default function () {
                     </button>
                 </div>
             </form>
-
-            <div className="text-gray-400 dark:text-gray-500 text-sm mt-24 text-left">
-                <strong>Teams</strong> feature is in{" "}
-                <PillLabel type="warn" className="font-semibold mt-2 ml-0 py-0.5 px-1 self-center">
-                    <a href="https://www.gitpod.io/docs/references/gitpod-releases">
-                        <span className="text-xs">BETA</span>
-                    </a>
-                </PillLabel>
-                &nbsp;&middot;&nbsp;
-                <a href="https://github.com/gitpod-io/gitpod/issues/5095" className="gp-link">
-                    Send feedback
-                </a>
-            </div>
         </div>
     );
 }


### PR DESCRIPTION
## Description

Following the changes to graduate Teams, Projects, and Billing from beta and early access, this will remove these labels from the dashboard. See [relevant discussion](https://gitpod.slack.com/archives/C027AUU7BC3/p1670507118066149) (internal).

See relevant docs: 
- [Teams](https://www.gitpod.io/docs/configure/teams)
- [Projects](https://www.gitpod.io/docs/configure/projects)
- [Billing](https://www.gitpod.io/docs/configure/billing)

## How to test
1. Try creating a new **team** and notice there's no beta label anymore.
2. Try creating a new **project** and notice there's no beta label anymore.
3. Create a team and go to team usage and notice there's no early access label anymore.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Remove beta and early access labels for Teams, Projects, and Billing
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [x] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
