### PR TITLE
Append "excluding VAT" to prices on billing pages

### DIFF
--- a/components/dashboard/src/components/UsageBasedBillingConfig.tsx
+++ b/components/dashboard/src/components/UsageBasedBillingConfig.tsx
@@ -290,7 +290,7 @@ export default function UsageBasedBillingConfig({ attributionId }: Props) {
                             <div className="flex flex-col">
                                 <span>
                                     {currency === "EUR" ? "€" : "$"}0.36 for 10 credits or 1 hour of Standard workspace
-                                    usage.{" "}
+                                    usage, excluding VAT.{" "}
                                     <a
                                         className="gp-link"
                                         href="https://www.gitpod.io/docs/configure/billing/usage-based-billing"
@@ -343,7 +343,7 @@ export default function UsageBasedBillingConfig({ attributionId }: Props) {
                                     <span className="font-bold">Pay-as-you-go after 1,000 credits</span>
                                     <span>
                                         {currency === "EUR" ? "€" : "$"}0.36 for 10 credits or 1 hour of Standard
-                                        workspace usage.
+                                        workspace usage, excluding VAT.
                                     </span>
                                 </div>
                             </div>
@@ -389,7 +389,7 @@ export default function UsageBasedBillingConfig({ attributionId }: Props) {
                                             </span>
                                             <span>
                                                 {currency === "EUR" ? "€" : "$"}0.36 for 10 credits or 1 hour of
-                                                Standard workspace usage.
+                                                Standard workspace usage, excluding VAT.
                                             </span>
                                         </div>
                                     </div>
@@ -404,7 +404,7 @@ export default function UsageBasedBillingConfig({ attributionId }: Props) {
                                         <div className="flex flex-col">
                                             <span>
                                                 {currency === "EUR" ? "€" : "$"}0.36 for 10 credits or 1 hour of
-                                                Standard workspace usage.{" "}
+                                                Standard workspace usage, excluding VAT.{" "}
                                                 <a
                                                     className="gp-link"
                                                     href="https://www.gitpod.io/docs/configure/billing/usage-based-billing"


### PR DESCRIPTION
Append "excluding VAT" to prices on billing pages

## Werft options:
- [x] /werft with-preview

```release-note
Quote Gitpod prices as excluding VAT. 
```