### PR TITLE
[OIDC] Call /session endpoint to create a session

### DIFF
--- a/components/iam/pkg/config/config.go
+++ b/components/iam/pkg/config/config.go
@@ -14,5 +14,7 @@ type ServiceConfig struct {
 
 	DatabaseConfigPath string `json:"databaseConfigPath"`
 
+	SessionServiceAddress string `json:"sessionServiceAddress"`
+
 	OIDCClientsConfigFile string `json:"oidcClientsConfigFile,omitempty"`
 }

--- a/components/iam/pkg/oidc/router_test.go
+++ b/components/iam/pkg/oidc/router_test.go
@@ -76,6 +76,8 @@ func TestRoute_callback(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Equal(t, http.StatusTemporaryRedirect, resp.StatusCode, "callback should response with redirect (307)")
+	require.NotEmpty(t, resp.Cookies(), "missing cookies on redirect")
+	require.Equal(t, "test-cookie", resp.Cookies()[0].Name, "missing cookie on redirect")
 
 	url, err := resp.Location()
 	require.NoError(t, err)
@@ -92,7 +94,8 @@ type testServerParams struct {
 
 func newTestServer(t *testing.T, params testServerParams) (url string, state *StateParam) {
 	router := chi.NewRouter()
-	oidcService := NewService()
+	sessionServerAddress := newFakeSessionServer(t)
+	oidcService := NewService(sessionServerAddress)
 	router.Mount("/oidc", Router(oidcService))
 
 	ts := httptest.NewServer(router)

--- a/components/iam/pkg/server/server.go
+++ b/components/iam/pkg/server/server.go
@@ -41,7 +41,7 @@ func Start(logger *logrus.Entry, version string, cfg *config.ServiceConfig) erro
 		return fmt.Errorf("failed to initialize IAM server: %w", err)
 	}
 
-	oidcService, err := oidc.NewServiceWithTestConfig(cfg.OIDCClientsConfigFile)
+	oidcService, err := oidc.NewServiceWithTestConfig(cfg.OIDCClientsConfigFile, cfg.SessionServiceAddress)
 	if err != nil {
 		return fmt.Errorf("failed to construct oidc service: %w", err)
 	}

--- a/components/server/src/iam/iam-session-app.ts
+++ b/components/server/src/iam/iam-session-app.ts
@@ -42,6 +42,10 @@ export class IamSessionApp {
     }
 
     protected async doCreateSession(req: express.Request) {
+        // We need an account to sign in, which is done by calling `req.login` below.
+        // As proper account creation/selection will be added in later on, we're creating a
+        // dummy account on each attempt.
+        //
         const user = await this.userService.createUser({
             identity: {
                 authId: "fake-id-" + Date.now(),

--- a/install/installer/cmd/testdata/render/aws-setup/output.golden
+++ b/install/installer/cmd/testdata/render/aws-setup/output.golden
@@ -2107,7 +2107,7 @@ data:
     kind: Deployment
     metadata:
       annotations:
-        gitpod.io/checksum_config: 7346723d23891c253f282241ed24e225e16dd2ddafa9b7c90d1da928a4923f4b
+        gitpod.io/checksum_config: 350c5081ae3f30253f80d07e0adfd8d82f0d8b416858b42d61fec05c2d1d246a
       creationTimestamp: null
       labels:
         app: gitpod
@@ -3464,7 +3464,8 @@ data:
           }
         }
       },
-      "databaseConfigPath": "/secrets/database-config"
+      "databaseConfigPath": "/secrets/database-config",
+      "sessionServiceAddress": "server.default.svc.cluster.local:9876"
     }
 kind: ConfigMap
 metadata:
@@ -8735,7 +8736,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    gitpod.io/checksum_config: 7346723d23891c253f282241ed24e225e16dd2ddafa9b7c90d1da928a4923f4b
+    gitpod.io/checksum_config: 350c5081ae3f30253f80d07e0adfd8d82f0d8b416858b42d61fec05c2d1d246a
   creationTimestamp: null
   labels:
     app: gitpod

--- a/install/installer/cmd/testdata/render/azure-setup/output.golden
+++ b/install/installer/cmd/testdata/render/azure-setup/output.golden
@@ -2113,7 +2113,7 @@ data:
     kind: Deployment
     metadata:
       annotations:
-        gitpod.io/checksum_config: 7346723d23891c253f282241ed24e225e16dd2ddafa9b7c90d1da928a4923f4b
+        gitpod.io/checksum_config: 350c5081ae3f30253f80d07e0adfd8d82f0d8b416858b42d61fec05c2d1d246a
       creationTimestamp: null
       labels:
         app: gitpod
@@ -3468,7 +3468,8 @@ data:
           }
         }
       },
