### PR TITLE
Learn more section under each settings

### DIFF
--- a/components/dashboard/src/components/BillingAccountSelector.tsx
+++ b/components/dashboard/src/components/BillingAccountSelector.tsx
@@ -96,7 +96,17 @@ export function BillingAccountSelector(props: { onSelected?: () => void }) {
             {teamsAvailableForAttribution === undefined && <Spinner className="m-2 h-5 w-5 animate-spin" />}
             {teamsAvailableForAttribution && (
                 <div>
-                    <p>Associate usage without a project to the billing account below.</p>
+                    <h2 className="text-gray-500">
+                        Associate usage without a project to the billing account below.{" "}
+                        <a
+                            className="gp-link"
+                            href="https://www.gitpod.io/docs/configure/billing"
+                            target="_blank"
+                            rel="noreferrer"
+                        >
+                            Learn more
+                        </a>
+                    </h2>
                     <div className="mt-4 max-w-2xl grid grid-cols-3 gap-3">
                         <SelectableCardSolid
                             className="h-18"

--- a/components/dashboard/src/settings/EnvironmentVariables.tsx
+++ b/components/dashboard/src/settings/EnvironmentVariables.tsx
@@ -222,7 +222,17 @@ export default function EnvVars() {
             <div className="flex items-start sm:justify-between mb-2">
                 <div>
                     <h3>Environment Variables</h3>
-                    <h2 className="text-gray-500">Variables are used to store information like passwords.</h2>
+                    <h2 className="text-gray-500">
+                        Variables are used to store information like passwords.{" "}
+                        <a
+                            className="gp-link"
+                            href="https://www.gitpod.io/docs/configure/projects/environment-variables#environment-variables"
+                            target="_blank"
+                            rel="noreferrer"
+                        >
+                            Learn more
+                        </a>
+                    </h2>
                 </div>
                 {envVars.length !== 0 ? (
                     <div className="mt-3 flex mt-0">
@@ -238,13 +248,7 @@ export default function EnvVars() {
                         <h3 className="text-center pb-3 text-gray-500 dark:text-gray-400">No Environment Variables</h3>
                         <div className="text-center pb-6 text-gray-500">
                             In addition to user-specific environment variables you can also pass variables through a
-                            workspace creation URL.{" "}
-                            <a
-                                className="gp-link"
-                                href="https://www.gitpod.io/docs/environment-variables/#using-the-account-settings"
-                            >
-                                Learn more
-                            </a>
+                            workspace creation URL.
                         </div>
                         <button onClick={add}>New Variable</button>
                     </div>

--- a/components/dashboard/src/settings/Integrations.tsx
+++ b/components/dashboard/src/settings/Integrations.tsx
@@ -320,7 +320,17 @@ function GitProviders() {
             )}
 
             <h3>Git Providers</h3>
-            <h2>Manage permissions for Git providers.</h2>
+            <h2 className="text-gray-500">
+                Manage permissions for Git providers.{" "}
+                <a
+                    className="gp-link"
+                    href="https://www.gitpod.io/docs/configure/authentication"
+                    target="_blank"
+                    rel="noreferrer"
+                >
+                    Learn more
+                </a>
+            </h2>
             <ItemsList className="pt-6">
                 {authProviders &&
                     authProviders.map((ap) => (

--- a/components/dashboard/src/settings/PersonalAccessTokens.tsx
+++ b/components/dashboard/src/settings/PersonalAccessTokens.tsx
@@ -156,7 +156,26 @@ function ListAccessTokensView() {
                             </a>
                         </PillLabel>
                     </h3>
-                    <h2 className="text-gray-500">Create or regenerate access tokens.</h2>
+                    <h2 className="text-gray-500">
+                        Create or regenerate access tokens.{" "}
+                        <a
+                            className="gp-link"
+                            href="https://www.gitpod.io/docs/configure/user-settings/access-tokens"
+                            target="_blank"
+                            rel="noreferrer"
+                        >
+                            Learn more
+                        </a>
+                        &nbsp;&middot;&nbsp;
+                        <a
+                            className="gp-link"
+                            href="https://github.com/gitpod-io/gitpod/issues/15433"
+                            target="_blank"
+                            rel="noreferrer"
+                        >
+                            Send feedback
+                        </a>
+                    </h2>
                 </div>
                 {tokens.length > 0 && (
                     <Link to={settingsPathPersonalAccessTokenCreate}>

--- a/components/dashboard/src/settings/Preferences.tsx
+++ b/components/dashboard/src/settings/Preferences.tsx
@@ -51,7 +51,17 @@ export default function Preferences() {
         <div>
             <PageWithSettingsSubMenu title="Preferences" subtitle="Configure user preferences.">
                 <h3>Editor</h3>
-                <p className="text-base text-gray-500 dark:text-gray-400">Choose the editor for opening workspaces.</p>
+                <p className="text-base text-gray-500 dark:text-gray-400">
+                    Choose the editor for opening workspaces.{" "}
+                    <a
+                        className="gp-link"
+                        href="https://www.gitpod.io/docs/references/ides-and-editors"
+                        target="_blank"
+                        rel="noreferrer"
+                    >
+                        Learn more
+                    </a>
+                </p>
                 <SelectIDE location="preferences" />
                 <h3 className="mt-12">Theme</h3>
                 <p className="text-base text-gray-500 dark:text-gray-400">Early bird or night owl? Choose your side.</p>

--- a/components/dashboard/src/settings/SSHKeys.tsx
+++ b/components/dashboard/src/settings/SSHKeys.tsx
@@ -188,7 +188,17 @@ export default function SSHKeys() {
             <div className="flex items-start sm:justify-between mb-2">
                 <div>
                     <h3>SSH Keys</h3>
-                    <h2 className="text-gray-500">Create and manage SSH keys.</h2>
+                    <h2 className="text-gray-500">
+                        Create and manage SSH keys.{" "}
+                        <a
+                            className="gp-link"
+                            href="https://www.gitpod.io/docs/configure/user-settings/ssh"
+                            target="_blank"
+                            rel="noreferrer"
+                        >
+                            Learn more
+                        </a>
+                    </h2>
                 </div>
                 {dataList.length !== 0 ? (
                     <div className="mt-3 flex">


### PR DESCRIPTION
> Signed-off-by: Siddhant Khare <siddhant@gitpod.io>

## Description

This PR Propose changes to Settings Dashboard for having `Learn More` section under required settings to make user learn about the feature or about how that actually works by linking it to our documentation. (Design Suggestions & Placeholder position suggestions are welcomed 🙏🏽 cc: @gtsiolis)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
- Open [Preview](https://dashboard-074a33b924.preview.gitpod-dev.com/)
- Go to `/settings` & See following 👀
    - Learn More section on `/preferences`
    - Learn More section on `/integrations`
    - Learn More section on `/keys`
    - Learn More section on `/variables`
    - Learn More section on `/billing`
    - Learn More & Send Feedback section on `/tokens`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
