### PR TITLE
Deploy custom certs on Ubuntu (ContainerD) GKE nodes

### DIFF
--- a/containerd-custom-certs.yaml
+++ b/containerd-custom-certs.yaml
@@ -1,0 +1,89 @@
+---
+apiVersion: v1
+data:
+  systest-ca-pem.crt: AA==
+kind: Secret
+metadata:
+  name: ca-certs
+  namespace: gitpod
+type: Opaque
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: node-initializer
+  namespace: gitpod
+  labels:
+    app: default-init
+spec:
+  selector:
+    matchLabels:
+      app: default-init
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        name: node-initializer
+        app: default-init
+    spec:
+      imagePullSecrets:
+        - name: artifact-registry
+      volumes:
+        - name: root-mount
+          hostPath:
+            path: /
+        - name: entrypoint
+          configMap:
+            name: entrypoint
+            defaultMode: 0744
+        - name: ca-certs
+          secret:
+            secretName: ca-certs
+            defaultMode: 420
+      hostNetwork: true
+      hostPID: true
+      initContainers:
+        - image: my-registry/ubuntu:18.04
+          name: node-initializer
+          command: ["/scripts/entrypoint.sh"]
+          env:
+            - name: ROOT_MOUNT_DIR
+              value: /mnt
+          securityContext:
+            capabilities:
+              add:
+                - NET_ADMIN
+            privileged: true
+          volumeMounts:
+            - name: root-mount
+              mountPath: /mnt
+            - name: entrypoint
+              mountPath: /scripts
+            - name: ca-certs
+              mountPath: /ca-certs
+      containers:
+        - image: "my-registry/pause:2.0"
+          name: pause
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: entrypoint
+  namespace: gitpod
+  labels:
+    app: default-init
+data:
+  entrypoint.sh: |
+    #!/usr/bin/env bash
+
+    set -euo pipefail
+
+    DEBIAN_FRONTEND=noninteractive
+    ROOT_MOUNT_DIR="${ROOT_MOUNT_DIR:-/root}"
+
+    echo "Refresh SSL custom certs"
+    ls -l $ROOT_MOUNT_DIR/usr/local/share/ca-certificates
+    cp /ca-certs/systest-ca-pem.crt $ROOT_MOUNT_DIR/usr/local/share/ca-certificates
+    nsenter --target 1 --mount update-ca-certificates
+    nsenter --target 1 --mount systemctl restart containerd


### PR DESCRIPTION
Signed-off-by: denismaggior8 <denis.maggiorotto@sunnyvale.it>

## Description
This PR contains a working YAML manifest useful to deploy custom certs on GKE nodes with Ubuntu and ContainerD.
It deploys custom CA certs on top of GKE nodes then restarts ContainerD to have them be cognised.

I did not know how to place the file within the repo so left it in the root path, please feel free to move it in a better folder.

## Related Issue(s)
References issue #9585

## How to test
Prior to test the YAML file, pse make sure you had:
1) put a base64 encoded CA PEM cert file, right into the config map named **ca-certs** and **data/systest-ca-pem.crt** section (by substituting the fake AA== base64 string)
2) substitute each occurrences of **my-registry** in front of image names, this is just a placeholder 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```
The containerd-custom-certs.yaml contains working manifests useful to deploy custom CA certificates on GKE nodes running Ubuntu and ContainerD (it doesn't work on Google COS nodes).

Prior to use this file, please make sure you had:
1) put a base64 encoded CA PEM cert file, right into the config map named **ca-certs** and **data/systest-ca-pem.crt** section (by substituting the fake AA== base64 string)
2) substitute each occurrences of **my-registry** in front of image names, this is just a placeholder 

Once applied, this file deploys custom CA certs on top of GKE nodes and restarts ContainerD to have them be cognised.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [x] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
