### PR TITLE
[launcher] hot-deploy loops through all ides

### DIFF
--- a/components/ide/jetbrains/launcher/hot-deploy.sh
+++ b/components/ide/jetbrains/launcher/hot-deploy.sh
@@ -19,24 +19,13 @@ dev_image="$(tar xfO "$bldfn" ./imgnames.txt | head -n1)"
 echo "Dev Image: $dev_image"
 
 cf_patch=$(kubectl get cm ide-config -o=json | jq '.data."config.json"' |jq -r)
-# TODO: replace with for loop over .ideOptions.clients."jetbrains-gateway".desktopIDEs
-# second image is always jb-launcher, if position is changed then this script should be updated as well
-cf_patch=$(echo "$cf_patch" |jq ".ideOptions.options.intellij.imageLayers[1] = \"$dev_image\"")
-cf_patch=$(echo "$cf_patch" |jq ".ideOptions.options.intellij.latestImageLayers[1] = \"$dev_image\"")
-cf_patch=$(echo "$cf_patch" |jq ".ideOptions.options.goland.imageLayers[1] = \"$dev_image\"")
-cf_patch=$(echo "$cf_patch" |jq ".ideOptions.options.goland.latestImageLayers[1] = \"$dev_image\"")
-cf_patch=$(echo "$cf_patch" |jq ".ideOptions.options.pycharm.imageLayers[1] = \"$dev_image\"")
-cf_patch=$(echo "$cf_patch" |jq ".ideOptions.options.pycharm.latestImageLayers[1] = \"$dev_image\"")
-cf_patch=$(echo "$cf_patch" |jq ".ideOptions.options.phpstorm.imageLayers[1] = \"$dev_image\"")
-cf_patch=$(echo "$cf_patch" |jq ".ideOptions.options.phpstorm.latestImageLayers[1] = \"$dev_image\"")
-cf_patch=$(echo "$cf_patch" |jq ".ideOptions.options.rubymine.imageLayers[1] = \"$dev_image\"")
-cf_patch=$(echo "$cf_patch" |jq ".ideOptions.options.rubymine.latestImageLayers[1] = \"$dev_image\"")
-cf_patch=$(echo "$cf_patch" |jq ".ideOptions.options.webstorm.imageLayers[1] = \"$dev_image\"")
-cf_patch=$(echo "$cf_patch" |jq ".ideOptions.options.webstorm.latestImageLayers[1] = \"$dev_image\"")
-cf_patch=$(echo "$cf_patch" |jq ".ideOptions.options.rider.imageLayers[1] = \"$dev_image\"")
-cf_patch=$(echo "$cf_patch" |jq ".ideOptions.options.rider.latestImageLayers[1] = \"$dev_image\"")
-cf_patch=$(echo "$cf_patch" |jq ".ideOptions.options.clion.imageLayers[1] = \"$dev_image\"")
-cf_patch=$(echo "$cf_patch" |jq ".ideOptions.options.clion.latestImageLayers[1] = \"$dev_image\"")
+ides=$(echo "$cf_patch" |jq '.ideOptions.clients."jetbrains-gateway".desktopIDEs')
+for ide in $(echo "$ides" | jq -r '.[]'); do
+  # second image is always jb-launcher, if position is changed then this script should be updated as well
+  cf_patch=$(echo "$cf_patch" |jq ".ideOptions.options.${ide}.imageLayers[1] = \"$dev_image\"")
+  cf_patch=$(echo "$cf_patch" |jq ".ideOptions.options.${ide}.latestImageLayers[1] = \"$dev_image\"")
+done
+
 cf_patch=$(echo "$cf_patch" |jq tostring)
 cf_patch="{\"data\": {\"config.json\": $cf_patch}}"
 


### PR DESCRIPTION
## Description
Addressing a todo comment left today in a previous PR: loop though IDEs instead of repeating the same commands over and over

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
Manually tested already ✅ 
To test again, run the script (you need a preview environment)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
