### PR TITLE
[dashboard] link to website's cost estimator

### DIFF
--- a/components/dashboard/src/components/UsageBasedBillingConfig.tsx
+++ b/components/dashboard/src/components/UsageBasedBillingConfig.tsx
@@ -293,11 +293,8 @@ export default function UsageBasedBillingConfig({ attributionId }: Props) {
                                 <span>
                                     {currency === "EUR" ? "€" : "$"}0.36 for 10 credits or 1 hour of Standard workspace
                                     usage, excluding VAT.{" "}
-                                    <a
-                                        className="gp-link"
-                                        href="https://www.gitpod.io/docs/configure/billing/usage-based-billing"
-                                    >
-                                        Learn more about credits
+                                    <a className="gp-link" href="https://www.gitpod.io/pricing#cost-estimator">
+                                        Estimate costs
                                     </a>
                                 </span>
                             </div>
@@ -319,11 +316,8 @@ export default function UsageBasedBillingConfig({ attributionId }: Props) {
                                 <span className="font-bold text-gray-500 dark:text-gray-400">{usageLimit} credits</span>
                                 <span>
                                     {usageLimit / 10} hours of Standard workspace usage.{" "}
-                                    <a
-                                        className="gp-link"
-                                        href="https://www.gitpod.io/docs/configure/billing/usage-based-billing"
-                                    >
-                                        Learn more about credits
+                                    <a className="gp-link" href="https://www.gitpod.io/pricing#cost-estimator">
+                                        Estimate costs
                                     </a>
                                 </span>
                             </div>


### PR DESCRIPTION
## Description
Change the link when subscribing to the cost estimator

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #15283

See also https://github.com/gitpod-io/website/pull/3166

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
