### PR TITLE
Revert "[configcat] Stop logging info messages"

### DIFF
--- a/components/common-go/experiments/configcat.go
+++ b/components/common-go/experiments/configcat.go
@@ -85,16 +85,3 @@ type configCatLogger struct {
 func (l *configCatLogger) GetLevel() configcat.LogLevel {
 	return configcat.LogLevelError
 }
-
-func (l *configCatLogger) Debugf(format string, args ...interface{}) {
-	l.Debugf(format, args...)
-}
-func (l *configCatLogger) Infof(format string, args ...interface{}) {
-	l.Debugf(format, args...)
-}
-func (l *configCatLogger) Warnf(format string, args ...interface{}) {
-	l.Debugf(format, args...)
-}
-func (l *configCatLogger) Errorf(format string, args ...interface{}) {
-	l.Errorf(format, args...)
-}

--- a/components/common-go/experiments/types.go
+++ b/components/common-go/experiments/types.go
@@ -38,14 +38,12 @@ type Attributes struct {
 // Otherwise, it returns a client which always returns the default value. This client is used for Self-Hosted installations.
 func NewClient() Client {
 	gitpodHost := os.Getenv("GITPOD_HOST")
-
 	if gitpodHost != "" {
 		return newConfigCatClient(configcat.Config{
 			SDKKey:       "gitpod",
 			BaseURL:      fmt.Sprintf("%s%s", gitpodHost, "/configcat"),
 			PollInterval: 1 * time.Minute,
 			HTTPTimeout:  3 * time.Second,
-			Logger:       &configCatLogger{log.Log},
 		})
 	}
 	sdkKey := os.Getenv("CONFIGCAT_SDK_KEY")


### PR DESCRIPTION
This reverts commit fbac9a213f6406a704d669245c0fb892a1e6cb16.

## Description
<!-- Describe your changes in detail -->

Can panic on request https://console.cloud.google.com/logs/query;query=resource.labels.pod_name%20:%20%2528%22public-api-server%22%2529;timeRange=PT1H;cursorTimestamp=2022-12-14T10:02:23.880147315Z?authuser=0&project=gitpod-191109

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
