### PR TITLE
Project list page updates

### DIFF
--- a/components/dashboard/src/components/ConfirmationModal.tsx
+++ b/components/dashboard/src/components/ConfirmationModal.tsx
@@ -20,7 +20,7 @@ export default function ConfirmationModal(props: {
     onConfirm: () => void;
 }) {
     const children: React.ReactChild[] = [
-        <p key="areYouSure" className="mt-3 mb-3 text-base text-gray-500">
+        <p key="areYouSure" className="mb-3 text-base text-gray-500">
             {props.areYouSureText}
         </p>,
     ];

--- a/components/dashboard/src/projects/ProjectListItem.tsx
+++ b/components/dashboard/src/projects/ProjectListItem.tsx
@@ -1,0 +1,135 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { FunctionComponent, useMemo, useState } from "react";
+import dayjs from "dayjs";
+import { PrebuildWithStatus, Project } from "@gitpod/gitpod-protocol";
+import { Link } from "react-router-dom";
+import ContextMenu from "../components/ContextMenu";
+import { useCurrentTeam } from "../teams/teams-context";
+import { RemoveProjectModal } from "./RemoveProjectModal";
+import { toRemoteURL } from "./render-utils";
+import { prebuildStatusIcon } from "./Prebuilds";
+
+type ProjectListItemProps = {
+    project: Project;
+    prebuild?: PrebuildWithStatus;
+    onProjectRemoved: () => void;
+};
+
+export const ProjectListItem: FunctionComponent<ProjectListItemProps> = ({ project, prebuild, onProjectRemoved }) => {
+    const team = useCurrentTeam();
+    const [showRemoveModal, setShowRemoveModal] = useState(false);
+
+    const teamOrUserSlug = useMemo(() => {
+        return !!team ? "t/" + team.slug : "projects";
+    }, [team]);
+
+    return (
+        <div key={`project-${project.id}`} className="h-52">
+            <div className="h-42 border border-gray-100 dark:border-gray-800 rounded-t-xl">
+                <div className="h-32 p-6">
+                    <div className="flex text-gray-700 dark:text-gray-200 font-medium">
+                        <ProjectLink project={project} teamOrUserSlug={teamOrUserSlug} />
+                        <span className="flex-grow" />
+                        <div className="justify-end">
+                            <ContextMenu
+                                menuEntries={[
+                                    {
+                                        title: "New Workspace",
+                                        href: `/#${project.cloneUrl}`,
+                                        separator: true,
+                                    },
+                                    {
+                                        title: "Remove Project",
+                                        customFontStyle:
+                                            "text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-300",
+                                        onClick: () => setShowRemoveModal(true),
+                                    },
+                                ]}
+                            />
+                        </div>
+                    </div>
+                    <a href={project.cloneUrl.replace(/\.git$/, "")}>
+                        <p className="hover:text-gray-600 dark:hover:text-gray-400 dark:text-gray-500 pr-10 truncate">
+                            {toRemoteURL(project.cloneUrl)}
+                        </p>
+                    </a>
+                </div>
+                <div className="h-10 px-6 py-1 text-gray-400 text-sm">
+                    <span className="hover:text-gray-600 dark:hover:text-gray-300">
+                        <Link to={`/${teamOrUserSlug}/${project.slug || project.name}`}>Branches</Link>
+                    </span>
+                    <span className="mx-2 my-auto">·</span>
+                    <span className="hover:text-gray-600 dark:hover:text-gray-300">
+                        <Link to={`/${teamOrUserSlug}/${project.slug || project.name}/prebuilds`}>Prebuilds</Link>
+                    </span>
+                </div>
+            </div>
+            <div className="h-10 px-4 border rounded-b-xl dark:border-gray-800 bg-gray-100 border-gray-100 dark:bg-gray-800">
+                {prebuild ? (
+                    <div className="flex flex-row h-full text-sm space-x-4">
+                        <Link
+                            to={`/${teamOrUserSlug}/${project.slug || project.name}/${prebuild?.info?.id}`}
+                            className="flex-grow flex items-center group space-x-2 truncate"
+                        >
+                            {prebuildStatusIcon(prebuild)}
+                            <div
+                                className="font-semibold text-gray-500 dark:text-gray-400 truncate"
+                                title={prebuild?.info?.branch}
+                            >
+                                {prebuild?.info?.branch}
+                            </div>
+                            <span className="flex-shrink-0 mx-1 text-gray-400 dark:text-gray-600">·</span>
+                            <div className="flex-shrink-0 text-gray-400 dark:text-gray-500 group-hover:text-gray-800 dark:group-hover:text-gray-300">
+                                {dayjs(prebuild?.info?.startedAt).fromNow()}
+                            </div>
+                        </Link>
+                        <Link
+                            to={`/${teamOrUserSlug}/${project.slug || project.name}/prebuilds`}
+                            className="flex-shrink-0 flex items-center text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
+                        >
+                            View All &rarr;
+                        </Link>
+                    </div>
+                ) : (
+                    <div className="flex h-full text-md">
+                        <p className="my-auto ">No recent prebuilds</p>
+                    </div>
+                )}
+            </div>
+            {showRemoveModal && (
+                <RemoveProjectModal
+                    project={project}
+                    onClose={() => setShowRemoveModal(false)}
+                    onRemoved={onProjectRemoved}
+                />
+            )}
+        </div>
+    );
+};
+
+type ProjectLinkProps = {
+    project: Project;
+    teamOrUserSlug: string;
+};
+const ProjectLink: FunctionComponent<ProjectLinkProps> = ({ project, teamOrUserSlug }) => {
+    let slug = "";
+    const name = project.name;
+
+    if (project.slug) {
+        slug = project.slug;
+    } else {
+        // For existing GitLab projects that don't have a slug yet
+        slug = name;
+    }
+
+    return (
+        <Link to={`/${teamOrUserSlug}/${slug}`}>
+            <span className="text-xl font-semibold">{name}</span>
+        </Link>
+    );
+};

--- a/components/dashboard/src/projects/ProjectSettings.tsx
+++ b/components/dashboard/src/projects/ProjectSettings.tsx
@@ -260,13 +260,13 @@ export default function () {
                     </Alert>
                 )}
             </div>
