### PR TITLE
ws-manager: Prevent duplication of stop metrics

### DIFF
--- a/components/ws-manager/pkg/manager/metrics.go
+++ b/components/ws-manager/pkg/manager/metrics.go
@@ -300,6 +300,14 @@ func (m *metrics) OnChange(status *api.WorkspaceStatus) {
 		hist.Observe(time.Since(t).Seconds())
 
 	case api.WorkspacePhase_STOPPED:
+		previousStatus, ok := m.phaseState[status.Id]
+		if !ok {
+			return
+		}
+		if previousStatus == api.WorkspacePhase_STOPPED {
+			return
+		}
+
 		var reason string
 		if strings.Contains(status.Message, string(activityClosed)) {
 			reason = "tab-closed"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

Fixes https://github.com/gitpod-io/gitpod/issues/15231

## How to test
<!-- Provide steps to test this PR -->

I created the preview env which has the below changes to test.
https://to-dup-stopped.preview.gitpod-dev.com/workspaces

```diff
gitpod /workspace/gitpod (to/dup-stopped) $ git diff
diff --git a/components/ws-daemon/pkg/iws/iws.go b/components/ws-daemon/pkg/iws/iws.go
index bda1e587f..95e1c3d09 100644
--- a/components/ws-daemon/pkg/iws/iws.go
+++ b/components/ws-daemon/pkg/iws/iws.go
@@ -155,7 +155,7 @@ func (wbs *InWorkspaceServiceServer) Start() error {
                return xerrors.Errorf("cannot create ServiceLocDaemon: %w", err)
        }
 
-       socketFN := filepath.Join(wbs.Session.ServiceLocDaemon, "daemon.sock")
+       socketFN := filepath.Join(wbs.Session.ServiceLocDaemon, "invalid.sock")
        if _, err := os.Stat(socketFN); err == nil {
                // a former ws-daemon instance left their sockets laying around.
                // Let's clean up after them.
diff --git a/components/ws-manager/pkg/manager/metrics.go b/components/ws-manager/pkg/manager/metrics.go
index a33cefb8e..a7d19868a 100644
--- a/components/ws-manager/pkg/manager/metrics.go
+++ b/components/ws-manager/pkg/manager/metrics.go
@@ -300,11 +300,14 @@ func (m *metrics) OnChange(status *api.WorkspaceStatus) {
                hist.Observe(time.Since(t).Seconds())
 
        case api.WorkspacePhase_STOPPED:
+               log.Warn("stopped in onChange")
                previousStatus, ok := m.phaseState[status.Id]
                if !ok {
+                       log.Warn("return in onChange")
                        return
                }
                if previousStatus == api.WorkspacePhase_STOPPED {
+                       log.Warn("return in onChange")
                        return
                }
 
```

You can open a new workspace and get failed. After that, please check the logs of `ws-manager`. You can find that metric isn't incremented two times.

<details>
<summary>Example logs</summary>

It is easier to see by searching the words `"level":"warning","message":"`. For the first time, there should be no return log.

```
{"auth":{"ownerToken":"[redacted]"},"conditions":{"failed":"container workspace ran with an error: exit code 1","volumeSnapshot":{}},"file":"manager.go:1411","func":"onChange","id":"599ad366-9def-403e-b26c-dfd87ded896a","instanceId":"599ad366-9def-403e-b26c-dfd87ded896a","level":"error","message":"workspace failed","metadata":{"metaId":"gitpodsampl-templategol-l2vkjb7fvyq","owner":"d16e6e8e-d86c-4bf9-b568-133a3308067e","startedAt":"2022-12-20T08:02:21Z"},"phase":"RUNNING","runtime":{"nodeIp":"10.0.2.2","nodeName":"to-dup-stopped","podName":"ws-599ad366-9def-403e-b26c-dfd87ded896a"},"serviceContext":{"service":"ws-manager","version":"commit-b528e01919b6404bfd98d42eee72a489b18a2209-921511ef38406ce05e8ac2f555730e536170ad91"},"severity":"ERROR","spec":{"class":"default","deprecatedIdeImage":"eu.gcr.io/gitpod-core-dev/build/ide/code:commit-73b9682c5040a9fec5a02e066aa48faa635f5ca5","ideImage":{"supervisorRef":"eu.gcr.io/gitpod-core-dev/build/supervisor:commit-07875d6c2172dec96b5b3006847879faac7df849","webRef":"eu.gcr.io/gitpod-core-dev/build/ide/code:commit-73b9682c5040a9fec5a02e066aa48faa635f5ca5"},"ideImageLayers":["",""],"timeout":"30m","url":"https://gitpodsampl-templategol-l2vkjb7fvyq.ws-dev.to-dup-stopped.preview.gitpod-dev.com","workspaceImage":"eu.gcr.io/gitpod-core-dev/build/workspace-images:aefa78bac7a3f471db1c6901dee79eb4f1809f963584f4fa230f4e1ccbaa07f8"},"statusVersion":"109544961671168","time":"2022-12-20T08:04:23.512691368Z","userId":"d16e6e8e-d86c-4bf9-b568-133a3308067e","workspaceId":"gitpodsampl-templategol-l2vkjb7fvyq"}
{"auth":{"ownerToken":"[redacted]"},"conditions":{"failed":"container workspace ran with an error: exit code 1","volumeSnapshot":{}},"file":"manager.go:1411","func":"onChange","id":"599ad366-9def-403e-b26c-dfd87ded896a","instanceId":"599ad366-9def-403e-b26c-dfd87ded896a","level":"error","message":"workspace failed","metadata":{"metaId":"gitpodsampl-templategol-l2vkjb7fvyq","owner":"d16e6e8e-d86c-4bf9-b568-133a3308067e","startedAt":"2022-12-20T08:02:21Z"},"phase":"RUNNING","runtime":{"nodeIp":"10.0.2.2","nodeName":"to-dup-stopped","podName":"ws-599ad366-9def-403e-b26c-dfd87ded896a"},"serviceContext":{"service":"ws-manager","version":"commit-b528e01919b6404bfd98d42eee72a489b18a2209-921511ef38406ce05e8ac2f555730e536170ad91"},"severity":"ERROR","spec":{"class":"default","deprecatedIdeImage":"eu.gcr.io/gitpod-core-dev/build/ide/code:commit-73b9682c5040a9fec5a02e066aa48faa635f5ca5","ideImage":{"supervisorRef":"eu.gcr.io/gitpod-core-dev/build/supervisor:commit-07875d6c2172dec96b5b3006847879faac7df849","webRef":"eu.gcr.io/gitpod-core-dev/build/ide/code:commit-73b9682c5040a9fec5a02e066aa48faa635f5ca5"},"ideImageLayers":["",""],"timeout":"30m","url":"https://gitpodsampl-templategol-l2vkjb7fvyq.ws-dev.to-dup-stopped.preview.gitpod-dev.com","workspaceImage":"eu.gcr.io/gitpod-core-dev/build/workspace-images:aefa78bac7a3f471db1c6901dee79eb4f1809f963584f4fa230f4e1ccbaa07f8"},"statusVersion":"109544961671170","time":"2022-12-20T08:04:23.55373329Z","userId":"d16e6e8e-d86c-4bf9-b568-133a3308067e","workspaceId":"gitpodsampl-templategol-l2vkjb7fvyq"}
{"auth":{"ownerToken":"[redacted]"},"conditions":{"failed":"workspace failed to start.","volumeSnapshot":{}},"file":"manager.go:1411","func":"onChange","id":"599ad366-9def-403e-b26c-dfd87ded896a","instanceId":"599ad366-9def-403e-b26c-dfd87ded896a","level":"error","message":"workspace failed","metadata":{"metaId":"gitpodsampl-templategol-l2vkjb7fvyq","owner":"d16e6e8e-d86c-4bf9-b568-133a3308067e","startedAt":"2022-12-20T08:02:21Z"},"phase":"STOPPING","runtime":{"nodeIp":"10.0.2.2","nodeName":"to-dup-stopped","podName":"ws-599ad366-9def-403e-b26c-dfd87ded896a"},"serviceContext":{"service":"ws-manager","version":"commit-b528e01919b6404bfd98d42eee72a489b18a2209-921511ef38406ce05e8ac2f555730e536170ad91"},"severity":"ERROR","spec":{"class":"default","deprecatedIdeImage":"eu.gcr.io/gitpod-core-dev/build/ide/code:commit-73b9682c5040a9fec5a02e066aa48faa635f5ca5","ideImage":{"supervisorRef":"eu.gcr.io/gitpod-core-dev/build/supervisor:commit-07875d6c2172dec96b5b3006847879faac7df849","webRef":"eu.gcr.io/gitpod-core-dev/build/ide/code:commit-73b9682c5040a9fec5a02e066aa48faa635f5ca5"},"ideImageLayers":["",""],"timeout":"30m","url":"https://gitpodsampl-templategol-l2vkjb7fvyq.ws-dev.to-dup-stopped.preview.gitpod-dev.com","workspaceImage":"eu.gcr.io/gitpod-core-dev/build/workspace-images:aefa78bac7a3f471db1c6901dee79eb4f1809f963584f4fa230f4e1ccbaa07f8"},"statusVersion":"109544961671173","time":"2022-12-20T08:04:23.621796423Z","userId":"d16e6e8e-d86c-4bf9-b568-133a3308067e","workspaceId":"gitpodsampl-templategol-l2vkjb7fvyq"}
{"file":"export.go:74","func":"Warn","level":"warning","message":"stopped in onChange","serviceContext":{"service":"ws-manager","version":"commit-b528e01919b6404bfd98d42eee72a489b18a2209-921511ef38406ce05e8ac2f555730e536170ad91"},"severity":"WARNING","time":"2022-12-20T08:04:23.638840326Z"}
{"auth":{"ownerToken":"[redacted]"},"conditions":{"failed":"workspace failed to start.","volumeSnapshot":{}},"file":"manager.go:1411","func":"onChange","id":"599ad366-9def-403e-b26c-dfd87ded896a","instanceId":"599ad366-9def-403e-b26c-dfd87ded896a","level":"error","message":"workspace failed","metadata":{"metaId":"gitpodsampl-templategol-l2vkjb7fvyq","owner":"d16e6e8e-d86c-4bf9-b568-133a3308067e","startedAt":"2022-12-20T08:02:21Z"},"phase":"STOPPED","runtime":{"nodeIp":"10.0.2.2","nodeName":"to-dup-stopped","podName":"ws-599ad366-9def-403e-b26c-dfd87ded896a"},"serviceContext":{"service":"ws-manager","version":"commit-b528e01919b6404bfd98d42eee72a489b18a2209-921511ef38406ce05e8ac2f555730e536170ad91"},"severity":"ERROR","spec":{"class":"default","deprecatedIdeImage":"eu.gcr.io/gitpod-core-dev/build/ide/code:commit-73b9682c5040a9fec5a02e066aa48faa635f5ca5","ideImage":{"supervisorRef":"eu.gcr.io/gitpod-core-dev/build/supervisor:commit-07875d6c2172dec96b5b3006847879faac7df849","webRef":"eu.gcr.io/gitpod-core-dev/build/ide/code:commit-73b9682c5040a9fec5a02e066aa48faa635f5ca5"},"ideImageLayers":["",""],"timeout":"30m","url":"https://gitpodsampl-templategol-l2vkjb7fvyq.ws-dev.to-dup-stopped.preview.gitpod-dev.com","workspaceImage":"eu.gcr.io/gitpod-core-dev/build/workspace-images:aefa78bac7a3f471db1c6901dee79eb4f1809f963584f4fa230f4e1ccbaa07f8"},"statusVersion":"109544961671174","time":"2022-12-20T08:04:23.639154535Z","userId":"d16e6e8e-d86c-4bf9-b568-133a3308067e","workspaceId":"gitpodsampl-templategol-l2vkjb7fvyq"}
{"file":"export.go:74","func":"Warn","level":"warning","message":"stopped in onChange","serviceContext":{"service":"ws-manager","version":"commit-b528e01919b6404bfd98d42eee72a489b18a2209-921511ef38406ce05e8ac2f555730e536170ad91"},"severity":"WARNING","time":"2022-12-20T08:04:23.661065178Z"}
{"file":"export.go:74","func":"Warn","level":"warning","message":"return in onChange","serviceContext":{"service":"ws-manager","version":"commit-b528e01919b6404bfd98d42eee72a489b18a2209-921511ef38406ce05e8ac2f555730e536170ad91"},"severity":"WARNING","time":"2022-12-20T08:04:23.66112525Z"}
{"auth":{"ownerToken":"[redacted]"},"conditions":{"failed":"workspace failed to start.","volumeSnapshot":{}},"file":"manager.go:1411","func":"onChange","id":"599ad366-9def-403e-b26c-dfd87ded896a","instanceId":"599ad366-9def-403e-b26c-dfd87ded896a","level":"error","message":"workspace failed","metadata":{"metaId":"gitpodsampl-templategol-l2vkjb7fvyq","owner":"d16e6e8e-d86c-4bf9-b568-133a3308067e","startedAt":"2022-12-20T08:02:21Z"},"phase":"STOPPED","runtime":{"nodeIp":"10.0.2.2","nodeName":"to-dup-stopped","podName":"ws-599ad366-9def-403e-b26c-dfd87ded896a"},"serviceContext":{"service":"ws-manager","version":"commit-b528e01919b6404bfd98d42eee72a489b18a2209-921511ef38406ce05e8ac2f555730e536170ad91"},"severity":"ERROR","spec":{"class":"default","deprecatedIdeImage":"eu.gcr.io/gitpod-core-dev/build/ide/code:commit-73b9682c5040a9fec5a02e066aa48faa635f5ca5","ideImage":{"supervisorRef":"eu.gcr.io/gitpod-core-dev/build/supervisor:commit-07875d6c2172dec96b5b3006847879faac7df849","webRef":"eu.gcr.io/gitpod-core-dev/build/ide/code:commit-73b9682c5040a9fec5a02e066aa48faa635f5ca5"},"ideImageLayers":["",""],"timeout":"30m","url":"https://gitpodsampl-templategol-l2vkjb7fvyq.ws-dev.to-dup-stopped.preview.gitpod-dev.com","workspaceImage":"eu.gcr.io/gitpod-core-dev/build/workspace-images:aefa78bac7a3f471db1c6901dee79eb4f1809f963584f4fa230f4e1ccbaa07f8"},"statusVersion":"109544961671175","time":"2022-12-20T08:04:23.661339552Z","userId":"d16e6e8e-d86c-4bf9-b568-133a3308067e","workspaceId":"gitpodsampl-templategol-l2vkjb7fvyq"}
{"file":"export.go:74","func":"Warn","level":"warning","message":"stopped in onChange","serviceContext":{"service":"ws-manager","version":"commit-b528e01919b6404bfd98d42eee72a489b18a2209-921511ef38406ce05e8ac2f555730e536170ad91"},"severity":"WARNING","time":"2022-12-20T08:04:23.84728036Z"}
{"file":"export.go:74","func":"Warn","level":"warning","message":"return in onChange","serviceContext":{"service":"ws-manager","version":"commit-b528e01919b6404bfd98d42eee72a489b18a2209-921511ef38406ce05e8ac2f555730e536170ad91"},"severity":"WARNING","time":"2022-12-20T08:04:23.847357986Z"}
{"auth":{"ownerToken":"[redacted]"},"conditions":{"failed":"workspace failed to start.","volumeSnapshot":{}},"file":"manager.go:1411","func":"onChange","id":"599ad366-9def-403e-b26c-dfd87ded896a","instanceId":"599ad366-9def-403e-b26c-dfd87ded896a","level":"error","message":"workspace failed","metadata":{"metaId":"gitpodsampl-templategol-l2vkjb7fvyq","owner":"d16e6e8e-d86c-4bf9-b568-133a3308067e","startedAt":"2022-12-20T08:02:21Z"},"phase":"STOPPED","runtime":{"nodeIp":"10.0.2.2","nodeName":"to-dup-stopped","podName":"ws-599ad366-9def-403e-b26c-dfd87ded896a"},"serviceContext":{"service":"ws-manager","version":"commit-b528e01919b6404bfd98d42eee72a489b18a2209-921511ef38406ce05e8ac2f555730e536170ad91"},"severity":"ERROR","spec":{"class":"default","deprecatedIdeImage":"eu.gcr.io/gitpod-core-dev/build/ide/code:commit-73b9682c5040a9fec5a02e066aa48faa635f5ca5","ideImage":{"supervisorRef":"eu.gcr.io/gitpod-core-dev/build/supervisor:commit-07875d6c2172dec96b5b3006847879faac7df849","webRef":"eu.gcr.io/gitpod-core-dev/build/ide/code:commit-73b9682c5040a9fec5a02e066aa48faa635f5ca5"},"ideImageLayers":["",""],"timeout":"30m","url":"https://gitpodsampl-templategol-l2vkjb7fvyq.ws-dev.to-dup-stopped.preview.gitpod-dev.com","workspaceImage":"eu.gcr.io/gitpod-core-dev/build/workspace-images:aefa78bac7a3f471db1c6901dee79eb4f1809f963584f4fa230f4e1ccbaa07f8"},"statusVersion":"109544961671176","time":"2022-12-20T08:04:23.847597034Z","userId":"d16e6e8e-d86c-4bf9-b568-133a3308067e","workspaceId":"gitpodsampl-templategol-l2vkjb7fvyq"}
{"file":"export.go:74","func":"Warn","level":"warning","message":"stopped in onChange","serviceContext":{"service":"ws-manager","version":"commit-b528e01919b6404bfd98d42eee72a489b18a2209-921511ef38406ce05e8ac2f555730e536170ad91"},"severity":"WARNING","time":"2022-12-20T08:04:24.654053238Z"}
{"file":"export.go:74","func":"Warn","level":"warning","message":"return in onChange","serviceContext":{"service":"ws-manager","version":"commit-b528e01919b6404bfd98d42eee72a489b18a2209-921511ef38406ce05e8ac2f555730e536170ad91"},"severity":"WARNING","time":"2022-12-20T08:04:24.654112099Z"}
{"auth":{"ownerToken":"[redacted]"},"conditions":{"failed":"workspace failed to start.","volumeSnapshot":{}},"file":"manager.go:1411","func":"onChange","id":"599ad366-9def-403e-b26c-dfd87ded896a","instanceId":"599ad366-9def-403e-b26c-dfd87ded896a","level":"error","message":"workspace failed","metadata":{"metaId":"gitpodsampl-templategol-l2vkjb7fvyq","owner":"d16e6e8e-d86c-4bf9-b568-133a3308067e","startedAt":"2022-12-20T08:02:21Z"},"phase":"STOPPED","runtime":{"nodeIp":"10.0.2.2","nodeName":"to-dup-stopped","podName":"ws-599ad366-9def-403e-b26c-dfd87ded896a"},"serviceContext":{"service":"ws-manager","version":"commit-b528e01919b6404bfd98d42eee72a489b18a2209-921511ef38406ce05e8ac2f555730e536170ad91"},"severity":"ERROR","spec":{"class":"default","deprecatedIdeImage":"eu.gcr.io/gitpod-core-dev/build/ide/code:commit-73b9682c5040a9fec5a02e066aa48faa635f5ca5","ideImage":{"supervisorRef":"eu.gcr.io/gitpod-core-dev/build/supervisor:commit-07875d6c2172dec96b5b3006847879faac7df849","webRef":"eu.gcr.io/gitpod-core-dev/build/ide/code:commit-73b9682c5040a9fec5a02e066aa48faa635f5ca5"},"ideImageLayers":["",""],"timeout":"30m","url":"https://gitpodsampl-templategol-l2vkjb7fvyq.ws-dev.to-dup-stopped.preview.gitpod-dev.com","workspaceImage":"eu.gcr.io/gitpod-core-dev/build/workspace-images:aefa78bac7a3f471db1c6901dee79eb4f1809f963584f4fa230f4e1ccbaa07f8"},"statusVersion":"109544961736704","time":"2022-12-20T08:04:24.654342511Z","userId":"d16e6e8e-d86c-4bf9-b568-133a3308067e","workspaceId":"gitpodsampl-templategol-l2vkjb7fvyq"}
{"file":"export.go:74","func":"Warn","level":"warning","message":"stopped in onChange","serviceContext":{"service":"ws-manager","version":"commit-b528e01919b6404bfd98d42eee72a489b18a2209-921511ef38406ce05e8ac2f555730e536170ad91"},"severity":"WARNING","time":"2022-12-20T08:04:25.067741184Z"}
{"file":"export.go:74","func":"Warn","level":"warning","message":"return in onChange","serviceContext":{"service":"ws-manager","version":"commit-b528e01919b6404bfd98d42eee72a489b18a2209-921511ef38406ce05e8ac2f555730e536170ad91"},"severity":"WARNING","time":"2022-12-20T08:04:25.06780191Z"}
{"auth":{"ownerToken":"[redacted]"},"conditions":{"failed":"workspace failed to start.","volumeSnapshot":{}},"file":"manager.go:1411","func":"onChange","id":"599ad366-9def-403e-b26c-dfd87ded896a","instanceId":"599ad366-9def-403e-b26c-dfd87ded896a","level":"error","message":"workspace failed","metadata":{"metaId":"gitpodsampl-templategol-l2vkjb7fvyq","owner":"d16e6e8e-d86c-4bf9-b568-133a3308067e","startedAt":"2022-12-20T08:02:21Z"},"phase":"STOPPED","runtime":{"nodeIp":"10.0.2.2","nodeName":"to-dup-stopped","podName":"ws-599ad366-9def-403e-b26c-dfd87ded896a"},"serviceContext":{"service":"ws-manager","version":"commit-b528e01919b6404bfd98d42eee72a489b18a2209-921511ef38406ce05e8ac2f555730e536170ad91"},"severity":"ERROR","spec":{"class":"default","deprecatedIdeImage":"eu.gcr.io/gitpod-core-dev/build/ide/code:commit-73b9682c5040a9fec5a02e066aa48faa635f5ca5","ideImage":{"supervisorRef":"eu.gcr.io/gitpod-core-dev/build/supervisor:commit-07875d6c2172dec96b5b3006847879faac7df849","webRef":"eu.gcr.io/gitpod-core-dev/build/ide/code:commit-73b9682c5040a9fec5a02e066aa48faa635f5ca5"},"ideImageLayers":["",""],"timeout":"30m","url":"https://gitpodsampl-templategol-l2vkjb7fvyq.ws-dev.to-dup-stopped.preview.gitpod-dev.com","workspaceImage":"eu.gcr.io/gitpod-core-dev/build/workspace-images:aefa78bac7a3f471db1c6901dee79eb4f1809f963584f4fa230f4e1ccbaa07f8"},"statusVersion":"109544961802240","time":"2022-12-20T08:04:25.068085871Z","userId":"d16e6e8e-d86c-4bf9-b568-133a3308067e","workspaceId":"gitpodsampl-templategol-l2vkjb7fvyq"}
{"file":"export.go:74","func":"Warn","level":"warning","message":"stopped in onChange","serviceContext":{"service":"ws-manager","version":"commit-b528e01919b6404bfd98d42eee72a489b18a2209-921511ef38406ce05e8ac2f555730e536170ad91"},"severity":"WARNING","time":"2022-12-20T08:04:25.084363338Z"}
{"file":"export.go:74","func":"Warn","level":"warning","message":"return in onChange","serviceContext":{"service":"ws-manager","version":"commit-b528e01919b6404bfd98d42eee72a489b18a2209-921511ef38406ce05e8ac2f555730e536170ad91"},"severity":"WARNING","time":"2022-12-20T08:04:25.084462985Z"}
{"auth":{"ownerToken":"[redacted]"},"conditions":{"failed":"workspace failed to start.","volumeSnapshot":{}},"file":"manager.go:1411","func":"onChange","id":"599ad366-9def-403e-b26c-dfd87ded896a","instanceId":"599ad366-9def-403e-b26c-dfd87ded896a","level":"error","message":"workspace failed","metadata":{"metaId":"gitpodsampl-templategol-l2vkjb7fvyq","owner":"d16e6e8e-d86c-4bf9-b568-133a3308067e","startedAt":"2022-12-20T08:02:21Z"},"phase":"STOPPED","runtime":{"nodeIp":"10.0.2.2","nodeName":"to-dup-stopped","podName":"ws-599ad366-9def-403e-b26c-dfd87ded896a"},"serviceContext":{"service":"ws-manager","version":"commit-b528e01919b6404bfd98d42eee72a489b18a2209-921511ef38406ce05e8ac2f555730e536170ad91"},"severity":"ERROR","spec":{"class":"default","deprecatedIdeImage":"eu.gcr.io/gitpod-core-dev/build/ide/code:commit-73b9682c5040a9fec5a02e066aa48faa635f5ca5","ideImage":{"supervisorRef":"eu.gcr.io/gitpod-core-dev/build/supervisor:commit-07875d6c2172dec96b5b3006847879faac7df849","webRef":"eu.gcr.io/gitpod-core-dev/build/ide/code:commit-73b9682c5040a9fec5a02e066aa48faa635f5ca5"},"ideImageLayers":["",""],"timeout":"30m","url":"https://gitpodsampl-templategol-l2vkjb7fvyq.ws-dev.to-dup-stopped.preview.gitpod-dev.com","workspaceImage":"eu.gcr.io/gitpod-core-dev/build/workspace-images:aefa78bac7a3f471db1c6901dee79eb4f1809f963584f4fa230f4e1ccbaa07f8"},"statusVersion":"109544961802241","time":"2022-12-20T08:04:25.084698726Z","userId":"d16e6e8e-d86c-4bf9-b568-133a3308067e","workspaceId":"gitpodsampl-templategol-l2vkjb7fvyq"}
{"file":"export.go:74","func":"Warn","level":"warning","message":"stopped in onChange","serviceContext":{"service":"ws-manager","version":"commit-b528e01919b6404bfd98d42eee72a489b18a2209-921511ef38406ce05e8ac2f555730e536170ad91"},"severity":"WARNING","time":"2022-12-20T08:04:25.089876173Z"}
{"file":"export.go:74","func":"Warn","level":"warning","message":"return in onChange","serviceContext":{"service":"ws-manager","version":"commit-b528e01919b6404bfd98d42eee72a489b18a2209-921511ef38406ce05e8ac2f555730e536170ad91"},"severity":"WARNING","time":"2022-12-20T08:04:25.089928571Z"}
{"auth":{"ownerToken":"[redacted]"},"conditions":{"failed":"workspace failed to start.","volumeSnapshot":{}},"file":"manager.go:1411","func":"onChange","id":"599ad366-9def-403e-b26c-dfd87ded896a","instanceId":"599ad366-9def-403e-b26c-dfd87ded896a","level":"error","message":"workspace failed","metadata":{"metaId":"gitpodsampl-templategol-l2vkjb7fvyq","owner":"d16e6e8e-d86c-4bf9-b568-133a3308067e","startedAt":"2022-12-20T08:02:21Z"},"phase":"STOPPED","runtime":{"nodeIp":"10.0.2.2","nodeName":"to-dup-stopped","podName":"ws-599ad366-9def-403e-b26c-dfd87ded896a"},"serviceContext":{"service":"ws-manager","version":"commit-b528e01919b6404bfd98d42eee72a489b18a2209-921511ef38406ce05e8ac2f555730e536170ad91"},"severity":"ERROR","spec":{"class":"default","deprecatedIdeImage":"eu.gcr.io/gitpod-core-dev/build/ide/code:commit-73b9682c5040a9fec5a02e066aa48faa635f5ca5","ideImage":{"supervisorRef":"eu.gcr.io/gitpod-core-dev/build/supervisor:commit-07875d6c2172dec96b5b3006847879faac7df849","webRef":"eu.gcr.io/gitpod-core-dev/build/ide/code:commit-73b9682c5040a9fec5a02e066aa48faa635f5ca5"},"ideImageLayers":["",""],"timeout":"30m","url":"https://gitpodsampl-templategol-l2vkjb7fvyq.ws-dev.to-dup-stopped.preview.gitpod-dev.com","workspaceImage":"eu.gcr.io/gitpod-core-dev/build/workspace-images:aefa78bac7a3f471db1c6901dee79eb4f1809f963584f4fa230f4e1ccbaa07f8"},"statusVersion":"109544961802242","time":"2022-12-20T08:04:25.090160526Z","userId":"d16e6e8e-d86c-4bf9-b568-133a3308067e","workspaceId":"gitpodsampl-templategol-l2vkjb7fvyq"}
```
</details>

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
