### PR TITLE
[ubp] reset usage on chargebee cancellation

### DIFF
--- a/components/ee/payment-endpoint/BUILD.yaml
+++ b/components/ee/payment-endpoint/BUILD.yaml
@@ -10,6 +10,7 @@ packages:
     deps:
       - components/gitpod-db:lib
       - components/gitpod-protocol:lib
+      - components/usage-api/typescript:lib
     config:
       packaging: offline-mirror
       yarnLock: ${coreYarnLockBase}/../yarn.lock
@@ -24,6 +25,7 @@ packages:
     deps:
       - components/gitpod-db:lib
       - components/gitpod-protocol:lib
+      - components/usage-api/typescript:lib
       - :dbtest
     config:
       packaging: library
@@ -54,6 +56,7 @@ packages:
       - components/gitpod-db:dbtest-init
       - components/gitpod-db:lib
       - components/gitpod-protocol:lib
+      - components/usage-api/typescript:lib
     config:
       packaging: library
       yarnLock: ${coreYarnLockBase}/../yarn.lock

--- a/components/ee/payment-endpoint/package.json
+++ b/components/ee/payment-endpoint/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "@gitpod/gitpod-db": "0.1.5",
     "@gitpod/gitpod-protocol": "0.1.5",
+    "@gitpod/usage-api": "0.1.5",
     "@octokit/rest": "18.5.6",
     "@octokit/webhooks": "9.17.0",
     "body-parser": "^1.19.2",

--- a/components/ee/payment-endpoint/src/accounting/team-subscription-service.ts
+++ b/components/ee/payment-endpoint/src/accounting/team-subscription-service.ts
@@ -27,6 +27,7 @@ import { SubscriptionModel } from "./subscription-model";
 import { SubscriptionService } from "./subscription-service";
 import { AccountService } from "./account-service";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
+import { UbpResetOnCancel } from "../chargebee/ubp-reset-on-cancel";
 
 type TS = string | TeamSubscription;
 
