### PR TITLE
fix: regex of workspace ID validator

### DIFF
--- a/components/common-go/namegen/workspaceid.go
+++ b/components/common-go/namegen/workspaceid.go
@@ -17,11 +17,11 @@ import (
 // gitpod-protocol/src/util/generate-workspace-id.ts is authoritative over the generation
 
 /*
-	 Regex Pattern Description:
-											Repo. Owner  	Repo. Name  	Random
-											2-16 chars   	2-11 chars  	11 chars
+  - Regex Pattern Description:
+    Repo. Owner & Repo. Name  	Random
+    3-23 chars  				11 chars
 */
-var WorkspaceIDPattern = regexp.MustCompile(`^[a-z]{2,16}-[a-z0-9]{2,11}-[a-z0-9]{11}$`)
+var WorkspaceIDPattern = regexp.MustCompile(`^[a-z0-9-]{3,23}-[a-z0-9]{11}$`)
 
 func GenerateWorkspaceID() (string, error) {
 	s1, err := chooseRandomly(colors, 1)

--- a/components/common-go/namegen/workspaceid.go
+++ b/components/common-go/namegen/workspaceid.go
@@ -15,7 +15,13 @@ import (
 
 // WorkspaceIDPattern is the expected Worksapce ID pattern
 // gitpod-protocol/src/util/generate-workspace-id.ts is authoritative over the generation
-var WorkspaceIDPattern = regexp.MustCompile(`^[a-z]{3,12}-[a-z]{2,16}-[a-z0-9]{11}$`)
+
+/*
+	 Regex Pattern Description:
+											Repo. Owner  	Repo. Name  	Random
+											2-16 chars   	2-11 chars  	11 chars
+*/
+var WorkspaceIDPattern = regexp.MustCompile(`^[a-z]{2,16}-[a-z0-9]{2,11}-[a-z0-9]{11}$`)
 
 func GenerateWorkspaceID() (string, error) {
 	s1, err := chooseRandomly(colors, 1)

--- a/components/common-go/namegen/workspaceid_test.go
+++ b/components/common-go/namegen/workspaceid_test.go
@@ -30,6 +30,10 @@ func TestValidateWorkspaceID(t *testing.T) {
 		"gitpodio-gitpod-65k8jqq6up4",
 		"testeraccountw-demoskv1-q2pnb88pvuo",
 		"testeraccountwit-empty-g6024jgir2j",
+		"a-b-g6024jgir2j",
+		"a-bcdefghijklmnopqrstux-g6024jgir2j",
+		"abcdefghijklmnopqrstu-x-g6024jgir2j",
+		"abcdefghijklmnopqrs24-x-g6024jgir2j",
 	}
 	for _, v := range valid {
 		require.NoError(t, namegen.ValidateWorkspaceID(v))

--- a/components/common-go/namegen/workspaceid_test.go
+++ b/components/common-go/namegen/workspaceid_test.go
@@ -28,6 +28,8 @@ func TestGenerateWorkspaceID(t *testing.T) {
 func TestValidateWorkspaceID(t *testing.T) {
 	valid := []string{
 		"gitpodio-gitpod-65k8jqq6up4",
+		"testeraccountw-demoskv1-q2pnb88pvuo",
+		"testeraccountwit-empty-g6024jgir2j",
 	}
 	for _, v := range valid {
 		require.NoError(t, namegen.ValidateWorkspaceID(v))


### PR DESCRIPTION
> Signed-off-by: Siddhant Khare <siddhant@gitpod.io>

## Description
Fixes the regex pattern for workspace ID validator :wrench:

On [this another example Repo.](https://github.com/Siddhant-K-code/cal.com)

|Before|After|
|:---:|:---:|
|![image](https://user-images.githubusercontent.com/55068936/210164115-8da21d94-c7d6-4261-948f-4fedf1326fee.png)|![image](https://user-images.githubusercontent.com/55068936/210164179-c6a73238-f4f7-4f82-a510-bfc7e6815e2b.png)|

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes Internal Conversations[[1](https://gitpod.slack.com/archives/C0201TXMV54/p1672373060710899)], [[2](https://gitpod.slack.com/archives/C01KGM9BH54/p1672488304693609)]

## How to test
<!-- Provide steps to test this PR -->
- Open [Preview](https://fix-workspf72253ab47.preview.gitpod-dev.com/workspaces)
- Open Following Repo. to VS Code Desktop:
    - [demo1](https://github.com/testerAccountWithLengthEqualThirtyeight/testerAccountWithLengthEqualThirtyeight)
    - [demo2](gitpod.io/#https://github.com/testerAccountWithLengthEqualThirtyeight/demo.sk-v1)
    - [demo3](gitpod.io/#https://github.com/testerAccountWithLengthEqualThirtyeight/demo.sk-v1)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Fix: edge cases on opening workspaces to VS Code Desktop 
```

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
