### PR TITLE
[supervisor] don't report metrics for ephemeral clusters

### DIFF
--- a/components/supervisor/pkg/supervisor/supervisor.go
+++ b/components/supervisor/pkg/supervisor/supervisor.go
@@ -280,16 +280,18 @@ func Run(options ...RunOption) {
 		if !cfg.isHeadless() {
 			go startAnalyze(ctx, cfg, gitpodConfigService, topService, gitpodService)
 		}
-		_, gitpodHost, err := cfg.GitpodAPIEndpoint()
-		if err != nil {
-			log.WithError(err).Error("grpc metrics: failed to parse gitpod host")
-		} else {
-			metricsReporter = metrics.NewGrpcMetricsReporter(gitpodHost)
-			if err := supervisorMetrics.Register(metricsReporter.Registry); err != nil {
-				log.WithError(err).Error("could not register supervisor metrics")
-			}
-			if err := gitpodService.RegisterMetrics(metricsReporter.Registry); err != nil {
-				log.WithError(err).Error("could not register public api metrics")
+		if !strings.Contains("ephemeral", cfg.WorkspaceClusterHost) {
+			_, gitpodHost, err := cfg.GitpodAPIEndpoint()
+			if err != nil {
+				log.WithError(err).Error("grpc metrics: failed to parse gitpod host")
+			} else {
+				metricsReporter = metrics.NewGrpcMetricsReporter(gitpodHost)
+				if err := supervisorMetrics.Register(metricsReporter.Registry); err != nil {
+					log.WithError(err).Error("could not register supervisor metrics")
+				}
+				if err := gitpodService.RegisterMetrics(metricsReporter.Registry); err != nil {
+					log.WithError(err).Error("could not register public api metrics")
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Alerts based on supervisor metrics are false positive when @gitpod-io/engineering-workspace is running load tests.
We cannot filter ephemeral workspace clusters in Grafana because supervisor metrics are aggregated in IDE proxy, i.e. in the application cluster. This PR disables metrics reporting from supervisor for ephemeral clusters.

[Internal thread](https://gitpod.slack.com/archives/C0201TXMV54/p1671697846070169)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

Check that metrics are still reported in preview envs.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
