### PR TITLE
[dashboard] support start-with-options URL

### DIFF
--- a/components/dashboard/src/components/RepositoryFinder.tsx
+++ b/components/dashboard/src/components/RepositoryFinder.tsx
@@ -14,7 +14,8 @@ const LOCAL_STORAGE_KEY = "open-in-gitpod-search-data";
 interface RepositoryFinderProps {
     initialValue?: string;
     maxDisplayItems?: number;
-    setSelection: (selection: string) => void;
+    setSelection?: (selection: string) => void;
+    onError?: (error: string) => void;
 }
 
 function stripOffProtocol(url: string): string {
@@ -67,6 +68,27 @@ export default function RepositoryFinder(props: RepositoryFinderProps) {
         [suggestedContextURLs],
     );
 
+    const element = (
+        <div className="flex h-12" title="Repository">
+            <div className="mx-2 my-2">
+                <img className="w-8 filter-grayscale self-center" src={Repository} alt="logo" />
+            </div>
+            <div className="flex-col ml-1 mt-1 flex-grow">
+                <div className="flex font-semibold text-gray-700">
+                    <div className="text-gray-700 dark:text-gray-300">Context URL</div>
+                </div>
+                <div className={"flex text-xs text-gray-500 dark:text-gray-400 font-semibold "}>
+                    {displayContextUrl(props.initialValue) || "Select a repository"}
+                </div>
+            </div>
+        </div>
+    );
+
+    if (!props.setSelection) {
+        // readonly display value
+        return <div className="m-2">{element}</div>;
+    }
+
     return (
         <DropDown2
             getElements={getElements}
@@ -74,19 +96,7 @@ export default function RepositoryFinder(props: RepositoryFinderProps) {
             onSelectionChange={props.setSelection}
             searchPlaceholder="Paste repository URL or type to find suggestions"
         >
-            <div className="flex h-12" title="Repository">
-                <div className="mx-2 my-2">
-                    <img className="w-8 filter-grayscale self-center" src={Repository} alt="logo" />
-                </div>
-                <div className="flex-col ml-1 mt-1 flex-grow">
-                    <div className="flex font-semibold text-gray-700">
-                        <div className="text-gray-700 dark:text-gray-300">Repository</div>
-                    </div>
-                    <div className={"flex text-xs text-gray-500 dark:text-gray-400 font-semibold "}>
-                        {displayContextUrl(props.initialValue) || "Select a repository"}
-                    </div>
-                </div>
-            </div>
+            {element}
         </DropDown2>
     );
 }

--- a/components/dashboard/src/components/SelectIDEComponent.tsx
+++ b/components/dashboard/src/components/SelectIDEComponent.tsx
@@ -14,6 +14,7 @@ interface SelectIDEComponentProps {
     selectedIdeOption?: string;
     useLatest?: boolean;
     onSelectionChange: (ide: string, latest: boolean) => void;
+    setError?: (error?: string) => void;
 }
 
 export default function SelectIDEComponent(props: SelectIDEComponentProps) {
@@ -51,8 +52,20 @@ export default function SelectIDEComponent(props: SelectIDEComponentProps) {
     const internalOnSelectionChange = (id: string) => {
         const { ide, useLatest } = parseId(id);
         props.onSelectionChange(ide, useLatest);
+        if (props.setError) {
+            props.setError(undefined);
+        }
     };
     const ide = props.selectedIdeOption || ideOptions?.defaultIde || "";
+    useEffect(() => {
+        if (!ideOptions) {
+            return;
+        }
+        const option = ideOptions.options[ide];
+        if (!option) {
+            props.setError?.(`The editor '${ide}' is not supported.`);
+        }
+    }, [ide, ideOptions, props]);
     return (
         <DropDown2
             getElements={getElements}
@@ -80,21 +93,24 @@ function capitalize(label?: string) {
 }
 
 function IdeOptionElementSelected({ option, useLatest }: IdeOptionElementProps): JSX.Element {
+    let version: string | undefined, label: string | undefined, title: string;
     if (!option) {
-        return <></>;
+        title = "Select Editor";
+    } else {
+        version = useLatest ? option.latestImageVersion : option.imageVersion;
+        label = option.type;
+        title = option.title;
     }
-    const version = useLatest ? option.latestImageVersion : option.imageVersion;
-    const label = option.type;
 
     return (
-        <div className="flex" title={option.title}>
+        <div className="flex" title={title}>
             <div className="mx-2 my-2">
                 <img className="w-8 filter-grayscale self-center" src={Editor} alt="logo" />
             </div>
             <div className="flex-col ml-1 mt-1 flex-grow">
                 <div className="text-gray-700 dark:text-gray-300 font-semibold">Editor</div>
                 <div className="flex text-xs text-gray-500 dark:text-gray-400">
-                    <div className="font-semibold">{option.title}</div>
+                    <div className="font-semibold">{title}</div>
                     {version && (
                         <>
                             <div className="mx-1">&middot;</div>

--- a/components/dashboard/src/components/SelectWorkspaceClassComponent.tsx
+++ b/components/dashboard/src/components/SelectWorkspaceClassComponent.tsx
@@ -5,7 +5,7 @@
  */
 
 import { SupportedWorkspaceClass } from "@gitpod/gitpod-protocol/lib/workspace-class";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { getGitpodService } from "../service/service";
 import WorkspaceClass from "../icons/WorkspaceClass.svg";
 import { DropDown2, DropDown2Element } from "./DropDown2";
@@ -13,6 +13,7 @@ import { DropDown2, DropDown2Element } from "./DropDown2";
 interface SelectWorkspaceClassProps {
     selectedWorkspaceClass?: string;
     onSelectionChange: (workspaceClass: string) => void;
+    setError?: (error?: string) => void;
 }
 
 export default function SelectWorkspaceClassComponent(props: SelectWorkspaceClassProps) {
@@ -37,35 +38,64 @@ export default function SelectWorkspaceClassComponent(props: SelectWorkspaceClas
             ];
         };
     }, [workspaceClasses]);
+    useEffect(() => {
+        if (!workspaceClasses) {
+            return;
+        }
+        // if the selected workspace class is not supported, we set an error and ask the user to pick one
+        if (props.selectedWorkspaceClass && !workspaceClasses.find((c) => c.id === props.selectedWorkspaceClass)) {
+            props.setError?.(`The workspace class '${props.selectedWorkspaceClass}' is not supported.`);
+        }
+    }, [workspaceClasses, props.selectedWorkspaceClass, props.setError, props]);
+    const internalOnSelectionChange = useCallback(
+        (id: string) => {
+            props.onSelectionChange(id);
+            if (props.setError) {
+                props.setError(undefined);
+            }
+        },
+        [props],
+    );
+    const selectedWsClass = useMemo(
+        () =>
+            workspaceClasses?.find(
+                (ws) => ws.id === (props.selectedWorkspaceClass || workspaceClasses.find((ws) => ws.isDefault)?.id),
+            ),
+        [props.selectedWorkspaceClass, workspaceClasses],
+    );
     return (
         <DropDown2
             getElements={getElements}
-            onSelectionChange={props.onSelectionChange}
+            onSelectionChange={internalOnSelectionChange}
             searchPlaceholder="Select class"
             disableSearch={true}
         >
-            <WorkspaceClassDropDownElementSelected
-                wsClass={workspaceClasses?.find(
-                    (ws) => ws.id === (props.selectedWorkspaceClass || workspaceClasses.find((ws) => ws.isDefault)?.id),
-                )}
-            />
+            <WorkspaceClassDropDownElementSelected wsClass={selectedWsClass} />
         </DropDown2>
     );
 }
 
 function WorkspaceClassDropDownElementSelected(props: { wsClass?: SupportedWorkspaceClass }): JSX.Element {
     const c = props.wsClass;
+    let title = "Select class";
+    if (c) {
+        title = c.displayName;
+    }
     return (
-        <div className="flex h-12" title={c?.displayName}>
+        <div className="flex h-12" title={title}>
             <div className="mx-2 my-2">
                 <img className="w-8 filter-grayscale self-center" src={WorkspaceClass} alt="logo" />
             </div>
             <div className="flex-col ml-1 mt-1 flex-grow">
                 <div className="text-gray-700 dark:text-gray-300 font-semibold">Class</div>
                 <div className="flex text-xs text-gray-500 dark:text-gray-400">
-                    <div className="font-semibold">{c?.displayName}</div>
-                    <div className="mx-1">&middot;</div>
-                    <div>{c?.description}</div>
+                    <div className="font-semibold">{title}</div>
+                    {c?.description && (
+                        <>
+                            <div className="mx-1">&middot;</div>
+                            <div>{c?.description}</div>
+                        </>
+                    )}
                 </div>
             </div>
         </div>

--- a/components/dashboard/src/start/CreateWorkspace.tsx
+++ b/components/dashboard/src/start/CreateWorkspace.tsx
@@ -27,7 +27,7 @@ import { isGitpodIo } from "../utils";
 import { BillingAccountSelector } from "../components/BillingAccountSelector";
 import { FeatureFlagContext } from "../contexts/FeatureFlagContext";
 import { UsageLimitReachedModal } from "../components/UsageLimitReachedModal";
-import { StartOptions } from "@gitpod/gitpod-protocol/lib/util/gitpod-host-url";
+import { StartWorkspaceOptions } from "./start-workspace-options";
 
 export interface CreateWorkspaceProps {
     contextUrl: string;
@@ -38,22 +38,6 @@ export interface CreateWorkspaceState {
     error?: StartWorkspaceError;
     selectAccountError?: SelectAccountPayload;
     stillParsing: boolean;
-}
-
-function parseSearchParams(search: string): GitpodServer.StartWorkspaceOptions {
-    const params = new URLSearchParams(search);
-    const options: GitpodServer.StartWorkspaceOptions = {};
-    if (params.has(StartOptions.WORKSPACE_CLASS)) {
-        options.workspaceClass = params.get(StartOptions.WORKSPACE_CLASS)!;
-    }
-    if (params.has(StartOptions.EDITOR)) {
-        const useLatestVersion = params.get(StartOptions.USE_LATEST_EDITOR) === "true";
-        options.ideSettings = {
-            defaultIde: params.get(StartOptions.EDITOR)!,
-            useLatestVersion,
-        };
-    }
-    return options;
 }
 
 export default class CreateWorkspace extends React.Component<CreateWorkspaceProps, CreateWorkspaceState> {
@@ -72,7 +56,7 @@ export default class CreateWorkspace extends React.Component<CreateWorkspaceProp
 
         // add options from search params
         const opts = options || {};
-        Object.assign(opts, parseSearchParams(window.location.search));
+        Object.assign(opts, StartWorkspaceOptions.parseSearchParams(window.location.search));
         // We assume anything longer than 3 seconds is no longer just parsing the context URL (i.e. it's now creating a workspace).
         let timeout = setTimeout(() => this.setState({ stillParsing: false }), 3000);
 

--- a/components/dashboard/src/start/start-workspace-options.ts
+++ b/components/dashboard/src/start/start-workspace-options.ts
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { GitpodServer } from "@gitpod/gitpod-protocol";
+
+export namespace StartWorkspaceOptions {
+    // The workspace class to use for the workspace. If not specified, the default workspace class is used.
+    export const WORKSPACE_CLASS = "workspaceClass";
+
+    // The editor to use for the workspace. If not specified, the default editor is used.
+    export const EDITOR = "editor";
+
+    export function parseSearchParams(search: string): GitpodServer.StartWorkspaceOptions {
+        const params = new URLSearchParams(search);
+        const options: GitpodServer.StartWorkspaceOptions = {};
+        const workspaceClass = params.get(StartWorkspaceOptions.WORKSPACE_CLASS);
+        if (workspaceClass) {
+            options.workspaceClass = workspaceClass;
+        }
+        const editorParam = params.get(StartWorkspaceOptions.EDITOR);
+        if (editorParam) {
+            if (editorParam?.endsWith("-latest")) {
+                options.ideSettings = {
+                    defaultIde: editorParam.slice(0, -7),
+                    useLatestVersion: true,
+                };
+            } else {
+                options.ideSettings = {
+                    defaultIde: editorParam,
+                    useLatestVersion: false,
+                };
+            }
+        }
+        return options;
+    }
+
+    export function toSearchParams(options: GitpodServer.StartWorkspaceOptions): string {
+        const params = new URLSearchParams();
+        if (options.workspaceClass) {
+            params.set(StartWorkspaceOptions.WORKSPACE_CLASS, options.workspaceClass);
+        }
+        if (options.ideSettings && options.ideSettings.defaultIde) {
+            const ide = options.ideSettings.defaultIde;
+            const latest = options.ideSettings.useLatestVersion;
+            params.set(StartWorkspaceOptions.EDITOR, latest ? ide + "-latest" : ide);
+        }
+        return params.toString();
+    }
+}

--- a/components/dashboard/src/workspaces/Workspaces.tsx
+++ b/components/dashboard/src/workspaces/Workspaces.tsx
@@ -45,7 +45,7 @@ export default function () {
     const [workspaceModel, setWorkspaceModel] = useState<WorkspaceModel>();
     const [showInactive, setShowInactive] = useState<boolean>();
     const [deleteModalVisible, setDeleteModalVisible] = useState<boolean>();
-    const { setIsStartWorkspaceModalVisible } = useContext(StartWorkspaceModalContext);
+    const { setStartWorkspaceModalProps } = useContext(StartWorkspaceModalContext);
 
     useEffect(() => {
         (async () => {
@@ -138,7 +138,7 @@ export default function () {
                                     ]}
                                 />
                             </div>
-                            <button onClick={() => setIsStartWorkspaceModalVisible(true)} className="ml-2">
+                            <button onClick={() => setStartWorkspaceModalProps({})} className="ml-2">
                                 New Workspace{" "}
                                 <span className="opacity-60 hidden md:inline">{StartWorkspaceModalKeyBinding}</span>
                             </button>
@@ -238,7 +238,7 @@ export default function () {
                                         </a>
                                     </div>
                                     <span>
-                                        <button onClick={() => setIsStartWorkspaceModalVisible(true)}>
+                                        <button onClick={() => setStartWorkspaceModalProps({})}>
                                             New Workspace{" "}
                                             <span className="opacity-60 hidden md:inline">
                                                 {StartWorkspaceModalKeyBinding}

--- a/components/dashboard/src/workspaces/start-workspace-modal-context.tsx
+++ b/components/dashboard/src/workspaces/start-workspace-modal-context.tsx
@@ -5,22 +5,27 @@
  */
 
 import React, { createContext, useEffect, useState } from "react";
+import { StartWorkspaceModalProps } from "./StartWorkspaceModal";
 
 export const StartWorkspaceModalContext = createContext<{
-    isStartWorkspaceModalVisible?: boolean;
-    setIsStartWorkspaceModalVisible: React.Dispatch<boolean>;
+    startWorkspaceModalProps?: StartWorkspaceModalProps;
+    setStartWorkspaceModalProps: React.Dispatch<StartWorkspaceModalProps | undefined>;
 }>({
-    setIsStartWorkspaceModalVisible: () => null,
+    setStartWorkspaceModalProps: () => null,
 });
 
 export const StartWorkspaceModalContextProvider: React.FC = ({ children }) => {
-    const [isStartWorkspaceModalVisible, setIsStartWorkspaceModalVisible] = useState<boolean>(false);
+    const [startWorkspaceModalProps, setStartWorkspaceModalProps] = useState<StartWorkspaceModalProps | undefined>(
+        undefined,
+    );
 
     useEffect(() => {
         const onKeyDown = (event: KeyboardEvent) => {
             if ((event.metaKey || event.ctrlKey) && event.key === "o") {
                 event.preventDefault();
-                setIsStartWorkspaceModalVisible(true);
+                setStartWorkspaceModalProps({
+                    onClose: () => setStartWorkspaceModalProps(undefined),
+                });
             }
         };
         window.addEventListener("keydown", onKeyDown);
@@ -30,7 +35,7 @@ export const StartWorkspaceModalContextProvider: React.FC = ({ children }) => {
     }, []);
 
     return (
-        <StartWorkspaceModalContext.Provider value={{ isStartWorkspaceModalVisible, setIsStartWorkspaceModalVisible }}>
+        <StartWorkspaceModalContext.Provider value={{ startWorkspaceModalProps, setStartWorkspaceModalProps }}>
             {children}
         </StartWorkspaceModalContext.Provider>
     );

--- a/components/gitpod-protocol/src/util/gitpod-host-url.ts
+++ b/components/gitpod-protocol/src/util/gitpod-host-url.ts
@@ -21,12 +21,6 @@ const workspaceIDRegex = RegExp(`^${baseWorkspaceIDRegex}$`);
 // this pattern matches URL prefixes of workspaces
 const workspaceUrlPrefixRegex = RegExp(`^([0-9]{4,6}-)?${baseWorkspaceIDRegex}\\.`);
 
-export namespace StartOptions {
-    export const WORKSPACE_CLASS = "workspaceClass";
-    export const EDITOR = "editor";
-    export const USE_LATEST_EDITOR = "useLatestEditor";
-}
-
 export class GitpodHostUrl {
     readonly url: URL;
 
@@ -127,31 +121,6 @@ export class GitpodHostUrl {
         return this.withoutWorkspacePrefix().with({
             pathname: "/start/",
             hash: "#" + workspaceId,
-        });
-    }
-
-    asCreateWorkspace(
-        contextUrl: string,
-        o?: {
-            workspaceClass?: string;
-            editor?: string;
-            useLatestEditor?: boolean;
-        },
-    ): GitpodHostUrl {
-        const searchParams: URLSearchParams = new URLSearchParams();
-        if (o?.workspaceClass && o?.workspaceClass.length > 0) {
-            searchParams.append(StartOptions.WORKSPACE_CLASS, o.workspaceClass);
-        }
-        if (o?.editor && o?.editor?.length > 0) {
-            searchParams.append(StartOptions.EDITOR, o.editor);
-        }
-        if (o?.useLatestEditor !== undefined) {
-            searchParams.append(StartOptions.USE_LATEST_EDITOR, o.useLatestEditor.toString());
-        }
-        return this.withoutWorkspacePrefix().with({
-            pathname: "/",
-            search: searchParams.toString(),
-            hash: "#" + contextUrl,
         });
     }
 


### PR DESCRIPTION
## Description
This change allows for starting new workspaces with an option dialog where users can select the IDE and workspace class.
The URL param is `showOptions=true` as in:
`https://gitpod.io?showOptions=true#<context-url>`

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #15566

## How to test
<!-- Provide steps to test this PR -->

Open this PR using the following link: 

- https://se-show-options.preview.gitpod-dev.com/?showOptions=true#https://github.com/gitpod-io/gitpod/pull/15567

It's also possible to preselect certain values:
- https://se-show-options.preview.gitpod-dev.com/?showOptions=true&editor=intellij#https://github.com/gitpod-io/gitpod/pull/15567

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Support start-with-options URL, for prompting users about the preferred IDE and workspace class when opening a fresh workspace.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