-      "databaseConfigPath": "/secrets/database-config"
+      "databaseConfigPath": "/secrets/database-config",
+      "sessionServiceAddress": "server.default.svc.cluster.local:9876"
     }
 kind: ConfigMap
 metadata:
@@ -8686,7 +8687,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    gitpod.io/checksum_config: 7346723d23891c253f282241ed24e225e16dd2ddafa9b7c90d1da928a4923f4b
+    gitpod.io/checksum_config: 350c5081ae3f30253f80d07e0adfd8d82f0d8b416858b42d61fec05c2d1d246a
   creationTimestamp: null
   labels:
     app: gitpod

--- a/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
+++ b/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
@@ -2266,7 +2266,7 @@ data:
     kind: Deployment
     metadata:
       annotations:
-        gitpod.io/checksum_config: 7346723d23891c253f282241ed24e225e16dd2ddafa9b7c90d1da928a4923f4b
+        gitpod.io/checksum_config: 350c5081ae3f30253f80d07e0adfd8d82f0d8b416858b42d61fec05c2d1d246a
       creationTimestamp: null
       labels:
         app: gitpod
@@ -3775,7 +3775,8 @@ data:
           }
         }
       },
-      "databaseConfigPath": "/secrets/database-config"
+      "databaseConfigPath": "/secrets/database-config",
+      "sessionServiceAddress": "server.default.svc.cluster.local:9876"
     }
 kind: ConfigMap
 metadata:
@@ -9406,7 +9407,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    gitpod.io/checksum_config: 7346723d23891c253f282241ed24e225e16dd2ddafa9b7c90d1da928a4923f4b
+    gitpod.io/checksum_config: 350c5081ae3f30253f80d07e0adfd8d82f0d8b416858b42d61fec05c2d1d246a
   creationTimestamp: null
   labels:
     app: gitpod

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -2546,7 +2546,7 @@ data:
     metadata:
       annotations:
         gitpod.io: hello
-        gitpod.io/checksum_config: 6c23f5fda26f7744c03f56515d6d5c8815df8861056ae46d07b95e01f9701648
+        gitpod.io/checksum_config: 61b5a062503803fd7264c1d96f9217c4cd0336c204eb03cd0dafa9094b508258
         hello: world
       creationTimestamp: null
       labels:
@@ -4328,7 +4328,8 @@ data:
           }
         }
       },
-      "databaseConfigPath": "/secrets/database-config"
+      "databaseConfigPath": "/secrets/database-config",
+      "sessionServiceAddress": "server.default.svc.cluster.local:9876"
     }
 kind: ConfigMap
 metadata:
@@ -10186,7 +10187,7 @@ kind: Deployment
 metadata:
   annotations:
     gitpod.io: hello
-    gitpod.io/checksum_config: 6c23f5fda26f7744c03f56515d6d5c8815df8861056ae46d07b95e01f9701648
+    gitpod.io/checksum_config: 61b5a062503803fd7264c1d96f9217c4cd0336c204eb03cd0dafa9094b508258
     hello: world
   creationTimestamp: null
   labels:

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -2160,7 +2160,7 @@ data:
     kind: Deployment
     metadata:
       annotations:
-        gitpod.io/checksum_config: 7346723d23891c253f282241ed24e225e16dd2ddafa9b7c90d1da928a4923f4b
+        gitpod.io/checksum_config: 350c5081ae3f30253f80d07e0adfd8d82f0d8b416858b42d61fec05c2d1d246a
       creationTimestamp: null
       labels:
         app: gitpod
@@ -3609,7 +3609,8 @@ data:
           }
         }
       },
-      "databaseConfigPath": "/secrets/database-config"
+      "databaseConfigPath": "/secrets/database-config",
+      "sessionServiceAddress": "server.default.svc.cluster.local:9876"
     }
 kind: ConfigMap
 metadata:
@@ -9126,7 +9127,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    gitpod.io/checksum_config: 7346723d23891c253f282241ed24e225e16dd2ddafa9b7c90d1da928a4923f4b
+    gitpod.io/checksum_config: 350c5081ae3f30253f80d07e0adfd8d82f0d8b416858b42d61fec05c2d1d246a
   creationTimestamp: null
   labels:
     app: gitpod

