### PR TITLE
[gitpod-db] Helper to construct db connection params from env

### DIFF
--- a/components/gitpod-db/go/conn.go
+++ b/components/gitpod-db/go/conn.go
@@ -8,6 +8,8 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"net"
+	"os"
 	"time"
 
 	"github.com/gitpod-io/gitpod/common-go/log"
@@ -24,6 +26,16 @@ type ConnectionParams struct {
 	Host     string
 	Database string
 	CaCert   string
+}
+
+func ConnectionParamsFromEnv() ConnectionParams {
+	return ConnectionParams{
+		User:     os.Getenv("DB_USERNAME"),
+		Password: os.Getenv("DB_PASSWORD"),
+		Host:     net.JoinHostPort(os.Getenv("DB_HOST"), os.Getenv("DB_PORT")),
+		Database: "gitpod",
+		CaCert:   os.Getenv("DB_CA_CERT"),
+	}
 }
 
 func Connect(p ConnectionParams) (*gorm.DB, error) {

--- a/components/gitpod-db/go/conn_test.go
+++ b/components/gitpod-db/go/conn_test.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package db
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestConnectionParamsFromEnv(t *testing.T) {
+	t.Setenv("DB_USERNAME", "username")
+	t.Setenv("DB_PASSWORD", "pass")
+	t.Setenv("DB_HOST", "dbhost")
+	t.Setenv("DB_PORT", "dbport")
+	t.Setenv("DB_CA_CERT", "cacert")
+
+	require.Equal(t, ConnectionParams{
+		User:     "username",
+		Password: "pass",
+		Host:     "dbhost:dbport",
+		Database: "gitpod",
+		CaCert:   "cacert",
+	}, ConnectionParamsFromEnv())
+}

--- a/components/public-api-server/pkg/server/server.go
+++ b/components/public-api-server/pkg/server/server.go
@@ -6,7 +6,6 @@ package server
 
 import (
 	"fmt"
-	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -44,13 +43,7 @@ func Start(logger *logrus.Entry, version string, cfg *config.Configuration) erro
 		return fmt.Errorf("failed to setup connection pool: %w", err)
 	}
 
-	dbConn, err := db.Connect(db.ConnectionParams{
-		User:     os.Getenv("DB_USERNAME"),
-		Password: os.Getenv("DB_PASSWORD"),
-		Host:     net.JoinHostPort(os.Getenv("DB_HOST"), os.Getenv("DB_PORT")),
-		Database: "gitpod",
-		CaCert:   os.Getenv("DB_CA_CERT"),
-	})
+	dbConn, err := db.Connect(db.ConnectionParamsFromEnv())
 	if err != nil {
 		return fmt.Errorf("failed to establish database connection: %w", err)
 	}

--- a/components/usage/pkg/server/server.go
+++ b/components/usage/pkg/server/server.go
@@ -6,8 +6,6 @@ package server
 
 import (
 	"fmt"
-	"net"
-	"os"
 	"time"
 
 	"github.com/gitpod-io/gitpod/usage/pkg/scheduler"
@@ -50,13 +48,7 @@ type Config struct {
 func Start(cfg Config, version string) error {
 	log.WithField("config", cfg).Info("Starting usage component.")
 
-	conn, err := db.Connect(db.ConnectionParams{
-		User:     os.Getenv("DB_USERNAME"),
-		Password: os.Getenv("DB_PASSWORD"),
-		Host:     net.JoinHostPort(os.Getenv("DB_HOST"), os.Getenv("DB_PORT")),
-		Database: "gitpod",
-		CaCert:   os.Getenv("DB_CA_CERT"),
-	})
+	conn, err := db.Connect(db.ConnectionParamsFromEnv())
 	if err != nil {
 		return fmt.Errorf("failed to establish database connection: %w", err)
 	}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Minor refactor to make it easier to stay consistent

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
