### PR TITLE
[iam] Add unimplemented CreateOIDCConfig RPC

### DIFF
--- a/components/iam/pkg/apiv1/oidc_config.go
+++ b/components/iam/pkg/apiv1/oidc_config.go
@@ -5,13 +5,29 @@
 package apiv1
 
 import (
+	"context"
+
+	db "github.com/gitpod-io/gitpod/components/gitpod-db/go"
 	v1 "github.com/gitpod-io/gitpod/components/iam-api/go/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"gorm.io/gorm"
 )
 
-func NewOIDCClientConfigService() *OIDCClientConfigService {
-	return &OIDCClientConfigService{}
+func NewOIDCClientConfigService(dbConn *gorm.DB, cipher db.Cipher) *OIDCClientConfigService {
+	return &OIDCClientConfigService{
+		dbConn: dbConn,
+		cipher: cipher,
+	}
 }
 
 type OIDCClientConfigService struct {
+	dbConn *gorm.DB
+	cipher db.Cipher
+
 	v1.UnimplementedOIDCServiceServer
+}
+
+func (s *OIDCClientConfigService) CreateClientConfig(ctx context.Context, req *v1.CreateClientConfigRequest) (*v1.CreateClientConfigResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method CreateClientConfig not implemented")
 }

--- a/components/iam/pkg/apiv1/oidc_config_test.go
+++ b/components/iam/pkg/apiv1/oidc_config_test.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package apiv1
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gitpod-io/gitpod/common-go/baseserver"
+	"github.com/gitpod-io/gitpod/components/gitpod-db/go/dbtest"
+	v1 "github.com/gitpod-io/gitpod/components/iam-api/go/v1"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+)
+
+func TestOIDCClientConfig_Create(t *testing.T) {
+
+	client := setupOIDCClientConfigService(t)
+
+	_, err := client.CreateClientConfig(context.Background(), &v1.CreateClientConfigRequest{})
+	require.Error(t, err)
+	require.Equal(t, codes.Unimplemented, status.Code(err))
+
+}
+
+func setupOIDCClientConfigService(t *testing.T) v1.OIDCServiceClient {
+	t.Helper()
+
+	dbConn := dbtest.ConnectForTests(t)
+	cipher := dbtest.CipherSet(t)
+
+	srv := baseserver.NewForTests(t, baseserver.WithGRPC(
+		baseserver.MustUseRandomLocalAddress(t)),
+	)
+
+	svc := NewOIDCClientConfigService(dbConn, cipher)
+	v1.RegisterOIDCServiceServer(srv.GRPC(), svc)
+
+	t.Cleanup(func() {
+		require.NoError(t, srv.Close())
+	})
+
+	go func(t *testing.T) {
+		require.NoError(t, srv.ListenAndServe())
+	}(t)
+
+	conn, err := grpc.Dial(srv.GRPCAddress(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+
+	return v1.NewOIDCServiceClient(conn)
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Adds unimplemented CreateOIDCConfig RPC, together with a test setup. Binds db and cipher into the struct.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
1. IAM components starts up OK
2. Unit tests

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
