### PR TITLE
ws-manager: Prevent to slip the CREATING phase

### DIFF
--- a/components/ws-manager/pkg/manager/annotations.go
+++ b/components/ws-manager/pkg/manager/annotations.go
@@ -85,6 +85,9 @@ const (
 
 	// attemptingToCreatePodAnnotation is set when ws-manager is trying to create pod and is removed when pod is successfully scheduled on the node
 	attemptingToCreatePodAnnotation = "gitpod.io/attemptingToCreate"
+
+	// alreadyInitializingAnnotation is set when initializing is done
+	alreadyInitializingAnnotation = "gitpod.io/alreadyInitializing"
 )
 
 // markWorkspaceAsReady adds annotations to a workspace pod

--- a/components/ws-manager/pkg/manager/monitor.go
+++ b/components/ws-manager/pkg/manager/monitor.go
@@ -317,7 +317,6 @@ func actOnPodEvent(ctx context.Context, m actingManager, manager *Manager, statu
 		// The workspace has been scheduled on the cluster which means that we can start initializing it
 		go func() {
 			err := m.initializeWorkspaceContent(ctx, pod)
-
 			if err != nil {
 				// workspace initialization failed, which means the workspace as a whole failed
 				err = m.markWorkspace(ctx, workspaceID, addMark(workspaceExplicitFailAnnotation, err.Error()))
@@ -325,6 +324,12 @@ func actOnPodEvent(ctx context.Context, m actingManager, manager *Manager, statu
 					log.WithError(err).Warn("was unable to mark workspace as failed")
 				}
 			}
+
+			err = m.markWorkspace(ctx, workspaceID, addMark(alreadyInitializingAnnotation, util.BooleanTrueString))
+			if err != nil {
+				log.WithError(err).Warn("was unable to mark workspace as already initializing")
+			}
+
 		}()
 
 	case api.WorkspacePhase_INITIALIZING:

--- a/components/ws-manager/pkg/manager/status.go
+++ b/components/ws-manager/pkg/manager/status.go
@@ -502,7 +502,7 @@ func (m *Manager) extractStatusFromPod(result *api.WorkspaceStatus, wso workspac
 			return nil
 		}
 
-		// the pod phase of pending is somtimes slipped because it may not be PENDING at the stage of retrieving information on the workspace pod.
+		// the pod phase of pending is sometimes slipped because it may not be PENDING at the stage of retrieving information on the workspace pod.
 		if !wso.AlreadyInitializing() {
 			result.Phase = api.WorkspacePhase_CREATING
 			result.Message = "pod is running but init has not started yet or is not finished"

--- a/components/ws-manager/pkg/manager/testdata/actOnPodEvent_wsstartup_Creating01.golden
+++ b/components/ws-manager/pkg/manager/testdata/actOnPodEvent_wsstartup_Creating01.golden
@@ -1,0 +1,3 @@
+{
+    "actions": null
+}

--- a/components/ws-manager/pkg/manager/testdata/status_firstUserActivity_RUNNING.json
+++ b/components/ws-manager/pkg/manager/testdata/status_firstUserActivity_RUNNING.json
@@ -26,6 +26,7 @@
         "gitpod/firstUserActivity": "2020-02-28T10:44:36.995133911Z",
         "gitpod/id": "df376c57-7a0e-4233-976a-7a021e6f088c",
         "gitpod/ready": "true",
+        "gitpod.io/alreadyInitializing": "true",
         "gitpod/servicePrefix": "c372bd58-ef61-4fc0-9083-bd61ef96ad9f",
         "gitpod/url": "https://c372bd58-ef61-4fc0-9083-bd61ef96ad9f.ws-eu01.gitpod-staging.com",
         "gitpod/exposedPorts": "CgUIuQoYAQoFCLgXGAEKBQi5FxgBCgUIoB8YAQoFCI1IGAEKBQiMLhgBCgUIwC8YAQoFCI9OGAEKBQjJZRgBCgUI4TwYAQoFCIRpGAE=",

--- a/components/ws-manager/pkg/manager/testdata/status_imagespec_RUNNING00.json
+++ b/components/ws-manager/pkg/manager/testdata/status_imagespec_RUNNING00.json
@@ -27,6 +27,7 @@
         "gitpod/firstUserActivity": "2020-03-09T15:31:26.855961185Z",
         "gitpod/id": "27e46234-5004-44c1-a2e8-56d68ac3c70b",
         "gitpod/ready": "true",
+        "gitpod.io/alreadyInitializing": "true",
         "gitpod/servicePrefix": "db334047-3c4b-49cc-a5fb-a089bff656e0",
         "gitpod/url": "http://db334047-3c4b-49cc-a5fb-a089bff656e0.ws-dev.cw-registry.staging.gitpod-dev.com",
         "gitpod/exposedPorts": "CgUIkD8YAQ==",

--- a/components/ws-manager/pkg/manager/testdata/status_interrupted.json
+++ b/components/ws-manager/pkg/manager/testdata/status_interrupted.json
@@ -24,6 +24,7 @@
         "gitpod/contentInitializer": "[redacted]",
         "gitpod/id": "283522ed-51f1-4838-951b-0f115c0a7aae",
         "gitpod/ready": "true",
+        "gitpod.io/alreadyInitializing": "true",
         "gitpod/servicePrefix": "b246b28e-4776-47d5-961d-10548ffac9a8",
         "gitpod/url": "https://b246b28e-4776-47d5-961d-10548ffac9a8.ws-eu0.gitpod-staging.com",
         "gitpod/exposedPorts": "CgMIjC4KAwiQPw==",

--- a/components/ws-manager/pkg/manager/testdata/status_interrupted_CREATING00.json
+++ b/components/ws-manager/pkg/manager/testdata/status_interrupted_CREATING00.json
@@ -23,6 +23,7 @@
         "gitpod/contentInitializer": "[redacted]",
         "gitpod/id": "4bf2e82d-cdc7-4764-b8ad-6973e3c4a629",
         "gitpod/ready": "true",
+        "gitpod.io/alreadyInitializing": "true",
         "gitpod/servicePrefix": "f75a430d-331d-4977-a4dc-16939c0752e1",
         "gitpod/url": "http://f75a430d-331d-4977-a4dc-16939c0752e1.ws-eu.cw-gh-2720.staging.gitpod.io"
       }

--- a/components/ws-manager/pkg/manager/testdata/status_interrupted_networkNotReady_1_event_only.json
+++ b/components/ws-manager/pkg/manager/testdata/status_interrupted_networkNotReady_1_event_only.json
@@ -25,6 +25,7 @@
         "gitpod/customTimeout": "30m",
         "gitpod/id": "da9ffbf1-a12d-4a58-8593-475394eedb00",
         "gitpod/ready": "true",
+        "gitpod.io/alreadyInitializing": "true",
         "gitpod/servicePrefix": "c0eabd01-6315-4fc4-8f60-1b008e100743",
         "gitpod/url": "https://c0eabd01-6315-4fc4-8f60-1b008e100743.ws-eu01.gitpod.io",
         "gitpod/exposedPorts": "CgUIuBcYAQ==",

--- a/components/ws-manager/pkg/manager/testdata/status_interrupted_networkNotReady_2_event_and_exitcode.json
+++ b/components/ws-manager/pkg/manager/testdata/status_interrupted_networkNotReady_2_event_and_exitcode.json
@@ -25,6 +25,7 @@
         "gitpod/customTimeout": "30m",
         "gitpod/id": "0c5a8ef3-052b-44a7-b11c-3542a0928076",
         "gitpod/ready": "true",
+        "gitpod.io/alreadyInitializing": "true",
         "gitpod/servicePrefix": "d6427c17-62b8-4bb5-a974-f97f77b370dc",
         "gitpod/url": "https://d6427c17-62b8-4bb5-a974-f97f77b370dc.ws-eu01.gitpod.io",
         "gitpod/exposedPorts": "CgUIkD8YAQ==",

--- a/components/ws-manager/pkg/manager/testdata/status_interrupted_networkNotReady_3_recovered_CONSTRUCTED.json
+++ b/components/ws-manager/pkg/manager/testdata/status_interrupted_networkNotReady_3_recovered_CONSTRUCTED.json
@@ -25,6 +25,7 @@
         "gitpod/customTimeout": "30m",
         "gitpod/id": "0c5a8ef3-052b-44a7-b11c-3542a0928076",
         "gitpod/ready": "true",
+        "gitpod.io/alreadyInitializing": "true",
         "gitpod/servicePrefix": "d6427c17-62b8-4bb5-a974-f97f77b370dc",
         "gitpod/url": "https://d6427c17-62b8-4bb5-a974-f97f77b370dc.ws-eu01.gitpod.io",
         "gitpod/exposedPorts": "CgUIkD8YAQ==",

--- a/components/ws-manager/pkg/manager/testdata/status_metadata.json
+++ b/components/ws-manager/pkg/manager/testdata/status_metadata.json
@@ -20,6 +20,7 @@
         "gitpod/id": "foobas",
         "gitpod/servicePrefix": "foobas",
         "gitpod/url": "http://10.0.0.114:8082",
+        "gitpod.io/alreadyInitializing": "true",
         "gitpod/exposedPorts": "CgMIkD8="
       }
     },

