### PR TITLE
Show team usage tab only for team owners

### DIFF
--- a/components/dashboard/src/Menu.tsx
+++ b/components/dashboard/src/Menu.tsx
@@ -231,7 +231,10 @@ export default function Menu() {
                 link: `/t/${team.slug}/members`,
             },
         ];
-        if (showUsageView || (teamBillingMode && teamBillingMode.mode === "usage-based")) {
+        if (
+            currentUserInTeam?.role === "owner" &&
+            (showUsageView || (teamBillingMode && teamBillingMode.mode === "usage-based"))
+        ) {
             teamSettingsList.push({
                 title: "Usage",
                 link: `/t/${team.slug}/usage`,


### PR DESCRIPTION
## Description

Not sure if the code changes here will work, but this will attempt to fix https://github.com/gitpod-io/gitpod/issues/11588.

Any hints or help is appreciated. 🏀 

See [relevant discussion](https://gitpod.slack.com/archives/C01KPEPNBD0/p1671022341946149) (internal). Cc @loujaybee 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/11588

## How to test

1. Join a team as a non-owner and notice that the team _Usage_ tab is no longer visible for you.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Show team usage tab only for team owners
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
