### PR TITLE
[iam] add preview env config

### DIFF
--- a/dev/preview/workflow/preview/deploy-gitpod.sh
+++ b/dev/preview/workflow/preview/deploy-gitpod.sh
@@ -446,6 +446,25 @@ yq w -i "${INSTALLER_CONFIG_PATH}" "experimental.webapp.server.chargebeeSecret" 
 yq w -i "${INSTALLER_CONFIG_PATH}" "experimental.webapp.server.stripeSecret" "stripe-api-keys"
 yq w -i "${INSTALLER_CONFIG_PATH}" "experimental.webapp.server.stripeConfig" "stripe-config"
 
+#
+# IAM
+#
+
+# copy secret from werft's space
+kubectl --kubeconfig "${DEV_KUBE_PATH}" --context "${DEV_KUBE_CONTEXT}" -n werft get secret preview-envs-oidc-clients-config-secret -o yaml > preview-envs-oidc-clients-config-secret.secret.yaml
+yq d -i preview-envs-oidc-clients-config-secret.secret.yaml metadata.name
+yq d -i preview-envs-oidc-clients-config-secret.secret.yaml metadata.creationTimestamp
+yq d -i preview-envs-oidc-clients-config-secret.secret.yaml metadata.uid
+yq d -i preview-envs-oidc-clients-config-secret.secret.yaml metadata.resourceVersion
+yq w -i preview-envs-oidc-clients-config-secret.secret.yaml metadata.name "oidc-clients-config-secret"
+yq w -i preview-envs-oidc-clients-config-secret.secret.yaml metadata.namespace "default"
+kubectl --kubeconfig "${PREVIEW_K3S_KUBE_PATH}" --context "${PREVIEW_K3S_KUBE_CONTEXT}" apply -f preview-envs-oidc-clients-config-secret.secret.yaml
+rm -f preview-envs-oidc-clients-config-secret.secret.yaml
+
+# enable config
+yq w -i "${INSTALLER_CONFIG_PATH}" "experimental.webapp.iam.oidsClientsConfigSecret" "oidc-clients-config-secret"
+
+
 log_success "Generated config at $INSTALLER_CONFIG_PATH"
 
 # ========

--- a/install/installer/pkg/components/iam/configmap.go
+++ b/install/installer/pkg/components/iam/configmap.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gitpod-io/gitpod/iam/pkg/config"
 
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
+	"github.com/gitpod-io/gitpod/installer/pkg/config/v1/experimental"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -38,6 +39,16 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 
 		DatabaseConfigPath: databaseSecretMountPath,
 	}
+
+	_ = ctx.WithExperimental(func(ucfg *experimental.Config) error {
+		_, _, path, ok := getOIDCClientsConfig(ucfg)
+		if !ok {
+			return nil
+		}
+
+		cfg.OIDCClientsConfigFile = path
+		return nil
+	})
 
 	fc, err := common.ToJSONString(cfg)
 	if err != nil {

--- a/install/installer/pkg/components/iam/constants.go
+++ b/install/installer/pkg/components/iam/constants.go
@@ -7,10 +7,12 @@ package iam
 const (
 	Component = "iam"
 
-	GRPCPortName      = "grpc"
-	GRPCContainerPort = 9001
-	GRPCServicePort   = 9001
-	HTTPContainerPort = 9002
-	HTTPServicePort   = 9002
-	HTTPPortName      = "http"
+	GRPCPortName               = "grpc"
+	GRPCContainerPort          = 9001
+	GRPCServicePort            = 9001
+	HTTPContainerPort          = 9002
+	HTTPServicePort            = 9002
+	HTTPPortName               = "http"
+	oidcClientsSecretMountPath = "oidc-clients-secret"
+	oidcClientsSecretFilename  = "config.json"
 )

--- a/install/installer/pkg/components/iam/deployment.go
+++ b/install/installer/pkg/components/iam/deployment.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gitpod-io/gitpod/installer/pkg/cluster"
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
+	"github.com/gitpod-io/gitpod/installer/pkg/config/v1/experimental"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -54,6 +55,17 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 		},
 		databaseSecretMount,
 	}
+
+	_ = ctx.WithExperimental(func(cfg *experimental.Config) error {
+		volume, mount, _, ok := getOIDCClientsConfig(cfg)
+		if !ok {
+			return nil
+		}
+
+		volumes = append(volumes, volume)
+		volumeMounts = append(volumeMounts, mount)
+		return nil
+	})
 
 	labels := common.CustomizeLabel(ctx, Component, common.TypeMetaDeployment)
 	return []runtime.Object{

--- a/install/installer/pkg/components/iam/oidc.go
+++ b/install/installer/pkg/components/iam/oidc.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the MIT License. See License-MIT.txt in the project root for license information.
+
+package iam
+
+import (
+	"path/filepath"
+
+	"github.com/gitpod-io/gitpod/installer/pkg/config/v1/experimental"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/pointer"
+)
+
+func getOIDCClientsConfig(cfg *experimental.Config) (corev1.Volume, corev1.VolumeMount, string, bool) {
+	var volume corev1.Volume
+	var mount corev1.VolumeMount
+	var path string
+
+	if cfg == nil || cfg.WebApp == nil || cfg.WebApp.IAM == nil || cfg.WebApp.IAM.OIDCClientsSecretName == "" {
+		return volume, mount, path, false
+	}
+
+	secretName := cfg.WebApp.IAM.OIDCClientsSecretName
+
+	volume = corev1.Volume{
+		Name: "oidc-clients-secret",
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{
+				SecretName: secretName,
+				Optional:   pointer.Bool(true),
+			},
+		},
+	}
+
+	mount = corev1.VolumeMount{
+		Name:      "oidc-clients-secret",
+		MountPath: oidcClientsSecretMountPath,
+		ReadOnly:  true,
+	}
+	path = filepath.Join(oidcClientsSecretMountPath, oidcClientsSecretFilename)
+
+	return volume, mount, path, true
+}

--- a/install/installer/pkg/config/v1/experimental/experimental.go
+++ b/install/installer/pkg/config/v1/experimental/experimental.go
@@ -185,6 +185,7 @@ type StripeConfig struct {
 }
 
 type IAMConfig struct {
+	OIDCClientsSecretName string `json:"oidsClientsConfigSecret,omitempty"`
 }
 
 type WebAppConfig struct {


### PR DESCRIPTION
Based on #15482

Injects config from `werft` namespace.

## Related Issue(s)
Part of https://github.com/gitpod-io/gitpod/issues/14955 (OIDC client implementation)
Relates to SSO Epic https://github.com/gitpod-io/gitpod/issues/7761

## How to test
Verify that the config (stored internally in `werft` namespace) is injected into the preview env.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
