### PR TITLE
[image-builder] Enable TLS in workspace clusters

### DIFF
--- a/components/ws-manager-api/go/config/config.go
+++ b/components/ws-manager-api/go/config/config.go
@@ -55,6 +55,11 @@ type ServiceConfiguration struct {
 	} `json:"rpcServer"`
 	ImageBuilderProxy struct {
 		TargetAddr string `json:"targetAddr"`
+		TLS        struct {
+			CA          string `json:"ca"`
+			Certificate string `json:"crt"`
+			PrivateKey  string `json:"key"`
+		} `json:"tls"`
 	} `json:"imageBuilderProxy"`
 
 	PProf struct {

--- a/install/installer/cmd/testdata/render/aws-setup/output.golden
+++ b/install/installer/cmd/testdata/render/aws-setup/output.golden
@@ -670,6 +670,7 @@ spec:
   - server
   - ws-manager-bridge
   - ws-proxy
+  - image-builder-mk3
   - ws-manager
   duration: 2160h0m0s
   issuerRef:
@@ -5538,7 +5539,12 @@ data:
         "ratelimits": {}
       },
       "imageBuilderProxy": {
-        "targetAddr": "image-builder-mk3.default.svc.cluster.local:8080"
+        "targetAddr": "image-builder-mk3.default.svc.cluster.local:8080",
+        "tls": {
+          "ca": "",
+          "crt": "",
+          "key": ""
+        }
       },
       "pprof": {
         "addr": "127.0.0.1:6060"
@@ -9985,7 +9991,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: bb6aec55bf0e44661ecc50247619e050b0b765292acb33f6ba18a706092443d2
+        gitpod.io/checksum_config: 4fb58e35c5a0f1d3f9435fecd1316c134c2b82a733e39e97aa3d36679e7bb8c4
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/azure-setup/output.golden
+++ b/install/installer/cmd/testdata/render/azure-setup/output.golden
@@ -670,6 +670,7 @@ spec:
   - server
   - ws-manager-bridge
   - ws-proxy
+  - image-builder-mk3
   - ws-manager
   duration: 2160h0m0s
   issuerRef:
@@ -5514,7 +5515,12 @@ data:
         "ratelimits": {}
       },
       "imageBuilderProxy": {
-        "targetAddr": "image-builder-mk3.default.svc.cluster.local:8080"
+        "targetAddr": "image-builder-mk3.default.svc.cluster.local:8080",
+        "tls": {
+          "ca": "",
+          "crt": "",
+          "key": ""
+        }
       },
       "pprof": {
         "addr": "127.0.0.1:6060"
@@ -10062,7 +10068,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: cd4b2686fe34e3488f453e58aabb2197bd886fb64b6e6fc3ab840694d09b6391
+        gitpod.io/checksum_config: 62fb425bd7800391dca7d008cd0c86cab613afef78e188a950e367ed7429ad73
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -695,6 +695,7 @@ spec:
   - server
   - ws-manager-bridge
   - ws-proxy
+  - image-builder-mk3
   - ws-manager
   duration: 2160h0m0s
   issuerRef:
@@ -6534,7 +6535,12 @@ data:
         "ratelimits": {}
       },
       "imageBuilderProxy": {
-        "targetAddr": "image-builder-mk3.default.svc.cluster.local:8080"
+        "targetAddr": "image-builder-mk3.default.svc.cluster.local:8080",
+        "tls": {
+          "ca": "",
+          "crt": "",
+          "key": ""
+        }
       },
       "pprof": {
         "addr": "127.0.0.1:6060"
@@ -11725,7 +11731,7 @@ spec:
     metadata:
       annotations:
         gitpod.io: hello
-        gitpod.io/checksum_config: 465314adb1f2f14db65f3f3feefc5c9baccd3de7b6c049be513e9dcc77faec13
+        gitpod.io/checksum_config: 6be9fbe9ae8dd0aaaf625651e4db07ef2a2cb1652b6b415c46885e2c5e2355ac
         hello: world
       creationTimestamp: null
       labels:

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -670,6 +670,7 @@ spec:
   - server
   - ws-manager-bridge
   - ws-proxy
+  - image-builder-mk3
   - ws-manager
   duration: 2160h0m0s
   issuerRef:
@@ -5701,7 +5702,12 @@ data:
         "ratelimits": {}
       },
       "imageBuilderProxy": {
-        "targetAddr": "image-builder-mk3.default.svc.cluster.local:8080"
+        "targetAddr": "image-builder-mk3.default.svc.cluster.local:8080",
+        "tls": {
+          "ca": "",
+          "crt": "",
+          "key": ""
+        }
       },
       "pprof": {
         "addr": "127.0.0.1:6060"
@@ -10488,7 +10494,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: cd4b2686fe34e3488f453e58aabb2197bd886fb64b6e6fc3ab840694d09b6391
+        gitpod.io/checksum_config: 62fb425bd7800391dca7d008cd0c86cab613afef78e188a950e367ed7429ad73
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/gcp-setup/output.golden
+++ b/install/installer/cmd/testdata/render/gcp-setup/output.golden
@@ -670,6 +670,7 @@ spec:
   - server
   - ws-manager-bridge
   - ws-proxy
+  - image-builder-mk3
   - ws-manager
   duration: 2160h0m0s
   issuerRef:
@@ -5473,7 +5474,12 @@ data:
         "ratelimits": {}
       },
       "imageBuilderProxy": {
-        "targetAddr": "image-builder-mk3.default.svc.cluster.local:8080"
+        "targetAddr": "image-builder-mk3.default.svc.cluster.local:8080",
+        "tls": {
+          "ca": "",
+          "crt": "",
+          "key": ""
+        }
       },
       "pprof": {
         "addr": "127.0.0.1:6060"
@@ -9956,7 +9962,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 976ed8287357e8079b43542aaf4d36daafd7ef829cd8d8d040a6cfeafebcfdab
+        gitpod.io/checksum_config: 7629f76880a0f748bca0c5ca8c67d2153b883f0ac096874c4f2af11ba264443a
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/http-proxy/output.golden
+++ b/install/installer/cmd/testdata/render/http-proxy/output.golden
@@ -695,6 +695,7 @@ spec:
   - server
   - ws-manager-bridge
   - ws-proxy
+  - image-builder-mk3
   - ws-manager
   duration: 2160h0m0s
   issuerRef:
@@ -5924,7 +5925,12 @@ data:
         "ratelimits": {}
       },
       "imageBuilderProxy": {
-        "targetAddr": "image-builder-mk3.default.svc.cluster.local:8080"
+        "targetAddr": "image-builder-mk3.default.svc.cluster.local:8080",
+        "tls": {
+          "ca": "",
+          "crt": "",
+          "key": ""
+        }
       },
       "pprof": {
         "addr": "127.0.0.1:6060"
@@ -12311,7 +12317,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: cd4b2686fe34e3488f453e58aabb2197bd886fb64b6e6fc3ab840694d09b6391
+        gitpod.io/checksum_config: 62fb425bd7800391dca7d008cd0c86cab613afef78e188a950e367ed7429ad73
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/kind-workspace/output.golden
+++ b/install/installer/cmd/testdata/render/kind-workspace/output.golden
@@ -347,6 +347,34 @@ spec:
       component: cluster
 status: {}
 ---
+# cert-manager.io/v1/Certificate image-builder-mk3-tls
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: image-builder-mk3
+  name: image-builder-mk3-tls
+  namespace: default
+spec:
+  dnsNames:
+  - image-builder-mk3.default.svc
+  - image-builder-mk3.default.svc.cluster.local
+  - image-builder-mk3
+  - image-builder-mk3-dev
+  duration: 2160h0m0s
+  issuerRef:
+    group: cert-manager.io
+    kind: Issuer
+    name: ca-issuer
+  secretName: image-builder-mk3-tls
+  secretTemplate:
+    labels:
+      app: gitpod
+      component: image-builder-mk3
+status: {}
+---
 # cert-manager.io/v1/Certificate ws-daemon-tls
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -391,6 +419,7 @@ spec:
   - server
   - ws-manager-bridge
   - ws-proxy
+  - image-builder-mk3
   - ws-manager
   duration: 2160h0m0s
   issuerRef:
@@ -1569,6 +1598,16 @@ data:
       name: image-builder-mk3
       namespace: default
     ---
+    apiVersion: cert-manager.io/v1
+    kind: Certificate
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: image-builder-mk3
+      name: image-builder-mk3-tls
+      namespace: default
+    ---
     apiVersion: v1
     kind: Secret
     metadata:
@@ -1677,7 +1716,12 @@ data:
       "server": {
         "services": {
           "grpc": {
-            "address": "0.0.0.0:8080"
+            "address": "0.0.0.0:8080",
+            "tls": {
+              "caPath": "/certs/ca.crt",
+              "certPath": "/certs/tls.crt",
+              "keyPath": "/certs/tls.key"
+            }
           }
         }
       }
@@ -2031,7 +2075,12 @@ data:
         "ratelimits": {}
       },
       "imageBuilderProxy": {
-        "targetAddr": "image-builder-mk3.default.svc.cluster.local:8080"
+        "targetAddr": "image-builder-mk3.default.svc.cluster.local:8080",
+        "tls": {
+          "ca": "/image-builder-mk3-tls-certs/ca.crt",
+          "crt": "/image-builder-mk3-tls-certs/tls.crt",
+          "key": "/image-builder-mk3-tls-certs/tls.key"
+        }
       },
       "pprof": {
         "addr": "127.0.0.1:6060"
@@ -3475,7 +3524,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: af26ec864db5be86adfb79b972614487639aa67ad16de869e23e22e468f0bed8
+        gitpod.io/checksum_config: 17379f665f26a7fe1e7ad830348985a5af3e35ba52bf2d8073bbdadb67c0aaeb
       creationTimestamp: null
       labels:
         app: gitpod
@@ -3537,6 +3586,9 @@ spec:
           readOnly: true
         - mountPath: /config/pull-secret
           name: pull-secret
+        - mountPath: /certs
+          name: image-builder-mk3-tls-certs
+          readOnly: true
       - args:
         - --logtostderr
         - --insecure-listen-address=[$(IP)]:9500
@@ -3599,6 +3651,9 @@ spec:
         name: gitpod-ca-certificate
       - emptyDir: {}
         name: cacerts
+      - name: image-builder-mk3-tls-certs
+        secret:
+          secretName: image-builder-mk3-tls
 status: {}
 ---
 # apps/v1/Deployment registry
@@ -3710,7 +3765,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: cd4b2686fe34e3488f453e58aabb2197bd886fb64b6e6fc3ab840694d09b6391
+        gitpod.io/checksum_config: 8e17df1f6904718d97532e9779c3342f517ed6366049cd670c4ca158e272c1ec
       creationTimestamp: null
       labels:
         app: gitpod
@@ -3777,6 +3832,9 @@ spec:
         - mountPath: /certs
           name: tls-certs
           readOnly: true
+        - mountPath: /image-builder-mk3-tls-certs
+          name: image-builder-mk3-tls-certs
+          readOnly: true
       - args:
         - --logtostderr
         - --insecure-listen-address=[$(IP)]:9500
@@ -3819,6 +3877,9 @@ spec:
       - name: tls-certs
         secret:
           secretName: ws-manager-tls
+      - name: image-builder-mk3-tls-certs
+        secret:
+          secretName: image-builder-mk3-tls
 status: {}
 ---
 # apps/v1/Deployment ws-proxy

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -695,6 +695,7 @@ spec:
   - server
   - ws-manager-bridge
   - ws-proxy
+  - image-builder-mk3
   - ws-manager
   duration: 2160h0m0s
   issuerRef:
@@ -5921,7 +5922,12 @@ data:
         "ratelimits": {}
       },
       "imageBuilderProxy": {
-        "targetAddr": "image-builder-mk3.default.svc.cluster.local:8080"
+        "targetAddr": "image-builder-mk3.default.svc.cluster.local:8080",
+        "tls": {
+          "ca": "",
+          "crt": "",
+          "key": ""
+        }
       },
       "pprof": {
         "addr": "127.0.0.1:6060"
@@ -10863,7 +10869,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: cd4b2686fe34e3488f453e58aabb2197bd886fb64b6e6fc3ab840694d09b6391
+        gitpod.io/checksum_config: 62fb425bd7800391dca7d008cd0c86cab613afef78e188a950e367ed7429ad73
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/shortname/output.golden
+++ b/install/installer/cmd/testdata/render/shortname/output.golden
@@ -695,6 +695,7 @@ spec:
   - server
   - ws-manager-bridge
   - ws-proxy
+  - image-builder-mk3
   - ws-manager
   duration: 2160h0m0s
   issuerRef:
@@ -5921,7 +5922,12 @@ data:
         "ratelimits": {}
       },
       "imageBuilderProxy": {
-        "targetAddr": "image-builder-mk3.default.svc.cluster.local:8080"
+        "targetAddr": "image-builder-mk3.default.svc.cluster.local:8080",
+        "tls": {
+          "ca": "",
+          "crt": "",
+          "key": ""
+        }
       },
       "pprof": {
         "addr": "127.0.0.1:6060"
@@ -10863,7 +10869,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3926ffab614564bb99699778fe8bccf6fff1cb3564511873377364d6be83d24e
+        gitpod.io/checksum_config: b1913e713ab1ed0f8a96ed0e9b4c655902e55087aba7f44268d34d0c111ad9c7
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -695,6 +695,7 @@ spec:
   - server
   - ws-manager-bridge
   - ws-proxy
+  - image-builder-mk3
   - ws-manager
   duration: 2160h0m0s
   issuerRef:
@@ -5933,7 +5934,12 @@ data:
         "ratelimits": {}
       },
       "imageBuilderProxy": {
-        "targetAddr": "image-builder-mk3.default.svc.cluster.local:8080"
+        "targetAddr": "image-builder-mk3.default.svc.cluster.local:8080",
+        "tls": {
+          "ca": "",
+          "crt": "",
+          "key": ""
+        }
       },
       "pprof": {
         "addr": "127.0.0.1:6060"
@@ -10875,7 +10881,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: cd4b2686fe34e3488f453e58aabb2197bd886fb64b6e6fc3ab840694d09b6391
+        gitpod.io/checksum_config: 62fb425bd7800391dca7d008cd0c86cab613afef78e188a950e367ed7429ad73
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
+++ b/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
@@ -695,6 +695,7 @@ spec:
   - server
   - ws-manager-bridge
   - ws-proxy
+  - image-builder-mk3
   - ws-manager
   duration: 2160h0m0s
   issuerRef:
@@ -6254,7 +6255,12 @@ data:
         "ratelimits": {}
       },
       "imageBuilderProxy": {
-        "targetAddr": "image-builder-mk3.default.svc.cluster.local:8080"
+        "targetAddr": "image-builder-mk3.default.svc.cluster.local:8080",
+        "tls": {
+          "ca": "",
+          "crt": "",
+          "key": ""
+        }
       },
       "pprof": {
         "addr": "127.0.0.1:6060"
@@ -11307,7 +11313,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: cd4b2686fe34e3488f453e58aabb2197bd886fb64b6e6fc3ab840694d09b6391
+        gitpod.io/checksum_config: 62fb425bd7800391dca7d008cd0c86cab613afef78e188a950e367ed7429ad73
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
+++ b/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
@@ -695,6 +695,7 @@ spec:
   - server
   - ws-manager-bridge
   - ws-proxy
+  - image-builder-mk3
   - ws-manager
   duration: 2160h0m0s
   issuerRef:
@@ -5923,7 +5924,12 @@ data:
         "ratelimits": {}
       },
       "imageBuilderProxy": {
-        "targetAddr": "image-builder-mk3.default.svc.cluster.local:8080"
+        "targetAddr": "image-builder-mk3.default.svc.cluster.local:8080",
+        "tls": {
+          "ca": "",
+          "crt": "",
+          "key": ""
+        }
       },
       "pprof": {
         "addr": "127.0.0.1:6060"
@@ -10853,7 +10859,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: cd4b2686fe34e3488f453e58aabb2197bd886fb64b6e6fc3ab840694d09b6391
+        gitpod.io/checksum_config: 62fb425bd7800391dca7d008cd0c86cab613afef78e188a950e367ed7429ad73
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
+++ b/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
@@ -695,6 +695,7 @@ spec:
   - server
   - ws-manager-bridge
   - ws-proxy
+  - image-builder-mk3
   - ws-manager
   duration: 2160h0m0s
   issuerRef:
@@ -5924,7 +5925,12 @@ data:
         "ratelimits": {}
       },
       "imageBuilderProxy": {
-        "targetAddr": "image-builder-mk3.default.svc.cluster.local:8080"
+        "targetAddr": "image-builder-mk3.default.svc.cluster.local:8080",
+        "tls": {
+          "ca": "",
+          "crt": "",
+          "key": ""
+        }
       },
       "pprof": {
         "addr": "127.0.0.1:6060"
@@ -10866,7 +10872,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: ef30523cf678442fdfca48946b758837341a473f21de3251f7ab89de5eee482f
+        gitpod.io/checksum_config: 298563e7c37240295bf1c4e80327389892858aa3339c84b06de7cc454947cafb
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/pkg/common/constants.go
+++ b/install/installer/pkg/common/constants.go
@@ -48,6 +48,8 @@ const (
 	WSProxyComponent            = "ws-proxy"
 	ImageBuilderComponent       = "image-builder-mk3"
 	ImageBuilderRPCPort         = 8080
+	ImageBuilderTLSSecret       = "image-builder-mk3-tls"
+	ImageBuilderVolumeTLSCerts  = "image-builder-mk3-tls-certs"
 	DebugNodePort               = 9229
 	DBCaCertEnvVarName          = "DB_CA_CERT"
 	DBCaFileName                = "ca.crt"

--- a/install/installer/pkg/components/image-builder-mk3/constants.go
+++ b/install/installer/pkg/components/image-builder-mk3/constants.go
@@ -7,8 +7,10 @@ package image_builder_mk3
 import "github.com/gitpod-io/gitpod/installer/pkg/common"
 
 const (
-	BuilderImage = "image-builder-mk3/bob"
-	Component    = common.ImageBuilderComponent
-	RPCPort      = common.ImageBuilderRPCPort
-	RPCPortName  = "service"
+	BuilderImage   = "image-builder-mk3/bob"
+	Component      = common.ImageBuilderComponent
+	RPCPort        = common.ImageBuilderRPCPort
+	RPCPortName    = "service"
+	TLSSecretName  = common.ImageBuilderTLSSecret
+	VolumeTLSCerts = common.ImageBuilderVolumeTLSCerts
 )

--- a/install/installer/pkg/components/image-builder-mk3/deployment.go
+++ b/install/installer/pkg/components/image-builder-mk3/deployment.go
@@ -109,6 +109,22 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 		volumes = append(volumes, *vol)
 		volumeMounts = append(volumeMounts, *mnt)
 	}
+	if ctx.Config.Kind == config.InstallationWorkspace {
+		// Only enable TLS in workspace clusters. This check can be removed
+		// once image-builder-mk3 has been removed from application clusters
+		// (https://github.com/gitpod-io/gitpod/issues/7845).
+		volumes = append(volumes, corev1.Volume{
+			Name: VolumeTLSCerts,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{SecretName: TLSSecretName},
+			},
+		})
+		volumeMounts = append(volumeMounts, corev1.VolumeMount{
+			Name:      VolumeTLSCerts,
+			MountPath: "/certs",
+			ReadOnly:  true,
+		})
+	}
 
 	var nodeAffinity = cluster.AffinityLabelMeta
 	if ctx.Config.Kind == config.InstallationWorkspace {

--- a/install/installer/pkg/components/image-builder-mk3/objects.go
+++ b/install/installer/pkg/components/image-builder-mk3/objects.go
@@ -20,4 +20,5 @@ var Objects = common.CompositeRenderFunc(
 		},
 	}),
 	common.DefaultServiceAccount(Component),
