### PR TITLE
Dashboard App component cleanup

### DIFF
--- a/components/dashboard/src/App.tsx
+++ b/components/dashboard/src/App.tsx
@@ -195,6 +195,20 @@ function App() {
         }
     }, []);
 
+    useEffect(() => {
+        const onHashChange = () => {
+            // Refresh on hash change if the path is '/' (new context URL)
+            if (window.location.pathname === "/") {
+                window.location.reload();
+            }
+        };
+        window.addEventListener("hashchange", onHashChange, false);
+
+        return () => {
+            window.removeEventListener("hashchange", onHashChange);
+        };
+    }, []);
+
     // redirect to website for any website slugs
     if (isGitpodIo() && isWebsiteSlug(window.location.pathname)) {
         window.location.host = "www.gitpod.io";
@@ -254,18 +268,6 @@ function App() {
             </Suspense>
         );
     }
-
-    // TODO: this will re-subscribe for every render, maybe move to a useEffect
-    window.addEventListener(
-        "hashchange",
-        () => {
-            // Refresh on hash change if the path is '/' (new context URL)
-            if (window.location.pathname === "/") {
-                window.location.reload();
-            }
-        },
-        false,
-    );
 
     let toRender: React.ReactElement = (
         <Route>

--- a/components/dashboard/src/App.tsx
+++ b/components/dashboard/src/App.tsx
@@ -10,7 +10,6 @@ import { Redirect, Route, Switch } from "react-router";
 
 import { Login } from "./Login";
 import { UserContext } from "./user-context";
-import { ThemeContext } from "./theme-context";
 import { shouldSeeWhatsNew, WhatsNew } from "./whatsnew/WhatsNew";
 import gitpodIcon from "./icons/gitpod.svg";
 import { ContextURL, User } from "@gitpod/gitpod-protocol";
@@ -149,43 +148,12 @@ function AdminRoute({ component }: any) {
 }
 
 function App() {
-    const { setIsDark } = useContext(ThemeContext);
     const [isWhatsNewShown, setWhatsNewShown] = useState(false);
     const [showUserIdePreference, setShowUserIdePreference] = useState(false);
     const { user, teams, isSetupRequired, loading } = useUserAndTeamsLoader();
 
     // Setup analytics/tracking
     useAnalyticsTracking();
-
-    // Sets theme
-    useEffect(() => {
-        const updateTheme = () => {
-            const isDark =
-                localStorage.theme === "dark" ||
-                (localStorage.theme !== "light" && window.matchMedia("(prefers-color-scheme: dark)").matches);
-            setIsDark(isDark);
-        };
-        updateTheme();
-        const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
-        if (mediaQuery instanceof EventTarget) {
-            mediaQuery.addEventListener("change", updateTheme);
-        } else {
-            // backward compatibility for Safari < 14
-            (mediaQuery as MediaQueryList).addListener(updateTheme);
-        }
-        window.addEventListener("storage", updateTheme);
-        return function cleanup() {
-            if (mediaQuery instanceof EventTarget) {
-                mediaQuery.removeEventListener("change", updateTheme);
-            } else {
-                // backward compatibility for Safari < 14
-                (mediaQuery as MediaQueryList).removeListener(updateTheme);
-            }
-            window.removeEventListener("storage", updateTheme);
-        };
-        // TODO: Add setIsDark to dep list after updating context to wrap setter w/ useCallback
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []);
 
     // Setup experiments
     useEffect(() => {

--- a/components/dashboard/src/hooks/use-analytics-tracking.ts
+++ b/components/dashboard/src/hooks/use-analytics-tracking.ts
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { useEffect } from "react";
+import { useHistory } from "react-router";
+import { trackButtonOrAnchor, trackPathChange } from "../Analytics";
+
+export const useAnalyticsTracking = () => {
+    const history = useHistory();
+
+    // listen and notify Segment of client-side path updates
+    useEffect(() => {
+        return history.listen((location: any) => {
+            const path = window.location.pathname;
+            trackPathChange({
+                prev: (window as any)._gp.path,
+                path: path,
+            });
+            (window as any)._gp.path = path;
+        });
+    }, [history]);
+
+    // Track button/anchor clicks
+    useEffect(() => {
+        const handleButtonOrAnchorTracking = (props: MouseEvent) => {
+            var curr = props.target as HTMLElement;
+
+            // TODO: Look at using curr.closest('a,button') instead - determine if divs w/ onClick are being used
+            //check if current target or any ancestor up to document is button or anchor
+            while (!(curr instanceof Document)) {
+                if (
+                    curr instanceof HTMLButtonElement ||
+                    curr instanceof HTMLAnchorElement ||
+                    (curr instanceof HTMLDivElement && curr.onclick)
+                ) {
+                    trackButtonOrAnchor(curr);
+                    break; //finding first ancestor is sufficient
+                }
+                curr = curr.parentNode as HTMLElement;
+            }
+        };
+        window.addEventListener("click", handleButtonOrAnchorTracking, true);
+        return () => window.removeEventListener("click", handleButtonOrAnchorTracking, true);
+    }, []);
+};

--- a/components/dashboard/src/theme-context.tsx
+++ b/components/dashboard/src/theme-context.tsx
@@ -4,7 +4,7 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import React, { createContext, useEffect, useState } from "react";
+import React, { createContext, useCallback, useEffect, useState } from "react";
 
 export const ThemeContext = createContext<{
     isDark?: boolean;
@@ -15,10 +15,11 @@ export const ThemeContext = createContext<{
 
 export const ThemeContextProvider: React.FC = ({ children }) => {
     const [isDark, setIsDark] = useState<boolean>(document.documentElement.classList.contains("dark"));
-    const actuallySetIsDark = (dark: boolean) => {
+
+    const actuallySetIsDark = useCallback((dark: boolean) => {
         document.documentElement.classList.toggle("dark", dark);
         setIsDark(dark);
-    };
+    }, []);
 
     useEffect(() => {
         const observer = new MutationObserver(() => {
@@ -30,7 +31,36 @@ export const ThemeContextProvider: React.FC = ({ children }) => {
         return function cleanUp() {
             observer.disconnect();
         };
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
+
+    // Sets theme, tracks it in local storage and listens for changes in localstorage
+    useEffect(() => {
+        const updateTheme = () => {
+            const isDark =
+                localStorage.theme === "dark" ||
+                (localStorage.theme !== "light" && window.matchMedia("(prefers-color-scheme: dark)").matches);
+            actuallySetIsDark(isDark);
+        };
+        updateTheme();
+        const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+        if (mediaQuery instanceof EventTarget) {
+            mediaQuery.addEventListener("change", updateTheme);
+        } else {
+            // backward compatibility for Safari < 14
+            (mediaQuery as MediaQueryList).addListener(updateTheme);
+        }
+        window.addEventListener("storage", updateTheme);
+        return function cleanup() {
+            if (mediaQuery instanceof EventTarget) {
+                mediaQuery.removeEventListener("change", updateTheme);
+            } else {
+                // backward compatibility for Safari < 14
+                (mediaQuery as MediaQueryList).removeListener(updateTheme);
+            }
+            window.removeEventListener("storage", updateTheme);
+        };
+    }, [actuallySetIsDark]);
 
     return <ThemeContext.Provider value={{ isDark, setIsDark: actuallySetIsDark }}>{children}</ThemeContext.Provider>;
 };


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This was a result of going through the `<App/>` component to get an understanding for how to plug in some new setup flows, and finding a few things aiming at cleaning up / improving the component to make it a bit easier to reason about and maintain. Made the following changes:

* Moved location/analytics tracking hooks into a new `useAnalyticsTracking()` hook
* Moved the theme defaulting/local storage tracking hook into the `ThemeContextProvider` with the rest of the theme-related setup/state management.
* Wrapped `hashchange` event listener w/ `useEffect()` so we don't subscribe w/ a new listener on each render.

## How to test
<!-- Provide steps to test this PR -->
**Preview Env:** https://bmh-top-app-updates.preview.gitpod-dev.com

Visually, nothing should change for the end user. Loading up the dashboard should exercise the changes. 

* You can verify we're still sending a `trackLocation` request over the websocket on load.
* Clicking a link or button should still send a `trackEvent` request over the ws.
* Change the theme in preferences, and verify it works as expected, and that when set to system it still changes if the os-level theme changes too.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
