### PR TITLE
[jb-launcher] no panic on resolving user env vars

### DIFF
--- a/components/ide/jetbrains/launcher/main.go
+++ b/components/ide/jetbrains/launcher/main.go
@@ -494,8 +494,21 @@ func resolveUserEnvs(launchCtx *LaunchContext) (userEnvs []string, err error) {
 		return
 	}
 	markByte := []byte(mark.String())
-	start := bytes.Index(output, markByte) + len(markByte)
+	start := bytes.Index(output, markByte)
+	if start == -1 {
+		err = fmt.Errorf("no %s in output", mark.String())
+		return
+	}
+	start = start + len(markByte)
+	if start > len(output) {
+		err = fmt.Errorf("no %s in output", mark.String())
+		return
+	}
 	end := bytes.LastIndex(output, markByte)
+	if end == -1 {
+		err = fmt.Errorf("no %s in output", mark.String())
+		return
+	}
 	err = json.Unmarshal(output[start:end], &userEnvs)
 	return
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

See [logs](https://console.cloud.google.com/logs/query;query=%22panic:%20runtime%20error:%20slice%20bounds%20out%20of%20range%20%5B:-1%5D%22%0A%22resolveUserEnvs%22;timeRange=P2D;pinnedLogId=2022-12-14T09:37:40.193710526Z%2Fit75m546wgdrp87t;lfeCustomFields=resource%252Flabels%252Fpod_name;cursorTimestamp=2022-12-14T09:34:11.535276598Z?project=workspace-clusters). Also adding logging to help us investigate the root cause.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