-            <div>
-                <h3 className="mt-12">Delete Project</h3>
+            <div className="">
+                <h3 className="mt-12">Remove Project</h3>
                 <p className="text-base text-gray-500 dark:text-gray-400 pb-4">
-                    Removing the project from this team will also remove team members access to it.
+                    Removing this project will also remove all associated data with this project, including workspaces.
                 </p>
                 <button className="danger secondary" onClick={() => setShowRemoveModal(true)}>
-                    Delete Project
+                    Remove Project
                 </button>
             </div>
             {showRemoveModal && (

--- a/components/dashboard/src/projects/ProjectSettings.tsx
+++ b/components/dashboard/src/projects/ProjectSettings.tsx
@@ -263,7 +263,8 @@ export default function () {
             <div className="">
                 <h3 className="mt-12">Remove Project</h3>
                 <p className="text-base text-gray-500 dark:text-gray-400 pb-4">
-                    Removing this project will also remove all associated data with this project, including workspaces.
+                    This will delete the project and all project-level environment variables you've set for this
+                    project.
                 </p>
                 <button className="danger secondary" onClick={() => setShowRemoveModal(true)}>
                     Remove Project

--- a/components/dashboard/src/projects/Projects.tsx
+++ b/components/dashboard/src/projects/Projects.tsx
@@ -10,19 +10,16 @@ import Header from "../components/Header";
 import projectsEmpty from "../images/projects-empty.svg";
 import projectsEmptyDark from "../images/projects-empty-dark.svg";
 import { useHistory, useLocation } from "react-router";
-import { useContext, useEffect, useState } from "react";
+import { useCallback, useContext, useEffect, useState } from "react";
 import { getGitpodService } from "../service/service";
 import { getCurrentTeam, TeamsContext } from "../teams/teams-context";
 import { ThemeContext } from "../theme-context";
 import { PrebuildWithStatus, Project } from "@gitpod/gitpod-protocol";
-import { toRemoteURL } from "./render-utils";
-import ContextMenu from "../components/ContextMenu";
-import ConfirmationModal from "../components/ConfirmationModal";
-import { prebuildStatusIcon } from "./Prebuilds";
 import Alert from "../components/Alert";
 import { FeatureFlagContext } from "../contexts/FeatureFlagContext";
-import { listAllProjects, projectsService } from "../service/public-api";
+import { listAllProjects } from "../service/public-api";
 import { UserContext } from "../user-context";
+import { ProjectListItem } from "./ProjectListItem";
 
 export default function () {
     const location = useLocation();
@@ -39,11 +36,7 @@ export default function () {
 
     const [searchFilter, setSearchFilter] = useState<string | undefined>();
 
-    useEffect(() => {
-        updateProjects();
-    }, [teams]);
-
-    const updateProjects = async () => {
+    const updateProjects = useCallback(async () => {
         if (!teams) {
             return;
         }
@@ -77,19 +70,15 @@ export default function () {
             }),
         );
         setLastPrebuilds(map);
-    };
+    }, [team, teams, usePublicApiProjectsService, user?.id]);
+
+    useEffect(() => {
+        updateProjects();
+    }, [teams, updateProjects]);
 
     const newProjectUrl = !!team ? `/new?team=${team.slug}` : "/new?user=1";
     const onNewProject = () => {
         history.push(newProjectUrl);
-    };
-
-    const onRemoveProject = async (p: Project) => {
-        setRemoveModalVisible(false);
-        usePublicApiProjectsService
-            ? await projectsService.deleteProject({ projectId: p.id })
-            : await getGitpodService().server.deleteProject(p.id);
-        await updateProjects();
     };
 
     const filter = (project: Project) => {
@@ -105,46 +94,8 @@ export default function () {
         );
     }
 
-    let [isRemoveModalVisible, setRemoveModalVisible] = useState(false);
-    let [removeProjectHandler, setRemoveProjectHandler] = useState<() => void>(() => () => {});
-    let [willRemoveProject, setWillRemoveProject] = useState<Project>();
-
-    function renderProjectLink(project: Project): React.ReactElement {
-        let slug = "";
-        const name = project.name;
-
-        if (project.slug) {
-            slug = project.slug;
-        } else {
-            // For existing GitLab projects that don't have a slug yet
-            slug = name;
-        }
-
-        return (
-            <Link to={`/${teamOrUserSlug}/${slug}`}>
-                <span className="text-xl font-semibold">{name}</span>
-            </Link>
-        );
-    }
-
-    const teamOrUserSlug = !!team ? "t/" + team.slug : "projects";
-
     return (
         <>
-            {isRemoveModalVisible && (
-                <ConfirmationModal
-                    title="Remove Project"
-                    areYouSureText="Are you sure you want to remove this project from this team? Team members will also lose access to this project."
-                    children={{
-                        name: willRemoveProject?.name ?? "",
-                        description: willRemoveProject?.cloneUrl ?? "",
-                    }}
-                    buttonText="Remove Project"
-                    visible={isRemoveModalVisible}
-                    onClose={() => setRemoveModalVisible(false)}
-                    onConfirm={removeProjectHandler}
-                />
-            )}
             {!team && (
                 <div className="app-container pt-2">
                     <Alert type={"message"} closable={false} showIcon={true} className="flex rounded mb-2 w-full">
@@ -224,91 +175,12 @@ export default function () {
                             .filter(filter)
                             .sort(hasNewerPrebuild)
                             .map((p) => (
-                                <div key={`project-${p.id}`} className="h-52">
-                                    <div className="h-42 border border-gray-100 dark:border-gray-800 rounded-t-xl">
-                                        <div className="h-32 p-6">
-                                            <div className="flex text-gray-700 dark:text-gray-200 font-medium">
-                                                {renderProjectLink(p)}
-                                                <span className="flex-grow" />
-                                                <div className="justify-end">
-                                                    <ContextMenu
-                                                        menuEntries={[
-                                                            {
-                                                                title: "New Workspace",
-                                                                href: `/#${p.cloneUrl}`,
-                                                                separator: true,
-                                                            },
-                                                            {
-                                                                title: "Remove Project",
-                                                                customFontStyle:
-                                                                    "text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-300",
-                                                                onClick: () => {
-                                                                    setWillRemoveProject(p);
-                                                                    setRemoveProjectHandler(() => () => {
-                                                                        onRemoveProject(p);
-                                                                    });
-                                                                    setRemoveModalVisible(true);
-                                                                },
-                                                            },
-                                                        ]}
-                                                    />
-                                                </div>
-                                            </div>
-                                            <a href={p.cloneUrl.replace(/\.git$/, "")}>
-                                                <p className="hover:text-gray-600 dark:hover:text-gray-400 dark:text-gray-500 pr-10 truncate">
-                                                    {toRemoteURL(p.cloneUrl)}
-                                                </p>
-                                            </a>
-                                        </div>
-                                        <div className="h-10 px-6 py-1 text-gray-400 text-sm">
-                                            <span className="hover:text-gray-600 dark:hover:text-gray-300">
-                                                <Link to={`/${teamOrUserSlug}/${p.slug || p.name}`}>Branches</Link>
-                                            </span>
-                                            <span className="mx-2 my-auto">·</span>
-                                            <span className="hover:text-gray-600 dark:hover:text-gray-300">
-                                                <Link to={`/${teamOrUserSlug}/${p.slug || p.name}/prebuilds`}>
-                                                    Prebuilds
-                                                </Link>
-                                            </span>
-                                        </div>
-                                    </div>
-                                    <div className="h-10 px-4 border rounded-b-xl dark:border-gray-800 bg-gray-100 border-gray-100 dark:bg-gray-800">
-                                        {lastPrebuilds.get(p.id) ? (
-                                            <div className="flex flex-row h-full text-sm space-x-4">
-                                                <Link
-                                                    to={`/${teamOrUserSlug}/${p.slug || p.name}/${
-                                                        lastPrebuilds.get(p.id)?.info?.id
-                                                    }`}
-                                                    className="flex-grow flex items-center group space-x-2 truncate"
-                                                >
-                                                    {prebuildStatusIcon(lastPrebuilds.get(p.id))}
-                                                    <div
-                                                        className="font-semibold text-gray-500 dark:text-gray-400 truncate"
-                                                        title={lastPrebuilds.get(p.id)?.info?.branch}
-                                                    >
-                                                        {lastPrebuilds.get(p.id)?.info?.branch}
-                                                    </div>
-                                                    <span className="flex-shrink-0 mx-1 text-gray-400 dark:text-gray-600">
-                                                        ·
-                                                    </span>
-                                                    <div className="flex-shrink-0 text-gray-400 dark:text-gray-500 group-hover:text-gray-800 dark:group-hover:text-gray-300">
-                                                        {dayjs(lastPrebuilds.get(p.id)?.info?.startedAt).fromNow()}
-                                                    </div>
-                                                </Link>
-                                                <Link
-                                                    to={`/${teamOrUserSlug}/${p.slug || p.name}/prebuilds`}
-                                                    className="flex-shrink-0 flex items-center text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
-                                                >
-                                                    View All &rarr;
-                                                </Link>
-                                            </div>
-                                        ) : (
-                                            <div className="flex h-full text-md">
-                                                <p className="my-auto ">No recent prebuilds</p>
-                                            </div>
-                                        )}
-                                    </div>
-                                </div>
+                                <ProjectListItem
+                                    project={p}
+                                    key={p.id}
+                                    prebuild={lastPrebuilds.get(p.id)}
+                                    onProjectRemoved={updateProjects}
+                                />
                             ))}
                         {!searchFilter && (
                             <div

--- a/components/dashboard/src/projects/Projects.tsx
+++ b/components/dashboard/src/projects/Projects.tsx
@@ -29,6 +29,7 @@ export default function () {
     const { user } = useContext(UserContext);
     const { usePublicApiProjectsService } = useContext(FeatureFlagContext);
     const team = getCurrentTeam(location, teams);
+    const [projectsLoaded, setProjectsLoaded] = useState(false);
     const [projects, setProjects] = useState<Project[]>([]);
     const [lastPrebuilds, setLastPrebuilds] = useState<Map<string, PrebuildWithStatus>>(new Map());
 
@@ -52,6 +53,7 @@ export default function () {
                 : await getGitpodService().server.getUserProjects();
         }
         setProjects(infos);
+        setProjectsLoaded(true);
 
         const map = new Map();
         await Promise.all(
@@ -72,6 +74,7 @@ export default function () {
         setLastPrebuilds(map);
     }, [team, teams, usePublicApiProjectsService, user?.id]);
 
+    // Reload projects if the team changes
     useEffect(() => {
         updateProjects();
     }, [teams, updateProjects]);
@@ -113,7 +116,8 @@ export default function () {
                 </div>
             )}
             <Header title="Projects" subtitle="Manage recently added projects." />
-            {projects.length === 0 && (
+            {/* only show if we're not still loading projects to avoid a content flash */}
+            {projectsLoaded && projects.length === 0 && (
                 <div>
                     <img
                         alt="Projects (empty)"

--- a/components/dashboard/src/teams/teams-context.tsx
+++ b/components/dashboard/src/teams/teams-context.tsx
@@ -5,8 +5,9 @@
  */
 
 import { Team } from "@gitpod/gitpod-protocol";
-import React, { createContext, useState } from "react";
+import React, { createContext, useContext, useState } from "react";
 import { Location } from "history";
+import { useLocation } from "react-router";
 
 export const TeamsContext = createContext<{
     teams?: Team[];
@@ -35,4 +36,12 @@ export function getCurrentTeam(location: Location<any>, teams?: Team[]): Team | 
 
 export function getSelectedTeamSlug(): string {
     return localStorage.getItem("team-selection") || "";
+}
+
+// Helper hook to return the current team if one is selected
+export function useCurrentTeam(): Team | undefined {
+    const location = useLocation();
+    const { teams } = useContext(TeamsContext);
+
+    return getCurrentTeam(location, teams);
 }


### PR DESCRIPTION
## Description
This is a followup PR to #15316 to share some updates made there with extracting a remove project modal. A couple other related updates on the Project list page are included.

* Simplify project list by extracting a `<ProjectListItem/>` component. This let us drop a bunch of state management we were doing around which project to remove.
* Memoized the sorting/filtering of projects so it only occurs when a relevant value changes instead of every render.
* Added a flag to track projects having been loaded to avoid a content flash on initial page load

## How to test
<!-- Provide steps to test this PR -->
Preview Env: https://bmh-projec70ae423ab3.preview.gitpod-dev.com/

* Navigate to your personal, or a team's Projects list.
* Try and Remove a project via the overflow menu action.
* It should open a confirmation modal like it used to (this is using a new component for that now).
* Canceling should close it, Removing should remove the project, and close the modal.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
