### PR TITLE
[dashboard] Prevent avatars from shrinking out of existence on narrow screens

### DIFF
--- a/components/dashboard/src/Menu.tsx
+++ b/components/dashboard/src/Menu.tsx
@@ -460,7 +460,7 @@ export default function Menu() {
                             </ul>
                         </nav>
                         <div
-                            className="ml-3 flex items-center justify-start mb-0 pointer-cursor m-l-auto rounded-full border-2 border-transparent hover:border-gray-200 dark:hover:border-gray-700 p-0.5 font-medium"
+                            className="ml-3 flex items-center justify-start mb-0 pointer-cursor m-l-auto rounded-full border-2 border-transparent hover:border-gray-200 dark:hover:border-gray-700 p-0.5 font-medium flex-shrink-0"
                             data-analytics='{"label":"Account"}'
                         >
                             <ContextMenu

--- a/components/dashboard/src/teams/Members.tsx
+++ b/components/dashboard/src/teams/Members.tsx
@@ -239,7 +239,7 @@ export default function () {
                         filteredMembers.map((m) => (
                             <Item className="grid grid-cols-3" key={m.userId}>
                                 <ItemField className="flex items-center my-auto">
-                                    <div className="w-14">
+                                    <div className="flex-shrink-0">
                                         {m.avatarUrl && (
                                             <img
                                                 className="rounded-full w-8 h-8"
@@ -248,11 +248,14 @@ export default function () {
                                             />
                                         )}
                                     </div>
-                                    <div>
-                                        <div className="text-base text-gray-900 dark:text-gray-50 font-medium">
+                                    <div className="ml-5 truncate">
+                                        <div
+                                            className="text-base text-gray-900 dark:text-gray-50 font-medium"
+                                            title={m.fullName}
+                                        >
                                             {m.fullName}
                                         </div>
-                                        <p>{m.primaryEmail}</p>
+                                        <p title={m.primaryEmail}>{m.primaryEmail}</p>
                                     </div>
                                 </ItemField>
                                 <ItemField className="my-auto">


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

On narrow screens, most avatars tend to shrink horizontally (which looks bad) until width 0 is reached (which makes them disappear). This is both awkward-looking and can break major functionality (e.g. no access to the top right avatar menu on mobiles).

| | BEFORE | AFTER |
| --- | --- | --- |
| **Top-Right Avatar Menu** | <img width="376" alt="Screenshot 2022-12-26 at 15 30 44" src="https://user-images.githubusercontent.com/599268/209559391-54825346-d4b2-4c29-9100-2edc49155746.png"> | <img width="376" alt="Screenshot 2022-12-26 at 15 30 21" src="https://user-images.githubusercontent.com/599268/209559389-c49f3242-1bad-4068-9db6-b994f05172f6.png"> |
| **Team Members List** | <img width="478" alt="Screenshot 2022-12-26 at 15 32 47" src="https://user-images.githubusercontent.com/599268/209559364-3df8e918-e087-43b3-925a-6246f2d20e20.png"> | <img width="477" alt="Screenshot 2022-12-26 at 15 33 45" src="https://user-images.githubusercontent.com/599268/209559365-2ad02f70-0d07-4466-a391-15840fd70325.png"> |


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

1. Make your screen narrow
2. Avatars should still be visible & not squashed

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
