### PR TITLE
[installer] Upgrade `bitnami/mysql` to `9.4.5`

### DIFF
--- a/install/installer/cmd/testdata/render/aws-setup/output.golden
+++ b/install/installer/cmd/testdata/render/aws-setup/output.golden
@@ -179,7 +179,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -721,7 +721,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -932,7 +932,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
@@ -1044,7 +1044,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1060,7 +1060,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1091,7 +1091,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1121,7 +1121,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -3247,7 +3247,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus
       namespace: default
     ---
@@ -3259,7 +3259,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus
       namespace: default
     ---
@@ -3271,7 +3271,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: rabbitmq
       namespace: default
     ---
@@ -3283,7 +3283,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus-config
       namespace: default
     ---
@@ -3295,7 +3295,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus
       namespace: default
     ---
@@ -3307,7 +3307,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: load-definition
       namespace: default
     ---
@@ -3319,7 +3319,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: rabbitmq
       namespace: default
     ---
@@ -3331,7 +3331,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus-endpoint-reader
       namespace: default
     ---
@@ -3343,7 +3343,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus-endpoint-reader
       namespace: default
     ---
@@ -3355,7 +3355,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus-headless
       namespace: default
     ---
@@ -3367,7 +3367,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus
       namespace: default
     ---
@@ -3379,7 +3379,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus
       namespace: default
     ---
@@ -6191,7 +6191,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 rules:
@@ -6556,7 +6556,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 subjects:
@@ -7046,7 +7046,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -7090,7 +7090,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -7989,7 +7989,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -8006,12 +8006,12 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/config: 2ca9db593e4ca6cdd01f7a65cce1ae90d0d45ecdf0049edfaa4ec72302fcbe8f
-        checksum/secret: c231bbb08185305defa8c4da0f3ee0f5e7a16795362a2133f74e53eb9a40453d
+        checksum/config: ccb825978bbf430cbaaf1b4d7c01a8fe2a1a98c853eccc8f52d744f86a426f73
+        checksum/secret: f868bf6193d744bac3cf4076eb14da2cf788e6e9092e106acc57aa6a4cc7148c
         prometheus.io/port: '9419'
         prometheus.io/scrape: "true"
     spec:
@@ -8031,7 +8031,7 @@ spec:
       initContainers:
       containers:
         - name: rabbitmq
-          image: docker.io/bitnami/rabbitmq:3.10.2-debian-10-r7
+          image: docker.io/bitnami/rabbitmq:3.10.7-debian-11-r4
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true
@@ -8127,9 +8127,9 @@ spec:
             timeoutSeconds: 20
             exec:
               command:
-                - /bin/bash
+                - sh
                 - -ec
-                - rabbitmq-diagnostics -q ping
+                - test "$(curl -f --user gitpod:$RABBITMQ_PASSWORD 127.0.0.1:15672/api/healthchecks/node)" = '{"status":"ok"}'
           readinessProbe:
             failureThreshold: 3
             initialDelaySeconds: 10
@@ -8138,9 +8138,9 @@ spec:
             timeoutSeconds: 20
             exec:
               command:
-                - /bin/bash
+                - sh
                 - -ec
-                - rabbitmq-diagnostics -q check_running && rabbitmq-diagnostics -q check_local_alarms
+                - curl -f --user gitpod:$RABBITMQ_PASSWORD 127.0.0.1:15672/api/health/checks/local-alarms
           resources:
             limits: {}
             requests: {}

--- a/install/installer/cmd/testdata/render/azure-setup/output.golden
+++ b/install/installer/cmd/testdata/render/azure-setup/output.golden
@@ -179,7 +179,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -721,7 +721,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -948,7 +948,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
@@ -1048,7 +1048,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1064,7 +1064,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1095,7 +1095,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1144,7 +1144,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -3251,7 +3251,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus
       namespace: default
     ---
@@ -3263,7 +3263,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus
       namespace: default
     ---
@@ -3275,7 +3275,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: rabbitmq
       namespace: default
     ---
@@ -3287,7 +3287,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus-config
       namespace: default
     ---
@@ -3299,7 +3299,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus
       namespace: default
     ---
@@ -3311,7 +3311,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: load-definition
       namespace: default
     ---
@@ -3323,7 +3323,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: rabbitmq
       namespace: default
     ---
@@ -3335,7 +3335,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus-endpoint-reader
       namespace: default
     ---
@@ -3347,7 +3347,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus-endpoint-reader
       namespace: default
     ---
@@ -3359,7 +3359,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus-headless
       namespace: default
     ---
@@ -3371,7 +3371,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus
       namespace: default
     ---
@@ -3383,7 +3383,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus
       namespace: default
     ---
@@ -6167,7 +6167,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 rules:
@@ -6510,7 +6510,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 subjects:
@@ -6982,7 +6982,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -7026,7 +7026,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -7946,7 +7946,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -7963,12 +7963,12 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/config: 2ca9db593e4ca6cdd01f7a65cce1ae90d0d45ecdf0049edfaa4ec72302fcbe8f
-        checksum/secret: c231bbb08185305defa8c4da0f3ee0f5e7a16795362a2133f74e53eb9a40453d
+        checksum/config: ccb825978bbf430cbaaf1b4d7c01a8fe2a1a98c853eccc8f52d744f86a426f73
+        checksum/secret: f868bf6193d744bac3cf4076eb14da2cf788e6e9092e106acc57aa6a4cc7148c
         prometheus.io/port: '9419'
         prometheus.io/scrape: "true"
     spec:
@@ -7988,7 +7988,7 @@ spec:
       initContainers:
       containers:
         - name: rabbitmq
-          image: docker.io/bitnami/rabbitmq:3.10.2-debian-10-r7
+          image: docker.io/bitnami/rabbitmq:3.10.7-debian-11-r4
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true
@@ -8084,9 +8084,9 @@ spec:
             timeoutSeconds: 20
             exec:
               command:
-                - /bin/bash
+                - sh
                 - -ec
-                - rabbitmq-diagnostics -q ping
+                - test "$(curl -f --user gitpod:$RABBITMQ_PASSWORD 127.0.0.1:15672/api/healthchecks/node)" = '{"status":"ok"}'
           readinessProbe:
             failureThreshold: 3
             initialDelaySeconds: 10
@@ -8095,9 +8095,9 @@ spec:
             timeoutSeconds: 20
             exec:
               command:
-                - /bin/bash
+                - sh
                 - -ec
-                - rabbitmq-diagnostics -q check_running && rabbitmq-diagnostics -q check_local_alarms
+                - curl -f --user gitpod:$RABBITMQ_PASSWORD 127.0.0.1:15672/api/health/checks/local-alarms
           resources:
             limits: {}
             requests: {}

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -179,7 +179,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -746,7 +746,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1070,7 +1070,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
@@ -1235,7 +1235,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1251,7 +1251,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1282,7 +1282,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1348,7 +1348,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -4101,7 +4101,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus
       namespace: default
     ---
@@ -4113,7 +4113,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus
       namespace: default
     ---
@@ -4125,7 +4125,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: rabbitmq
       namespace: default
     ---
@@ -4137,7 +4137,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus-config
       namespace: default
     ---
@@ -4149,7 +4149,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus
       namespace: default
     ---
@@ -4161,7 +4161,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: load-definition
       namespace: default
     ---
@@ -4173,7 +4173,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: rabbitmq
       namespace: default
     ---
@@ -4185,7 +4185,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus-endpoint-reader
       namespace: default
     ---
@@ -4197,7 +4197,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus-endpoint-reader
       namespace: default
     ---
@@ -4209,7 +4209,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus-headless
       namespace: default
     ---
@@ -4221,7 +4221,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus
       namespace: default
     ---
@@ -4233,7 +4233,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus
       namespace: default
     ---
@@ -7240,7 +7240,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 rules:
@@ -7601,7 +7601,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 subjects:
@@ -8139,7 +8139,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -8183,7 +8183,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -9249,7 +9249,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -9266,12 +9266,12 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/config: 2ca9db593e4ca6cdd01f7a65cce1ae90d0d45ecdf0049edfaa4ec72302fcbe8f
-        checksum/secret: c231bbb08185305defa8c4da0f3ee0f5e7a16795362a2133f74e53eb9a40453d
+        checksum/config: ccb825978bbf430cbaaf1b4d7c01a8fe2a1a98c853eccc8f52d744f86a426f73
+        checksum/secret: f868bf6193d744bac3cf4076eb14da2cf788e6e9092e106acc57aa6a4cc7148c
         prometheus.io/port: '9419'
         prometheus.io/scrape: "true"
     spec:
