### PR TITLE
Fix the issue of modified `go.sum` files when Gitpod Repo workspace starts

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -83,7 +83,3 @@ vscode:
     - dbaeumer.vscode-eslint
     - esbenp.prettier-vscode
     - akosyakov.gitpod-monitor
-jetbrains:
-  goland:
-    prebuilds:
-      version: stable


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Don't run GoLand Prebuild during workspace initialization anymore.

This prevents the workspace starting up with changed `go.sum` files.

| Before | After |
| --- | --- |
| <img width="343" alt="image" src="https://user-images.githubusercontent.com/418083/209375895-2c3137fa-0b12-4b76-b991-f8bb4334f560.png"> | <img width="339" alt="image" src="https://user-images.githubusercontent.com/418083/209375595-43cb25b9-101b-4a2a-b0dd-29d01849efe5.png"> |

This also reduces the time, from ~35 minutes to ~9 minutes, to prebuild Gitpod repository.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
- https://github.com/gitpod-io/gitpod/pull/15497

## How to test
<!-- Provide steps to test this PR -->
1. Check if Werft Build succeeds.
2. Open a workspace from this PR in gitpod.io (https://gitpod.io/#https://github.com/gitpod-io/gitpod/pull/15529) ([which has already been prebuilt](https://gitpod.io/t/gitpod/gitpod/e253677f-a55e-47e6-98aa-886765a27361)) and confirm there's no file changed when the workspace starts.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
