### PR TITLE
test: Plant a lot of logs for QA report

### DIFF
--- a/test/pkg/report/features.go
+++ b/test/pkg/report/features.go
@@ -7,11 +7,15 @@ package report
 type Feature string
 
 const (
-	FeatureExample       Feature = "example"
-	FeatureResourceLimit Feature = "resource limit"
-	FeatureContentInit   Feature = "content init"
-	FeatureDocker        Feature = "docker"
-	FeatureDotfiles      Feature = "dotfiles"
-	FeatureMultiRepos    Feature = "multi repos"
-	FeaturePrebuild      Feature = "prebuild"
+	FeatureExample          Feature = "example"
+	FeatureResourceLimit    Feature = "resource limit"
+	FeatureContentInit      Feature = "content init"
+	FeatureContentOperation Feature = "content operations"
+	FeatureDocker           Feature = "docker"
+	FeatureDotfiles         Feature = "dotfiles"
+	FeatureMultiRepos       Feature = "multi repos"
+	FeaturePrebuild         Feature = "prebuild"
+	FeatureGit              Feature = "git"
+	FeatureK3s              Feature = "k3s"
+	FeatureImageBuild       Feature = "image build"
 )

--- a/test/pkg/report/features.go
+++ b/test/pkg/report/features.go
@@ -18,4 +18,5 @@ const (
 	FeatureGit              Feature = "git"
 	FeatureK3s              Feature = "k3s"
 	FeatureImageBuild       Feature = "image build"
+	FeatureBackup           Feature = "backup"
 )

