### PR TITLE
Tag VS Code Insiders versions accordingly

### DIFF
--- a/components/ide/code/leeway.Dockerfile
+++ b/components/ide/code/leeway.Dockerfile
@@ -55,6 +55,7 @@ RUN commitVersion=$(cat package.json | jq -r .version) \
 RUN nameShort=$(jq --raw-output '.nameShort' product.json) && \
     nameLong=$(jq --raw-output '.nameLong' product.json) && \
     if [ "$CODE_QUALITY" = "insider" ]; then \
+        ${CODE_VERSION}=${CODE_VERSION}-insider \
         nameShort="$nameShort - Insiders" \
         nameLong="$nameLong - Insiders" \
     ; fi  && \
@@ -67,6 +68,8 @@ RUN nameShort=$(jq --raw-output '.nameShort' product.json) && \
     cat product.json | jq "${jqCommands}" > product.json.tmp && \
     mv product.json.tmp product.json && \
     jq '{quality,nameLong,nameShort}' product.json
+
+ENV CODE_VERSION=$CODE_VERSION
 
 RUN yarn --cwd extensions compile \
     && yarn gulp vscode-web-min \


### PR DESCRIPTION
## Description

When building VS Code Browser images, take a look at whether it's a stable or insiders release and if the latter, tag it as such (e.g. `1.74.0-insider`). Previously, we did not take quality into account.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