--- a/components/ws-manager/pkg/manager/testdata/status_ownerToken.json
+++ b/components/ws-manager/pkg/manager/testdata/status_ownerToken.json
@@ -25,6 +25,7 @@
         "gitpod/firstUserActivity": "2020-02-28T10:44:36.995133911Z",
         "gitpod/id": "df376c57-7a0e-4233-976a-7a021e6f088c",
         "gitpod/ready": "true",
+        "gitpod.io/alreadyInitializing": "true",
         "gitpod/servicePrefix": "c372bd58-ef61-4fc0-9083-bd61ef96ad9f",
         "gitpod/url": "https://c372bd58-ef61-4fc0-9083-bd61ef96ad9f.ws-eu01.gitpod-staging.com",
         "gitpod/exposedPorts": "CgUIuQoYAQoFCLgXGAEKBQi5FxgBCgUIoB8YAQoFCI1IGAEKBQiMLhgBCgUIwC8YAQoFCI9OGAEKBQjJZRgBCgUI4TwYAQoFCIRpGAE=",

--- a/components/ws-manager/pkg/manager/testdata/status_regularStart_Initializing00.json
+++ b/components/ws-manager/pkg/manager/testdata/status_regularStart_Initializing00.json
@@ -19,6 +19,7 @@
         "gitpod/id": "foobas",
         "gitpod/servicePrefix": "foobas",
         "gitpod/url": "http://10.0.0.114:8082",
