### PR TITLE
[ws-manager] remove unneeded metric

### DIFF
--- a/components/ws-manager/pkg/manager/metrics.go
+++ b/components/ws-manager/pkg/manager/metrics.go
@@ -48,7 +48,6 @@ type metrics struct {
 	totalStartsCounterVec                     *prometheus.CounterVec
 	totalStartsFailureCounterVec              *prometheus.CounterVec
 	totalStopsCounterVec                      *prometheus.CounterVec
-	totalStopsFailureCounterVec               *prometheus.CounterVec
 	totalBackupCounterVec                     *prometheus.CounterVec
 	totalBackupFailureCounterVec              *prometheus.CounterVec
 	totalRestoreCounterVec                    *prometheus.CounterVec
@@ -122,12 +121,6 @@ func newMetrics(m *Manager) *metrics {
 			Name:      "workspace_stops_total",
 			Help:      "total number of workspaces stopped",
 		}, []string{"reason", "type", "class"}),
-		totalStopsFailureCounterVec: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Namespace: metricsNamespace,
-			Subsystem: metricsWorkspaceSubsystem,
-			Name:      "workspace_stops_failure_total",
-			Help:      "total number of workspaces failed to stop",
-		}, []string{"type", "class"}),
 		totalBackupCounterVec: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Namespace: metricsNamespace,
 			Subsystem: metricsWorkspaceSubsystem,
@@ -229,7 +222,6 @@ func (m *metrics) Register(reg prometheus.Registerer) error {
 		m.totalStartsCounterVec,
 		m.totalStartsFailureCounterVec,
 		m.totalStopsCounterVec,
-		m.totalStopsFailureCounterVec,
 		m.totalBackupCounterVec,
 		m.totalBackupFailureCounterVec,
 		m.totalRestoreCounterVec,
@@ -328,14 +320,6 @@ func (m *metrics) OnChange(status *api.WorkspaceStatus) {
 		}
 		counter.Inc()
 
-		if reason == "failed" {
-			counter, err = m.totalStopsFailureCounterVec.GetMetricWithLabelValues(tpe, status.Spec.Class)
-			if err != nil {
-				log.WithError(err).WithField("type", tpe).Warn("cannot get counter for workspace stop failure metric")
-				return
-			}
-			counter.Inc()
-		}
 		removeFromState = true
 	}
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
That metric is not needed, as we get same data from `workspace_stops_total{reason=failed}`

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
none
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