--- a/install/installer/cmd/testdata/render/gcp-setup/output.golden
+++ b/install/installer/cmd/testdata/render/gcp-setup/output.golden
@@ -2091,7 +2091,7 @@ data:
     kind: Deployment
     metadata:
       annotations:
-        gitpod.io/checksum_config: 7346723d23891c253f282241ed24e225e16dd2ddafa9b7c90d1da928a4923f4b
+        gitpod.io/checksum_config: 350c5081ae3f30253f80d07e0adfd8d82f0d8b416858b42d61fec05c2d1d246a
       creationTimestamp: null
       labels:
         app: gitpod
@@ -3439,7 +3439,8 @@ data:
           }
         }
       },
-      "databaseConfigPath": "/secrets/database-config"
+      "databaseConfigPath": "/secrets/database-config",
+      "sessionServiceAddress": "server.default.svc.cluster.local:9876"
     }
 kind: ConfigMap
 metadata:
@@ -8742,7 +8743,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    gitpod.io/checksum_config: 7346723d23891c253f282241ed24e225e16dd2ddafa9b7c90d1da928a4923f4b
+    gitpod.io/checksum_config: 350c5081ae3f30253f80d07e0adfd8d82f0d8b416858b42d61fec05c2d1d246a
   creationTimestamp: null
   labels:
     app: gitpod

--- a/install/installer/cmd/testdata/render/http-proxy/output.golden
+++ b/install/installer/cmd/testdata/render/http-proxy/output.golden
@@ -2269,7 +2269,7 @@ data:
     kind: Deployment
     metadata:
       annotations:
-        gitpod.io/checksum_config: 7346723d23891c253f282241ed24e225e16dd2ddafa9b7c90d1da928a4923f4b
+        gitpod.io/checksum_config: 350c5081ae3f30253f80d07e0adfd8d82f0d8b416858b42d61fec05c2d1d246a
       creationTimestamp: null
       labels:
         app: gitpod
@@ -3778,7 +3778,8 @@ data:
           }
         }
       },
-      "databaseConfigPath": "/secrets/database-config"
+      "databaseConfigPath": "/secrets/database-config",
+      "sessionServiceAddress": "server.default.svc.cluster.local:9876"
     }
 kind: ConfigMap
 metadata:
@@ -10091,7 +10092,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    gitpod.io/checksum_config: 7346723d23891c253f282241ed24e225e16dd2ddafa9b7c90d1da928a4923f4b
+    gitpod.io/checksum_config: 350c5081ae3f30253f80d07e0adfd8d82f0d8b416858b42d61fec05c2d1d246a
   creationTimestamp: null
   labels:
     app: gitpod

--- a/install/installer/cmd/testdata/render/kind-meta/output.golden
+++ b/install/installer/cmd/testdata/render/kind-meta/output.golden
@@ -1813,7 +1813,7 @@ data:
     kind: Deployment
     metadata:
       annotations:
-        gitpod.io/checksum_config: 7346723d23891c253f282241ed24e225e16dd2ddafa9b7c90d1da928a4923f4b
+        gitpod.io/checksum_config: 350c5081ae3f30253f80d07e0adfd8d82f0d8b416858b42d61fec05c2d1d246a
       creationTimestamp: null
       labels:
         app: gitpod
@@ -2746,7 +2746,8 @@ data:
           }
         }
       },
-      "databaseConfigPath": "/secrets/database-config"
+      "databaseConfigPath": "/secrets/database-config",
+      "sessionServiceAddress": "server.default.svc.cluster.local:9876"
     }
 kind: ConfigMap
 metadata:
@@ -6722,7 +6723,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    gitpod.io/checksum_config: 7346723d23891c253f282241ed24e225e16dd2ddafa9b7c90d1da928a4923f4b
+    gitpod.io/checksum_config: 350c5081ae3f30253f80d07e0adfd8d82f0d8b416858b42d61fec05c2d1d246a
   creationTimestamp: null
   labels:
     app: gitpod

--- a/install/installer/cmd/testdata/render/kind-webapp/output.golden
+++ b/install/installer/cmd/testdata/render/kind-webapp/output.golden
@@ -1192,7 +1192,7 @@ data:
     kind: Deployment
     metadata:
       annotations:
-        gitpod.io/checksum_config: 7346723d23891c253f282241ed24e225e16dd2ddafa9b7c90d1da928a4923f4b
+        gitpod.io/checksum_config: 350c5081ae3f30253f80d07e0adfd8d82f0d8b416858b42d61fec05c2d1d246a
       creationTimestamp: null
       labels:
         app: gitpod
