### PR TITLE
adding team.slug to findTeams query

### DIFF
--- a/components/gitpod-db/src/team-db.spec.db.ts
+++ b/components/gitpod-db/src/team-db.spec.db.ts
@@ -151,6 +151,17 @@ class TeamDBSpec {
         const result = await this.db.findTeams(0, 10, "creationTime", "DESC", searchTerm);
         expect(result.rows.length).to.eq(1);
     }
+
+    @test(timeout(10000))
+    public async findTeamsBySlug() {
+        const user = await this.userDb.newUser();
+        await this.db.createTeam(user.id, "First Team");
+        await this.db.createTeam(user.id, "Second Team");
+
+        const searchTerm = "first-team";
+        const result = await this.db.findTeams(0, 10, "creationTime", "DESC", searchTerm);
+        expect(result.rows.length).to.eq(1);
+    }
 }
 
 module.exports = new TeamDBSpec();

--- a/components/gitpod-db/src/typeorm/team-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/team-db-impl.ts
@@ -52,7 +52,7 @@ export class TeamDBImpl implements TeamDB {
         const teamRepo = await this.getTeamRepo();
         const queryBuilder = teamRepo
             .createQueryBuilder("team")
-            .where("team.name LIKE :searchTerm", { searchTerm: `%${searchTerm}%` })
+            .where("team.name LIKE :searchTerm OR team.slug LIKE :searchTerm", { searchTerm: `%${searchTerm}%` })
             .skip(offset)
             .take(limit)
             .orderBy(orderBy, orderDir);


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Adjusting the `findTeams` query to use the `searchTerm` for either `team.name` or `team.slug`.

Searching by team-slug
<img width="797" alt="image" src="https://user-images.githubusercontent.com/367275/207477373-b8b267e4-6b44-469e-8ff4-8239d7fda332.png">


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #12982

## How to test
<!-- Provide steps to test this PR -->
**Preview Env:** https://bmh-searche1a0adc542.preview.gitpod-dev.com/

* Create a team named something like `Test Team`
* Go to Admin/Teams and search for the team by it's slug, `test-team`
* The team should display in the results

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
The Admin Teams search will also search by team slug in addition to team name.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
