### PR TITLE
[installer]: fix config struct documentation

### DIFF
--- a/install/installer/pkg/config/v1/config.md
+++ b/install/installer/pkg/config/v1/config.md
@@ -6,7 +6,7 @@ Config defines the v1 version structure of the gitpod config file
 ## Supported parameters
 | Property | Type | Required | Allowed| Description |
 | --- | --- | --- | --- | --- |
-|`kind`|string|N| `Meta`, `Workspace`, `Full` ||
+|`kind`|string|N| `IDE`, `WebApp`, `Meta`, `Workspace`, `Full` ||
 |`domain`|string|Y|  |  The domain to deploy to|
 |`metadata.region`|string|Y|  |  Location for your objectStorage provider|
 |`metadata.shortname`|string|N|  |  InstallationShortname establishes the "identity" of the (application) cluster.|
@@ -14,6 +14,7 @@ Config defines the v1 version structure of the gitpod config file
 |`observability.logLevel`|string|N| `trace`, `debug`, `info`, `warning`, `error`, `fatal`, `panic` |Taken from github.com/gitpod-io/gitpod/components/gitpod-protocol/src/util/logging.ts|
 |`observability.tracing.endpoint`|string|N|  ||
 |`observability.tracing.agentHost`|string|N|  ||
+|`observability.tracing.secretName`|string|N|  |  Name of the kubernetes secret to use for Jaeger authentication  The secret should contains two definitions: JAEGER_USER and JAEGER_PASSWORD|
 |`analytics.segmentKey`|string|N|  ||
 |`analytics.writer`|string|N|  ||
 |`database.inCluster`|bool|N|  ||
@@ -27,15 +28,16 @@ Config defines the v1 version structure of the gitpod config file
 |`objectStorage.s3.credentials.kind`|string|N| `secret` ||
 |`objectStorage.s3.credentials.name`|string|Y|  ||
 |`objectStorage.s3.bucket`|string|N|  |  BucketName sets the name of an existing bucket to enable the "single bucket mode"  If no name is configured, the old "one bucket per user" behaviour kicks in.|
+|`objectStorage.s3.allowInsecureConnection`|bool|N|  ||
 |`objectStorage.cloudStorage.serviceAccount.kind`|string|N| `secret` ||
 |`objectStorage.cloudStorage.serviceAccount.name`|string|Y|  ||
 |`objectStorage.cloudStorage.project`|string|Y|  ||
 |`objectStorage.azure.credentials.kind`|string|N| `secret` ||
 |`objectStorage.azure.credentials.name`|string|Y|  ||
+|`objectStorage.maximumBackupCount`|int|N|  |  DEPRECATED|
 |`objectStorage.blobQuota`|int64|N|  ||
 |`objectStorage.resources.requests`||Y|  |  todo(sje): add custom validation to corev1.ResourceList|
 |`objectStorage.resources.limits`||N|  ||
-|`objectStorage.resources.dynamicLimits`||N|  ||
 |`containerRegistry.inCluster`|bool|Y|  ||
 |`containerRegistry.external.url`|string|Y|  ||
 |`containerRegistry.external.certificate.kind`|string|N| `secret` ||
@@ -48,6 +50,8 @@ Config defines the v1 version structure of the gitpod config file
 |`containerRegistry.privateBaseImageAllowList[ ]`|[]string|N|  ||
 |`certificate.kind`|string|N| `secret` ||
 |`certificate.name`|string|Y|  ||
+|`httpProxy.kind`|string|N| `secret` ||
+|`httpProxy.name`|string|Y|  ||
 |`imagePullSecrets[ ].kind`|string|N| `secret` ||
 |`imagePullSecrets[ ].name`|string|Y|  ||
 |`workspace.runtime.fsShiftMethod`|string|N| `fuse`, `shiftfs` ||
@@ -55,27 +59,27 @@ Config defines the v1 version structure of the gitpod config file
 |`workspace.runtime.containerdSocket`|string|Y|  |  The location of containerd socket on the host machine|
 |`workspace.resources.requests`||Y|  |  todo(sje): add custom validation to corev1.ResourceList|
 |`workspace.resources.limits`||N|  ||
-|`workspace.resources.dynamicLimits`||N|  ||
 |`workspace.templates.default`||N|  ||
 |`workspace.templates.prebuild`||N|  ||
 |`workspace.templates.imagebuild`||N|  ||
 |`workspace.templates.regular`||N|  ||
