### PR TITLE
Ensure that oom scores are applied

### DIFF
--- a/install/installer/pkg/components/ws-daemon/configmap.go
+++ b/install/installer/pkg/components/ws-daemon/configmap.go
@@ -149,6 +149,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 			IOLimit:   ioLimitConfig,
 			ProcLimit: procLimit,
 			NetLimit:  networkLimitConfig,
+			OOMScores: oomScoreAdjConfig,
 			Hosts: hosts.Config{
 				Enabled:       true,
 				NodeHostsFile: "/mnt/hosts",


### PR DESCRIPTION
## Description
OOM scores specified in the installer config did not end up in the configmap for ws-daemon.

## Related Issue(s)
n.a.

## How to test
- Open workspace in gitpod ops repository
- Download installer `docker run --entrypoint sh --rm eu.gcr.io/gitpod-core-dev/build/installer:fo-set-oom-scores.0 -c "cat /app/installer" > gitpod-installer`
- `sudo chmod +x ./gitpod-installer`
- `./gitpod-installer render --config deploy/workspace/installer-values.yaml --use-experimental-config > /tmp/render.yaml`
- Check that values were applied

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Fixed an issue where oom scores for workspace processes were not applied correctly
```

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
