### PR TITLE
Use older version for fluent-bit in preview envs

### DIFF
--- a/dev/preview/workflow/preview/deploy-gitpod.sh
+++ b/dev/preview/workflow/preview/deploy-gitpod.sh
@@ -194,7 +194,7 @@ function installFluentBit {
     helm3 \
       --kubeconfig "${PREVIEW_K3S_KUBE_PATH}" \
       --kube-context "${PREVIEW_K3S_KUBE_CONTEXT}" \
-      upgrade --install fluent-bit fluent/fluent-bit -n "${PREVIEW_NAMESPACE}" -f "$ROOT/.werft/vm/charts/fluentbit/values.yaml"
+      upgrade --install fluent-bit fluent/fluent-bit --version 0.21.6 -n "${PREVIEW_NAMESPACE}" -f "$ROOT/.werft/vm/charts/fluentbit/values.yaml"
 }
 
 # ====================================


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
We're using always the latest fluent-bit helm chart and a new version with [fluent-bit v2.0.8](https://fluentbit.io/announcements/v2.0.8/)  got released yesterday and matches with the time the issue started occuring. It contains a change around StackDriver logging, which seems to be the one causing the problem:
```
[Stackdriver (Output)](https://docs.fluentbit.io/manual/pipeline/outputs/stackdriver/)
Add Cache token expiration and use it when using cached tokens (#6453)
```

This PR pins the helm chart to the previous version and seems to solve the problem (tested in a preview env). Will investigate another time if there is some configuration we can provide to the newer version of fluent-bit so it doesn't break.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/15530

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
