### PR TITLE
supervisor: use textformatter when in run-gp

### DIFF
--- a/components/supervisor/.gitignore
+++ b/components/supervisor/.gitignore
@@ -1,0 +1,1 @@
+supervisor

--- a/components/supervisor/cmd/run.go
+++ b/components/supervisor/cmd/run.go
@@ -23,7 +23,7 @@ var runCmd = &cobra.Command{
 	Short: "starts the supervisor",
 
 	Run: func(cmd *cobra.Command, args []string) {
-		log.Init(ServiceName, Version, true, os.Getenv("SUPERVISOR_DEBUG_ENABLE") == "true")
+		log.Init(ServiceName, Version, !runOpts.RunGP, os.Getenv("SUPERVISOR_DEBUG_ENABLE") == "true")
 		common_grpc.SetupLogging()
 		supervisor.Version = Version
 		supervisor.Run(supervisor.WithRunGP(runOpts.RunGP))

--- a/components/supervisor/hot-swap.sh
+++ b/components/supervisor/hot-swap.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+# Licensed under the GNU Affero General Public License (AGPL).
+# See License.AGPL.txt in the project root for license information.
+
+set -Eeuo pipefail
+
+# This script swaps the backend startup endpoint with a built one
+# in a workspace and restarts the JB backend.
+
+component=${PWD##*/}
+workspaceUrl=$(echo "${1}" |sed -e "s/\/$//")
+echo "URL: $workspaceUrl"
+
+workspaceDesc=$(gpctl workspaces describe "$workspaceUrl" -o=json)
+
+podName=$(echo "$workspaceDesc" | jq .runtime.pod_name -r)
+echo "Pod: $podName"
+
+workspaceId=$(echo "$workspaceDesc" | jq .metadata.meta_id -r)
+echo "ID: $workspaceId"
+
+clusterHost=$(kubectl exec -it "$podName" -- printenv GITPOD_WORKSPACE_CLUSTER_HOST |sed -e "s/\s//g")
+echo "Cluster Host: $clusterHost"
+
+# prepare ssh
+ownerToken=$(kubectl get pod "$podName" -o=json | jq ".metadata.annotations.\"gitpod\/ownerToken\"" -r)
+sshConfig="./ssh-config"
+echo "Host $workspaceId" > "$sshConfig"
+echo "    Hostname \"$workspaceId.ssh.$clusterHost\"" >> "$sshConfig"
+echo "    User \"$workspaceId#$ownerToken\"" >> "$sshConfig"
+
+# build
+go build .
+echo "$component built"
+
+# upload
+uploadDest="/.supervisor/$component"
+echo "Upload Dest: $uploadDest"
+ssh -F "$sshConfig" "$workspaceId" "sudo chmod 777 $uploadDest && sudo rm $uploadDest"
+scp -F "$sshConfig" -r "./supervisor" "$workspaceId":"$uploadDest"
+echo "Swap complete"

--- a/components/supervisor/local-hot-swap.sh
+++ b/components/supervisor/local-hot-swap.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+# Licensed under the GNU Affero General Public License (AGPL).
+# See License.AGPL.txt in the project root for license information.
+
+set -Eeuo pipefail
+
+# This script swaps the backend startup endpoint with a built one
+# in a workspace and restarts the JB backend.
+
+component=${PWD##*/}
+
+# build
+go build .
+echo "$component built"
+
+sudo rm /.supervisor/supervisor
+sudo mv ./"$component" /.supervisor
+echo "Local Swap complete"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
https://ide-superv378ed03f08.preview.gitpod-dev.com/workspaces

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