@@ -9291,7 +9291,7 @@ spec:
       initContainers:
       containers:
         - name: rabbitmq
-          image: docker.io/bitnami/rabbitmq:3.10.2-debian-10-r7
+          image: docker.io/bitnami/rabbitmq:3.10.7-debian-11-r4
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true
@@ -9387,9 +9387,9 @@ spec:
             timeoutSeconds: 20
             exec:
               command:
-                - /bin/bash
+                - sh
                 - -ec
-                - rabbitmq-diagnostics -q ping
+                - test "$(curl -f --user gitpod:$RABBITMQ_PASSWORD 127.0.0.1:15672/api/healthchecks/node)" = '{"status":"ok"}'
           readinessProbe:
             failureThreshold: 3
             initialDelaySeconds: 10
@@ -9398,9 +9398,9 @@ spec:
             timeoutSeconds: 20
             exec:
               command:
-                - /bin/bash
+                - sh
                 - -ec
-                - rabbitmq-diagnostics -q check_running && rabbitmq-diagnostics -q check_local_alarms
+                - curl -f --user gitpod:$RABBITMQ_PASSWORD 127.0.0.1:15672/api/health/checks/local-alarms
           resources:
             limits: {}
             requests: {}

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -3990,7 +3990,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql
       namespace: default
     ---
@@ -4003,7 +4003,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql-headless
       namespace: default
     ---
@@ -4016,7 +4016,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql
       namespace: default
     ---
@@ -4029,7 +4029,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql
       namespace: default
     ---
@@ -5623,7 +5623,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
@@ -5640,7 +5640,7 @@ data:
     datadir=/bitnami/mysql/data
     tmpdir=/opt/bitnami/mysql/tmp
     max_allowed_packet=16M
-    bind-address=0.0.0.0
+    bind-address=*
     pid-file=/opt/bitnami/mysql/tmp/mysqld.pid
     log-error=/opt/bitnami/mysql/logs/mysqld.log
     character-set-server=UTF8
@@ -8245,7 +8245,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
@@ -8273,11 +8273,10 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
-  annotations:
 spec:
   type: ClusterIP
   clusterIP: None
@@ -9447,7 +9446,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
@@ -9465,10 +9464,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/configuration: 11b8361c0fbf695cec6ec7f47ed4118ad3c7d71a391ca246df129803d3e205a5
+        checksum/configuration: 0c1e0d4282c8f8f820f3c9d1d79b3f423c4676afac2e3a6de555f8553f146eb4
       labels:
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: primary
@@ -9487,7 +9486,7 @@ spec:
         fsGroup: 1001
       initContainers:
         - name: volume-permissions
-          image: docker.io/bitnami/bitnami-shell:10-debian-10-r431
+          image: /docker.io/bitnami/bitnami-shell:11-debian-11-r60
           imagePullPolicy: "IfNotPresent"
           command:
             - /bin/bash
@@ -9503,7 +9502,7 @@ spec:
               mountPath: /bitnami/mysql
       containers:
         - name: mysql
-          image: docker.io/bitnami/mysql:5.7.34-debian-10-r55
+          image: /docker.io/bitnami/mysql:5.7.34-debian-10-r55
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -179,7 +179,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -721,7 +721,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -948,7 +948,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
@@ -1062,7 +1062,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1078,7 +1078,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1109,7 +1109,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1175,7 +1175,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -3392,7 +3392,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus
       namespace: default
     ---
@@ -3404,7 +3404,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus
       namespace: default
     ---
@@ -3416,7 +3416,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: rabbitmq
       namespace: default
     ---
@@ -3428,7 +3428,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus-config
       namespace: default
     ---
@@ -3440,7 +3440,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus
       namespace: default
     ---
@@ -3452,7 +3452,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: load-definition
       namespace: default
     ---
@@ -3464,7 +3464,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: rabbitmq
       namespace: default
     ---
@@ -3476,7 +3476,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus-endpoint-reader
       namespace: default
     ---
@@ -3488,7 +3488,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus-endpoint-reader
       namespace: default
     ---
@@ -3500,7 +3500,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus-headless
       namespace: default
     ---
@@ -3512,7 +3512,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus
       namespace: default
     ---
@@ -3524,7 +3524,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus
       namespace: default
     ---
@@ -6373,7 +6373,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 rules:
@@ -6716,7 +6716,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 subjects:
@@ -7209,7 +7209,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -7253,7 +7253,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -8227,7 +8227,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -8244,12 +8244,12 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/config: 2ca9db593e4ca6cdd01f7a65cce1ae90d0d45ecdf0049edfaa4ec72302fcbe8f
-        checksum/secret: c231bbb08185305defa8c4da0f3ee0f5e7a16795362a2133f74e53eb9a40453d
+        checksum/config: ccb825978bbf430cbaaf1b4d7c01a8fe2a1a98c853eccc8f52d744f86a426f73
+        checksum/secret: f868bf6193d744bac3cf4076eb14da2cf788e6e9092e106acc57aa6a4cc7148c
         prometheus.io/port: '9419'
         prometheus.io/scrape: "true"
     spec:
@@ -8269,7 +8269,7 @@ spec:
       initContainers:
       containers:
         - name: rabbitmq
-          image: docker.io/bitnami/rabbitmq:3.10.2-debian-10-r7
+          image: docker.io/bitnami/rabbitmq:3.10.7-debian-11-r4
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true
@@ -8365,9 +8365,9 @@ spec:
             timeoutSeconds: 20
             exec:
               command:
-                - /bin/bash
+                - sh
                 - -ec
-                - rabbitmq-diagnostics -q ping
+                - test "$(curl -f --user gitpod:$RABBITMQ_PASSWORD 127.0.0.1:15672/api/healthchecks/node)" = '{"status":"ok"}'
           readinessProbe:
             failureThreshold: 3
             initialDelaySeconds: 10
@@ -8376,9 +8376,9 @@ spec:
             timeoutSeconds: 20
             exec:
               command:
-                - /bin/bash
+                - sh
                 - -ec
-                - rabbitmq-diagnostics -q check_running && rabbitmq-diagnostics -q check_local_alarms
+                - curl -f --user gitpod:$RABBITMQ_PASSWORD 127.0.0.1:15672/api/health/checks/local-alarms
           resources:
             limits: {}
             requests: {}

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -3281,7 +3281,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql
       namespace: default
     ---
@@ -3294,7 +3294,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql-headless
       namespace: default
     ---
@@ -3307,7 +3307,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql
       namespace: default
     ---
@@ -3320,7 +3320,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql
       namespace: default
     ---
@@ -4879,7 +4879,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
@@ -4896,7 +4896,7 @@ data:
     datadir=/bitnami/mysql/data
     tmpdir=/opt/bitnami/mysql/tmp
     max_allowed_packet=16M
-    bind-address=0.0.0.0
+    bind-address=*
     pid-file=/opt/bitnami/mysql/tmp/mysqld.pid
     log-error=/opt/bitnami/mysql/logs/mysqld.log
     character-set-server=UTF8
@@ -7315,7 +7315,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
@@ -7343,11 +7343,10 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
-  annotations:
 spec:
   type: ClusterIP
   clusterIP: None
@@ -8425,7 +8424,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
@@ -8443,10 +8442,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/configuration: 11b8361c0fbf695cec6ec7f47ed4118ad3c7d71a391ca246df129803d3e205a5
+        checksum/configuration: 0c1e0d4282c8f8f820f3c9d1d79b3f423c4676afac2e3a6de555f8553f146eb4
       labels:
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: primary
@@ -8465,7 +8464,7 @@ spec:
         fsGroup: 1001
       initContainers:
         - name: volume-permissions
-          image: docker.io/bitnami/bitnami-shell:10-debian-10-r431
+          image: /docker.io/bitnami/bitnami-shell:11-debian-11-r60
           imagePullPolicy: "IfNotPresent"
           command:
             - /bin/bash
@@ -8481,7 +8480,7 @@ spec:
               mountPath: /bitnami/mysql
       containers:
         - name: mysql
-          image: docker.io/bitnami/mysql:5.7.34-debian-10-r55
+          image: /docker.io/bitnami/mysql:5.7.34-debian-10-r55
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true

--- a/install/installer/cmd/testdata/render/gcp-setup/output.golden
+++ b/install/installer/cmd/testdata/render/gcp-setup/output.golden
@@ -179,7 +179,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -721,7 +721,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -944,7 +944,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
@@ -1044,7 +1044,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1060,7 +1060,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1091,7 +1091,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1121,7 +1121,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -3222,7 +3222,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus
       namespace: default
     ---
