### PR TITLE
[public-api] Validate Workspace IDs

### DIFF
--- a/components/common-go/namegen/workspaceid_test.go
+++ b/components/common-go/namegen/workspaceid_test.go
@@ -5,20 +5,45 @@
 package namegen_test
 
 import (
+	"github.com/stretchr/testify/require"
 	"testing"
 
 	"github.com/gitpod-io/gitpod/common-go/namegen"
 )
 
 func TestGenerateWorkspaceID(t *testing.T) {
-
 	for i := 0; i < 1000; i++ {
 		name, err := namegen.GenerateWorkspaceID()
 		if err != nil {
 			t.Error(err)
 		}
-		if !namegen.WorkspaceIDPattern.MatchString(name) {
+
+		err = namegen.ValidateWorkspaceID(name)
+		if err != nil {
 			t.Errorf("The workspace id \"%s\" didn't met the expectation.", name)
 		}
 	}
+}
+
+func TestValidateWorkspaceID(t *testing.T) {
+	valid := []string{
+		"gitpodio-gitpod-65k8jqq6up4",
+	}
+	for _, v := range valid {
+		require.NoError(t, namegen.ValidateWorkspaceID(v))
+	}
+
+	invalid := []string{
+		"",
+		"foo",
+		"foo-bar",
+		"fo-bo",
+		"foo-bar-12",
+		"foo--",
+		"---",
+	}
+	for _, i := range invalid {
+		require.Error(t, namegen.ValidateWorkspaceID(i))
+	}
+
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Adds validation to Workspace IDs on the API level

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
Unit tests

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
