### PR TITLE
Adding a tooltip w/ full expiration date

### DIFF
--- a/components/dashboard/package.json
+++ b/components/dashboard/package.json
@@ -21,6 +21,8 @@
     "react-datepicker": "^4.8.0",
     "react-dom": "^17.0.1",
     "react-intl-tel-input": "^8.2.0",
+    "react-popper": "^2.3.0",
+    "react-portal": "^4.2.2",
     "react-router-dom": "^5.2.0",
     "xterm": "^4.11.0",
     "xterm-addon-fit": "^0.5.0"
@@ -38,6 +40,7 @@
     "@types/node": "^16.11.0",
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.3",
+    "@types/react-portal": "^4.0.4",
     "@types/react-router": "^5.1.13",
     "@types/react-router-dom": "^5.1.7",
     "@types/uuid": "^8.3.1",

--- a/components/dashboard/src/settings/TokenEntry.tsx
+++ b/components/dashboard/src/settings/TokenEntry.tsx
@@ -8,6 +8,7 @@ import { PersonalAccessToken } from "@gitpod/public-api/lib/gitpod/experimental/
 import dayjs from "dayjs";
 import { ContextMenuEntry } from "../components/ContextMenu";
 import { ItemFieldContextMenu } from "../components/ItemsList";
+import Tooltip from "../components/Tooltip";
 import { ReactComponent as ExclamationIcon } from "../images/exclamation.svg";
 import { AllPermissions } from "./PersonalAccessTokens";
 