@@ -2125,7 +2125,8 @@ data:
           }
         }
       },
-      "databaseConfigPath": "/secrets/database-config"
+      "databaseConfigPath": "/secrets/database-config",
+      "sessionServiceAddress": "server.default.svc.cluster.local:9876"
     }
 kind: ConfigMap
 metadata:
@@ -3983,7 +3984,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    gitpod.io/checksum_config: 7346723d23891c253f282241ed24e225e16dd2ddafa9b7c90d1da928a4923f4b
+    gitpod.io/checksum_config: 350c5081ae3f30253f80d07e0adfd8d82f0d8b416858b42d61fec05c2d1d246a
   creationTimestamp: null
   labels:
     app: gitpod

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -2266,7 +2266,7 @@ data:
     kind: Deployment
     metadata:
       annotations:
-        gitpod.io/checksum_config: 7346723d23891c253f282241ed24e225e16dd2ddafa9b7c90d1da928a4923f4b
+        gitpod.io/checksum_config: 350c5081ae3f30253f80d07e0adfd8d82f0d8b416858b42d61fec05c2d1d246a
       creationTimestamp: null
       labels:
         app: gitpod
@@ -3775,7 +3775,8 @@ data:
           }
         }
       },
-      "databaseConfigPath": "/secrets/database-config"
+      "databaseConfigPath": "/secrets/database-config",
+      "sessionServiceAddress": "server.default.svc.cluster.local:9876"
     }
 kind: ConfigMap
 metadata:
@@ -9406,7 +9407,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    gitpod.io/checksum_config: 7346723d23891c253f282241ed24e225e16dd2ddafa9b7c90d1da928a4923f4b
+    gitpod.io/checksum_config: 350c5081ae3f30253f80d07e0adfd8d82f0d8b416858b42d61fec05c2d1d246a
   creationTimestamp: null
   labels:
     app: gitpod

--- a/install/installer/cmd/testdata/render/shortname/output.golden
+++ b/install/installer/cmd/testdata/render/shortname/output.golden
@@ -2266,7 +2266,7 @@ data:
     kind: Deployment
     metadata:
       annotations:
-        gitpod.io/checksum_config: 7346723d23891c253f282241ed24e225e16dd2ddafa9b7c90d1da928a4923f4b
+        gitpod.io/checksum_config: 350c5081ae3f30253f80d07e0adfd8d82f0d8b416858b42d61fec05c2d1d246a
       creationTimestamp: null
       labels:
         app: gitpod
@@ -3775,7 +3775,8 @@ data:
           }
         }
       },
-      "databaseConfigPath": "/secrets/database-config"
+      "databaseConfigPath": "/secrets/database-config",
+      "sessionServiceAddress": "server.default.svc.cluster.local:9876"
     }
 kind: ConfigMap
 metadata:
@@ -9406,7 +9407,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    gitpod.io/checksum_config: 7346723d23891c253f282241ed24e225e16dd2ddafa9b7c90d1da928a4923f4b
+    gitpod.io/checksum_config: 350c5081ae3f30253f80d07e0adfd8d82f0d8b416858b42d61fec05c2d1d246a
   creationTimestamp: null
   labels:
     app: gitpod

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -2278,7 +2278,7 @@ data:
     kind: Deployment
     metadata:
       annotations:
-        gitpod.io/checksum_config: 7346723d23891c253f282241ed24e225e16dd2ddafa9b7c90d1da928a4923f4b
+        gitpod.io/checksum_config: 350c5081ae3f30253f80d07e0adfd8d82f0d8b416858b42d61fec05c2d1d246a
       creationTimestamp: null
       labels:
         app: gitpod
@@ -3787,7 +3787,8 @@ data:
           }
         }
       },
-      "databaseConfigPath": "/secrets/database-config"
+      "databaseConfigPath": "/secrets/database-config",
+      "sessionServiceAddress": "server.default.svc.cluster.local:9876"
     }
 kind: ConfigMap
 metadata:
@@ -9418,7 +9419,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    gitpod.io/checksum_config: 7346723d23891c253f282241ed24e225e16dd2ddafa9b7c90d1da928a4923f4b
+    gitpod.io/checksum_config: 350c5081ae3f30253f80d07e0adfd8d82f0d8b416858b42d61fec05c2d1d246a
   creationTimestamp: null
   labels:
     app: gitpod

--- a/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
+++ b/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
@@ -2554,7 +2554,7 @@ data:
     kind: Deployment
     metadata:
       annotations:
