### PR TITLE
[iam] Implement basic OIDC CreateClientConfig RPC

### DIFF
--- a/components/gitpod-db/go/dbtest/oidc_client_config.go
+++ b/components/gitpod-db/go/dbtest/oidc_client_config.go
@@ -6,12 +6,13 @@ package dbtest
 
 import (
 	"context"
+	"testing"
+	"time"
+
 	db "github.com/gitpod-io/gitpod/components/gitpod-db/go"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	"gorm.io/gorm"
-	"testing"
-	"time"
 )
 
 func NewOIDCClientConfig(t *testing.T, record db.OIDCClientConfig) db.OIDCClientConfig {
@@ -59,10 +60,14 @@ func CreateOIDCClientConfigs(t *testing.T, conn *gorm.DB, entries ...db.OIDCClie
 	}
 
 	t.Cleanup(func() {
-		if len(ids) > 0 {
-			require.NoError(t, conn.Where(ids).Delete(&db.OIDCClientConfig{}).Error)
-		}
+		HardDeleteOIDCClientConfigs(t, ids...)
 	})
 
 	return records
+}
+
+func HardDeleteOIDCClientConfigs(t *testing.T, ids ...string) {
+	if len(ids) > 0 {
+		require.NoError(t, conn.Where(ids).Delete(&db.OIDCClientConfig{}).Error)
+	}
 }

--- a/components/gitpod-db/go/oidc_client_config.go
+++ b/components/gitpod-db/go/oidc_client_config.go
@@ -8,9 +8,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
+
 	"github.com/google/uuid"
 	"gorm.io/gorm"
-	"time"
 )
 
 type OIDCClientConfig struct {
@@ -29,7 +30,22 @@ func (c *OIDCClientConfig) TableName() string {
 	return "d_b_oidc_client_config"
 }
 
+// It feels wrong to have to define re-define all of these fields.
+// However, I could not find a Go library which would include json annotations on the structs to guarantee the fields
+// will remain consistent over time (and resilient to rename). If we find one, we can change this.
 type OIDCSpec struct {
+	// ClientID is the application's ID.
+	ClientID string `json:"clientId"`
+
+	// ClientSecret is the application's secret.
+	ClientSecret string `json:"clientSecret"`
+
+	// RedirectURL is the URL to redirect users going through
+	// the OAuth flow, after the resource owner's URLs.
+	RedirectURL string `json:"redirectUrl"`
+
+	// Scope specifies optional requested permissions.
+	Scopes []string `json:"scopes"`
 }
 
 func CreateOIDCCLientConfig(ctx context.Context, conn *gorm.DB, cfg OIDCClientConfig) (OIDCClientConfig, error) {

--- a/components/iam/pkg/apiv1/oidc_config.go
+++ b/components/iam/pkg/apiv1/oidc_config.go
@@ -7,8 +7,11 @@ package apiv1
 import (
 	"context"
 
+	goidc "github.com/coreos/go-oidc/v3/oidc"
+	"github.com/gitpod-io/gitpod/common-go/log"
 	db "github.com/gitpod-io/gitpod/components/gitpod-db/go"
 	v1 "github.com/gitpod-io/gitpod/components/iam-api/go/v1"
+	"github.com/google/uuid"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"gorm.io/gorm"
@@ -29,5 +32,38 @@ type OIDCClientConfigService struct {
 }
 
 func (s *OIDCClientConfigService) CreateClientConfig(ctx context.Context, req *v1.CreateClientConfigRequest) (*v1.CreateClientConfigResponse, error) {
-	return nil, status.Errorf(codes.Unimplemented, "method CreateClientConfig not implemented")
+	oauth2Config := req.GetConfig().GetOauth2Config()
+	oidcConfig := req.GetConfig().GetOidcConfig()
+
+	data, err := db.EncryptJSON(s.cipher, toDBSpec(oauth2Config, oidcConfig))
+	if err != nil {
+		log.Log.WithError(err).Error("Failed to encrypt oidc client config.")
+		return nil, status.Errorf(codes.Internal, "Failed to store OIDC client config.")
+	}
+
+	created, err := db.CreateOIDCCLientConfig(ctx, s.dbConn, db.OIDCClientConfig{
+		ID:     uuid.New(),
+		Issuer: oidcConfig.GetIssuer(),
+		Data:   data,
+	})
+	if err != nil {
+		log.Log.WithError(err).Error("Failed to store oidc client config in the database.")
+		return nil, status.Errorf(codes.Internal, "Failed to store OIDC client config.")
+	}
+
+	return &v1.CreateClientConfigResponse{
+		Config: &v1.OIDCClientConfig{
+			Id: created.ID.String(),
+			// TODO: Populate remainder of fields
+		},
+	}, nil
+}
+
+func toDBSpec(oauth2Config *v1.OAuth2Config, oidcConfig *v1.OIDCConfig) db.OIDCSpec {
+	return db.OIDCSpec{
+		ClientID:     oauth2Config.GetClientId(),
+		ClientSecret: oauth2Config.GetClientSecret(),
+		RedirectURL:  oauth2Config.GetAuthorizationEndpoint(),
+		Scopes:       append([]string{goidc.ScopeOpenID, "profile", "email"}, oauth2Config.GetScopesSupported()...),
+	}
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Super basic implementation of CreateClientConfig RPC. Doesn't yet handle validation and mostly accepts the config from the client.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Part of https://github.com/gitpod-io/gitpod/issues/15150

## How to test
<!-- Provide steps to test this PR -->
Unit tests

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
