### PR TITLE
Remove Kubescape from preview environments

### DIFF
--- a/dev/preview/workflow/config/monitoring-satellite.yaml
+++ b/dev/preview/workflow/config/monitoring-satellite.yaml
@@ -33,8 +33,6 @@ imports:
     - gitURL: https://github.com/gitpod-io/observability
       path: monitoring-satellite/manifests/kube-prometheus-rules
     - gitURL: https://github.com/gitpod-io/observability
-      path: monitoring-satellite/manifests/kubescape
-    - gitURL: https://github.com/gitpod-io/observability
       path: monitoring-satellite/manifests/grafana
     - gitURL: https://github.com/gitpod-io/observability
       path: monitoring-satellite/manifests/probers


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Since we're no longer using the Prometheus integration with Kubescape anywhere anymore, there's no reason to keep it in preview environments as well.

There are a couple of issues and PRs for extra context[[1](https://github.com/gitpod-io/ops/pull/7329)][[2](https://github.com/gitpod-io/ops/pull/7065)][[3](https://github.com/gitpod-io/security/issues/84)]

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
