### PR TITLE
[dashboard] access invoices after cancellation

### DIFF
--- a/components/usage/pkg/apiv1/billing.go
+++ b/components/usage/pkg/apiv1/billing.go
@@ -194,6 +194,12 @@ func (s *BillingService) CreateStripeSubscription(ctx context.Context, req *v1.C
 	if err != nil {
 		return nil, err
 	}
+	// if the customer has a subscription, return error
+	for _, subscription := range stripeCustomer.Subscriptions.Data {
+		if subscription.Status != "canceled" {
+			return nil, status.Errorf(codes.AlreadyExists, "Customer (%s) already has an active subscription (%s)", attributionID, subscription.ID)
+		}
+	}
 
 	priceID, err := getPriceIdentifier(attributionID, stripeCustomer, s)
 	if err != nil {

--- a/components/usage/pkg/stripe/stripe.go
+++ b/components/usage/pkg/stripe/stripe.go
@@ -234,7 +234,7 @@ func (c *Client) GetCustomer(ctx context.Context, customerID string) (customer *
 	customer, err = c.sc.Customers.Get(customerID, &stripe.CustomerParams{
 		Params: stripe.Params{
 			Context: ctx,
-			Expand:  []*string{stripe.String("tax")},
+			Expand:  []*string{stripe.String("tax"), stripe.String("subscriptions")},
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Show a button to the stripe portal for customers who have cancelled their subscription, so they can download invoices later.

<img width="624" alt="Screenshot 2022-12-29 at 17 45 18" src="https://user-images.githubusercontent.com/372735/209983591-b07d0aa9-b8be-4fde-8606-24e58db36ed5.png">

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #15236

## How to test
<!-- Provide steps to test this PR -->
- after login go to billing and verify there is no button for previous invoices.
- subscribe
- cancel and verify there is now a button to go to the portal and see previous invoices.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-payment
- [x] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