+        "gitpod.io/alreadyInitializing": "true",
         "gitpod/never-ready": "true"
       }
     },

--- a/components/ws-manager/pkg/manager/testdata/status_stoppedByRequest_000_RUNNING00.json
+++ b/components/ws-manager/pkg/manager/testdata/status_stoppedByRequest_000_RUNNING00.json
@@ -31,6 +31,7 @@
         "gitpod/contentInitializer": "[redacted]",
         "gitpod/exposedPorts": "ClEIuBciTGh0dHBzOi8vMzAwMC1saW1lLW9wb3NzdW0tM2pmdGY2NWkud3MtZGV2LmN3LWZpeC02MjEzLnN0YWdpbmcuZ2l0cG9kLWRldi5jb20KUwiJ0wEiTWh0dHBzOi8vMjcwMTctbGltZS1vcG9zc3VtLTNqZnRmNjVpLndzLWRldi5jdy1maXgtNjIxMy5zdGFnaW5nLmdpdHBvZC1kZXYuY29tClEIjUgiTGh0dHBzOi8vOTIyOS1saW1lLW9wb3NzdW0tM2pmdGY2NWkud3MtZGV2LmN3LWZpeC02MjEzLnN0YWdpbmcuZ2l0cG9kLWRldi5jb20=",
         "gitpod/customTimeout": "60m",
+        "gitpod.io/alreadyInitializing": "true",
         "gitpod/firstUserActivity": "2021-10-14T19:11:43.983492544Z",
         "gitpod/id": "18f99de5-090f-4318-9759-05f5ef0277f7",
         "gitpod/imageSpec": "CnRldS5nY3IuaW8vZ2l0cG9kLWNvcmUtZGV2L3JlZ2lzdHJ5L3dvcmtzcGFjZS1pbWFnZXM6M2JkNWNlMTJmN2FjZDFmZjE5NDk0YTI1YWEyZmYwMWZmOWE3YjkzODU2N2M4NGQ1MmNlNmFhMGIyYmQ0MDA5MhJYZXUuZ2NyLmlvL2dpdHBvZC1jb3JlLWRldi9idWlsZC9pZGUvY29kZTpjb21taXQtNzEwN2ZiOGJkZTBiMWY5MjI2NTQwMmFkNWZhMDlhNTEwMjJiMTRkZA==",

