### PR TITLE
[server] Allow options on ws start (1/2)

### DIFF
--- a/components/gitpod-protocol/go/gitpod-service.go
+++ b/components/gitpod-protocol/go/gitpod-service.go
@@ -1899,7 +1899,9 @@ type WorkspaceInstanceStatus struct {
 
 // StartWorkspaceOptions is the StartWorkspaceOptions message type
 type StartWorkspaceOptions struct {
-	ForceDefaultImage bool `json:"forceDefaultImage,omitempty"`
+	ForceDefaultImage bool         `json:"forceDefaultImage,omitempty"`
+	WorkspaceClass    string       `json:"workspaceClass,omitempty"`
+	IdeSettings       *IDESettings `json:"ideSettings,omitempty"`
 }
 
 // GetWorkspaceTimeoutResult is the GetWorkspaceTimeoutResult message type

--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -26,6 +26,7 @@ import {
     PrebuiltWorkspace,
     UserSSHPublicKeyValue,
     SSHPublicKeyValue,
+    IDESettings,
 } from "./protocol";
 import {
     Team,
@@ -414,16 +415,20 @@ export namespace GitpodServer {
     export interface GetAccountStatementOptions {
         date?: string;
     }
-    export interface CreateWorkspaceOptions {
+    export interface CreateWorkspaceOptions extends StartWorkspaceOptions {
         contextUrl: string;
+
         // whether running workspaces on the same context should be ignored. If false (default) users will be asked.
         ignoreRunningWorkspaceOnSameCommit?: boolean;
         ignoreRunningPrebuild?: boolean;
         allowUsingPreviousPrebuilds?: boolean;
         forceDefaultConfig?: boolean;
     }
+
     export interface StartWorkspaceOptions {
-        forceDefaultImage: boolean;
+        forceDefaultImage?: boolean;
+        workspaceClass?: string;
+        ideSettings?: IDESettings;
     }
     export interface TakeSnapshotOptions {
         workspaceId: string;

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -734,9 +734,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
             await projectPromise,
             await userEnvVars,
             await projectEnvVarsPromise,
-            {
-                forceDefaultImage: !!options.forceDefaultImage,
-            },
+            options,
         );
         traceWI(ctx, { instanceId: result.instanceID });
         return result;
@@ -1207,6 +1205,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
                 project,
                 await envVars,
                 await projectEnvVarsPromise,
+                options,
             );
             ctx.span?.log({ event: "startWorkspaceComplete", ...startWorkspaceResult });
 


### PR DESCRIPTION
## Description

Introduces optional IDE and workspace class arguments on workspace start.
This is a precursor for https://github.com/gitpod-io/gitpod/issues/15287

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
