### PR TITLE
[codehelper] ignore NODE_OPTIONS env var

### DIFF
--- a/components/ide/code/codehelper/main.go
+++ b/components/ide/code/codehelper/main.go
@@ -100,7 +100,17 @@ func main() {
 	args = append(args, "--do-not-sync")
 	args = append(args, "--start-server")
 	log.WithField("cost", time.Now().Local().Sub(startTime).Milliseconds()).Info("starting server")
-	if err := syscall.Exec(Code, append([]string{"gitpod-code"}, args...), os.Environ()); err != nil {
+
+	// Excluding NODE_OPTIONS as it can break VS Code
+	env := os.Environ()
+	safeEnv := []string{}
+	for _, v := range env {
+		if !strings.HasPrefix(v, "NODE_OPTIONS=") {
+			safeEnv = append(safeEnv, v)
+		}
+	}
+
+	if err := syscall.Exec(Code, append([]string{"gitpod-code"}, args...), safeEnv); err != nil {
 		log.WithError(err).Error("install ext and start code server failed")
 	}
 }


### PR DESCRIPTION
## Description
See #15519 for context, the `NODE_OPTIONS` can break VS Code, so when we launch the process we ingore it, in case the user has provided one.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #15519

## How to test
1. Sign up to https://andreafalzf8fcc5e542.preview.gitpod-dev.com
2. Choose `VS Code latest`
3. Go to your variables https://andreafalzf8fcc5e542.preview.gitpod-dev.com/variables
4. Add `NODE_OPTIONS` with scope `*/*` and value `--experiemental-vm-modules`
5. Start a workspace https://andreafalzf8fcc5e542.preview.gitpod-dev.com/#https://github.com/gitpod-io/empty
6. Make sure the workspace starts successfully
7. Run `env | grep NODE_OPTIONS` and make sure the user env var is present 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
