### PR TITLE
Fix the License filename in headers

### DIFF
--- a/components/content-service/cmd/test.go
+++ b/components/content-service/cmd/test.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2022 Gitpod GmbH. All rights reserved.
 // Licensed under the GNU Affero General Public License (AGPL).
-// See License-AGPL.txt in the project root for license information.
+// See License.AGPL.txt in the project root for license information.
 
 package cmd
 

--- a/components/content-service/pkg/storage/s3.go
+++ b/components/content-service/pkg/storage/s3.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2022 Gitpod GmbH. All rights reserved.
 // Licensed under the GNU Affero General Public License (AGPL).
-// See License-AGPL.txt in the project root for license information.
+// See License.AGPL.txt in the project root for license information.
 
 package storage
 

--- a/components/content-service/pkg/storage/s3_test.go
+++ b/components/content-service/pkg/storage/s3_test.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2022 Gitpod GmbH. All rights reserved.
 // Licensed under the GNU Affero General Public License (AGPL).
-// See License-AGPL.txt in the project root for license information.
+// See License.AGPL.txt in the project root for license information.
 
 package storage_test
 

--- a/components/content-service/pkg/storage/suite_test.go
+++ b/components/content-service/pkg/storage/suite_test.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2022 Gitpod GmbH. All rights reserved.
 // Licensed under the GNU Affero General Public License (AGPL).
-// See License-AGPL.txt in the project root for license information.
+// See License.AGPL.txt in the project root for license information.
 
 package storage_test
 

--- a/components/dashboard/src/components/UsageLimitReachedModal.tsx
+++ b/components/dashboard/src/components/UsageLimitReachedModal.tsx
@@ -1,7 +1,7 @@
 /**
  * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
  * Licensed under the GNU Affero General Public License (AGPL).
- * See License-AGPL.txt in the project root for license information.
+ * See License.AGPL.txt in the project root for license information.
  */
 
 import { Team } from "@gitpod/gitpod-protocol";

--- a/components/iam/pkg/oidc/demo.go
+++ b/components/iam/pkg/oidc/demo.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2022 Gitpod GmbH. All rights reserved.
 // Licensed under the GNU Affero General Public License (AGPL).
-// See License-AGPL.txt in the project root for license information.
+// See License.AGPL.txt in the project root for license information.
 
 package oidc
 

--- a/components/iam/pkg/oidc/oauth2.go
+++ b/components/iam/pkg/oidc/oauth2.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2022 Gitpod GmbH. All rights reserved.
 // Licensed under the GNU Affero General Public License (AGPL).
-// See License-AGPL.txt in the project root for license information.
+// See License.AGPL.txt in the project root for license information.
 
 package oidc
 

--- a/components/ide/jetbrains/image/create-supervisor-config.js
+++ b/components/ide/jetbrains/image/create-supervisor-config.js
@@ -1,6 +1,6 @@
 // Copyright (c) 2022 Gitpod GmbH. All rights reserved.
 // Licensed under the GNU Affero General Public License (AGPL).
-// See License-AGPL.txt in the project root for license information.
+// See License.AGPL.txt in the project root for license information.
 
 // @ts-check
 const fs = require("fs");

--- a/components/ide/jetbrains/image/resolve-latest-ide-version.sh
+++ b/components/ide/jetbrains/image/resolve-latest-ide-version.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Copyright (c) 2022 Gitpod GmbH. All rights reserved.
 # Licensed under the GNU Affero General Public License (AGPL).
-# See License-AGPL.txt in the project root for license information.
+# See License.AGPL.txt in the project root for license information.
 
 set -Eeuo pipefail
 

--- a/components/ide/jetbrains/launcher/leeway.Dockerfile
+++ b/components/ide/jetbrains/launcher/leeway.Dockerfile
@@ -1,6 +1,6 @@
 # Copyright (c) 2022 Gitpod GmbH. All rights reserved.
 # Licensed under the GNU Affero General Public License (AGPL).
-# See License-AGPL.txt in the project root for license information.
+# See License.AGPL.txt in the project root for license information.
 
 FROM alpine:3.16 as base_builder
 RUN mkdir /ide-desktop

--- a/components/ide/jetbrains/launcher/main_test.go
+++ b/components/ide/jetbrains/launcher/main_test.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2022 Gitpod GmbH. All rights reserved.
 // Licensed under the GNU Affero General Public License (AGPL).
-// See License-AGPL.txt in the project root for license information.
+// See License.AGPL.txt in the project root for license information.
 
 package main
 

--- a/components/ide/jetbrains/launcher/testdata/.gitpod.yml
+++ b/components/ide/jetbrains/launcher/testdata/.gitpod.yml
@@ -1,6 +1,6 @@
 # Copyright (c) 2022 Gitpod GmbH. All rights reserved.
 # Licensed under the GNU Affero General Public License (AGPL).
-# See License-AGPL.txt in the project root for license information.
+# See License.AGPL.txt in the project root for license information.
 
 # see https://github.com/gitpod-io/spring-petclinic/blob/master/.gitpod.yml
 tasks:

--- a/components/ipfs/ipfs-cluster/leeway.Dockerfile
+++ b/components/ipfs/ipfs-cluster/leeway.Dockerfile
@@ -1,6 +1,6 @@
 # Copyright (c) 2022 Gitpod GmbH. All rights reserved.
 # Licensed under the GNU Affero General Public License (AGPL).
-# See License-AGPL.txt in the project root for license information.
+# See License.AGPL.txt in the project root for license information.
 
 ARG VERSION
 

