### PR TITLE
[public-api] Implement StopWorkspace and use from Dashboard

### DIFF
--- a/components/dashboard/src/service/public-api.ts
+++ b/components/dashboard/src/service/public-api.ts
@@ -9,6 +9,7 @@ import { Project as ProtocolProject, Team as ProtocolTeam } from "@gitpod/gitpod
 import { TeamsService } from "@gitpod/public-api/lib/gitpod/experimental/v1/teams_connectweb";
 import { TokensService } from "@gitpod/public-api/lib/gitpod/experimental/v1/tokens_connectweb";
 import { ProjectsService } from "@gitpod/public-api/lib/gitpod/experimental/v1/projects_connectweb";
+import { WorkspacesService } from "@gitpod/public-api/lib/gitpod/experimental/v1/workspaces_connectweb";
 import { Team } from "@gitpod/public-api/lib/gitpod/experimental/v1/teams_pb";
 import { TeamMemberInfo, TeamMemberRole } from "@gitpod/gitpod-protocol";
 import { TeamMember, TeamRole } from "@gitpod/public-api/lib/gitpod/experimental/v1/teams_pb";
@@ -22,6 +23,7 @@ const transport = createConnectTransport({
 export const teamsService = createPromiseClient(TeamsService, transport);
 export const personalAccessTokensService = createPromiseClient(TokensService, transport);
 export const projectsService = createPromiseClient(ProjectsService, transport);
+export const workspacesService = createPromiseClient(WorkspacesService, transport);
 
 export function publicApiTeamToProtocol(team: Team): ProtocolTeam {
     return {

--- a/components/dashboard/src/start/StartWorkspace.tsx
+++ b/components/dashboard/src/start/StartWorkspace.tsx
@@ -29,6 +29,8 @@ import { getGitpodService, gitpodHostUrl } from "../service/service";
 import { StartPage, StartPhase, StartWorkspaceError } from "./StartPage";
 import ConnectToSSHModal from "../workspaces/ConnectToSSHModal";
 import Alert from "../components/Alert";
+import { FeatureFlagContext } from "../contexts/FeatureFlagContext";
+import { workspacesService } from "../service/public-api";
 
 const sessionId = v4();
 
@@ -99,6 +101,8 @@ export interface StartWorkspaceState {
 }
 
 export default class StartWorkspace extends React.Component<StartWorkspaceProps, StartWorkspaceState> {
+    static contextType = FeatureFlagContext;
+
     constructor(props: StartWorkspaceProps) {
         super(props);
         this.state = {};
@@ -523,7 +527,11 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
                                         {
                                             title: "Stop Workspace",
                                             onClick: () =>
-                                                getGitpodService().server.stopWorkspace(this.props.workspaceId),
+                                                this.context.usePublicApiWorkspacesService
+                                                    ? workspacesService.stopWorkspace({
+                                                          workspaceId: this.props.workspaceId,
+                                                      })
+                                                    : getGitpodService().server.stopWorkspace(this.props.workspaceId),
                                         },
                                         {
                                             title: "Connect via SSH",

--- a/components/dashboard/src/workspaces/WorkspaceEntry.tsx
+++ b/components/dashboard/src/workspaces/WorkspaceEntry.tsx
@@ -37,7 +37,7 @@ interface Props {
     desc: WorkspaceInfo;
     model: WorkspaceModel;
     isAdmin?: boolean;
-    stopWorkspace: (ws: string) => Promise<void>;
+    stopWorkspace: (ws: string) => Promise<any>;
 }
 
 export function WorkspaceEntry({ desc, model, isAdmin, stopWorkspace }: Props) {

--- a/components/dashboard/src/workspaces/Workspaces.tsx
+++ b/components/dashboard/src/workspaces/Workspaces.tsx
@@ -21,6 +21,8 @@ import SelectIDEModal from "../settings/SelectIDEModal";
 import Arrow from "../components/Arrow";
 import ConfirmationModal from "../components/ConfirmationModal";
 import { ProfileState } from "../settings/ProfileInformation";
+import { FeatureFlagContext } from "../contexts/FeatureFlagContext";
+import { workspacesService } from "../service/public-api";
 
 export interface WorkspacesProps {}
 
@@ -37,6 +39,7 @@ export default function () {
 
     const { user } = useContext(UserContext);
     const { teams } = useContext(TeamsContext);
+    const { usePublicApiWorkspacesService } = useContext(FeatureFlagContext);
     const [activeWorkspaces, setActiveWorkspaces] = useState<WorkspaceInfo[]>([]);
     const [inactiveWorkspaces, setInactiveWorkspaces] = useState<WorkspaceInfo[]>([]);
     const [workspaceModel, setWorkspaceModel] = useState<WorkspaceModel>();
@@ -146,7 +149,11 @@ export default function () {
                                         key={e.workspace.id}
                                         desc={e}
                                         model={workspaceModel}
-                                        stopWorkspace={(wsId) => getGitpodService().server.stopWorkspace(wsId)}
+                                        stopWorkspace={(wsId) =>
+                                            usePublicApiWorkspacesService
+                                                ? workspacesService.stopWorkspace({ workspaceId: wsId })
+                                                : getGitpodService().server.stopWorkspace(wsId)
+                                        }
                                     />
                                 );
                             })}
@@ -202,7 +209,9 @@ export default function () {
                                                         desc={e}
                                                         model={workspaceModel}
                                                         stopWorkspace={(wsId) =>
-                                                            getGitpodService().server.stopWorkspace(wsId)
+                                                            usePublicApiWorkspacesService
+                                                                ? workspacesService.stopWorkspace({ workspaceId: wsId })
+                                                                : getGitpodService().server.stopWorkspace(wsId)
                                                         }
                                                     />
                                                 );

--- a/components/public-api-server/pkg/apiv1/workspace.go
+++ b/components/public-api-server/pkg/apiv1/workspace.go
@@ -168,6 +168,26 @@ func (s *WorkspaceService) UpdatePort(ctx context.Context, req *connect.Request[
 	), nil
 }
 
+func (s *WorkspaceService) StopWorkspace(ctx context.Context, req *connect.Request[v1.StopWorkspaceRequest]) (*connect.Response[v1.StopWorkspaceResponse], error) {
+	workspaceID, err := validateWorkspaceID(req.Msg.GetWorkspaceId())
+	if err != nil {
+		return nil, err
+	}
+
+	conn, err := getConnection(ctx, s.connectionPool)
+	if err != nil {
+		return nil, err
+	}
+
+	err = conn.StopWorkspace(ctx, workspaceID)
+	if err != nil {
+		log.WithField("workspace_id", workspaceID).WithError(err).Error("Failed to stop workspace.")
+		return nil, proxy.ConvertError(err)
+	}
+
+	return connect.NewResponse(&v1.StopWorkspaceResponse{}), nil
+}
+
 func getLimitFromPagination(pagination *v1.Pagination) (int, error) {
 	const (
 		defaultLimit = 20


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Implements StopWorkspace on public API, and uses it from dashboard - behind an expeirment.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Depends on https://github.com/gitpod-io/gitpod/pull/15458

## How to test
<!-- Provide steps to test this PR -->
1. Preview
2. Start a workspace
3. Stop it from the list workspaces view
4. Stop it from started workspace view (when not using in-browser VS Code)
5. Observe that for both the request is made against `api.gitpod.io` and it's HTTP with JSON (dev tools)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
