### PR TITLE
GH PoC: Add Job Summary to install job

### DIFF
--- a/.github/workflows/poc-build.yml
+++ b/.github/workflows/poc-build.yml
@@ -161,6 +161,7 @@ jobs:
           echo "${PREVIEW_ENV_DEV_SA_KEY}" > "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
           previewctl install-context --timeout 10m --gcp-service-account "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
           leeway run dev/preview:deploy-gitpod
+          previewctl report >> $GITHUB_STEP_SUMMARY
 
   monitoring:
     needs: [previewctl, infrastructure]

--- a/.github/workflows/poc-build.yml
+++ b/.github/workflows/poc-build.yml
@@ -200,3 +200,7 @@ jobs:
           echo "${PREVIEW_ENV_DEV_SA_KEY}" > "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
           previewctl install-context --timeout 10m --gcp-service-account "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
           leeway run dev/preview:deploy-monitoring-satellite
+          echo '<p>Monitoring satellite has been installed in your preview environment.</p>' >> $GITHUB_STEP_SUMMARY
+          echo '<ul>' >> $GITHUB_STEP_SUMMARY
+          echo '<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/f2938b2bcb0c4c8c99afe1d2b872380e" target="_blank">internal documentation</a> on how to use it.</li>' >> $GITHUB_STEP_SUMMARY
+          echo '</ul>' >> $GITHUB_STEP_SUMMARY

--- a/dev/preview/previewctl/cmd/report.go
+++ b/dev/preview/previewctl/cmd/report.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package cmd
+
+import (
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/gitpod-io/gitpod/previewctl/pkg/preview"
+
+	"text/template"
+)
+
+var tmplString = `
+<p>Gitpod was successfully deployed to your preview environment.</p>
+<ul>
+	<li><b>🏷️ Name</b> - {{ .Name }}</li>
+	<li><b>🔗 URL</b> - <a href="https://{{ .Name }}.preview.gitpod-dev.com/workspaces" target="_blank">{{ .Name }}.preview.gitpod-dev.com/workspaces</a>.</li>
+	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
+</ul>
+`
+
+func newReportNameCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "report",
+		Short: "Writes an HTML report to stdout with information about the current preview environment.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			previewName, err := preview.GetName(branch)
+			if err != nil {
+				return err
+			}
+
+			tmpl, _ := template.New("Report").Parse(strings.TrimSpace(strings.ReplaceAll(tmplString, "'", "`")))
+
+			vars := make(map[string]interface{})
+			vars["Name"] = previewName
+			vars["Url"] = previewName
+
+			err = tmpl.Execute(os.Stdout, vars)
+			if err != nil {
+				return err
+			}
+
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/dev/preview/previewctl/cmd/root.go
+++ b/dev/preview/previewctl/cmd/root.go
@@ -45,6 +45,7 @@ func NewRootCmd(logger *logrus.Logger) *cobra.Command {
 		newGetCredentialsCommand(logger),
 		newGetCmd(logger),
 		newHasAccessCmd(logger),
+		newReportNameCmd(),
 	)
 
 	return cmd


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This adds a very simple Job Summary to do the deploy job. For now it just includes the name and URL where the Gitpod installation is reachable. In the future it could include any relevant configuration options for Gitpod that were selected for the preview environment.

I also adds a simple Job Summary to the monitoring job.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/15487
Fixes https://github.com/gitpod-io/gitpod/issues/15495

## How to test
<!-- Provide steps to test this PR -->

See the result [here](https://github.com/gitpod-io/gitpod/actions/runs/3765182576).

<img width="1160" alt="Screenshot 2022-12-23 at 12 13 32" src="https://user-images.githubusercontent.com/83561/209326490-4f5bab4a-acfa-493c-878b-3fe614069d1d.png">


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

N/A

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
