### PR TITLE
[server] Take the service name for tracing from the environment

### DIFF
--- a/components/server/src/init.ts
+++ b/components/server/src/init.ts
@@ -107,7 +107,7 @@ log.enableJSONLogging("server", process.env.VERSION, LogrusLogLevel.getFromEnv()
 
 export async function start(container: Container) {
     const tracing = container.get(TracingManager);
-    tracing.setup("server", {
+    tracing.setup(process.env.JAEGER_SERVICE_NAME ?? "server", {
         perOpSampling: {
             createWorkspace: true,
             startWorksace: true,


### PR DESCRIPTION
## Description

Rather than hardcoding the name of the service for tracing to `"server"`, use the `JAEGER_SERVICE_NAME` environment variable.

This should ensure that we see separate services in Honeycomb for `server` and `slow-server`.

See [internal discussion](https://gitpod.slack.com/archives/C01KLC56NP7/p1671015605121669) for more context.

## Related Issue(s)
Part of https://github.com/gitpod-io/gitpod/issues/15297

## How to test

`slow-server` now appears as a separate service name in Honeycomb for the `preview-environments` dataset [[1](https://ui.honeycomb.io/gitpod/datasets/preview-environments/result/opmVeXgsxxh)].


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-slow-database
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
