### PR TITLE
[public-api] Handle context cancelled as deadline exceeded error

### DIFF
--- a/components/public-api-server/pkg/proxy/errors.go
+++ b/components/public-api-server/pkg/proxy/errors.go
@@ -5,6 +5,7 @@
 package proxy
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -51,6 +52,10 @@ func categorizeRPCError(err error) *connect.Error {
 		default:
 			return connect.NewError(connect.CodeInternal, fmt.Errorf(rpcErr.Message))
 		}
+	}
+
+	if errors.Is(err, context.Canceled) {
+		return connect.NewError(connect.CodeDeadlineExceeded, fmt.Errorf("Request timed out"))
 	}
 
 	if handshakeErr := new(protocol.ErrBadHandshake); errors.As(err, &handshakeErr) {

--- a/components/public-api-server/pkg/proxy/errors_test.go
+++ b/components/public-api-server/pkg/proxy/errors_test.go
@@ -5,6 +5,7 @@
 package proxy
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -17,55 +18,59 @@ import (
 
 func TestConvertError(t *testing.T) {
 	scenarios := []struct {
-		WebsocketError error
-		ExpectedError  error
+		Input         error
+		ExpectedError error
 	}{
 		{
-			WebsocketError: &protocol.ErrBadHandshake{
+			Input: &protocol.ErrBadHandshake{
 				URL: "https://foo.bar",
 			},
 			ExpectedError: connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("Failed to establish caller identity")),
 		},
 		{
-			WebsocketError: &jsonrpc2.Error{
+			Input: &jsonrpc2.Error{
 				Code:    400,
 				Message: "user id is a required argument",
 			},
 			ExpectedError: connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("user id is a required argument")),
 		},
 		{
-			WebsocketError: &jsonrpc2.Error{
+			Input: &jsonrpc2.Error{
 				Code:    -32603,
 				Message: "Request getWorkspace failed with message: No workspace with id 'some-id' found.",
 			},
 			ExpectedError: connect.NewError(connect.CodeInternal, fmt.Errorf("Request getWorkspace failed with message: No workspace with id 'some-id' found.")),
 		},
 		{
-			WebsocketError: &jsonrpc2.Error{
+			Input: &jsonrpc2.Error{
 				Code:    409,
 				Message: "already exists",
 			},
 			ExpectedError: connect.NewError(connect.CodeAlreadyExists, fmt.Errorf("already exists")),
 		},
 		{
-			WebsocketError: &jsonrpc2.Error{
+			Input: &jsonrpc2.Error{
 				Code:    470,
 				Message: "user blocked",
 			},
 			ExpectedError: connect.NewError(connect.CodePermissionDenied, fmt.Errorf("user blocked")),
 		},
 		{
-			WebsocketError: nil,
-			ExpectedError:  nil,
+			Input:         nil,
+			ExpectedError: nil,
 		},
 		{
-			WebsocketError: errors.New("some other random error returns internal error"),
-			ExpectedError:  connect.NewError(connect.CodeInternal, fmt.Errorf("some other random error returns internal error")),
+			Input:         errors.New("some other random error returns internal error"),
+			ExpectedError: connect.NewError(connect.CodeInternal, fmt.Errorf("some other random error returns internal error")),
+		},
+		{
+			Input:         context.Canceled,
+			ExpectedError: connect.NewError(connect.CodeDeadlineExceeded, fmt.Errorf("Request timed out")),
 		},
 	}
 
 	for _, s := range scenarios {
-		converted := ConvertError(s.WebsocketError)
+		converted := ConvertError(s.Input)
 		require.Equal(t, s.ExpectedError, converted)
 	}
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

When the caller does not wait long enough for the response (or redirects on dashboard before the request completes), the context is cancelled and propagated. However, we would return Internal error because we did not handle the cancellation correctly.

See examples in logs: https://console.cloud.google.com/logs/query;query=resource.labels.pod_name%20:%20%2528%22public-api-server%22%2529;timeRange=PT3H;cursorTimestamp=2022-12-12T13:00:31.560856275Z?authuser=0&project=gitpod-191109

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
Unit tests

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
