### PR TITLE
test: Add the script to create QA report

### DIFF
--- a/test/report.sh
+++ b/test/report.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Convenience script to create the Quality Assurance Report
+#
+# Usage:
+#
+#   report.sh [input.json]
+#
+# Examples
+#
+#   run.sh result.json
+#
+
+set -euo pipefail
+
+input_file=${1}
+
+d=$(date "+%Y%m%d-%H%M%S")
+tempdir=$(mktemp -d /tmp/report-"$d".XXXXX)
+
+exec {base}< <( \
+  jq -r 'select( .Action | test("(pass|fail|skip)") ) | select( .Elapsed | . != 0) | select( .Test | . != null) | [.Package,.Test,.Action]|@csv' "$input_file" | \
+  sed 's/github.com\/gitpod-io\/gitpod\/test\/tests\///' > "$tempdir"/base.csv
+)
+
+jq -r 'select( .Action | test("(pass|fail|skip)") ) | select( .Elapsed | . != 0) | select( .Test | . != null).Test' "$input_file" > "$tempdir"/list.txt
+
+exec {feature}< <( \
+  while read -r test_name; do
+    jq -r -s --arg name "$test_name" 'map(select( . | .Test == $name) | select( . | .Output != null ) | select( .Output | startswith("===") | not) | select( .Output | contains("---") | not) | .Output | gsub("[\\n\\t]"; ""))[0]' "$input_file"
+  done < "$tempdir"/list.txt | sed 's/^[ \t]*//' | sed 's/,/ /g' | cut -d ':' -f 3 > "$tempdir"/features.txt
+)
+
+exec {desc}< <( \
+  while read -r test_name; do
+    jq -r -s --arg name "$test_name" 'map(select( . | .Test == $name) | select( . | .Output != null ) | select( .Output | startswith("===") | not) | select( .Output | contains("---") | not) | .Output | gsub("[\\n\\t]"; ""))[1]' "$input_file"
+  done < "$tempdir"/list.txt | sed 's/^[ \t]*//' | sed 's/,/ /g' | cut -d ':' -f 3 > "$tempdir"/desc.txt
+)
+
+cat <&${base}
+cat <&${feature}
+cat <&${desc}
+
+paste "$tempdir"/features.txt "$tempdir"/base.csv "$tempdir"/desc.txt -d ',' | \
+  awk -F"," 'OFS="," {print $3,$1,$2,$4,$5}' | \
+  sed  "/null/d" |\
+  sed '1iname,feature,component,status,desc'


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

I forgot to attach this script when I send out https://github.com/gitpod-io/gitpod/pull/15386

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

Follow-up: https://github.com/gitpod-io/gitpod/pull/15386

## How to test
<!-- Provide steps to test this PR -->

```console
 ./run.sh -r report.csv -s workspace 
cat report.csv
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-integration-tests=workspace
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
