### PR TITLE
[image-builder] Change affinity in ws clusters

### DIFF
--- a/install/installer/cmd/testdata/render/kind-workspace/output.golden
+++ b/install/installer/cmd/testdata/render/kind-workspace/output.golden
@@ -3483,7 +3483,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: gitpod.io/workload_meta
+              - key: gitpod.io/workload_workspace_services
                 operator: Exists
       containers:
       - args:

--- a/install/installer/pkg/components/image-builder-mk3/deployment.go
+++ b/install/installer/pkg/components/image-builder-mk3/deployment.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"github.com/gitpod-io/gitpod/installer/pkg/cluster"
+	"github.com/gitpod-io/gitpod/installer/pkg/config/v1"
 
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 	dockerregistry "github.com/gitpod-io/gitpod/installer/pkg/components/docker-registry"
@@ -109,6 +110,11 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 		volumeMounts = append(volumeMounts, *mnt)
 	}
 
+	var nodeAffinity = cluster.AffinityLabelMeta
+	if ctx.Config.Kind == config.InstallationWorkspace {
+		nodeAffinity = cluster.AffinityLabelWorkspaceServices
+	}
+
 	return []runtime.Object{&appsv1.Deployment{
 		TypeMeta: common.TypeMetaDeployment,
 		ObjectMeta: metav1.ObjectMeta{
@@ -133,7 +139,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 					}),
 				},
 				Spec: corev1.PodSpec{
-					Affinity:                      common.NodeAffinity(cluster.AffinityLabelMeta),
+					Affinity:                      common.NodeAffinity(nodeAffinity),
 					ServiceAccountName:            Component,
 					EnableServiceLinks:            pointer.Bool(false),
 					DNSPolicy:                     "ClusterFirst",


### PR DESCRIPTION
## Description
Update image-builder-mk3 node affinity to `gitpod.io/workload_workspace_services` for workspace installs.

Should not have an effect for gitpod.io, but removes dependency of `gitpod.io/workload_meta` label in workspace clusters for image builder, e.g. needed for dedicated. Context: https://github.com/gitpod-io/gitpod/issues/7845#issuecomment-1351330180

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

## How to test
<!-- Provide steps to test this PR -->

Verified that the `gitpod.io/workload_workspace_services` label is present on the `services` nodes (which run the image-builder) in workspace clusters.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
