### PR TITLE
Fix AuthCodeRepositoryDB.getByIdentifier

### DIFF
--- a/components/gitpod-db/src/typeorm/auth-code-repository-db.spec.db.ts
+++ b/components/gitpod-db/src/typeorm/auth-code-repository-db.spec.db.ts
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { suite, test, timeout } from "mocha-typescript";
+import { testContainer } from "../test-container";
+import { AuthCodeRepositoryDB } from "./auth-code-repository-db";
+import { UserDB } from "../user-db";
+import { DBOAuthAuthCodeEntry } from "./entity/db-oauth-auth-code";
+import { TypeORM } from "./typeorm";
+import { DBUser } from "./entity/db-user";
+import * as chai from "chai";
+import { User } from "@gitpod/gitpod-protocol";
+const expect = chai.expect;
+
+@suite(timeout(10000))
+export class AuthCodeRepositoryDBSpec {
+    private readonly codeDB = testContainer.get<AuthCodeRepositoryDB>(AuthCodeRepositoryDB);
+    private readonly userDB = testContainer.get<UserDB>(UserDB);
+
+    async before() {
+        await this.wipeRepo();
+    }
+
+    async after() {
+        await this.wipeRepo();
+    }
+
+    async wipeRepo() {
+        const typeorm = testContainer.get<TypeORM>(TypeORM);
+        const manager = await typeorm.getConnection();
+        await manager.getRepository(DBOAuthAuthCodeEntry).delete({});
+        await manager.getRepository(DBUser).delete({});
+    }
+
+    @test()
+    async testPersistAndRead(): Promise<void> {
+        let user = await this.userDB.newUser();
+        user.identities.push({
+            authProviderId: "GitHub",
+            authId: "1234",
+            authName: "newUser",
+            primaryEmail: "newuser@git.com",
+        });
+        user = await this.userDB.storeUser(user);
+
+        const code = this.createCode(user);
+        await this.codeDB.persist(code);
+
+        const persistedCodeEntry = await this.codeDB.getByIdentifier(code.code);
+        expect(persistedCodeEntry.user, "persistedCodeEntry.user").not.to.be.undefined;
+    }
+
+    protected createCode(user: User) {
+        // OAuth2 server layer
+        const code = this.codeDB.issueAuthCode(
+            {
+                id: "foo-1",
+                name: "foo",
+                redirectUris: [],
+                allowedGrants: [],
+                scopes: [],
+            },
+            user,
+            [],
+        );
+        // DBOAuthAuthCodeEntry layer
+        const code2: DBOAuthAuthCodeEntry = {
+            user: user as any, // this is as weak as it sounds :-(
+            client: {} as any,
+            code: code.code,
+            codeChallenge: "abc",
+            codeChallengeMethod: "plain",
+            expiresAt: code.expiresAt,
+            scopes: [],
+            id: "foo1",
+        };
+        return code2;
+    }
+}


### PR DESCRIPTION
## Description
`AuthCodeRepositoryDB.getByIdentifier` didn't join with d_b_user table, this PR fixes issues with OAuth2Server integration (+ desktop IDEs)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #14464

## How to test
Beyond the db-test included, one would need to connect to the preview environment using a desktop IDE. No `userId` errors in SQL statements should be logged. 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
