### PR TITLE
Add a remove project button on the project settings page

### DIFF
--- a/components/dashboard/src/contexts/FeatureFlagContext.tsx
+++ b/components/dashboard/src/contexts/FeatureFlagContext.tsx
@@ -107,3 +107,7 @@ const FeatureFlagContextProvider: React.FC = ({ children }) => {
 };
 
 export { FeatureFlagContext, FeatureFlagContextProvider };
+
+export const useFeatureFlags = () => {
+    return useContext(FeatureFlagContext);
+};

--- a/components/dashboard/src/projects/ProjectSettings.tsx
+++ b/components/dashboard/src/projects/ProjectSettings.tsx
@@ -260,7 +260,7 @@ export default function () {
                     </Alert>
                 )}
             </div>
-            <div className="">
+            <div>
                 <h3 className="mt-12">Delete Project</h3>
                 <p className="text-base text-gray-500 dark:text-gray-400 pb-4">
                     Removing the project from this team will also remove team members access to it.

--- a/components/dashboard/src/projects/RemoveProjectModal.tsx
+++ b/components/dashboard/src/projects/RemoveProjectModal.tsx
@@ -19,25 +19,16 @@ type RemoveProjectModalProps = {
 
 export const RemoveProjectModal: FunctionComponent<RemoveProjectModalProps> = ({ project, onClose, onRemoved }) => {
     const { usePublicApiProjectsService } = useFeatureFlags();
-
     const [disabled, setDisabled] = useState(false);
 
     const removeProject = useCallback(async () => {
-        setDisabled(true);
-        setDisabled(false);
-        onRemoved();
-    }, [onRemoved]);
-
-    const removeProject2 = useCallback(async () => {
         setDisabled(true);
         usePublicApiProjectsService
             ? await projectsService.deleteProject({ projectId: project.id })
             : await getGitpodService().server.deleteProject(project.id);
         setDisabled(false);
         onRemoved();
-        // onClose();
     }, [onRemoved, project.id, usePublicApiProjectsService]);
-    console.log("derp", removeProject2);
 
     return (
         <ConfirmationModal

--- a/components/dashboard/src/projects/RemoveProjectModal.tsx
+++ b/components/dashboard/src/projects/RemoveProjectModal.tsx
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { FunctionComponent, useCallback, useState } from "react";
+import type { Project } from "@gitpod/gitpod-protocol";
+import { projectsService } from "../service/public-api";
+import { getGitpodService } from "../service/service";
+import ConfirmationModal from "../components/ConfirmationModal";
+import { useFeatureFlags } from "../contexts/FeatureFlagContext";
+
+type RemoveProjectModalProps = {
+    project: Project;
+    onClose: () => void;
+    onRemoved: () => void;
+};
+
+export const RemoveProjectModal: FunctionComponent<RemoveProjectModalProps> = ({ project, onClose, onRemoved }) => {
+    const { usePublicApiProjectsService } = useFeatureFlags();
+
+    const [disabled, setDisabled] = useState(false);
+
+    const removeProject = useCallback(async () => {
+        setDisabled(true);
+        setDisabled(false);
+        onRemoved();
+    }, [onRemoved]);
+
+    const removeProject2 = useCallback(async () => {
+        setDisabled(true);
+        usePublicApiProjectsService
+            ? await projectsService.deleteProject({ projectId: project.id })
+            : await getGitpodService().server.deleteProject(project.id);
+        setDisabled(false);
+        onRemoved();
+        // onClose();
+    }, [onRemoved, project.id, usePublicApiProjectsService]);
+    console.log("derp", removeProject2);
+
+    return (
+        <ConfirmationModal
+            title="Remove Project"
+            areYouSureText="Are you sure you want to remove this project from this team? Team members will also lose access to this project."
+            children={{
+                name: project?.name ?? "",
+                description: project?.cloneUrl ?? "",
+            }}
+            buttonText="Remove Project"
+            buttonDisabled={disabled}
+            onClose={onClose}
+            onConfirm={removeProject}
+            visible
+        />
+    );
+};


### PR DESCRIPTION
## Description
Adds a "Remove Project" button on the project settings page.

<img width="692" alt="image" src="https://user-images.githubusercontent.com/367275/207179829-cc79f4f0-90de-42fc-85d9-e4829f783279.png">

Clicking the button brings up the same modal that is shown from the Projects list page when using the context menu action for removing.
<img width="546" alt="image" src="https://user-images.githubusercontent.com/367275/207180049-137d5e17-a18c-4f06-a50e-ec2263f2592c.png">

### Followup
To help keep this PR small I'll open a followup one that updates the Projects list page use the new `<RemoveProjectModal/>` component, along with a few other improvements for that page.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #14251

## How to test
<!-- Provide steps to test this PR -->
**Preivew Env:** https://bmh-deleted93c550a0b.preview.gitpod-dev.com/

* Create a new Project
* Navigate to the Settings page for that project
* Scroll to the bottom and click the `Remove Project` button
* You should see a confirmation modal that you can dismiss, or proceed with.
* After the project is deleted you should get navigated to the Projects list page

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Projects can now be deleted from the corresponding Settings page for that project.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
