### PR TITLE
[public-api] Thin wrapper for improved usability

### DIFF
--- a/components/public-api/go/README.md
+++ b/components/public-api/go/README.md
@@ -7,31 +7,34 @@ go get -u github.com/gitpod-io/gitpod/components/public-api/go
 ```
 
 ```golang
-
 import (
-    "github.com/bufbuild/connect-go"
+    "context"
+    "fmt"
+    "os"
+    "time"
 
-    gitpod_experimental_v1 "github.com/gitpod-io/gitpod/components/public-api/go/experimental/v1"
-    gitpod_experimental_v1connect "github.com/gitpod-io/gitpod/components/public-api/go/experimental/v1/v1connect"
+    "github.com/bufbuild/connect-go"
+    "github.com/gitpod-io/gitpod/components/public-api/go/client"
+    v1 "github.com/gitpod-io/gitpod/components/public-api/go/experimental/v1"
 )
 
-// Define an interceptor to attach credentials onto outgoing requests
-interceptor := connect.UnaryInterceptorFunc(func(next connect.UnaryFunc) connect.UnaryFunc {
-    return connect.UnaryFunc(func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
-      if req.Spec().IsClient {
-        // Send a token with client requests.
-        req.Header().Set("Authorization", "Bearer your-access-token")
-      }
+func ExampleListTeams() {
+    token := "gitpod_pat_example.personal-access-token"
 
-      return next(ctx, req)
-    })
-  })
+    gitpod, err := client.New(client.WithCredentials(token))
+    if err != nil {
+        fmt.Fprintf(os.Stderr, "Failed to construct gitpod client %v", err)
+        return
+    }
 
-// Construct a new client to interact with Gitpod
-client := gitpod_experimental_v1connect.NewTeamsServiceClient(http.DefaultClient, "https://api.gitpod.io", connect.WithInterceptors(
-    inteceptor,
-))
+    response, err := gitpod.Teams.ListTeams(context.Background(), connect.NewRequest(&v1.ListTeamsRequest{}))
+    if err != nil {
+        fmt.Fprintf(os.Stderr, "Failed to list teams %v", err)
+        return
+    }
 
