### PR TITLE
[iam] Read db encryption keys on component startup

### DIFF
--- a/components/iam/pkg/server/server.go
+++ b/components/iam/pkg/server/server.go
@@ -6,9 +6,11 @@ package server
 
 import (
 	"fmt"
-	db "github.com/gitpod-io/gitpod/components/gitpod-db/go"
 	"net"
 	"os"
+	"path/filepath"
+
+	db "github.com/gitpod-io/gitpod/components/gitpod-db/go"
 
 	goidc "github.com/coreos/go-oidc/v3/oidc"
 	"github.com/gitpod-io/gitpod/common-go/baseserver"
@@ -32,6 +34,11 @@ func Start(logger *logrus.Entry, version string, cfg *config.ServiceConfig) erro
 	})
 	if err != nil {
 		return fmt.Errorf("failed to establish database connection: %w", err)
+	}
+
+	_, err = db.NewCipherSetFromKeysInFile(filepath.Join(cfg.DatabaseConfigPath, "encryptionKeys"))
+	if err != nil {
+		return fmt.Errorf("failed to read cipherset from file: %w", err)
 	}
 
 	srv, err := baseserver.New("iam",


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Reads encryption keys on component startup. Keys are not yet used.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
