### PR TITLE
Replace prebuild duration message emoji

### DIFF
--- a/components/supervisor/pkg/supervisor/tasks.go
+++ b/components/supervisor/pkg/supervisor/tasks.go
@@ -498,7 +498,7 @@ func (tm *tasksManager) watch(task *task, term *terminal.Term) {
 		duration := ""
 		if elapsed >= 1*time.Minute {
 			elapsedInMinutes := strconv.Itoa(int(math.Round(elapsed.Minutes())))
-			duration = "🎉 Well done on saving " + elapsedInMinutes + " minute"
+			duration = "⏱️ Well done on saving " + elapsedInMinutes + " minute"
 			if elapsedInMinutes != "1" {
 				duration += "s"
 			}
@@ -539,7 +539,7 @@ func importParentLogAndGetDuration(fn string, out io.Writer) time.Duration {
 	if !scanner.Scan() {
 		return 0
 	}
-	reg, err := regexp.Compile(`🎉 Well done on saving (\d+) minute`)
+	reg, err := regexp.Compile(`⏱️ Well done on saving (\d+) minute`)
 	if err != nil {
 		return 0
 	}


### PR DESCRIPTION
## Description

Following up from a relevant discussions[[1](https://gitpod.slack.com/archives/C02EN94AEPL/p1653324863539719)][[2](https://gitpod.slack.com/archives/C02EN94AEPL/p1671105716932369)] (internal), this will replace the prebuild duration message emoji from 🎉 to ⏱️ to help disassociate the prebuild status (`SUCCESS`, `FAIL`) for from the prebuild task status.

```
// BEFORE 
🎉 Well done on saving 7 minutes

// AFTER
⏱️ Well done on saving 7 minutes
```

See parallel fix https://github.com/gitpod-io/website/pull/3164. 🏓 

Follow-up improvements could include:
- https://github.com/gitpod-io/gitpod/issues/9994
- https://github.com/gitpod-io/gitpod/issues/9111

## How to test
Run a prebuild with a task that fails, causing a prebuild to fail, but notice the prebuilds duration message is using a different emoji that does not imply a successful prebuild. 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Replace prebuild duration message emoji
```

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
