### PR TITLE
Wait for the  workspace secret before creating the workspace pod

### DIFF
--- a/components/ws-manager/pkg/manager/manager.go
+++ b/components/ws-manager/pkg/manager/manager.go
@@ -354,6 +354,11 @@ func (m *Manager) StartWorkspace(ctx context.Context, req *api.StartWorkspaceReq
 		return nil, xerrors.Errorf("cannot create secret for workspace pod: %w", err)
 	}
 
+	err = waitForSecretInNamespace(m.Clientset, m.Config.Namespace, podName(startContext.Request))
+	if err != nil && !k8serr.IsAlreadyExists(err) {
+		return nil, xerrors.Errorf("timeout waiting for secret required by workspace pod: %w", err)
+	}
+
 	err = m.Clientset.Create(ctx, pod)
 	if err != nil {
 		m, _ := json.Marshal(pod)
@@ -1726,4 +1731,24 @@ func extractExposedPorts(pod *corev1.Pod) *api.ExposedPorts {
 	}
 
 	return &api.ExposedPorts{}
+}
+
+func waitForSecretInNamespace(client client.Client, namespace, name string) error {
+	return wait.Poll(200*time.Millisecond, 1*time.Minute, secretInNamespace(client, namespace, name))
+}
+
+func secretInNamespace(client client.Client, namespace, name string) wait.ConditionFunc {
+	return func() (bool, error) {
+		var secret corev1.Secret
+		err := client.Get(context.TODO(), types.NamespacedName{Namespace: namespace, Name: name}, &secret)
+		if k8serr.IsNotFound(err) {
+			return false, nil
+		}
+
+		if err != nil {
+			return false, err
+		}
+
+		return true, nil
+	}
 }


### PR DESCRIPTION
## Description

We cannot expect any latency or that the load on the API server can provide time guarantees for object persistence.

```
default     0s          Normal    Scheduled                pod/ws-5d18c42e-c8eb-4db5-af28-4e9161927998           Successfully assigned default/ws-5d18c42e-c8eb-4db5-af28-4e9161927998 to i-09682c625b5eeb3fb.eu-central-1.compute.internal
default     0s          Normal    Pulling                  pod/ws-5d18c42e-c8eb-4db5-af28-4e9161927998           Pulling image "reg.doptig10.gitpod.cloud:20000/remote/5d18c42e-c8eb-4db5-af28-4e9161927998"
default     0s          Normal    Pulled                   pod/ws-5d18c42e-c8eb-4db5-af28-4e9161927998           Successfully pulled image "reg.doptig10.gitpod.cloud:20000/remote/5d18c42e-c8eb-4db5-af28-4e9161927998" in 97.809814ms
default     0s          Warning   Failed                   pod/ws-5d18c42e-c8eb-4db5-af28-4e9161927998           Error: secret "ws-5d18c42e-c8eb-4db5-af28-4e9161927998" not found
```

## Related Issue(s)

Fixes https://github.com/gitpod-io/scout-foundation/issues/255

## How to test
- Pass Integration tests
- Workspaces should open normally

## Release Notes
```release-note
NONE
```

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [X] /werft with-large-vm
- [X] /werft with-integration-tests=workspace
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
