### PR TITLE
[installer]: add required bucket name to mirror kots command

### DIFF
--- a/install/installer/cmd/mirror_list.go
+++ b/install/installer/cmd/mirror_list.go
@@ -125,7 +125,8 @@ func renderAllKubernetesObject(cfgVersion string, cfg *configv1.Config) ([]strin
 			cfg.ObjectStorage = configv1.ObjectStorage{
 				InCluster: pointer.Bool(false),
 				S3: &configv1.ObjectStorageS3{
-					Endpoint: "endpoint",
+					Endpoint:   "endpoint",
+					BucketName: "some-bucket",
 					Credentials: configv1.ObjectRef{
 						Kind: configv1.ObjectRefSecret,
 						Name: "value",

--- a/install/installer/go.mod
+++ b/install/installer/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/google/go-cmp v0.5.8
 	github.com/jetstack/cert-manager v1.5.0
 	github.com/mikefarah/yq/v4 v4.25.3
+	github.com/prometheus/client_golang v1.13.0
 	github.com/replicatedhq/kots v1.67.0
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/cobra v1.5.0
@@ -264,7 +265,6 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/polydawn/refmt v0.0.0-20201211092308-30ac6d18308e // indirect
-	github.com/prometheus/client_golang v1.13.0 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.37.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
The new required bucket name from #14970 is now implemented in the `mirror kots` command, which is used by Werft to generate the list of images for KOTS air-gapped support.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #15294

## How to test
<!-- Provide steps to test this PR -->
Use `/werft run publish-to-kots` to make Werft publish the KOTS release (I've done this already)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[installer]: add required bucket name to mirror kots command
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
