### PR TITLE
Temporarily add `hold` label when creating PRs that can be auto-approved

### DIFF
--- a/.github/workflows/jetbrains-update-plugin-platform-template.yml
+++ b/.github/workflows/jetbrains-update-plugin-platform-template.yml
@@ -89,14 +89,14 @@ jobs:
                       ```
 
                       ## Werft options:
-                      - [x] /werft with-preview
-                      - [x] /werft with-large-vm
+                      - [ ] /werft with-preview
+                      - [ ] /werft with-large-vm
                       - [x] /werft with-integration-tests=jetbrains
 
                       _This PR was created automatically with GitHub Actions using [this](https://github.com/gitpod-io/gitpod/blob/main/.github/workflows/jetbrains-update-plugin-platform-template.yml) template._
                   commit-message: "Update Platform Version of ${{ inputs.pluginName }} to ${{ steps.latest-version.outputs.result }}"
                   branch: "jetbrains/${{ inputs.pluginId }}-platform"
-                  labels: "team: IDE,editor: jetbrains"
+                  labels: "team: IDE,editor: jetbrains,do-not-merge/hold"
                   team-reviewers: "engineering-ide"
                   token: ${{ secrets.roboquatRepoPat }}
                   committer: Robo Quat <roboquat@gitpod.io>
@@ -136,7 +136,7 @@ jobs:
                       _This PR was created automatically with GitHub Actions using [this](https://github.com/gitpod-io/gitpod/blob/main/.github/workflows/jetbrains-update-plugin-platform-template.yml) template._
                   commit-message: "Update Platform Version of ${{ inputs.pluginName }} to ${{ steps.latest-version.outputs.result }}"
                   branch: "jetbrains/${{ inputs.pluginId }}-platform"
-                  labels: "team: IDE,editor: jetbrains"
+                  labels: "team: IDE,editor: jetbrains,do-not-merge/hold"
                   team-reviewers: "engineering-ide"
                   token: ${{ secrets.roboquatRepoPat }}
                   committer: Robo Quat <roboquat@gitpod.io>


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Currently, when PRs are auto-approved, they end up blocking the merging queue due to the bot don't taking into account the GitHub checks (e.g. Werft Build). As we run integration tests, it can take up to one hour for the PR to get ready to be merged, preventing all the other PRs from merging.

Adding the `do-not-merge/hold` label, we avoid blocking the queue until we find a solution for this problem.

Also, remove `with-preview` and `with-large-vm` werft parameters, as we don't need them for testing Gateway Plugin.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
- https://github.com/gitpod-io/gitpod/pull/15096#issuecomment-1333720598

## How to test
<!-- Provide steps to test this PR -->
No need to test.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