-        gitpod.io/checksum_config: 7346723d23891c253f282241ed24e225e16dd2ddafa9b7c90d1da928a4923f4b
+        gitpod.io/checksum_config: 350c5081ae3f30253f80d07e0adfd8d82f0d8b416858b42d61fec05c2d1d246a
       creationTimestamp: null
       labels:
         app: gitpod
@@ -4108,7 +4108,8 @@ data:
           }
         }
       },
-      "databaseConfigPath": "/secrets/database-config"
+      "databaseConfigPath": "/secrets/database-config",
+      "sessionServiceAddress": "server.default.svc.cluster.local:9876"
     }
 kind: ConfigMap
 metadata:
@@ -9850,7 +9851,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    gitpod.io/checksum_config: 7346723d23891c253f282241ed24e225e16dd2ddafa9b7c90d1da928a4923f4b
+    gitpod.io/checksum_config: 350c5081ae3f30253f80d07e0adfd8d82f0d8b416858b42d61fec05c2d1d246a
   creationTimestamp: null
   labels:
     app: gitpod

--- a/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
+++ b/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
@@ -2268,7 +2268,7 @@ data:
     kind: Deployment
     metadata:
       annotations:
-        gitpod.io/checksum_config: 7346723d23891c253f282241ed24e225e16dd2ddafa9b7c90d1da928a4923f4b
+        gitpod.io/checksum_config: 350c5081ae3f30253f80d07e0adfd8d82f0d8b416858b42d61fec05c2d1d246a
       creationTimestamp: null
       labels:
         app: gitpod
@@ -3777,7 +3777,8 @@ data:
           }
         }
       },
-      "databaseConfigPath": "/secrets/database-config"
+      "databaseConfigPath": "/secrets/database-config",
+      "sessionServiceAddress": "server.default.svc.cluster.local:9876"
     }
 kind: ConfigMap
 metadata:
@@ -9396,7 +9397,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    gitpod.io/checksum_config: 7346723d23891c253f282241ed24e225e16dd2ddafa9b7c90d1da928a4923f4b
+    gitpod.io/checksum_config: 350c5081ae3f30253f80d07e0adfd8d82f0d8b416858b42d61fec05c2d1d246a
   creationTimestamp: null
   labels:
     app: gitpod

--- a/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
+++ b/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
@@ -2269,7 +2269,7 @@ data:
     kind: Deployment
     metadata:
       annotations:
-        gitpod.io/checksum_config: 7346723d23891c253f282241ed24e225e16dd2ddafa9b7c90d1da928a4923f4b
+        gitpod.io/checksum_config: 350c5081ae3f30253f80d07e0adfd8d82f0d8b416858b42d61fec05c2d1d246a
       creationTimestamp: null
       labels:
         app: gitpod
@@ -3778,7 +3778,8 @@ data:
           }
         }
       },
-      "databaseConfigPath": "/secrets/database-config"
+      "databaseConfigPath": "/secrets/database-config",
+      "sessionServiceAddress": "server.default.svc.cluster.local:9876"
     }
 kind: ConfigMap
 metadata:
@@ -9409,7 +9410,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    gitpod.io/checksum_config: 7346723d23891c253f282241ed24e225e16dd2ddafa9b7c90d1da928a4923f4b
+    gitpod.io/checksum_config: 350c5081ae3f30253f80d07e0adfd8d82f0d8b416858b42d61fec05c2d1d246a
   creationTimestamp: null
   labels:
     app: gitpod

--- a/install/installer/pkg/components/iam/configmap.go
+++ b/install/installer/pkg/components/iam/configmap.go
@@ -6,6 +6,8 @@ package iam
 
 import (
 	"fmt"
+	"net"
+	"strconv"
 
 	"github.com/gitpod-io/gitpod/common-go/baseserver"
 	"github.com/gitpod-io/gitpod/iam/pkg/config"
@@ -36,6 +38,8 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 				},
 			},
 		},
+
+		SessionServiceAddress: net.JoinHostPort(fmt.Sprintf("%s.%s.svc.cluster.local", common.ServerComponent, ctx.Namespace), strconv.Itoa(common.ServerIAMSessionPort)),
 
 		DatabaseConfigPath: databaseSecretMountPath,
 	}


### PR DESCRIPTION
Based on #15472

## Description
This change set enables sending of the ID token (+ claims) to the /session endpoint of server.

As the server is still in charge of creating an HTTP session, it will response with the `Set-Cookie` header, which will be forwarded with the HTTP redirect to the client.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of #14954
Belongs to epic #7761

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
