### PR TITLE
[dashboard] Add feature flag to use Public API Workspaces Service

### DIFF
--- a/components/dashboard/src/contexts/FeatureFlagContext.tsx
+++ b/components/dashboard/src/contexts/FeatureFlagContext.tsx
@@ -21,6 +21,7 @@ const FeatureFlagContext = createContext<{
     showUseLastSuccessfulPrebuild: boolean;
     usePublicApiTeamsService: boolean;
     usePublicApiProjectsService: boolean;
+    usePublicApiWorkspacesService: boolean;
     enablePersonalAccessTokens: boolean;
 }>({
     showUsageView: false,
@@ -28,6 +29,7 @@ const FeatureFlagContext = createContext<{
     showUseLastSuccessfulPrebuild: false,
     usePublicApiTeamsService: false,
     usePublicApiProjectsService: false,
+    usePublicApiWorkspacesService: false,
     enablePersonalAccessTokens: false,
 });
 
@@ -43,6 +45,7 @@ const FeatureFlagContextProvider: React.FC = ({ children }) => {
     const [usePublicApiTeamsService, setUsePublicApiTeamsService] = useState<boolean>(false);
     const [usePublicApiProjectsService, setUsePublicApiProjectsService] = useState<boolean>(false);
     const [enablePersonalAccessTokens, setPersonalAccessTokensEnabled] = useState<boolean>(false);
+    const [usePublicApiWorkspacesService, setUsePublicApiWorkspacesService] = useState<boolean>(false);
 
     useEffect(() => {
         if (!user) return;
@@ -54,6 +57,10 @@ const FeatureFlagContextProvider: React.FC = ({ children }) => {
                 publicApiExperimentalTeamsService: { defaultValue: false, setter: setUsePublicApiTeamsService },
                 publicApiExperimentalProjectsService: { defaultValue: false, setter: setUsePublicApiProjectsService },
                 personalAccessTokensEnabled: { defaultValue: false, setter: setPersonalAccessTokensEnabled },
+                publicApiExperimentalWorkspaceService: {
+                    defaultValue: false,
+                    setter: setUsePublicApiWorkspacesService,
+                },
             };
 
             for (const [flagName, config] of Object.entries(featureFlags)) {
@@ -99,6 +106,7 @@ const FeatureFlagContextProvider: React.FC = ({ children }) => {
                 usePublicApiTeamsService,
                 enablePersonalAccessTokens,
                 usePublicApiProjectsService,
+                usePublicApiWorkspacesService,
             }}
         >
             {children}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Setup the feature flag

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