+	tlssecret,
 )

--- a/install/installer/pkg/components/image-builder-mk3/tlssecret.go
+++ b/install/installer/pkg/components/image-builder-mk3/tlssecret.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
 // Licensed under the GNU Affero General Public License (AGPL).
 // See License-AGPL.txt in the project root for license information.
 

--- a/install/installer/pkg/components/image-builder-mk3/tlssecret.go
+++ b/install/installer/pkg/components/image-builder-mk3/tlssecret.go
@@ -1,13 +1,14 @@
 // Copyright (c) 2021 Gitpod GmbH. All rights reserved.
 // Licensed under the GNU Affero General Public License (AGPL).
-// See License.AGPL.txt in the project root for license information.
+// See License-AGPL.txt in the project root for license information.
 
-package wsmanager
+package image_builder_mk3
 
 import (
 	"fmt"
 
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
+	"github.com/gitpod-io/gitpod/installer/pkg/config/v1"
 
 	certmanagerv1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
@@ -16,58 +17,34 @@ import (
 )
 
 func tlssecret(ctx *common.RenderContext) ([]runtime.Object, error) {
+	// Only enable TLS in workspace clusters. This check can be removed
+	// once image-builder-mk3 has been removed from application clusters
+	// (https://github.com/gitpod-io/gitpod/issues/7845).
+	if ctx.Config.Kind != config.InstallationWorkspace {
+		return nil, nil
+	}
+
 	serverAltNames := []string{
-		fmt.Sprintf("gitpod.%s", ctx.Namespace),
 		fmt.Sprintf("%s.%s.svc", Component, ctx.Namespace),
+		fmt.Sprintf("%s.%s.svc.cluster.local", Component, ctx.Namespace),
 		Component,
 		fmt.Sprintf("%s-dev", Component),
 	}
-	clientAltNames := []string{
-		common.RegistryFacadeComponent,
-		common.ServerComponent,
-		common.WSManagerBridgeComponent,
-		common.WSProxyComponent,
-		common.ImageBuilderComponent,
-		Component,
-	}
-
-	issuer := common.CertManagerCAIssuer
 
 	return []runtime.Object{
 		&certmanagerv1.Certificate{
 			TypeMeta: common.TypeMetaCertificate,
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      TLSSecretNameSecret,
+				Name:      TLSSecretName,
 				Namespace: ctx.Namespace,
 				Labels:    common.DefaultLabels(Component),
 			},
 			Spec: certmanagerv1.CertificateSpec{
 				Duration:   common.InternalCertDuration,
-				SecretName: TLSSecretNameSecret,
+				SecretName: TLSSecretName,
 				DNSNames:   serverAltNames,
 				IssuerRef: cmmeta.ObjectReference{
-					Name:  issuer,
-					Kind:  "Issuer",
-					Group: "cert-manager.io",
-				},
-				SecretTemplate: &certmanagerv1.CertificateSecretTemplate{
-					Labels: common.DefaultLabels(Component),
-				},
-			},
-		},
-		&certmanagerv1.Certificate{
-			TypeMeta: common.TypeMetaCertificate,
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      Component,
-				Namespace: ctx.Namespace,
-				Labels:    common.DefaultLabels(Component),
-			},
-			Spec: certmanagerv1.CertificateSpec{
-				Duration:   common.InternalCertDuration,
-				SecretName: TLSSecretNameClient,
-				DNSNames:   clientAltNames,
-				IssuerRef: cmmeta.ObjectReference{
-					Name:  issuer,
+					Name:  common.CertManagerCAIssuer,
 					Kind:  "Issuer",
 					Group: "cert-manager.io",
 				},

--- a/install/installer/pkg/components/ws-manager/configmap.go
+++ b/install/installer/pkg/components/ws-manager/configmap.go
@@ -163,7 +163,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		return nil, err
 	}
 
-	var imageBuilderTls struct {
+	var imageBuilderTLS struct {
 		CA          string `json:"ca"`
 		Certificate string `json:"crt"`
 		PrivateKey  string `json:"key"`
@@ -172,7 +172,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		// Image builder TLS is only enabled in workspace clusters. This check
 		// can be removed once image-builder-mk3 has been removed from application clusters
 		// (https://github.com/gitpod-io/gitpod/issues/7845).
-		imageBuilderTls = struct {
+		imageBuilderTLS = struct {
 			CA          string `json:"ca"`
 			Certificate string `json:"crt"`
 			PrivateKey  string `json:"key"`
@@ -260,7 +260,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 			} `json:"tls"`
 		}{
 			TargetAddr: fmt.Sprintf("%s.%s.svc.cluster.local:%d", common.ImageBuilderComponent, ctx.Namespace, common.ImageBuilderRPCPort),
-			TLS:        imageBuilderTls,
+			TLS:        imageBuilderTLS,
 		},
 		PProf: struct {
 			Addr string `json:"addr"`

--- a/install/installer/pkg/components/ws-manager/deployment.go
+++ b/install/installer/pkg/components/ws-manager/deployment.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gitpod-io/gitpod/installer/pkg/cluster"
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 	wsdaemon "github.com/gitpod-io/gitpod/installer/pkg/components/ws-daemon"
+	"github.com/gitpod-io/gitpod/installer/pkg/config/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -22,6 +23,25 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 	configHash, err := common.ObjectHash(configmap(ctx))
 	if err != nil {
 		return nil, err
+	}
+
+	var volumes []corev1.Volume
+	var volumeMounts []corev1.VolumeMount
+	if ctx.Config.Kind == config.InstallationWorkspace {
+		// Image builder TLS is only enabled in workspace clusters. This check
+		// can be removed once image-builder-mk3 has been removed from application clusters
+		// (https://github.com/gitpod-io/gitpod/issues/7845).
+		volumes = append(volumes, corev1.Volume{
+			Name: common.ImageBuilderVolumeTLSCerts,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{SecretName: common.ImageBuilderTLSSecret},
+			},
+		})
+		volumeMounts = append(volumeMounts, corev1.VolumeMount{
+			Name:      common.ImageBuilderVolumeTLSCerts,
+			MountPath: "/image-builder-mk3-tls-certs",
+			ReadOnly:  true,
+		})
 	}
 
 	podSpec := corev1.PodSpec{
@@ -58,58 +78,64 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 				common.WorkspaceTracingEnv(ctx, Component),
 				[]corev1.EnvVar{{Name: "GRPC_GO_RETRY", Value: "on"}},
 			)),
-			VolumeMounts: []corev1.VolumeMount{
-				{
-					Name:      VolumeConfig,
-					MountPath: "/config",
-					ReadOnly:  true,
-				}, {
-					Name:      VolumeWorkspaceTemplate,
-					MountPath: WorkspaceTemplatePath,
-					ReadOnly:  true,
-				}, {
-					Name:      wsdaemon.VolumeTLSCerts,
-					MountPath: "/ws-daemon-tls-certs",
-					ReadOnly:  true,
-				}, {
-					Name:      VolumeTLSCerts,
-					MountPath: "/certs",
-					ReadOnly:  true,
+			VolumeMounts: append(
+				[]corev1.VolumeMount{
+					{
+						Name:      VolumeConfig,
+						MountPath: "/config",
+						ReadOnly:  true,
+					}, {
+						Name:      VolumeWorkspaceTemplate,
+						MountPath: WorkspaceTemplatePath,
+						ReadOnly:  true,
+					}, {
+						Name:      wsdaemon.VolumeTLSCerts,
+						MountPath: "/ws-daemon-tls-certs",
+						ReadOnly:  true,
+					}, {
+						Name:      VolumeTLSCerts,
+						MountPath: "/certs",
+						ReadOnly:  true,
+					},
 				},
-			},
+				volumeMounts...,
+			),
 		},
 			*common.KubeRBACProxyContainerWithConfig(ctx),
 		},
-		Volumes: []corev1.Volume{
-			{
-				Name: VolumeConfig,
-				VolumeSource: corev1.VolumeSource{
-					ConfigMap: &corev1.ConfigMapVolumeSource{
-						LocalObjectReference: corev1.LocalObjectReference{Name: Component},
+		Volumes: append(
+			[]corev1.Volume{
+				{
+					Name: VolumeConfig,
+					VolumeSource: corev1.VolumeSource{
+						ConfigMap: &corev1.ConfigMapVolumeSource{
+							LocalObjectReference: corev1.LocalObjectReference{Name: Component},
+						},
+					},
+				},
+				{
+					Name: VolumeWorkspaceTemplate,
+					VolumeSource: corev1.VolumeSource{
+						ConfigMap: &corev1.ConfigMapVolumeSource{
+							LocalObjectReference: corev1.LocalObjectReference{Name: WorkspaceTemplateConfigMap},
+						},
+					},
+				},
+				{
+					Name: wsdaemon.VolumeTLSCerts,
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{SecretName: wsdaemon.TLSSecretName},
+					},
+				},
+				{
+					Name: VolumeTLSCerts,
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{SecretName: TLSSecretNameSecret},
 					},
 				},
 			},
-			{
-				Name: VolumeWorkspaceTemplate,
-				VolumeSource: corev1.VolumeSource{
-					ConfigMap: &corev1.ConfigMapVolumeSource{
-						LocalObjectReference: corev1.LocalObjectReference{Name: WorkspaceTemplateConfigMap},
-					},
-				},
-			},
-			{
-				Name: wsdaemon.VolumeTLSCerts,
-				VolumeSource: corev1.VolumeSource{
-					Secret: &corev1.SecretVolumeSource{SecretName: wsdaemon.TLSSecretName},
-				},
-			},
-			{
-				Name: VolumeTLSCerts,
-				VolumeSource: corev1.VolumeSource{
-					Secret: &corev1.SecretVolumeSource{SecretName: TLSSecretNameSecret},
-				},
-			},
-		},
+			volumes...,
+		),
 	}
 
 	err = common.AddStorageMounts(ctx, &podSpec, Component)


### PR DESCRIPTION
## Description

Enable TLS on the `image-builder-mk3` service, in workspace clusters only. See https://github.com/gitpod-io/ops/issues/6905#issuecomment-1326586653 for more context behind this change.


Opted to keep `insecure` connections for image-builder in **application** clusters, because:
- The image-builder-mk3 NetworkPolicy was only changed in workspace clusters to allow all ingress.
- Workspace components should get removed soon from the application cluster once image builds move to workspace clusters, did not want to make server/application cluster changes which would get removed soon again.
  - Also simplifies the rollout of this change, as it's now a workspace-only change.

No need to mount image-builder TLS certs on `server`, as server proxies through `ws-manager` to call the image-builder api in workspace clusters.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Relates to https://github.com/gitpod-io/ops/issues/6905

## How to test
<!-- Provide steps to test this PR -->

Did the following tests:

Ephemeral cluster:
- Create a goverened `workspace` cluster. Register it with an application cluster.
- Check image-builder TLS is enabled inside the workspace cluster (TLS certs are mounted)
- Enable the `movedImageBuilder` ConfigCat feature flag for your user
- Check image builds work by starting a workspace: https://gitpod.io/#imagebuild/github.com/gitpod-io/gitpod

For single-cluster installs:
- Create a preview environment, or a `workspace-preview` cluster with the `-f full` flavour.
- Check that image builds still work by starting a workspace

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=workspace
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