-// Use the client to retreive teams
-response, err := client.ListTeams(context.Background(), gitpod_experimental_v1connect.NewRequest(&gitpod_experimental_v1.ListTeamsRequest{}))
+    fmt.Fprintf(os.Stdout, "Retrieved teams %v", response.Msg.GetTeams())
+}
 ```
+
+For more examples, see [examples](./examples) directory.

--- a/components/public-api/go/client/client.go
+++ b/components/public-api/go/client/client.go
@@ -1,0 +1,91 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package client
+
+import (
+	"errors"
+	"fmt"
+	"github.com/bufbuild/connect-go"
+	gitpod_experimental_v1connect "github.com/gitpod-io/gitpod/components/public-api/go/experimental/v1/v1connect"
+	"net/http"
+)
+
+type Gitpod struct {
+	Workspaces           gitpod_experimental_v1connect.WorkspacesServiceClient
+	Teams                gitpod_experimental_v1connect.TeamsServiceClient
+	Projects             gitpod_experimental_v1connect.ProjectsServiceClient
+	PersonalAccessTokens gitpod_experimental_v1connect.TokensServiceClient
+}
+
+func New(options ...Option) (*Gitpod, error) {
+	opts, err := evaluateOptions(defaultOptions(), options...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to evaluate client options: %w", err)
+	}
+
+	if opts.credentials == "" {
+		return nil, errors.New("no authentication credentials specified")
+	}
+
+	client := opts.client
+	url := opts.url
+
+	serviceOpts := []connect.ClientOption{
+		connect.WithInterceptors(
+			AuthorizationInterceptor(opts.credentials),
+		),
+	}
+
+	teams := gitpod_experimental_v1connect.NewTeamsServiceClient(client, url, serviceOpts...)
+	projects := gitpod_experimental_v1connect.NewProjectsServiceClient(client, url, serviceOpts...)
+	tokens := gitpod_experimental_v1connect.NewTokensServiceClient(client, url, serviceOpts...)
+	workspaces := gitpod_experimental_v1connect.NewWorkspacesServiceClient(client, url, serviceOpts...)
+
+	return &Gitpod{
+		Teams:                teams,
+		Projects:             projects,
+		PersonalAccessTokens: tokens,
+		Workspaces:           workspaces,
+	}, nil
+}
+
+type Option func(opts *options) error
+
+func WithURL(url string) Option {
+	return func(opts *options) error {
+		opts.url = url
+		return nil
+	}
+}
+
+func WithCredentials(token string) Option {
+	return func(opts *options) error {
+		opts.credentials = token
+		return nil
+	}
+}
+
+type options struct {
+	url         string
+	client      *http.Client
+	credentials string
+}
+
+func defaultOptions() *options {
+	return &options{
+		url:    "https://api.gitpod.io",
+		client: http.DefaultClient,
+	}
+}
+
+func evaluateOptions(base *options, opts ...Option) (*options, error) {
+	for _, opt := range opts {
+		if err := opt(base); err != nil {
+			return nil, fmt.Errorf("failed to evaluate options: %w", err)
+		}
+	}
+
+	return base, nil
+}

--- a/components/public-api/go/client/client.go
+++ b/components/public-api/go/client/client.go
@@ -13,6 +13,8 @@ import (
 )
 
 type Gitpod struct {
+	cfg *options
+
 	Workspaces           gitpod_experimental_v1connect.WorkspacesServiceClient
 	Teams                gitpod_experimental_v1connect.TeamsServiceClient
 	Projects             gitpod_experimental_v1connect.ProjectsServiceClient
@@ -44,6 +46,7 @@ func New(options ...Option) (*Gitpod, error) {
 	workspaces := gitpod_experimental_v1connect.NewWorkspacesServiceClient(client, url, serviceOpts...)
 
 	return &Gitpod{
+		cfg:                  opts,
 		Teams:                teams,
 		Projects:             projects,
 		PersonalAccessTokens: tokens,
@@ -63,6 +66,13 @@ func WithURL(url string) Option {
 func WithCredentials(token string) Option {
 	return func(opts *options) error {
 		opts.credentials = token
+		return nil
+	}
+}
+
+func WithHTTPClient(client *http.Client) Option {
+	return func(opts *options) error {
+		opts.client = client
 		return nil
 	}
 }

--- a/components/public-api/go/client/client_test.go
+++ b/components/public-api/go/client/client_test.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package client
+
+import (
+	"github.com/stretchr/testify/require"
+	"net/http"
+	"testing"
+)
+
+func TestNew(t *testing.T) {
+
+	t.Run("with all options", func(t *testing.T) {
+		expectedOptions := &options{
+			url:         "https://foo.bar.com",
+			client:      &http.Client{},
+			credentials: "my_awesome_credentials",
+		}
+		gitpod, err := New(
+			WithURL(expectedOptions.url),
+			WithCredentials(expectedOptions.credentials),
+			WithHTTPClient(expectedOptions.client),
+		)
+		require.NoError(t, err)
+		require.Equal(t, expectedOptions, gitpod.cfg)
+
+		require.NotNil(t, gitpod.PersonalAccessTokens)
+		require.NotNil(t, gitpod.Workspaces)
+		require.NotNil(t, gitpod.Projects)
+		require.NotNil(t, gitpod.PersonalAccessTokens)
+	})
+
+	t.Run("fails when no credentials specified", func(t *testing.T) {
+		_, err := New()
+		require.Error(t, err)
+	})
+
+	t.Run("defaults to https://api.gitpod.io", func(t *testing.T) {
+		gitpod, err := New(WithCredentials("foo"))
+		require.NoError(t, err)
+
+		require.Equal(t, "https://api.gitpod.io", gitpod.cfg.url)
+	})
+
+}

--- a/components/public-api/go/client/interceptors.go
+++ b/components/public-api/go/client/interceptors.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package client
+
+import (
+	"context"
+	"fmt"
+	"github.com/bufbuild/connect-go"
+)
+
+func AuthorizationInterceptor(token string) connect.Interceptor {
+	interceptor := connect.UnaryInterceptorFunc(func(next connect.UnaryFunc) connect.UnaryFunc {
+		return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+			if req.Spec().IsClient {
+				// Send a token with client requests.
+				req.Header().Set("Authorization", fmt.Sprintf("Bearer %s", token))
+			}
+
+			return next(ctx, req)
+		}
+	})
+
+	return interceptor
+}

--- a/components/public-api/go/client/interceptors_test.go
+++ b/components/public-api/go/client/interceptors_test.go
@@ -1,0 +1,5 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package client

--- a/components/public-api/go/examples/client_example.go
+++ b/components/public-api/go/examples/client_example.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package examples
+
+import (
+	"context"
+	"fmt"
+	"github.com/bufbuild/connect-go"
+	"github.com/gitpod-io/gitpod/components/public-api/go/client"
+	v1 "github.com/gitpod-io/gitpod/components/public-api/go/experimental/v1"
+	"os"
+)
+
+func ExampleClient() {
+	token := "gitpod_pat_example.personal-access-token"
+	gitpod, err := client.New(client.WithCredentials(token))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to construct gitpod client %v", err)
+		return
+	}
+
+	// use the gitpod client to access resources
+	gitpod.Teams.ListTeams(context.Background(), connect.NewRequest(&v1.ListTeamsRequest{}))
+}

--- a/components/public-api/go/examples/teams_example.go
+++ b/components/public-api/go/examples/teams_example.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package examples
+
+import (
+	"context"
+	"fmt"
+	"github.com/bufbuild/connect-go"
+	"github.com/gitpod-io/gitpod/components/public-api/go/client"
+	v1 "github.com/gitpod-io/gitpod/components/public-api/go/experimental/v1"
+	"os"
+	"time"
+)
+
+func ExampleListTeams() {
+	token := "gitpod_pat_example.personal-access-token"
+
+	gitpod, err := client.New(client.WithCredentials(token))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to construct gitpod client %v", err)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	response, err := gitpod.Teams.ListTeams(ctx, connect.NewRequest(&v1.ListTeamsRequest{}))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to list teams %v", err)
+		return
+	}
+
+	fmt.Fprintf(os.Stdout, "Retrieved teams %v", response.Msg.GetTeams())
+}

--- a/components/public-api/go/go.mod
+++ b/components/public-api/go/go.mod
@@ -5,6 +5,7 @@ go 1.19
 require (
 	github.com/bufbuild/connect-go v1.0.0
 	github.com/gitpod-io/gitpod/common-go v0.0.0-00010101000000-000000000000
+	github.com/stretchr/testify v1.7.0
 	google.golang.org/grpc v1.49.0
 	google.golang.org/protobuf v1.28.1
 )
@@ -27,7 +28,6 @@ require (
 	github.com/prometheus/procfs v0.8.0 // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/slok/go-http-metrics v0.10.0 // indirect
-	github.com/stretchr/testify v1.7.0 // indirect
 	golang.org/x/net v0.0.0-20220225172249-27dd8689420f // indirect
 	golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f // indirect
 	golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a // indirect


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Adds a thin wrapper around Go public-api client construction. The contructor accepts options to parametrize the client.

Includes runnable (compile time verified) examples of use

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
Unit tests

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