--- a/components/ws-manager/pkg/manager/testdata/status_stuckInCreating_CREATING00.golden
+++ b/components/ws-manager/pkg/manager/testdata/status_stuckInCreating_CREATING00.golden
@@ -15,11 +15,12 @@
             "timeout": "30m",
             "ide_image": {}
         },
-        "phase": 4,
+        "phase": 2,
         "conditions": {
             "timeout": "workspace timed out after I've meddled with this test data set",
             "volume_snapshot": {}
         },
+        "message": "pod is running but init has not started yet or is not finished",
         "runtime": {
             "node_name": "gke-production--gitp-workspace-pool-2-a3afc0b4-tmz8",
             "pod_name": "ws-2513d0b4-3c18-4735-b32e-1bbdead24b78",

--- a/components/ws-manager/pkg/manager/testdata/status_wsstartup_Creating01.golden
+++ b/components/ws-manager/pkg/manager/testdata/status_wsstartup_Creating01.golden
@@ -1,0 +1,29 @@
+{
+    "status": {
+        "id": "foobas",
+        "status_version": 65536,
+        "metadata": {
+            "owner": "foobar",
+            "meta_id": "metameta",
+            "started_at": {
+                "seconds": 1552236488
+            }
+        },
+        "spec": {
+            "workspace_image": "nginx:latest",
+            "url": "http://10.0.0.114:8082",
+            "ide_image": {}
+        },
+        "phase": 2,
+        "conditions": {
+            "volume_snapshot": {}
+        },
+        "message": "pod is running but init has not started yet or is not finished",
+        "runtime": {
+            "node_name": "minikube",
+            "pod_name": "ws-foobas",
+            "node_ip": "10.0.2.15"
+        },
+        "auth": {}
+    }
+}

--- a/components/ws-manager/pkg/manager/testdata/status_wsstartup_Creating01.json
+++ b/components/ws-manager/pkg/manager/testdata/status_wsstartup_Creating01.json
@@ -1,25 +1,24 @@
 {
   "pod": {
     "metadata": {
-      "name": "ws-foobar",
-      "namespace": "staging-cw-ws-manager",
-      "selfLink": "/api/v1/namespaces/staging-cw-ws-manager/pods/ws-foobar",
-      "uid": "7168b1fa-6216-11e9-8627-42010a8401ee",
-      "resourceVersion": "92956603",
-      "creationTimestamp": "2019-04-18T20:13:34Z",
+      "name": "ws-foobas",
+      "namespace": "default",
+      "selfLink": "/api/v1/namespaces/default/pods/ws-foobas",
+      "uid": "486e5f88-4354-11e9-aee4-080027861af1",
+      "resourceVersion": "64953",
+      "creationTimestamp": "2019-03-10T16:48:08Z",
       "labels": {
         "gpwsman": "true",
         "headless": "false",
         "owner": "foobar",
         "metaID": "metameta",
-        "workspaceID": "foobar",
+        "workspaceID": "foobas",
         "workspaceType": "regular"
       },
       "annotations": {
-        "gitpod/id": "foobar",
-        "gitpod/servicePrefix": "foobar",
+        "gitpod/id": "foobas",
+        "gitpod/servicePrefix": "foobas",
         "gitpod/url": "http://10.0.0.114:8082",
-        "gitpod.io/alreadyInitializing": "true",
         "gitpod/never-ready": "true"
       }
     },
@@ -28,7 +27,7 @@
         {
           "name": "vol-this-workspace",
           "hostPath": {
-            "path": "/tmp/workspaces/foobar",
+            "path": "/tmp/workspaces/foobas",
             "type": "DirectoryOrCreate"
           }
         },
@@ -40,9 +39,9 @@
           }
         },
         {
-          "name": "default-token-n8csj",
+          "name": "default-token-6qnvx",
           "secret": {
-            "secretName": "default-token-n8csj",
+            "secretName": "default-token-6qnvx",
             "defaultMode": 420
           }
         }
@@ -50,7 +49,7 @@
       "containers": [
         {
           "name": "workspace",
-          "image": "eu.gcr.io/gitpod-dev/workspace-images/ac1c0755007966e4d6e090ea821729ac747d22ac/eu.gcr.io/gitpod-dev/workspace-base-images/github.com/typefox/gitpod:80a7d427a1fcd346d420603d80a31d57cf75a7af",
+          "image": "nginx:latest",
           "ports": [
             {
               "containerPort": 23000,
@@ -76,7 +75,7 @@
             },
             {
               "name": "GITPOD_WSSYNC_APITOKEN",
-              "value": "f6d7e843-f1d9-4e80-b71d-c1750999d451"
+              "value": "c17a7eaf-e5de-4e9d-815a-7919379e2bf8"
             },
             {
               "name": "GITPOD_WSSYNC_APIPORT",
@@ -88,11 +87,11 @@
             },
             {
               "name": "GITPOD_CLI_APITOKEN",
-              "value": "05ecaed4-ab7c-4951-b5a1-a244bd67b38f"
+              "value": "690516e2-c416-4a28-ba74-e36f125922aa"
             },
             {
               "name": "GITPOD_WORKSPACE_ID",
-              "value": "foobar"
+              "value": "foobas"
             },
             {
               "name": "GITPOD_GIT_USER_NAME",
@@ -101,10 +100,6 @@
             {
               "name": "GITPOD_GIT_USER_EMAIL",
               "value": "some@user.com"
-            },
-            {
-              "name": "USER_ENV_foo",
-              "value": "bar"
             }
           ],
           "resources": {
@@ -123,7 +118,7 @@
               "mountPath": "/workspace"
             },
             {
-              "name": "default-token-n8csj",
+              "name": "default-token-6qnvx",
               "readOnly": true,
               "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
             }
@@ -152,7 +147,7 @@
           },
           "terminationMessagePath": "/dev/termination-log",
           "terminationMessagePolicy": "File",
-          "imagePullPolicy": "IfNotPresent"
+          "imagePullPolicy": "Always"
         }
       ],
       "restartPolicy": "Always",
@@ -160,7 +155,7 @@
       "dnsPolicy": "ClusterFirst",
       "serviceAccountName": "default",
       "serviceAccount": "default",
-      "nodeName": "gke-gitpod-dev-worker-pool-2-184c607e-g6l3",
+      "nodeName": "minikube",
       "securityContext": {},
       "schedulerName": "default-scheduler",
       "tolerations": [
@@ -185,58 +180,52 @@
           "type": "Initialized",
           "status": "True",
           "lastProbeTime": null,
-          "lastTransitionTime": "2019-04-18T20:13:34Z"
+          "lastTransitionTime": "2019-03-10T16:48:08Z"
         },
         {
           "type": "Ready",
-          "status": "False",
+          "status": "True",
           "lastProbeTime": null,
-          "lastTransitionTime": "2019-04-18T20:13:34Z",
-          "reason": "ContainersNotReady",
-          "message": "containers with unready status: [workspace sync]"
+          "lastTransitionTime": "2019-03-10T16:48:13Z"
         },
         {
           "type": "PodScheduled",
           "status": "True",
           "lastProbeTime": null,
-          "lastTransitionTime": "2019-04-18T20:13:34Z"
+          "lastTransitionTime": "2019-03-10T16:48:08Z"
         }
       ],
