### PR TITLE
[dashboard] allow setting ws class for prebuilds

### DIFF
--- a/components/dashboard/src/projects/ProjectSettings.tsx
+++ b/components/dashboard/src/projects/ProjectSettings.tsx
@@ -76,13 +76,53 @@ export default function () {
             return value;
         }
         const before = project.settings?.workspaceClasses?.regular;
-        updateProjectSettings({ workspaceClasses: { prebuild: value, regular: value } });
+        updateProjectSettings({ workspaceClasses: { ...project.settings?.workspaceClasses, regular: value } });
+        return before;
+    };
+
+    const setWorkspaceClassForPrebuild = async (value: string) => {
+        if (!project) {
+            return value;
+        }
+        const before = project.settings?.workspaceClasses?.prebuild;
+        updateProjectSettings({ workspaceClasses: { ...project.settings?.workspaceClasses, prebuild: value } });
         return before;
     };
 
     return (
         <ProjectSettingsPage project={project}>
             <h3>Prebuilds</h3>
+            <p className="text-base text-gray-500 dark:text-gray-400">
+                Choose the workspace machine type for your prebuilds.
+            </p>
+            {BillingMode.canSetWorkspaceClass(billingMode) ? (
+                <SelectWorkspaceClass
+                    workspaceClass={project.settings?.workspaceClasses?.prebuild}
+                    setWorkspaceClass={setWorkspaceClassForPrebuild}
+                />
+            ) : (
+                <Alert type="message" className="mt-4">
+                    <div className="flex flex-col">
+                        <span>
+                            To access{" "}
+                            <a
+                                className="gp-link"
+                                href="https://www.gitpod.io/docs/configure/workspaces/workspace-classes"
+                            >
+                                large workspaces
+                            </a>{" "}
+                            and{" "}
+                            <a className="gp-link" href="https://www.gitpod.io/docs/configure/billing/pay-as-you-go">
+                                pay-as-you-go
+                            </a>
+                            , first cancel your existing plan.
+                        </span>
+                        <Link className="mt-2" to={project.teamId ? "../billing" : "/plans"}>
+                            <button>Go to {project.teamId ? "Team" : "Personal"} Billing</button>
+                        </Link>
+                    </div>
+                </Alert>
+            )}
             <CheckBox
                 title={<span>Enable Incremental Prebuilds </span>}
                 desc={

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -255,8 +255,8 @@ export type IDESettings = {
 };
 
 export interface WorkspaceClasses {
-    regular: string;
-    prebuild: string;
+    regular?: string;
+    prebuild?: string;
 }
 
 export interface UserPlatform {


### PR DESCRIPTION
## Description
Allow selecting the workspace class for prebuilds

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #14811

## How to test
<!-- Provide steps to test this PR -->
- [join this team](https://sefftinge-ab2f42f948.preview.gitpod-dev.com/teams/join?inviteId=46a123e8-225d-4631-9bf4-ff786b2f31c6)
- [start a workspace on this branch](https://sefftinge-ab2f42f948.preview.gitpod-dev.com/#https://github.com/svenefftinge/2048-in-terminal/tree/se/ws-class)
- Verify that the `prebuild.txt` contains information about using a small workspace class
- Verify that running `gp info` reveals that the workspace is running in a default workspace class

<img width="934" alt="Screenshot 2022-12-12 at 07 40 34" src="https://user-images.githubusercontent.com/372735/206978059-dc753760-6954-4d31-bd01-844832d8fbfb.png">

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Allow setting workspace class for prebuilds
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
