### PR TITLE
Set refresh-credential code owner to the workspace team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -47,6 +47,7 @@
 /install/installer/pkg/components/image-builder-mk3 @gitpod-io/engineering-workspace
 /install/installer/pkg/components/openvsx-proxy @gitpod-io/engineering-ide
 /install/installer/pkg/components/proxy @gitpod-io/engineering-webapp
+/install/installer/pkg/components/refresh-credential @gitpod-io/engineering-workspace
 /install/installer/pkg/components/registry-facade @gitpod-io/engineering-workspace
 /install/installer/pkg/components/public-api-server @gitpod-io/engineering-webapp
 /install/installer/pkg/components/iam @gitpod-io/engineering-webapp
@@ -73,6 +74,7 @@
 # Any team can make changes to the experimental package
 /components/public-api/gitpod/experimental @gitpod-io/engineering-workspace @gitpod-io/engineering-webapp @gitpod-io/engineering-delivery-operations-experience @gitpod-io/engineering-ide
 /components/public-api-server @gitpod-io/engineering-webapp
+/components/refresh-credential @gitpod-io/engineering-workspace
 /components/registry-facade-api @csweichel @aledbf
 /components/registry-facade @gitpod-io/engineering-workspace
 /components/server @gitpod-io/engineering-webapp


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Set refresh-credential code owner to the workspace team.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related to #12104

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
None

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
