### PR TITLE
[JetBrains] Run Auto-JDK during project warmup

### DIFF
--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/GitpodProjectManager.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/GitpodProjectManager.kt
@@ -37,7 +37,7 @@ class GitpodProjectManager(
      * It is a workaround for https://youtrack.jetbrains.com/issue/GTW-88
      */
     private fun configureSdks() {
-        if (application.isHeadlessEnvironment || Registry.get("gitpod.autoJdk.disabled").asBoolean()) {
+        if ((application.isHeadlessEnvironment && !System.getenv("JETBRAINS_GITPOD_RUNNING_WARMUP").toBoolean()) || Registry.get("gitpod.autoJdk.disabled").asBoolean()) {
             return
         }
         val pendingSdk = CompletableFuture<Sdk>()

--- a/components/ide/jetbrains/launcher/main.go
+++ b/components/ide/jetbrains/launcher/main.go
@@ -457,6 +457,7 @@ func run(launchCtx *LaunchContext) {
 
 	cmd := remoteDevServerCmd(args, launchCtx)
 	cmd.Env = append(cmd.Env, "JETBRAINS_GITPOD_BACKEND_KIND="+launchCtx.alias)
+	cmd.Env = append(cmd.Env, "JETBRAINS_GITPOD_RUNNING_WARMUP="+strconv.FormatBool(launchCtx.warmup))
 	workspaceUrl, err := url.Parse(launchCtx.wsInfo.WorkspaceUrl)
 	if err == nil {
 		cmd.Env = append(cmd.Env, "JETBRAINS_GITPOD_WORKSPACE_HOST="+workspaceUrl.Hostname())


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Run Auto-JDK during project warmup.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
- Related to https://github.com/gitpod-io/gitpod/issues/6740

## How to test
<!-- Provide steps to test this PR -->
Open Stable IntelliJ IDEA using [this repository](https://github.com/Gitpod-Samples/spring-petclinic) and confirm if you see the message:

> gitpod: 'spting-petclinic' project: SDK detected: 17

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```
## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
