### PR TITLE
[server] increate request timeout to ide-service to 5 sec

### DIFF
--- a/components/server/src/ide-service.ts
+++ b/components/server/src/ide-service.ts
@@ -118,18 +118,24 @@ export class IDEService {
             if (attempt != 0) {
                 await new Promise((resolve) => setTimeout(resolve, 1000));
             }
-            const controller = new AbortController();
-            setTimeout(() => controller.abort(), 1000);
             try {
-                const resp = await this.ideService.resolveWorkspaceConfig(req, {
-                    signal: controller.signal,
-                });
+                const resp = await this.tryResolveWorkspaceConfig(req);
                 return resp;
             } catch (e) {
                 console.error("ide-service: failed to resolve workspace config: ", e);
             }
         }
         throw new Error("failed to resolve workspace IDE configuration");
+    }
+
+    private tryResolveWorkspaceConfig(
+        req: IdeServiceApi.ResolveWorkspaceConfigRequest,
+    ): Promise<ResolveWorkspaceConfigResponse> {
+        const controller = new AbortController();
+        setTimeout(() => controller.abort(), 5000);
+        return this.ideService.resolveWorkspaceConfig(req, {
+            signal: controller.signal,
+        });
     }
 
     resolveGitpodTasks(ws: Workspace, ideConfig: ResolveWorkspaceConfigResponse): TaskConfig[] {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

During deployment of ide-service, server by using nice-grpc is struggling to connect to new instances of ide-service. We are investigating separately what is going wrong, but for now we also want to increase overall timeout from 30 to 90 sec to reduce a risk of failed workspace startups. See [internal discussion](https://gitpod.slack.com/archives/C03QM0ZHF5Z/p1670926091722999).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
