### PR TITLE
ws-manager: maintenance mode

### DIFF
--- a/components/ws-manager-api/go/config/config.go
+++ b/components/ws-manager-api/go/config/config.go
@@ -110,8 +110,8 @@ type Configuration struct {
 	EventTraceLog string `json:"eventTraceLog,omitempty"`
 	// ReconnectionInterval configures the time we wait until we reconnect to the various other services
 	ReconnectionInterval util.Duration `json:"reconnectionInterval"`
-	// DryRun prevents us from ever stopping a pod. It is considered equivalent to a listener mode
-	DryRun bool `json:"dryRun,omitempty"`
+	// MaintenanceMode prevents to start workspace, stop workspace, and take snapshot
+	MaintenanceMode bool `json:"maintenanceMode,omitempty"`
 	// WorkspaceDaemon configures our connection to the workspace sync daemons runnin on the nodes
 	WorkspaceDaemon WorkspaceDaemonConfiguration `json:"wsdaemon"`
 	// RegistryFacadeHost is the host (possibly including port) on which the registry facade resolves

--- a/components/ws-manager-api/go/config/config.go
+++ b/components/ws-manager-api/go/config/config.go
@@ -110,7 +110,7 @@ type Configuration struct {
 	EventTraceLog string `json:"eventTraceLog,omitempty"`
 	// ReconnectionInterval configures the time we wait until we reconnect to the various other services
 	ReconnectionInterval util.Duration `json:"reconnectionInterval"`
-	// MaintenanceMode prevents to start workspace, stop workspace, and take snapshot
+	// MaintenanceMode prevents start workspace, stop workspace, and take snapshot operations
 	MaintenanceMode bool `json:"maintenanceMode,omitempty"`
 	// WorkspaceDaemon configures our connection to the workspace sync daemons runnin on the nodes
 	WorkspaceDaemon WorkspaceDaemonConfiguration `json:"wsdaemon"`

--- a/components/ws-manager/cmd/run.go
+++ b/components/ws-manager/cmd/run.go
@@ -124,7 +124,7 @@ var runCmd = &cobra.Command{
 			mgmt.Config = cfg.Manager
 		})
 		if err != nil {
-			log.WithError(err).Fatal("cannot start watch of configuration file")
+			log.WithError(err).WithField("cfgFile", cfgFile).Fatal("cannot start watch of configuration file")
 		}
 
 		if cfg.Prometheus.Addr != "" {

--- a/components/ws-manager/cmd/run.go
+++ b/components/ws-manager/cmd/run.go
@@ -31,6 +31,7 @@ import (
 	common_grpc "github.com/gitpod-io/gitpod/common-go/grpc"
 	"github.com/gitpod-io/gitpod/common-go/log"
 	"github.com/gitpod-io/gitpod/common-go/pprof"
+	"github.com/gitpod-io/gitpod/common-go/watch"
 	"github.com/gitpod-io/gitpod/content-service/pkg/layer"
 	imgbldr "github.com/gitpod-io/gitpod/image-builder/api"
 	"github.com/gitpod-io/gitpod/ws-manager/pkg/manager"
@@ -117,6 +118,14 @@ var runCmd = &cobra.Command{
 			log.WithError(err).Fatal("cannot create manager")
 		}
 		defer mgmt.Close()
+
+		err = watch.File(context.Background(), cfgFile, func() {
+			cfg := getConfig()
+			mgmt.Config = cfg.Manager
+		})
+		if err != nil {
+			log.WithError(err).Fatal("cannot start watch of configuration file")
+		}
 
 		if cfg.Prometheus.Addr != "" {
 			err = mgmt.RegisterMetrics(metrics.Registry)

--- a/components/ws-manager/pkg/manager/manager_ee.go
+++ b/components/ws-manager/pkg/manager/manager_ee.go
@@ -26,6 +26,10 @@ import (
 
 // TakeSnapshot creates a copy of the workspace content and stores it so that another workspace can be created from it.
 func (m *Manager) TakeSnapshot(ctx context.Context, req *api.TakeSnapshotRequest) (res *api.TakeSnapshotResponse, err error) {
+	if m.Config.MaintenanceMode {
+		return &api.TakeSnapshotResponse{}, status.Error(codes.FailedPrecondition, "under maintenance mode")
+	}
+
 	span, ctx := tracing.FromContext(ctx, "TakeSnapshot")
 	tracing.ApplyOWI(span, log.OWI("", "", req.Id))
 	defer tracing.FinishSpan(span, &err)

--- a/install/installer/pkg/components/ws-manager/configmap.go
+++ b/install/installer/pkg/components/ws-manager/configmap.go
@@ -188,7 +188,6 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 			Namespace:      ctx.Namespace,
 			SchedulerName:  schedulerName,
 			SeccompProfile: fmt.Sprintf("workspace_default_%s.json", ctx.VersionManifest.Version),
-			DryRun:         false,
 			WorkspaceDaemon: config.WorkspaceDaemonConfiguration{
 				Port: 8080,
 				TLS: struct {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

A short-term solution for upgrading the ws-manager within a cluster rather than traffic shift to a new cluster.
Before upgrading the ws-manager to a newer one, we will
- update the ws-manager ConfigMap `"maintenanceMode": true,`.
- the other component will check if is there any workspace backing content to remote _or_ takes a snapshot. If none, replace the ws-manager with a newer one.
- after rolling out the ws-manager finished, update the ws-manager ConfigMap `"maintenanceMode": false,`.

While the maintenance mode is enabled, the user can't start the workspace, stop the workspace, or take snapshots. Also, during the maintenance mode, the workspace would not time out.

Suppose there is workspace time out during the maintenance mode. After maintenance mode is disabled, the ws-manager needs to restart or restart a new one to stop the timed-out workspace.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #15409

## How to test
<!-- Provide steps to test this PR -->

Test it by gRPC call
```console
# install grpcurl
go install github.com/fullstorydev/grpcurl/cmd/grpcurl@latest

# port-forward ws-manager port 8080 locally
kubectl port-forward deployment/ws-manager 8080:8080

# update the ws-manager ConfigMap, add `"maintenanceMode": true,`
# waits for the configuration hot-reloading (check the ws-manager log with `reloading file after change`)
kubectl edit cm ws-manager

# run grpcurl, make sure the below requests response status code `FailedPrecondition` and error message `under maintenance mode`.
grpcurl -insecure -proto /workspace/gitpod/components/ws-manager-api/core.proto -import-path=/workspace/gitpod/components/ localhost:8080 wsman.WorkspaceManager.StartWorkspace
grpcurl -insecure -proto /workspace/gitpod/components/ws-manager-api/core.proto -import-path=/workspace/gitpod/components/ localhost:8080 wsman.WorkspaceManager.StopWorkspace
grpcurl -insecure -proto /workspace/gitpod/components/ws-manager-api/core.proto -import-path=/workspace/gitpod/components/ localhost:8080 wsman.WorkspaceManager.TakeSnapshot
```

User experience when maintenanceMode is enabled.
- Start Workspace
   ![image](https://user-images.githubusercontent.com/49380831/208799355-62c66d7d-ce45-4dad-8b57-822f16643cb0.png)
- Stop Workspace: nothing happens
- Take Snapshot
   ![image](https://user-images.githubusercontent.com/49380831/208799239-11e3e4b5-840b-4d18-aff3-d574619ec82c.png)


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
None

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