-      "hostIP": "10.132.15.216",
-      "podIP": "10.0.7.138",
-      "startTime": "2019-04-18T20:13:34Z",
+      "hostIP": "10.0.2.15",
+      "podIP": "172.17.0.5",
+      "startTime": "2019-03-10T16:48:08Z",
       "containerStatuses": [
         {
           "name": "sync",
           "state": {
-            "terminated": {
-              "exitCode": 0,
-              "reason": "Completed",
-              "startedAt": "2019-04-18T20:13:36Z",
-              "finishedAt": "2019-04-18T20:13:36Z",
-              "containerID": "docker://350b2aab9bec5b6e507980d2a68dd70cc73c1dd40961614a3e32032c7ffb027c"
+            "running": {
+              "startedAt": "2019-03-10T16:48:13Z"
             }
           },
           "lastState": {},
-          "ready": false,
+          "ready": true,
           "restartCount": 0,
-          "image": "eu.gcr.io/gitpod-dev/gitpod-ws-daemon:cw-ws-manager.14",
-          "imageID": "docker-pullable://eu.gcr.io/gitpod-dev/gitpod-ws-daemon@sha256:be172b330ca6bbea9437c0dfb1cb84d67bd387a61295be6023f4273eba0ed6c2",
-          "containerID": "docker://350b2aab9bec5b6e507980d2a68dd70cc73c1dd40961614a3e32032c7ffb027c"
+          "image": "csweichel/noop:latest",
+          "imageID": "docker-pullable://csweichel/noop@sha256:aaa6b993f4c853fac7101aa7fc087926f829004e62cbce6e1852e5a3aac87c52",
+          "containerID": "docker://9961f75ea72f36bb0ba1e42b3b2da98eb44a9dc12e7c7e8edfb52512b3b04016"
         },
         {
           "name": "workspace",
           "state": {
             "running": {
-              "startedAt": "2019-04-18T20:13:36Z"
+              "startedAt": "2019-03-10T16:48:12Z"
             }
           },
           "lastState": {},
-          "ready": false,
+          "ready": true,
           "restartCount": 0,
-          "image": "eu.gcr.io/gitpod-dev/workspace-images/ac1c0755007966e4d6e090ea821729ac747d22ac/eu.gcr.io/gitpod-dev/workspace-base-images/github.com/typefox/gitpod:80a7d427a1fcd346d420603d80a31d57cf75a7af",
-          "imageID": "docker-pullable://eu.gcr.io/gitpod-dev/workspace-images/ac1c0755007966e4d6e090ea821729ac747d22ac/eu.gcr.io/gitpod-dev/workspace-base-images/github.com/typefox/gitpod@sha256:b54ab89543a41cf92072908be3837025fda4ce30722c43e5e088fb62c4a881f4",
-          "containerID": "docker://71c0b81bd5e95e0e096a4b5b12980140895504576a7c825c4ba962bf69a0ad33"
+          "image": "nginx:latest",
+          "imageID": "docker-pullable://nginx@sha256:98efe605f61725fd817ea69521b0eeb32bef007af0e3d0aeb6258c6e6fe7fc1a",
+          "containerID": "docker://e7080b843a47db414d6c94cfda7f657b99d8aa5bbf7c9c118ec98c0eefb6c0df"
         }
       ],
       "qosClass": "Guaranteed"
@@ -244,18 +233,18 @@
   },
   "theiaService": {
     "metadata": {
-      "name": "foobar-theia",
-      "namespace": "staging-cw-ws-manager",
-      "selfLink": "/api/v1/namespaces/staging-cw-ws-manager/services/foobar-theia",
-      "uid": "7164c38f-6216-11e9-8627-42010a8401ee",
-      "resourceVersion": "92956585",
-      "creationTimestamp": "2019-04-18T20:13:34Z",
+      "name": "foobas-theia",
+      "namespace": "default",
+      "selfLink": "/api/v1/namespaces/default/services/foobas-theia",
+      "uid": "48687212-4354-11e9-aee4-080027861af1",
+      "resourceVersion": "64923",
+      "creationTimestamp": "2019-03-10T16:48:08Z",
       "labels": {
         "gpwsman": "true",
         "headless": "false",
         "owner": "foobar",
         "metaID": "metameta",
-        "workspaceID": "foobar"
+        "workspaceID": "foobas"
       }
     },
     "spec": {
@@ -271,9 +260,9 @@
         "gpwsman": "true",
         "headless": "false",
         "owner": "foobar",
-        "workspaceID": "foobar"
+        "workspaceID": "foobas"
       },
-      "clusterIP": "10.3.248.227",
+      "clusterIP": "10.103.194.121",
       "type": "ClusterIP",
       "sessionAffinity": "None"
     },
