### PR TITLE
Move IPFS docker build to Gitpod monorepo

### DIFF
--- a/components/BUILD.yaml
+++ b/components/BUILD.yaml
@@ -62,6 +62,8 @@ packages:
       - components/ide/jetbrains/image:clion-latest
       - components/image-builder-bob:docker
       - components/image-builder-mk3:docker
+      - components/ipfs/ipfs-cluster:docker
+      - components/ipfs/kubo:docker
       - components/local-app:docker
       - components/public-api-server:docker
       - components/usage:docker

--- a/components/ipfs/ipfs-cluster/BUILD.yaml
+++ b/components/ipfs/ipfs-cluster/BUILD.yaml
@@ -1,0 +1,9 @@
+packages:
+  - name: docker
+    type: docker
+    config:
+      dockerfile: leeway.Dockerfile
+      buildArgs:
+        VERSION: 1.0.4
+      image:
+        - ${imageRepoBase}/ipfs/ipfs-cluster:v1.0.4

--- a/components/ipfs/ipfs-cluster/README.md
+++ b/components/ipfs/ipfs-cluster/README.md
@@ -1,0 +1,4 @@
+# ipfs-cluster
+
+[ipfs-cluster](https://github.com/ipfs-cluster/ipfs-cluster) is a pinset orchestration for IPFS.
+This component is for building the ipfs-cluster container image now.

--- a/components/ipfs/ipfs-cluster/leeway.Dockerfile
+++ b/components/ipfs/ipfs-cluster/leeway.Dockerfile
@@ -1,0 +1,20 @@
+# Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+# Licensed under the GNU Affero General Public License (AGPL).
+# See License-AGPL.txt in the project root for license information.
+
+ARG VERSION
+
+FROM alpine as dependencies
+
+RUN apk add -U wget
+
+RUN wget -O /jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 \
+    && chmod +x /jq
+
+RUN wget -O /kubectl https://dl.k8s.io/release/v1.24.3/bin/linux/amd64/kubectl \
+    && chmod +x /kubectl
+
+FROM docker.io/ipfs/ipfs-cluster:${VERSION}
+
+COPY --from=dependencies /jq /usr/bin/jq
+COPY --from=dependencies /kubectl /usr/bin/kubectl

--- a/components/ipfs/kubo/BUILD.yaml
+++ b/components/ipfs/kubo/BUILD.yaml
@@ -1,0 +1,9 @@
+packages:
+  - name: docker
+    type: docker
+    config:
+      dockerfile: leeway.Dockerfile
+      buildArgs:
+        VERSION: v0.16.0
+      image:
+        - ${imageRepoBase}/ipfs/kubo:v0.16.0

--- a/components/ipfs/kubo/README.md
+++ b/components/ipfs/kubo/README.md
@@ -1,0 +1,4 @@
+# kubo
+
+[kubo](https://github.com/ipfs/kubo) is an An IPFS implementation in Go.
+This component is for building the kubo container image now.

--- a/components/ipfs/kubo/leeway.Dockerfile
+++ b/components/ipfs/kubo/leeway.Dockerfile
@@ -1,0 +1,16 @@
+# Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+# Licensed under the GNU Affero General Public License (AGPL).
+# See License-AGPL.txt in the project root for license information.
+
+ARG VERSION
+
+FROM alpine as dependencies
+
+RUN apk add -U wget
+
+RUN wget -O /jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 \
+    && chmod +x /jq
+
+FROM docker.io/ipfs/kubo:${VERSION}
+
+COPY --from=dependencies /jq /usr/bin/jq


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

We manually build and publish the IPFS images to 
- https://hub.docker.com/r/aledbf/go-ipfs
- https://hub.docker.com/r/aledbf/ipfs-cluster

Move the Dockerfiles to Gitpod monorepo, and build and publish it by leeway+werft.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related to https://github.com/gitpod-io/gitpod-packer-gcp-image/issues/199

## How to test
<!-- Provide steps to test this PR -->

Check the container image located in GCP container registry.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
None

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