@@ -3234,7 +3234,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus
       namespace: default
     ---
@@ -3246,7 +3246,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: rabbitmq
       namespace: default
     ---
@@ -3258,7 +3258,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus-config
       namespace: default
     ---
@@ -3270,7 +3270,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus
       namespace: default
     ---
@@ -3282,7 +3282,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: load-definition
       namespace: default
     ---
@@ -3294,7 +3294,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: rabbitmq
       namespace: default
     ---
@@ -3306,7 +3306,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus-endpoint-reader
       namespace: default
     ---
@@ -3318,7 +3318,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus-endpoint-reader
       namespace: default
     ---
@@ -3330,7 +3330,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus-headless
       namespace: default
     ---
@@ -3342,7 +3342,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus
       namespace: default
     ---
@@ -3354,7 +3354,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus
       namespace: default
     ---
@@ -6126,7 +6126,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 rules:
@@ -6487,7 +6487,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 subjects:
@@ -6983,7 +6983,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -7027,7 +7027,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -7926,7 +7926,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -7943,12 +7943,12 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/config: 2ca9db593e4ca6cdd01f7a65cce1ae90d0d45ecdf0049edfaa4ec72302fcbe8f
-        checksum/secret: c231bbb08185305defa8c4da0f3ee0f5e7a16795362a2133f74e53eb9a40453d
+        checksum/config: ccb825978bbf430cbaaf1b4d7c01a8fe2a1a98c853eccc8f52d744f86a426f73
+        checksum/secret: f868bf6193d744bac3cf4076eb14da2cf788e6e9092e106acc57aa6a4cc7148c
         prometheus.io/port: '9419'
         prometheus.io/scrape: "true"
     spec:
@@ -7968,7 +7968,7 @@ spec:
       initContainers:
       containers:
         - name: rabbitmq
-          image: docker.io/bitnami/rabbitmq:3.10.2-debian-10-r7
+          image: docker.io/bitnami/rabbitmq:3.10.7-debian-11-r4
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true
@@ -8064,9 +8064,9 @@ spec:
             timeoutSeconds: 20
             exec:
               command:
-                - /bin/bash
+                - sh
                 - -ec
-                - rabbitmq-diagnostics -q ping
+                - test "$(curl -f --user gitpod:$RABBITMQ_PASSWORD 127.0.0.1:15672/api/healthchecks/node)" = '{"status":"ok"}'
           readinessProbe:
             failureThreshold: 3
             initialDelaySeconds: 10
@@ -8075,9 +8075,9 @@ spec:
             timeoutSeconds: 20
             exec:
               command:
-                - /bin/bash
+                - sh
                 - -ec
-                - rabbitmq-diagnostics -q check_running && rabbitmq-diagnostics -q check_local_alarms
+                - curl -f --user gitpod:$RABBITMQ_PASSWORD 127.0.0.1:15672/api/health/checks/local-alarms
           resources:
             limits: {}
             requests: {}

--- a/install/installer/cmd/testdata/render/http-proxy/output.golden
+++ b/install/installer/cmd/testdata/render/http-proxy/output.golden
@@ -179,7 +179,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -746,7 +746,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -985,7 +985,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
@@ -1115,7 +1115,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1131,7 +1131,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1162,7 +1162,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1228,7 +1228,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -3561,7 +3561,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus
       namespace: default
     ---
@@ -3573,7 +3573,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus
       namespace: default
     ---
@@ -3585,7 +3585,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: rabbitmq
       namespace: default
     ---
@@ -3597,7 +3597,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus-config
       namespace: default
     ---
@@ -3609,7 +3609,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus
       namespace: default
     ---
@@ -3621,7 +3621,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: load-definition
       namespace: default
     ---
@@ -3633,7 +3633,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: rabbitmq
       namespace: default
     ---
@@ -3645,7 +3645,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus-endpoint-reader
       namespace: default
     ---
@@ -3657,7 +3657,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus-endpoint-reader
       namespace: default
     ---
@@ -3669,7 +3669,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus-headless
       namespace: default
     ---
@@ -3681,7 +3681,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus
       namespace: default
     ---
@@ -3693,7 +3693,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus
       namespace: default
     ---
@@ -6615,7 +6615,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 rules:
@@ -6976,7 +6976,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 subjects:
@@ -7469,7 +7469,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -7513,7 +7513,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -8912,7 +8912,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -8929,12 +8929,12 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/config: 2ca9db593e4ca6cdd01f7a65cce1ae90d0d45ecdf0049edfaa4ec72302fcbe8f
-        checksum/secret: c231bbb08185305defa8c4da0f3ee0f5e7a16795362a2133f74e53eb9a40453d
+        checksum/config: ccb825978bbf430cbaaf1b4d7c01a8fe2a1a98c853eccc8f52d744f86a426f73
+        checksum/secret: f868bf6193d744bac3cf4076eb14da2cf788e6e9092e106acc57aa6a4cc7148c
         prometheus.io/port: '9419'
         prometheus.io/scrape: "true"
     spec:
@@ -8954,7 +8954,7 @@ spec:
       initContainers:
       containers:
         - name: rabbitmq
-          image: docker.io/bitnami/rabbitmq:3.10.2-debian-10-r7
+          image: docker.io/bitnami/rabbitmq:3.10.7-debian-11-r4
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true
@@ -9050,9 +9050,9 @@ spec:
             timeoutSeconds: 20
             exec:
               command:
-                - /bin/bash
+                - sh
                 - -ec
-                - rabbitmq-diagnostics -q ping
+                - test "$(curl -f --user gitpod:$RABBITMQ_PASSWORD 127.0.0.1:15672/api/healthchecks/node)" = '{"status":"ok"}'
           readinessProbe:
             failureThreshold: 3
             initialDelaySeconds: 10
@@ -9061,9 +9061,9 @@ spec:
             timeoutSeconds: 20
             exec:
               command:
-                - /bin/bash
+                - sh
                 - -ec
-                - rabbitmq-diagnostics -q check_running && rabbitmq-diagnostics -q check_local_alarms
+                - curl -f --user gitpod:$RABBITMQ_PASSWORD 127.0.0.1:15672/api/health/checks/local-alarms
           resources:
             limits: {}
             requests: {}

--- a/install/installer/cmd/testdata/render/http-proxy/output.golden
+++ b/install/installer/cmd/testdata/render/http-proxy/output.golden
@@ -3450,7 +3450,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql
       namespace: default
     ---
@@ -3463,7 +3463,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql-headless
       namespace: default
     ---
@@ -3476,7 +3476,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql
       namespace: default
     ---
@@ -3489,7 +3489,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql
       namespace: default
     ---
@@ -5048,7 +5048,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
@@ -5065,7 +5065,7 @@ data:
     datadir=/bitnami/mysql/data
     tmpdir=/opt/bitnami/mysql/tmp
     max_allowed_packet=16M
-    bind-address=0.0.0.0
+    bind-address=*
     pid-file=/opt/bitnami/mysql/tmp/mysqld.pid
     log-error=/opt/bitnami/mysql/logs/mysqld.log
     character-set-server=UTF8
@@ -7575,7 +7575,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
@@ -7603,11 +7603,10 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
-  annotations:
 spec:
   type: ClusterIP
   clusterIP: None
@@ -9110,7 +9109,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
@@ -9128,10 +9127,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/configuration: 11b8361c0fbf695cec6ec7f47ed4118ad3c7d71a391ca246df129803d3e205a5
+        checksum/configuration: 0c1e0d4282c8f8f820f3c9d1d79b3f423c4676afac2e3a6de555f8553f146eb4
       labels:
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: primary
@@ -9150,7 +9149,7 @@ spec:
         fsGroup: 1001
       initContainers:
         - name: volume-permissions
-          image: docker.io/bitnami/bitnami-shell:10-debian-10-r431
+          image: /docker.io/bitnami/bitnami-shell:11-debian-11-r60
           imagePullPolicy: "IfNotPresent"
           command:
             - /bin/bash
@@ -9166,7 +9165,7 @@ spec:
               mountPath: /bitnami/mysql
       containers:
         - name: mysql
-          image: docker.io/bitnami/mysql:5.7.34-debian-10-r55
+          image: /docker.io/bitnami/mysql:5.7.34-debian-10-r55
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true

--- a/install/installer/cmd/testdata/render/kind-meta/output.golden
+++ b/install/installer/cmd/testdata/render/kind-meta/output.golden
@@ -2418,7 +2418,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql
       namespace: default
     ---
