### PR TITLE
Update beta notice for the JetBrains integration

### DIFF
--- a/components/dashboard/src/settings/SelectIDE.tsx
+++ b/components/dashboard/src/settings/SelectIDE.tsx
@@ -13,6 +13,7 @@ import { getGitpodService } from "../service/service";
 import { UserContext } from "../user-context";
 import CheckBox from "../components/CheckBox";
 import { User } from "@gitpod/gitpod-protocol";
+import PillLabel from "../components/PillLabel";
 
 export type IDEChangedTrackLocation = "workspace_list" | "workspace_start" | "preferences";
 interface SelectIDEProps {
@@ -105,24 +106,21 @@ export default function SelectIDE(props: SelectIDEProps) {
                                 </InfoBox>
                             )}
 
-                            <p className="text-left w-full text-gray-500 dark:text-gray-400">
-                                The <strong>JetBrains desktop IDEs</strong> are currently in beta.{" "}
+                            <p className="text-left w-full text-gray-400 dark:text-gray-500">
+                                <strong>JetBrains </strong> integration is currently in{" "}
+                                <PillLabel type="warn" className="font-semibold mt-2 ml-0 py-0.5 px-1 self-center">
+                                    <a href="https://www.gitpod.io/docs/references/gitpod-releases">
+                                        <span className="text-xs">Beta</span>
+                                    </a>
+                                </PillLabel>
+                                &nbsp;&middot;&nbsp;
                                 <a
                                     href="https://github.com/gitpod-io/gitpod/issues/6576"
-                                    target="gitpod-feedback-issue"
-                                    rel="noopener"
-                                    className="gp-link"
-                                >
-                                    Send feedback
-                                </a>{" "}
-                                ·{" "}
-                                <a
-                                    href="https://www.gitpod.io/docs/integrations/jetbrains"
                                     target="_blank"
                                     rel="noopener noreferrer"
                                     className="gp-link"
                                 >
-                                    Documentation
+                                    Send feedback
                                 </a>
                             </p>
                         </>


### PR DESCRIPTION
## Description

This will update the beta notice for the JetBrains integration, making the beta label more prominent. 

See [relevant discussion](https://gitpod.slack.com/archives/C02CBKZEVS8/p1671112085737199?thread_ts=1671106002.085899&cid=C02CBKZEVS8) (internal). Cc @akosyakov @loujaybee @easyCZ 

> Benefits:
> - Making beta notice more prominent.
> - Better UX (colors, structure, etc)
> - Linking to the Gitpod releases page.
> - Reusing the PillLabel component.
> - Using similar pattern as in #15017.
>     - X feature is in BETA · Send Feedback
>     - Y integration is in BETA · Send Feedback

| BEFORE | AFTER |
|-|-|
| <img width="682" alt="beta-before" src="https://user-images.githubusercontent.com/120486/207886527-04471396-d199-458c-b441-cdeabc876146.png"> | <img width="682" alt="beta-after" src="https://user-images.githubusercontent.com/120486/207886533-0a73190f-f6e7-4e52-b31b-035d1679ad1d.png"> |

## How to test

Go to user `/preferences` and notice the new beta notice for the JetBrains integration.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Update beta notice for the JetBrains integration
```


## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
