### PR TITLE
blobserve: dynamically reload Docker auth config

### DIFF
--- a/components/blobserve/go.mod
+++ b/components/blobserve/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/docker/docker-credential-helpers v0.6.4 // indirect
 	github.com/felixge/httpsnoop v1.0.1 // indirect
+	github.com/fsnotify/fsnotify v1.4.9 // indirect
 	github.com/gitpod-io/gitpod/registry-facade/api v0.0.0-00010101000000-000000000000 // indirect
 	github.com/go-logr/logr v1.2.2 // indirect
 	github.com/go-redis/redis/v8 v8.11.5 // indirect


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

AWS ECR requires regular secret rotation.
This PR adds hot-reloading authentication credentials to pull images from the Gitpod container registry.

Similar code change https://github.com/gitpod-io/gitpod/pull/14679/files#diff-9efd0bd7f5ebc628c240ccf20295bf47583097f0d6f426826a0dc5d18b96a096 for reference.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #15426

## How to test
<!-- Provide steps to test this PR -->
1. Open the workspace preview
2. Update the secret `gcp-sa-registry-auth` with another docker credential
3. Watch the blobserve log, and check the below log display
    ```console
    "message":"reloading file after change","path":"/mnt/pull-secret/pull-secret.json"
    ``` 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
None

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
