### PR TITLE
[db] Support cipher-set in go

### DIFF
--- a/components/gitpod-db/go/dbtest/encryption.go
+++ b/components/gitpod-db/go/dbtest/encryption.go
@@ -26,3 +26,27 @@ func GetTestCipher(t *testing.T) (*db.AES256CBC, db.CipherMetadata) {
 	require.NoError(t, err)
 	return cipher, metadata
 }
+
+func CipherSet(t *testing.T) *db.CipherSet {
+	t.Helper()
+
+	configs := []db.CipherConfig{
+		{
+			Name:     "default",
+			Version:  1,
+			Primary:  true,
+			Material: "ZMaTPrF7s9gkLbY45zP59O0LTpLvDd/cgqPE9Ptghh8=",
+		},
+		{
+			Name:     "secondary",
+			Version:  1,
+			Primary:  false,
+			Material: "A3iUCT27LVbN67Fa+yfcMmLgNFdUWEl22JcdoER44gA=",
+		},
+	}
+
+	set, err := db.NewCipherSet(configs)
+	require.NoError(t, err)
+
+	return set
+}

--- a/components/gitpod-db/go/encryption_test.go
+++ b/components/gitpod-db/go/encryption_test.go
@@ -5,6 +5,7 @@
 package db_test
 
 import (
+	"crypto/rand"
 	"encoding/base64"
 	"fmt"
 	db "github.com/gitpod-io/gitpod/components/gitpod-db/go"
@@ -59,4 +60,133 @@ func TestAES256CBCCipher_EncryptedByServer(t *testing.T) {
 	fmt.Println(err)
 	require.NoError(t, err)
 	require.Equal(t, "12345678901234567890", string(decrypted))
+}
+
+func TestCipherSet(t *testing.T) {
+	t.Run("errors when no config specified", func(t *testing.T) {
+		_, err := db.NewCipherSet(nil)
+		require.Error(t, err)
+	})
+
+	t.Run("errors when no primary configs", func(t *testing.T) {
+		_, err := db.NewCipherSet([]db.CipherConfig{
+			{
+				Name:     "first",
+				Version:  0,
+				Primary:  false,
+				Material: "something",
+			},
+			{
+				Name:     "second",
+				Version:  0,
+				Primary:  false,
+				Material: "something else",
+			},
+		})
+		require.Error(t, err)
+	})
+
+	t.Run("errors when multiple primary configs", func(t *testing.T) {
+		_, err := db.NewCipherSet([]db.CipherConfig{
+			{
+				Name:     "first",
+				Version:  0,
+				Primary:  true,
+				Material: "something",
+			},
+			{
+				Name:     "second",
+				Version:  0,
+				Primary:  true,
+				Material: "something else",
+			},
+		})
+		require.Error(t, err)
+	})
+
+	t.Run("uses primary to encrypt", func(t *testing.T) {
+		cipherset, err := db.NewCipherSet([]db.CipherConfig{
+			{
+				Name:     "first",
+				Version:  1,
+				Primary:  true,
+				Material: base64.StdEncoding.EncodeToString(generateSecret(t, 32)),
+			},
+			{
+				Name:     "second",
+				Version:  0,
+				Primary:  false,
+				Material: base64.StdEncoding.EncodeToString(generateSecret(t, 32)),
+			},
+		})
+		require.NoError(t, err)
+
+		data := []byte(`random`)
+		encrypted, err := cipherset.Encrypt(data)
+		require.NoError(t, err)
+		require.Equal(t, "first", encrypted.Metadata.Name)
+		require.Equal(t, 1, encrypted.Metadata.Version)
+	})
+
+	t.Run("uses all to decrypt", func(t *testing.T) {
+		data := []byte(`random`)
+
+		// Construct a cipher, and encrypt some data. This serves as an "old" encrypted piece
+		secret := generateSecret(t, 32)
+		metadata := db.CipherMetadata{
+			Name:    "second",
+			Version: 0,
+		}
+		oldCipher, err := db.NewAES256CBCCipher(string(secret), metadata)
+		require.NoError(t, err)
+
+		encrypted, err := oldCipher.Encrypt(data)
+		require.NoError(t, err)
+
+		cipherset, err := db.NewCipherSet([]db.CipherConfig{
+			{
+				Name:     "first",
+				Version:  0,
+				Primary:  true,
+				Material: base64.StdEncoding.EncodeToString(generateSecret(t, 32)),
+			},
+			{
+				Name:     metadata.Name,
+				Version:  metadata.Version,
+				Primary:  false,
+				Material: base64.StdEncoding.EncodeToString(secret),
+			},
+		})
+		require.NoError(t, err)
+
+		decrypted, err := cipherset.Decrypt(encrypted)
+		require.NoError(t, err)
+		require.Equal(t, string(data), string(decrypted))
+	})
+
+	t.Run("no matching metadata returns an error when decrypting", func(t *testing.T) {
+		encrypted := db.EncryptedData{
+			EncodedData: "foobar",
+			Params:      db.KeyParams{},
+			Metadata: db.CipherMetadata{
+				Name:    "non-existent",
+				Version: 0,
+			},
+		}
+
+		cipherset := dbtest.CipherSet(t)
+		_, err := cipherset.Decrypt(encrypted)
+		require.Error(t, err)
+	})
+
+}
+
+func generateSecret(t *testing.T, size int) []byte {
+	t.Helper()
+
+	b := make([]byte, size)
+	_, err := rand.Read(b)
+	require.NoError(t, err)
+
+	return b
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Builds on top of https://github.com/gitpod-io/gitpod/pull/15381, to provide support for multiple ciphers from config. This behaviour matches what Server already does in `encryption-engine.ts` and `encryption-service.ts`

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Part of https://github.com/gitpod-io/gitpod/issues/15150
* Depends on https://github.com/gitpod-io/gitpod/pull/15381

## How to test
<!-- Provide steps to test this PR -->
Unit tests

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold for dependency on https://github.com/gitpod-io/gitpod/pull/15381