-|`workspace.prebuildPVC.size`||Y|  |  Size is a size of prebuild workspace persistent volume claim to use|
-|`workspace.prebuildPVC.storageClass`|string|N|  |  StorageClass is a storage class of prebuild workspace persistent volume claim to use|
-|`workspace.prebuildPVC.snapshotClass`|string|N|  |  SnapshotClass is a snapshot class name that is used to create volume snapshot for prebuild workspace|
-|`workspace.pvc.size`||Y|  |  Size is a size of regular workspace persistent volume claim to use|
-|`workspace.pvc.storageClass`|string|N|  |  StorageClass is a storage class of regular workspace persistent volume claim to use|
-|`workspace.pvc.snapshotClass`|string|N|  |  SnapshotClass is a snapshot class name that is used to create volume snapshot for regular workspace|
+|`workspace.prebuildPVC.size`||Y|  |  Size is a size of persistent volume claim to use|
+|`workspace.prebuildPVC.storageClass`|string|N|  |  StorageClass is a storage class of persistent volume claim to use|
+|`workspace.prebuildPVC.snapshotClass`|string|N|  |  SnapshotClass is a snapshot class name that is used to create volume snapshot|
+|`workspace.pvc.size`||Y|  |  Size is a size of persistent volume claim to use|
+|`workspace.pvc.storageClass`|string|N|  |  StorageClass is a storage class of persistent volume claim to use|
+|`workspace.pvc.snapshotClass`|string|N|  |  SnapshotClass is a snapshot class name that is used to create volume snapshot|
 |`workspace.maxLifetime`||Y|  |  MaxLifetime is the maximum time a workspace is allowed to run. After that, the workspace times out despite activity|
 |`workspace.timeoutDefault`||N|  |  TimeoutDefault is the default timeout of a regular workspace|
 |`workspace.timeoutExtended`||N|  |  TimeoutExtended is the workspace timeout that a user can extend to for one workspace|
 |`workspace.timeoutAfterClose`||N|  |  TimeoutAfterClose is the time a workspace timed out after it has been closed (“closed” means that it does not get a heartbeat from an IDE anymore)|
 |`workspace.workspaceImage`|string|N|  ||
 |`openVSX.url`|string|N|  ||
+|`openVSX.proxy.disablePVC`|bool|N|  ||
 |`authProviders[ ].kind`|string|N| `secret` ||
 |`authProviders[ ].name`|string|Y|  ||
 |`blockNewUsers.enabled`|bool|N|  ||
-|`blockNewUsers.passlist[ ]`|[]string|N|  ||
+|`blockNewUsers.passlist[ ]`|[]string|N|  |  Passlist []string `json:"passlist" validate:"min=1,unique,dive,fqdn"`|
 |`license.kind`|string|N| `secret` ||
 |`license.name`|string|Y|  ||
 |`sshGatewayHostKey.kind`|string|N| `secret` ||
@@ -106,13 +110,18 @@ Additional config parameters that are in experimental state
 |`experimental.workspace.workspacePortURLTemplate`|string|N|  ||
 |`experimental.workspace.workspacePortURLTemplate`|string|N|  ||
 |`experimental.workspace.ioLimits`||N|  ||
+|`experimental.workspace.networkLimits`||N|  ||
+|`experimental.workspace.oomScores`||N|  ||
 |`experimental.workspace.procLimit`|int64|N|  ||
 |`experimental.workspace.wsManagerRateLimits`||N|  ||
 |`experimental.workspace.registryFacade`||N|  ||
 |`experimental.workspace.wsDaemon`||N|  ||
 |`experimental.workspace.classes`||N|  ||
 |`experimental.workspace.wsProxy`||N|  ||
-|`experimental.webapp.publicApi.enabled`|bool|N|  ||
+|`experimental.workspace.contentService`||N|  ||
+|`experimental.workspace.enableProtectedSecrets`|bool|N|  ||
+|`experimental.webapp.publicApi.stripeSecretName`|string|N|  |  Name of the kubernetes secret to use for Stripe secrets|
+|`experimental.webapp.publicApi.personalAccessTokenSigningKeySecretName`|string|N|  |  Name of the kubernetes secret to use for signature of Personal Access Tokens|
 |`experimental.webapp.server.workspaceDefaults.workspaceImage`|string|N|  |  @deprecated use workspace.workspaceImage instead|
 |`experimental.webapp.server.oauthServer.jwtSecret`|string|N|  ||
 |`experimental.webapp.server.session.secret`|string|N|  ||
@@ -131,13 +140,14 @@ Additional config parameters that are in experimental state
 |`experimental.webapp.server.disableDynamicAuthProviderLogin`|bool|N|  ||
 |`experimental.webapp.server.enableLocalApp`|bool|N|  ||
 |`experimental.webapp.server.runDbDeleter`|bool|N|  ||
-|`experimental.webapp.server.defaultBaseImageRegistryWhitelist[ ]`|[]string|N|  |  @deprecated use containerRegistry.privateBaseImageAllowList instead|
 |`experimental.webapp.server.disableWorkspaceGarbageCollection`|bool|N|  ||
