### PR TITLE
License: Public API npm package

### DIFF
--- a/components/public-api/typescript/package.json
+++ b/components/public-api/typescript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gitpod/public-api",
   "version": "0.1.5",
-  "license": "UNLICENSED",
+  "license": "AGPL-3.0",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "files": [


### PR DESCRIPTION
## Description

Currently, we are using default version of `package.json` which shows public-API package as `UNLICENSED`. This PR propose changes to make it AGPL-3.0:

![image](https://user-images.githubusercontent.com/55068936/209290062-2a3df57e-d9fd-41f1-b571-60b779e02bd8.png)


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
No

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