--- a/components/ipfs/kubo/leeway.Dockerfile
+++ b/components/ipfs/kubo/leeway.Dockerfile
@@ -1,6 +1,6 @@
 # Copyright (c) 2022 Gitpod GmbH. All rights reserved.
 # Licensed under the GNU Affero General Public License (AGPL).
-# See License-AGPL.txt in the project root for license information.
+# See License.AGPL.txt in the project root for license information.
 
 ARG VERSION
 

--- a/components/refresh-credential/cmd/root.go
+++ b/components/refresh-credential/cmd/root.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2022 Gitpod GmbH. All rights reserved.
 // Licensed under the GNU Affero General Public License (AGPL).
-// See License-AGPL.txt in the project root for license information.
+// See License.AGPL.txt in the project root for license information.
 
 package cmd
 

--- a/components/refresh-credential/leeway.Dockerfile
+++ b/components/refresh-credential/leeway.Dockerfile
@@ -1,6 +1,6 @@
 # Copyright (c) 2022 Gitpod GmbH. All rights reserved.
 # Licensed under the GNU Affero General Public License (AGPL).
-# See License-AGPL.txt in the project root for license information.
+# See License.AGPL.txt in the project root for license information.
 
 FROM alpine:3.16
 

--- a/components/refresh-credential/main.go
+++ b/components/refresh-credential/main.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2022 Gitpod GmbH. All rights reserved.
 // Licensed under the GNU Affero General Public License (AGPL).
-// See License-AGPL.txt in the project root for license information.
+// See License.AGPL.txt in the project root for license information.
 
 package main
 

--- a/components/refresh-credential/pkg/config/config.go
+++ b/components/refresh-credential/pkg/config/config.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2022 Gitpod GmbH. All rights reserved.
 // Licensed under the GNU Affero General Public License (AGPL).
-// See License-AGPL.txt in the project root for license information.
+// See License.AGPL.txt in the project root for license information.
 
 package config
 

--- a/components/refresh-credential/pkg/ecr/updater.go
+++ b/components/refresh-credential/pkg/ecr/updater.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2022 Gitpod GmbH. All rights reserved.
 // Licensed under the GNU Affero General Public License (AGPL).
-// See License-AGPL.txt in the project root for license information.
+// See License.AGPL.txt in the project root for license information.
 
 package ecr
 

--- a/install/installer/pkg/components/image-builder-mk3/tlssecret.go
+++ b/install/installer/pkg/components/image-builder-mk3/tlssecret.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2022 Gitpod GmbH. All rights reserved.
 // Licensed under the GNU Affero General Public License (AGPL).
-// See License-AGPL.txt in the project root for license information.
+// See License.AGPL.txt in the project root for license information.
 
 package image_builder_mk3
 

--- a/install/installer/pkg/components/refresh-credential/common.go
+++ b/install/installer/pkg/components/refresh-credential/common.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2022 Gitpod GmbH. All rights reserved.
 // Licensed under the GNU Affero General Public License (AGPL).
-// See License-AGPL.txt in the project root for license information.
+// See License.AGPL.txt in the project root for license information.
 
 package refresh_credential
 

--- a/install/installer/pkg/components/refresh-credential/common_test.go
+++ b/install/installer/pkg/components/refresh-credential/common_test.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2022 Gitpod GmbH. All rights reserved.
 // Licensed under the GNU Affero General Public License (AGPL).
-// See License-AGPL.txt in the project root for license information.
+// See License.AGPL.txt in the project root for license information.
 
 package refresh_credential
 

--- a/install/installer/pkg/components/refresh-credential/constants.go
+++ b/install/installer/pkg/components/refresh-credential/constants.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2022 Gitpod GmbH. All rights reserved.
 // Licensed under the GNU Affero General Public License (AGPL).
-// See License-AGPL.txt in the project root for license information.
+// See License.AGPL.txt in the project root for license information.
 
 package refresh_credential
 

--- a/install/installer/pkg/components/refresh-credential/cronjob.go
+++ b/install/installer/pkg/components/refresh-credential/cronjob.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2022 Gitpod GmbH. All rights reserved.
 // Licensed under the GNU Affero General Public License (AGPL).
-// See License-AGPL.txt in the project root for license information.
+// See License.AGPL.txt in the project root for license information.
 
 package refresh_credential
 

--- a/install/installer/pkg/components/refresh-credential/objects.go
+++ b/install/installer/pkg/components/refresh-credential/objects.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2022 Gitpod GmbH. All rights reserved.
 // Licensed under the GNU Affero General Public License (AGPL).
-// See License-AGPL.txt in the project root for license information.
+// See License.AGPL.txt in the project root for license information.
 
 package refresh_credential
 

--- a/install/installer/pkg/components/refresh-credential/role.go
+++ b/install/installer/pkg/components/refresh-credential/role.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2022 Gitpod GmbH. All rights reserved.
 // Licensed under the GNU Affero General Public License (AGPL).
-// See License-AGPL.txt in the project root for license information.
+// See License.AGPL.txt in the project root for license information.
 
 package refresh_credential
 

--- a/install/installer/pkg/components/refresh-credential/rolebinding.go
+++ b/install/installer/pkg/components/refresh-credential/rolebinding.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2022 Gitpod GmbH. All rights reserved.
 // Licensed under the GNU Affero General Public License (AGPL).
-// See License-AGPL.txt in the project root for license information.
+// See License.AGPL.txt in the project root for license information.
 
 package refresh_credential
 


### PR DESCRIPTION
## Description
Fix the License filename in headers (`License-AGPL.txt` -> `License.AGPL.txt`)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
- Left-overs from https://github.com/gitpod-io/gitpod/pull/15241

## How to test
<!-- Provide steps to test this PR -->
Check if there's only one line changed per file:
```
// See License.AGPL.txt in the project root for license information.
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```