-|`experimental.webapp.server.blockedRepositories[ ].urlRegExp`|string|N|  ||
-|`experimental.webapp.server.blockedRepositories[ ].blockUser`|bool|N|  ||
+|`experimental.webapp.server.inactivityPeriodForReposInDays`|int|N|  ||
+|`experimental.webapp.server.defaultBaseImageRegistryWhitelist[ ]`|[]string|N|  |  @deprecated use containerRegistry.privateBaseImageAllowList instead|
 |`experimental.webapp.proxy.staticIP`|string|N|  ||
 |`experimental.webapp.proxy.serviceAnnotations`||N|  ||
 |`experimental.webapp.proxy.serviceType`||N|  |  @deprecated use components.proxy.service.serviceType instead|
+|`experimental.webapp.proxy.configcat.baseUrl`|string|N|  ||
+|`experimental.webapp.proxy.configcat.pollInterval`|string|N|  ||
 |`experimental.webapp.wsManagerBridge.skipSelf`|bool|N|  ||
 |`experimental.webapp.tracing.samplerType`|string|N| `const`, `probabilistic`, `rateLimiting`, `remote` |Values taken from https://github.com/jaegertracing/jaeger-client-go/blob/967f9c36f0fa5a2617c9a0993b03f9a3279fadc8/config/config.go#L71|
 |`experimental.webapp.tracing.samplerParam`|float64|N|  ||
@@ -145,14 +155,32 @@ Additional config parameters that are in experimental state
 |`experimental.webapp.disableMigration`|bool|N|  ||
 |`experimental.webapp.usage.enabled`|bool|N|  ||
 |`experimental.webapp.usage.schedule`|string|N|  ||
-|`experimental.webapp.usage.defaultSpendingLimit.ForUsers`||N|  ||
-|`experimental.webapp.usage.defaultSpendingLimit.ForTeams`||N|  ||
+|`experimental.webapp.usage.resetUsageSchedule`|string|N|  ||
+|`experimental.webapp.usage.billInstancesAfter`||N|  ||
+|`experimental.webapp.usage.defaultSpendingLimit`||N|  ||
 |`experimental.webapp.usage.creditsPerMinuteByWorkspaceClass`||N|  ||
 |`experimental.webapp.configcatKey`|string|N|  ||
+|`experimental.webapp.workspaceClasses[ ].id`|string|N|  ||
+|`experimental.webapp.workspaceClasses[ ].category`|string|N|  ||
+|`experimental.webapp.workspaceClasses[ ].displayName`|string|N|  ||
+|`experimental.webapp.workspaceClasses[ ].description`|string|N|  ||
+|`experimental.webapp.workspaceClasses[ ].powerups`|uint32|N|  ||
+|`experimental.webapp.workspaceClasses[ ].isDefault`|bool|N|  ||
+|`experimental.webapp.workspaceClasses[ ].deprecated`|bool|N|  ||
+|`experimental.webapp.workspaceClasses[ ].marker`||N|  ||
+|`experimental.webapp.workspaceClasses[ ].credits.perMinute`|float64|N|  ||
+|`experimental.webapp.stripe.individualUsagePriceIds.eur`|string|N|  ||
+|`experimental.webapp.stripe.individualUsagePriceIds.usd`|string|N|  ||
+|`experimental.webapp.stripe.teamUsagePriceIds.eur`|string|N|  ||
+|`experimental.webapp.stripe.teamUsagePriceIds.usd`|string|N|  ||
+|`experimental.webapp.slowDatabase`|bool|N|  ||
+|`experimental.webapp.iam`|IAMConfig|N|  ||
 |`experimental.ide.resolveLatest`|bool|N|  |  Disable resolution of latest images and use bundled latest versions instead|
 |`experimental.ide.ideProxy.serviceAnnotations`||N|  ||
 |`experimental.ide.openvsxProxy.serviceAnnotations`||N|  ||
+|`experimental.ide.ideMetrics.enabledErrorReporting`|bool|N|  ||
 |`experimental.common.podConfig`||N|  ||
 |`experimental.common.staticMessagebusPassword`|string|N|  ||
+|`experimental.common.usePodSecurityPolicies`|bool|N|  |  @deprecated PodSecurityPolicies are deprecated in k8s 1.21 and removed in 1.25|
 |`experimental.telemetry.data`||N|  ||
 |`experimental.agentSmith`||N|  ||

--- a/install/installer/scripts/structdoc.go
+++ b/install/installer/scripts/structdoc.go
@@ -53,6 +53,8 @@ func extractTags(tag string) (result fieldSpec, err error) {
 
 	metadata, err := tagObj.Get("json")
 	if err != nil {
+		// There is no "json" tag in this key - move on
+		err = nil
 		return
 	}
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

1. fixes the config struct documentation script as the presence of env reflect tags had broken it
1. update the config docs

## How to test
<!-- Provide steps to test this PR -->
Run `make config-doc`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
