### PR TITLE
[code-sync] Update `/v1/collection` endpoint response

### DIFF
--- a/components/gitpod-db/src/typeorm/code-sync-resource-db.spec.db.ts
+++ b/components/gitpod-db/src/typeorm/code-sync-resource-db.spec.db.ts
@@ -177,7 +177,7 @@ export class CodeSyncResourceDBSpec {
 
     @test()
     async createDeleteCollection(): Promise<void> {
-        const currentCollections1 = await this.db.getCollections(this.userId);
+        const currentCollections1 = (await this.db.getCollections(this.userId)).map(({ id }) => id);
         expect(currentCollections1).to.be.empty;
 
         const collections: string[] = [];
@@ -186,7 +186,7 @@ export class CodeSyncResourceDBSpec {
         }
         expect(collections.length).to.be.equal(5);
 
-        const currentCollections2 = await this.db.getCollections(this.userId);
+        const currentCollections2 = (await this.db.getCollections(this.userId)).map(({ id }) => id);
         expect(currentCollections2.sort()).to.deep.equal(collections.slice().sort());
 
         await this.db.deleteCollection(this.userId, collections[0], async () => {});
@@ -194,12 +194,12 @@ export class CodeSyncResourceDBSpec {
         collections.shift();
         collections.shift();
 
-        const currentCollections3 = await this.db.getCollections(this.userId);
+        const currentCollections3 = (await this.db.getCollections(this.userId)).map(({ id }) => id);
         expect(currentCollections3.sort()).to.deep.equal(collections.slice().sort());
 
         await this.db.deleteCollection(this.userId, undefined, async () => {});
 
-        const currentCollections4 = await this.db.getCollections(this.userId);
+        const currentCollections4 = (await this.db.getCollections(this.userId)).map(({ id }) => id);
         expect(currentCollections4).to.be.empty;
     }
 

--- a/components/gitpod-db/src/typeorm/code-sync-resource-db.ts
+++ b/components/gitpod-db/src/typeorm/code-sync-resource-db.ts
@@ -271,13 +271,13 @@ export class CodeSyncResourceDB {
             .getMany();
     }
 
-    async getCollections(userId: string): Promise<string[]> {
+    async getCollections(userId: string): Promise<{ id: string }[]> {
         const connection = await this.typeORM.getConnection();
         const result = await connection.manager
             .createQueryBuilder(DBCodeSyncCollection, "collection")
             .where("collection.userId = :userId AND collection.deleted = 0", { userId })
             .getMany();
-        return result.map((r) => r.collection);
+        return result.map((r) => ({ id: r.collection }));
     }
 
     async isCollection(userId: string, collection: string): Promise<boolean> {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Updates `/v1/collection` endpoint response

Ref: https://github.com/microsoft/vscode/pull/168115 `src/vs/platform/userDataSync/common/userDataSyncStoreService.ts`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
