### PR TITLE
[supervisor] make it compatible with run-gp

### DIFF
--- a/components/supervisor/.gitignore
+++ b/components/supervisor/.gitignore
@@ -1,0 +1,1 @@
+supervisor

--- a/components/supervisor/cmd/run.go
+++ b/components/supervisor/cmd/run.go
@@ -23,7 +23,7 @@ var runCmd = &cobra.Command{
 	Short: "starts the supervisor",
 
 	Run: func(cmd *cobra.Command, args []string) {
-		log.Init(ServiceName, Version, true, os.Getenv("SUPERVISOR_DEBUG_ENABLE") == "true")
+		log.Init(ServiceName, Version, !runOpts.RunGP, os.Getenv("SUPERVISOR_DEBUG_ENABLE") == "true")
 		common_grpc.SetupLogging()
 		supervisor.Version = Version
 		supervisor.Run(supervisor.WithRunGP(runOpts.RunGP))

--- a/components/supervisor/hot-swap.sh
+++ b/components/supervisor/hot-swap.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+# Licensed under the GNU Affero General Public License (AGPL).
+# See License.AGPL.txt in the project root for license information.
+
+set -Eeuo pipefail
+
+# This script swaps the backend startup endpoint with a built one
+# in a workspace and restarts the JB backend.
+
+component=${PWD##*/}
+workspaceUrl=$(echo "${1}" |sed -e "s/\/$//")
+echo "URL: $workspaceUrl"
+
+workspaceDesc=$(gpctl workspaces describe "$workspaceUrl" -o=json)
+
+podName=$(echo "$workspaceDesc" | jq .runtime.pod_name -r)
+echo "Pod: $podName"
+
+workspaceId=$(echo "$workspaceDesc" | jq .metadata.meta_id -r)
+echo "ID: $workspaceId"
+
+clusterHost=$(kubectl exec -it "$podName" -- printenv GITPOD_WORKSPACE_CLUSTER_HOST |sed -e "s/\s//g")
+echo "Cluster Host: $clusterHost"
+
+# prepare ssh
+ownerToken=$(kubectl get pod "$podName" -o=json | jq ".metadata.annotations.\"gitpod\/ownerToken\"" -r)
+sshConfig="./ssh-config"
+echo "Host $workspaceId" > "$sshConfig"
+echo "    Hostname \"$workspaceId.ssh.$clusterHost\"" >> "$sshConfig"
+echo "    User \"$workspaceId#$ownerToken\"" >> "$sshConfig"
+
+# build
+go build .
+echo "$component built"
+
+# upload
+uploadDest="/.supervisor/$component"
+echo "Upload Dest: $uploadDest"
+ssh -F "$sshConfig" "$workspaceId" "sudo chmod 777 $uploadDest && sudo rm $uploadDest"
+scp -F "$sshConfig" -r "./supervisor" "$workspaceId":"$uploadDest"
+echo "Swap complete"

--- a/components/supervisor/local-hot-swap.sh
+++ b/components/supervisor/local-hot-swap.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+# Licensed under the GNU Affero General Public License (AGPL).
+# See License.AGPL.txt in the project root for license information.
+
+set -Eeuo pipefail
+
+# This script swaps the backend startup endpoint with a built one
+# in a workspace and restarts the JB backend.
+
+component=${PWD##*/}
+
+# build
+go build .
+echo "$component built"
+
+sudo rm /.supervisor/supervisor
+sudo mv ./"$component" /.supervisor
+echo "Local Swap complete"

--- a/components/supervisor/pkg/ports/ports.go
+++ b/components/supervisor/pkg/ports/ports.go
@@ -872,3 +872,13 @@ func defaultRoutableIP() string {
 
 	return addresses[0].(*net.IPNet).IP.String()
 }
+
+func (pm *Manager) IsServed(port uint32) bool {
+	served := pm.served
+	for _, served := range served {
+		if served.Port == port {
+			return true
+		}
+	}
+	return false
+}

--- a/components/supervisor/pkg/run/run.go
+++ b/components/supervisor/pkg/run/run.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package run
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/gitpod-io/gitpod/supervisor/api"
+	"github.com/gitpod-io/gitpod/supervisor/pkg/ports"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+type Option struct {
+	Port  uint32
+	Ports *ports.Manager
+}
+
+type Client struct {
+	option *Option
+
+	conn      *grpc.ClientConn
+	closeOnce sync.Once
+
+	Status   api.StatusServiceClient
+	Terminal api.TerminalServiceClient
+}
+
+func New(ctx context.Context, option *Option) (*Client, error) {
+	url := fmt.Sprintf("localhost:%d", option.Port)
+	conn, err := grpc.DialContext(ctx, url, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return nil, err
+	}
+	return &Client{
+		option:   option,
+		conn:     conn,
+		Status:   api.NewStatusServiceClient(conn),
+		Terminal: api.NewTerminalServiceClient(conn),
+	}, nil
+}
+
+func (client *Client) Close() {
+	client.closeOnce.Do(func() {
+		client.conn.Close()
+	})
+}
+
+func (client *Client) Available() bool {
+	if client == nil {
+		return false
+	}
+	return client.option.Ports.IsServed(client.option.Port)
+}

--- a/components/supervisor/pkg/supervisor/config.go
+++ b/components/supervisor/pkg/supervisor/config.go
@@ -85,6 +85,9 @@ type StaticConfig struct {
 
 	// SSHPort is the port we run the SSH server on
 	SSHPort int `json:"sshPort"`
+
+	// RunEndpointPort is the port where to serve the run API endpoint on
+	RunEndpointPort *int `json:"runEndpointPort,omitempty"`
 }
 
 // Validate validates this configuration.

--- a/components/supervisor/pkg/supervisor/supervisor_test.go
+++ b/components/supervisor/pkg/supervisor/supervisor_test.go
@@ -122,7 +122,7 @@ func TestBuildChildProcEnv(t *testing.T) {
 				cfg.EnvvarOTS = srv.URL
 			}
 
-			act := buildChildProcEnv(cfg, test.Input)
+			act := buildChildProcEnv(cfg, test.Input, false)
 			assert(t, act)
 		})
 	}

--- a/components/supervisor/pkg/supervisor/tasks.go
+++ b/components/supervisor/pkg/supervisor/tasks.go
@@ -109,9 +109,10 @@ type tasksManager struct {
 	reporter        headlessTaskProgressReporter
 	ideReady        *ideReadyState
 	desktopIdeReady *ideReadyState
+	runGP           bool
 }
 
-func newTasksManager(config *Config, terminalService *terminal.MuxTerminalService, contentState ContentState, reporter headlessTaskProgressReporter, ideReady *ideReadyState, desktopIdeReady *ideReadyState) *tasksManager {
+func newTasksManager(config *Config, terminalService *terminal.MuxTerminalService, contentState ContentState, reporter headlessTaskProgressReporter, ideReady *ideReadyState, desktopIdeReady *ideReadyState, runGP bool) *tasksManager {
 	return &tasksManager{
 		config:          config,
 		terminalService: terminalService,
@@ -122,6 +123,7 @@ func newTasksManager(config *Config, terminalService *terminal.MuxTerminalServic
 		storeLocation:   logs.TerminalStoreLocation,
 		ideReady:        ideReady,
 		desktopIdeReady: desktopIdeReady,
+		runGP:           runGP,
 	}
 }
 
@@ -203,11 +205,19 @@ func (tm *tasksManager) init(ctx context.Context) {
 	for i, config := range *tasks {
 		id := strconv.Itoa(i)
 		presentation := &api.TaskPresentation{}
+
+		var name string
 		if config.Name != nil {
-			presentation.Name = *config.Name
-		} else {
-			presentation.Name = "Gitpod Task " + strconv.Itoa(i+1)
+			name = *config.Name
 		}
+		if name == "" {
+			name = "Gitpod Task " + strconv.Itoa(i+1)
+		}
+		if tm.runGP {
+			name = "Run: " + name
+		}
+		presentation.Name = name
+
 		if config.OpenIn != nil {
 			presentation.OpenIn = *config.OpenIn
 		}

--- a/components/supervisor/pkg/supervisor/tasks_test.go
+++ b/components/supervisor/pkg/supervisor/tasks_test.go
@@ -216,7 +216,7 @@ func TestTaskManager(t *testing.T) {
 			}
 
 			var (
-				terminalService = terminal.NewMuxTerminalService(terminal.NewMux())
+				terminalService = terminal.NewMuxTerminalService(terminal.NewMux(), nil)
 				contentState    = NewInMemoryContentState("")
 				reporter        = testHeadlessTaskProgressReporter{}
 				taskManager     = newTasksManager(&Config{
@@ -224,7 +224,7 @@ func TestTaskManager(t *testing.T) {
 						GitpodTasks:    gitpodTasks,
 						GitpodHeadless: strconv.FormatBool(test.Headless),
 					},
-				}, terminalService, contentState, &reporter, nil, nil)
+				}, terminalService, contentState, &reporter, nil, nil, false)
 			)
 			taskManager.storeLocation = storeLocation
 			contentState.MarkContentReady(test.Source)

--- a/components/supervisor/pkg/terminal/terminal_test.go
+++ b/components/supervisor/pkg/terminal/terminal_test.go
@@ -56,7 +56,7 @@ func TestTitle(t *testing.T) {
 			}
 			defer os.RemoveAll(tmpWorkdir)
 
-			terminalService := NewMuxTerminalService(mux)
+			terminalService := NewMuxTerminalService(mux, nil)
 			terminalService.DefaultWorkdir = tmpWorkdir
 
 			term, err := terminalService.OpenWithOptions(context.Background(), &api.OpenTerminalRequest{}, TermOptions{
@@ -189,7 +189,7 @@ func TestAnnotations(t *testing.T) {
 			mux := NewMux()
 			defer mux.Close(context.Background())
 
-			terminalService := NewMuxTerminalService(mux)
+			terminalService := NewMuxTerminalService(mux, nil)
 			var err error
 			if test.Opts == nil {
 				_, err = terminalService.Open(context.Background(), test.Req)
@@ -240,7 +240,7 @@ func TestTerminals(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.Desc, func(t *testing.T) {
-			terminalService := NewMuxTerminalService(NewMux())
+			terminalService := NewMuxTerminalService(NewMux(), nil)
 			resp, err := terminalService.Open(context.Background(), &api.OpenTerminalRequest{})
 			if err != nil {
 				t.Fatal(err)
@@ -317,7 +317,7 @@ func TestWorkDirProvider(t *testing.T) {
 	mux := NewMux()
 	defer mux.Close(context.Background())
 
-	terminalService := NewMuxTerminalService(mux)
+	terminalService := NewMuxTerminalService(mux, nil)
 
 	type AssertWorkDirTest struct {
 		expectedWorkDir string

--- a/components/supervisor/supervisor-config.json
+++ b/components/supervisor/supervisor-config.json
@@ -3,5 +3,6 @@
   "desktopIdeConfigLocation": "/ide-desktop/supervisor-ide-config.json",
   "frontendLocation": "/.supervisor/frontend/",
   "apiEndpointPort": 22999,
-  "sshPort": 23001
+  "sshPort": 23001,
+  "runEndpointPort": 25000
 }


### PR DESCRIPTION
## Description
This PR introduces changes to supervisor to make it work nicely when running inside `run-gp`. Some changes will actually skip some logic from supervisor which is not required. Other changes are extending supervisor capabilities to fetch tasks from 2 supervisor instances.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
https://ak-merge-run-tasks.preview.gitpod-dev.com/workspaces

Start a workspace and test for regressions for `gp tasks` 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