@@ -36,6 +37,7 @@ export class TeamSubscriptionService {
     @inject(AccountingDB) protected readonly accountingDb: AccountingDB;
     @inject(AccountService) protected readonly accountService: AccountService;
     @inject(SubscriptionService) protected readonly subscriptionService: SubscriptionService;
+    @inject(UbpResetOnCancel) protected readonly ubpResetOnCancel: UbpResetOnCancel;
 
     /**
      * Adds new, free slots to the given TeamSubscription
@@ -178,6 +180,7 @@ export class TeamSubscriptionService {
             // Cancel assignee's subscription (if present)
             if (state === "assigned") {
                 const assignedSlot = slot as TeamSubscriptionSlotAssigned;
+                await this.ubpResetOnCancel.resetUsage(assignedSlot.assigneeId);
                 await this.cancelSubscription(db, assignedSlot.assigneeId, ts.planId, slot.id, now);
             }
 
@@ -453,6 +456,7 @@ export class TeamSubscriptionService {
             throw new Error(`Cannot find subscription for Team Subscription Slot ${slotId}!`);
         }
         model.cancel(subscription, cancellationDate, cancellationDate);
+        await this.ubpResetOnCancel.resetUsage(assigneeId);
         await this.subscriptionService.store(db, model);
     }
 

--- a/components/ee/payment-endpoint/src/accounting/team-subscription-service.ts
+++ b/components/ee/payment-endpoint/src/accounting/team-subscription-service.ts
@@ -180,7 +180,6 @@ export class TeamSubscriptionService {
             // Cancel assignee's subscription (if present)
             if (state === "assigned") {
                 const assignedSlot = slot as TeamSubscriptionSlotAssigned;
-                await this.ubpResetOnCancel.resetUsage(assignedSlot.assigneeId);
                 await this.cancelSubscription(db, assignedSlot.assigneeId, ts.planId, slot.id, now);
             }
 

--- a/components/ee/payment-endpoint/src/accounting/team-subscription2-service.ts
+++ b/components/ee/payment-endpoint/src/accounting/team-subscription2-service.ts
@@ -9,6 +9,7 @@ import { AssignedTeamSubscription2, Subscription } from "@gitpod/gitpod-protocol
 import { Plans } from "@gitpod/gitpod-protocol/lib/plans";
 import { TeamSubscription2 } from "@gitpod/gitpod-protocol/lib/team-subscription-protocol";
 import { inject, injectable } from "inversify";
+import { UbpResetOnCancel } from "../chargebee/ubp-reset-on-cancel";
 import { SubscriptionModel } from "./subscription-model";
 import { SubscriptionService } from "./subscription-service";
 
@@ -17,6 +18,7 @@ export class TeamSubscription2Service {
     @inject(TeamDB) protected readonly teamDB: TeamDB;
     @inject(AccountingDB) protected readonly accountingDb: AccountingDB;
     @inject(SubscriptionService) protected readonly subscriptionService: SubscriptionService;
+    @inject(UbpResetOnCancel) protected readonly ubpResetOnCancel: UbpResetOnCancel;
 
     async addAllTeamMemberSubscriptions(ts2: TeamSubscription2): Promise<void> {
         const members = await this.teamDB.findMembersByTeam(ts2.teamId);
@@ -102,6 +104,7 @@ export class TeamSubscription2Service {
         teamMembershipId: string,
         cancellationDate: string,
     ) {
+        await this.ubpResetOnCancel.resetUsage(userId);
         const model = await this.loadSubscriptionModel(db, userId);
         const subscription = model.findSubscriptionByTeamMembershipId(teamMembershipId);
         if (!subscription) {

--- a/components/ee/payment-endpoint/src/chargebee/ubp-reset-on-cancel.ts
+++ b/components/ee/payment-endpoint/src/chargebee/ubp-reset-on-cancel.ts
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { AttributionId } from "@gitpod/gitpod-protocol/lib/attribution";
+import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
+import { UsageServiceClient, UsageServiceDefinition } from "@gitpod/usage-api/lib/usage/v1/usage.pb";
+import { inject, injectable } from "inversify";
+
+@injectable()
+export class UbpResetOnCancel {
+    @inject(UsageServiceDefinition.name) protected readonly usageService: UsageServiceClient;
+
+    async resetUsage(userId: string) {
+        try {
+            const attributionId = AttributionId.render({ kind: "user", userId: userId });
+            const balanceResponse = await this.usageService.getBalance({ attributionId });
+            const balance = balanceResponse.credits;
+            log.info({ userId }, "Chargbee subscription cancelled, adding credit note for remaining balance", {
+                balance,
+                attributionId,
+            });
+            if (balance > 0) {
+                await this.usageService.addUsageCreditNote({
+                    attributionId,
+                    credits: balance,
+                    description: "Resetting balance after chargebee subscription cancellation",
+                });
+            } else {
+                log.info({ userId }, "No balance to reset", { balance, attributionId });
+            }
+        } catch (err) {
+            log.error({ userId }, "Failed to reset usage balance", err);
+        }
+    }
+}

--- a/components/ee/payment-endpoint/src/config.ts
+++ b/components/ee/payment-endpoint/src/config.ts
@@ -41,6 +41,8 @@ export GITPOD_GITHUB_APP_MKT_NAME=gitpod-draft-development-app
     readonly maxTeamSlotsOnCreation: number = !!process.env.TS_MAX_SLOTS_ON_CREATION
         ? parseInt(process.env.TS_MAX_SLOTS_ON_CREATION)
         : 1000;
+
+    readonly usageServiceAddr: string = process.env.GITPOD_USAGE_SERVICE_ADDR || "usage.default.svc.cluster.local:9001";
 }
 
 export interface ChargebeeWebhook {

--- a/components/licensor/typescript/ee/src/api.ts
+++ b/components/licensor/typescript/ee/src/api.ts
@@ -3,7 +3,6 @@
  * Licensed under the GNU Affero General Public License (AGPL).
  * See License.AGPL.txt in the project root for license information.
  */
-
 // generated using github.com/32leaves/bel
 // DO NOT MODIFY
 export enum Feature {
@@ -14,10 +13,10 @@ export enum Feature {
     FeatureWorkspaceSharing = "workspace-sharing",
 }
 export interface LicenseData {
-    type: LicenseType;
-    payload: LicensePayload;
-    plan: LicenseSubscriptionLevel;
-    fallbackAllowed: boolean;
+    type: LicenseType
+    payload: LicensePayload
+    plan: LicenseSubscriptionLevel
+    fallbackAllowed: boolean
 }
 
 export enum LicenseLevel {
@@ -25,12 +24,12 @@ export enum LicenseLevel {
     LevelEnterprise = 1,
 }
 export interface LicensePayload {
-    id: string;
-    domain: string;
-    level: LicenseLevel;
-    validUntil: string;
-    seats: number;
-    customerID?: string;
+    id: string
+    domain: string
+    level: LicenseLevel
+    validUntil: string
+    seats: number
+    customerID?: string
 }
 
 export enum LicenseSubscriptionLevel {

--- a/components/server/src/container-module.ts
+++ b/components/server/src/container-module.ts
@@ -114,6 +114,7 @@ import { prometheusClientMiddleware } from "@gitpod/gitpod-protocol/lib/util/nic
 import { UsageService, UsageServiceImpl } from "./user/usage-service";
 import { OpenPrebuildPrefixContextParser } from "./workspace/open-prebuild-prefix-context-parser";
 import { contentServiceBinder } from "./util/content-service-sugar";
+import { UbpResetOnCancel } from "@gitpod/gitpod-payment-endpoint/lib/chargebee/ubp-reset-on-cancel";
 
 export const productionContainerModule = new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(Config).toConstantValue(ConfigFile.fromFile());
@@ -301,4 +302,5 @@ export const productionContainerModule = new ContainerModule((bind, unbind, isBo
 
     bind(UsageServiceImpl).toSelf().inSingletonScope();
     bind(UsageService).toService(UsageServiceImpl);
+    bind(UbpResetOnCancel).toSelf().inSingletonScope();
 });

--- a/components/usage/pkg/apiv1/usage.go
+++ b/components/usage/pkg/apiv1/usage.go
@@ -477,11 +477,6 @@ func (s *UsageService) AddUsageCreditNote(ctx context.Context, req *v1.AddUsageC
 		return nil, status.Error(codes.InvalidArgument, "The description must not be empty.")
 	}
 
-	userId, err := uuid.Parse(req.UserId)
-	if err != nil {
-		return nil, fmt.Errorf("The user id is not a valid UUID. %w", err)
-	}
-
 	usage := db.Usage{
 		ID:            uuid.New(),
 		AttributionID: attributionId,
@@ -492,9 +487,15 @@ func (s *UsageService) AddUsageCreditNote(ctx context.Context, req *v1.AddUsageC
 		Draft:         false,
 	}
 
-	err = usage.SetCreditNoteMetaData(db.CreditNoteMetaData{UserId: userId.String()})
-	if err != nil {
-		return nil, err
+	if req.UserId != "" {
+		userId, err := uuid.Parse(req.UserId)
+		if err != nil {
+			return nil, fmt.Errorf("The user id is not a valid UUID. %w", err)
+		}
+		err = usage.SetCreditNoteMetaData(db.CreditNoteMetaData{UserId: userId.String()})
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	err = db.InsertUsage(ctx, s.conn, usage)

--- a/install/installer/pkg/common/constants.go
+++ b/install/installer/pkg/common/constants.go
@@ -41,6 +41,7 @@ const (
 	SlowServerComponent         = "slow-server"
 	ServerInstallationAdminPort = 9000
 	SystemNodeCritical          = "system-node-critical"
+	PaymentEndpointComponent    = "payment-endpoint"
 	PublicApiComponent          = "public-api-server"
 	WSManagerComponent          = "ws-manager"
 	WSManagerBridgeComponent    = "ws-manager-bridge"

--- a/install/installer/pkg/components/usage/networkpolicy.go
+++ b/install/installer/pkg/components/usage/networkpolicy.go
@@ -53,6 +53,13 @@ func networkpolicy(ctx *common.RenderContext) ([]runtime.Object, error) {
 							{
 								PodSelector: &metav1.LabelSelector{
 									MatchLabels: map[string]string{
+										"component": common.PaymentEndpointComponent,
+									},
+								},
+							},
+							{
+								PodSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
 										"component": common.PublicApiComponent,
 									},
 								},


### PR DESCRIPTION
## Description

Creates a credit note for negative balance for users that are canceled (team slot or individual), so that those users start with a zero balance.

I've tested teamsubscription, teamsubscription2, individual subscription.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #15055

## How to test
<!-- Provide steps to test this PR -->
- create a team "Chargebee something" and sign up with chargebee
- create usage with one of the team's users
- cancel chargebee
- verify the usage has been reset.

Note: the `AddUsageCreditNote` endpoint uses entire credits and can't handle creditcents. So if balance is 12.34 the credit note will be 12.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-payment
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
