### PR TITLE
[previewctl] change staleness logic

### DIFF
--- a/dev/preview/previewctl/cmd/stale.go
+++ b/dev/preview/previewctl/cmd/stale.go
@@ -67,7 +67,7 @@ func newListStaleCmd(logger *logrus.Logger) *cobra.Command {
 }
 
 func (o *listWorkspaceOpts) listWorskpaceStatus(ctx context.Context) ([]preview.Status, error) {
-	branches, err := preview.GetRecentBranches(time.Now().AddDate(0, 0, -3))
+	branches, err := preview.GetRecentBranches(time.Now().AddDate(0, 0, -30))
 	if err != nil {
 		return nil, err
 	}
@@ -95,7 +95,7 @@ func (o *listWorkspaceOpts) listWorskpaceStatus(ctx context.Context) ([]preview.
 		}
 
 		if _, ok := branchlessWorkspaces[ws]; ok && !strings.HasPrefix(ws, "platform-") {
-			status.Reason = "branch doesn't exist, or last commit older than 3 days"
+			status.Reason = "branch doesn't exist, or last commit older than 30 days"
 			statuses = append(statuses, status)
 			continue
 			// there's (should be) nothing in the default worskpace, and we ignore main

--- a/dev/preview/previewctl/pkg/preview/status.go
+++ b/dev/preview/previewctl/pkg/preview/status.go
@@ -122,8 +122,6 @@ func (c *Config) dbStatus(ctx context.Context, password, port string) (Status, e
 	clog.Log.Logger.SetLevel(3)
 
 	queries := []string{
-		"SELECT TIMESTAMPDIFF(HOUR, creationTime, NOW()) as timediff FROM d_b_workspace_instance WHERE creationTime > DATE_SUB(NOW(), INTERVAL 48 HOUR) ORDER BY creationTime DESC LIMIT 1",
-		"SELECT TIMESTAMPDIFF(HOUR, creationTime, NOW()) as timediff FROM d_b_workspace_instance WHERE creationTime > DATE_SUB(NOW(), INTERVAL 48 HOUR) ORDER BY creationTime DESC LIMIT 1",
 		"SELECT TIMESTAMPDIFF(HOUR, _lastModified, NOW()) as timediff FROM d_b_user WHERE _lastModified > DATE_SUB(NOW(), INTERVAL 48 HOUR) ORDER BY _lastModified DESC LIMIT 1",
 		"SELECT TIMESTAMPDIFF(HOUR, lastSeen, NOW()) as timediff FROM d_b_workspace_instance_user WHERE lastSeen > DATE_SUB(NOW(), INTERVAL 48 HOUR) ORDER BY lastSeen DESC LIMIT 1",
 	}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Currently, all preview environments for branches that haven't had recent commits are considered stale and cleaned up no matter they are in use. This results in people rerunning `/werft build` over and over again and being surprised that they don't get a preview environment or that it dies in the middle of using it.

This change makes it so that all branches that have had a commit in the past 30 days are considered. And also adjusts the activity check on those branches by not treating workspace instances as activity as that includes prebuilds and would create false positive activity (i.e. prebuilds could keep a preview environment active forever).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/ops/issues/7576

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
