### PR TITLE
Better looking version strings in the Dashboard

### DIFF
--- a/components/dashboard/src/components/SelectIDEComponent.tsx
+++ b/components/dashboard/src/components/SelectIDEComponent.tsx
@@ -4,7 +4,7 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { IDEOption, IDEOptions } from "@gitpod/gitpod-protocol/lib/ide-protocol";
+import { IDEOption, IDEOptions, makeIdeVersionHumanReadable } from "@gitpod/gitpod-protocol";
 import { useCallback, useEffect, useState } from "react";
 import { getGitpodService } from "../service/service";
 import { DropDown2, DropDown2Element } from "./DropDown2";
@@ -149,7 +149,7 @@ function IdeOptionElementInDropDown(p: IdeOptionElementProps): JSX.Element {
                 {version && (
                     <>
                         <div className="mx-1">&middot;</div>
-                        <div>{version}</div>
+                        <div>{makeIdeVersionHumanReadable(version)}</div>
                     </>
                 )}
                 {label && (

--- a/components/dashboard/src/user-settings/SelectIDE.tsx
+++ b/components/dashboard/src/user-settings/SelectIDE.tsx
@@ -12,7 +12,7 @@ import Tooltip from "../components/Tooltip";
 import { getGitpodService } from "../service/service";
 import { UserContext } from "../user-context";
 import CheckBox from "../components/CheckBox";
-import { User } from "@gitpod/gitpod-protocol";
+import { User, makeIdeVersionHumanReadable } from "@gitpod/gitpod-protocol";
 import PillLabel from "../components/PillLabel";
 
 export type IDEChangedTrackLocation = "workspace_list" | "workspace_start" | "preferences";
@@ -94,7 +94,12 @@ export default function SelectIDE(props: SelectIDEProps) {
                                     const selected = defaultIde === id;
                                     const version = useLatestVersion ? option.latestImageVersion : option.imageVersion;
                                     const onSelect = () => actuallySetDefaultIde(id);
-                                    return renderIdeOption(option, selected, version, onSelect);
+                                    return renderIdeOption(
+                                        option,
+                                        selected,
+                                        makeIdeVersionHumanReadable(version),
+                                        onSelect,
+                                    );
                                 })}
                             </div>
                             {ideOptions.options[defaultIde]?.notes && (

--- a/components/gitpod-protocol/src/ide-protocol.spec.ts
+++ b/components/gitpod-protocol/src/ide-protocol.spec.ts
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2020 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License-AGPL.txt in the project root for license information.
+ */
+
+import { suite, test } from "mocha-typescript";
+import * as chai from "chai";
+import { makeIdeVersionHumanReadable } from ".";
+
+const expect = chai.expect;
+
+@suite
+class TestIdeProtocol {
+    @test public testSuffixedIdeVersion() {
+        const versionString = "v1.74.0-insider";
+
+        expect(makeIdeVersionHumanReadable(versionString)).to.deep.equal("v1.74.0 Insider");
+    }
+    @test public testUnsuffixedIdeVersion() {
+        const versionString = "v1.74.0";
+
+        expect(makeIdeVersionHumanReadable(versionString)).to.deep.equal("v1.74.0");
+    }
+}
+module.exports = new TestIdeProtocol(); // Only to circumvent no usage warning :-/

--- a/components/gitpod-protocol/src/ide-protocol.ts
+++ b/components/gitpod-protocol/src/ide-protocol.ts
@@ -145,3 +145,27 @@ export interface IDEOption {
      */
     latestImageVersion?: string;
 }
+
+/**
+ * Takes a version string of the form `X.Y.Z-<pre-release-tag>` and returns a human-readable version string
+ * where the pre-release tag is capitalized and separated from the version number by a space.
+ *
+ * @example
+ * makeIdeVersionHumanReadable("1.74.0-insider") // returns "1.74.0 Insider"
+ *
+ * @param [versionString] - The version string to convert to human-readable format
+ * @returns A human-readable version string, or `undefined` if `versionString` is falsy
+ */
+export const makeIdeVersionHumanReadable = (versionString?: string): string | undefined => {
+    if (!versionString) {
+        return undefined;
+    }
+
+    let [version, pre] = versionString.split("-");
+    if (pre) {
+        // Capitalize the string, so that 1.74.0-insider becomes 1.74.0 Insider
+        pre = pre[0].toUpperCase() + pre.slice(1);
+    }
+
+    return [version, pre].join(" ").trim();
+};

--- a/components/gitpod-protocol/src/index.ts
+++ b/components/gitpod-protocol/src/index.ts
@@ -20,3 +20,4 @@ export * from "./snapshot-url";
 export * from "./oss-allowlist";
 export * from "./installation-admin-protocol";
 export * from "./webhook-event";
+export * from "./ide-protocol";


### PR DESCRIPTION
## Description

This PR makes sure that in the IDE selector, we prettify version string containing hyphens. 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
