### PR TITLE
[public-api] Define DeleteWorkspace

### DIFF
--- a/components/dashboard/src/workspaces/WorkspaceEntry.tsx
+++ b/components/dashboard/src/workspaces/WorkspaceEntry.tsx
@@ -14,7 +14,7 @@ import {
     ContextURL,
 } from "@gitpod/gitpod-protocol";
 import { GitpodHostUrl } from "@gitpod/gitpod-protocol/lib/util/gitpod-host-url";
-import { useRef, useState } from "react";
+import { useContext, useRef, useState } from "react";
 import ConfirmationModal from "../components/ConfirmationModal";
 import Modal from "../components/Modal";
 import { ContextMenuEntry } from "../components/ContextMenu";
@@ -25,6 +25,7 @@ import { WorkspaceModel } from "./workspace-model";
 import { getGitpodService } from "../service/service";
 import ConnectToSSHModal from "./ConnectToSSHModal";
 import dayjs from "dayjs";
+import { FeatureFlagContext } from "../contexts/FeatureFlagContext";
 
 function getLabel(state: WorkspaceInstancePhase, conditions?: WorkspaceInstanceConditions) {
     if (conditions?.failed) {
@@ -44,6 +45,7 @@ export function WorkspaceEntry({ desc, model, isAdmin, stopWorkspace }: Props) {
     const [isDeleteModalVisible, setDeleteModalVisible] = useState(false);
     const [isRenameModalVisible, setRenameModalVisible] = useState(false);
     const [isSSHModalVisible, setSSHModalVisible] = useState(false);
+    const { usePublicApiWorkspacesService } = useContext(FeatureFlagContext);
     const renameInputRef = useRef<HTMLInputElement>(null);
     const [errorMessage, setErrorMessage] = useState("");
     const state: WorkspaceInstancePhase = desc.latestInstance?.status?.phase || "stopped";
@@ -206,7 +208,7 @@ export function WorkspaceEntry({ desc, model, isAdmin, stopWorkspace }: Props) {
                     buttonText="Delete Workspace"
                     visible={isDeleteModalVisible}
                     onClose={() => setDeleteModalVisible(false)}
-                    onConfirm={() => model.deleteWorkspace(ws.id)}
+                    onConfirm={() => model.deleteWorkspace(ws.id, usePublicApiWorkspacesService)}
                 />
             )}
             {/* TODO: Use title and buttons props */}

--- a/components/dashboard/src/workspaces/Workspaces.tsx
+++ b/components/dashboard/src/workspaces/Workspaces.tsx
@@ -67,7 +67,9 @@ export default function () {
                 visible={!!deleteModalVisible}
                 onClose={() => setDeleteModalVisible(false)}
                 onConfirm={() => {
-                    inactiveWorkspaces.forEach((ws) => workspaceModel?.deleteWorkspace(ws.workspace.id));
+                    inactiveWorkspaces.forEach((ws) =>
+                        workspaceModel?.deleteWorkspace(ws.workspace.id, usePublicApiWorkspacesService),
+                    );
                     setDeleteModalVisible(false);
                 }}
             ></ConfirmationModal>

--- a/components/dashboard/src/workspaces/workspace-model.ts
+++ b/components/dashboard/src/workspaces/workspace-model.ts
@@ -12,6 +12,7 @@ import {
     WorkspaceInstance,
 } from "@gitpod/gitpod-protocol";
 import { hoursBefore, isDateSmallerOrEqual } from "@gitpod/gitpod-protocol/lib/util/timeutil";
+import { workspacesService } from "../service/public-api";
 import { getGitpodService } from "../service/service";
 
 export class WorkspaceModel implements Disposable, Partial<GitpodClient> {
@@ -93,8 +94,11 @@ export class WorkspaceModel implements Disposable, Partial<GitpodClient> {
         }
     }
 
-    async deleteWorkspace(id: string): Promise<void> {
-        await getGitpodService().server.deleteWorkspace(id);
+    async deleteWorkspace(id: string, usePublicAPI: boolean): Promise<void> {
+        usePublicAPI
+            ? await workspacesService.deleteWorkspace({ workspaceId: id })
+            : await getGitpodService().server.deleteWorkspace(id);
+
         this.workspaces.delete(id);
         this.notifyWorkpaces();
     }

--- a/components/public-api-server/pkg/apiv1/workspace.go
+++ b/components/public-api-server/pkg/apiv1/workspace.go
@@ -7,6 +7,7 @@ package apiv1
 import (
 	"context"
 	"fmt"
+
 	connect "github.com/bufbuild/connect-go"
 	"github.com/gitpod-io/gitpod/common-go/log"
 	"github.com/gitpod-io/gitpod/common-go/namegen"
@@ -186,6 +187,26 @@ func (s *WorkspaceService) StopWorkspace(ctx context.Context, req *connect.Reque
 	}
 
 	return connect.NewResponse(&v1.StopWorkspaceResponse{}), nil
+}
+
+func (s *WorkspaceService) DeleteWorkspace(ctx context.Context, req *connect.Request[v1.DeleteWorkspaceRequest]) (*connect.Response[v1.DeleteWorkspaceResponse], error) {
+	workspaceID, err := validateWorkspaceID(req.Msg.GetWorkspaceId())
+	if err != nil {
+		return nil, err
+	}
+
+	conn, err := getConnection(ctx, s.connectionPool)
+	if err != nil {
+		return nil, err
+	}
+
+	err = conn.DeleteWorkspace(ctx, workspaceID)
+	if err != nil {
+		log.WithField("workspace_id", workspaceID).WithError(err).Error("Failed to delete workspace.")
+		return nil, proxy.ConvertError(err)
+	}
+
+	return connect.NewResponse(&v1.DeleteWorkspaceResponse{}), nil
 }
 
 func getLimitFromPagination(pagination *v1.Pagination) (int, error) {

--- a/components/public-api-server/pkg/apiv1/workspace_test.go
+++ b/components/public-api-server/pkg/apiv1/workspace_test.go
@@ -6,11 +6,12 @@ package apiv1
 
 import (
 	"context"
-	"github.com/gitpod-io/gitpod/common-go/namegen"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
+
+	"github.com/gitpod-io/gitpod/common-go/namegen"
 
 	fuzz "github.com/AdaLogics/go-fuzz-headers"
 	connect "github.com/bufbuild/connect-go"
@@ -129,6 +130,59 @@ func TestWorkspaceService_StopWorkspace(t *testing.T) {
 		require.NoError(t, err)
 
 		requireEqualProto(t, &v1.StopWorkspaceResponse{}, resp.Msg)
+	})
+}
+
+func TestWorkspaceService_DeleteWorkspace(t *testing.T) {
+
+	workspaceID := workspaceTestData[0].Protocol.Workspace.ID
+
+	t.Run("invalid argument when workspace ID is missing", func(t *testing.T) {
+		_, client := setupWorkspacesService(t)
+
+		_, err := client.DeleteWorkspace(context.Background(), connect.NewRequest(&v1.DeleteWorkspaceRequest{
+			WorkspaceId: "",
+		}))
+		require.Error(t, err)
+		require.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+	})
+
+	t.Run("invalid argument when workspace ID does not validate", func(t *testing.T) {
+		_, client := setupWorkspacesService(t)
+
+		_, err := client.DeleteWorkspace(context.Background(), connect.NewRequest(&v1.DeleteWorkspaceRequest{
+			WorkspaceId: "some-random-not-valid-workspace-id",
+		}))
+		require.Error(t, err)
+		require.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+	})
+
+	t.Run("not found when workspace does not exist", func(t *testing.T) {
+		serverMock, client := setupWorkspacesService(t)
+
+		serverMock.EXPECT().DeleteWorkspace(gomock.Any(), workspaceID).Return(&jsonrpc2.Error{
+			Code:    404,
+			Message: "not found",
+		})
+
+		_, err := client.DeleteWorkspace(context.Background(), connect.NewRequest(&v1.DeleteWorkspaceRequest{
+			WorkspaceId: workspaceID,
+		}))
+		require.Error(t, err)
+		require.Equal(t, connect.CodeNotFound, connect.CodeOf(err))
+	})
+
+	t.Run("delegates to server", func(t *testing.T) {
+		serverMock, client := setupWorkspacesService(t)
+
+		serverMock.EXPECT().DeleteWorkspace(gomock.Any(), workspaceID).Return(nil)
+
+		resp, err := client.DeleteWorkspace(context.Background(), connect.NewRequest(&v1.DeleteWorkspaceRequest{
+			WorkspaceId: workspaceID,
+		}))
+		require.NoError(t, err)
+
+		requireEqualProto(t, &v1.DeleteWorkspaceResponse{}, resp.Msg)
 	})
 }
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Implements DeleteWorkspace RPC on the Public API, and uses it (behind an experiment) from Dashboard.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Depends on https://github.com/gitpod-io/gitpod/pull/15554

## How to test
<!-- Provide steps to test this PR -->
1. Preview
2. Delete workspace
3. Observe the request goes to public API
4. Dashboard works as before

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold for dependency on https://github.com/gitpod-io/gitpod/pull/15554