### PR TITLE
Add gitpod-monitor by default

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -81,6 +81,7 @@ vscode:
     - fwcd.kotlin
     - dbaeumer.vscode-eslint
     - esbenp.prettier-vscode
+    - akosyakov.gitpod-monitor
 jetbrains:
   goland:
     prebuilds:


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This adds @akosyakov's extension `gitpod-monitor` to the list of vscode extensions we use in the repository. The extension is a great way to inform users of the load they're workspace is under, helping identify resource-heavy tasks that might be worth optimising.


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/15061

## How to test

Open a workspace, see the extension as the bottom:

![Screenshot 2022-12-13 at 14 34 23](https://user-images.githubusercontent.com/83561/207336587-020aa98d-873b-4f47-bab1-d7f8311a8d86.png)


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