@@ -2431,7 +2431,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql-headless
       namespace: default
     ---
@@ -2444,7 +2444,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql
       namespace: default
     ---
@@ -2457,7 +2457,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql
       namespace: default
     ---
@@ -3973,7 +3973,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
@@ -3990,7 +3990,7 @@ data:
     datadir=/bitnami/mysql/data
     tmpdir=/opt/bitnami/mysql/tmp
     max_allowed_packet=16M
-    bind-address=0.0.0.0
+    bind-address=*
     pid-file=/opt/bitnami/mysql/tmp/mysqld.pid
     log-error=/opt/bitnami/mysql/logs/mysqld.log
     character-set-server=UTF8
@@ -5615,7 +5615,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
@@ -5643,11 +5643,10 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
-  annotations:
 spec:
   type: ClusterIP
   clusterIP: None
@@ -6021,7 +6020,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
@@ -6039,10 +6038,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/configuration: 11b8361c0fbf695cec6ec7f47ed4118ad3c7d71a391ca246df129803d3e205a5
+        checksum/configuration: 0c1e0d4282c8f8f820f3c9d1d79b3f423c4676afac2e3a6de555f8553f146eb4
       labels:
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: primary
@@ -6061,7 +6060,7 @@ spec:
         fsGroup: 1001
       initContainers:
         - name: volume-permissions
-          image: docker.io/bitnami/bitnami-shell:10-debian-10-r431
+          image: /docker.io/bitnami/bitnami-shell:11-debian-11-r60
           imagePullPolicy: "IfNotPresent"
           command:
             - /bin/bash
@@ -6077,7 +6076,7 @@ spec:
               mountPath: /bitnami/mysql
       containers:
         - name: mysql
-          image: docker.io/bitnami/mysql:5.7.34-debian-10-r55
+          image: /docker.io/bitnami/mysql:5.7.34-debian-10-r55
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true

--- a/install/installer/cmd/testdata/render/kind-meta/output.golden
+++ b/install/installer/cmd/testdata/render/kind-meta/output.golden
@@ -130,7 +130,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -403,7 +403,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -618,7 +618,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
@@ -688,7 +688,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -704,7 +704,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -735,7 +735,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -801,7 +801,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -2529,7 +2529,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus
       namespace: default
     ---
@@ -2541,7 +2541,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus
       namespace: default
     ---
@@ -2553,7 +2553,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: rabbitmq
       namespace: default
     ---
@@ -2565,7 +2565,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus-config
       namespace: default
     ---
@@ -2577,7 +2577,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus
       namespace: default
     ---
@@ -2589,7 +2589,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: load-definition
       namespace: default
     ---
@@ -2601,7 +2601,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: rabbitmq
       namespace: default
     ---
@@ -2613,7 +2613,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus-endpoint-reader
       namespace: default
     ---
@@ -2625,7 +2625,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus-endpoint-reader
       namespace: default
     ---
@@ -2637,7 +2637,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus-headless
       namespace: default
     ---
@@ -2649,7 +2649,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus
       namespace: default
     ---
@@ -2661,7 +2661,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus
       namespace: default
     ---
@@ -4879,7 +4879,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 rules:
@@ -5130,7 +5130,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 subjects:
@@ -5509,7 +5509,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -5553,7 +5553,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -5823,7 +5823,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -5840,12 +5840,12 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/config: 2ca9db593e4ca6cdd01f7a65cce1ae90d0d45ecdf0049edfaa4ec72302fcbe8f
-        checksum/secret: c231bbb08185305defa8c4da0f3ee0f5e7a16795362a2133f74e53eb9a40453d
+        checksum/config: ccb825978bbf430cbaaf1b4d7c01a8fe2a1a98c853eccc8f52d744f86a426f73
+        checksum/secret: f868bf6193d744bac3cf4076eb14da2cf788e6e9092e106acc57aa6a4cc7148c
         prometheus.io/port: '9419'
         prometheus.io/scrape: "true"
     spec:
@@ -5865,7 +5865,7 @@ spec:
       initContainers:
       containers:
         - name: rabbitmq
-          image: docker.io/bitnami/rabbitmq:3.10.2-debian-10-r7
+          image: docker.io/bitnami/rabbitmq:3.10.7-debian-11-r4
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true
@@ -5961,9 +5961,9 @@ spec:
             timeoutSeconds: 20
             exec:
               command:
-                - /bin/bash
+                - sh
                 - -ec
-                - rabbitmq-diagnostics -q ping
+                - test "$(curl -f --user gitpod:$RABBITMQ_PASSWORD 127.0.0.1:15672/api/healthchecks/node)" = '{"status":"ok"}'
           readinessProbe:
             failureThreshold: 3
             initialDelaySeconds: 10
@@ -5972,9 +5972,9 @@ spec:
             timeoutSeconds: 20
             exec:
               command:
-                - /bin/bash
+                - sh
                 - -ec
-                - rabbitmq-diagnostics -q check_running && rabbitmq-diagnostics -q check_local_alarms
+                - curl -f --user gitpod:$RABBITMQ_PASSWORD 127.0.0.1:15672/api/health/checks/local-alarms
           resources:
             limits: {}
             requests: {}

--- a/install/installer/cmd/testdata/render/kind-webapp/output.golden
+++ b/install/installer/cmd/testdata/render/kind-webapp/output.golden
@@ -56,7 +56,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -296,7 +296,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -451,7 +451,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
@@ -521,7 +521,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -537,7 +537,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -568,7 +568,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -634,7 +634,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1908,7 +1908,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus
       namespace: default
     ---
@@ -1920,7 +1920,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus
       namespace: default
     ---
@@ -1932,7 +1932,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: rabbitmq
       namespace: default
     ---
@@ -1944,7 +1944,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus-config
       namespace: default
     ---
@@ -1956,7 +1956,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus
       namespace: default
     ---
@@ -1968,7 +1968,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: load-definition
       namespace: default
     ---
@@ -1980,7 +1980,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: rabbitmq
       namespace: default
     ---
@@ -1992,7 +1992,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus-endpoint-reader
       namespace: default
     ---
@@ -2004,7 +2004,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus-endpoint-reader
       namespace: default
     ---
@@ -2016,7 +2016,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus-headless
       namespace: default
     ---
@@ -2028,7 +2028,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus
       namespace: default
     ---
@@ -2040,7 +2040,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus
       namespace: default
     ---
@@ -2649,7 +2649,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 rules:
@@ -2828,7 +2828,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 subjects:
@@ -3093,7 +3093,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -3137,7 +3137,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -3379,7 +3379,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -3396,12 +3396,12 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/config: 2ca9db593e4ca6cdd01f7a65cce1ae90d0d45ecdf0049edfaa4ec72302fcbe8f
-        checksum/secret: c231bbb08185305defa8c4da0f3ee0f5e7a16795362a2133f74e53eb9a40453d
+        checksum/config: ccb825978bbf430cbaaf1b4d7c01a8fe2a1a98c853eccc8f52d744f86a426f73
+        checksum/secret: f868bf6193d744bac3cf4076eb14da2cf788e6e9092e106acc57aa6a4cc7148c
         prometheus.io/port: '9419'
         prometheus.io/scrape: "true"
     spec:
@@ -3421,7 +3421,7 @@ spec:
       initContainers:
       containers:
         - name: rabbitmq
-          image: docker.io/bitnami/rabbitmq:3.10.2-debian-10-r7
+          image: docker.io/bitnami/rabbitmq:3.10.7-debian-11-r4
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true
@@ -3517,9 +3517,9 @@ spec:
             timeoutSeconds: 20
             exec:
               command:
-                - /bin/bash
+                - sh
                 - -ec
-                - rabbitmq-diagnostics -q ping
+                - test "$(curl -f --user gitpod:$RABBITMQ_PASSWORD 127.0.0.1:15672/api/healthchecks/node)" = '{"status":"ok"}'
           readinessProbe:
             failureThreshold: 3
             initialDelaySeconds: 10
@@ -3528,9 +3528,9 @@ spec:
             timeoutSeconds: 20
             exec:
               command:
-                - /bin/bash
+                - sh
                 - -ec
-                - rabbitmq-diagnostics -q check_running && rabbitmq-diagnostics -q check_local_alarms
+                - curl -f --user gitpod:$RABBITMQ_PASSWORD 127.0.0.1:15672/api/health/checks/local-alarms
           resources:
             limits: {}
             requests: {}

--- a/install/installer/cmd/testdata/render/kind-webapp/output.golden
+++ b/install/installer/cmd/testdata/render/kind-webapp/output.golden
@@ -1797,7 +1797,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql
       namespace: default
     ---
