### PR TITLE
[installer]: make the kots install overwrite the config if exists

### DIFF
--- a/install/installer/scripts/kots-install.sh
+++ b/install/installer/scripts/kots-install.sh
@@ -90,7 +90,7 @@ EOF
     echo "Gitpod: Installer version - $(/app/installer version | yq e '.version' -)"
 
     echo "Gitpod: Generate the base Installer config"
-    /app/installer config init
+    /app/installer config init --overwrite
 
     if [ "${INSTALLER_DRY_RUN}" != "true" ]; then
         echo "Gitpod: auto-detecting ShiftFS support on host machine"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Reports in [Discord](https://discord.com/channels/816244985187008514/1046633264514863116/1046633264514863116) of people having issues where the `/tmp/gitpod.config.yaml` file already exists, meaning the `config init` fails.

This uses `--overwrite` to avoid that problem entirely

## How to test
<!-- Provide steps to test this PR -->
Install via KOTS

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[installer]: make the kots install overwrite the config if exists
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
