### PR TITLE
Use terraform to manage preview environment certificates

### DIFF
--- a/dev/preview/infrastructure/harvester/cert.tf
+++ b/dev/preview/infrastructure/harvester/cert.tf
@@ -1,29 +1,119 @@
-resource "kubernetes_manifest" "cert" {
+# resource "kubernetes_manifest" "cert" {
+#   provider = k8s.dev
+#   manifest = {
+#     apiVersion = "cert-manager.io/v1"
+#     kind       = "Certificate"
+
+#     metadata = {
+#       annotations = {
+#         "preview/owner" = var.preview_name
+#       }
+#       name      = "harvester-${var.preview_name}"
+#       namespace = "certs"
+#     }
+
+#     spec = {
+#       dnsNames = [
+#         "${var.preview_name}.preview.gitpod-dev.com",
+#         "*.${var.preview_name}.preview.gitpod-dev.com",
+#         "*.ws-dev.${var.preview_name}.preview.gitpod-dev.com"
+#       ]
+#       issuerRef = {
+#         kind = "ClusterIssuer"
+#         name = var.cert_issuer
+#       }
+#       renewBefore = "24h0m0s"
+#       secretName  = "harvester-${var.preview_name}"
+#     }
+#   }
+# }
+
+data "kubernetes_secret" "zerossl_external_account_binding" {
   provider = k8s.dev
-  manifest = {
-    apiVersion = "cert-manager.io/v1"
-    kind       = "Certificate"
+  metadata {
+    name      = "zerossl-external-account-binding"
+    namespace = "certmanager"
+  }
+}
 
-    metadata = {
-      annotations = {
-        "preview/owner" = var.preview_name
-      }
-      name      = "harvester-${var.preview_name}"
-      namespace = "certs"
-    }
+data "kubernetes_secret" "zerossl_private_key" {
+  provider = k8s.dev
+  metadata {
+    name      = "zerossl-private-key"
+    namespace = "certmanager"
+  }
+}
 
-    spec = {
-      dnsNames = [
-        "${var.preview_name}.preview.gitpod-dev.com",
-        "*.${var.preview_name}.preview.gitpod-dev.com",
-        "*.ws-dev.${var.preview_name}.preview.gitpod-dev.com"
-      ]
-      issuerRef = {
-        kind = "ClusterIssuer"
-        name = var.cert_issuer
-      }
-      renewBefore = "24h0m0s"
-      secretName  = "harvester-${var.preview_name}"
+data "kubernetes_secret" "letsencrypt_private_key" {
+  provider = k8s.dev
+  metadata {
+    name      = "letsencrypt-private-key"
+    namespace = "certmanager"
+  }
+}
+
+# resource "acme_registration" "letsencrypt" {
+#   provider = acme.letsencrypt
+#   account_key_pem = lookup(data.kubernetes_secret.letsencrypt_private_key.data, "tls.key")
+#   # TODO: "letsencrypt-throwaway@gitpod.io" was used for letsencrypt previously. Is is okay to just change the email?
+#   email_address = "preview-environment-certificate-throwaway@gitpod.io"
+# }
+
+resource "acme_registration" "zerossl" {
+  # provider = acme.zerossl
+  account_key_pem = lookup(data.kubernetes_secret.zerossl_private_key.data, "tls.key")
+  email_address   = "preview-environment-certificate-throwaway@gitpod.io"
+
+  # kubectl --context=dev get clusterissuer zerossl-issuer-gitpod-core-dev -o yaml
+  # kubectl --context=dev -n certmanager get secret zerossl-external-account-binding -o yaml
+  external_account_binding {
+    # TODO: It's currently present in zerossl-issuer-gitpod-core-dev but not in any secret we can read yet
+    key_id      = "XXX"
+    hmac_base64 = data.kubernetes_secret.zerossl_external_account_binding.data.secret
+  }
+}
+
+resource "acme_certificate" "certificate" {
+  # provider = acme.zerossl
+  account_key_pem = acme_registration.zerossl.account_key_pem
+  # TODO When using ${data.google_dns_managed_zone.preview-gitpod-dev.dns_name} below it complained about an ending "."
+  common_name = "${var.preview_name}.preview.gitpod-dev.com"
+  subject_alternative_names = [
+    "*.${var.preview_name}.preview.gitpod-dev.com",
+    "*.ws-dev.${var.preview_name}.preview.gitpod-dev.com"
+  ]
+  preferred_chain = "ISRG Root X1"
+
+  dns_challenge {
+    provider = "gcloud"
+    config = {
+      GCE_PROJECT = "gitpod-core-dev" # TODO: Don't hardcode
     }
   }
+}
+
+resource "kubernetes_secret" "certificate" {
+  provider = k8s.dev
+
+  type = "kubernetes.io/tls"
+
+  metadata {
+    name      = "harvester-${var.preview_name}"
+    namespace = "certs"
+    annotations = {
+      "preview/owner" = var.preview_name
+    }
+  }
+
+  data = {
+    # lookup(acme_certificate.certificate, "certificate_pem")
+    # lookup(acme_certificate.certificate, "issuer_pem")
+    # lookup(acme_certificate.certificate, "private_key_pem")
+    "tls.crt" = "${lookup(acme_certificate.certificate, "certificate_pem")}"
+    "tls.key" = "${lookup(acme_certificate.certificate, "private_key_pem")}"
+  }
+
+  depends_on = [
+    acme_certificate.certificate
+  ]
 }

--- a/dev/preview/infrastructure/harvester/provider.tf
+++ b/dev/preview/infrastructure/harvester/provider.tf
@@ -19,6 +19,10 @@ terraform {
       source  = "hashicorp/google"
       version = ">=4.40.0"
     }
+    acme = {
+      source  = "vancluever/acme"
+      version = "~> 2.0"
+    }
   }
 }
 
@@ -43,4 +47,18 @@ provider "k8s" {
 provider "google" {
   project = "gitpod-core-dev"
   region  = "us-central1"
+}
+
+# provider "acme" {
+#   alias = "letsencrypt"
+#   # https://acme-v02.api.letsencrypt.org/directory
+#   # https://acme-staging-v02.api.letsencrypt.org/directory
+#   server_url = "https://acme-v02.api.letsencrypt.org/directory"
+# }
+
+provider "acme" {
+  # alias = "zerossl"
+  # kubectl get clusterissuer zerossl-issuer-gitpod-core-dev -o yaml
+  # https://acme.zerossl.com/v2/DV90
+  server_url = "https://acme.zerossl.com/v2/DV90"
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

DRAFT: Switch to using Terraform to manage preview environment certificates.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/15146

## How to test
<!-- Provide steps to test this PR -->

```

# ZeroSSL
TF_VAR_cert_issuer=zerossl-issuer-gitpod-core-dev leeway run dev/preview:create-preview
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