@@ -1810,7 +1810,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql-headless
       namespace: default
     ---
@@ -1823,7 +1823,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql
       namespace: default
     ---
@@ -1836,7 +1836,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql
       namespace: default
     ---
@@ -2098,7 +2098,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
@@ -2115,7 +2115,7 @@ data:
     datadir=/bitnami/mysql/data
     tmpdir=/opt/bitnami/mysql/tmp
     max_allowed_packet=16M
-    bind-address=0.0.0.0
+    bind-address=*
     pid-file=/opt/bitnami/mysql/tmp/mysqld.pid
     log-error=/opt/bitnami/mysql/logs/mysqld.log
     character-set-server=UTF8
@@ -3199,7 +3199,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
@@ -3227,11 +3227,10 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
-  annotations:
 spec:
   type: ClusterIP
   clusterIP: None
@@ -3577,7 +3576,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
@@ -3595,10 +3594,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/configuration: 11b8361c0fbf695cec6ec7f47ed4118ad3c7d71a391ca246df129803d3e205a5
+        checksum/configuration: 0c1e0d4282c8f8f820f3c9d1d79b3f423c4676afac2e3a6de555f8553f146eb4
       labels:
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: primary
@@ -3617,7 +3616,7 @@ spec:
         fsGroup: 1001
       initContainers:
         - name: volume-permissions
-          image: docker.io/bitnami/bitnami-shell:10-debian-10-r431
+          image: /docker.io/bitnami/bitnami-shell:11-debian-11-r60
           imagePullPolicy: "IfNotPresent"
           command:
             - /bin/bash
@@ -3633,7 +3632,7 @@ spec:
               mountPath: /bitnami/mysql
       containers:
         - name: mysql
-          image: docker.io/bitnami/mysql:5.7.34-debian-10-r55
+          image: /docker.io/bitnami/mysql:5.7.34-debian-10-r55
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -179,7 +179,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -746,7 +746,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -985,7 +985,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
@@ -1115,7 +1115,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1131,7 +1131,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1162,7 +1162,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1228,7 +1228,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -3558,7 +3558,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus
       namespace: default
     ---
@@ -3570,7 +3570,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus
       namespace: default
     ---
@@ -3582,7 +3582,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: rabbitmq
       namespace: default
     ---
@@ -3594,7 +3594,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus-config
       namespace: default
     ---
@@ -3606,7 +3606,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus
       namespace: default
     ---
@@ -3618,7 +3618,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: load-definition
       namespace: default
     ---
@@ -3630,7 +3630,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: rabbitmq
       namespace: default
     ---
@@ -3642,7 +3642,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus-endpoint-reader
       namespace: default
     ---
@@ -3654,7 +3654,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus-endpoint-reader
       namespace: default
     ---
@@ -3666,7 +3666,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus-headless
       namespace: default
     ---
@@ -3678,7 +3678,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus
       namespace: default
     ---
@@ -3690,7 +3690,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus
       namespace: default
     ---
@@ -6612,7 +6612,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 rules:
@@ -6973,7 +6973,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 subjects:
@@ -7466,7 +7466,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -7510,7 +7510,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -8507,7 +8507,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -8524,12 +8524,12 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/config: 2ca9db593e4ca6cdd01f7a65cce1ae90d0d45ecdf0049edfaa4ec72302fcbe8f
-        checksum/secret: c231bbb08185305defa8c4da0f3ee0f5e7a16795362a2133f74e53eb9a40453d
+        checksum/config: ccb825978bbf430cbaaf1b4d7c01a8fe2a1a98c853eccc8f52d744f86a426f73
+        checksum/secret: f868bf6193d744bac3cf4076eb14da2cf788e6e9092e106acc57aa6a4cc7148c
         prometheus.io/port: '9419'
         prometheus.io/scrape: "true"
     spec:
@@ -8549,7 +8549,7 @@ spec:
       initContainers:
       containers:
         - name: rabbitmq
-          image: docker.io/bitnami/rabbitmq:3.10.2-debian-10-r7
+          image: docker.io/bitnami/rabbitmq:3.10.7-debian-11-r4
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true
@@ -8645,9 +8645,9 @@ spec:
             timeoutSeconds: 20
             exec:
               command:
-                - /bin/bash
+                - sh
                 - -ec
-                - rabbitmq-diagnostics -q ping
+                - test "$(curl -f --user gitpod:$RABBITMQ_PASSWORD 127.0.0.1:15672/api/healthchecks/node)" = '{"status":"ok"}'
           readinessProbe:
             failureThreshold: 3
             initialDelaySeconds: 10
@@ -8656,9 +8656,9 @@ spec:
             timeoutSeconds: 20
             exec:
               command:
-                - /bin/bash
+                - sh
                 - -ec
-                - rabbitmq-diagnostics -q check_running && rabbitmq-diagnostics -q check_local_alarms
+                - curl -f --user gitpod:$RABBITMQ_PASSWORD 127.0.0.1:15672/api/health/checks/local-alarms
           resources:
             limits: {}
             requests: {}

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -3447,7 +3447,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql
       namespace: default
     ---
@@ -3460,7 +3460,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql-headless
       namespace: default
     ---
@@ -3473,7 +3473,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql
       namespace: default
     ---
@@ -3486,7 +3486,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql
       namespace: default
     ---
@@ -5045,7 +5045,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
@@ -5062,7 +5062,7 @@ data:
     datadir=/bitnami/mysql/data
     tmpdir=/opt/bitnami/mysql/tmp
     max_allowed_packet=16M
-    bind-address=0.0.0.0
+    bind-address=*
     pid-file=/opt/bitnami/mysql/tmp/mysqld.pid
     log-error=/opt/bitnami/mysql/logs/mysqld.log
     character-set-server=UTF8
@@ -7572,7 +7572,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
@@ -7600,11 +7600,10 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
-  annotations:
 spec:
   type: ClusterIP
   clusterIP: None
@@ -8705,7 +8704,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
@@ -8723,10 +8722,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/configuration: 11b8361c0fbf695cec6ec7f47ed4118ad3c7d71a391ca246df129803d3e205a5
+        checksum/configuration: 0c1e0d4282c8f8f820f3c9d1d79b3f423c4676afac2e3a6de555f8553f146eb4
       labels:
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: primary
@@ -8745,7 +8744,7 @@ spec:
         fsGroup: 1001
       initContainers:
         - name: volume-permissions
-          image: docker.io/bitnami/bitnami-shell:10-debian-10-r431
+          image: /docker.io/bitnami/bitnami-shell:11-debian-11-r60
           imagePullPolicy: "IfNotPresent"
           command:
             - /bin/bash
@@ -8761,7 +8760,7 @@ spec:
               mountPath: /bitnami/mysql
       containers:
         - name: mysql
-          image: docker.io/bitnami/mysql:5.7.34-debian-10-r55
+          image: /docker.io/bitnami/mysql:5.7.34-debian-10-r55
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true

--- a/install/installer/cmd/testdata/render/shortname/output.golden
+++ b/install/installer/cmd/testdata/render/shortname/output.golden
@@ -179,7 +179,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -746,7 +746,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -985,7 +985,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
@@ -1115,7 +1115,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1131,7 +1131,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1162,7 +1162,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1228,7 +1228,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -3558,7 +3558,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus
       namespace: default
     ---
@@ -3570,7 +3570,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus
       namespace: default
     ---
@@ -3582,7 +3582,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: rabbitmq
       namespace: default
     ---
@@ -3594,7 +3594,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus-config
       namespace: default
     ---
@@ -3606,7 +3606,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus
       namespace: default
     ---
@@ -3618,7 +3618,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: load-definition
       namespace: default
     ---
@@ -3630,7 +3630,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: rabbitmq
       namespace: default
     ---
@@ -3642,7 +3642,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus-endpoint-reader
       namespace: default
     ---
@@ -3654,7 +3654,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus-endpoint-reader
       namespace: default
     ---
@@ -3666,7 +3666,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus-headless
       namespace: default
     ---
@@ -3678,7 +3678,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus
       namespace: default
     ---
@@ -3690,7 +3690,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus
       namespace: default
     ---
