### PR TITLE
fix: trim repo url while open new workspace

### DIFF
--- a/components/dashboard/src/components/RepositoryFinder.tsx
+++ b/components/dashboard/src/components/RepositoryFinder.tsx
@@ -35,6 +35,7 @@ export default function RepositoryFinder(props: RepositoryFinderProps) {
     const getElements = useCallback(
         (searchString: string) => {
             const result = [...suggestedContextURLs];
+            searchString = searchString.trim();
             try {
                 // If the searchString is a URL, and it's not present in the proposed results, "artificially" add it here.
                 new URL(searchString);


### PR DESCRIPTION
> Signed-off-by: Siddhant Khare <siddhant@gitpod.io>

## Description
Bug Fix: This PR propose change to trim url while staring a new workspace from dashboard.


|Before|After **_(ignore UI Change)_**|
|:---:|:---:|
|<video src="https://user-images.githubusercontent.com/55068936/210498585-b0888eb5-15de-42e0-a6c6-7cff3b866c24.mov">|<video src="https://user-images.githubusercontent.com/55068936/210498644-90423345-0cbc-4158-912b-6c26b4f2426a.mov">|


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #12079

## How to test
<!-- Provide steps to test this PR -->
- Open [Preview](https://fix-12079.preview.gitpod-dev.com)
- Open [/workspaces](https://fix-12079.preview.gitpod-dev.com/workspaces)
- Click on New Workspace Button
- Type `       https://github.com/gitpod-io/empty` in Repo. URL text box. It will start a new workspace without any error (_repeat same in prod. to exp. the difference_)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
