### PR TITLE
[installer] Update third_party charts to use full index

### DIFF
--- a/install/installer/third_party/charts/minio/Chart.yaml
+++ b/install/installer/third_party/charts/minio/Chart.yaml
@@ -9,4 +9,4 @@ version: 1.0.0
 dependencies:
   - name: minio
     version: 11.6.3
-    repository: https://charts.bitnami.com/bitnami
+    repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami

--- a/install/installer/third_party/charts/mysql/Chart.yaml
+++ b/install/installer/third_party/charts/mysql/Chart.yaml
@@ -9,4 +9,4 @@ version: 1.0.0
 dependencies:
   - name: mysql
     version: 9.1.2
-    repository: https://charts.bitnami.com/bitnami
+    repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami

--- a/install/installer/third_party/charts/rabbitmq/Chart.yaml
+++ b/install/installer/third_party/charts/rabbitmq/Chart.yaml
@@ -9,4 +9,4 @@ version: 1.0.0
 dependencies:
   - name: rabbitmq
     version: 10.1.1
-    repository: https://charts.bitnami.com/bitnami
+    repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This PR updates the `repository` field for third_party charts to use full index so that we don't loose out on older version charts as they get truncated.

As per https://github.com/bitnami/charts/issues/10833

Signed-off-by: Tarun Pothulapati <tarun@gitpod.io>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[installer] Update third_party charts to use full index
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [x] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