@@ -6612,7 +6612,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 rules:
@@ -6973,7 +6973,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 subjects:
@@ -7466,7 +7466,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -7510,7 +7510,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -8507,7 +8507,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -8524,12 +8524,12 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/config: 2ca9db593e4ca6cdd01f7a65cce1ae90d0d45ecdf0049edfaa4ec72302fcbe8f
-        checksum/secret: c231bbb08185305defa8c4da0f3ee0f5e7a16795362a2133f74e53eb9a40453d
+        checksum/config: ccb825978bbf430cbaaf1b4d7c01a8fe2a1a98c853eccc8f52d744f86a426f73
+        checksum/secret: f868bf6193d744bac3cf4076eb14da2cf788e6e9092e106acc57aa6a4cc7148c
         prometheus.io/port: '9419'
         prometheus.io/scrape: "true"
     spec:
@@ -8549,7 +8549,7 @@ spec:
       initContainers:
       containers:
         - name: rabbitmq
-          image: docker.io/bitnami/rabbitmq:3.10.2-debian-10-r7
+          image: docker.io/bitnami/rabbitmq:3.10.7-debian-11-r4
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true
@@ -8645,9 +8645,9 @@ spec:
             timeoutSeconds: 20
             exec:
               command:
-                - /bin/bash
+                - sh
                 - -ec
-                - rabbitmq-diagnostics -q ping
+                - test "$(curl -f --user gitpod:$RABBITMQ_PASSWORD 127.0.0.1:15672/api/healthchecks/node)" = '{"status":"ok"}'
           readinessProbe:
             failureThreshold: 3
             initialDelaySeconds: 10
@@ -8656,9 +8656,9 @@ spec:
             timeoutSeconds: 20
             exec:
               command:
-                - /bin/bash
+                - sh
                 - -ec
-                - rabbitmq-diagnostics -q check_running && rabbitmq-diagnostics -q check_local_alarms
+                - curl -f --user gitpod:$RABBITMQ_PASSWORD 127.0.0.1:15672/api/health/checks/local-alarms
           resources:
             limits: {}
             requests: {}

--- a/install/installer/cmd/testdata/render/shortname/output.golden
+++ b/install/installer/cmd/testdata/render/shortname/output.golden
@@ -3447,7 +3447,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql
       namespace: default
     ---
@@ -3460,7 +3460,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql-headless
       namespace: default
     ---
@@ -3473,7 +3473,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql
       namespace: default
     ---
@@ -3486,7 +3486,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql
       namespace: default
     ---
@@ -5045,7 +5045,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
@@ -5062,7 +5062,7 @@ data:
     datadir=/bitnami/mysql/data
     tmpdir=/opt/bitnami/mysql/tmp
     max_allowed_packet=16M
-    bind-address=0.0.0.0
+    bind-address=*
     pid-file=/opt/bitnami/mysql/tmp/mysqld.pid
     log-error=/opt/bitnami/mysql/logs/mysqld.log
     character-set-server=UTF8
@@ -7572,7 +7572,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
@@ -7600,11 +7600,10 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
-  annotations:
 spec:
   type: ClusterIP
   clusterIP: None
@@ -8705,7 +8704,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
@@ -8723,10 +8722,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/configuration: 11b8361c0fbf695cec6ec7f47ed4118ad3c7d71a391ca246df129803d3e205a5
+        checksum/configuration: 0c1e0d4282c8f8f820f3c9d1d79b3f423c4676afac2e3a6de555f8553f146eb4
       labels:
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: primary
@@ -8745,7 +8744,7 @@ spec:
         fsGroup: 1001
       initContainers:
         - name: volume-permissions
-          image: docker.io/bitnami/bitnami-shell:10-debian-10-r431
+          image: /docker.io/bitnami/bitnami-shell:11-debian-11-r60
           imagePullPolicy: "IfNotPresent"
           command:
             - /bin/bash
@@ -8761,7 +8760,7 @@ spec:
               mountPath: /bitnami/mysql
       containers:
         - name: mysql
-          image: docker.io/bitnami/mysql:5.7.34-debian-10-r55
+          image: /docker.io/bitnami/mysql:5.7.34-debian-10-r55
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -3459,7 +3459,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql
       namespace: default
     ---
@@ -3472,7 +3472,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql-headless
       namespace: default
     ---
@@ -3485,7 +3485,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql
       namespace: default
     ---
@@ -3498,7 +3498,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql
       namespace: default
     ---
@@ -5057,7 +5057,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
@@ -5074,7 +5074,7 @@ data:
     datadir=/bitnami/mysql/data
     tmpdir=/opt/bitnami/mysql/tmp
     max_allowed_packet=16M
-    bind-address=0.0.0.0
+    bind-address=*
     pid-file=/opt/bitnami/mysql/tmp/mysqld.pid
     log-error=/opt/bitnami/mysql/logs/mysqld.log
     character-set-server=UTF8
@@ -7584,7 +7584,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
@@ -7612,11 +7612,10 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
-  annotations:
 spec:
   type: ClusterIP
   clusterIP: None
@@ -8717,7 +8716,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
@@ -8735,10 +8734,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/configuration: 11b8361c0fbf695cec6ec7f47ed4118ad3c7d71a391ca246df129803d3e205a5
+        checksum/configuration: 0c1e0d4282c8f8f820f3c9d1d79b3f423c4676afac2e3a6de555f8553f146eb4
       labels:
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: primary
@@ -8757,7 +8756,7 @@ spec:
         fsGroup: 1001
       initContainers:
         - name: volume-permissions
-          image: docker.io/bitnami/bitnami-shell:10-debian-10-r431
+          image: /docker.io/bitnami/bitnami-shell:11-debian-11-r60
           imagePullPolicy: "IfNotPresent"
           command:
             - /bin/bash
@@ -8773,7 +8772,7 @@ spec:
               mountPath: /bitnami/mysql
       containers:
         - name: mysql
-          image: docker.io/bitnami/mysql:5.7.34-debian-10-r55
+          image: /docker.io/bitnami/mysql:5.7.34-debian-10-r55
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -179,7 +179,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -746,7 +746,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -985,7 +985,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
@@ -1115,7 +1115,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1131,7 +1131,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1162,7 +1162,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1228,7 +1228,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -3570,7 +3570,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus
       namespace: default
     ---
@@ -3582,7 +3582,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus
       namespace: default
     ---
@@ -3594,7 +3594,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: rabbitmq
       namespace: default
     ---
@@ -3606,7 +3606,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus-config
       namespace: default
     ---
@@ -3618,7 +3618,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus
       namespace: default
     ---
@@ -3630,7 +3630,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: load-definition
       namespace: default
     ---
@@ -3642,7 +3642,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: rabbitmq
       namespace: default
     ---
@@ -3654,7 +3654,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus-endpoint-reader
       namespace: default
     ---
@@ -3666,7 +3666,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus-endpoint-reader
       namespace: default
     ---
@@ -3678,7 +3678,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus-headless
       namespace: default
     ---
@@ -3690,7 +3690,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus
       namespace: default
     ---
@@ -3702,7 +3702,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus
       namespace: default
     ---
@@ -6624,7 +6624,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 rules:
@@ -6985,7 +6985,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 subjects:
@@ -7478,7 +7478,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -7522,7 +7522,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -8519,7 +8519,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -8536,12 +8536,12 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/config: 2ca9db593e4ca6cdd01f7a65cce1ae90d0d45ecdf0049edfaa4ec72302fcbe8f
-        checksum/secret: c231bbb08185305defa8c4da0f3ee0f5e7a16795362a2133f74e53eb9a40453d
+        checksum/config: ccb825978bbf430cbaaf1b4d7c01a8fe2a1a98c853eccc8f52d744f86a426f73
+        checksum/secret: f868bf6193d744bac3cf4076eb14da2cf788e6e9092e106acc57aa6a4cc7148c
         prometheus.io/port: '9419'
         prometheus.io/scrape: "true"
     spec:
@@ -8561,7 +8561,7 @@ spec:
       initContainers:
       containers:
         - name: rabbitmq
-          image: docker.io/bitnami/rabbitmq:3.10.2-debian-10-r7
+          image: docker.io/bitnami/rabbitmq:3.10.7-debian-11-r4
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true
@@ -8657,9 +8657,9 @@ spec:
             timeoutSeconds: 20
             exec:
               command:
-                - /bin/bash
+                - sh
                 - -ec
-                - rabbitmq-diagnostics -q ping
+                - test "$(curl -f --user gitpod:$RABBITMQ_PASSWORD 127.0.0.1:15672/api/healthchecks/node)" = '{"status":"ok"}'
           readinessProbe:
             failureThreshold: 3
             initialDelaySeconds: 10
@@ -8668,9 +8668,9 @@ spec:
             timeoutSeconds: 20
             exec:
               command:
-                - /bin/bash
+                - sh
                 - -ec
