### PR TITLE
Add PoC to build in GitHub actions

### DIFF
--- a/.github/workflows/poc-build.yml
+++ b/.github/workflows/poc-build.yml
@@ -1,0 +1,201 @@
+name: PoC-Build
+on: workflow_dispatch
+
+jobs:
+
+  previewctl:
+    runs-on: [self-hosted]
+    container:
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-remove-adc.9
+    steps:
+     - uses: actions/checkout@v3
+     - name: Configure workspace
+       run: cp -r /__w/gitpod/gitpod /workspace
+     - name: Build previewctl
+       shell: bash
+       working-directory: /workspace/gitpod
+       run: |
+         leeway run dev/preview/previewctl:install --dont-test
+         cp /workspace/bin/previewctl /__w/gitpod/gitpod/previewctl
+     - name: 'Upload Installer artifacts'
+       uses: actions/upload-artifact@v3
+       with:
+         name: previewctl
+         path: previewctl
+
+  infrastructure:
+    runs-on: [self-hosted]
+    needs: [previewctl]
+    container:
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-remove-adc.9
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
+        with:
+          name: previewctl
+      - name: Configure workspace
+        run: |
+          cp -r /__w/gitpod/gitpod /workspace
+          chmod +x ./previewctl
+          sudo mv ./previewctl /usr/local/bin/
+      - name: Terraform
+        id: terraform
+        shell: bash
+        working-directory: /workspace/gitpod
+        env:
+          HOME: /home/gitpod
+          PREVIEW_ENV_DEV_SA_KEY: ${{ secrets.GCP_CREDENTIALS }}
+          PREVIEW_ENV_DEV_SA_KEY_PATH: /home/gitpod/.config/gcloud/preview-environment-dev-sa.json
+          # Don't prompt user before terraform apply
+          TF_INPUT: 0
+          TF_IN_AUTOMATION: true
+        run: |
+          echo "${PREVIEW_ENV_DEV_SA_KEY}" > "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
+          gcloud auth activate-service-account --key-file "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
+
+          previewctl get-credentials --gcp-service-account "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
+          leeway run dev/preview:create-preview
+
+  build:
+    runs-on: [self-hosted]
+    outputs:
+      version: ${{ steps.leeway.outputs.version }}
+    container:
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-remove-adc.9
+    steps:
+      - uses: actions/checkout@v3
+      - name: Configure workspace
+        run: |
+          cp -r /__w/gitpod/gitpod /workspace
+          # Needed by google-github-actions/setup-gcloud
+          sudo chown -R gitpod:gitpod /__t
+          # Needed by docker/login-action
+          sudo chmod goa+rw /var/run/docker.sock
+      - id: auth
+        uses: google-github-actions/auth@v1
+        with:
+          token_format: access_token
+          credentials_json: '${{ secrets.GCP_CREDENTIALS }}'
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v1
+      - uses: docker/login-action@v2
+        with:
+          registry: eu.gcr.io
+          username: oauth2accesstoken
+          password: '${{ steps.auth.outputs.access_token }}'
+      - name: "Determine Branch"
+        id: branches
+        uses: transferwise/sanitize-branch-name@v1
+      - name: Leeway
+        id: leeway
+        shell: bash
+        working-directory: /workspace/gitpod
+        env:
+          JAVA_HOME: /home/gitpod/.sdkman/candidates/java/current
+          VERSION: "${{ steps.branches.outputs.sanitized-branch-name }}.${{github.run_number}}"
+        run: |
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+          RESULT=0
+          leeway build dev/preview:deploy-dependencies \
+            -Dversion=$VERSION \
+            -DSEGMENT_IO_TOKEN=value \
+            -DpublishToNPM=false \
+            --dont-test \
+            --report report.html || RESULT=$?
+
+          cat report.html >> $GITHUB_STEP_SUMMARY
+          cp /tmp/versions.yaml /__w/gitpod/gitpod/versions.yaml
+          cp /usr/local/bin/installer /__w/gitpod/gitpod/installer
+
+          exit $RESULT
+      - name: 'Upload Installer artifacts'
+        uses: actions/upload-artifact@v3
+        with:
+          name: installer-artifacts
+          path: |
+            versions.yaml
+            installer
+
+  install:
+    needs: [previewctl, build, infrastructure]
+    runs-on: [self-hosted]
+    container:
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-remove-adc.9
+    steps:
+      - uses: actions/checkout@v3
+      - name: Configure workspace
+        run: |
+          cp -r /__w/gitpod/gitpod /workspace
+          # Needed by google-github-actions/setup-gcloud
+          sudo chown -R gitpod:gitpod /__t
+      - uses: actions/download-artifact@v3
+        with:
+          name: installer-artifacts
+      - uses: actions/download-artifact@v3
+        with:
+          name: previewctl
+      - name: Install artifacts
+        run: |
+          cp versions.yaml /tmp/versions.yaml
+          chmod +x ./installer
+          sudo mv ./installer /usr/local/bin/
+          chmod +x ./previewctl
+          sudo mv ./previewctl /usr/local/bin/
+      - id: auth
+        uses: google-github-actions/auth@v1
+        with:
+          token_format: access_token
+          credentials_json: '${{ secrets.GCP_CREDENTIALS }}'
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v1
+      - name: Install
+        shell: bash
+        working-directory: /workspace/gitpod
+        env:
+          VERSION: ${{needs.build.outputs.version}}
+          HOME: /home/gitpod
+          PREVIEW_ENV_DEV_SA_KEY: ${{ secrets.GCP_CREDENTIALS }}
+          PREVIEW_ENV_DEV_SA_KEY_PATH: /home/gitpod/.config/gcloud/preview-environment-dev-sa.json
+        run: |
+          echo "${PREVIEW_ENV_DEV_SA_KEY}" > "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
+          previewctl install-context --timeout 10m --gcp-service-account "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
+          leeway run dev/preview:deploy-gitpod
+
+  monitoring:
+    needs: [previewctl, infrastructure]
+    runs-on: [self-hosted]
+    container:
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-remove-adc.9
+    steps:
+      - uses: actions/checkout@v3
+      - name: Configure workspace
+        run: |
+          cp -r /__w/gitpod/gitpod /workspace
+          # Needed by google-github-actions/setup-gcloud
+          sudo chown -R gitpod:gitpod /__t
+      - uses: actions/download-artifact@v3
+        with:
+          name: previewctl
+      - id: auth
+        uses: google-github-actions/auth@v1
+        with:
+          token_format: access_token
+          credentials_json: '${{ secrets.GCP_CREDENTIALS }}'
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v1
+      - name: Install artifacts
+        run: |
+          chmod +x ./previewctl
+          sudo mv ./previewctl /usr/local/bin/
+      - name: Install
+        shell: bash
+        working-directory: /workspace/gitpod
+        env:
+          HOME: /home/gitpod
+          PREVIEW_ENV_DEV_SA_KEY: ${{ secrets.GCP_CREDENTIALS }}
+          PREVIEW_ENV_DEV_SA_KEY_PATH: /home/gitpod/.config/gcloud/preview-environment-dev-sa.json
+        run: |
+          echo "${PREVIEW_ENV_DEV_SA_KEY}" > "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
+          previewctl install-context --timeout 10m --gcp-service-account "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
+          leeway run dev/preview:deploy-monitoring-satellite


### PR DESCRIPTION
## Description
Add a Proof of Concept to run our main build in GitHub actions. The intention is to get this PoC into the hands of our colleagues for a more informed discussion. 

For details, see:
https://www.notion.so/gitpod/Main-Build-via-GitHub-Actions-PoC-5d157d5f4c604a3a89d4e35ee26da3a7

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/ops/issues/5749

## How to test
<!-- Provide steps to test this PR -->
See https://www.notion.so/gitpod/Main-Build-via-GitHub-Actions-PoC-5d157d5f4c604a3a89d4e35ee26da3a7

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
