### PR TITLE
[dashboard] access invoices after cancellation

### DIFF
--- a/components/dashboard/src/components/UsageBasedBillingConfig.tsx
+++ b/components/dashboard/src/components/UsageBasedBillingConfig.tsx
@@ -302,9 +302,18 @@ export default function UsageBasedBillingConfig({ attributionId }: Props) {
                                 </span>
                             </div>
                         </div>
-                        <button className="mt-5 self-end" onClick={() => setShowBillingSetupModal(true)}>
-                            Upgrade Plan
-                        </button>
+                        <div className="flex">
+                            {stripePortalUrl && (
+                                <a className="mt-5" href={stripePortalUrl}>
+                                    <button className="secondary" disabled={!stripePortalUrl}>
+                                        View Past Invoices ↗
+                                    </button>
+                                </a>
+                            )}
+                            <button className="mt-5 self-end" onClick={() => setShowBillingSetupModal(true)}>
+                                Upgrade Plan
+                            </button>
+                        </div>
                     </div>
                 )}
                 {showUpgradeUser && (
@@ -349,7 +358,14 @@ export default function UsageBasedBillingConfig({ attributionId }: Props) {
                                     </span>
                                 </div>
                             </div>
-                            <div className="mt-5 flex flex-col">
+                            <div className="mt-5 flex">
+                                {stripePortalUrl && (
+                                    <a className="mt-5" href={stripePortalUrl}>
+                                        <button className="secondary" disabled={!stripePortalUrl}>
+                                            View Past Invoices ↗
+                                        </button>
+                                    </a>
+                                )}
                                 <button className="self-end" onClick={() => setShowBillingSetupModal(true)}>
                                     Upgrade Plan
                                 </button>


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Show a link to the stripe portal for customers who have cancelled their subscription, so they can download invoices later.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #15236

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-payment
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