-                - rabbitmq-diagnostics -q check_running && rabbitmq-diagnostics -q check_local_alarms
+                - curl -f --user gitpod:$RABBITMQ_PASSWORD 127.0.0.1:15672/api/health/checks/local-alarms
           resources:
             limits: {}
             requests: {}

--- a/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
+++ b/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
@@ -179,7 +179,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -968,7 +968,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1207,7 +1207,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
@@ -1337,7 +1337,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1353,7 +1353,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1384,7 +1384,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1450,7 +1450,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -3891,7 +3891,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus
       namespace: default
     ---
@@ -3903,7 +3903,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus
       namespace: default
     ---
@@ -3915,7 +3915,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: rabbitmq
       namespace: default
     ---
@@ -3927,7 +3927,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus-config
       namespace: default
     ---
@@ -3939,7 +3939,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus
       namespace: default
     ---
@@ -3951,7 +3951,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: load-definition
       namespace: default
     ---
@@ -3963,7 +3963,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: rabbitmq
       namespace: default
     ---
@@ -3975,7 +3975,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus-endpoint-reader
       namespace: default
     ---
@@ -3987,7 +3987,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus-endpoint-reader
       namespace: default
     ---
@@ -3999,7 +3999,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus-headless
       namespace: default
     ---
@@ -4011,7 +4011,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus
       namespace: default
     ---
@@ -4023,7 +4023,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus
       namespace: default
     ---
@@ -7036,7 +7036,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 rules:
@@ -7417,7 +7417,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 subjects:
@@ -7910,7 +7910,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -7954,7 +7954,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -8951,7 +8951,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -8968,12 +8968,12 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/config: 2ca9db593e4ca6cdd01f7a65cce1ae90d0d45ecdf0049edfaa4ec72302fcbe8f
-        checksum/secret: c231bbb08185305defa8c4da0f3ee0f5e7a16795362a2133f74e53eb9a40453d
+        checksum/config: ccb825978bbf430cbaaf1b4d7c01a8fe2a1a98c853eccc8f52d744f86a426f73
+        checksum/secret: f868bf6193d744bac3cf4076eb14da2cf788e6e9092e106acc57aa6a4cc7148c
         prometheus.io/port: '9419'
         prometheus.io/scrape: "true"
     spec:
@@ -8993,7 +8993,7 @@ spec:
       initContainers:
       containers:
         - name: rabbitmq
-          image: docker.io/bitnami/rabbitmq:3.10.2-debian-10-r7
+          image: docker.io/bitnami/rabbitmq:3.10.7-debian-11-r4
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true
@@ -9089,9 +9089,9 @@ spec:
             timeoutSeconds: 20
             exec:
               command:
-                - /bin/bash
+                - sh
                 - -ec
-                - rabbitmq-diagnostics -q ping
+                - test "$(curl -f --user gitpod:$RABBITMQ_PASSWORD 127.0.0.1:15672/api/healthchecks/node)" = '{"status":"ok"}'
           readinessProbe:
             failureThreshold: 3
             initialDelaySeconds: 10
@@ -9100,9 +9100,9 @@ spec:
             timeoutSeconds: 20
             exec:
               command:
-                - /bin/bash
+                - sh
                 - -ec
-                - rabbitmq-diagnostics -q check_running && rabbitmq-diagnostics -q check_local_alarms
+                - curl -f --user gitpod:$RABBITMQ_PASSWORD 127.0.0.1:15672/api/health/checks/local-alarms
           resources:
             limits: {}
             requests: {}

--- a/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
+++ b/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
@@ -3780,7 +3780,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql
       namespace: default
     ---
@@ -3793,7 +3793,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql-headless
       namespace: default
     ---
@@ -3806,7 +3806,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql
       namespace: default
     ---
@@ -3819,7 +3819,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql
       namespace: default
     ---
@@ -5378,7 +5378,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
@@ -5395,7 +5395,7 @@ data:
     datadir=/bitnami/mysql/data
     tmpdir=/opt/bitnami/mysql/tmp
     max_allowed_packet=16M
-    bind-address=0.0.0.0
+    bind-address=*
     pid-file=/opt/bitnami/mysql/tmp/mysqld.pid
     log-error=/opt/bitnami/mysql/logs/mysqld.log
     character-set-server=UTF8
@@ -8016,7 +8016,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
@@ -8044,11 +8044,10 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
-  annotations:
 spec:
   type: ClusterIP
   clusterIP: None
@@ -9149,7 +9148,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
@@ -9167,10 +9166,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/configuration: 11b8361c0fbf695cec6ec7f47ed4118ad3c7d71a391ca246df129803d3e205a5
+        checksum/configuration: 0c1e0d4282c8f8f820f3c9d1d79b3f423c4676afac2e3a6de555f8553f146eb4
       labels:
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: primary
@@ -9189,7 +9188,7 @@ spec:
         fsGroup: 1001
       initContainers:
         - name: volume-permissions
-          image: docker.io/bitnami/bitnami-shell:10-debian-10-r431
+          image: /docker.io/bitnami/bitnami-shell:11-debian-11-r60
           imagePullPolicy: "IfNotPresent"
           command:
             - /bin/bash
@@ -9205,7 +9204,7 @@ spec:
               mountPath: /bitnami/mysql
       containers:
         - name: mysql
-          image: docker.io/bitnami/mysql:5.7.34-debian-10-r55
+          image: /docker.io/bitnami/mysql:5.7.34-debian-10-r55
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true

--- a/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
+++ b/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
@@ -179,7 +179,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -746,7 +746,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -985,7 +985,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
@@ -1115,7 +1115,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1131,7 +1131,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1162,7 +1162,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1228,7 +1228,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -3560,7 +3560,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus
       namespace: default
     ---
@@ -3572,7 +3572,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus
       namespace: default
     ---
@@ -3584,7 +3584,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: rabbitmq
       namespace: default
     ---
@@ -3596,7 +3596,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus-config
       namespace: default
     ---
@@ -3608,7 +3608,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus
       namespace: default
     ---
@@ -3620,7 +3620,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: load-definition
       namespace: default
     ---
@@ -3632,7 +3632,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: rabbitmq
       namespace: default
     ---
@@ -3644,7 +3644,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus-endpoint-reader
       namespace: default
     ---
@@ -3656,7 +3656,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus-endpoint-reader
       namespace: default
     ---
@@ -3668,7 +3668,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus-headless
       namespace: default
     ---
@@ -3680,7 +3680,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus
       namespace: default
     ---
@@ -3692,7 +3692,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus
       namespace: default
     ---
@@ -6614,7 +6614,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 rules:
@@ -6975,7 +6975,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 subjects:
@@ -7468,7 +7468,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -7512,7 +7512,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -8509,7 +8509,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -8526,12 +8526,12 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/config: 2ca9db593e4ca6cdd01f7a65cce1ae90d0d45ecdf0049edfaa4ec72302fcbe8f
-        checksum/secret: c231bbb08185305defa8c4da0f3ee0f5e7a16795362a2133f74e53eb9a40453d
+        checksum/config: ccb825978bbf430cbaaf1b4d7c01a8fe2a1a98c853eccc8f52d744f86a426f73
+        checksum/secret: f868bf6193d744bac3cf4076eb14da2cf788e6e9092e106acc57aa6a4cc7148c
         prometheus.io/port: '9419'
         prometheus.io/scrape: "true"
     spec:
@@ -8551,7 +8551,7 @@ spec:
       initContainers:
       containers:
         - name: rabbitmq
-          image: docker.io/bitnami/rabbitmq:3.10.2-debian-10-r7
+          image: docker.io/bitnami/rabbitmq:3.10.7-debian-11-r4
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true
@@ -8647,9 +8647,9 @@ spec:
             timeoutSeconds: 20
             exec:
               command:
-                - /bin/bash
+                - sh
                 - -ec
-                - rabbitmq-diagnostics -q ping
+                - test "$(curl -f --user gitpod:$RABBITMQ_PASSWORD 127.0.0.1:15672/api/healthchecks/node)" = '{"status":"ok"}'
           readinessProbe:
             failureThreshold: 3
             initialDelaySeconds: 10
@@ -8658,9 +8658,9 @@ spec:
             timeoutSeconds: 20
             exec:
               command:
-                - /bin/bash
+                - sh
                 - -ec
-                - rabbitmq-diagnostics -q check_running && rabbitmq-diagnostics -q check_local_alarms
+                - curl -f --user gitpod:$RABBITMQ_PASSWORD 127.0.0.1:15672/api/health/checks/local-alarms
           resources:
             limits: {}
             requests: {}

