### PR TITLE
Skip stale branch check for artificial jobs

### DIFF
--- a/dev/preview/previewctl/cmd/stale.go
+++ b/dev/preview/previewctl/cmd/stale.go
@@ -60,7 +60,7 @@ func newListStaleCmd(logger *logrus.Logger) *cobra.Command {
 	}
 
 	cmd.PersistentFlags().StringVar(&opts.TFDir, "tf-dir", "dev/preview/infrastructure/harvester", "TF working directory")
-	cmd.Flags().DurationVarP(&opts.timeout, "timeout", "t", 6*time.Minute, "Duration to wait for a preview enviroment contexts' to get installed")
+	cmd.Flags().DurationVarP(&opts.timeout, "timeout", "t", 10*time.Minute, "Duration to wait for a preview enviroment contexts' to get installed")
 	cmd.PersistentFlags().StringVar(&opts.sshPrivateKeyPath, "private-key-path", fmt.Sprintf("%s/.ssh/vm_id_rsa", homedir.HomeDir()), "path to the private key used to authenticate with the VM")
 
 	return cmd
@@ -94,7 +94,7 @@ func (o *listWorkspaceOpts) listWorskpaceStatus(ctx context.Context) ([]preview.
 			Active: false,
 		}
 
-		if _, ok := branchlessWorkspaces[ws]; ok {
+		if _, ok := branchlessWorkspaces[ws]; ok && !strings.HasPrefix(ws, "platform-") {
 			status.Reason = "branch doesn't exist, or last commit older than 3 days"
 			statuses = append(statuses, status)
 			continue


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Artificial jobs don't have branches, therefore do a full check. Ideally it gets cleaned up by the artificial job itself, otherwise it will get cleaned up the stale job.

Also increase the timeout for installing the context to 10m

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
