### PR TITLE
Default to letsencrypt cert isuser

### DIFF
--- a/.werft/jobs/build/job-config.ts
+++ b/.werft/jobs/build/job-config.ts
@@ -113,12 +113,12 @@ export function jobConfig(werft: Werft, context: any): JobConfig {
     const withPreview = decideWithPreview({werft, sliceID: sliceId, buildConfig, mainBuild, withIntegrationTests})
 
     switch (buildConfig["cert-issuer"]) {
-        case "letsencrypt":
-            buildConfig["cert-issuer"] = "letsencrypt-issuer-gitpod-core-dev"
-            break
         case "zerossl":
-        default:
             buildConfig["cert-issuer"] = "zerossl-issuer-gitpod-core-dev"
+            break
+        case "letsencrypt":
+        default:
+            buildConfig["cert-issuer"] = "letsencrypt-issuer-gitpod-core-dev"
     }
     const certIssuer = buildConfig["cert-issuer"];
 

--- a/dev/preview/BUILD.yaml
+++ b/dev/preview/BUILD.yaml
@@ -25,7 +25,7 @@ scripts:
     script: |
       export GOOGLE_APPLICATION_CREDENTIALS="${GOOGLE_APPLICATION_CREDENTIALS:-$PREVIEW_ENV_DEV_SA_KEY_PATH}"
       export GOOGLE_BACKEND_CREDENTIALS="${GOOGLE_BACKEND_CREDENTIALS:-$PREVIEW_ENV_DEV_SA_KEY_PATH}"
-      export TF_VAR_cert_issuer="${TF_VAR_cert_issuer:-zerossl-issuer-gitpod-core-dev}"
+      export TF_VAR_cert_issuer="${TF_VAR_cert_issuer:-letsencrypt-issuer-gitpod-core-dev}"
       export TF_VAR_dev_kube_path="${TF_VAR_dev_kube_path:-/home/gitpod/.kube/config}"
       export TF_VAR_dev_kube_context="${TF_VAR_dev_kube_context:-dev}"
       export TF_VAR_harvester_kube_path="${TF_VAR_harvester_kube_path:-$HOME/.kube/config}"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
