### PR TITLE
chore: repository template for JetBrains IDEs

### DIFF
--- a/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodStartWorkspaceView.kt
+++ b/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodStartWorkspaceView.kt
@@ -9,10 +9,7 @@ import com.intellij.openapi.CompositeDisposable
 import com.intellij.openapi.components.service
 import com.intellij.openapi.wm.impl.welcomeScreen.WelcomeScreenUIManager
 import com.intellij.remoteDev.util.onTerminationOrNow
-import com.intellij.ui.dsl.builder.MAX_LINE_LENGTH_WORD_WRAP
-import com.intellij.ui.dsl.builder.RightGap
-import com.intellij.ui.dsl.builder.TopGap
-import com.intellij.ui.dsl.builder.panel
+import com.intellij.ui.dsl.builder.*
 import com.intellij.ui.dsl.gridLayout.HorizontalAlign
 import com.intellij.ui.layout.ComponentPredicate
 import com.intellij.ui.layout.enteredTextSatisfies
@@ -30,6 +27,7 @@ import kotlinx.coroutines.future.await
 import java.util.*
 import javax.swing.DefaultComboBoxModel
 
+@Suppress("UnstableApiUsage", "OPT_IN_USAGE")
 class GitpodStartWorkspaceView(
     lifetime: Lifetime
 ) {
@@ -63,15 +61,38 @@ class GitpodStartWorkspaceView(
             label("Start from any GitLab, GitHub or Bitbucket URL:")
         }
         row {
-            comboBox(backendsModel)
+            val backendsComboBox = comboBox(backendsModel)
                 .gap(RightGap.SMALL)
                 .visibleIf(backendsLoaded)
+            var hasContextUrlChangedFromUi = false
             val contextUrl = textField()
                 .resizableColumn()
                 .horizontalAlign(HorizontalAlign.FILL)
                 .applyToComponent {
                     this.text = "https://github.com/gitpod-samples/spring-petclinic"
                 }
+                .whenTextChangedFromUi {
+                    hasContextUrlChangedFromUi = true
+                }
+            backendsComboBox.whenItemSelectedFromUi {
+                if (!hasContextUrlChangedFromUi) {
+                    contextUrl.applyToComponent {
+                        backendsModel.selectedItem.let {
+                            text = when(it) {
+                                "IntelliJ IDEA" -> "https://github.com/gitpod-samples/spring-petclinic"
+                                "WebStorm" -> "https://github.com/gitpod-samples/template-typescript-react"
+                                "PyCharm" -> "https://github.com/gitpod-samples/template-python-django"
+                                "GoLand" -> "https://github.com/gitpod-samples/template-golang-cli"
+                                "Rider" -> "https://github.com/gitpod-samples/template-dotnet-core-cli-csharp"
+                                "CLion" -> "https://github.com/gitpod-samples/template-cpp"
+                                "RubyMine" -> "https://github.com/gitpod-samples/template-ruby-on-rails-postgres"
+                                "PhpStorm" -> "https://github.com/gitpod-samples/template-php-laravel-mysql"
+                                else -> "https://github.com/gitpod-io/empty"
+                            }
+                        }
+                    }
+                }
+            }
             button("New Workspace") {
                 if (contextUrl.component.text.isNotBlank()) {
                     backendsModel.selectedItem?.let {


### PR DESCRIPTION
> Signed-off-by: Siddhant Khare <siddhant@gitpod.io>

## Description
Example Repo. URL Changes with new selection. Would not change if user has changed the text field. 

**Demo Video**:


https://user-images.githubusercontent.com/55068936/209700323-e81446c5-22b9-445b-b0bd-32cc356dc8ac.mov







## Related Issue(s)
<!-- List the issue(s) this PR solves -->

Currently, It only shows `https://github.com/gitpod-samples/spring-petclinic` doesn't matter which IDE you select (IntelliJ/PyCharm/WebStorm/etc.)


## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Customised example repositories on the basis of selected IDE options 
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-clean-slate-deployment
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