--- a/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
+++ b/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
@@ -3449,7 +3449,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql
       namespace: default
     ---
@@ -3462,7 +3462,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql-headless
       namespace: default
     ---
@@ -3475,7 +3475,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql
       namespace: default
     ---
@@ -3488,7 +3488,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql
       namespace: default
     ---
@@ -5047,7 +5047,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
@@ -5064,7 +5064,7 @@ data:
     datadir=/bitnami/mysql/data
     tmpdir=/opt/bitnami/mysql/tmp
     max_allowed_packet=16M
-    bind-address=0.0.0.0
+    bind-address=*
     pid-file=/opt/bitnami/mysql/tmp/mysqld.pid
     log-error=/opt/bitnami/mysql/logs/mysqld.log
     character-set-server=UTF8
@@ -7574,7 +7574,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
@@ -7602,11 +7602,10 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
-  annotations:
 spec:
   type: ClusterIP
   clusterIP: None
@@ -8707,7 +8706,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
@@ -8725,10 +8724,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/configuration: 11b8361c0fbf695cec6ec7f47ed4118ad3c7d71a391ca246df129803d3e205a5
+        checksum/configuration: 0c1e0d4282c8f8f820f3c9d1d79b3f423c4676afac2e3a6de555f8553f146eb4
       labels:
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: primary
@@ -8747,7 +8746,7 @@ spec:
         fsGroup: 1001
       initContainers:
         - name: volume-permissions
-          image: docker.io/bitnami/bitnami-shell:10-debian-10-r431
+          image: /docker.io/bitnami/bitnami-shell:11-debian-11-r60
           imagePullPolicy: "IfNotPresent"
           command:
             - /bin/bash
@@ -8763,7 +8762,7 @@ spec:
               mountPath: /bitnami/mysql
       containers:
         - name: mysql
-          image: docker.io/bitnami/mysql:5.7.34-debian-10-r55
+          image: /docker.io/bitnami/mysql:5.7.34-debian-10-r55
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true

--- a/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
+++ b/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
@@ -179,7 +179,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -746,7 +746,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -985,7 +985,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
@@ -1115,7 +1115,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1131,7 +1131,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1162,7 +1162,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1228,7 +1228,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -3561,7 +3561,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus
       namespace: default
     ---
@@ -3573,7 +3573,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus
       namespace: default
     ---
@@ -3585,7 +3585,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: rabbitmq
       namespace: default
     ---
@@ -3597,7 +3597,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus-config
       namespace: default
     ---
@@ -3609,7 +3609,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus
       namespace: default
     ---
@@ -3621,7 +3621,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: load-definition
       namespace: default
     ---
@@ -3633,7 +3633,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: rabbitmq
       namespace: default
     ---
@@ -3645,7 +3645,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus-endpoint-reader
       namespace: default
     ---
@@ -3657,7 +3657,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus-endpoint-reader
       namespace: default
     ---
@@ -3669,7 +3669,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus-headless
       namespace: default
     ---
@@ -3681,7 +3681,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus
       namespace: default
     ---
@@ -3693,7 +3693,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
       name: messagebus
       namespace: default
     ---
@@ -6615,7 +6615,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 rules:
@@ -6976,7 +6976,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 subjects:
@@ -7469,7 +7469,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -7513,7 +7513,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -8510,7 +8510,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-10.1.19
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -8527,12 +8527,12 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-10.1.19
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/config: 2ca9db593e4ca6cdd01f7a65cce1ae90d0d45ecdf0049edfaa4ec72302fcbe8f
-        checksum/secret: c231bbb08185305defa8c4da0f3ee0f5e7a16795362a2133f74e53eb9a40453d
+        checksum/config: ccb825978bbf430cbaaf1b4d7c01a8fe2a1a98c853eccc8f52d744f86a426f73
+        checksum/secret: f868bf6193d744bac3cf4076eb14da2cf788e6e9092e106acc57aa6a4cc7148c
         prometheus.io/port: '9419'
         prometheus.io/scrape: "true"
     spec:
@@ -8552,7 +8552,7 @@ spec:
       initContainers:
       containers:
         - name: rabbitmq
-          image: docker.io/bitnami/rabbitmq:3.10.2-debian-10-r7
+          image: docker.io/bitnami/rabbitmq:3.10.7-debian-11-r4
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true
@@ -8648,9 +8648,9 @@ spec:
             timeoutSeconds: 20
             exec:
               command:
-                - /bin/bash
+                - sh
                 - -ec
-                - rabbitmq-diagnostics -q ping
+                - test "$(curl -f --user gitpod:$RABBITMQ_PASSWORD 127.0.0.1:15672/api/healthchecks/node)" = '{"status":"ok"}'
           readinessProbe:
             failureThreshold: 3
             initialDelaySeconds: 10
@@ -8659,9 +8659,9 @@ spec:
             timeoutSeconds: 20
             exec:
               command:
-                - /bin/bash
+                - sh
                 - -ec
-                - rabbitmq-diagnostics -q check_running && rabbitmq-diagnostics -q check_local_alarms
+                - curl -f --user gitpod:$RABBITMQ_PASSWORD 127.0.0.1:15672/api/health/checks/local-alarms
           resources:
             limits: {}
             requests: {}

--- a/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
+++ b/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
@@ -3450,7 +3450,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql
       namespace: default
     ---
@@ -3463,7 +3463,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql-headless
       namespace: default
     ---
@@ -3476,7 +3476,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql
       namespace: default
     ---
@@ -3489,7 +3489,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql
       namespace: default
     ---
@@ -5048,7 +5048,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
@@ -5065,7 +5065,7 @@ data:
     datadir=/bitnami/mysql/data
     tmpdir=/opt/bitnami/mysql/tmp
     max_allowed_packet=16M
-    bind-address=0.0.0.0
+    bind-address=*
     pid-file=/opt/bitnami/mysql/tmp/mysqld.pid
     log-error=/opt/bitnami/mysql/logs/mysqld.log
     character-set-server=UTF8
@@ -7575,7 +7575,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
@@ -7603,11 +7603,10 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
-  annotations:
 spec:
   type: ClusterIP
   clusterIP: None
@@ -8708,7 +8707,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
@@ -8726,10 +8725,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/configuration: 11b8361c0fbf695cec6ec7f47ed4118ad3c7d71a391ca246df129803d3e205a5
+        checksum/configuration: 0c1e0d4282c8f8f820f3c9d1d79b3f423c4676afac2e3a6de555f8553f146eb4
       labels:
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: primary
@@ -8748,7 +8747,7 @@ spec:
         fsGroup: 1001
       initContainers:
         - name: volume-permissions
-          image: docker.io/bitnami/bitnami-shell:10-debian-10-r431
+          image: /docker.io/bitnami/bitnami-shell:11-debian-11-r60
           imagePullPolicy: "IfNotPresent"
           command:
             - /bin/bash
@@ -8764,7 +8763,7 @@ spec:
               mountPath: /bitnami/mysql
       containers:
         - name: mysql
-          image: docker.io/bitnami/mysql:5.7.34-debian-10-r55
+          image: /docker.io/bitnami/mysql:5.7.34-debian-10-r55
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true

--- a/install/installer/third_party/charts/mysql/Chart.yaml
+++ b/install/installer/third_party/charts/mysql/Chart.yaml
@@ -8,5 +8,5 @@ name: mysql
 version: 1.0.0
 dependencies:
   - name: mysql
-    version: 9.1.2
+    version: 9.4.5
     repository: https://charts.bitnami.com/bitnami

--- a/install/installer/third_party/charts/rabbitmq/Chart.yaml
+++ b/install/installer/third_party/charts/rabbitmq/Chart.yaml
@@ -8,5 +8,5 @@ name: rabbitmq
 version: 1.0.0
 dependencies:
   - name: rabbitmq
-    version: 10.1.1
+    version: 10.1.19
     repository: https://charts.bitnami.com/bitnami


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

[Build issues](https://gitpod.slack.com/archives/C01KGM9EBD4/p1671478789723099) seem to occur as our current mysql chart version does not seem to be available. This seems to be due to [bitnami's 6 month retention policy](https://github.com/bitnami/charts/issues/14029#issuecomment-1357925642)

This PR tries to fix that by upgrading `mysql` to the latest `9.4.5` version

Signed-off-by: Tarun Pothulapati <tarun@gitpod.io>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

Test a preview environment with incluster database to work fine.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[installer] Upgrade `bitnami/mysql` to `9.4.5`
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
