### PR TITLE
Wrong cloud provider

### DIFF
--- a/install/infra/single-cluster/azure/README.md
+++ b/install/infra/single-cluster/azure/README.md
@@ -1,4 +1,4 @@
-# Terraform setup for AWS Single-cluster Gitpod reference architecture
+# Terraform setup for AKS Single-cluster Gitpod reference architecture
 
 This directory has terraform configuration necessary to achieve a infrastructure
 corresponding to the Single-cluster reference architecture for Gitpod on Azure.


### PR DESCRIPTION
The cloud provider name was wrong, I corrected it, from AWS to AKA.

## Description
The cloud provider name was wrong, I corrected it, from AWS to AKA.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
Update terraform configuration documentation
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