--- a/test/tests/components/content-service/content-service_test.go
+++ b/test/tests/components/content-service/content-service_test.go
@@ -21,6 +21,7 @@ import (
 
 	content_service_api "github.com/gitpod-io/gitpod/content-service/api"
 	"github.com/gitpod-io/gitpod/test/pkg/integration"
+	"github.com/gitpod-io/gitpod/test/pkg/report"
 )
 
 var (
@@ -81,6 +82,8 @@ func TestUploadUrl(t *testing.T) {
 
 			for _, test := range tests {
 				t.Run(test.Name, func(t *testing.T) {
+					report.SetupReport(t, report.FeatureContentOperation, fmt.Sprintf("test to upload the content - %s", test.Name))
+
 					resp, err := bs.UploadUrl(ctx, &content_service_api.UploadUrlRequest{OwnerId: test.InputOwnerID, Name: test.InputName})
 					if err != nil && test.ExpectedErrorCode == codes.OK {
 						t.Fatal(err)
@@ -141,6 +144,8 @@ func TestDownloadUrl(t *testing.T) {
 
 			for _, test := range tests {
 				t.Run(test.Name, func(t *testing.T) {
+					report.SetupReport(t, report.FeatureContentOperation, fmt.Sprintf("test to downlod the content - %s", test.Name))
+
 					resp, err := bs.DownloadUrl(ctx, &content_service_api.DownloadUrlRequest{OwnerId: test.InputOwnerID, Name: test.InputName})
 					if err != nil && test.ExpectedErrorCode == codes.OK {
 						t.Fatal(err)
@@ -172,6 +177,8 @@ func TestUploadDownloadBlob(t *testing.T) {
 	f := features.New("UploadDownloadBlob").
 		WithLabel("component", "server").
 		Assess("it should upload and download blob", func(_ context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			report.SetupReport(t, report.FeatureContentOperation, "test to delete the content")
+
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 			defer cancel()
 

--- a/test/tests/components/image-builder/builder_test.go
+++ b/test/tests/components/image-builder/builder_test.go
@@ -21,12 +21,15 @@ import (
 	csapi "github.com/gitpod-io/gitpod/content-service/api"
 	imgapi "github.com/gitpod-io/gitpod/image-builder/api"
 	"github.com/gitpod-io/gitpod/test/pkg/integration"
+	"github.com/gitpod-io/gitpod/test/pkg/report"
 )
 
 func TestBaseImageBuild(t *testing.T) {
 	f := features.New("database").
 		WithLabel("component", "image-builder").
 		Assess("it should build a base image", func(_ context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			report.SetupReport(t, report.FeatureImageBuild, "build a new base image")
+
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 			defer cancel()
 
@@ -107,6 +110,8 @@ func TestParallelBaseImageBuild(t *testing.T) {
 	f := features.New("image-builder").
 		WithLabel("component", "image-builder").
 		Assess("it should allow parallel build of images", func(_ context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			report.SetupReport(t, report.FeatureImageBuild, "build the images in parallel")
+
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 			defer cancel()
 

--- a/test/tests/components/ws-daemon/cpu_burst_test.go
+++ b/test/tests/components/ws-daemon/cpu_burst_test.go
@@ -19,6 +19,7 @@ import (
 	daemon "github.com/gitpod-io/gitpod/test/pkg/agent/daemon/api"
 	wsapi "github.com/gitpod-io/gitpod/test/pkg/agent/workspace/api"
 	"github.com/gitpod-io/gitpod/test/pkg/integration"
+	"github.com/gitpod-io/gitpod/test/pkg/report"
 	wsmanapi "github.com/gitpod-io/gitpod/ws-manager/api"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -33,6 +34,7 @@ type DaemonConfig struct {
 
 func TestCpuBurst(t *testing.T) {
 	f := features.New("cpulimiting").WithLabel("component", "ws-manager").Assess("check cpu limiting", func(_ context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+		report.SetupReport(t, report.FeatureResourceLimit, "generic cpu limiting is applied")
 		t.Parallel()
 
 		ctx, cancel := context.WithTimeout(context.Background(), 8*time.Minute)

--- a/test/tests/components/ws-manager/additional_repositories_test.go
+++ b/test/tests/components/ws-manager/additional_repositories_test.go
@@ -17,6 +17,7 @@ import (
 	csapi "github.com/gitpod-io/gitpod/content-service/api"
 	agent "github.com/gitpod-io/gitpod/test/pkg/agent/workspace/api"
 	"github.com/gitpod-io/gitpod/test/pkg/integration"
+	"github.com/gitpod-io/gitpod/test/pkg/report"
 	wsmanapi "github.com/gitpod-io/gitpod/ws-manager/api"
 )
 
@@ -40,6 +41,7 @@ func TestAdditionalRepositories(t *testing.T) {
 					CloneTaget: "aledbf/test-additional-repositories-with-branches",
 				},
 			}
+			report.SetupReport(t, report.FeatureMultiRepos, "all repositories are available in the workspace")
 
 			for _, test := range tests {
 				t.Run(test.Name, func(t *testing.T) {

--- a/test/tests/components/ws-manager/content_test.go
+++ b/test/tests/components/ws-manager/content_test.go
@@ -18,6 +18,7 @@ import (
 	csapi "github.com/gitpod-io/gitpod/content-service/api"
 	agent "github.com/gitpod-io/gitpod/test/pkg/agent/workspace/api"
 	"github.com/gitpod-io/gitpod/test/pkg/integration"
+	"github.com/gitpod-io/gitpod/test/pkg/report"
 	wsmanapi "github.com/gitpod-io/gitpod/ws-manager/api"
 )
 
@@ -56,6 +57,8 @@ func TestBackup(t *testing.T) {
 					},
 				*/
 			}
+			report.SetupReport(t, report.FeatureBackup, "workspace can be backed up using object storage")
+
 			for _, test := range tests {
 				t.Run(test.Name, func(t *testing.T) {
 					t.Parallel()

--- a/test/tests/components/ws-manager/dotfiles_test.go
+++ b/test/tests/components/ws-manager/dotfiles_test.go
@@ -21,6 +21,7 @@ import (
 	csapi "github.com/gitpod-io/gitpod/content-service/api"
 	agent "github.com/gitpod-io/gitpod/test/pkg/agent/workspace/api"
 	"github.com/gitpod-io/gitpod/test/pkg/integration"
+	"github.com/gitpod-io/gitpod/test/pkg/report"
 	wsmanapi "github.com/gitpod-io/gitpod/ws-manager/api"
 )
 
@@ -30,6 +31,7 @@ func TestDotfiles(t *testing.T) {
 	integration.SkipWithoutUserToken(t, userToken)
 
 	f := features.New("dotfiles").WithLabel("component", "ws-manager").Assess("ensure dotfiles are loaded", func(_ context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+		report.SetupReport(t, report.FeatureDotfiles, "dotfiles have been installed")
 		t.Parallel()
 
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)

--- a/test/tests/components/ws-manager/multi_repo_test.go
+++ b/test/tests/components/ws-manager/multi_repo_test.go
@@ -17,6 +17,7 @@ import (
 	csapi "github.com/gitpod-io/gitpod/content-service/api"
 	agent "github.com/gitpod-io/gitpod/test/pkg/agent/workspace/api"
 	"github.com/gitpod-io/gitpod/test/pkg/integration"
+	"github.com/gitpod-io/gitpod/test/pkg/report"
 	wsmanapi "github.com/gitpod-io/gitpod/ws-manager/api"
 )
 
@@ -66,6 +67,7 @@ var repos = []struct {
 
 func TestMultiRepoWorkspaceSuccess(t *testing.T) {
 	f := features.New("multi-repo").WithLabel("component", "ws-manager").Assess("can create multi repo workspace", func(_ context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+		report.SetupReport(t, report.FeatureMultiRepos, "all repositories are available in the workspace")
 		t.Parallel()
 
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)

--- a/test/tests/components/ws-manager/prebuild_test.go
+++ b/test/tests/components/ws-manager/prebuild_test.go
@@ -24,6 +24,7 @@ import (
 	gitpod "github.com/gitpod-io/gitpod/gitpod-protocol"
 	agent "github.com/gitpod-io/gitpod/test/pkg/agent/workspace/api"
 	"github.com/gitpod-io/gitpod/test/pkg/integration"
+	"github.com/gitpod-io/gitpod/test/pkg/report"
 	wsmanapi "github.com/gitpod-io/gitpod/ws-manager/api"
 
 	volumesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
@@ -64,6 +65,8 @@ func TestPrebuildWorkspaceTaskSuccess(t *testing.T) {
 					},
 				*/
 			}
+			report.SetupReport(t, report.FeaturePrebuild, "can execute prebuild successfully")
+
 			for _, test := range tests {
 				t.Run(test.Name, func(t *testing.T) {
 					t.Parallel()
@@ -138,6 +141,7 @@ func TestPrebuildWorkspaceTaskFail(t *testing.T) {
 	f := features.New("prebuild").
 		WithLabel("component", "server").
 		Assess("it should create a prebuild and fail after running the defined tasks", func(_ context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			report.SetupReport(t, report.FeaturePrebuild, "errors should be reported")
 			t.Parallel()
 
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
@@ -247,6 +251,7 @@ func TestOpenWorkspaceFromPrebuildSerialOnly(t *testing.T) {
 					},
 				*/
 			}
+			report.SetupReport(t, report.FeaturePrebuild, "workspace can be created from prebuild")
 
 			for _, test := range tests {
 				t.Run(test.Name, func(t *testing.T) {
@@ -538,6 +543,7 @@ func TestOpenWorkspaceFromOutdatedPrebuild(t *testing.T) {
 					WorkspaceRoot:           "/workspace/test-incremental-workspace",
 				},
 			}
+			report.SetupReport(t, report.FeaturePrebuild, "workspace can be created from outdated prebuild")
 
 			for _, test := range tests {
 				t.Run(test.Name, func(t *testing.T) {

--- a/test/tests/workspace/docker_test.go
+++ b/test/tests/workspace/docker_test.go
@@ -15,12 +15,14 @@ import (
 
 	agent "github.com/gitpod-io/gitpod/test/pkg/agent/workspace/api"
 	"github.com/gitpod-io/gitpod/test/pkg/integration"
+	"github.com/gitpod-io/gitpod/test/pkg/report"
 )
 
 func TestRunDocker(t *testing.T) {
 	f := features.New("docker").
 		WithLabel("component", "workspace").
 		Assess("it should start a container", func(_ context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			report.SetupReport(t, report.FeatureDocker, "test to verify that docker is able to run on the workspace")
 			t.Parallel()
 
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)

--- a/test/tests/workspace/git_hooks_test.go
+++ b/test/tests/workspace/git_hooks_test.go
@@ -15,6 +15,7 @@ import (
 
 	agent "github.com/gitpod-io/gitpod/test/pkg/agent/workspace/api"
 	"github.com/gitpod-io/gitpod/test/pkg/integration"
+	"github.com/gitpod-io/gitpod/test/pkg/report"
 )
 
 const (
@@ -74,6 +75,8 @@ func TestGitHooks(t *testing.T) {
 			for _, ff := range ffs {
 				for _, test := range tests {
 					t.Run(test.ContextURL+"_"+ff.Name, func(t *testing.T) {
+						report.SetupReport(t, report.FeatureGit, "test to verify that git checkout hooks are not executed")
+
 						t.Parallel()
 
 						ctx, cancel := context.WithTimeout(context.Background(), time.Duration(5*len(tests)*len(ffs))*time.Minute)
@@ -116,7 +119,7 @@ func TestGitHooks(t *testing.T) {
 						}
 						for _, f := range ls.Files {
 							if f == FILE_CREATED_HOOKS {
-								t.Fatal("Checkout hooks are executed")
+								t.Fatal("checkout hooks are executed")
 							}
 						}
 					})

--- a/test/tests/workspace/git_test.go
+++ b/test/tests/workspace/git_test.go
@@ -15,6 +15,7 @@ import (
 
 	agent "github.com/gitpod-io/gitpod/test/pkg/agent/workspace/api"
 	"github.com/gitpod-io/gitpod/test/pkg/integration"
+	"github.com/gitpod-io/gitpod/test/pkg/report"
 )
 
 type GitTest struct {
@@ -142,6 +143,8 @@ func TestGitActions(t *testing.T) {
 			for _, ff := range ffs {
 				for _, test := range tests {
 					t.Run(test.ContextURL+"_"+ff.Name, func(t *testing.T) {
+						report.SetupReport(t, report.FeatureK3s, "test verifies whether git operation is possible")
+
 						t.Parallel()
 						if test.Skip {
 							t.SkipNow()

--- a/test/tests/workspace/k3s_test.go
+++ b/test/tests/workspace/k3s_test.go
@@ -15,6 +15,7 @@ import (
 
 	agent "github.com/gitpod-io/gitpod/test/pkg/agent/workspace/api"
 	"github.com/gitpod-io/gitpod/test/pkg/integration"
+	"github.com/gitpod-io/gitpod/test/pkg/report"
 )
 
 const (
@@ -26,6 +27,7 @@ func TestK3s(t *testing.T) {
 	f := features.New("k3s").
 		WithLabel("component", "workspace").
 		Assess("it should start a k3s when cgroup v2 enable", func(_ context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			report.SetupReport(t, report.FeatureGit, "test to verify that k3s is able to run on the workspace")
 			t.Parallel()
 
 			ctx, cancel := context.WithTimeout(context.Background(), TIME_OUT)

--- a/test/tests/workspace/mount_proc_test.go
+++ b/test/tests/workspace/mount_proc_test.go
@@ -16,6 +16,7 @@ import (
 
 	agent "github.com/gitpod-io/gitpod/test/pkg/agent/workspace/api"
 	"github.com/gitpod-io/gitpod/test/pkg/integration"
+	"github.com/gitpod-io/gitpod/test/pkg/report"
 )
 
 const (
@@ -47,6 +48,8 @@ func TestMountProc(t *testing.T) {
 	f := features.New("proc mount").
 		WithLabel("component", "workspace").
 		Assess("load test proc mount", func(_ context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			report.SetupReport(t, report.FeatureK3s, "laod test for mout proc of system call")
+
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 			defer cancel()
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

NONE

## How to test
<!-- Provide steps to test this PR -->

```console
 ./run.sh -r report.csv -s workspace 
cat report.csv
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