@@ -283,15 +272,15 @@
   },
   "portsService": {
     "metadata": {
-      "name": "foobar-ports",
-      "namespace": "staging-cw-ws-manager",
-      "selfLink": "/api/v1/namespaces/staging-cw-ws-manager/services/foobar-ports",
-      "uid": "71662387-6216-11e9-8627-42010a8401ee",
-      "resourceVersion": "92956587",
-      "creationTimestamp": "2019-04-18T20:13:34Z",
+      "name": "foobas-ports",
+      "namespace": "default",
+      "selfLink": "/api/v1/namespaces/default/services/foobas-ports",
+      "uid": "486cb304-4354-11e9-aee4-080027861af1",
+      "resourceVersion": "64926",
+      "creationTimestamp": "2019-03-10T16:48:08Z",
       "labels": {
         "gpwsman": "true",
-        "workspaceID": "foobar"
+        "workspaceID": "foobas"
       }
     },
     "spec": {
@@ -304,9 +293,9 @@
       ],
       "selector": {
         "gpwsman": "true",
-        "workspaceID": "foobar"
+        "workspaceID": "foobas"
       },
-      "clusterIP": "10.3.250.22",
+      "clusterIP": "10.110.184.222",
       "type": "ClusterIP",
       "sessionAffinity": "None"
     },

