### PR TITLE
[server] Fix clientIp extraction for analytics

### DIFF
--- a/components/server/src/analytics.ts
+++ b/components/server/src/analytics.ts
@@ -8,6 +8,7 @@ import { Request } from "express";
 import { IAnalyticsWriter } from "@gitpod/gitpod-protocol/lib/analytics";
 import { SubscriptionService } from "@gitpod/gitpod-payment-endpoint/lib/accounting";
 import * as crypto from "crypto";
+import { clientIp } from "./express-util";
 
 export async function trackLogin(
     user: User,
@@ -18,7 +19,7 @@ export async function trackLogin(
 ) {
     // make new complete identify call for each login
     await fullIdentify(user, request, analytics, subscriptionService);
-    const ip = request.ips[0];
+    const ip = clientIp(request);
     const ua = request.headers["user-agent"];
 
     // track the login
@@ -35,7 +36,7 @@ export async function trackLogin(
 export async function trackSignup(user: User, request: Request, analytics: IAnalyticsWriter) {
     // make new complete identify call for each signup
     await fullIdentify(user, request, analytics);
-    const ip = request.ips[0];
+    const ip = clientIp(request);
     const ua = request.headers["user-agent"];
 
     // track the signup
@@ -79,7 +80,7 @@ async function fullIdentify(
 ) {
     // makes a full identify call for authenticated users
     const coords = request.get("x-glb-client-city-lat-long")?.split(", ");
-    const ip = request.ips[0];
+    const ip = clientIp(request);
     const ua = request.headers["user-agent"];
     var subscriptionIDs: string[] = [];
     const subscriptions = await subscriptionService?.getNotYetCancelledSubscriptions(user, new Date().toISOString());

--- a/components/server/src/express-util.ts
+++ b/components/server/src/express-util.ts
@@ -92,7 +92,7 @@ export function destroySession(session: session.Session): Promise<void> {
  * @returns fingerprint which is a hash over (potential) client ip (or just proxy ip) and User Agent
  */
 export function getRequestingClientInfo(req: express.Request) {
-    const ip = req.ips[0] || req.ip; // on PROD this should be a client IP address
+    const ip = clientIp(req);
     const ua = req.get("user-agent");
     const fingerprint = crypto.createHash("sha256").update(`${ip}–${ua}`).digest("hex");
     return { ua, fingerprint };
@@ -170,3 +170,13 @@ export const takeFirst = (h: string | string[] | undefined): string | undefined 
     }
     return h;
 };
+
+export function clientIp(req: express.Request): string | undefined {
+    const forwardedFor = takeFirst(req.headers["x-forwarded-for"]);
+    if (!forwardedFor) {
+        return undefined;
+    }
+
+    // We now have a ,-separated string of IPs, where the first one is the (closest to) client IP
+    return forwardedFor.split(",")[0];
+}


### PR DESCRIPTION
## Description
Fixes extraction of (masked) client IP for websocket connections.

Turns this output
![image](https://user-images.githubusercontent.com/32448529/207830680-ad036045-409b-4d23-9aea-3777229bcf80.png)
into this
![image](https://user-images.githubusercontent.com/32448529/207830710-89df9e82-65df-4599-a28b-8d781cdd2a53.png)



## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Follow-up for: https://github.com/gitpod-io/gitpod/pull/14978

## How to test
- turn on debug logging with: `gpctl debug log server`
- visit the [preview env's dashboard](https://gpl-analytics.preview.gitpod-dev.com/workspaces)
- check server logs, and notice these lines:
![image](https://user-images.githubusercontent.com/32448529/207831052-846b2185-5aaf-4831-835d-f03379ddd33e.png)


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
