### PR TITLE
Fix the metric workspace_starts_failure_total

### DIFF
--- a/components/ws-manager/pkg/manager/metrics.go
+++ b/components/ws-manager/pkg/manager/metrics.go
@@ -241,25 +241,6 @@ func (m *metrics) Register(reg prometheus.Registerer) error {
 	return nil
 }
 
-func (m *metrics) OnWorkspaceStarted(tpe api.WorkspaceType, class string, success bool) {
-	nme := api.WorkspaceType_name[int32(tpe)]
-	counter, err := m.totalStartsCounterVec.GetMetricWithLabelValues(nme, class)
-	if err != nil {
-		log.WithError(err).WithField("type", tpe).Warn("cannot get counter for workspace start metric")
-		return
-	}
-	counter.Inc()
-
-	if !success {
-		counter, err = m.totalStartsFailureCounterVec.GetMetricWithLabelValues(nme, class)
-		if err != nil {
-			log.WithError(err).WithField("type", tpe).Warn("cannot get counter for workspace start failure metric")
-			return
-		}
-		counter.Inc()
-	}
-}
-
 func (m *metrics) OnChange(status *api.WorkspaceStatus) {
 	var removeFromState bool
 	tpe := api.WorkspaceType_name[int32(status.Spec.Type)]
@@ -300,6 +281,8 @@ func (m *metrics) OnChange(status *api.WorkspaceStatus) {
 			return
 		}
 
+		removeFromState = true
+
 		var reason string
 		if strings.Contains(status.Message, string(activityClosed)) {
 			reason = "tab-closed"
@@ -313,14 +296,27 @@ func (m *metrics) OnChange(status *api.WorkspaceStatus) {
 			reason = "regular-stop"
 		}
 
-		counter, err := m.totalStopsCounterVec.GetMetricWithLabelValues(reason, tpe, status.Spec.Class)
-		if err != nil {
-			log.WithError(err).WithField("reason", reason).Warn("cannot get counter for workspace stops metric")
-			return
+		// The workspace never ready annotation exists, which means the workspace starts failing.
+		_, isNeverReady := status.Metadata.Annotations[workspaceNeverReadyAnnotation]
+		if isNeverReady {
+			startC, err := m.totalStartsFailureCounterVec.GetMetricWithLabelValues(tpe, status.Spec.Class)
+			if err != nil {
+				log.WithError(err).WithField("type", tpe).Warn("cannot get counter for workspace start failure metric")
+				return
+			}
+			startC.Inc()
 		}
-		counter.Inc()
 
-		removeFromState = true
+		if isNeverReady && reason == "failed" {
+			// we don't increase stop workspace failure metric if the workspace pod is failed and never ready.
+		} else {
+			stopC, err := m.totalStopsCounterVec.GetMetricWithLabelValues(reason, tpe, status.Spec.Class)
+			if err != nil {
+				log.WithError(err).WithField("reason", reason).Warn("cannot get counter for workspace stops metric")
+				return
+			}
+			stopC.Inc()
+		}
 	}
 }
 

--- a/components/ws-manager/pkg/manager/status.go
+++ b/components/ws-manager/pkg/manager/status.go
@@ -312,7 +312,8 @@ func getWorkspaceMetadata(pod *corev1.Pod) *api.WorkspaceMetadata {
 	started := timestamppb.New(pod.CreationTimestamp.Time)
 	annotations := make(map[string]string)
 	for k, v := range pod.Annotations {
-		if !strings.HasPrefix(k, workspaceAnnotationPrefix) {
+		if !strings.HasPrefix(k, workspaceAnnotationPrefix) &&
+			!strings.HasPrefix(k, workspaceNeverReadyAnnotation) {
 			continue
 		}
 		annotations[strings.TrimPrefix(k, workspaceAnnotationPrefix)] = v

--- a/components/ws-manager/pkg/manager/testdata/status_brokenScheduler_UNKNOWN00.golden
+++ b/components/ws-manager/pkg/manager/testdata/status_brokenScheduler_UNKNOWN00.golden
@@ -7,6 +7,9 @@
             "meta_id": "a9949b21-d6d8-443a-85f5-44f5ac3065c0",
             "started_at": {
                 "seconds": 1560429513
+            },
+            "annotations": {
+                "gitpod/never-ready": "true"
             }
         },
         "spec": {

--- a/components/ws-manager/pkg/manager/testdata/status_cannotPull_004_CREATING00.golden
+++ b/components/ws-manager/pkg/manager/testdata/status_cannotPull_004_CREATING00.golden
@@ -7,6 +7,9 @@
             "meta_id": "silver-dormouse-is733prg",
             "started_at": {
                 "seconds": 1629371675
+            },
+            "annotations": {
+                "gitpod/never-ready": "true"
             }
         },
         "spec": {

--- a/components/ws-manager/pkg/manager/testdata/status_cannotPull_005_STOPPED00.golden
+++ b/components/ws-manager/pkg/manager/testdata/status_cannotPull_005_STOPPED00.golden
@@ -7,6 +7,9 @@
             "meta_id": "silver-dormouse-is733prg",
             "started_at": {
                 "seconds": 1629371675
+            },
+            "annotations": {
+                "gitpod/never-ready": "true"
             }
         },
         "spec": {

--- a/components/ws-manager/pkg/manager/testdata/status_contentInitFailed_005_STOPPED00.golden
+++ b/components/ws-manager/pkg/manager/testdata/status_contentInitFailed_005_STOPPED00.golden
@@ -7,6 +7,9 @@
             "meta_id": "aqua-chimpanzee-35q6f08k",
             "started_at": {
                 "seconds": 1629374870
+            },
+            "annotations": {
+                "gitpod/never-ready": "true"
             }
         },
         "spec": {

--- a/components/ws-manager/pkg/manager/testdata/status_errimgpull.golden
+++ b/components/ws-manager/pkg/manager/testdata/status_errimgpull.golden
@@ -7,6 +7,9 @@
             "meta_id": "ba66e4d4-3eae-4c9c-83da-75b6dbc2f592",
             "started_at": {
                 "seconds": 1567668824
+            },
+            "annotations": {
+                "gitpod/never-ready": "true"
             }
         },
         "spec": {

--- a/components/ws-manager/pkg/manager/testdata/status_errimgpull_CREATING01.golden
+++ b/components/ws-manager/pkg/manager/testdata/status_errimgpull_CREATING01.golden
@@ -7,6 +7,9 @@
             "meta_id": "f29012c4-c6b9-4bd1-9c48-151bdeec6940",
             "started_at": {
                 "seconds": 1583850986
+            },
+            "annotations": {
+                "gitpod/never-ready": "true"
             }
         },
         "spec": {

--- a/components/ws-manager/pkg/manager/testdata/status_failedBeforeStopping_explicitFail.golden
+++ b/components/ws-manager/pkg/manager/testdata/status_failedBeforeStopping_explicitFail.golden
@@ -7,6 +7,9 @@
             "meta_id": "eb694666-269a-4d8c-a031-3cd6ea8135f9",
             "started_at": {
                 "seconds": 1560927009
+            },
+            "annotations": {
+                "gitpod/never-ready": "true"
             }
         },
         "spec": {

--- a/components/ws-manager/pkg/manager/testdata/status_failedLogs_RUNNING00.golden
+++ b/components/ws-manager/pkg/manager/testdata/status_failedLogs_RUNNING00.golden
@@ -7,6 +7,9 @@
             "meta_id": "ba826db9-9d93-4f3b-a10e-8bc08bbb99f1",
             "started_at": {
                 "seconds": 1604645309
+            },
+            "annotations": {
+                "gitpod/never-ready": "true"
             }
         },
         "spec": {

--- a/components/ws-manager/pkg/manager/testdata/status_failedPending_evicted_UNKNOWN01.golden
+++ b/components/ws-manager/pkg/manager/testdata/status_failedPending_evicted_UNKNOWN01.golden
@@ -7,6 +7,9 @@
             "meta_id": "ab451d8b-7a3a-42ec-b173-20a0e49773d4",
             "started_at": {
                 "seconds": 1581948130
+            },
+            "annotations": {
+                "gitpod/never-ready": "true"
             }
         },
         "spec": {

--- a/components/ws-manager/pkg/manager/testdata/status_failedPending_evicted_UNKNOWN02.golden
+++ b/components/ws-manager/pkg/manager/testdata/status_failedPending_evicted_UNKNOWN02.golden
@@ -7,6 +7,9 @@
             "meta_id": "ab451d8b-7a3a-42ec-b173-20a0e49773d4",
             "started_at": {
                 "seconds": 1581948130
+            },
+            "annotations": {
+                "gitpod/never-ready": "true"
             }
         },
         "spec": {

--- a/components/ws-manager/pkg/manager/testdata/status_failedWorkspaceMount_PENDING00.golden
+++ b/components/ws-manager/pkg/manager/testdata/status_failedWorkspaceMount_PENDING00.golden
@@ -7,6 +7,9 @@
             "meta_id": "d4562d0d-46ae-4a4b-b0a4-a5e94ea4a2f3",
             "started_at": {
                 "seconds": 1559033178
+            },
+            "annotations": {
+                "gitpod/never-ready": "true"
             }
         },
         "spec": {

--- a/components/ws-manager/pkg/manager/testdata/status_headlessTaskFailed_STOPPING00.golden
+++ b/components/ws-manager/pkg/manager/testdata/status_headlessTaskFailed_STOPPING00.golden
@@ -7,6 +7,9 @@
             "meta_id": "sapphire-alligator-jakcgz44",
             "started_at": {
                 "seconds": 1627410546
+            },
+            "annotations": {
+                "gitpod/never-ready": "true"
             }
         },
         "spec": {

--- a/components/ws-manager/pkg/manager/testdata/status_headless_STOPPING00.golden
+++ b/components/ws-manager/pkg/manager/testdata/status_headless_STOPPING00.golden
@@ -10,6 +10,7 @@
             },
             "annotations": {
                 "baseref": "eu.gcr.io/gitpod-core-dev/registry/base-images:d04c64d5d108632a1768e4af9c3a8a3e6a87c96d2566fb1b0d1aec2fd630e8bd",
+                "gitpod/never-ready": "true",
                 "ref": "eu.gcr.io/gitpod-core-dev/registry/workspace-images:a277dab62e839192eb320da283d4e8488a2b2f46fceb4677a7d571431e239aa5"
             }
         },

--- a/components/ws-manager/pkg/manager/testdata/status_ideFailedToStart_005_RUNNING00.golden
+++ b/components/ws-manager/pkg/manager/testdata/status_ideFailedToStart_005_RUNNING00.golden
@@ -7,6 +7,9 @@
             "meta_id": "rose-donkey-wfapr095",
             "started_at": {
                 "seconds": 1629308528
+            },
+            "annotations": {
+                "gitpod/never-ready": "true"
             }
         },
         "spec": {

--- a/components/ws-manager/pkg/manager/testdata/status_prebuildSuccess2_CREATING01.golden
+++ b/components/ws-manager/pkg/manager/testdata/status_prebuildSuccess2_CREATING01.golden
@@ -7,6 +7,9 @@
             "meta_id": "green-wombat-62dzneud",
             "started_at": {
                 "seconds": 1622206099
+            },
+            "annotations": {
+                "gitpod/never-ready": "true"
             }
         },
         "spec": {

--- a/components/ws-manager/pkg/manager/testdata/status_prebuildSuccess2_CREATING02.golden
+++ b/components/ws-manager/pkg/manager/testdata/status_prebuildSuccess2_CREATING02.golden
@@ -7,6 +7,9 @@
             "meta_id": "green-wombat-62dzneud",
             "started_at": {
                 "seconds": 1622206099
+            },
+            "annotations": {
+                "gitpod/never-ready": "true"
             }
         },
         "spec": {

--- a/components/ws-manager/pkg/manager/testdata/status_regularStart_Initializing00.golden
+++ b/components/ws-manager/pkg/manager/testdata/status_regularStart_Initializing00.golden
@@ -7,6 +7,9 @@
             "meta_id": "metameta",
             "started_at": {
                 "seconds": 1552236488
+            },
+            "annotations": {
+                "gitpod/never-ready": "true"
             }
         },
         "spec": {

--- a/components/ws-manager/pkg/manager/testdata/status_stuckInStopping_RUNNING00.golden
+++ b/components/ws-manager/pkg/manager/testdata/status_stuckInStopping_RUNNING00.golden
@@ -7,6 +7,9 @@
             "meta_id": "purple-raven-cu9cj532",
             "started_at": {
                 "seconds": 1629350059
+            },
+            "annotations": {
+                "gitpod/never-ready": "true"
             }
         },
         "spec": {

--- a/components/ws-manager/pkg/manager/testdata/status_stuckInStopping_STOPPING00.golden
+++ b/components/ws-manager/pkg/manager/testdata/status_stuckInStopping_STOPPING00.golden
@@ -7,6 +7,9 @@
             "meta_id": "purple-raven-cu9cj532",
             "started_at": {
                 "seconds": 1629350059
+            },
+            "annotations": {
+                "gitpod/never-ready": "true"
             }
         },
         "spec": {

--- a/components/ws-manager/pkg/manager/testdata/status_workspace_startup_failed.golden
+++ b/components/ws-manager/pkg/manager/testdata/status_workspace_startup_failed.golden
@@ -7,6 +7,9 @@
             "meta_id": "gitpodio-templategolang-cdhvbek9fyg",
             "started_at": {
                 "seconds": 1653358271
+            },
+            "annotations": {
+                "gitpod/never-ready": "true"
             }
         },
         "spec": {

--- a/components/ws-manager/pkg/manager/testdata/status_wsstartup_Creating00.golden
+++ b/components/ws-manager/pkg/manager/testdata/status_wsstartup_Creating00.golden
@@ -7,6 +7,9 @@
             "meta_id": "metameta",
             "started_at": {
                 "seconds": 1555618414
+            },
+            "annotations": {
+                "gitpod/never-ready": "true"
             }
         },
         "spec": {

--- a/components/ws-manager/pkg/manager/testdata/status_wsstartup_Creating01.golden
+++ b/components/ws-manager/pkg/manager/testdata/status_wsstartup_Creating01.golden
@@ -7,6 +7,9 @@
             "meta_id": "metameta",
             "started_at": {
                 "seconds": 1552236488
+            },
+            "annotations": {
+                "gitpod/never-ready": "true"
             }
         },
         "spec": {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Increase the metric `workspace_starts_failure_total` when the workspace stops and the pod's annotation "gitpod/never-ready" exist. It means the workspace pod never went into the running state, probably because
- the workspace pod can't allocate to the workspace node
- content initialization failure
- the workspace pod is never ready

Increase the metric workspace_stop_total when the workspace stops and the pod's annotation "gitpod/never-ready" does not exist. So, the metric `workspace_stop_total` does not increase on the start failure.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #15335

## How to test
<!-- Provide steps to test this PR -->
1. Port-forward the ws-manager metric port 9500.
    ```console
    kubectl port-forward svc/gitpod-ws-manager 9500:9500
    ```
2. From a harvester preview VM, start a workspace, write some data, and stop the workspace.
3. Check the metrics `workspace_starts_total` increase by one.
    ```console
    curl -XGET 'localhost:9500/metrics' 
    ```
5. After the workspace is stopped (workspace content is backed up), scale MinIO to zero.
    ```console
    kubectl scale --replicas=0 deploy/minio
    ```
6. Start the workspace which workspace can't start because content initialization fails. Check the metrics `workspace_starts_total` and `workspace_starts_failure_total` increase by one, and `workspace_stop_total{reason="failed"}` does not increase.
7. Scale up the MinIO to one.
    ```console
    kubectl scale --replicas=1 deploy/minio
    ```
8. Update registry-facade NetworkPolicy, allow the egress traffic to registry-facade only (i.e., drop the traffic for kubelet pulling the container image).
    ```yaml
    apiVersion: networking.k8s.io/v1
    kind: NetworkPolicy
    metadata:
      labels:
        app: gitpod
        component: registry-facade
      name: registry-facade
      namespace: default
    spec:
      podSelector:
         matchLabels:
           app: gitpod
           component: registry-facade
      policyTypes:
      - Egress
    ```
9. Start the workspace which can't start because the image pull fails. Check the metrics `workspace_starts_total` and `workspace_starts_failure_total` increase by one, and `workspace_stop_total{reason="failed"}` does not increase.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
None

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-integration-tests=workspace
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`