@@ -19,6 +20,7 @@ interface TokenEntryProps {
 function TokenEntry(props: TokenEntryProps) {
     const expirationDay = dayjs(props.token.expirationTime!.toDate());
     const expired = expirationDay.isBefore(dayjs());
+    const expirationDateString = expirationDay.format("MMM D, YYYY, hh:mm A");
 
     const getScopes = () => {
         if (!props.token.scopes) {
@@ -44,7 +46,11 @@ function TokenEntry(props: TokenEntryProps) {
                 <div className="flex items-center w-3/12 text-gray-400">
                     <span className={"flex items-center gap-1 truncate" + (expired ? " text-orange-600" : "")}>
                         <span>{expirationDay.format("MMM D, YYYY")}</span>
-                        {expired && <ExclamationIcon fill="#D97706" className="h-4 w-4" />}
+                        {expired && (
+                            <Tooltip content={expirationDateString}>
+                                <ExclamationIcon fill="#D97706" className="h-4 w-4" />
+                            </Tooltip>
+                        )}
                     </span>
                 </div>
                 <div className="flex items-center justify-end w-1/12">

--- a/components/dashboard/src/settings/TokenEntry.tsx
+++ b/components/dashboard/src/settings/TokenEntry.tsx
@@ -35,29 +35,27 @@ function TokenEntry(props: TokenEntryProps) {
     };
 
     return (
-        <>
-            <div className="rounded-xl whitespace-nowrap flex space-x-2 py-4 px-4 w-full justify-between hover:bg-gray-100 dark:hover:bg-gray-800 focus:bg-gitpod-kumquat-light group">
-                <div className="flex items-center pr-3 w-4/12">
-                    <span className="truncate">{props.token.name || ""}</span>
-                </div>
-                <div className="flex items-center w-4/12 text-gray-400 font-medium">
-                    <span className="truncate whitespace-pre-line">{getScopes()}</span>
-                </div>
-                <div className="flex items-center w-3/12 text-gray-400">
-                    <span className={"flex items-center gap-1 truncate" + (expired ? " text-orange-600" : "")}>
-                        <span>{expirationDay.format("MMM D, YYYY")}</span>
-                        {expired && (
-                            <Tooltip content={expirationDateString}>
-                                <ExclamationIcon fill="#D97706" className="h-4 w-4" />
-                            </Tooltip>
-                        )}
-                    </span>
-                </div>
-                <div className="flex items-center justify-end w-1/12">
-                    <ItemFieldContextMenu menuEntries={props.menuEntries} />
-                </div>
+        <div className="rounded-xl whitespace-nowrap flex space-x-2 py-4 px-4 w-full justify-between hover:bg-gray-100 dark:hover:bg-gray-800 focus:bg-gitpod-kumquat-light group">
+            <div className="flex items-center pr-3 w-4/12">
+                <span className="truncate">{props.token.name || ""}</span>
             </div>
-        </>
+            <div className="flex items-center w-4/12 text-gray-400 font-medium">
+                <span className="truncate whitespace-pre-line">{getScopes()}</span>
+            </div>
+            <div className="flex items-center w-3/12 text-gray-400">
+                <span className={"flex items-center gap-1 truncate" + (expired ? " text-orange-600" : "")}>
+                    <span>{expirationDay.format("MMM D, YYYY")}</span>
+                    {expired && (
+                        <Tooltip content={expirationDateString}>
+                            <ExclamationIcon fill="#D97706" className="h-4 w-4" />
+                        </Tooltip>
+                    )}
+                </span>
+            </div>
+            <div className="flex items-center justify-end w-1/12">
+                <ItemFieldContextMenu menuEntries={props.menuEntries} />
+            </div>
+        </div>
     );
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3188,6 +3188,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-portal@^4.0.4":
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/@types/react-portal/-/react-portal-4.0.4.tgz#1c0e5a248f6e18a66f981139c13b6e796f4a92b6"
+  integrity sha512-ecVWngYHeSymq5XdrQOXRpIb9ay5SM4Stm/ur6+wc0Z+r05gafZ5SuMRbXKYsj4exNJa+4CTKK6J7qcTKm9K5g==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-router-dom@^5.1.7":
   version "5.3.2"
   resolved "https://registry.npmjs.org/@types/react-router-dom/-/react-router-dom-5.3.2.tgz"
@@ -14572,7 +14579,7 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.5.4, prop-types@^15.6.1:
+prop-types@^15.5.4, prop-types@^15.5.8, prop-types@^15.6.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -15039,13 +15046,20 @@ react-onclickoutside@^6.12.0:
   resolved "https://registry.yarnpkg.com/react-onclickoutside/-/react-onclickoutside-6.12.2.tgz#8e6cf80c7d17a79f2c908399918158a7b02dda01"
   integrity sha512-NMXGa223OnsrGVp5dJHkuKxQ4czdLmXSp5jSV9OqiCky9LOpPATn3vLldc+q5fK3gKbEHvr7J1u0yhBh/xYkpA==
 
-react-popper@^2.2.5:
+react-popper@^2.2.5, react-popper@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-2.3.0.tgz#17891c620e1320dce318bad9fede46a5f71c70ba"
   integrity sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==
   dependencies:
     react-fast-compare "^3.0.1"
     warning "^4.0.2"
+
+react-portal@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/react-portal/-/react-portal-4.2.2.tgz#bff1e024147d6041ba8c530ffc99d4c8248f49fa"
+  integrity sha512-vS18idTmevQxyQpnde0Td6ZcUlv+pD8GTyR42n3CHUQq9OHi1C4jDE4ZWEbEsrbrLRhSECYiao58cvocwMtP7Q==
+  dependencies:
+    prop-types "^15.5.8"
 
 react-refresh@^0.8.3:
   version "0.8.3"


### PR DESCRIPTION
## Description
Adds a tooltip w/ the full expiration date of a Personal Access Token for expired tokens.

## `<Tooltip/>` Updates

The positioning currently used for tooltips results in some potential inherited styling issues. For the PAT expired tooltip, it wasn't displaying due to a parent container using the `truncate` class (which it needs to and is ok). A class of these types of bugs can be resolved by rendering the Tooltip outside of the DOM hierarchy the of the React component structure via React Portals (I used `react-portal` for this). This appends the node to the `document.body`. I also used `react-popper`, which assists in calculating the positioning of the tooltip in comparison to the target that shows it on hover. The `react-datepicker` library we use also uses `react-popper`, and I've used it in the past and been happy with it.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #15103 

## How to test
**Preview Env**: https://bmh-pat-ex451962a03f.preview.gitpod-dev.com/tokens
(latest build seems to be taking a long time, not sure if there's a way to cancel/restart a new one?)

This is slightly tricky to test, as you need an expired personal access token. I wasn't sure if there was a way to expire them manually, so I ended up negating the flag [here](https://github.com/gitpod-io/gitpod/blob/7ec92c0eee653e314ce6c0f613774a10f2838f5e/components/dashboard/src/settings/TokenEntry.tsx#L22) manually as I was developing.

I did verify all of the other areas that use our `<Tooltip/>` component, such as the Workspace list, Members list, and a few others. Creating a new token, or regenerating one also has an input with a copy icon that has a tooltip that can be tested.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Expired Personal Access Tokens exclamation indicator now has a tooltip w/ the full expiration date so you can see exactly when it expired.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
