### PR TITLE
[db] handle race in `gorm.Save`

### DIFF
--- a/components/gitpod-db/go/cost_center_test.go
+++ b/components/gitpod-db/go/cost_center_test.go
@@ -6,6 +6,7 @@ package db_test
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -36,6 +37,28 @@ func TestCostCenter_WriteRead(t *testing.T) {
 	require.NoError(t, tx.Error)
 	require.Equal(t, costCenter.ID, read.ID)
 	require.Equal(t, costCenter.SpendingLimit, read.SpendingLimit)
+}
+
+func TestCostCenterManager_GetOrCreateCostCenter_concurrent(t *testing.T) {
+	conn := dbtest.ConnectForTests(t)
+	mnr := db.NewCostCenterManager(conn, db.DefaultSpendingLimit{
+		ForTeams: 0,
+		ForUsers: 500,
+	})
+	id := db.NewTeamAttributionID(uuid.New().String())
+	cleanUp(t, conn, id)
+
+	waitgroup := &sync.WaitGroup{}
+	save := func() {
+		_, err := mnr.GetOrCreateCostCenter(context.Background(), id)
+		require.NoError(t, err)
+		waitgroup.Done()
+	}
+	waitgroup.Add(10)
+	for i := 0; i < 10; i++ {
+		go save()
+	}
+	waitgroup.Wait()
 }
 
 func TestCostCenterManager_GetOrCreateCostCenter(t *testing.T) {


### PR DESCRIPTION
When calling `gorm.Save` concurrently, we see duplicate entry errors
because gorm is only trying to update and if that doe not succeed does
an insert.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #15346

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