--- a/components/ws-manager/pkg/manager/testdata/stopping_basic.json
+++ b/components/ws-manager/pkg/manager/testdata/stopping_basic.json
@@ -27,6 +27,7 @@
                     "gitpod/firstUserActivity": "2020-02-28T10:44:36.995133911Z",
                     "gitpod/id": "df376c57-7a0e-4233-976a-7a021e6f088c",
                     "gitpod/ready": "true",
+                    "gitpod.io/alreadyInitializing": "true",
                     "gitpod/servicePrefix": "c372bd58-ef61-4fc0-9083-bd61ef96ad9f",
                     "gitpod/url": "https://c372bd58-ef61-4fc0-9083-bd61ef96ad9f.ws-eu01.gitpod-staging.com",
                     "kubernetes.io/psp": "default-ns-privileged-unconfined"

--- a/components/ws-manager/pkg/manager/testdata/timeout_customTimeout_invalidValue.json
+++ b/components/ws-manager/pkg/manager/testdata/timeout_customTimeout_invalidValue.json
@@ -20,6 +20,7 @@
                 "annotations": {
                     "gitpod/id": "foobas",
                     "gitpod/ready": "true",
+                    "gitpod.io/alreadyInitializing": "true",
                     "gitpod/servicePrefix": "foobas",
                     "gitpod/url": "http://10.0.0.114:8082",
                     "gitpod/customTimeout": "this is not a valid duration"

--- a/components/ws-manager/pkg/manager/testdata/timeout_customTimeout_noActivity.json
+++ b/components/ws-manager/pkg/manager/testdata/timeout_customTimeout_noActivity.json
@@ -20,6 +20,7 @@
                 "annotations": {
                     "gitpod/id": "foobas",
                     "gitpod/ready": "true",
+                    "gitpod.io/alreadyInitializing": "true",
                     "gitpod/servicePrefix": "foobas",
                     "gitpod/url": "http://10.0.0.114:8082",
                     "gitpod/customTimeout": "10m"

--- a/components/ws-manager/pkg/manager/testdata/timeout_customTimeout_validValue.json
+++ b/components/ws-manager/pkg/manager/testdata/timeout_customTimeout_validValue.json
@@ -21,6 +21,7 @@
                 "annotations": {
                     "gitpod/id": "foobas",
                     "gitpod/ready": "true",
+                    "gitpod.io/alreadyInitializing": "true",
                     "gitpod/servicePrefix": "foobas",
                     "gitpod/url": "http://10.0.0.114:8082",
                     "gitpod/customTimeout": "2h"

--- a/components/ws-manager/pkg/manager/testdata/timeout_interrupted_noActivity.json
+++ b/components/ws-manager/pkg/manager/testdata/timeout_interrupted_noActivity.json
@@ -26,6 +26,7 @@
           "gitpod/contentInitializer": "[redacted]",
           "gitpod/id": "283522ed-51f1-4838-951b-0f115c0a7aae",
           "gitpod/ready": "true",
+          "gitpod.io/alreadyInitializing": "true",
           "gitpod/servicePrefix": "b246b28e-4776-47d5-961d-10548ffac9a8",
           "gitpod/url": "https://b246b28e-4776-47d5-961d-10548ffac9a8.ws-eu0.gitpod-staging.com",
           "kubernetes.io/psp": "workspace"

--- a/components/ws-manager/pkg/manager/testdata/timeout_interrupted_withActivity.json
+++ b/components/ws-manager/pkg/manager/testdata/timeout_interrupted_withActivity.json
@@ -27,6 +27,7 @@
           "gitpod/contentInitializer": "[redacted]",
           "gitpod/id": "283522ed-51f1-4838-951b-0f115c0a7aae",
           "gitpod/ready": "true",
+          "gitpod.io/alreadyInitializing": "true",
           "gitpod/servicePrefix": "b246b28e-4776-47d5-961d-10548ffac9a8",
           "gitpod/url": "https://b246b28e-4776-47d5-961d-10548ffac9a8.ws-eu0.gitpod-staging.com",
           "kubernetes.io/psp": "workspace"

--- a/components/ws-manager/pkg/manager/testdata/timeout_prebuild_customTimeout.json
+++ b/components/ws-manager/pkg/manager/testdata/timeout_prebuild_customTimeout.json
@@ -20,6 +20,7 @@
                 "annotations": {
                     "gitpod/id": "foobas",
                     "gitpod/ready": "true",
+                    "gitpod.io/alreadyInitializing": "true",
                     "gitpod/servicePrefix": "foobas",
                     "gitpod/url": "http://10.0.0.114:8082",
                     "gitpod/customTimeout": "2h"

--- a/components/ws-manager/pkg/manager/testdata/timeout_prebuild_overdue.json
+++ b/components/ws-manager/pkg/manager/testdata/timeout_prebuild_overdue.json
@@ -20,6 +20,7 @@
                 "annotations": {
                     "gitpod/id": "foobas",
                     "gitpod/ready": "true",
+                    "gitpod.io/alreadyInitializing": "true",
                     "gitpod/servicePrefix": "foobas",
                     "gitpod/url": "http://10.0.0.114:8082"
                 }

--- a/components/ws-manager/pkg/manager/testdata/timeout_regular_closed.json
+++ b/components/ws-manager/pkg/manager/testdata/timeout_regular_closed.json
@@ -21,6 +21,7 @@
                 "annotations": {
                     "gitpod/id": "foobas",
                     "gitpod/ready": "true",
+                    "gitpod.io/alreadyInitializing": "true",
                     "gitpod/closed": "true",
                     "gitpod/servicePrefix": "foobas",
                     "gitpod/url": "http://10.0.0.114:8082"

--- a/components/ws-manager/pkg/manager/testdata/timeout_regular_maxLifetime.json
+++ b/components/ws-manager/pkg/manager/testdata/timeout_regular_maxLifetime.json
@@ -21,6 +21,7 @@
                 "annotations": {
                     "gitpod/id": "foobas",
                     "gitpod/ready": "true",
+                    "gitpod.io/alreadyInitializing": "true",
                     "gitpod/servicePrefix": "foobas",
                     "gitpod/url": "http://10.0.0.114:8082"
                 }

--- a/components/ws-manager/pkg/manager/testdata/timeout_regular_noActivity.json
+++ b/components/ws-manager/pkg/manager/testdata/timeout_regular_noActivity.json
@@ -20,6 +20,7 @@
                 "annotations": {
                     "gitpod/id": "foobas",
                     "gitpod/ready": "true",
+                    "gitpod.io/alreadyInitializing": "true",
                     "gitpod/servicePrefix": "foobas",
                     "gitpod/url": "http://10.0.0.114:8082"
                 }

--- a/components/ws-manager/pkg/manager/testdata/timeout_regular_withActivityOK.json
+++ b/components/ws-manager/pkg/manager/testdata/timeout_regular_withActivityOK.json
@@ -21,6 +21,7 @@
                 "annotations": {
                     "gitpod/id": "foobas",
                     "gitpod/ready": "true",
+                    "gitpod.io/alreadyInitializing": "true",
                     "gitpod/servicePrefix": "foobas",
                     "gitpod/url": "http://10.0.0.114:8082"
                 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

For some reason, some workspaces slip through the CREATING phase. I assume that there is a problem with the reconcile handler. Because reconcile handler tries to get the workspace pod information via k8s API, I assume there is some lag from when the event happened.
https://github.com/gitpod-io/gitpod/blob/408619e8fe3253df2654b7af9b5b1a2d786f6c21/components/ws-manager/pkg/manager/pod_controller.go#L36

This PR has
- Improve performance of the reconcile handler
- Plant some traces
- Add annotation to prevent missing CREATING


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/15406
Probably fixs https://github.com/gitpod-io/gitpod/issues/12983

## How to test
<!-- Provide steps to test this PR -->

- Pass the integration test
- Run loadgen and pass

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
No failures even if a large number of workspaces are launched at once
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-integration-tests=workspace
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
