### PR TITLE
Update Helm dependencies in Installer

### DIFF
--- a/install/installer/cmd/root.go
+++ b/install/installer/cmd/root.go
@@ -57,7 +57,7 @@ func setSeed() {
 		rand.Seed(rootOpts.SeedValue)
 
 		// crypto/rand is used by the bcrypt package to generate its random values
-		str, err := common.RandomString(64)
+		str, err := common.RandomString(128)
 		if err != nil {
 			panic(err)
 		}

--- a/install/installer/cmd/testdata/render/aws-setup/output.golden
+++ b/install/installer/cmd/testdata/render/aws-setup/output.golden
@@ -5050,7 +5050,7 @@ data:
       },
       "oauthServer": {
         "enabled": true,
-        "jwtSecret": "8QMIxwyCGe5U0NAj6Uei"
+        "jwtSecret": "m30EH-M2-cWMgkgdy7pu"
       },
       "rateLimiter": {
         "groups": {
@@ -9769,7 +9769,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 8b2dddff40256f6233f1fcdbf9fcc9f048ff3485aef5a2656f61735559bdefbb
+        gitpod.io/checksum_config: 8c05f78bde8894a461a3d382e567b6d00d34026fa916c9e7baf2c1e81e43b239
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/aws-setup/output.golden
+++ b/install/installer/cmd/testdata/render/aws-setup/output.golden
@@ -208,7 +208,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -758,7 +758,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -969,7 +969,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
@@ -1081,7 +1081,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1097,7 +1097,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1128,13 +1128,13 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
 data:
   rabbitmq.conf: |-
-    IyMgVXNlcm5hbWUgYW5kIHBhc3N3b3JkCiMjCmRlZmF1bHRfdXNlciA9IGdpdHBvZApkZWZhdWx0X3Bhc3MgPSBDSEFOR0VNRQojIyBDbHVzdGVyaW5nCiMjCmNsdXN0ZXJfZm9ybWF0aW9uLnBlZXJfZGlzY292ZXJ5X2JhY2tlbmQgID0gcmFiYml0X3BlZXJfZGlzY292ZXJ5X2s4cwpjbHVzdGVyX2Zvcm1hdGlvbi5rOHMuaG9zdCA9IGt1YmVybmV0ZXMuZGVmYXVsdApjbHVzdGVyX2Zvcm1hdGlvbi5ub2RlX2NsZWFudXAuaW50ZXJ2YWwgPSAxMApjbHVzdGVyX2Zvcm1hdGlvbi5ub2RlX2NsZWFudXAub25seV9sb2dfd2FybmluZyA9IHRydWUKY2x1c3Rlcl9wYXJ0aXRpb25faGFuZGxpbmcgPSBhdXRvaGVhbApsb2FkX2RlZmluaXRpb25zID0gL2FwcC9sb2FkX2RlZmluaXRpb24uanNvbgojIHF1ZXVlIG1hc3RlciBsb2NhdG9yCnF1ZXVlX21hc3Rlcl9sb2NhdG9yID0gbWluLW1hc3RlcnMKIyBlbmFibGUgZ3Vlc3QgdXNlcgpsb29wYmFja191c2Vycy5ndWVzdCA9IGZhbHNlCmxvYWRfZGVmaW5pdGlvbnMgPSAvYXBwL2xvYWRfZGVmaW5pdGlvbi5qc29uCiMgSW5jcmVhc2Ugc3RhdGlzdGljcyBlbWlzc2lvbiBpbnRlcnZhbCBodHRwczovL3d3dy5yYWJiaXRtcS5jb20vbWFuYWdlbWVudC5odG1sI3N0YXRpc3RpY3MtaW50ZXJ2YWwKY29sbGVjdF9zdGF0aXN0aWNzX2ludGVydmFsID0gMTUwMDAKCnNzbF9vcHRpb25zLnZlcmlmeSA9IHZlcmlmeV9wZWVyCmxpc3RlbmVycy5zc2wuZGVmYXVsdCA9IDU2NzEKc3NsX29wdGlvbnMuZmFpbF9pZl9ub19wZWVyX2NlcnQgPSB0cnVlCnNzbF9vcHRpb25zLmNhY2VydGZpbGUgPSAvb3B0L2JpdG5hbWkvcmFiYml0bXEvY2VydHMvY2FfY2VydGlmaWNhdGUucGVtCnNzbF9vcHRpb25zLmNlcnRmaWxlID0gL29wdC9iaXRuYW1pL3JhYmJpdG1xL2NlcnRzL3NlcnZlcl9jZXJ0aWZpY2F0ZS5wZW0Kc3NsX29wdGlvbnMua2V5ZmlsZSA9IC9vcHQvYml0bmFtaS9yYWJiaXRtcS9jZXJ0cy9zZXJ2ZXJfa2V5LnBlbQojIyBQcm9tZXRoZXVzIG1ldHJpY3MKIyMKcHJvbWV0aGV1cy50Y3AucG9ydCA9IDk0MTk=
+    IyMgVXNlcm5hbWUgYW5kIHBhc3N3b3JkCiMjCmRlZmF1bHRfdXNlciA9IGdpdHBvZAojIyBDbHVzdGVyaW5nCiMjCmNsdXN0ZXJfZm9ybWF0aW9uLnBlZXJfZGlzY292ZXJ5X2JhY2tlbmQgID0gcmFiYml0X3BlZXJfZGlzY292ZXJ5X2s4cwpjbHVzdGVyX2Zvcm1hdGlvbi5rOHMuaG9zdCA9IGt1YmVybmV0ZXMuZGVmYXVsdApjbHVzdGVyX2Zvcm1hdGlvbi5ub2RlX2NsZWFudXAuaW50ZXJ2YWwgPSAxMApjbHVzdGVyX2Zvcm1hdGlvbi5ub2RlX2NsZWFudXAub25seV9sb2dfd2FybmluZyA9IHRydWUKY2x1c3Rlcl9wYXJ0aXRpb25faGFuZGxpbmcgPSBhdXRvaGVhbApsb2FkX2RlZmluaXRpb25zID0gL2FwcC9sb2FkX2RlZmluaXRpb24uanNvbgojIHF1ZXVlIG1hc3RlciBsb2NhdG9yCnF1ZXVlX21hc3Rlcl9sb2NhdG9yID0gbWluLW1hc3RlcnMKIyBlbmFibGUgZ3Vlc3QgdXNlcgpsb29wYmFja191c2Vycy5ndWVzdCA9IGZhbHNlCmxvYWRfZGVmaW5pdGlvbnMgPSAvYXBwL2xvYWRfZGVmaW5pdGlvbi5qc29uCiMgSW5jcmVhc2Ugc3RhdGlzdGljcyBlbWlzc2lvbiBpbnRlcnZhbCBodHRwczovL3d3dy5yYWJiaXRtcS5jb20vbWFuYWdlbWVudC5odG1sI3N0YXRpc3RpY3MtaW50ZXJ2YWwKY29sbGVjdF9zdGF0aXN0aWNzX2ludGVydmFsID0gMTUwMDAKCnNzbF9vcHRpb25zLnZlcmlmeSA9IHZlcmlmeV9wZWVyCmxpc3RlbmVycy5zc2wuZGVmYXVsdCA9IDU2NzEKc3NsX29wdGlvbnMuZmFpbF9pZl9ub19wZWVyX2NlcnQgPSB0cnVlCnNzbF9vcHRpb25zLmNhY2VydGZpbGUgPSAvb3B0L2JpdG5hbWkvcmFiYml0bXEvY2VydHMvY2FfY2VydGlmaWNhdGUucGVtCnNzbF9vcHRpb25zLmNlcnRmaWxlID0gL29wdC9iaXRuYW1pL3JhYmJpdG1xL2NlcnRzL3NlcnZlcl9jZXJ0aWZpY2F0ZS5wZW0Kc3NsX29wdGlvbnMua2V5ZmlsZSA9IC9vcHQvYml0bmFtaS9yYWJiaXRtcS9jZXJ0cy9zZXJ2ZXJfa2V5LnBlbQojIyBQcm9tZXRoZXVzIG1ldHJpY3MKIyMKcHJvbWV0aGV1cy50Y3AucG9ydCA9IDk0MTk=
 ---
 # v1/Secret messagebus-erlang-cookie
 apiVersion: v1
@@ -1158,7 +1158,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -3294,7 +3294,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus
       namespace: default
     ---
@@ -3306,7 +3306,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus
       namespace: default
     ---
@@ -3318,7 +3318,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: rabbitmq
       namespace: default
     ---
@@ -3330,7 +3330,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus-config
       namespace: default
     ---
@@ -3342,7 +3342,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus
       namespace: default
     ---
@@ -3354,7 +3354,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: load-definition
       namespace: default
     ---
@@ -3366,7 +3366,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: rabbitmq
       namespace: default
     ---
@@ -3378,7 +3378,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus-endpoint-reader
       namespace: default
     ---
@@ -3390,7 +3390,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus-endpoint-reader
       namespace: default
     ---
@@ -3402,7 +3402,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus-headless
       namespace: default
     ---
@@ -3414,7 +3414,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus
       namespace: default
     ---
@@ -3426,7 +3426,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus
       namespace: default
     ---
@@ -6244,7 +6244,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 rules:
@@ -6609,7 +6609,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 subjects:
@@ -7099,7 +7099,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -7143,7 +7143,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -8046,7 +8046,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -8063,12 +8063,12 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/config: 2ca9db593e4ca6cdd01f7a65cce1ae90d0d45ecdf0049edfaa4ec72302fcbe8f
-        checksum/secret: c231bbb08185305defa8c4da0f3ee0f5e7a16795362a2133f74e53eb9a40453d
+        checksum/config: d5780a0c58210a2062d54feb61cfb1d5a9c076f95569c4a77076d22c9bad4190
+        checksum/secret: 64c39dd3a8570ed4b0cc71bc0402bc814d016e16f68732938722b12a57c8e82c
         prometheus.io/port: '9419'
         prometheus.io/scrape: "true"
     spec:
@@ -8088,7 +8088,7 @@ spec:
       initContainers:
       containers:
         - name: rabbitmq
-          image: docker.io/bitnami/rabbitmq:3.10.2-debian-10-r7
+          image: docker.io/bitnami/rabbitmq:3.11.5-debian-11-r2
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true
@@ -8223,11 +8223,10 @@ spec:
               - key: tls.key
                 path: server_key.pem
         - name: configuration
-          secret:
-            secretName: messagebus-config
-            items:
-              - key: rabbitmq.conf
-                path: rabbitmq.conf
+          projected:
+            sources:
+              - secret:
+                  name: messagebus-config
         - name: load-definition-volume
           secret:
             secretName: "load-definition"

--- a/install/installer/cmd/testdata/render/azure-setup/output.golden
+++ b/install/installer/cmd/testdata/render/azure-setup/output.golden
@@ -208,7 +208,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -758,7 +758,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -921,7 +921,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: minio
-    helm.sh/chart: minio-11.6.3
+    helm.sh/chart: minio-11.10.24
     app.kubernetes.io/instance: minio
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
@@ -985,7 +985,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
@@ -1085,7 +1085,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1101,7 +1101,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1132,13 +1132,13 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
 data:
   rabbitmq.conf: |-
-    IyMgVXNlcm5hbWUgYW5kIHBhc3N3b3JkCiMjCmRlZmF1bHRfdXNlciA9IGdpdHBvZApkZWZhdWx0X3Bhc3MgPSBDSEFOR0VNRQojIyBDbHVzdGVyaW5nCiMjCmNsdXN0ZXJfZm9ybWF0aW9uLnBlZXJfZGlzY292ZXJ5X2JhY2tlbmQgID0gcmFiYml0X3BlZXJfZGlzY292ZXJ5X2s4cwpjbHVzdGVyX2Zvcm1hdGlvbi5rOHMuaG9zdCA9IGt1YmVybmV0ZXMuZGVmYXVsdApjbHVzdGVyX2Zvcm1hdGlvbi5ub2RlX2NsZWFudXAuaW50ZXJ2YWwgPSAxMApjbHVzdGVyX2Zvcm1hdGlvbi5ub2RlX2NsZWFudXAub25seV9sb2dfd2FybmluZyA9IHRydWUKY2x1c3Rlcl9wYXJ0aXRpb25faGFuZGxpbmcgPSBhdXRvaGVhbApsb2FkX2RlZmluaXRpb25zID0gL2FwcC9sb2FkX2RlZmluaXRpb24uanNvbgojIHF1ZXVlIG1hc3RlciBsb2NhdG9yCnF1ZXVlX21hc3Rlcl9sb2NhdG9yID0gbWluLW1hc3RlcnMKIyBlbmFibGUgZ3Vlc3QgdXNlcgpsb29wYmFja191c2Vycy5ndWVzdCA9IGZhbHNlCmxvYWRfZGVmaW5pdGlvbnMgPSAvYXBwL2xvYWRfZGVmaW5pdGlvbi5qc29uCiMgSW5jcmVhc2Ugc3RhdGlzdGljcyBlbWlzc2lvbiBpbnRlcnZhbCBodHRwczovL3d3dy5yYWJiaXRtcS5jb20vbWFuYWdlbWVudC5odG1sI3N0YXRpc3RpY3MtaW50ZXJ2YWwKY29sbGVjdF9zdGF0aXN0aWNzX2ludGVydmFsID0gMTUwMDAKCnNzbF9vcHRpb25zLnZlcmlmeSA9IHZlcmlmeV9wZWVyCmxpc3RlbmVycy5zc2wuZGVmYXVsdCA9IDU2NzEKc3NsX29wdGlvbnMuZmFpbF9pZl9ub19wZWVyX2NlcnQgPSB0cnVlCnNzbF9vcHRpb25zLmNhY2VydGZpbGUgPSAvb3B0L2JpdG5hbWkvcmFiYml0bXEvY2VydHMvY2FfY2VydGlmaWNhdGUucGVtCnNzbF9vcHRpb25zLmNlcnRmaWxlID0gL29wdC9iaXRuYW1pL3JhYmJpdG1xL2NlcnRzL3NlcnZlcl9jZXJ0aWZpY2F0ZS5wZW0Kc3NsX29wdGlvbnMua2V5ZmlsZSA9IC9vcHQvYml0bmFtaS9yYWJiaXRtcS9jZXJ0cy9zZXJ2ZXJfa2V5LnBlbQojIyBQcm9tZXRoZXVzIG1ldHJpY3MKIyMKcHJvbWV0aGV1cy50Y3AucG9ydCA9IDk0MTk=
+    IyMgVXNlcm5hbWUgYW5kIHBhc3N3b3JkCiMjCmRlZmF1bHRfdXNlciA9IGdpdHBvZAojIyBDbHVzdGVyaW5nCiMjCmNsdXN0ZXJfZm9ybWF0aW9uLnBlZXJfZGlzY292ZXJ5X2JhY2tlbmQgID0gcmFiYml0X3BlZXJfZGlzY292ZXJ5X2s4cwpjbHVzdGVyX2Zvcm1hdGlvbi5rOHMuaG9zdCA9IGt1YmVybmV0ZXMuZGVmYXVsdApjbHVzdGVyX2Zvcm1hdGlvbi5ub2RlX2NsZWFudXAuaW50ZXJ2YWwgPSAxMApjbHVzdGVyX2Zvcm1hdGlvbi5ub2RlX2NsZWFudXAub25seV9sb2dfd2FybmluZyA9IHRydWUKY2x1c3Rlcl9wYXJ0aXRpb25faGFuZGxpbmcgPSBhdXRvaGVhbApsb2FkX2RlZmluaXRpb25zID0gL2FwcC9sb2FkX2RlZmluaXRpb24uanNvbgojIHF1ZXVlIG1hc3RlciBsb2NhdG9yCnF1ZXVlX21hc3Rlcl9sb2NhdG9yID0gbWluLW1hc3RlcnMKIyBlbmFibGUgZ3Vlc3QgdXNlcgpsb29wYmFja191c2Vycy5ndWVzdCA9IGZhbHNlCmxvYWRfZGVmaW5pdGlvbnMgPSAvYXBwL2xvYWRfZGVmaW5pdGlvbi5qc29uCiMgSW5jcmVhc2Ugc3RhdGlzdGljcyBlbWlzc2lvbiBpbnRlcnZhbCBodHRwczovL3d3dy5yYWJiaXRtcS5jb20vbWFuYWdlbWVudC5odG1sI3N0YXRpc3RpY3MtaW50ZXJ2YWwKY29sbGVjdF9zdGF0aXN0aWNzX2ludGVydmFsID0gMTUwMDAKCnNzbF9vcHRpb25zLnZlcmlmeSA9IHZlcmlmeV9wZWVyCmxpc3RlbmVycy5zc2wuZGVmYXVsdCA9IDU2NzEKc3NsX29wdGlvbnMuZmFpbF9pZl9ub19wZWVyX2NlcnQgPSB0cnVlCnNzbF9vcHRpb25zLmNhY2VydGZpbGUgPSAvb3B0L2JpdG5hbWkvcmFiYml0bXEvY2VydHMvY2FfY2VydGlmaWNhdGUucGVtCnNzbF9vcHRpb25zLmNlcnRmaWxlID0gL29wdC9iaXRuYW1pL3JhYmJpdG1xL2NlcnRzL3NlcnZlcl9jZXJ0aWZpY2F0ZS5wZW0Kc3NsX29wdGlvbnMua2V5ZmlsZSA9IC9vcHQvYml0bmFtaS9yYWJiaXRtcS9jZXJ0cy9zZXJ2ZXJfa2V5LnBlbQojIyBQcm9tZXRoZXVzIG1ldHJpY3MKIyMKcHJvbWV0aGV1cy50Y3AucG9ydCA9IDk0MTk=
 ---
 # v1/Secret messagebus-erlang-cookie
 apiVersion: v1
@@ -1162,7 +1162,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: minio
-    helm.sh/chart: minio-11.6.3
+    helm.sh/chart: minio-11.10.24
     app.kubernetes.io/instance: minio
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1181,7 +1181,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -3250,7 +3250,7 @@ data:
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: minio
-        helm.sh/chart: minio-11.6.3
+        helm.sh/chart: minio-11.10.24
       name: minio
       namespace: default
     ---
@@ -3262,7 +3262,7 @@ data:
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: minio
-        helm.sh/chart: minio-11.6.3
+        helm.sh/chart: minio-11.10.24
       name: minio
       namespace: default
     ---
@@ -3274,7 +3274,7 @@ data:
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: minio
-        helm.sh/chart: minio-11.6.3
+        helm.sh/chart: minio-11.10.24
       name: minio
       namespace: default
     ---
@@ -3286,7 +3286,7 @@ data:
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: minio
-        helm.sh/chart: minio-11.6.3
+        helm.sh/chart: minio-11.10.24
       name: minio
       namespace: default
     ---
@@ -3298,7 +3298,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus
       namespace: default
     ---
@@ -3310,7 +3310,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus
       namespace: default
     ---
@@ -3322,7 +3322,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: rabbitmq
       namespace: default
     ---
@@ -3334,7 +3334,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus-config
       namespace: default
     ---
@@ -3346,7 +3346,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus
       namespace: default
     ---
@@ -3358,7 +3358,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: load-definition
       namespace: default
     ---
@@ -3370,7 +3370,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: rabbitmq
       namespace: default
     ---
@@ -3382,7 +3382,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus-endpoint-reader
       namespace: default
     ---
@@ -3394,7 +3394,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus-endpoint-reader
       namespace: default
     ---
@@ -3406,7 +3406,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus-headless
       namespace: default
     ---
@@ -3418,7 +3418,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus
       namespace: default
     ---
@@ -3430,7 +3430,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus
       namespace: default
     ---
@@ -6220,7 +6220,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 rules:
@@ -6563,7 +6563,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 subjects:
@@ -7035,7 +7035,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -7079,7 +7079,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -7114,7 +7114,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: minio
-    helm.sh/chart: minio-11.6.3
+    helm.sh/chart: minio-11.10.24
     app.kubernetes.io/instance: minio
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -8003,7 +8003,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -8020,12 +8020,12 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/config: 2ca9db593e4ca6cdd01f7a65cce1ae90d0d45ecdf0049edfaa4ec72302fcbe8f
-        checksum/secret: c231bbb08185305defa8c4da0f3ee0f5e7a16795362a2133f74e53eb9a40453d
+        checksum/config: d5780a0c58210a2062d54feb61cfb1d5a9c076f95569c4a77076d22c9bad4190
+        checksum/secret: 64c39dd3a8570ed4b0cc71bc0402bc814d016e16f68732938722b12a57c8e82c
         prometheus.io/port: '9419'
         prometheus.io/scrape: "true"
     spec:
@@ -8045,7 +8045,7 @@ spec:
       initContainers:
       containers:
         - name: rabbitmq
-          image: docker.io/bitnami/rabbitmq:3.10.2-debian-10-r7
+          image: docker.io/bitnami/rabbitmq:3.11.5-debian-11-r2
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true
@@ -8180,11 +8180,10 @@ spec:
               - key: tls.key
                 path: server_key.pem
         - name: configuration
-          secret:
-            secretName: messagebus-config
-            items:
-              - key: rabbitmq.conf
-                path: rabbitmq.conf
+          projected:
+            sources:
+              - secret:
+                  name: messagebus-config
         - name: load-definition-volume
           secret:
             secretName: "load-definition"
@@ -9366,7 +9365,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: minio
-    helm.sh/chart: minio-11.6.3
+    helm.sh/chart: minio-11.10.24
     app.kubernetes.io/instance: minio
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -9381,11 +9380,11 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: minio
-        helm.sh/chart: minio-11.6.3
+        helm.sh/chart: minio-11.10.24
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/credentials-secret: 31ca5e20dec5cc79ce6a424f6bad5283e868082022f029ebfaf8c621768eed34
+        checksum/credentials-secret: dc0c118ec7ab833ae492735c24173ba43d98921c390f862db14fadbb0b26ac94
     spec:
       
       serviceAccountName: minio
@@ -9399,8 +9398,6 @@ spec:
                   matchLabels:
                     app.kubernetes.io/name: minio
                     app.kubernetes.io/instance: minio
-                namespaces:
-                  - "default"
                 topologyKey: kubernetes.io/hostname
               weight: 1
         nodeAffinity:

--- a/install/installer/cmd/testdata/render/azure-setup/output.golden
+++ b/install/installer/cmd/testdata/render/azure-setup/output.golden
@@ -1167,8 +1167,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 type: Opaque
 data:
-  root-user: "OC1XR3F3Mm9UbnNQZlVETlNrMFk="
-  root-password: "RHBDLmFTQXhrV0JQdTJfYkpfQUU="
+  root-user: "UkJqaTZSMGJHRzgxZ3lFeWUyNVA="
+  root-password: "dFg2TUw4Z0NXMzFtaXcwVDhRTUk="
   azure-storage-account-name: ""
   azure-storage-account-key: ""
 ---
@@ -1328,9 +1328,9 @@ data:
         },
         "minio": {
           "endpoint": "minio.default.svc.cluster.local:9000",
-          "accessKey": "8-WGqw2oTnsPfUDNSk0Y",
+          "accessKey": "RBji6R0bGG81gyEye25P",
           "accessKeyFile": "",
-          "secretKey": "DpC.aSAxkWBPu2_bJ_AE",
+          "secretKey": "tX6ML8gCW31miw0T8QMI",
           "secretKeyFile": "",
           "region": "local",
           "parallelUpload": 6
@@ -5034,7 +5034,7 @@ data:
       },
       "oauthServer": {
         "enabled": true,
-        "jwtSecret": "8QMIxwyCGe5U0NAj6Uei"
+        "jwtSecret": "m30EH-M2-cWMgkgdy7pu"
       },
       "rateLimiter": {
         "groups": {
@@ -5364,9 +5364,9 @@ data:
             },
             "minio": {
               "endpoint": "minio.default.svc.cluster.local:9000",
-              "accessKey": "8-WGqw2oTnsPfUDNSk0Y",
+              "accessKey": "RBji6R0bGG81gyEye25P",
               "accessKeyFile": "",
-              "secretKey": "DpC.aSAxkWBPu2_bJ_AE",
+              "secretKey": "tX6ML8gCW31miw0T8QMI",
               "secretKeyFile": "",
               "region": "local",
               "parallelUpload": 6
@@ -5548,9 +5548,9 @@ data:
           },
           "minio": {
             "endpoint": "minio.default.svc.cluster.local:9000",
-            "accessKey": "8-WGqw2oTnsPfUDNSk0Y",
+            "accessKey": "RBji6R0bGG81gyEye25P",
             "accessKeyFile": "",
-            "secretKey": "DpC.aSAxkWBPu2_bJ_AE",
+            "secretKey": "tX6ML8gCW31miw0T8QMI",
             "secretKeyFile": "",
             "region": "local",
             "parallelUpload": 6
@@ -7723,7 +7723,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: b938c6e286051c22b503c29f5de266741c2045a3ed69be85d7fd9f22a9346254
+        gitpod.io/checksum_config: 2a29ef265c219405bda658cb21613f40ad5e692590d2779476a3ff90917ed6fb
         seccomp.security.alpha.kubernetes.io/shiftfs-module-loader: unconfined
       creationTimestamp: null
       labels:
@@ -8504,7 +8504,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 20782435cc6d6e080cf720b57dca8d4d5cfe40942fc71c4bfd54934fdc34c766
+        gitpod.io/checksum_config: 21ad538d4c7daef6619e5dda6fd71a49a5e5b551f0fc1365d3b7db1d1f38f9ce
       creationTimestamp: null
       labels:
         app: gitpod
@@ -9385,7 +9385,7 @@ spec:
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/credentials-secret: c1cd36703ad730b3d641029a684127a2da119d23e4838caa5c0e21553887c478
+        checksum/credentials-secret: 31ca5e20dec5cc79ce6a424f6bad5283e868082022f029ebfaf8c621768eed34
     spec:
       
       serviceAccountName: minio
@@ -9846,7 +9846,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 8b2dddff40256f6233f1fcdbf9fcc9f048ff3485aef5a2656f61735559bdefbb
+        gitpod.io/checksum_config: 8c05f78bde8894a461a3d382e567b6d00d34026fa916c9e7baf2c1e81e43b239
       creationTimestamp: null
       labels:
         app: gitpod
@@ -10127,7 +10127,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 62fb425bd7800391dca7d008cd0c86cab613afef78e188a950e367ed7429ad73
+        gitpod.io/checksum_config: 21c3b53bac44cf0f98bc57e43353e3136dc5806409951038c2ba36aea69dd218
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/custom-pull-repository/config.yaml
+++ b/install/installer/cmd/testdata/render/custom-pull-repository/config.yaml
@@ -1,0 +1,7 @@
+# Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+# Licensed under the GNU Affero General Public License (AGPL).
+# See License.AGPL.txt in the project root for license information.
+
+apiVersion: v1
+domain: gitpod.example.com
+repository: registry.mydomain.com/namespace

--- a/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
+++ b/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
@@ -1116,9 +1116,9 @@ metadata:
 # v1/Secret builtin-registry-auth
 apiVersion: v1
 data:
-  .dockerconfigjson: eyJhdXRocyI6eyJyZWdpc3RyeS5naXRwb2QuZXhhbXBsZS5jb20iOnsiYXV0aCI6ImVGTmxaRXBwUkdkS1VWRm5ORUpyVnpWNFMzVTZRMWMwUTFKQ2FtazJVakJpUjBjNE1XZDVSWGs9In19fQ==
-  password: Q1c0Q1JCamk2UjBiR0c4MWd5RXk=
-  user: eFNlZEppRGdKUVFnNEJrVzV4S3U=
+  .dockerconfigjson: eyJhdXRocyI6eyJyZWdpc3RyeS5naXRwb2QuZXhhbXBsZS5jb20iOnsiYXV0aCI6ImVIZDVRMGRsTlZVd1RrRnFObFZsYVhFM1RqQTZWbE5UYkcxaFMxZFFhaTVRVVhCdFZXWnNWR1E9In19fQ==
+  password: VlNTbG1hS1dQai5QUXBtVWZsVGQ=
+  user: eHd5Q0dlNVUwTkFqNlVlaXE3TjA=
 kind: Secret
 metadata:
   creationTimestamp: null
@@ -1234,8 +1234,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 type: Opaque
 data:
-  root-user: "OC1XR3F3Mm9UbnNQZlVETlNrMFk="
-  root-password: "RHBDLmFTQXhrV0JQdTJfYkpfQUU="
+  root-user: "UkJqaTZSMGJHRzgxZ3lFeWUyNVA="
+  root-password: "dFg2TUw4Z0NXMzFtaXcwVDhRTUk="
   key.json: ""
 ---
 # v1/Secret mysql
@@ -1430,9 +1430,9 @@ data:
         },
         "minio": {
           "endpoint": "minio.default.svc.cluster.local:9000",
-          "accessKey": "8-WGqw2oTnsPfUDNSk0Y",
+          "accessKey": "RBji6R0bGG81gyEye25P",
           "accessKeyFile": "",
-          "secretKey": "DpC.aSAxkWBPu2_bJ_AE",
+          "secretKey": "tX6ML8gCW31miw0T8QMI",
           "secretKeyFile": "",
           "region": "local",
           "parallelUpload": 6
@@ -5170,7 +5170,7 @@ data:
         import ssl_configuration
 
         basicauth bcrypt "Docker Registry" {
-            xSedJiDgJQQg4BkW5xKu JDJhJDEwJFFTRGRRMHZZY2pIS2JqUC9aMDNnVC5HbEg2Z1dOQm5TL0pySnpYSm5iNy9DeVh0ZUw2cFM2
+            xwyCGe5U0NAj6Ueiq7N0 JDJhJDEwJFFTRGRRMHZZY2pIS2JqUC9aMDNnVC5CY0M3RDZsVVg0LzBpZmdnTGovT0VVWXoxTG8ud0lX
         }
 
         reverse_proxy https://registry.default.svc.cluster.local {
@@ -5441,7 +5441,7 @@ data:
       },
       "oauthServer": {
         "enabled": true,
-        "jwtSecret": "8QMIxwyCGe5U0NAj6Uei"
+        "jwtSecret": "m30EH-M2-cWMgkgdy7pu"
       },
       "rateLimiter": {
         "groups": {
@@ -5771,9 +5771,9 @@ data:
             },
             "minio": {
               "endpoint": "minio.default.svc.cluster.local:9000",
-              "accessKey": "8-WGqw2oTnsPfUDNSk0Y",
+              "accessKey": "RBji6R0bGG81gyEye25P",
               "accessKeyFile": "",
-              "secretKey": "DpC.aSAxkWBPu2_bJ_AE",
+              "secretKey": "tX6ML8gCW31miw0T8QMI",
               "secretKeyFile": "",
               "region": "local",
               "parallelUpload": 6
@@ -5955,9 +5955,9 @@ data:
           },
           "minio": {
             "endpoint": "minio.default.svc.cluster.local:9000",
-            "accessKey": "8-WGqw2oTnsPfUDNSk0Y",
+            "accessKey": "RBji6R0bGG81gyEye25P",
             "accessKeyFile": "",
-            "secretKey": "DpC.aSAxkWBPu2_bJ_AE",
+            "secretKey": "tX6ML8gCW31miw0T8QMI",
             "secretKeyFile": "",
             "region": "local",
             "parallelUpload": 6
@@ -8068,7 +8068,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 68e15719c683f7d74cb1f3c076690c92ee58595cd163dea3446ec8962e0e1e2c
+        gitpod.io/checksum_config: c89ca2c9729c189ef1739d1bfc113c8c52bc46f8155c4a9b195ccd4de910a23b
       creationTimestamp: null
       labels:
         app: gitpod
@@ -8285,7 +8285,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: b938c6e286051c22b503c29f5de266741c2045a3ed69be85d7fd9f22a9346254
+        gitpod.io/checksum_config: 2a29ef265c219405bda658cb21613f40ad5e692590d2779476a3ff90917ed6fb
         seccomp.security.alpha.kubernetes.io/shiftfs-module-loader: unconfined
       creationTimestamp: null
       labels:
@@ -9084,7 +9084,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 27119b1d1b269fec9f51d6d6be3af57db521e2ce9d30391c96a8fe306a8e74df
+        gitpod.io/checksum_config: ca8305ae7d44552aace863e8af17bbdef1c57b0259ee7bdc20a7ab9061d2fb9f
       creationTimestamp: null
       labels:
         app: gitpod
@@ -9225,7 +9225,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 20782435cc6d6e080cf720b57dca8d4d5cfe40942fc71c4bfd54934fdc34c766
+        gitpod.io/checksum_config: 21ad538d4c7daef6619e5dda6fd71a49a5e5b551f0fc1365d3b7db1d1f38f9ce
       creationTimestamp: null
       labels:
         app: gitpod
@@ -9952,7 +9952,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: a42344ad04c98efcbf37f4ea2193593c0cb67c8491b37973ac6cf57fbd2d7a59
+        gitpod.io/checksum_config: dcca6a2e85fae554d69e6fe11a64ea7cc27c5bb94968d368599896acf6d9e829
       creationTimestamp: null
       labels:
         app: gitpod
@@ -10105,7 +10105,7 @@ spec:
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/credentials-secret: 0a5790906818b3f8eeee0bd3b3e990b3ad02d79bb23c62c0d91a4ca010fb5579
+        checksum/credentials-secret: 094325f216720012cacde9f52fd71c7e8b06dd6386492f6980e0f3588f1b1e7c
     spec:
       
       serviceAccountName: minio
@@ -10213,7 +10213,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: c52c73e63eaa95613a8f4fe77167c754cd48eaf757dd69c2048400311a5ae0a6
+        gitpod.io/checksum_config: a7bd71558cb04a04656bafe7651d4192a9d37be96d2d817f9b6225f63e3a6989
       creationTimestamp: null
       labels:
         app: gitpod
@@ -10564,7 +10564,7 @@ spec:
         release: docker-registry
       annotations:
         checksum/config: 1d22b82e19bbc654e029029c4fb86ad02dc13422dc3ac52f8175ad190e52a0bb
-        gitpod.io/checksum_config: 0ce55d51677cd683df3c7a244542c6aeaaf5dd6dca0f0458e8053a713228f535
+        gitpod.io/checksum_config: 1c66f4ccdb7f6331da2edaecefcb40f6c1b6315c9277eb0418fef3cc584a28bd
     spec:
       serviceAccountName: docker-registry
       securityContext:
@@ -10647,7 +10647,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: f7bdf2a221081ccd3bf2588232d706ded37099dcc3e01ae0249cafaa87c29cd7
+        gitpod.io/checksum_config: 4b4c3a473e5569c39bda206c756538858ff6f5495b563c523705666ba3ec4930
       creationTimestamp: null
       labels:
         app: gitpod
@@ -10928,7 +10928,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 62fb425bd7800391dca7d008cd0c86cab613afef78e188a950e367ed7429ad73
+        gitpod.io/checksum_config: 21c3b53bac44cf0f98bc57e43353e3136dc5806409951038c2ba36aea69dd218
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
+++ b/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
@@ -1,0 +1,11652 @@
+---
+# networking.k8s.io/v1/NetworkPolicy agent-smith
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: agent-smith
+  name: agent-smith
+  namespace: default
+spec:
+  podSelector:
+    matchLabels:
+      app: gitpod
+      component: agent-smith
+  policyTypes:
+    - Ingress
+
+---
+# networking.k8s.io/v1/NetworkPolicy blobserve
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: blobserve
+  name: blobserve
+  namespace: default
+spec:
+  ingress:
+    - {}
+  podSelector:
+    matchLabels:
+      app: gitpod
+      component: blobserve
+  policyTypes:
+    - Ingress
+
+---
+# networking.k8s.io/v1/NetworkPolicy content-service
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: content-service
+  name: content-service
+  namespace: default
+spec:
+  ingress:
+    - {}
+  podSelector:
+    matchLabels:
+      app: gitpod
+      component: content-service
+  policyTypes:
+    - Ingress
+
+---
+# networking.k8s.io/v1/NetworkPolicy dashboard-deny-all-allow-explicit
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: dashboard
+  name: dashboard-deny-all-allow-explicit
+  namespace: default
+spec:
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              component: proxy
+      ports:
+        - port: 80
+          protocol: TCP
+  podSelector:
+    matchLabels:
+      app: gitpod
+      component: dashboard
+  policyTypes:
+    - Ingress
+
+---
+# networking.k8s.io/v1/NetworkPolicy iam
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: iam
+  name: iam
+  namespace: default
+spec:
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              component: proxy
+      ports:
+        - port: 9001
+          protocol: TCP
+        - port: 9002
+          protocol: TCP
+  podSelector:
+    matchLabels:
+      app: gitpod
+      component: iam
+  policyTypes:
+    - Ingress
+
+---
+# networking.k8s.io/v1/NetworkPolicy ide-metrics
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ide-metrics
+  name: ide-metrics
+  namespace: default
+spec:
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              component: proxy
+        - podSelector:
+            matchLabels:
+              component: ide-proxy
+      ports:
+        - port: 3000
+          protocol: TCP
+  podSelector:
+    matchLabels:
+      app: gitpod
+      component: ide-metrics
+  policyTypes:
+    - Ingress
+
+---
+# networking.k8s.io/v1/NetworkPolicy ide-service
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ide-service
+  name: ide-service
+  namespace: default
+spec:
+  ingress:
+    - ports:
+        - port: 9001
+          protocol: TCP
+  podSelector:
+    matchLabels:
+      app: gitpod
+      component: ide-service
+  policyTypes:
+    - Ingress
+
+---
+# networking.k8s.io/v1/NetworkPolicy image-builder-mk3
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: image-builder-mk3
+  name: image-builder-mk3
+  namespace: default
+spec:
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              component: server
+        - podSelector:
+            matchLabels:
+              component: slow-server
+        - podSelector:
+            matchLabels:
+              component: ws-manager
+  podSelector:
+    matchLabels:
+      app: gitpod
+      component: image-builder-mk3
+  policyTypes:
+    - Ingress
+
+---
+# networking.k8s.io/v1/NetworkPolicy messagebus
+# Source: rabbitmq/charts/rabbitmq/templates/networkpolicy.yaml
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: messagebus
+  namespace: "default"
+  labels:
+    app.kubernetes.io/name: rabbitmq
+    helm.sh/chart: rabbitmq-10.1.1
+    app.kubernetes.io/instance: rabbitmq
+    app.kubernetes.io/managed-by: Helm
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: rabbitmq
+      app.kubernetes.io/instance: rabbitmq
+  ingress:
+    # Allow inbound connections
+    - ports:
+        - port: 4369 # EPMD
+        - port: 5672
+        - port: 5671
+        - port: 25672
+        - port: 15672
+    # Allow prometheus scrapes
+    - ports:
+        - port: 9419
+
+---
+# networking.k8s.io/v1/NetworkPolicy openvsx-proxy
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: openvsx-proxy
+  name: openvsx-proxy
+  namespace: default
+spec:
+  ingress:
+    - ports:
+        - port: 8080
+          protocol: TCP
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              chart: monitoring
+          podSelector:
+            matchLabels:
+              component: server
+      ports:
+        - port: 8080
+          protocol: TCP
+  podSelector:
+    matchLabels:
+      app: gitpod
+      component: openvsx-proxy
+  policyTypes:
+    - Ingress
+
+---
+# networking.k8s.io/v1/NetworkPolicy proxy-deny-all-allow-explicit
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: proxy
+  name: proxy-deny-all-allow-explicit
+  namespace: default
+spec:
+  ingress:
+    - ports:
+        - port: 80
+          protocol: TCP
+        - port: 443
+          protocol: TCP
+        - port: 22
+          protocol: TCP
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              chart: monitoring
+          podSelector:
+            matchLabels:
+              component: server
+      ports:
+        - port: 9500
+          protocol: TCP
+  podSelector:
+    matchLabels:
+      app: gitpod
+      component: proxy
+  policyTypes:
+    - Ingress
+
+---
+# networking.k8s.io/v1/NetworkPolicy public-api-server
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: public-api-server
+  name: public-api-server
+  namespace: default
+spec:
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              component: proxy
+      ports:
+        - port: 9001
+          protocol: TCP
+        - port: 9002
+          protocol: TCP
+  podSelector:
+    matchLabels:
+      app: gitpod
+      component: public-api-server
+  policyTypes:
+    - Ingress
+
+---
+# networking.k8s.io/v1/NetworkPolicy registry-facade
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: registry-facade
+  name: registry-facade
+  namespace: default
+spec:
+  ingress:
+    - {}
+  podSelector:
+    matchLabels:
+      app: gitpod
+      component: registry-facade
+  policyTypes:
+    - Ingress
+
+---
+# networking.k8s.io/v1/NetworkPolicy server
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: server
+  name: server
+  namespace: default
+spec:
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              component: proxy
+      ports:
+        - port: 3000
+          protocol: TCP
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              chart: monitoring
+          podSelector:
+            matchLabels:
+              component: proxy
+      ports:
+        - port: 9500
+          protocol: TCP
+    - from:
+        - podSelector:
+            matchLabels:
+              component: gitpod
+      ports:
+        - port: 9000
+          protocol: TCP
+    - from:
+        - podSelector:
+            matchLabels:
+              app: gitpod
+              component: iam
+      ports:
+        - port: 9876
+          protocol: TCP
+  podSelector:
+    matchLabels:
+      app: gitpod
+      component: server
+  policyTypes:
+    - Ingress
+
+---
+# networking.k8s.io/v1/NetworkPolicy workspace-default
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: workspace
+  name: workspace-default
+  namespace: default
+spec:
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 169.254.169.254/32
+    - to:
+        - podSelector:
+            matchLabels:
+              app: gitpod
+              component: proxy
+    - ports:
+        - port: 53
+          protocol: TCP
+        - port: 53
+          protocol: UDP
+      to:
+        - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+        - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              k8s-app: coredns
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: gitpod
+              component: proxy
+    - from:
+        - podSelector:
+            matchLabels:
+              app: gitpod
+              component: ws-proxy
+    - from:
+        - podSelector:
+            matchLabels:
+              app: gitpod
+              component: agent-smith
+    - from:
+        - podSelector:
+            matchLabels:
+              app: gitpod
+              component: ws-daemon
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              chart: monitoring
+          podSelector:
+            matchLabels:
+              app: gitpod
+              component: server
+      ports:
+        - port: 23000
+          protocol: TCP
+  podSelector:
+    matchLabels:
+      app: gitpod
+      component: workspace
+      gitpod.io/networkpolicy: default
+  policyTypes:
+    - Ingress
+    - Egress
+
+---
+# networking.k8s.io/v1/NetworkPolicy ws-daemon
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ws-daemon
+  name: ws-daemon
+  namespace: default
+spec:
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: gitpod
+              component: ws-manager
+      ports:
+        - port: 8080
+          protocol: TCP
+    - from:
+        - podSelector:
+            matchLabels:
+              app: prometheus
+              component: server
+      ports:
+        - port: 9500
+          protocol: TCP
+  podSelector:
+    matchLabels:
+      app: gitpod
+      component: ws-daemon
+  policyTypes:
+    - Ingress
+
+---
+# networking.k8s.io/v1/NetworkPolicy ws-manager
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ws-manager
+  name: ws-manager
+  namespace: default
+spec:
+  ingress:
+    - {}
+  podSelector:
+    matchLabels:
+      app: gitpod
+      component: ws-manager
+  policyTypes:
+    - Ingress
+
+---
+# networking.k8s.io/v1/NetworkPolicy ws-proxy
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ws-proxy
+  name: ws-proxy
+  namespace: default
+spec:
+  ingress:
+    - ports:
+        - port: 8080
+          protocol: TCP
+        - port: 9090
+          protocol: TCP
+        - port: 2200
+          protocol: TCP
+  podSelector:
+    matchLabels:
+      app: gitpod
+      component: ws-proxy
+  policyTypes:
+    - Ingress
+
+---
+# v1/ResourceQuota gitpod-resource-quota
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  creationTimestamp: null
+  name: gitpod-resource-quota
+  namespace: default
+spec:
+  hard:
+    pods: 10k
+  scopeSelector:
+    matchExpressions:
+    - operator: In
+      scopeName: PriorityClass
+      values:
+      - system-node-critical
+status: {}
+---
+# cert-manager.io/v1/Issuer ca-issuer
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: cluster
+  name: ca-issuer
+  namespace: default
+spec:
+  ca:
+    secretName: ca-issuer-ca
+status: {}
+---
+# cert-manager.io/v1/Issuer gitpod-selfsigned-issuer
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: cluster
+  name: gitpod-selfsigned-issuer
+  namespace: default
+spec:
+  selfSigned: {}
+status: {}
+---
+# cert-manager.io/v1/Certificate builtin-registry-certs
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: docker-registry
+  name: builtin-registry-certs
+  namespace: default
+spec:
+  dnsNames:
+  - registry.default.svc.cluster.local
+  duration: 2160h0m0s
+  issuerRef:
+    group: cert-manager.io
+    kind: Issuer
+    name: ca-issuer
+  secretName: builtin-registry-certs
+  secretTemplate:
+    labels:
+      app: gitpod
+      component: docker-registry
+status: {}
+---
+# cert-manager.io/v1/Certificate builtin-registry-facade-cert
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: registry-facade
+  name: builtin-registry-facade-cert
+  namespace: default
+spec:
+  dnsNames:
+  - reg.gitpod.example.com
+  duration: 2160h0m0s
+  issuerRef:
+    group: cert-manager.io
+    kind: Issuer
+    name: ca-issuer
+  secretName: builtin-registry-facade-cert
+  secretTemplate:
+    labels:
+      app: gitpod
+      component: registry-facade
+status: {}
+---
+# cert-manager.io/v1/Certificate ca-issuer-ca
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: cluster
+  name: ca-issuer-ca
+  namespace: default
+spec:
+  commonName: ca-issuer-ca
+  duration: 2160h0m0s
+  isCA: true
+  issuerRef:
+    group: cert-manager.io
+    kind: Issuer
+    name: gitpod-selfsigned-issuer
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  secretName: ca-issuer-ca
+  secretTemplate:
+    labels:
+      app: gitpod
+      component: cluster
+status: {}
+---
+# cert-manager.io/v1/Certificate ws-daemon-tls
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ws-daemon
+  name: ws-daemon-tls
+  namespace: default
+spec:
+  dnsNames:
+  - gitpod.default
+  - ws-daemon.default.svc
+  - ws-daemon
+  - wsdaemon
+  duration: 2160h0m0s
+  issuerRef:
+    group: cert-manager.io
+    kind: Issuer
+    name: ca-issuer
+  secretName: ws-daemon-tls
+  secretTemplate:
+    labels:
+      app: gitpod
+      component: ws-daemon
+status: {}
+---
+# cert-manager.io/v1/Certificate ws-manager
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ws-manager
+  name: ws-manager
+  namespace: default
+spec:
+  dnsNames:
+  - registry-facade
+  - server
+  - ws-manager-bridge
+  - ws-proxy
+  - image-builder-mk3
+  - ws-manager
+  duration: 2160h0m0s
+  issuerRef:
+    group: cert-manager.io
+    kind: Issuer
+    name: ca-issuer
+  secretName: ws-manager-client-tls
+  secretTemplate:
+    labels:
+      app: gitpod
+      component: ws-manager
+status: {}
+---
+# cert-manager.io/v1/Certificate ws-manager-tls
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ws-manager
+  name: ws-manager-tls
+  namespace: default
+spec:
+  dnsNames:
+  - gitpod.default
+  - ws-manager.default.svc
+  - ws-manager
+  - ws-manager-dev
+  duration: 2160h0m0s
+  issuerRef:
+    group: cert-manager.io
+    kind: Issuer
+    name: ca-issuer
+  secretName: ws-manager-tls
+  secretTemplate:
+    labels:
+      app: gitpod
+      component: ws-manager
+status: {}
+---
+# policy/v1/PodDisruptionBudget messagebus
+# Source: rabbitmq/charts/rabbitmq/templates/pdb.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: messagebus
+  namespace: "default"
+  labels:
+    app.kubernetes.io/name: rabbitmq
+    helm.sh/chart: rabbitmq-10.1.1
+    app.kubernetes.io/instance: rabbitmq
+    app.kubernetes.io/managed-by: Helm
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels: 
+      app.kubernetes.io/name: rabbitmq
+      app.kubernetes.io/instance: rabbitmq
+---
+# v1/ServiceAccount agent-smith
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: agent-smith
+  name: agent-smith
+  namespace: default
+---
+# v1/ServiceAccount blobserve
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: blobserve
+  name: blobserve
+  namespace: default
+---
+# v1/ServiceAccount content-service
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: content-service
+  name: content-service
+  namespace: default
+---
+# v1/ServiceAccount dashboard
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: dashboard
+  name: dashboard
+  namespace: default
+---
+# v1/ServiceAccount db
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: db
+  name: db
+  namespace: default
+---
+# v1/ServiceAccount docker-registry
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: docker-registry
+  name: docker-registry
+  namespace: default
+---
+# v1/ServiceAccount gitpod
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: gitpod
+  name: gitpod
+  namespace: default
+---
+# v1/ServiceAccount iam
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: iam
+  name: iam
+  namespace: default
+---
+# v1/ServiceAccount ide-metrics
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ide-metrics
+  name: ide-metrics
+  namespace: default
+---
+# v1/ServiceAccount ide-proxy
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ide-proxy
+  name: ide-proxy
+  namespace: default
+---
+# v1/ServiceAccount ide-service
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ide-service
+  name: ide-service
+  namespace: default
+---
+# v1/ServiceAccount image-builder-mk3
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: image-builder-mk3
+  name: image-builder-mk3
+  namespace: default
+---
+# v1/ServiceAccount migrations
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: migrations
+  name: migrations
+  namespace: default
+---
+# v1/ServiceAccount minio
+# Source: minio/charts/minio/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: minio
+  namespace: "default"
+  labels:
+    app.kubernetes.io/name: minio
+    helm.sh/chart: minio-11.6.3
+    app.kubernetes.io/instance: minio
+    app.kubernetes.io/managed-by: Helm
+automountServiceAccountToken: true
+secrets:
+  - name: minio
+---
+# v1/ServiceAccount nobody
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: nobody
+  name: nobody
+  namespace: default
+---
+# v1/ServiceAccount openvsx-proxy
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: openvsx-proxy
+  name: openvsx-proxy
+  namespace: default
+---
+# v1/ServiceAccount proxy
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: proxy
+  name: proxy
+  namespace: default
+---
+# v1/ServiceAccount public-api-server
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: public-api-server
+  name: public-api-server
+  namespace: default
+---
+# v1/ServiceAccount rabbitmq
+# Source: rabbitmq/charts/rabbitmq/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rabbitmq
+  namespace: "default"
+  labels:
+    app.kubernetes.io/name: rabbitmq
+    helm.sh/chart: rabbitmq-10.1.1
+    app.kubernetes.io/instance: rabbitmq
+    app.kubernetes.io/managed-by: Helm
+automountServiceAccountToken: true
+secrets:
+  - name: messagebus
+---
+# v1/ServiceAccount registry-facade
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: registry-facade
+  name: registry-facade
+  namespace: default
+---
+# v1/ServiceAccount server
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: server
+  name: server
+  namespace: default
+---
+# v1/ServiceAccount workspace
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: workspace
+  name: workspace
+  namespace: default
+---
+# v1/ServiceAccount ws-daemon
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ws-daemon
+  name: ws-daemon
+  namespace: default
+---
+# v1/ServiceAccount ws-manager
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ws-manager
+  name: ws-manager
+  namespace: default
+---
+# v1/ServiceAccount ws-manager-bridge
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ws-manager-bridge
+  name: ws-manager-bridge
+  namespace: default
+---
+# v1/ServiceAccount ws-proxy
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ws-proxy
+  name: ws-proxy
+  namespace: default
+---
+# v1/Secret builtin-registry-auth
+apiVersion: v1
+data:
+  .dockerconfigjson: eyJhdXRocyI6eyJyZWdpc3RyeS5naXRwb2QuZXhhbXBsZS5jb20iOnsiYXV0aCI6ImVGTmxaRXBwUkdkS1VWRm5ORUpyVnpWNFMzVTZRMWMwUTFKQ2FtazJVakJpUjBjNE1XZDVSWGs9In19fQ==
+  password: Q1c0Q1JCamk2UjBiR0c4MWd5RXk=
+  user: eFNlZEppRGdKUVFnNEJrVzV4S3U=
+kind: Secret
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: docker-registry
+  name: builtin-registry-auth
+  namespace: default
+type: kubernetes.io/dockerconfigjson
+---
+# v1/Secret db-password
+apiVersion: v1
+data:
+  mysql-password: akJ6Vk1lMnc0WWk3R2FnYWRzeUI=
+  mysql-root-password: UEhlak1mc0x2ZkxjRzFEcnM0MGg=
+kind: Secret
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: db
+  name: db-password
+  namespace: default
+---
+# v1/Secret load-definition
+# Source: rabbitmq/charts/rabbitmq/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: load-definition
+  namespace: "default"
+  labels:
+    app.kubernetes.io/name: rabbitmq
+    helm.sh/chart: rabbitmq-10.1.1
+    app.kubernetes.io/instance: rabbitmq
+    app.kubernetes.io/managed-by: Helm
+type: Opaque
+stringData:
+  load_definition.json: '{"users":[{"name":"gitpod","password":"uq4KxOLtrA-QsDTfuwQ-","tags":"administrator"}],"vhosts":[{"name":"/"}],"parameters":[],"permissions":[{"user":"gitpod","vhost":"/","configure":".*","write":".*","read":".*"}],"exchanges":[{"name":"gitpod.ws.local","vhost":"/","type":"topic","durable":true,"auto_delete":false},{"name":"consensus-leader","vhost":"/","type":"fanout","durable":false,"auto_delete":false}],"bindings":[],"queues":[{"name":"consensus-peers","vhost":"/","durable":false,"auto_delete":false,"arguments":{}},{"name":"pwsupdatable","vhost":"/","durable":true,"auto_delete":false,"arguments":{}}],"policies":[{"name":"ha-all","vhost":"/","pattern":".*","definition":{"ha-mode":"all","ha-sync-mode":"automatic","ha-sync-batch-size":5}}]}'
+---
+# v1/Secret messagebus
+# Source: rabbitmq/charts/rabbitmq/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: messagebus
+  namespace: "default"
+  labels:
+    app.kubernetes.io/name: rabbitmq
+    helm.sh/chart: rabbitmq-10.1.1
+    app.kubernetes.io/instance: rabbitmq
+    app.kubernetes.io/managed-by: Helm
+type: Opaque
+data:
+  rabbitmq-password: "dXE0S3hPTHRyQS1Rc0RUZnV3US0="
+---
+# v1/Secret messagebus-certificates-secret-core
+apiVersion: v1
+data:
+  ca.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUZkVENDQTEyZ0F3SUJBZ0lVRko4ZlFiMHdqUGpFRkdPQ2VWUHljVEtuVmdBd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1NqRUxNQWtHQTFVRUJoTUNRVlV4RXpBUkJnTlZCQWdNQ2xOdmJXVXRVM1JoZEdVeEZUQVRCZ05WQkFvTQpERlI1Y0dWR2IzZ2dSMjFpU0RFUE1BMEdBMVVFQ3d3R1IybDBjRzlrTUI0WERURTVNRFV5T0RBNU5UZzBORm9YCkRUSTVNRFV5TlRBNU5UZzBORm93U2pFTE1Ba0dBMVVFQmhNQ1FWVXhFekFSQmdOVkJBZ01DbE52YldVdFUzUmgKZEdVeEZUQVRCZ05WQkFvTURGUjVjR1ZHYjNnZ1IyMWlTREVQTUEwR0ExVUVDd3dHUjJsMGNHOWtNSUlDSWpBTgpCZ2txaGtpRzl3MEJBUUVGQUFPQ0FnOEFNSUlDQ2dLQ0FnRUFzbzBWY05vcE5jZXdtQjdZZGdJS0VoTHo4a3BmCldaMyttNUVndmlZS2tmKzQ1dDYreWg1cERKRHprT2Y1QWN6UHZKRTRYdlFoK0w1a0puNnBLaXpMYkYzVTdHSDcKVXJld2FTS3FGRnM0S2xjYkFJMHBtbnFLbHdKQzR3ZzI0MVVyQ2VzbUpEWHk2Q25vZzlhOHVvbUd2Y3N3dWRRZQpUNlhMSURNNFFyYUhUVWo1WUdwc0lwVUY1bm1ma2VjL3NDcHU5TGNVWlVwMy84TXBVSjlDZmxqSHpVakR0aWxuCjdBaUhVb0FGVDlDVUJQbWpiTURQODBpK2VIc2FLTFovWlVsWUJhbXJmcHl6UVIvUU5iQjA2dVRTUWV2emVGMUsKQWg0VXgxK0NVb0huKzdId2gxaFhCR3BUNHowWm1RbWwwSXVYRm1hTGYvaTZJWWVhL0szSnhUNDlPM0hXQmVXdApORkxlc1FKdXFSZ01zaHAzbVB0ZEExam0xZVNxVmE4eTIrRGh2UVhVYk5nL3BJdEdMNnNNdUxoTDJaKzZaRUppCkZxM1J3djJFR0wwa0h6a3dCbGhxUUVlbGZpWENsOElmR1VMU2tvVk9GU1hNanE0L2Vwamh1bnBRNTlWeXZZQlgKYURmMnQwdFRZa2RqTk1RaDh2RDJoMGp4dmVncE02VmxPSUJtTFRzZ0dzeERpTk1mWURhMjErWFBXTDJXQ2wvOApNL1AzZEhsKzU4UFl5eGhPL1Uwa2RBMW81ck1YT1NtMzVPTjBzMWtDY1FyTFg1eHY4OVJ1STB6L2lLZXVyTmFJCnVDN21Tb3lISGo3YVVENEUrdVVOa3Q4WTdHbnAxWW1hWjEreVZ6QkpQSCtweTN3ekd5aGtpYjlIcUhhSWxqNy8KaTZHTUorRlhjQUpEdXpjQ0F3RUFBYU5UTUZFd0hRWURWUjBPQkJZRUZGT2huNWFWZ2crV014YTBhM2owVDYvdQoyeUk1TUI4R0ExVWRJd1FZTUJhQUZGT2huNWFWZ2crV014YTBhM2owVDYvdTJ5STVNQThHQTFVZEV3RUIvd1FGCk1BTUJBZjh3RFFZSktvWklodmNOQVFFTEJRQURnZ0lCQUYveG5qVTg4TzdBVFpMblY1Q1IvVWZiL1pWaE1mMzYKQXVGL1MrSktMWkZ2WGlabm1oMjlEa1EyNU5SWTN1V1JlT2RKMVZFN0tjeE9sZ2t1LysyZWt4ek5qTDlVNWZnegpRbVpQbFNTS05ZVHdCKy9PQXNYbG9YdTM3OFIzUSs0RENtTk5zazF5K3N2R2hIbkJNYjdLdHZUSXZlZjI0bTJvCnlRaUdPVGxWUmlRbTQ1VUNnQUNwek5xTllXalViQXlVM0d6dkF2b1RUbTJCN1VFbENncGdVQ2lXYWhTY013ZVgKSm9sSjY5UHkzcXdrcnZjOWZmZWd0dnk2clhSZkZTZ3k3QWw2NVJvNEVBOFVXNlRjSUdoV1RuWkJMQWFRSHVjNgo2T01BQ21yalN4SDAwcnhiUmdzcy9teHBqT2hNYmk1eExwblNrY0FWcDRmR3dRbUFQY0NzMHF3bUhjVEVyK0JsCkM5ZDNTUkxBZlB0c2hscGV4Vzl0MnEyZmVqVFFVVnJHY1ppSmlabnJyOVJ1Z2VMUlgveWxKOERDVklsQjJBREIKMTllRDArcGw2Ri9sQ09uUXJpazJlRjNVU01GY0tiNXlxYkZ3clN2b2E4QlZyc0pVdFdTS2RRWlhaZnBvSzZDbApoWGlvMkxKL3U1RE42R29HU1BXbk5nVHJoVHV2WGJlUk8yeG1KMHB4NERnck9jcENMdk5wdVRXRmVsdW9rR3pECmcwelMvNjNNZW1JWHVEemFxZ3ZONkZqQ1NNMnhYWExxNUJROHFDeWxpZE5EUTBSeko0ekd1cVp5RW0ydzNSRTEKWFgwQzQ1NzFUemJsUkZzbGdFV3B5a0pWcmFsTXVBc2tEVVR3U2xEZjRwTitWMmFzODVSY290YWs5dkF2d25rWgpCbWl5bDdVWGpzRE8KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
+  tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUZNekNDQXhzQ0ZHamhiNWlQMWJNSWNtdCtBSWU4L0tzL2c5OTVNQTBHQ1NxR1NJYjNEUUVCQ3dVQU1Fb3gKQ3pBSkJnTlZCQVlUQWtGVk1STXdFUVlEVlFRSURBcFRiMjFsTFZOMFlYUmxNUlV3RXdZRFZRUUtEQXhVZVhCbApSbTk0SUVkdFlrZ3hEekFOQmdOVkJBc01Ca2RwZEhCdlpEQWVGdzB4T1RBMU1qZ3hNVEV6TkRGYUZ3MHlPVEExCk1qVXhNVEV6TkRGYU1HSXhDekFKQmdOVkJBWVRBa0ZWTVJNd0VRWURWUVFJREFwVGIyMWxMVk4wWVhSbE1SVXcKRXdZRFZRUUtEQXhVZVhCbFJtOTRJRWR0WWtneER6QU5CZ05WQkFzTUJrZHBkSEJ2WkRFV01CUUdBMVVFQXd3TgpiWE5uWW5WekxXTnNhV1Z1ZERDQ0FpSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnSVBBRENDQWdvQ2dnSUJBT3BUCkxDY0dTb1JDRDk1TkV2RDlhZDAxRzQzbXdMemZkdkUrNVVrN04xcEV1L2JLaFFINUlwRHh6VkVhTDZEdnNHYWoKeUFzZ2ppT3ZUTTFTOTFOMGU3d2c2WS9oZmZXWksvOWd0ejBwTXI3MHo2QllKSXFQeldHWDVscjUxV0NlVWNVUgpjV0dNVWIxcmRwbVF0WFFhbU5jWFpFTGxzNzBsRGZSUEd4L3BhVU5pcjhaVU5hUjIraDN5RVpSYUI2dE9yRGE4ClpnemFjakZEcEZvMTRBeGlBOGhFZUlFdFpnbUI0TzhTZTZWSk92U3lPL3lnWmVlNEhuYU5vT2x5eEEzdXNFdUcKQUgvaHY4aWpyeGRBbkd4Mm5QRDhpZWxrUTFjbnl5dE83YzI5WXZiS1BWV2tQZUczd3VMSXh0b1Baam9SYVVidwpvb2w2Ui9VUU9UdmlGQmQzbDNOQ21UQkZJZ3ZqS3BPbnA4WDZVazZwdmVEVHZ0WFprZFNsaFVqeXd5cDJrV2pvCkYyTGFKYXhuak1sYktBUHNvOHljaGQyTE1WSHF0T0swS29SdVNvK0Q1TElUbUF4VTY0RFVCVzcrRXA3RGFxM2UKU2cwUm1HUWtxNk5WYjlCZ1hRbjV0b1NoV3JGTzk3QmxvSVFUQVpvQ2dhcjlrRTlvNDc4eXJJejZDWlpXOENRcgo0YUhvT0J3SjlIUkRKY0NrVnU5di9EWm5jRUZxaGNmMVpDeURGemhZaFRzekIzVjRLMDlqellzZzQzeU1UUEdiClUzbWxBZVIrVy9vazRmZmZFa2JCYXdZclI5NU5WNXpzbGVFN2E1Z1poQzRJd1p2c1RyWnJkUjYwM21DRVJmbzYKU1ZxRmJRdks1dG8ydHhST3daZEZEa1JmbFFEMUZHWTRrVmxoZXNwTEFnTUJBQUV3RFFZSktvWklodmNOQVFFTApCUUFEZ2dJQkFEdEMxOHNQaFpQVzRDSjB3Mkx1K1N2b0tnN0hxZ1RKNVNaMWFJYVpUK21JR2NoZ0hMU05wN3BhCkNaUFU0YTArMGxwd0l3M3F5NUV2YnpucGYxcitrUVJLK1UwQkw0KzE3SGh4cmZCNDFIcU5meXUwY1UwR0dqMy8KV29xSXJCN0I4eXhZOEpES0pPREs1UllFa0dqYWRwZGNKMytTVDErMXNMMEtITVBLMlBjVXpTbGxWNVVuOU1vNAoxOGhyZm5IVlNsMnZ3RnZSeVgzTHZ4ZzdCdTRUWnJLelZ4NVZQK29IdmFJRXRFMW9SNkM0RlpteStHZDJZRnZ0CmcxRVNVVjZ4a20xWHhQeElhclc5bytzVk9ESG8zbnp3MGhEcDZXVCsxbCt3bVpKR09IenhWVHZFU29VMFo1ZDgKdWdtelNyVGFlaW9BMTF0eERrN0N5RmJoQTJPek1GR0p2eGN6cUkzMHZ3WVVDK3YrbVZCcWw4WFBjR24wNyt1KwpRTnBMZWJRWmszTDRsQ2ZPT0lYQVNxK2FvYURBdnV6eW5OSU1ueXAvL0dKU05tczdhNTRtcnB5T2pEdjNLNFYwCmlsQTB0eHlieXpkWWtGTFZNSlI0RHFzd3Fhakd0eGMzYjRUNzRjL1pUWVhSWkVkNTh1SmlWOUpMYjVNR01tc2MKWWFiN28wNlpORDAzeDgrRGN1MUFMZ2JhTFBWeTliM3lOKzk4UENhTkpWYWZwc05TSkN5VjZCM21uYTFuOHZXZApiK1FrRFNiUkh5ZGRjWnhBR0swTjdpeGRPN1hzNFNoeVZCZXpVQmJ2eDFna2d5YTZCWVoyZHVXbzR2OEpPamlHClQzM1ZWWkVUUFdZWHFyelhxQmpSYVQzRkxFWER6QmYzKzljaGxLYUpaaFNBRmtkcmgwVjIKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
+  tls.key: LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlKS0FJQkFBS0NBZ0VBNmxNc0p3WktoRUlQM2swUzhQMXAzVFViamViQXZOOTI4VDdsU1RzM1drUzc5c3FGCkFma2lrUEhOVVJvdm9PK3dacVBJQ3lDT0k2OU16VkwzVTNSN3ZDRHBqK0Y5OVprci8yQzNQU2t5dnZUUG9GZ2sKaW8vTllaZm1Xdm5WWUo1UnhSRnhZWXhSdld0Mm1aQzFkQnFZMXhka1F1V3p2U1VOOUU4YkgrbHBRMkt2eGxRMQpwSGI2SGZJUmxGb0hxMDZzTnJ4bUROcHlNVU9rV2pYZ0RHSUR5RVI0Z1MxbUNZSGc3eEo3cFVrNjlMSTcvS0JsCjU3Z2VkbzJnNlhMRURlNndTNFlBZitHL3lLT3ZGMENjYkhhYzhQeUo2V1JEVnlmTEswN3R6YjFpOXNvOVZhUTkKNGJmQzRzakcyZzltT2hGcFJ2Q2lpWHBIOVJBNU8rSVVGM2VYYzBLWk1FVWlDK01xazZlbnhmcFNUcW05NE5PKwoxZG1SMUtXRlNQTERLbmFSYU9nWFl0b2xyR2VNeVZzb0EreWp6SnlGM1lzeFVlcTA0clFxaEc1S2o0UGtzaE9ZCkRGVHJnTlFGYnY0U25zTnFyZDVLRFJHWVpDU3JvMVZ2MEdCZENmbTJoS0Zhc1U3M3NHV2doQk1CbWdLQnF2MlEKVDJqanZ6S3NqUG9KbGxid0pDdmhvZWc0SEFuMGRFTWx3S1JXNzIvOE5tZHdRV3FGeC9Wa0xJTVhPRmlGT3pNSApkWGdyVDJQTml5RGpmSXhNOFp0VGVhVUI1SDViK2lUaDk5OFNSc0ZyQml0SDNrMVhuT3lWNFR0cm1CbUVMZ2pCCm0reE90bXQxSHJUZVlJUkYranBKV29WdEM4cm0yamEzRkU3QmwwVU9SRitWQVBVVVpqaVJXV0Y2eWtzQ0F3RUEKQVFLQ0FnRUF0QnBoWVUxUWtQOUZ1eE42YjRnWGlsSjdiMEhnK2txMzNReitwcDdCR0x5anpEZzBxeU9XRWRvSQplVUdyUWdONGppdHNZa0VQZnhZSjdmYks2bllwZEp2SGFUTmo0UlZ0MzhleWoydk8rVDZwSnhFWVpQZktZQ3lrCmZXQnhST1hxNjVGUW1DMkYxaFYyL3VsZXpuSnk3eituYkZPcEpzUUlTYk5Ub2QrQmJLMjVkTExjMkNBcWRrSE0KaVQzNWp3M1ZCKzBlY3RxajBvR3ZIVGN6a2REMEgwV2hhWWcvV1NkZWYrS3c3b1d1cnMwZmxqaWltc3ZGZmxHMQpVRGxKdjN1cVBTSXQyQnpuajR0ZjFIdHd2MTBibTQ0L1lnZ1NTamJuemMzSXNjM1M5dVRTNTdScGE4Z1dIc0U3Ck5mZUlGekd5dlRmUGRlTnEwMDA0OEhJQUIxbUFLVHFDdVdYSWRtWUMzcFJPSU5YZTVRY3N2M1N1S09UMFFhTjYKQU9zVXNvbTBOYmxJd1YyV3VnMTBZNGVWZ1ZTRDlvMFlyemdzK0Y1K2haZjBFd21qNllzRFdCQUVzaFQ5bXBnQgpVY3IvbmR4Mi9kc1pncDRQTGZtd3ZsUVkzdFRvYjYzVlRrUlJTYTBIVENPK09TQ09TaFhhVmFiM1VXMXNNME5oCnZpKytPMnFMc3pjNHlZQXdkYWFJWEo4RC90TVU5aHRzWnRYRWw0TFNDT1JSVzhrT25qaVZ1dDU4Rk9XRiszNW8KTTZ0eHE4V2RJOGxWUXpJcGdLUStsdEUwcDJwaWNVQ2o2SlAyRzVSUVhpV293cEZjRndDelk3MEtiNjhxejA5Qwppc21BdlNjTkE3cmdVZmhKZHhrRmRFY0pXTVlhbVZDdjFSb01yZExxV1IwUm5Cb1VCOEVDZ2dFQkFQbGNyNkc5CkdvanlJV3p5M3NSUTRrdkkySktNRGdTbG1sVDZEdUljUlZpZERQTWdaUnZ3c1BGdkVnUTBMRmdzckwyTERXZXgKU1FCM09yYks2WUU2eXkvaHZUME1qWFVrbCsvc3I5UW15enZjS1JkNE11MEJOYjlIeWZnV1BENDFVQlA1d0pCZAo0ZnZURTg1emhsdEliZEJpNDJZbmR2NUVUdlRHUW9keW1YenZHUlhrbmJPZ0E3NWZyaHRnZ0VWNjRTZHh6WFBMCkdLQndmZkt6Q1hES1FNTTkxWmV6R3ZzYmJYNWYzU0ltZmlQSkNiOWpMTHhkcDRVaEZTdnU3Y25WalJnMnRRTjUKNVJuTnVFOVNuVk1qSVhZQi8ybVYxR2pVN1U0TEdYZG5oaWRnZ1BBMzZLckRjcitoSEJ1N0JhSGY2RmJpYllJWQorUGV3T25LaXJkMHF2V01DZ2dFQkFQQ1FBM09DdVRaUVA0aWFVK056clM5VmxKamVPYTFnb3l2ME05YkVpK0hFCmQ3S3paNm9LVlpraFR6SVNKY3R5c3BRSUVOYzV4cUFySXVLQ3ZRZHB1YzJuZ0lVcVFLT2xhUGxzQmtXcHJCSXMKbFZCSk5yNGFxdDFXRU9zNmRmVGR6czNkekxLazRMd1liY2M5d2dTdzRxcDhFaUZnT1ZjWlUzL0NkcXpwTGw1VQpFOHJGbmUwd2grZThoV1FmbW5qbTNWbWYyR2M4dzhJcTIvL3FjWGViWVBpdnp1Tm1lRE4xRXVMekt3VEtGdWgxCnRZaHNQZjJKTlA3dEQzWHB0SkNWS0R2VWE0cjVsTGxza1FNZGlMQm4rSjNpdUp4MHkrcXhSVUNJWnN3c3JpRHEKWVJRTjdHNzJzQVh4aU1mVTdPbDhHbjVSRFZ0a1NiSEVkOWlwWFFJL3Ava0NnZ0VBWXRZUjV4R0ZDdkt0dlBrbQp3cmtzZU0xS3lnc3BJejVnUlg0M2wvZU1wT3JhenlMdjhIc2VKeFBYR0VOMXNCMUUrbnU2L0hhUWNOYlJOdEtHCmF1cGF6c2V5c2hmZm1hYS9jaUZtTDdpUXBWRkdHRDlVTUF4aXVVWkREMG9BNXNkS3ppQVg2eURMQ1gxSVJIUVYKdE9pb1hnaFVDWkZxNEsxQ2ZsSjIzQ2pZSFdUSGxKM2d3K21Ra2t4cVBmK3AxK0EwamVYVmdTZm13dkRUZXZicgpyd0Q3V21lUDJXanNNTXRXUXRqTVZWVGNlbUtjc25ja3JDU1MyWG1iWXFaNUtaNnpKZjNKRVcrbkZ1c3JPb1dNClJmK09xNjl2QlBLV0ZsY1BGL2ZlU0MySVJ1TkJOL1Z4Q3Y0YzVVZCtWSjkwUkF6emtqeDlHeXU2d3JIZStNRHkKR005djhRS0NBUUIwYSs0UHFCTkVzdCtjbDd2RGwwY1lZbDJSQWZOOThnZm1ETUJOeno4M1d5TG16Q1orUjVRWAprT1JJQWpwaVZMY1NKemtuUUNIZGdDTFk1cGJmRUk3SWRha2dTVXVSSjBzL2NzVXlUNlFrQTRtYm1tTXc2NjBICmcxQ2ExdWNoUTN1RGJEVlZ1Nis3dUVMZ3F3WEx5V05aU01ScGZLMGpkdkZQSW1qVzA5OEo3YnpLWkl0Q3NEc0YKcnRvTGs3UHBrU2xNNTZ3T2duem02bUVnWUhEYmhzb09jTjg2ZEd2MTAxSDVuZCtTNk03Zlg2QWtUdVpOWG1yVQplUndEWDhCd1BJK0ZMUStDNmJqTmFEcGgvSmdiYjZZRm15VG5LeXRKQU5QWUlHdEhvdFArd0ErTmFoT2p2Q1dDCkt0dWNnbkxKcUxNVnNObzdBYlVjb0UyMEFIc3Z6R2paQW9JQkFEaE52aUJlWmZNSUZuWjVvMzF3YVdsM0phQjMKTzFZcStiVXM0cmJjMnRvaVVGVTdyZTZuV211b202RzUwQmdBTmpnNzlwZGt2Q1ZUUkNYRi8wR3VDd081TVd5OQpNR2VuRHB3NllCc29Fa3Z4ZC9yc1hlN0kvNVFDV3lod0VSRFZtV0RONlZWdXJEbDNDVXJyVGIxNEd3dldaRktLCnd0Rzl4am9vZlJOc1U0Y09tQk1JdnhNK25UaTFKaFBrQXVlUk8wank0a2hEdkFPM0FIdGd2NWp2d0VOZXg1Qk8KN3l0T0FNcDkxeVVmQjB6bis5dXU5b1l0dDlIYmZxelJ2UmhSK3Y3bU90eGRtU1krM1FLbzFDdnlLSHZwYVB0VwpJRGNraUpFUmw1cjlldkhHd0dFWW8zQkl4aGxkTThsd3NFWFJHaTNDRjNUQnpzZVR0ZERaSGRCeHhmTT0KLS0tLS1FTkQgUlNBIFBSSVZBVEUgS0VZLS0tLS0K
+kind: Secret
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: rabbitmq
+  name: messagebus-certificates-secret-core
+  namespace: default
+---
+# v1/Secret messagebus-config
+# Source: rabbitmq/charts/rabbitmq/templates/config-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: messagebus-config
+  namespace: "default"
+  labels:
+    app.kubernetes.io/name: rabbitmq
+    helm.sh/chart: rabbitmq-10.1.1
+    app.kubernetes.io/instance: rabbitmq
+    app.kubernetes.io/managed-by: Helm
+type: Opaque
+data:
+  rabbitmq.conf: |-
+    IyMgVXNlcm5hbWUgYW5kIHBhc3N3b3JkCiMjCmRlZmF1bHRfdXNlciA9IGdpdHBvZApkZWZhdWx0X3Bhc3MgPSBDSEFOR0VNRQojIyBDbHVzdGVyaW5nCiMjCmNsdXN0ZXJfZm9ybWF0aW9uLnBlZXJfZGlzY292ZXJ5X2JhY2tlbmQgID0gcmFiYml0X3BlZXJfZGlzY292ZXJ5X2s4cwpjbHVzdGVyX2Zvcm1hdGlvbi5rOHMuaG9zdCA9IGt1YmVybmV0ZXMuZGVmYXVsdApjbHVzdGVyX2Zvcm1hdGlvbi5ub2RlX2NsZWFudXAuaW50ZXJ2YWwgPSAxMApjbHVzdGVyX2Zvcm1hdGlvbi5ub2RlX2NsZWFudXAub25seV9sb2dfd2FybmluZyA9IHRydWUKY2x1c3Rlcl9wYXJ0aXRpb25faGFuZGxpbmcgPSBhdXRvaGVhbApsb2FkX2RlZmluaXRpb25zID0gL2FwcC9sb2FkX2RlZmluaXRpb24uanNvbgojIHF1ZXVlIG1hc3RlciBsb2NhdG9yCnF1ZXVlX21hc3Rlcl9sb2NhdG9yID0gbWluLW1hc3RlcnMKIyBlbmFibGUgZ3Vlc3QgdXNlcgpsb29wYmFja191c2Vycy5ndWVzdCA9IGZhbHNlCmxvYWRfZGVmaW5pdGlvbnMgPSAvYXBwL2xvYWRfZGVmaW5pdGlvbi5qc29uCiMgSW5jcmVhc2Ugc3RhdGlzdGljcyBlbWlzc2lvbiBpbnRlcnZhbCBodHRwczovL3d3dy5yYWJiaXRtcS5jb20vbWFuYWdlbWVudC5odG1sI3N0YXRpc3RpY3MtaW50ZXJ2YWwKY29sbGVjdF9zdGF0aXN0aWNzX2ludGVydmFsID0gMTUwMDAKCnNzbF9vcHRpb25zLnZlcmlmeSA9IHZlcmlmeV9wZWVyCmxpc3RlbmVycy5zc2wuZGVmYXVsdCA9IDU2NzEKc3NsX29wdGlvbnMuZmFpbF9pZl9ub19wZWVyX2NlcnQgPSB0cnVlCnNzbF9vcHRpb25zLmNhY2VydGZpbGUgPSAvb3B0L2JpdG5hbWkvcmFiYml0bXEvY2VydHMvY2FfY2VydGlmaWNhdGUucGVtCnNzbF9vcHRpb25zLmNlcnRmaWxlID0gL29wdC9iaXRuYW1pL3JhYmJpdG1xL2NlcnRzL3NlcnZlcl9jZXJ0aWZpY2F0ZS5wZW0Kc3NsX29wdGlvbnMua2V5ZmlsZSA9IC9vcHQvYml0bmFtaS9yYWJiaXRtcS9jZXJ0cy9zZXJ2ZXJfa2V5LnBlbQojIyBQcm9tZXRoZXVzIG1ldHJpY3MKIyMKcHJvbWV0aGV1cy50Y3AucG9ydCA9IDk0MTk=
+---
+# v1/Secret messagebus-erlang-cookie
+apiVersion: v1
+data:
+  rabbitmq-erlang-cookie: WlgzbTM3V0RadmRIOHp5MDNaVlo=
+kind: Secret
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: rabbitmq
+  name: messagebus-erlang-cookie
+  namespace: default
+---
+# v1/Secret minio
+# Source: minio/charts/minio/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: minio
+  namespace: "default"
+  labels:
+    app.kubernetes.io/name: minio
+    helm.sh/chart: minio-11.6.3
+    app.kubernetes.io/instance: minio
+    app.kubernetes.io/managed-by: Helm
+type: Opaque
+data:
+  root-user: "OC1XR3F3Mm9UbnNQZlVETlNrMFk="
+  root-password: "RHBDLmFTQXhrV0JQdTJfYkpfQUU="
+  key.json: ""
+---
+# v1/Secret mysql
+apiVersion: v1
+data:
+  database: Z2l0cG9k
+  encryptionKeys: WwogIHsKICAgICJuYW1lIjogImdlbmVyYWwiLAogICAgInZlcnNpb24iOiAxLAogICAgInByaW1hcnkiOiB0cnVlLAogICAgIm1hdGVyaWFsIjogIjR1R2gxcTh5MkRZcnlKd3JWTUhzMGtXWEpscXZIV1d0L0tKdU5pMDRlZEk9IgogIH0KXQ==
+  host: ZGI=
+  password: akJ6Vk1lMnc0WWk3R2FnYWRzeUI=
+  port: MzMwNg==
+  username: Z2l0cG9k
+kind: Secret
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: db
+  name: mysql
+  namespace: default
+---
+# v1/Secret rabbitmq
+# Source: rabbitmq/charts/rabbitmq/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rabbitmq
+  namespace: "default"
+  labels:
+    app.kubernetes.io/name: rabbitmq
+    helm.sh/chart: rabbitmq-10.1.1
+    app.kubernetes.io/instance: rabbitmq
+    app.kubernetes.io/managed-by: Helm
+type: Opaque
+stringData:
+  password: uq4KxOLtrA-QsDTfuwQ-
+  username: gitpod
+---
+# v1/Secret registry-secret
+# Source: docker-registry/charts/docker-registry/templates/secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: registry-secret
+  namespace: default
+  labels:
+    app: docker-registry
+    chart: docker-registry-1.16.0
+    heritage: Helm
+    release: docker-registry
+type: Opaque
+data:
+  haSharedSecret: "a2pjcXpkdHRjd3BRY3Brcw=="
+  proxyUsername: ""
+  proxyPassword: ""
+---
+# v1/ConfigMap agent-smith
+apiVersion: v1
+data:
+  config.json: |-
+    {
+      "gitpodAPI": {
+        "hostURL": "https://gitpod.example.com",
+        "apiToken": ""
+      },
+      "enforcement": {},
+      "kubernetes": {
+        "enabled": true
+      },
+      "namespace": "default",
+      "pprofAddr": "127.0.0.1:6060",
+      "prometheusAddr": "127.0.0.1:9500"
+    }
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: agent-smith
+  name: agent-smith
+  namespace: default
+---
+# v1/ConfigMap blobserve
+apiVersion: v1
+data:
+  config.json: |-
+    {
+      "blobserve": {
+        "port": 32224,
+        "timeout": "5s",
+        "repos": {
+          "registry.mydomain.com/namespace/ide/code": {
+            "workdir": "/ide",
+            "replacements": [
+              {
+                "path": "/ide/out/vs/workbench/workbench.web.main.js",
+                "search": "vscode-cdn.net",
+                "replacement": "gitpod.example.com"
+              },
+              {
+                "path": "/ide/out/vs/workbench/workbench.web.main.js",
+                "search": "open-vsx.org",
+                "replacement": "open-vsx.gitpod.example.com"
+              },
+              {
+                "path": "/ide/out/vs/workbench/workbench.web.api.js",
+                "search": "{{extensionsGalleryItemUrl}}",
+                "replacement": "https://open-vsx.org/vscode/item"
+              },
+              {
+                "path": "/ide/out/vs/workbench/workbench.web.main.js",
+                "search": "{{extensionsGalleryItemUrl}}",
+                "replacement": "https://open-vsx.org/vscode/item"
+              },
+              {
+                "path": "/ide/out/vs/workbench/workbench.web.api.js",
+                "search": "{{trustedDomain}}",
+                "replacement": "https://open-vsx.org"
+              },
+              {
+                "path": "/ide/out/vs/workbench/workbench.web.main.js",
+                "search": "{{trustedDomain}}",
+                "replacement": "https://open-vsx.org"
+              },
+              {
+                "path": "/ide/out/vs/workbench/workbench.web.main.js",
+                "search": "ide.gitpod.io/code/markeplace.json",
+                "replacement": "ide.gitpod.example.com/code/marketplace.json"
+              }
+            ],
+            "inlineStatic": [
+              {
+                "search": "${window.location.origin}",
+                "replacement": "."
+              },
+              {
+                "search": "value.startsWith(window.location.origin)",
+                "replacement": "value.startsWith(window.location.origin) || value.startsWith('${ide}')"
+              },
+              {
+                "search": "./out",
+                "replacement": "${ide}/out"
+              },
+              {
+                "search": "./node_modules",
+                "replacement": "${ide}/node_modules"
+              },
+              {
+                "search": "/_supervisor/frontend",
+                "replacement": "${supervisor}"
+              }
+            ]
+          },
+          "registry.mydomain.com/namespace/supervisor": {
+            "workdir": "/.supervisor/frontend"
+          }
+        },
+        "allowAnyRepo": false,
+        "blobSpace": {
+          "location": "/mnt/cache/blobserve",
+          "maxSizeBytes": 1073741824
+        }
+      },
+      "dockerAuth": "/mnt/pull-secret/pull-secret.json",
+      "pprofAddr": "127.0.0.1:6060",
+      "prometheusAddr": "127.0.0.1:9500",
+      "readinessProbeAddr": ":8086"
+    }
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: blobserve
+  name: blobserve
+  namespace: default
+---
+# v1/ConfigMap content-service
+apiVersion: v1
+data:
+  config.json: |-
+    {
+      "service": {
+        "address": "0.0.0.0:8080"
+      },
+      "storage": {
+        "stage": "",
+        "kind": "minio",
+        "gcloud": {
+          "credentialsFile": "",
+          "region": "",
+          "projectId": ""
+        },
+        "minio": {
+          "endpoint": "minio.default.svc.cluster.local:9000",
+          "accessKey": "8-WGqw2oTnsPfUDNSk0Y",
+          "accessKeyFile": "",
+          "secretKey": "DpC.aSAxkWBPu2_bJ_AE",
+          "secretKeyFile": "",
+          "region": "local",
+          "parallelUpload": 6
+        },
+        "blobQuota": 5368709120
+      }
+    }
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: content-service
+  name: content-service
+  namespace: default
+---
+# v1/ConfigMap db-init-scripts
+apiVersion: v1
+data:
+  init.sql: |
+    -- 01-create-and-init-sessions-db.sql
+
+    -- Copyright (c) 2020 Gitpod GmbH. All rights reserved.
+    -- Licensed under the GNU Affero General Public License (AGPL). See License.AGPL.txt in the project root for license information.
+
+    -- must be idempotent
+
+    CREATE DATABASE IF NOT EXISTS `gitpod-sessions` CHARSET utf8mb4;
+
+    USE `gitpod-sessions`;
+
+    CREATE TABLE IF NOT EXISTS sessions (
+       `session_id` varchar(128) COLLATE utf8mb4_bin NOT NULL,
+       `expires` int(11) unsigned NOT NULL,
+       `data` text COLLATE utf8mb4_bin,
+       `_lastModified` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+       PRIMARY KEY (`session_id`)
+    );
+
+    -- Grant privileges
+    GRANT ALL ON `gitpod-sessions`.* TO "gitpod"@"%";
+    -- 02-recreate-gitpod-db.sql
+
+    -- Copyright (c) 2020 Gitpod GmbH. All rights reserved.
+    -- Licensed under the GNU Affero General Public License (AGPL). See License.AGPL.txt in the project root for license information.
+
+    -- must be idempotent
+
+    -- @gitpodDB contains name of the DB the script manipulates, and is replaced by the file reader
+    SET
+    @gitpodDB = IFNULL(@gitpodDB, '`gitpod`');
+
+    SET
+    @statementStr = CONCAT('DROP DATABASE IF EXISTS ', @gitpodDB);
+    PREPARE statement FROM @statementStr;
+    EXECUTE statement;
+
+    SET
+    @statementStr = CONCAT('CREATE DATABASE ', @gitpodDB, ' CHARSET utf8mb4');
+    PREPARE statement FROM @statementStr;
+    EXECUTE statement;
+  tuneMysql.sql: SET GLOBAL innodb_lru_scan_depth=256;
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: db
+  name: db-init-scripts
+  namespace: default
+---
+# v1/ConfigMap gitpod
+apiVersion: v1
+data:
+  config.yaml: |
+    apiVersion: v1
+    authProviders: []
+    blockNewUsers:
+      enabled: false
+      passlist: []
+    certificate:
+      kind: secret
+      name: https-certificates
+    containerRegistry:
+      inCluster: true
+      privateBaseImageAllowList: []
+    database:
+      inCluster: true
+    disableDefinitelyGp: true
+    domain: gitpod.example.com
+    kind: Full
+    metadata:
+      region: local
+      shortname: default
+    objectStorage:
+      inCluster: true
+      resources:
+        requests:
+          memory: 2Gi
+    observability:
+      logLevel: info
+    openVSX:
+      url: https://open-vsx.org
+    repository: registry.mydomain.com/namespace
+    workspace:
+      maxLifetime: 36h0m0s
+      prebuildPVC:
+        size: 30Gi
+        snapshotClass: ""
+        storageClass: ""
+      pvc:
+        size: 30Gi
+        snapshotClass: ""
+        storageClass: ""
+      resources:
+        requests:
+          cpu: "1"
+          memory: 2Gi
+      runtime:
+        containerdRuntimeDir: /var/lib/containerd/io.containerd.runtime.v2.task/k8s.io
+        containerdSocket: /run/containerd/containerd.sock
+        fsShiftMethod: fuse
+  versions.json: |-
+    {
+      "versions": {
+        "version": "pd-ide-metrics.23",
+        "components": {
+          "agentSmith": {
+            "version": "test"
+          },
+          "blobserve": {
+            "version": "test"
+          },
+          "caUpdater": {
+            "version": "test"
+          },
+          "contentService": {
+            "version": "test"
+          },
+          "dashboard": {
+            "version": "test"
+          },
+          "dbMigrations": {
+            "version": "test"
+          },
+          "dbSync": {
+            "version": "test"
+          },
+          "iam": {
+            "version": "test"
+          },
+          "ideProxy": {
+            "version": "test"
+          },
+          "ideMetrics": {
+            "version": "test"
+          },
+          "ideService": {
+            "version": "test"
+          },
+          "imageBuilder": {
+            "version": ""
+          },
+          "imageBuilderMk3": {
+            "version": "test",
+            "builderImage": {
+              "version": "test"
+            }
+          },
+          "installationTelemetry": {
+            "version": "test"
+          },
+          "integrationTests": {
+            "version": ""
+          },
+          "openVSXProxy": {
+            "version": "test"
+          },
+          "paymentEndpoint": {
+            "version": "test"
+          },
+          "proxy": {
+            "version": "test"
+          },
+          "public-api-server": {
+            "version": "test"
+          },
+          "refreshCredential": {
+            "version": "test"
+          },
+          "registryFacade": {
+            "version": "test"
+          },
+          "server": {
+            "version": "test"
+          },
+          "serviceWaiter": {
+            "version": "test"
+          },
+          "toxic-config": {
+            "version": "test"
+          },
+          "usage": {
+            "version": "test"
+          },
+          "workspace": {
+            "codeImage": {
+              "version": "test"
+            },
+            "dockerUp": {
+              "version": "test"
+            },
+            "supervisor": {
+              "version": "test"
+            },
+            "workspacekit": {
+              "version": "test"
+            },
+            "desktopIdeImages": {
+              "codeDesktop": {
+                "version": "test"
+              },
+              "codeDesktopInsiders": {
+                "version": "test"
+              },
+              "intellij": {
+                "version": "test"
+              },
+              "intellijLatest": {
+                "version": "test"
+              },
+              "goland": {
+                "version": "test"
+              },
+              "golandLatest": {
+                "version": "test"
+              },
+              "pycharm": {
+                "version": "test"
+              },
+              "pycharmLatest": {
+                "version": "test"
+              },
+              "phpstorm": {
+                "version": "test"
+              },
+              "phpstormLatest": {
+                "version": "test"
+              },
+              "rubymine": {
+                "version": "test"
+              },
+              "rubymineLatest": {
+                "version": "test"
+              },
+              "webstorm": {
+                "version": "test"
+              },
+              "webstormLatest": {
+                "version": "test"
+              },
+              "rider": {
+                "version": "test"
+              },
+              "riderLatest": {
+                "version": "test"
+              },
+              "clion": {
+                "version": "test"
+              },
+              "clionLatest": {
+                "version": "test"
+              },
+              "jbBackendPlugin": {
+                "version": "test"
+              },
+              "jbBackendPluginLatest": {
+                "version": "test"
+              },
+              "jbLauncher": {
+                "version": "test"
+              }
+            }
+          },
+          "wsDaemon": {
+            "version": "test",
+            "userNamespaces": {
+              "seccompProfileInstaller": {
+                "version": "test"
+              },
+              "shiftfsModuleLoader": {
+                "version": "test"
+              }
+            }
+          },
+          "wsManager": {
+            "version": "test"
+          },
+          "wsManagerBridge": {
+            "version": "test"
+          },
+          "wsProxy": {
+            "version": "test"
+          }
+        }
+      }
+    }
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: gitpod
+  name: gitpod
+  namespace: default
+---
+# v1/ConfigMap gitpod-app
+apiVersion: v1
+data:
+  app.yaml: |
+    apiVersion: cert-manager.io/v1
+    kind: Certificate
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: docker-registry
+      name: builtin-registry-certs
+      namespace: default
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: docker-registry
+      name: docker-registry
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: docker-registry
+      name: builtin-registry-auth
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: docker-registry
+      name: docker-registry
+      namespace: default
+    ---
+    apiVersion: cert-manager.io/v1
+    kind: Issuer
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: cluster
+      name: gitpod-selfsigned-issuer
+      namespace: default
+    ---
+    apiVersion: cert-manager.io/v1
+    kind: Certificate
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: cluster
+      name: ca-issuer-ca
+      namespace: default
+    ---
+    apiVersion: cert-manager.io/v1
+    kind: Issuer
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: cluster
+      name: ca-issuer
+      namespace: default
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      creationTimestamp: null
+      name: default-kube-rbac-proxy
+    ---
+    apiVersion: v1
+    kind: ResourceQuota
+    metadata:
+      creationTimestamp: null
+      name: gitpod-resource-quota
+      namespace: default
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      creationTimestamp: null
+      name: default-ns-nobody
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: nobody
+      name: nobody
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: gitpod
+      name: gitpod
+      namespace: default
+    ---
+    apiVersion: batch/v1
+    kind: CronJob
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: gitpod
+      name: gitpod-telemetry
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: gitpod
+      name: gitpod
+      namespace: default
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: gitpod
+      name: gitpod
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: blobserve
+      name: blobserve
+      namespace: default
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: blobserve
+      name: blobserve
+      namespace: default
+    ---
+    apiVersion: networking.k8s.io/v1
+    kind: NetworkPolicy
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: blobserve
+      name: blobserve
+      namespace: default
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: blobserve
+      name: blobserve
+      namespace: default
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: blobserve
+      name: default-blobserve-kube-rbac-proxy
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: blobserve
+        kind: service
+      name: blobserve
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: blobserve
+      name: blobserve
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ide-metrics
+      name: ide-metrics
+      namespace: default
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ide-metrics
+      name: ide-metrics
+      namespace: default
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ide-metrics
+      name: default-ide-metrics-kube-rbac-proxy
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ide-metrics
+      name: ide-metrics
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ide-metrics
+      name: ide-metrics
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ide-metrics
+        kind: service
+      name: ide-metrics
+      namespace: default
+    ---
+    apiVersion: networking.k8s.io/v1
+    kind: NetworkPolicy
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ide-metrics
+      name: ide-metrics
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ide-metrics
+      name: ide-metrics
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ide-service
+      name: ide-service
+      namespace: default
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ide-service
+      name: ide-service
+      namespace: default
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ide-service
+      name: default-ide-service-kube-rbac-proxy
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ide-service
+      name: ide-service
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ide-service
+      name: ide-service
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ide-service
+        kind: service
+      name: ide-service
+      namespace: default
+    ---
+    apiVersion: networking.k8s.io/v1
+    kind: NetworkPolicy
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ide-service
+      name: ide-service
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ide-service
+      name: ide-config
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: server
+      name: server-ide-config
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ide-service
+      name: ide-service
+      namespace: default
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ide-proxy
+      name: ide-proxy
+      namespace: default
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ide-proxy
+      name: ide-proxy
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ide-proxy
+        kind: service
+      name: ide-proxy
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ide-proxy
+      name: ide-proxy
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: openvsx-proxy
+      name: openvsx-proxy-config
+      namespace: default
+    ---
+    apiVersion: networking.k8s.io/v1
+    kind: NetworkPolicy
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: openvsx-proxy
+      name: openvsx-proxy
+      namespace: default
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: openvsx-proxy
+      name: openvsx-proxy
+      namespace: default
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: openvsx-proxy
+      name: default-openvsx-proxy-kube-rbac-proxy
+    ---
+    apiVersion: apps/v1
+    kind: StatefulSet
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: openvsx-proxy
+      name: openvsx-proxy
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: openvsx-proxy
+        kind: service
+      name: openvsx-proxy
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: openvsx-proxy
+      name: openvsx-proxy
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: iam
+      name: iam
+      namespace: default
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      annotations:
+        gitpod.io/checksum_config: 7346723d23891c253f282241ed24e225e16dd2ddafa9b7c90d1da928a4923f4b
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: iam
+      name: iam
+      namespace: default
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: iam
+      name: default-iam-rb-kube-rbac-proxy
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: iam
+      name: iam
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: iam
+      name: iam
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: iam
+        kind: service
+      name: iam
+      namespace: default
+    ---
+    apiVersion: networking.k8s.io/v1
+    kind: NetworkPolicy
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: iam
+      name: iam
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: content-service
+      name: content-service
+      namespace: default
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: content-service
+      name: content-service
+      namespace: default
+    ---
+    apiVersion: networking.k8s.io/v1
+    kind: NetworkPolicy
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: content-service
+      name: content-service
+      namespace: default
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: content-service
+      name: content-service
+      namespace: default
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: content-service
+      name: default-content-service-rb-kube-rbac-proxy
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: content-service
+        kind: service
+      name: content-service
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: content-service
+      name: content-service
+      namespace: default
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: dashboard
+      name: dashboard
+      namespace: default
+    ---
+    apiVersion: networking.k8s.io/v1
+    kind: NetworkPolicy
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: dashboard
+      name: dashboard-deny-all-allow-explicit
+      namespace: default
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: dashboard
+      name: dashboard
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: dashboard
+        kind: service
+      name: dashboard
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: dashboard
+      name: dashboard
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: db
+      name: db-init-scripts
+      namespace: default
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: db
+      name: db
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: db
+      name: db-password
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: db
+      name: mysql
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: db
+      name: db
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: db
+      name: db
+      namespace: default
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: migrations
+      name: migrations
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: migrations
+      name: migrations
+      namespace: default
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: minio
+      name: minio
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: proxy
+      name: proxy-config
+      namespace: default
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: proxy
+      name: proxy
+      namespace: default
+    ---
+    apiVersion: networking.k8s.io/v1
+    kind: NetworkPolicy
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: proxy
+      name: proxy-deny-all-allow-explicit
+      namespace: default
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: proxy
+      name: proxy
+      namespace: default
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: proxy
+      name: default-proxy-kube-rbac-proxy
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      annotations:
+        cloud.google.com/neg: '{"exposed_ports": {"80":{},"443": {}}}'
+        external-dns.alpha.kubernetes.io/hostname: gitpod.example.com,*.gitpod.example.com,*.ws.gitpod.example.com
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: proxy
+        kind: service
+      name: proxy
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: proxy
+      name: proxy
+      namespace: default
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: rabbitmq
+      name: rabbitmq
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: rabbitmq
+      name: messagebus-erlang-cookie
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: rabbitmq
+      name: messagebus-certificates-secret-core
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: server
+      name: server-config
+      namespace: default
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: server
+      name: server
+      namespace: default
+    ---
+    apiVersion: networking.k8s.io/v1
+    kind: NetworkPolicy
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: server
+      name: server
+      namespace: default
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: server
+      name: server
+      namespace: default
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: server
+      name: server
+      namespace: default
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: server
+      name: default-server-rb-kube-rbac-proxy
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: server
+      name: server-unprivileged
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: server
+        kind: service
+      name: server
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: server
+      name: server
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ws-manager-bridge
+      name: ws-manager-bridge-config
+      namespace: default
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ws-manager-bridge
+      name: ws-manager-bridge
+      namespace: default
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ws-manager-bridge
+      name: default-ws-manager-bridge-rb-kube-rbac-proxy
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ws-manager-bridge
+      name: ws-manager-bridge
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ws-manager-bridge
+      name: ws-manager-bridge
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: public-api-server
+      name: public-api-server
+      namespace: default
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      annotations:
+        gitpod.io/checksum_config: 74ab9c5d2ac7f57832d1df15f9764c3abfc450f45beb9a31d8aefb9bcf1aaea8
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: public-api-server
+      name: public-api-server
+      namespace: default
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: public-api-server
+      name: default-public-api-server-rb-kube-rbac-proxy
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: public-api-server
+      name: public-api-server
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: public-api-server
+      name: public-api-server
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: public-api-server
+        kind: service
+      name: public-api-server
+      namespace: default
+    ---
+    apiVersion: networking.k8s.io/v1
+    kind: NetworkPolicy
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: public-api-server
+      name: public-api-server
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: agent-smith
+      name: agent-smith
+      namespace: default
+    ---
+    apiVersion: apps/v1
+    kind: DaemonSet
+    metadata:
+      annotations:
+        gitpod.io/checksum_config: e5f1dd2a1327394b4bef4172c43487842026ef965fe8cec2475f00b1588de01f
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: agent-smith
+      name: agent-smith
+      namespace: default
+    ---
+    apiVersion: networking.k8s.io/v1
+    kind: NetworkPolicy
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: agent-smith
+      name: agent-smith
+      namespace: default
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: agent-smith
+      name: agent-smith
+      namespace: default
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: agent-smith
+      name: agent-smith
+      namespace: default
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: agent-smith
+      name: default-agent-smith-rb-kube-rbac-proxy
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: agent-smith
+      name: agent-smith
+      namespace: default
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: registry-facade
+      name: default-ns-registry-facade
+    ---
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: registry-facade
+      name: registry-facade
+      namespace: default
+    ---
+    apiVersion: apps/v1
+    kind: DaemonSet
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: registry-facade
+      name: registry-facade
+      namespace: default
+    ---
+    apiVersion: networking.k8s.io/v1
+    kind: NetworkPolicy
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: registry-facade
+      name: registry-facade
+      namespace: default
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: registry-facade
+      name: default-registry-facade-rb
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: registry-facade
+      name: default-registry-facade-kube-rbac-proxy
+    ---
+    apiVersion: cert-manager.io/v1
+    kind: Certificate
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: registry-facade
+      name: builtin-registry-facade-cert
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: registry-facade
+        kind: service
+      name: registry-facade
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: registry-facade
+      name: registry-facade
+      namespace: default
+    ---
+    apiVersion: networking.k8s.io/v1
+    kind: NetworkPolicy
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: workspace
+      name: workspace-default
+      namespace: default
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: workspace
+      name: workspace
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: workspace
+      name: workspace
+      namespace: default
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ws-daemon
+      name: default-ns-ws-daemon
+    ---
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ws-daemon
+      name: ws-daemon
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ws-daemon
+      name: ws-daemon
+      namespace: default
+    ---
+    apiVersion: apps/v1
+    kind: DaemonSet
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ws-daemon
+      name: ws-daemon
+      namespace: default
+    ---
+    apiVersion: networking.k8s.io/v1
+    kind: NetworkPolicy
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ws-daemon
+      name: ws-daemon
+      namespace: default
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ws-daemon
+      name: default-ws-daemon-rb-kube-rbac-proxy
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ws-daemon
+      name: default-ws-daemon-rb
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ws-daemon
+        kind: service
+      name: ws-daemon
+      namespace: default
+    ---
+    apiVersion: cert-manager.io/v1
+    kind: Certificate
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ws-daemon
+      name: ws-daemon-tls
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ws-manager
+      name: ws-manager
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ws-manager
+      name: workspace-templates
+      namespace: default
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ws-manager
+      name: ws-manager
+      namespace: default
+    ---
+    apiVersion: networking.k8s.io/v1
+    kind: NetworkPolicy
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ws-manager
+      name: ws-manager
+      namespace: default
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ws-manager
+      name: ws-manager
+      namespace: default
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ws-manager
+      name: ws-manager
+      namespace: default
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ws-manager
+      name: default-ws-manager-kube-rbac-proxy
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ws-manager
+      name: ws-manager
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ws-manager
+      name: ws-manager
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ws-manager
+      name: ws-manager
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ws-manager
+        kind: service
+      name: ws-manager
+      namespace: default
+    ---
+    apiVersion: cert-manager.io/v1
+    kind: Certificate
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ws-manager
+      name: ws-manager-tls
+      namespace: default
+    ---
+    apiVersion: cert-manager.io/v1
+    kind: Certificate
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ws-manager
+      name: ws-manager
+      namespace: default
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ws-manager
+      name: ws-manager-unpriviledged
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ws-proxy
+      name: ws-proxy
+      namespace: default
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ws-proxy
+      name: ws-proxy
+      namespace: default
+    ---
+    apiVersion: networking.k8s.io/v1
+    kind: NetworkPolicy
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ws-proxy
+      name: ws-proxy
+      namespace: default
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ws-proxy
+      name: default-ws-proxy-kube-rbac-proxy
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ws-proxy
+      name: ws-proxy
+      namespace: default
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ws-proxy
+      name: ws-proxy-api
+      namespace: default
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ws-proxy
+      name: ws-proxy
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ws-proxy
+        kind: service
+      name: ws-proxy
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ws-proxy
+      name: ws-proxy
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: image-builder-mk3
+      name: image-builder-mk3-config
+      namespace: default
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: image-builder-mk3
+      name: image-builder-mk3
+      namespace: default
+    ---
+    apiVersion: networking.k8s.io/v1
+    kind: NetworkPolicy
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: image-builder-mk3
+      name: image-builder-mk3
+      namespace: default
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: image-builder-mk3
+      name: image-builder-mk3
+      namespace: default
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: image-builder-mk3
+      name: default-image-builder-mk3-proxy-kube-rbac-proxy
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: image-builder-mk3
+        kind: service
+      name: image-builder-mk3
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: image-builder-mk3
+      name: image-builder-mk3
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: docker-registry
+        chart: docker-registry-1.16.0
+        heritage: Helm
+        release: docker-registry
+      name: registry-secret
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: docker-registry
+        chart: docker-registry-1.16.0
+        heritage: Helm
+        release: docker-registry
+      name: registry-config
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: registry
+        chart: docker-registry-1.16.0
+        heritage: Helm
+        release: docker-registry
+      name: registry
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: docker-registry
+        chart: docker-registry-1.16.0
+        heritage: Helm
+        release: docker-registry
+      name: registry
+      namespace: default
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: docker-registry
+        chart: docker-registry-1.16.0
+        heritage: Helm
+        release: docker-registry
+      name: registry
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      creationTimestamp: null
+      labels:
+        app.kubernetes.io/component: primary
+        app.kubernetes.io/instance: mysql
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: mysql
+        helm.sh/chart: mysql-9.1.2
+      name: mysql
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      creationTimestamp: null
+      labels:
+        app.kubernetes.io/component: primary
+        app.kubernetes.io/instance: mysql
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: mysql
+        helm.sh/chart: mysql-9.1.2
+      name: mysql-headless
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      creationTimestamp: null
+      labels:
+        app.kubernetes.io/component: primary
+        app.kubernetes.io/instance: mysql
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: mysql
+        helm.sh/chart: mysql-9.1.2
+      name: mysql
+      namespace: default
+    ---
+    apiVersion: apps/v1
+    kind: StatefulSet
+    metadata:
+      creationTimestamp: null
+      labels:
+        app.kubernetes.io/component: primary
+        app.kubernetes.io/instance: mysql
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: mysql
+        helm.sh/chart: mysql-9.1.2
+      name: mysql
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      creationTimestamp: null
+      labels:
+        app.kubernetes.io/instance: minio
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: minio
+        helm.sh/chart: minio-11.6.3
+      name: minio
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      creationTimestamp: null
+      labels:
+        app.kubernetes.io/instance: minio
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: minio
+        helm.sh/chart: minio-11.6.3
+      name: minio
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      creationTimestamp: null
+      labels:
+        app.kubernetes.io/instance: minio
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: minio
+        helm.sh/chart: minio-11.6.3
+      name: minio
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      creationTimestamp: null
+      labels:
+        app.kubernetes.io/instance: minio
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: minio
+        helm.sh/chart: minio-11.6.3
+      name: minio
+      namespace: default
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      creationTimestamp: null
+      labels:
+        app.kubernetes.io/instance: minio
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: minio
+        helm.sh/chart: minio-11.6.3
+      name: minio
+      namespace: default
+    ---
+    apiVersion: networking.k8s.io/v1
+    kind: NetworkPolicy
+    metadata:
+      creationTimestamp: null
+      labels:
+        app.kubernetes.io/instance: rabbitmq
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: rabbitmq
+        helm.sh/chart: rabbitmq-10.1.1
+      name: messagebus
+      namespace: default
+    ---
+    apiVersion: policy/v1
+    kind: PodDisruptionBudget
+    metadata:
+      creationTimestamp: null
+      labels:
+        app.kubernetes.io/instance: rabbitmq
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: rabbitmq
+        helm.sh/chart: rabbitmq-10.1.1
+      name: messagebus
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      creationTimestamp: null
+      labels:
+        app.kubernetes.io/instance: rabbitmq
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: rabbitmq
+        helm.sh/chart: rabbitmq-10.1.1
+      name: rabbitmq
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      creationTimestamp: null
+      labels:
+        app.kubernetes.io/instance: rabbitmq
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: rabbitmq
+        helm.sh/chart: rabbitmq-10.1.1
+      name: messagebus-config
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      creationTimestamp: null
+      labels:
+        app.kubernetes.io/instance: rabbitmq
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: rabbitmq
+        helm.sh/chart: rabbitmq-10.1.1
+      name: messagebus
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      creationTimestamp: null
+      labels:
+        app.kubernetes.io/instance: rabbitmq
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: rabbitmq
+        helm.sh/chart: rabbitmq-10.1.1
+      name: load-definition
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      creationTimestamp: null
+      labels:
+        app.kubernetes.io/instance: rabbitmq
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: rabbitmq
+        helm.sh/chart: rabbitmq-10.1.1
+      name: rabbitmq
+      namespace: default
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      creationTimestamp: null
+      labels:
+        app.kubernetes.io/instance: rabbitmq
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: rabbitmq
+        helm.sh/chart: rabbitmq-10.1.1
+      name: messagebus-endpoint-reader
+      namespace: default
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      creationTimestamp: null
+      labels:
+        app.kubernetes.io/instance: rabbitmq
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: rabbitmq
+        helm.sh/chart: rabbitmq-10.1.1
+      name: messagebus-endpoint-reader
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      creationTimestamp: null
+      labels:
+        app.kubernetes.io/instance: rabbitmq
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: rabbitmq
+        helm.sh/chart: rabbitmq-10.1.1
+      name: messagebus-headless
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      creationTimestamp: null
+      labels:
+        app.kubernetes.io/instance: rabbitmq
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: rabbitmq
+        helm.sh/chart: rabbitmq-10.1.1
+      name: messagebus
+      namespace: default
+    ---
+    apiVersion: apps/v1
+    kind: StatefulSet
+    metadata:
+      creationTimestamp: null
+      labels:
+        app.kubernetes.io/instance: rabbitmq
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: rabbitmq
+        helm.sh/chart: rabbitmq-10.1.1
+      name: messagebus
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: gitpod-app
+      name: gitpod-app
+      namespace: default
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: gitpod-app
+  name: gitpod-app
+  namespace: default
+
+---
+# v1/ConfigMap iam
+apiVersion: v1
+data:
+  config.json: |-
+    {
+      "server": {
+        "services": {
+          "grpc": {
+            "address": "0.0.0.0:9001"
+          },
+          "http": {
+            "address": "0.0.0.0:9002"
+          }
+        }
+      },
+      "databaseConfigPath": "/secrets/database-config"
+    }
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: iam
+  name: iam
+  namespace: default
+---
+# v1/ConfigMap ide-config
+apiVersion: v1
+data:
+  config.json: |-
+    {
+      "gpRunImage": "registry.hub.docker.com/gitpod/gp-run:latest",
+      "supervisorImage": "registry.mydomain.com/namespace/supervisor:test",
+      "ideOptions": {
+        "options": {
+          "clion": {
+            "orderKey": "11",
+            "title": "CLion",
+            "type": "desktop",
+            "logo": "https://ide.gitpod.example.com/image/ide-logo/clionLogo.svg",
+            "image": "registry.mydomain.com/namespace/ide/clion:test",
+            "latestImage": "registry.mydomain.com/namespace/ide/clion:latest",
+            "pluginImage": "registry.mydomain.com/namespace/ide/jb-backend-plugin:test",
+            "pluginLatestImage": "registry.mydomain.com/namespace/ide/jb-backend-plugin:latest",
+            "imageLayers": [
+              "registry.mydomain.com/namespace/ide/jb-backend-plugin:test",
+              "registry.mydomain.com/namespace/ide/jb-launcher:test"
+            ],
+            "latestImageLayers": [
+              "registry.mydomain.com/namespace/ide/jb-backend-plugin:latest",
+              "registry.mydomain.com/namespace/ide/jb-launcher:test"
+            ]
+          },
+          "code": {
+            "orderKey": "00",
+            "title": "VS Code",
+            "type": "browser",
+            "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
+            "label": "Browser",
+            "image": "registry.mydomain.com/namespace/ide/code:commit-fdf6a08a681c53ddd97c7bae9acc7d49158a41a0",
+            "latestImage": "registry.mydomain.com/namespace/ide/code:nightly"
+          },
+          "code-desktop": {
+            "orderKey": "02",
+            "title": "VS Code",
+            "type": "desktop",
+            "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
+            "image": "registry.mydomain.com/namespace/ide/code-desktop:test",
+            "latestImage": "registry.mydomain.com/namespace/ide/code-desktop-insiders:test"
+          },
+          "goland": {
+            "orderKey": "05",
+            "title": "GoLand",
+            "type": "desktop",
+            "logo": "https://ide.gitpod.example.com/image/ide-logo/golandLogo.svg",
+            "image": "registry.mydomain.com/namespace/ide/goland:test",
+            "latestImage": "registry.mydomain.com/namespace/ide/goland:latest",
+            "pluginImage": "registry.mydomain.com/namespace/ide/jb-backend-plugin:test",
+            "pluginLatestImage": "registry.mydomain.com/namespace/ide/jb-backend-plugin:latest",
+            "imageLayers": [
+              "registry.mydomain.com/namespace/ide/jb-backend-plugin:test",
+              "registry.mydomain.com/namespace/ide/jb-launcher:test"
+            ],
+            "latestImageLayers": [
+              "registry.mydomain.com/namespace/ide/jb-backend-plugin:latest",
+              "registry.mydomain.com/namespace/ide/jb-launcher:test"
+            ]
+          },
+          "intellij": {
+            "orderKey": "04",
+            "title": "IntelliJ IDEA",
+            "type": "desktop",
+            "logo": "https://ide.gitpod.example.com/image/ide-logo/intellijIdeaLogo.svg",
+            "label": "Ultimate",
+            "image": "registry.mydomain.com/namespace/ide/intellij:test",
+            "latestImage": "registry.mydomain.com/namespace/ide/intellij:latest",
+            "pluginImage": "registry.mydomain.com/namespace/ide/jb-backend-plugin:test",
+            "pluginLatestImage": "registry.mydomain.com/namespace/ide/jb-backend-plugin:latest",
+            "imageLayers": [
+              "registry.mydomain.com/namespace/ide/jb-backend-plugin:test",
+              "registry.mydomain.com/namespace/ide/jb-launcher:test"
+            ],
+            "latestImageLayers": [
+              "registry.mydomain.com/namespace/ide/jb-backend-plugin:latest",
+              "registry.mydomain.com/namespace/ide/jb-launcher:test"
+            ]
+          },
+          "phpstorm": {
+            "orderKey": "07",
+            "title": "PhpStorm",
+            "type": "desktop",
+            "logo": "https://ide.gitpod.example.com/image/ide-logo/phpstormLogo.svg",
+            "image": "registry.mydomain.com/namespace/ide/phpstorm:test",
+            "latestImage": "registry.mydomain.com/namespace/ide/phpstorm:latest",
+            "pluginImage": "registry.mydomain.com/namespace/ide/jb-backend-plugin:test",
+            "pluginLatestImage": "registry.mydomain.com/namespace/ide/jb-backend-plugin:latest",
+            "imageLayers": [
+              "registry.mydomain.com/namespace/ide/jb-backend-plugin:test",
+              "registry.mydomain.com/namespace/ide/jb-launcher:test"
+            ],
+            "latestImageLayers": [
+              "registry.mydomain.com/namespace/ide/jb-backend-plugin:latest",
+              "registry.mydomain.com/namespace/ide/jb-launcher:test"
+            ]
+          },
+          "pycharm": {
+            "orderKey": "06",
+            "title": "PyCharm",
+            "type": "desktop",
+            "logo": "https://ide.gitpod.example.com/image/ide-logo/pycharmLogo.svg",
+            "label": "Professional",
+            "image": "registry.mydomain.com/namespace/ide/pycharm:test",
+            "latestImage": "registry.mydomain.com/namespace/ide/pycharm:latest",
+            "pluginImage": "registry.mydomain.com/namespace/ide/jb-backend-plugin:test",
+            "pluginLatestImage": "registry.mydomain.com/namespace/ide/jb-backend-plugin:latest",
+            "imageLayers": [
+              "registry.mydomain.com/namespace/ide/jb-backend-plugin:test",
+              "registry.mydomain.com/namespace/ide/jb-launcher:test"
+            ],
+            "latestImageLayers": [
+              "registry.mydomain.com/namespace/ide/jb-backend-plugin:latest",
+              "registry.mydomain.com/namespace/ide/jb-launcher:test"
+            ]
+          },
+          "rider": {
+            "orderKey": "10",
+            "title": "Rider",
+            "type": "desktop",
+            "logo": "https://ide.gitpod.example.com/image/ide-logo/riderLogo.svg",
+            "image": "registry.mydomain.com/namespace/ide/rider:test",
+            "latestImage": "registry.mydomain.com/namespace/ide/rider:latest",
+            "pluginImage": "registry.mydomain.com/namespace/ide/jb-backend-plugin:test",
+            "pluginLatestImage": "registry.mydomain.com/namespace/ide/jb-backend-plugin:latest",
+            "imageLayers": [
+              "registry.mydomain.com/namespace/ide/jb-backend-plugin:test",
+              "registry.mydomain.com/namespace/ide/jb-launcher:test"
+            ],
+            "latestImageLayers": [
+              "registry.mydomain.com/namespace/ide/jb-backend-plugin:latest",
+              "registry.mydomain.com/namespace/ide/jb-launcher:test"
+            ]
+          },
+          "rubymine": {
+            "orderKey": "08",
+            "title": "RubyMine",
+            "type": "desktop",
+            "logo": "https://ide.gitpod.example.com/image/ide-logo/rubymineLogo.svg",
+            "image": "registry.mydomain.com/namespace/ide/rubymine:test",
+            "latestImage": "registry.mydomain.com/namespace/ide/rubymine:latest",
+            "pluginImage": "registry.mydomain.com/namespace/ide/jb-backend-plugin:test",
+            "pluginLatestImage": "registry.mydomain.com/namespace/ide/jb-backend-plugin:latest",
+            "imageLayers": [
+              "registry.mydomain.com/namespace/ide/jb-backend-plugin:test",
+              "registry.mydomain.com/namespace/ide/jb-launcher:test"
+            ],
+            "latestImageLayers": [
+              "registry.mydomain.com/namespace/ide/jb-backend-plugin:latest",
+              "registry.mydomain.com/namespace/ide/jb-launcher:test"
+            ]
+          },
+          "webstorm": {
+            "orderKey": "09",
+            "title": "WebStorm",
+            "type": "desktop",
+            "logo": "https://ide.gitpod.example.com/image/ide-logo/webstormLogo.svg",
+            "image": "registry.mydomain.com/namespace/ide/webstorm:test",
+            "latestImage": "registry.mydomain.com/namespace/ide/webstorm:latest",
+            "pluginImage": "registry.mydomain.com/namespace/ide/jb-backend-plugin:test",
+            "pluginLatestImage": "registry.mydomain.com/namespace/ide/jb-backend-plugin:latest",
+            "imageLayers": [
+              "registry.mydomain.com/namespace/ide/jb-backend-plugin:test",
+              "registry.mydomain.com/namespace/ide/jb-launcher:test"
+            ],
+            "latestImageLayers": [
+              "registry.mydomain.com/namespace/ide/jb-backend-plugin:latest",
+              "registry.mydomain.com/namespace/ide/jb-launcher:test"
+            ]
+          }
+        },
+        "defaultIde": "code",
+        "defaultDesktopIde": "code-desktop",
+        "clients": {
+          "jetbrains-gateway": {
+            "defaultDesktopIDE": "intellij",
+            "desktopIDEs": [
+              "intellij",
+              "goland",
+              "pycharm",
+              "phpstorm",
+              "rubymine",
+              "webstorm",
+              "rider",
+              "clion"
+            ],
+            "installationSteps": [
+              "If you don't see an open dialog in your browser, make sure you have the \u003ca target='_blank' class='gp-link' href='https://www.gitpod.io/docs/ides-and-editors/jetbrains-gateway#getting-started-jetbrains-gateway'\u003eJetBrains Gateway with Gitpod Plugin\u003c/a\u003e installed on your machine, and then click \u003cb\u003e${OPEN_LINK_LABEL}\u003c/b\u003e below."
+            ]
+          },
+          "vscode": {
+            "defaultDesktopIDE": "code-desktop",
+            "desktopIDEs": [
+              "code-desktop"
+            ],
+            "installationSteps": [
+              "If you don't see an open dialog in your browser, make sure you have \u003ca target='_blank' class='gp-link' href='https://code.visualstudio.com/download'\u003eVS Code\u003c/a\u003e installed on your machine, and then click \u003cb\u003e${OPEN_LINK_LABEL}\u003c/b\u003e below."
+            ]
+          },
+          "vscode-insiders": {
+            "defaultDesktopIDE": "code-desktop",
+            "desktopIDEs": [
+              "code-desktop"
+            ],
+            "installationSteps": [
+              "If you don't see an open dialog in your browser, make sure you have \u003ca target='_blank' class='gp-link' href='https://code.visualstudio.com/insiders'\u003eVS Code Insiders\u003c/a\u003e installed on your machine, and then click \u003cb\u003e${OPEN_LINK_LABEL}\u003c/b\u003e below."
+            ]
+          }
+        }
+      }
+    }
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ide-service
+  name: ide-config
+  namespace: default
+---
+# v1/ConfigMap ide-metrics
+apiVersion: v1
+data:
+  config.json: |-
+    {
+      "server": {
+        "port": 3000,
+        "ratelimits": null,
+        "counterMetrics": [
+          {
+            "name": "grpc_server_handled_total",
+            "help": "Total number of RPCs completed on the server, regardless of success or failure.",
+            "labels": [
+              {
+                "name": "grpc_method",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "grpc_service",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "grpc_type",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "grpc_code",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              }
+            ]
+          },
+          {
+            "name": "grpc_server_msg_received_total",
+            "help": "Total number of RPC stream messages received on the server.",
+            "labels": [
+              {
+                "name": "grpc_method",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "grpc_service",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "grpc_type",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              }
+            ]
+          },
+          {
+            "name": "grpc_server_msg_sent_total",
+            "help": "Total number of gRPC stream messages sent by the server.",
+            "labels": [
+              {
+                "name": "grpc_method",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "grpc_service",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "grpc_type",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              }
+            ]
+          },
+          {
+            "name": "grpc_server_started_total",
+            "help": "Total number of RPCs started on the server",
+            "labels": [
+              {
+                "name": "grpc_method",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "grpc_service",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "grpc_type",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              }
+            ]
+          },
+          {
+            "name": "gitpod_supervisor_frontend_error_total",
+            "help": "Total count of supervisor frontend client errors",
+            "labels": [
+              {
+                "name": "resource",
+                "allowValues": [
+                  "vscode-web-workbench",
+                  "unknown"
+                ],
+                "defaultValue": "unknown"
+              },
+              {
+                "name": "error",
+                "allowValues": [
+                  "LoadError",
+                  "Unknown"
+                ],
+                "defaultValue": "Unknown"
+              }
+            ]
+          },
+          {
+            "name": "gitpod_vscode_web_load_total",
+            "help": "Total count of attempts to load VS Code Web workbench",
+            "labels": [
+              {
+                "name": "status",
+                "allowValues": [
+                  "loading",
+                  "failed"
+                ],
+                "defaultValue": ""
+              }
+            ]
+          },
+          {
+            "name": "gitpod_supervisor_frontend_client_total",
+            "help": "Total count of supervisor frontend client",
+            "labels": null
+          },
+          {
+            "name": "gitpod_vscode_extension_gallery_operation_total",
+            "help": "Total count of extension operations",
+            "labels": [
+              {
+                "name": "operation",
+                "allowValues": [
+                  "install",
+                  "update",
+                  "uninstall",
+                  "unknown"
+                ],
+                "defaultValue": "unknown"
+              },
+              {
+                "name": "status",
+                "allowValues": [
+                  "success",
+                  "failure",
+                  "unknown"
+                ],
+                "defaultValue": "unknown"
+              },
+              {
+                "name": "galleryHost",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              }
+            ]
+          },
+          {
+            "name": "gitpod_vscode_extension_gallery_query_total",
+            "help": "Total count of extension gallery queries",
+            "labels": [
+              {
+                "name": "status",
+                "allowValues": [
+                  "success",
+                  "failure",
+                  "unknown"
+                ],
+                "defaultValue": "unknown"
+              },
+              {
+                "name": "statusCode",
+                "allowValues": [
+                  "100",
+                  "101",
+                  "102",
+                  "103",
+                  "104",
+                  "105",
+                  "106",
+                  "107",
+                  "108",
+                  "109",
+                  "110",
+                  "111",
+                  "112",
+                  "113",
+                  "114",
+                  "115",
+                  "116",
+                  "117",
+                  "118",
+                  "119",
+                  "120",
+                  "121",
+                  "122",
+                  "123",
+                  "124",
+                  "125",
+                  "126",
+                  "127",
+                  "128",
+                  "129",
+                  "130",
+                  "131",
+                  "132",
+                  "133",
+                  "134",
+                  "135",
+                  "136",
+                  "137",
+                  "138",
+                  "139",
+                  "140",
+                  "141",
+                  "142",
+                  "143",
+                  "144",
+                  "145",
+                  "146",
+                  "147",
+                  "148",
+                  "149",
+                  "150",
+                  "151",
+                  "152",
+                  "153",
+                  "154",
+                  "155",
+                  "156",
+                  "157",
+                  "158",
+                  "159",
+                  "160",
+                  "161",
+                  "162",
+                  "163",
+                  "164",
+                  "165",
+                  "166",
+                  "167",
+                  "168",
+                  "169",
+                  "170",
+                  "171",
+                  "172",
+                  "173",
+                  "174",
+                  "175",
+                  "176",
+                  "177",
+                  "178",
+                  "179",
+                  "180",
+                  "181",
+                  "182",
+                  "183",
+                  "184",
+                  "185",
+                  "186",
+                  "187",
+                  "188",
+                  "189",
+                  "190",
+                  "191",
+                  "192",
+                  "193",
+                  "194",
+                  "195",
+                  "196",
+                  "197",
+                  "198",
+                  "199",
+                  "200",
+                  "201",
+                  "202",
+                  "203",
+                  "204",
+                  "205",
+                  "206",
+                  "207",
+                  "208",
+                  "209",
+                  "210",
+                  "211",
+                  "212",
+                  "213",
+                  "214",
+                  "215",
+                  "216",
+                  "217",
+                  "218",
+                  "219",
+                  "220",
+                  "221",
+                  "222",
+                  "223",
+                  "224",
+                  "225",
+                  "226",
+                  "227",
+                  "228",
+                  "229",
+                  "230",
+                  "231",
+                  "232",
+                  "233",
+                  "234",
+                  "235",
+                  "236",
+                  "237",
+                  "238",
+                  "239",
+                  "240",
+                  "241",
+                  "242",
+                  "243",
+                  "244",
+                  "245",
+                  "246",
+                  "247",
+                  "248",
+                  "249",
+                  "250",
+                  "251",
+                  "252",
+                  "253",
+                  "254",
+                  "255",
+                  "256",
+                  "257",
+                  "258",
+                  "259",
+                  "260",
+                  "261",
+                  "262",
+                  "263",
+                  "264",
+                  "265",
+                  "266",
+                  "267",
+                  "268",
+                  "269",
+                  "270",
+                  "271",
+                  "272",
+                  "273",
+                  "274",
+                  "275",
+                  "276",
+                  "277",
+                  "278",
+                  "279",
+                  "280",
+                  "281",
+                  "282",
+                  "283",
+                  "284",
+                  "285",
+                  "286",
+                  "287",
+                  "288",
+                  "289",
+                  "290",
+                  "291",
+                  "292",
+                  "293",
+                  "294",
+                  "295",
+                  "296",
+                  "297",
+                  "298",
+                  "299",
+                  "300",
+                  "301",
+                  "302",
+                  "303",
+                  "304",
+                  "305",
+                  "306",
+                  "307",
+                  "308",
+                  "309",
+                  "310",
+                  "311",
+                  "312",
+                  "313",
+                  "314",
+                  "315",
+                  "316",
+                  "317",
+                  "318",
+                  "319",
+                  "320",
+                  "321",
+                  "322",
+                  "323",
+                  "324",
+                  "325",
+                  "326",
+                  "327",
+                  "328",
+                  "329",
+                  "330",
+                  "331",
+                  "332",
+                  "333",
+                  "334",
+                  "335",
+                  "336",
+                  "337",
+                  "338",
+                  "339",
+                  "340",
+                  "341",
+                  "342",
+                  "343",
+                  "344",
+                  "345",
+                  "346",
+                  "347",
+                  "348",
+                  "349",
+                  "350",
+                  "351",
+                  "352",
+                  "353",
+                  "354",
+                  "355",
+                  "356",
+                  "357",
+                  "358",
+                  "359",
+                  "360",
+                  "361",
+                  "362",
+                  "363",
+                  "364",
+                  "365",
+                  "366",
+                  "367",
+                  "368",
+                  "369",
+                  "370",
+                  "371",
+                  "372",
+                  "373",
+                  "374",
+                  "375",
+                  "376",
+                  "377",
+                  "378",
+                  "379",
+                  "380",
+                  "381",
+                  "382",
+                  "383",
+                  "384",
+                  "385",
+                  "386",
+                  "387",
+                  "388",
+                  "389",
+                  "390",
+                  "391",
+                  "392",
+                  "393",
+                  "394",
+                  "395",
+                  "396",
+                  "397",
+                  "398",
+                  "399",
+                  "400",
+                  "401",
+                  "402",
+                  "403",
+                  "404",
+                  "405",
+                  "406",
+                  "407",
+                  "408",
+                  "409",
+                  "410",
+                  "411",
+                  "412",
+                  "413",
+                  "414",
+                  "415",
+                  "416",
+                  "417",
+                  "418",
+                  "419",
+                  "420",
+                  "421",
+                  "422",
+                  "423",
+                  "424",
+                  "425",
+                  "426",
+                  "427",
+                  "428",
+                  "429",
+                  "430",
+                  "431",
+                  "432",
+                  "433",
+                  "434",
+                  "435",
+                  "436",
+                  "437",
+                  "438",
+                  "439",
+                  "440",
+                  "441",
+                  "442",
+                  "443",
+                  "444",
+                  "445",
+                  "446",
+                  "447",
+                  "448",
+                  "449",
+                  "450",
+                  "451",
+                  "452",
+                  "453",
+                  "454",
+                  "455",
+                  "456",
+                  "457",
+                  "458",
+                  "459",
+                  "460",
+                  "461",
+                  "462",
+                  "463",
+                  "464",
+                  "465",
+                  "466",
+                  "467",
+                  "468",
+                  "469",
+                  "470",
+                  "471",
+                  "472",
+                  "473",
+                  "474",
+                  "475",
+                  "476",
+                  "477",
+                  "478",
+                  "479",
+                  "480",
+                  "481",
+                  "482",
+                  "483",
+                  "484",
+                  "485",
+                  "486",
+                  "487",
+                  "488",
+                  "489",
+                  "490",
+                  "491",
+                  "492",
+                  "493",
+                  "494",
+                  "495",
+                  "496",
+                  "497",
+                  "498",
+                  "499",
+                  "500",
+                  "501",
+                  "502",
+                  "503",
+                  "504",
+                  "505",
+                  "506",
+                  "507",
+                  "508",
+                  "509",
+                  "510",
+                  "511",
+                  "512",
+                  "513",
+                  "514",
+                  "515",
+                  "516",
+                  "517",
+                  "518",
+                  "519",
+                  "520",
+                  "521",
+                  "522",
+                  "523",
+                  "524",
+                  "525",
+                  "526",
+                  "527",
+                  "528",
+                  "529",
+                  "530",
+                  "531",
+                  "532",
+                  "533",
+                  "534",
+                  "535",
+                  "536",
+                  "537",
+                  "538",
+                  "539",
+                  "540",
+                  "541",
+                  "542",
+                  "543",
+                  "544",
+                  "545",
+                  "546",
+                  "547",
+                  "548",
+                  "549",
+                  "550",
+                  "551",
+                  "552",
+                  "553",
+                  "554",
+                  "555",
+                  "556",
+                  "557",
+                  "558",
+                  "559",
+                  "560",
+                  "561",
+                  "562",
+                  "563",
+                  "564",
+                  "565",
+                  "566",
+                  "567",
+                  "568",
+                  "569",
+                  "570",
+                  "571",
+                  "572",
+                  "573",
+                  "574",
+                  "575",
+                  "576",
+                  "577",
+                  "578",
+                  "579",
+                  "580",
+                  "581",
+                  "582",
+                  "583",
+                  "584",
+                  "585",
+                  "586",
+                  "587",
+                  "588",
+                  "589",
+                  "590",
+                  "591",
+                  "592",
+                  "593",
+                  "594",
+                  "595",
+                  "596",
+                  "597",
+                  "598",
+                  "599",
+                  "unknown"
+                ],
+                "defaultValue": "unknown"
+              },
+              {
+                "name": "errorCode",
+                "allowValues": [
+                  "canceled",
+                  "timeout",
+                  "failed",
+                  "unknown"
+                ],
+                "defaultValue": "unknown"
+              },
+              {
+                "name": "galleryHost",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              }
+            ]
+          },
+          {
+            "name": "grpc_client_started_total",
+            "help": "Total number of RPCs started on the client.",
+            "labels": [
+              {
+                "name": "grpc_method",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "grpc_service",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "grpc_type",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              }
+            ]
+          },
+          {
+            "name": "grpc_client_handled_total",
+            "help": "Total number of RPCs completed by the client, regardless of success or failure.",
+            "labels": [
+              {
+                "name": "grpc_method",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "grpc_service",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "grpc_type",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "grpc_code",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              }
+            ]
+          }
+        ],
+        "histogramMetrics": [
+          {
+            "name": "gitpod_vscode_extension_gallery_operation_duration_seconds",
+            "help": "Duration of extension operations in seconds",
+            "labels": [
+              {
+                "name": "operation",
+                "allowValues": [
+                  "install",
+                  "update",
+                  "uninstall",
+                  "unknown"
+                ],
+                "defaultValue": "unknown"
+              },
+              {
+                "name": "galleryHost",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              }
+            ],
+            "buckets": [
+              0.1,
+              0.5,
+              1,
+              5,
+              10,
+              15,
+              30
+            ]
+          },
+          {
+            "name": "gitpod_vscode_extension_gallery_query_duration_seconds",
+            "help": "Duration of extension gallery query in seconds",
+            "labels": [
+              {
+                "name": "galleryHost",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              }
+            ],
+            "buckets": [
+              0.1,
+              0.5,
+              1,
+              5,
+              10,
+              15,
+              30
+            ]
+          }
+        ],
+        "aggregatedHistogramMetrics": [
+          {
+            "name": "grpc_server_handling_seconds",
+            "help": "Histogram of response latency (seconds) of gRPC that had been application-level handled by the server.",
+            "labels": [
+              {
+                "name": "grpc_method",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "grpc_service",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "grpc_type",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              }
+            ],
+            "buckets": [
+              0.005,
+              0.025,
+              0.05,
+              0.1,
+              0.5,
+              1,
+              2.5,
+              5,
+              30,
+              60,
+              120,
+              240,
+              600
+            ]
+          },
+          {
+            "name": "supervisor_ide_ready_duration_total",
+            "help": "the IDE startup time",
+            "labels": [
+              {
+                "name": "kind",
+                "allowValues": [
+                  "web",
+                  "desktop"
+                ],
+                "defaultValue": ""
+              }
+            ],
+            "buckets": [
+              0.1,
+              0.5,
+              1,
+              1.5,
+              2,
+              2.5,
+              5,
+              10
+            ]
+          },
+          {
+            "name": "supervisor_initializer_bytes_second",
+            "help": "initializer speed in bytes per second",
+            "labels": [
+              {
+                "name": "kind",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              }
+            ],
+            "buckets": [
+              1048576,
+              2097152,
+              4194304,
+              8388608,
+              16777216,
+              33554432,
+              67108864,
+              134217728,
+              268435456,
+              536870912,
+              1073741824,
+              2147483648
+            ]
+          },
+          {
+            "name": "grpc_client_handling_seconds",
+            "help": "Histogram of response latency (seconds) of the gRPC until it is finished by the application.",
+            "labels": [
+              {
+                "name": "grpc_type",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "grpc_service",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              },
+              {
+                "name": "grpc_method",
+                "allowValues": [
+                  "*"
+                ],
+                "defaultValue": ""
+              }
+            ],
+            "buckets": [
+              0.1,
+              0.2,
+              0.5,
+              1,
+              2,
+              5,
+              10
+            ]
+          }
+        ],
+        "errorReporting": {
+          "allowComponents": [
+            "supervisor-frontend",
+            "vscode-workbench",
+            "vscode-server",
+            "vscode-web",
+            "gitpod-cli"
+          ]
+        }
+      },
+      "debug": false,
+      "pprof": {
+        "addr": ""
+      },
+      "prometheus": {
+        "addr": "127.0.0.1:9500"
+      }
+    }
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ide-metrics
+  name: ide-metrics
+  namespace: default
+---
+# v1/ConfigMap ide-service
+apiVersion: v1
+data:
+  config.json: |-
+    {
+      "server": {
+        "services": {
+          "grpc": {
+            "address": "0.0.0.0:9001"
+          }
+        }
+      },
+      "ideConfigPath": "/ide-config/config.json"
+    }
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ide-service
+  name: ide-service
+  namespace: default
+---
+# v1/ConfigMap image-builder-mk3-config
+apiVersion: v1
+data:
+  image-builder.json: |-
+    {
+      "orchestrator": {
+        "wsman": {
+          "address": "ws-manager:8080",
+          "tls": {
+            "ca": "/wsman-certs/ca.crt",
+            "crt": "/wsman-certs/tls.crt",
+            "key": "/wsman-certs/tls.key"
+          }
+        },
+        "pullSecret": "builtin-registry-auth",
+        "pullSecretFile": "/config/pull-secret/pull-secret.json",
+        "baseImageRepository": "registry.gitpod.example.com/base-images",
+        "workspaceImageRepository": "registry.gitpod.example.com/workspace-images",
+        "builderImage": "registry.mydomain.com/namespace/image-builder-mk3/bob:test"
+      },
+      "refCache": {
+        "interval": "6h0m0s",
+        "refs": [
+          "registry.mydomain.com/namespace/gitpod/workspace-full:latest"
+        ]
+      },
+      "server": {
+        "services": {
+          "grpc": {
+            "address": "0.0.0.0:8080"
+          }
+        }
+      }
+    }
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: image-builder-mk3
+  name: image-builder-mk3-config
+  namespace: default
+---
+# v1/ConfigMap mysql
+# Source: mysql/charts/mysql/templates/primary/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mysql
+  namespace: "default"
+  labels:
+    app.kubernetes.io/name: mysql
+    helm.sh/chart: mysql-9.1.2
+    app.kubernetes.io/instance: mysql
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: primary
+data:
+  my.cnf: |-
+    [mysqld]
+    default_authentication_plugin=mysql_native_password
+    skip-name-resolve
+    explicit_defaults_for_timestamp
+    basedir=/opt/bitnami/mysql
+    plugin_dir=/opt/bitnami/mysql/lib/plugin
+    port=3306
+    socket=/opt/bitnami/mysql/tmp/mysql.sock
+    datadir=/bitnami/mysql/data
+    tmpdir=/opt/bitnami/mysql/tmp
+    max_allowed_packet=16M
+    bind-address=0.0.0.0
+    pid-file=/opt/bitnami/mysql/tmp/mysqld.pid
+    log-error=/opt/bitnami/mysql/logs/mysqld.log
+    character-set-server=UTF8
+    collation-server=utf8_general_ci
+    slow_query_log=0
+    slow_query_log_file=/opt/bitnami/mysql/logs/mysqld.log
+    long_query_time=10.0
+    
+    [client]
+    port=3306
+    socket=/opt/bitnami/mysql/tmp/mysql.sock
+    default-character-set=UTF8
+    plugin_dir=/opt/bitnami/mysql/lib/plugin
+    
+    [manager]
+    port=3306
+    socket=/opt/bitnami/mysql/tmp/mysql.sock
+    pid-file=/opt/bitnami/mysql/tmp/mysqld.pid
+---
+# v1/ConfigMap openvsx-proxy-config
+apiVersion: v1
+data:
+  config.json: |-
+    {
+      "log_debug": false,
+      "cache_duration_regular": "5m0s",
+      "cache_duration_backup": "72h0m0s",
+      "url_upstream": "https://open-vsx.org",
+      "url_local": "https://open-vsx.gitpod.example.com",
+      "max_idle_conns": 1000,
+      "max_idle_conns_per_host": 1000,
+      "redis_addr": "localhost:6379",
+      "prometheusAddr": "127.0.0.1:9500",
+      "allow_cache_domain": [
+        "open-vsx.org"
+      ]
+    }
+  redis.conf: "\nmaxmemory 100mb\nmaxmemory-policy allkeys-lfu\n\t"
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: openvsx-proxy
+  name: openvsx-proxy-config
+  namespace: default
+---
+# v1/ConfigMap proxy-config
+apiVersion: v1
+data:
+  vhost.docker-registry: |-
+    https://registry.gitpod.example.com {
+        import enable_log
+        import remove_server_header
+        import ssl_configuration
+
+        basicauth bcrypt "Docker Registry" {
+            xSedJiDgJQQg4BkW5xKu JDJhJDEwJFFTRGRRMHZZY2pIS2JqUC9aMDNnVC5HbEg2Z1dOQm5TL0pySnpYSm5iNy9DeVh0ZUw2cFM2
+        }
+
+        reverse_proxy https://registry.default.svc.cluster.local {
+            flush_interval -1
+            transport http {
+                tls_trusted_ca_certs /etc/caddy/registry-certs/ca.crt
+            }
+        }
+    }
+  vhost.empty: '# Placeholder to avoid errors loading files using a glob pattern'
+  vhost.ide-proxy: |
+    https://ide.gitpod.example.com {
+        import enable_log_debug
+        import remove_server_header
+        import ssl_configuration
+
+        reverse_proxy  {
+            to h2c://ide-proxy.default.svc.cluster.local:80
+        }
+    }
+  vhost.minio: |-
+    https://minio.gitpod.example.com {
+        import enable_log
+        import remove_server_header
+        import ssl_configuration
+
+        reverse_proxy minio.default.svc.cluster.local:9001 {
+            flush_interval -1
+        }
+    }
+  vhost.open-vsx: |-
+    https://open-vsx.gitpod.example.com {
+        import enable_log_debug
+        import remove_server_header
+        import ssl_configuration
+
+        reverse_proxy  {
+            to openvsx-proxy.default.svc.cluster.local:8080
+        }
+    }
+  vhost.payment-endpoint: |
+    https://payment.gitpod.example.com {
+        import enable_log
+        import remove_server_header
+        import ssl_configuration
+        import debug_headers
+
+        reverse_proxy payment-endpoint.default.svc.cluster.local:3002 {
+            import upstream_headers
+            import upstream_connection
+        }
+
+        @backend path /stripe/invoices/webhook
+        handle @backend {
+            reverse_proxy public-api-server.{$KUBE_NAMESPACE}.{$KUBE_DOMAIN}:9002 {
+                import upstream_headers
+                import upstream_connection
+            }
+        }
+
+        handle_errors {
+            respond "Internal Server Error" 500
+        }
+    }
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: proxy
+  name: proxy-config
+  namespace: default
+---
+# v1/ConfigMap public-api-server
+apiVersion: v1
+data:
+  config.json: |-
+    {
+      "gitpodServiceUrl": "wss://gitpod.example.com",
+      "billingServiceAddress": "usage.default.svc.cluster.local:9001",
+      "stripeWebhookSigningSecretPath": "",
+      "personalAccessTokenSigningKeyPath": "",
+      "server": {
+        "services": {
+          "grpc": {
+            "address": "0.0.0.0:9001"
+          },
+          "http": {
+            "address": "0.0.0.0:9002"
+          }
+        }
+      }
+    }
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: public-api-server
+  name: public-api-server
+  namespace: default
+---
+# v1/ConfigMap registry-config
+# Source: docker-registry/charts/docker-registry/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: registry-config
+  namespace: default
+  labels:
+    app: docker-registry
+    chart: docker-registry-1.16.0
+    heritage: Helm
+    release: docker-registry
+data:
+  config.yml: |-
+    health:
+      storagedriver:
+        enabled: true
+        interval: 10s
+        threshold: 3
+    http:
+      addr: :5000
+      debug:
+        addr: :5001
+        prometheus:
+          enabled: false
+          path: /metrics
+      headers:
+        X-Content-Type-Options:
+        - nosniff
+    log:
+      fields:
+        service: registry
+    storage:
+      cache:
+        blobdescriptor: inmemory
+    version: 0.1
+---
+# v1/ConfigMap registry-facade
+apiVersion: v1
+data:
+  config.json: |-
+    {
+      "registry": {
+        "port": 32223,
+        "prefix": "",
+        "staticLayer": [
+          {
+            "ref": "registry.mydomain.com/namespace/supervisor:test",
+            "type": "image"
+          },
+          {
+            "ref": "registry.mydomain.com/namespace/workspacekit:test",
+            "type": "image"
+          },
+          {
+            "ref": "registry.mydomain.com/namespace/docker-up:test",
+            "type": "image"
+          }
+        ],
+        "remoteSpecProvider": {
+          "addr": "dns:///ws-manager:8080",
+          "tls": {
+            "ca": "/ws-manager-client-tls-certs/ca.crt",
+            "crt": "/ws-manager-client-tls-certs/tls.crt",
+            "key": "/ws-manager-client-tls-certs/tls.key"
+          }
+        },
+        "store": "/mnt/cache/registry",
+        "requireAuth": false,
+        "tls": {
+          "ca": "",
+          "crt": "/mnt/certificates/tls.crt",
+          "key": "/mnt/certificates/tls.key"
+        }
+      },
+      "dockerAuth": "/mnt/pull-secret/pull-secret.json",
+      "pprofAddr": "127.0.0.1:6060",
+      "prometheusAddr": "127.0.0.1:9500",
+      "readinessProbeAddr": ":8086"
+    }
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: registry-facade
+  name: registry-facade
+  namespace: default
+---
+# v1/ConfigMap server-config
+apiVersion: v1
+data:
+  config.json: |-
+    {
+      "version": "pd-ide-metrics.23",
+      "hostUrl": "https://gitpod.example.com",
+      "installationShortname": "default",
+      "devBranch": "",
+      "insecureNoDomain": false,
+      "license": "",
+      "licenseFile": "",
+      "definitelyGpDisabled": true,
+      "enableLocalApp": true,
+      "disableDynamicAuthProviderLogin": false,
+      "maxEnvvarPerUserCount": 4048,
+      "maxConcurrentPrebuildsPerRef": 10,
+      "makeNewUsersAdmin": false,
+      "defaultBaseImageRegistryWhitelist": [],
+      "runDbDeleter": true,
+      "contentServiceAddr": "content-service.default.svc.cluster.local:8080",
+      "imageBuilderAddr": "image-builder-mk3.default.svc.cluster.local:8080",
+      "usageServiceAddr": "usage.default.svc.cluster.local:9001",
+      "ideServiceAddr": "ide-service.default.svc.cluster.local:9001",
+      "maximumEventLoopLag": 0.35,
+      "vsxRegistryUrl": "https://open-vsx.gitpod.example.com",
+      "chargebeeProviderOptionsFile": "/chargebee/providerOptions",
+      "stripeSecretsFile": "/stripe-secret/apikeys",
+      "stripeConfigFile": "",
+      "enablePayment": false,
+      "patSigningKeyFile": "",
+      "withoutWorkspaceComponents": false,
+      "workspaceHeartbeat": {
+        "intervalSeconds": 60,
+        "timeoutSeconds": 300
+      },
+      "workspaceDefaults": {
+        "workspaceImage": "registry.mydomain.com/namespace/gitpod/workspace-full:latest",
+        "previewFeatureFlags": [],
+        "defaultFeatureFlags": []
+      },
+      "session": {
+        "maxAgeMs": 259200000,
+        "secret": "Important!Really-Change-This-Key!"
+      },
+      "githubApp": {
+        "enabled": false,
+        "appId": 0,
+        "baseUrl": "",
+        "webhookSecret": "",
+        "authProviderId": "",
+        "certPath": "",
+        "marketplaceName": "",
+        "logLevel": "",
+        "certSecretName": ""
+      },
+      "workspaceGarbageCollection": {
+        "disabled": false,
+        "startDate": 0,
+        "intervalSeconds": 300,
+        "chunkLimit": 1000,
+        "minAgeDays": 14,
+        "minAgePrebuildDays": 7,
+        "contentRetentionPeriodDays": 21,
+        "contentChunkLimit": 100,
+        "purgeRetentionPeriodDays": 365,
+        "purgeChunkLimit": 5000
+      },
+      "authProviderConfigFiles": [],
+      "incrementalPrebuilds": {
+        "repositoryPasslist": [],
+        "commitHistory": 100
+      },
+      "blockNewUsers": {
+        "enabled": false,
+        "passlist": []
+      },
+      "oauthServer": {
+        "enabled": true,
+        "jwtSecret": "8QMIxwyCGe5U0NAj6Uei"
+      },
+      "rateLimiter": {
+        "groups": {
+          "inWorkspaceUserAction": {
+            "points": 10,
+            "durationsSec": 2
+          }
+        },
+        "functions": {
+          "closePort": {
+            "group": "inWorkspaceUserAction",
+            "points": 0
+          },
+          "controlAdmission": {
+            "group": "inWorkspaceUserAction",
+            "points": 0
+          },
+          "openPort": {
+            "group": "inWorkspaceUserAction",
+            "points": 0
+          },
+          "shareSnapshot": {
+            "group": "inWorkspaceUserAction",
+            "points": 0
+          }
+        }
+      },
+      "codeSync": {
+        "revLimit": 0,
+        "contentLimit": 0,
+        "resources": null
+      },
+      "prebuildLimiter": {
+        "*": {
+          "limit": 100,
+          "period": 600
+        }
+      },
+      "workspaceClasses": [
+        {
+          "id": "default",
+          "category": "GENERAL PURPOSE",
+          "displayName": "Default",
+          "description": "Default workspace class",
+          "powerups": 1,
+          "isDefault": true,
+          "deprecated": false
+        }
+      ],
+      "inactivityPeriodForReposInDays": 0
+    }
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: server
+  name: server-config
+  namespace: default
+---
+# v1/ConfigMap server-ide-config
+apiVersion: v1
+data:
+  config.json: |-
+    {
+      "gpRunImage": "registry.hub.docker.com/gitpod/gp-run:latest",
+      "supervisorImage": "registry.mydomain.com/namespace/supervisor:test",
+      "ideOptions": {
+        "options": {
+          "clion": {
+            "orderKey": "11",
+            "title": "CLion",
+            "type": "desktop",
+            "logo": "https://ide.gitpod.example.com/image/ide-logo/clionLogo.svg",
+            "image": "registry.mydomain.com/namespace/ide/clion:test",
+            "latestImage": "registry.mydomain.com/namespace/ide/clion:latest",
+            "pluginImage": "registry.mydomain.com/namespace/ide/jb-backend-plugin:test",
+            "pluginLatestImage": "registry.mydomain.com/namespace/ide/jb-backend-plugin:latest",
+            "imageLayers": [
+              "registry.mydomain.com/namespace/ide/jb-backend-plugin:test",
+              "registry.mydomain.com/namespace/ide/jb-launcher:test"
+            ],
+            "latestImageLayers": [
+              "registry.mydomain.com/namespace/ide/jb-backend-plugin:latest",
+              "registry.mydomain.com/namespace/ide/jb-launcher:test"
+            ]
+          },
+          "code": {
+            "orderKey": "00",
+            "title": "VS Code",
+            "type": "browser",
+            "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
+            "label": "Browser",
+            "image": "registry.mydomain.com/namespace/ide/code:commit-fdf6a08a681c53ddd97c7bae9acc7d49158a41a0",
+            "latestImage": "registry.mydomain.com/namespace/ide/code:nightly"
+          },
+          "code-desktop": {
+            "orderKey": "02",
+            "title": "VS Code",
+            "type": "desktop",
+            "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
+            "image": "registry.mydomain.com/namespace/ide/code-desktop:test",
+            "latestImage": "registry.mydomain.com/namespace/ide/code-desktop-insiders:test"
+          },
+          "goland": {
+            "orderKey": "05",
+            "title": "GoLand",
+            "type": "desktop",
+            "logo": "https://ide.gitpod.example.com/image/ide-logo/golandLogo.svg",
+            "image": "registry.mydomain.com/namespace/ide/goland:test",
+            "latestImage": "registry.mydomain.com/namespace/ide/goland:latest",
+            "pluginImage": "registry.mydomain.com/namespace/ide/jb-backend-plugin:test",
+            "pluginLatestImage": "registry.mydomain.com/namespace/ide/jb-backend-plugin:latest",
+            "imageLayers": [
+              "registry.mydomain.com/namespace/ide/jb-backend-plugin:test",
+              "registry.mydomain.com/namespace/ide/jb-launcher:test"
+            ],
+            "latestImageLayers": [
+              "registry.mydomain.com/namespace/ide/jb-backend-plugin:latest",
+              "registry.mydomain.com/namespace/ide/jb-launcher:test"
+            ]
+          },
+          "intellij": {
+            "orderKey": "04",
+            "title": "IntelliJ IDEA",
+            "type": "desktop",
+            "logo": "https://ide.gitpod.example.com/image/ide-logo/intellijIdeaLogo.svg",
+            "label": "Ultimate",
+            "image": "registry.mydomain.com/namespace/ide/intellij:test",
+            "latestImage": "registry.mydomain.com/namespace/ide/intellij:latest",
+            "pluginImage": "registry.mydomain.com/namespace/ide/jb-backend-plugin:test",
+            "pluginLatestImage": "registry.mydomain.com/namespace/ide/jb-backend-plugin:latest",
+            "imageLayers": [
+              "registry.mydomain.com/namespace/ide/jb-backend-plugin:test",
+              "registry.mydomain.com/namespace/ide/jb-launcher:test"
+            ],
+            "latestImageLayers": [
+              "registry.mydomain.com/namespace/ide/jb-backend-plugin:latest",
+              "registry.mydomain.com/namespace/ide/jb-launcher:test"
+            ]
+          },
+          "phpstorm": {
+            "orderKey": "07",
+            "title": "PhpStorm",
+            "type": "desktop",
+            "logo": "https://ide.gitpod.example.com/image/ide-logo/phpstormLogo.svg",
+            "image": "registry.mydomain.com/namespace/ide/phpstorm:test",
+            "latestImage": "registry.mydomain.com/namespace/ide/phpstorm:latest",
+            "pluginImage": "registry.mydomain.com/namespace/ide/jb-backend-plugin:test",
+            "pluginLatestImage": "registry.mydomain.com/namespace/ide/jb-backend-plugin:latest",
+            "imageLayers": [
+              "registry.mydomain.com/namespace/ide/jb-backend-plugin:test",
+              "registry.mydomain.com/namespace/ide/jb-launcher:test"
+            ],
+            "latestImageLayers": [
+              "registry.mydomain.com/namespace/ide/jb-backend-plugin:latest",
+              "registry.mydomain.com/namespace/ide/jb-launcher:test"
+            ]
+          },
+          "pycharm": {
+            "orderKey": "06",
+            "title": "PyCharm",
+            "type": "desktop",
+            "logo": "https://ide.gitpod.example.com/image/ide-logo/pycharmLogo.svg",
+            "label": "Professional",
+            "image": "registry.mydomain.com/namespace/ide/pycharm:test",
+            "latestImage": "registry.mydomain.com/namespace/ide/pycharm:latest",
+            "pluginImage": "registry.mydomain.com/namespace/ide/jb-backend-plugin:test",
+            "pluginLatestImage": "registry.mydomain.com/namespace/ide/jb-backend-plugin:latest",
+            "imageLayers": [
+              "registry.mydomain.com/namespace/ide/jb-backend-plugin:test",
+              "registry.mydomain.com/namespace/ide/jb-launcher:test"
+            ],
+            "latestImageLayers": [
+              "registry.mydomain.com/namespace/ide/jb-backend-plugin:latest",
+              "registry.mydomain.com/namespace/ide/jb-launcher:test"
+            ]
+          },
+          "rider": {
+            "orderKey": "10",
+            "title": "Rider",
+            "type": "desktop",
+            "logo": "https://ide.gitpod.example.com/image/ide-logo/riderLogo.svg",
+            "image": "registry.mydomain.com/namespace/ide/rider:test",
+            "latestImage": "registry.mydomain.com/namespace/ide/rider:latest",
+            "pluginImage": "registry.mydomain.com/namespace/ide/jb-backend-plugin:test",
+            "pluginLatestImage": "registry.mydomain.com/namespace/ide/jb-backend-plugin:latest",
+            "imageLayers": [
+              "registry.mydomain.com/namespace/ide/jb-backend-plugin:test",
+              "registry.mydomain.com/namespace/ide/jb-launcher:test"
+            ],
+            "latestImageLayers": [
+              "registry.mydomain.com/namespace/ide/jb-backend-plugin:latest",
+              "registry.mydomain.com/namespace/ide/jb-launcher:test"
+            ]
+          },
+          "rubymine": {
+            "orderKey": "08",
+            "title": "RubyMine",
+            "type": "desktop",
+            "logo": "https://ide.gitpod.example.com/image/ide-logo/rubymineLogo.svg",
+            "image": "registry.mydomain.com/namespace/ide/rubymine:test",
+            "latestImage": "registry.mydomain.com/namespace/ide/rubymine:latest",
+            "pluginImage": "registry.mydomain.com/namespace/ide/jb-backend-plugin:test",
+            "pluginLatestImage": "registry.mydomain.com/namespace/ide/jb-backend-plugin:latest",
+            "imageLayers": [
+              "registry.mydomain.com/namespace/ide/jb-backend-plugin:test",
+              "registry.mydomain.com/namespace/ide/jb-launcher:test"
+            ],
+            "latestImageLayers": [
+              "registry.mydomain.com/namespace/ide/jb-backend-plugin:latest",
+              "registry.mydomain.com/namespace/ide/jb-launcher:test"
+            ]
+          },
+          "webstorm": {
+            "orderKey": "09",
+            "title": "WebStorm",
+            "type": "desktop",
+            "logo": "https://ide.gitpod.example.com/image/ide-logo/webstormLogo.svg",
+            "image": "registry.mydomain.com/namespace/ide/webstorm:test",
+            "latestImage": "registry.mydomain.com/namespace/ide/webstorm:latest",
+            "pluginImage": "registry.mydomain.com/namespace/ide/jb-backend-plugin:test",
+            "pluginLatestImage": "registry.mydomain.com/namespace/ide/jb-backend-plugin:latest",
+            "imageLayers": [
+              "registry.mydomain.com/namespace/ide/jb-backend-plugin:test",
+              "registry.mydomain.com/namespace/ide/jb-launcher:test"
+            ],
+            "latestImageLayers": [
+              "registry.mydomain.com/namespace/ide/jb-backend-plugin:latest",
+              "registry.mydomain.com/namespace/ide/jb-launcher:test"
+            ]
+          }
+        },
+        "defaultIde": "code",
+        "defaultDesktopIde": "code-desktop",
+        "clients": {
+          "jetbrains-gateway": {
+            "defaultDesktopIDE": "intellij",
+            "desktopIDEs": [
+              "intellij",
+              "goland",
+              "pycharm",
+              "phpstorm",
+              "rubymine",
+              "webstorm",
+              "rider",
+              "clion"
+            ],
+            "installationSteps": [
+              "If you don't see an open dialog in your browser, make sure you have the \u003ca target='_blank' class='gp-link' href='https://www.gitpod.io/docs/ides-and-editors/jetbrains-gateway#getting-started-jetbrains-gateway'\u003eJetBrains Gateway with Gitpod Plugin\u003c/a\u003e installed on your machine, and then click \u003cb\u003e${OPEN_LINK_LABEL}\u003c/b\u003e below."
+            ]
+          },
+          "vscode": {
+            "defaultDesktopIDE": "code-desktop",
+            "desktopIDEs": [
+              "code-desktop"
+            ],
+            "installationSteps": [
+              "If you don't see an open dialog in your browser, make sure you have \u003ca target='_blank' class='gp-link' href='https://code.visualstudio.com/download'\u003eVS Code\u003c/a\u003e installed on your machine, and then click \u003cb\u003e${OPEN_LINK_LABEL}\u003c/b\u003e below."
+            ]
+          },
+          "vscode-insiders": {
+            "defaultDesktopIDE": "code-desktop",
+            "desktopIDEs": [
+              "code-desktop"
+            ],
+            "installationSteps": [
+              "If you don't see an open dialog in your browser, make sure you have \u003ca target='_blank' class='gp-link' href='https://code.visualstudio.com/insiders'\u003eVS Code Insiders\u003c/a\u003e installed on your machine, and then click \u003cb\u003e${OPEN_LINK_LABEL}\u003c/b\u003e below."
+            ]
+          }
+        }
+      }
+    }
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: server
+  name: server-ide-config
+  namespace: default
+---
+# v1/ConfigMap workspace-templates
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ws-manager
+  name: workspace-templates
+  namespace: default
+---
+# v1/ConfigMap ws-daemon
+apiVersion: v1
+data:
+  config.json: |-
+    {
+      "daemon": {
+        "runtime": {
+          "containerRuntime": {
+            "mounts": {
+              "proc": "/mnt/mounts"
+            },
+            "nodeToContainerMapping": {
+              "/var/lib/containerd/io.containerd.runtime.v2.task/k8s.io": "/mnt/node0"
+            },
+            "runtime": "containerd",
+            "containerd": {
+              "socket": "/mnt/containerd.sock"
+            }
+          },
+          "kubeconfig": "",
+          "namespace": "default"
+        },
+        "content": {
+          "workingArea": "/mnt/workingarea",
+          "workingAreaNode": "/var/gitpod/workspaces",
+          "tempDir": "/tmp",
+          "storage": {
+            "stage": "",
+            "kind": "minio",
+            "gcloud": {
+              "credentialsFile": "",
+              "region": "",
+              "projectId": ""
+            },
+            "minio": {
+              "endpoint": "minio.default.svc.cluster.local:9000",
+              "accessKey": "8-WGqw2oTnsPfUDNSk0Y",
+              "accessKeyFile": "",
+              "secretKey": "DpC.aSAxkWBPu2_bJ_AE",
+              "secretKeyFile": "",
+              "region": "local",
+              "parallelUpload": 6
+            },
+            "blobQuota": 5368709120
+          },
+          "backup": {
+            "timeout": "5m0s",
+            "attempts": 3,
+            "period": "0s"
+          },
+          "userNamespaces": {
+            "fsShift": "FUSE"
+          },
+          "initializer": {
+            "command": "/app/content-initializer",
+            "args": null
+          }
+        },
+        "uidmapper": {
+          "procLocation": "/proc",
+          "rootUIDRange": {
+            "start": 33333,
+            "size": 1
+          },
+          "userUIDRange": [
+            {
+              "start": 100000,
+              "size": 70000
+            }
+          ]
+        },
+        "cpulimit": {
+          "enabled": false,
+          "totalBandwidth": "0",
+          "limit": "0",
+          "burstLimit": "0",
+          "controlPeriod": "15s",
+          "cgroupBasePath": "/mnt/node-cgroups"
+        },
+        "ioLimit": {
+          "writeBandwidthPerSecond": "0",
+          "readBandwidthPerSecond": "0",
+          "writeIOPS": 0,
+          "readIOPS": 0
+        },
+        "procLimit": 0,
+        "netlimit": {
+          "enabled": false,
+          "enforce": false,
+          "connectionsPerMinute": 3000,
+          "bucketSize": 1000
+        },
+        "oomScores": {
+          "enabled": false,
+          "tier1": 0,
+          "tier2": 0
+        },
+        "hosts": {
+          "enabled": true,
+          "nodeHostsFile": "/mnt/hosts",
+          "fixedHosts": {
+            "registryFacade": [
+              {
+                "addr": "127.0.0.1",
+                "name": "reg.gitpod.example.com"
+              }
+            ]
+          }
+        },
+        "disk": {
+          "enabled": true,
+          "interval": "5m0s",
+          "locations": [
+            {
+              "path": "/mnt/workingarea",
+              "minBytesAvail": 21474836480
+            }
+          ]
+        }
+      },
+      "service": {
+        "address": "0.0.0.0:8080",
+        "tls": {
+          "caPath": "/certs/ca.crt",
+          "certPath": "/certs/tls.crt",
+          "keyPath": "/certs/tls.key"
+        }
+      }
+    }
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ws-daemon
+  name: ws-daemon
+  namespace: default
+---
+# v1/ConfigMap ws-manager
+apiVersion: v1
+data:
+  config.json: |-
+    {
+      "manager": {
+        "namespace": "default",
+        "schedulerName": "",
+        "seccompProfile": "workspace_default_pd-ide-metrics.23.json",
+        "timeouts": {
+          "startup": "1h0m0s",
+          "initialization": "30m0s",
+          "regularWorkspace": "30m0s",
+          "maxLifetime": "36h0m0s",
+          "headlessWorkspace": "1h0m0s",
+          "afterClose": "2m0s",
+          "contentFinalization": "1h0m0s",
+          "stopping": "1h0m0s",
+          "interrupted": "5m0s"
+        },
+        "initProbe": {
+          "timeout": "1s"
+        },
+        "urlTemplate": "https://{{ .Prefix }}.ws.gitpod.example.com",
+        "portUrlTemplate": "https://{{ .WorkspacePort }}-{{ .Prefix }}.ws.gitpod.example.com",
+        "workspaceHostPath": "/var/gitpod/workspaces",
+        "heartbeatInterval": "30s",
+        "hostURL": "https://gitpod.example.com",
+        "reconnectionInterval": "30s",
+        "wsdaemon": {
+          "port": 8080,
+          "tls": {
+            "ca": "/ws-daemon-tls-certs/ca.crt",
+            "crt": "/ws-daemon-tls-certs/tls.crt",
+            "key": "/ws-daemon-tls-certs/tls.key"
+          }
+        },
+        "registryFacadeHost": "reg.gitpod.example.com:20000",
+        "workspaceClusterHost": "ws.gitpod.example.com",
+        "workspaceClass": {
+          "default": {
+            "name": "default",
+            "container": {
+              "requests": {
+                "cpu": "1",
+                "memory": "2Gi",
+                "ephemeral-storage": ""
+              },
+              "limits": {
+                "cpu": {
+                  "min": "",
+                  "burst": ""
+                },
+                "memory": "",
+                "ephemeral-storage": ""
+              }
+            },
+            "templates": {},
+            "prebuildPVC": {
+              "size": "30Gi",
+              "storageClass": "",
+              "snapshotClass": ""
+            },
+            "pvc": {
+              "size": "30Gi",
+              "storageClass": "",
+              "snapshotClass": ""
+            }
+          }
+        }
+      },
+      "content": {
+        "storage": {
+          "stage": "",
+          "kind": "minio",
+          "gcloud": {
+            "credentialsFile": "",
+            "region": "",
+            "projectId": ""
+          },
+          "minio": {
+            "endpoint": "minio.default.svc.cluster.local:9000",
+            "accessKey": "8-WGqw2oTnsPfUDNSk0Y",
+            "accessKeyFile": "",
+            "secretKey": "DpC.aSAxkWBPu2_bJ_AE",
+            "secretKeyFile": "",
+            "region": "local",
+            "parallelUpload": 6
+          },
+          "blobQuota": 5368709120
+        }
+      },
+      "rpcServer": {
+        "addr": ":8080",
+        "tls": {
+          "ca": "/certs/ca.crt",
+          "crt": "/certs/tls.crt",
+          "key": "/certs/tls.key"
+        },
+        "ratelimits": {}
+      },
+      "imageBuilderProxy": {
+        "targetAddr": "image-builder-mk3.default.svc.cluster.local:8080",
+        "tls": {
+          "ca": "",
+          "crt": "",
+          "key": ""
+        }
+      },
+      "pprof": {
+        "addr": "127.0.0.1:6060"
+      },
+      "prometheus": {
+        "addr": "127.0.0.1:9500"
+      }
+    }
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ws-manager
+  name: ws-manager
+  namespace: default
+---
+# v1/ConfigMap ws-manager-bridge-config
+apiVersion: v1
+data:
+  ws-manager-bridge.json: |-
+    {
+      "installation": "default",
+      "staticBridges": [
+        {
+          "name": "default",
+          "url": "dns:///ws-manager:8080",
+          "tls": {
+            "ca": "/ws-manager-client-tls-certs/ca.crt",
+            "crt": "/ws-manager-client-tls-certs/tls.crt",
+            "key": "/ws-manager-client-tls-certs/tls.key"
+          },
+          "state": "available",
+          "maxScore": 100,
+          "score": 50,
+          "govern": true,
+          "admissionConstraints": null,
+          "applicationCluster": "default"
+        }
+      ],
+      "clusterService": {
+        "port": 8080,
+        "host": "localhost"
+      },
+      "wsClusterDBReconcileIntervalSeconds": 60,
+      "controllerIntervalSeconds": 60,
+      "controllerMaxDisconnectSeconds": 150,
+      "emulatePreparingIntervalSeconds": 10,
+      "timeouts": {
+        "preparingPhaseSeconds": 3600,
+        "buildingPhaseSeconds": 3600,
+        "unknownPhaseSeconds": 600,
+        "pendingPhaseSeconds": 3600,
+        "stoppingPhaseSeconds": 3600
+      },
+      "clusterSyncIntervalSeconds": 60
+    }
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ws-manager-bridge
+  name: ws-manager-bridge-config
+  namespace: default
+---
+# v1/ConfigMap ws-proxy
+apiVersion: v1
+data:
+  config.json: |-
+    {
+      "ingress": {
+        "httpAddress": "0.0.0.0:8080",
+        "httpsAddress": "0.0.0.0:9090",
+        "header": "x-wsproxy-host"
+      },
+      "proxy": {
+        "https": {
+          "key": "/mnt/certificates/tls.key",
+          "crt": "/mnt/certificates/tls.crt"
+        },
+        "transportConfig": {
+          "connectTimeout": "10s",
+          "idleConnTimeout": "1m0s",
+          "maxIdleConns": 0,
+          "maxIdleConnsPerHost": 100
+        },
+        "blobServer": {
+          "scheme": "https",
+          "host": "ide.gitpod.example.com",
+          "pathPrefix": "/blobserve"
+        },
+        "gitpodInstallation": {
+          "scheme": "https",
+          "hostName": "gitpod.example.com",
+          "workspaceHostSuffix": ".ws.gitpod.example.com",
+          "workspaceHostSuffixRegex": "\\.ws[^\\.]*\\.gitpod.example.com"
+        },
+        "workspacePodConfig": {
+          "theiaPort": 23000,
+          "supervisorPort": 22999,
+          "supervisorImage": "registry.mydomain.com/namespace/supervisor:test"
+        },
+        "builtinPages": {
+          "location": "/app/public"
+        }
+      },
+      "pprofAddr": "127.0.0.1:6060",
+      "prometheusAddr": "127.0.0.1:9500",
+      "readinessProbeAddr": ":8086",
+      "namespace": "default",
+      "wsManager": {
+        "addr": "ws-manager:8080",
+        "tls": {
+          "ca": "/ws-manager-client-tls-certs/ca.crt",
+          "crt": "/ws-manager-client-tls-certs/tls.crt",
+          "key": "/ws-manager-client-tls-certs/tls.key"
+        }
+      }
+    }
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ws-proxy
+  name: ws-proxy
+  namespace: default
+---
+# v1/PersistentVolumeClaim minio
+# Source: minio/charts/minio/templates/pvc.yaml
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: minio
+  namespace: "default"
+  labels:
+    app.kubernetes.io/name: minio
+    helm.sh/chart: minio-11.6.3
+    app.kubernetes.io/instance: minio
+    app.kubernetes.io/managed-by: Helm
+spec:
+  accessModes:
+    - "ReadWriteOnce"
+  resources:
+    requests:
+      storage: "8Gi"
+---
+# v1/PersistentVolumeClaim registry
+# Source: docker-registry/charts/docker-registry/templates/pvc.yaml
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: registry
+  namespace: default
+  labels:
+    app: registry
+    chart: "docker-registry-1.16.0"
+    release: "docker-registry"
+    heritage: "Helm"
+spec:
+  accessModes:
+    - "ReadWriteOnce"
+  resources:
+    requests:
+      storage: "10Gi"
+---
+# rbac.authorization.k8s.io/v1/ClusterRole default-kube-rbac-proxy
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: default-kube-rbac-proxy
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+---
+# rbac.authorization.k8s.io/v1/ClusterRole default-ns-registry-facade
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: registry-facade
+  name: default-ns-registry-facade
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - update
+  - patch
+---
+# rbac.authorization.k8s.io/v1/ClusterRole default-ns-ws-daemon
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ws-daemon
+  name: default-ns-ws-daemon
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - delete
+  - update
+  - patch
+---
+# rbac.authorization.k8s.io/v1/ClusterRole ws-manager
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ws-manager
+  name: ws-manager
+  namespace: default
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotcontents
+  - volumesnapshotclasses
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - patch
+  - watch
+  - delete
+  - deletecollection
+---
+# rbac.authorization.k8s.io/v1/ClusterRoleBinding default-agent-smith-rb-kube-rbac-proxy
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: agent-smith
+  name: default-agent-smith-rb-kube-rbac-proxy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-kube-rbac-proxy
+subjects:
+- kind: ServiceAccount
+  name: agent-smith
+  namespace: default
+---
+# rbac.authorization.k8s.io/v1/ClusterRoleBinding default-blobserve-kube-rbac-proxy
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: blobserve
+  name: default-blobserve-kube-rbac-proxy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-kube-rbac-proxy
+subjects:
+- kind: ServiceAccount
+  name: blobserve
+  namespace: default
+---
+# rbac.authorization.k8s.io/v1/ClusterRoleBinding default-content-service-rb-kube-rbac-proxy
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: content-service
+  name: default-content-service-rb-kube-rbac-proxy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-kube-rbac-proxy
+subjects:
+- kind: ServiceAccount
+  name: content-service
+  namespace: default
+---
+# rbac.authorization.k8s.io/v1/ClusterRoleBinding default-iam-rb-kube-rbac-proxy
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: iam
+  name: default-iam-rb-kube-rbac-proxy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-kube-rbac-proxy
+subjects:
+- kind: ServiceAccount
+  name: iam
+  namespace: default
+---
+# rbac.authorization.k8s.io/v1/ClusterRoleBinding default-ide-metrics-kube-rbac-proxy
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ide-metrics
+  name: default-ide-metrics-kube-rbac-proxy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-kube-rbac-proxy
+subjects:
+- kind: ServiceAccount
+  name: ide-metrics
+  namespace: default
+---
+# rbac.authorization.k8s.io/v1/ClusterRoleBinding default-ide-service-kube-rbac-proxy
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ide-service
+  name: default-ide-service-kube-rbac-proxy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-kube-rbac-proxy
+subjects:
+- kind: ServiceAccount
+  name: ide-service
+  namespace: default
+---
+# rbac.authorization.k8s.io/v1/ClusterRoleBinding default-image-builder-mk3-proxy-kube-rbac-proxy
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: image-builder-mk3
+  name: default-image-builder-mk3-proxy-kube-rbac-proxy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-kube-rbac-proxy
+subjects:
+- kind: ServiceAccount
+  name: image-builder-mk3
+  namespace: default
+---
+# rbac.authorization.k8s.io/v1/ClusterRoleBinding default-openvsx-proxy-kube-rbac-proxy
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: openvsx-proxy
+  name: default-openvsx-proxy-kube-rbac-proxy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-kube-rbac-proxy
+subjects:
+- kind: ServiceAccount
+  name: openvsx-proxy
+  namespace: default
+---
+# rbac.authorization.k8s.io/v1/ClusterRoleBinding default-proxy-kube-rbac-proxy
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: proxy
+  name: default-proxy-kube-rbac-proxy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-kube-rbac-proxy
+subjects:
+- kind: ServiceAccount
+  name: proxy
+  namespace: default
+---
+# rbac.authorization.k8s.io/v1/ClusterRoleBinding default-public-api-server-rb-kube-rbac-proxy
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: public-api-server
+  name: default-public-api-server-rb-kube-rbac-proxy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-kube-rbac-proxy
+subjects:
+- kind: ServiceAccount
+  name: public-api-server
+  namespace: default
+---
+# rbac.authorization.k8s.io/v1/ClusterRoleBinding default-registry-facade-kube-rbac-proxy
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: registry-facade
+  name: default-registry-facade-kube-rbac-proxy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-kube-rbac-proxy
+subjects:
+- kind: ServiceAccount
+  name: registry-facade
+  namespace: default
+---
+# rbac.authorization.k8s.io/v1/ClusterRoleBinding default-registry-facade-rb
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: registry-facade
+  name: default-registry-facade-rb
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-ns-registry-facade
+subjects:
+- kind: ServiceAccount
+  name: registry-facade
+  namespace: default
+---
+# rbac.authorization.k8s.io/v1/ClusterRoleBinding default-server-rb-kube-rbac-proxy
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: server
+  name: default-server-rb-kube-rbac-proxy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-kube-rbac-proxy
+subjects:
+- kind: ServiceAccount
+  name: server
+  namespace: default
+---
+# rbac.authorization.k8s.io/v1/ClusterRoleBinding default-ws-daemon-rb
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ws-daemon
+  name: default-ws-daemon-rb
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-ns-ws-daemon
+subjects:
+- kind: ServiceAccount
+  name: ws-daemon
+  namespace: default
+---
+# rbac.authorization.k8s.io/v1/ClusterRoleBinding default-ws-daemon-rb-kube-rbac-proxy
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ws-daemon
+  name: default-ws-daemon-rb-kube-rbac-proxy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-kube-rbac-proxy
+subjects:
+- kind: ServiceAccount
+  name: ws-daemon
+  namespace: default
+---
+# rbac.authorization.k8s.io/v1/ClusterRoleBinding default-ws-manager-bridge-rb-kube-rbac-proxy
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ws-manager-bridge
+  name: default-ws-manager-bridge-rb-kube-rbac-proxy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-kube-rbac-proxy
+subjects:
+- kind: ServiceAccount
+  name: ws-manager-bridge
+  namespace: default
+---
+# rbac.authorization.k8s.io/v1/ClusterRoleBinding default-ws-manager-kube-rbac-proxy
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ws-manager
+  name: default-ws-manager-kube-rbac-proxy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-kube-rbac-proxy
+subjects:
+- kind: ServiceAccount
+  name: ws-manager
+  namespace: default
+---
+# rbac.authorization.k8s.io/v1/ClusterRoleBinding default-ws-proxy-kube-rbac-proxy
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ws-proxy
+  name: default-ws-proxy-kube-rbac-proxy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-kube-rbac-proxy
+subjects:
+- kind: ServiceAccount
+  name: ws-proxy
+  namespace: default
+---
+# rbac.authorization.k8s.io/v1/ClusterRoleBinding ide-metrics
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ide-metrics
+  name: ide-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ide-metrics
+subjects:
+- kind: ServiceAccount
+  name: ide-metrics
+  namespace: default
+---
+# rbac.authorization.k8s.io/v1/ClusterRoleBinding ide-service
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ide-service
+  name: ide-service
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ide-service
+subjects:
+- kind: ServiceAccount
+  name: ide-service
+  namespace: default
+---
+# rbac.authorization.k8s.io/v1/ClusterRoleBinding ws-manager
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ws-manager
+  name: ws-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ws-manager
+subjects:
+- kind: ServiceAccount
+  name: ws-manager
+  namespace: default
+---
+# rbac.authorization.k8s.io/v1/Role agent-smith
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: agent-smith
+  name: agent-smith
+  namespace: default
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - update
+---
+# rbac.authorization.k8s.io/v1/Role messagebus-endpoint-reader
+# Source: rabbitmq/charts/rabbitmq/templates/role.yaml
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: messagebus-endpoint-reader
+  namespace: "default"
+  labels:
+    app.kubernetes.io/name: rabbitmq
+    helm.sh/chart: rabbitmq-10.1.1
+    app.kubernetes.io/instance: rabbitmq
+    app.kubernetes.io/managed-by: Helm
+rules:
+  - apiGroups: [""]
+    resources: ["endpoints"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create"]
+---
+# rbac.authorization.k8s.io/v1/Role server
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: server
+  name: server
+  namespace: default
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - patch
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - pods/log
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - patch
+  - watch
+---
+# rbac.authorization.k8s.io/v1/Role ws-manager
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ws-manager
+  name: ws-manager
+  namespace: default
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - pods/log
+  - events
+  - services
+  - endpoints
+  - configmaps
+  - persistentvolumeclaims
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - patch
+  - watch
+  - delete
+  - deletecollection
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - create
+  - delete
+  - watch
+  - list
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshots
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - patch
+  - watch
+  - delete
+  - deletecollection
+---
+# rbac.authorization.k8s.io/v1/Role ws-proxy
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ws-proxy
+  name: ws-proxy
+  namespace: default
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+---
+# rbac.authorization.k8s.io/v1/RoleBinding agent-smith
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: agent-smith
+  name: agent-smith
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: agent-smith
+subjects:
+- kind: ServiceAccount
+  name: agent-smith
+---
+# rbac.authorization.k8s.io/v1/RoleBinding blobserve
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: blobserve
+  name: blobserve
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-ns-psp:restricted-root-user
+subjects:
+- kind: ServiceAccount
+  name: blobserve
+---
+# rbac.authorization.k8s.io/v1/RoleBinding content-service
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: content-service
+  name: content-service
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-ns-psp:restricted-root-user
+subjects:
+- kind: ServiceAccount
+  name: content-service
+---
+# rbac.authorization.k8s.io/v1/RoleBinding dashboard
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: dashboard
+  name: dashboard
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-ns-psp:restricted-root-user
+subjects:
+- kind: ServiceAccount
+  name: dashboard
+---
+# rbac.authorization.k8s.io/v1/RoleBinding db
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: db
+  name: db
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-ns-psp:restricted-root-user
+subjects:
+- kind: ServiceAccount
+  name: db
+---
+# rbac.authorization.k8s.io/v1/RoleBinding default-ns-nobody
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  name: default-ns-nobody
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-ns-psp:unprivileged
+subjects:
+- kind: ServiceAccount
+  name: nobody
+  namespace: default
+---
+# rbac.authorization.k8s.io/v1/RoleBinding docker-registry
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: docker-registry
+  name: docker-registry
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-ns-psp:restricted-root-user
+subjects:
+- kind: ServiceAccount
+  name: docker-registry
+---
+# rbac.authorization.k8s.io/v1/RoleBinding gitpod
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: gitpod
+  name: gitpod
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-ns-psp:restricted-root-user
+subjects:
+- kind: ServiceAccount
+  name: gitpod
+---
+# rbac.authorization.k8s.io/v1/RoleBinding iam
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: iam
+  name: iam
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-ns-psp:restricted-root-user
+subjects:
+- kind: ServiceAccount
+  name: iam
+---
+# rbac.authorization.k8s.io/v1/RoleBinding ide-metrics
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ide-metrics
+  name: ide-metrics
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-ns-psp:restricted-root-user
+subjects:
+- kind: ServiceAccount
+  name: ide-metrics
+---
+# rbac.authorization.k8s.io/v1/RoleBinding ide-proxy
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ide-proxy
+  name: ide-proxy
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-ns-psp:restricted-root-user
+subjects:
+- kind: ServiceAccount
+  name: ide-proxy
+---
+# rbac.authorization.k8s.io/v1/RoleBinding ide-service
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ide-service
+  name: ide-service
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-ns-psp:restricted-root-user
+subjects:
+- kind: ServiceAccount
+  name: ide-service
+---
+# rbac.authorization.k8s.io/v1/RoleBinding image-builder-mk3
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: image-builder-mk3
+  name: image-builder-mk3
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-ns-image-builder-mk3
+subjects:
+- kind: ServiceAccount
+  name: image-builder-mk3
+---
+# rbac.authorization.k8s.io/v1/RoleBinding messagebus-endpoint-reader
+# Source: rabbitmq/charts/rabbitmq/templates/rolebinding.yaml
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: messagebus-endpoint-reader
+  namespace: "default"
+  labels:
+    app.kubernetes.io/name: rabbitmq
+    helm.sh/chart: rabbitmq-10.1.1
+    app.kubernetes.io/instance: rabbitmq
+    app.kubernetes.io/managed-by: Helm
+subjects:
+  - kind: ServiceAccount
+    name: rabbitmq
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: messagebus-endpoint-reader
+---
+# rbac.authorization.k8s.io/v1/RoleBinding migrations
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: migrations
+  name: migrations
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-ns-psp:restricted-root-user
+subjects:
+- kind: ServiceAccount
+  name: migrations
+---
+# rbac.authorization.k8s.io/v1/RoleBinding minio
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: minio
+  name: minio
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-ns-psp:unprivileged
+subjects:
+- kind: ServiceAccount
+  name: minio
+---
+# rbac.authorization.k8s.io/v1/RoleBinding openvsx-proxy
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: openvsx-proxy
+  name: openvsx-proxy
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-ns-psp:restricted-root-user
+subjects:
+- kind: ServiceAccount
+  name: openvsx-proxy
+---
+# rbac.authorization.k8s.io/v1/RoleBinding proxy
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: proxy
+  name: proxy
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-ns-psp:restricted-root-user
+subjects:
+- kind: ServiceAccount
+  name: proxy
+---
+# rbac.authorization.k8s.io/v1/RoleBinding public-api-server
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: public-api-server
+  name: public-api-server
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-ns-psp:restricted-root-user
+subjects:
+- kind: ServiceAccount
+  name: public-api-server
+---
+# rbac.authorization.k8s.io/v1/RoleBinding rabbitmq
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: rabbitmq
+  name: rabbitmq
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-ns-psp:restricted-root-user
+subjects:
+- kind: ServiceAccount
+  name: rabbitmq
+---
+# rbac.authorization.k8s.io/v1/RoleBinding server
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: server
+  name: server
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: server
+subjects:
+- kind: ServiceAccount
+  name: server
+---
+# rbac.authorization.k8s.io/v1/RoleBinding server-unprivileged
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: server
+  name: server-unprivileged
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-ns-psp:unprivileged
+subjects:
+- kind: ServiceAccount
+  name: server
+---
+# rbac.authorization.k8s.io/v1/RoleBinding workspace
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: workspace
+  name: workspace
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: workspace
+subjects:
+- kind: ServiceAccount
+  name: workspace
+---
+# rbac.authorization.k8s.io/v1/RoleBinding ws-manager
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ws-manager
+  name: ws-manager
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ws-manager
+subjects:
+- kind: ServiceAccount
+  name: ws-manager
+---
+# rbac.authorization.k8s.io/v1/RoleBinding ws-manager-bridge
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ws-manager-bridge
+  name: ws-manager-bridge
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-ns-psp:unprivileged
+subjects:
+- kind: ServiceAccount
+  name: ws-manager-bridge
+---
+# rbac.authorization.k8s.io/v1/RoleBinding ws-manager-unpriviledged
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ws-manager
+  name: ws-manager-unpriviledged
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-ns-psp:unprivileged
+subjects:
+- kind: ServiceAccount
+  name: ws-manager
+---
+# rbac.authorization.k8s.io/v1/RoleBinding ws-proxy
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ws-proxy
+  name: ws-proxy
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-ns-psp:unprivileged
+subjects:
+- kind: ServiceAccount
+  name: ws-proxy
+---
+# rbac.authorization.k8s.io/v1/RoleBinding ws-proxy-api
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ws-proxy
+  name: ws-proxy-api
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ws-proxy
+subjects:
+- kind: ServiceAccount
+  name: ws-proxy
+---
+# v1/Service blobserve
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: blobserve
+    kind: service
+  name: blobserve
+  namespace: default
+spec:
+  ports:
+  - name: service
+    port: 4000
+    protocol: TCP
+    targetPort: 32224
+  selector:
+    app: gitpod
+    component: blobserve
+  type: ClusterIP
+status:
+  loadBalancer: {}
+---
+# v1/Service content-service
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: content-service
+    kind: service
+  name: content-service
+  namespace: default
+spec:
+  ports:
+  - name: rpc
+    port: 8080
+    protocol: TCP
+    targetPort: 8080
+  - name: metrics
+    port: 9500
+    protocol: TCP
+    targetPort: 9500
+  selector:
+    app: gitpod
+    component: content-service
+  type: ClusterIP
+status:
+  loadBalancer: {}
+---
+# v1/Service dashboard
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: dashboard
+    kind: service
+  name: dashboard
+  namespace: default
+spec:
+  ports:
+  - name: http
+    port: 3001
+    protocol: TCP
+    targetPort: 80
+  selector:
+    app: gitpod
+    component: dashboard
+  type: ClusterIP
+status:
+  loadBalancer: {}
+---
+# v1/Service db
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: db
+  name: db
+  namespace: default
+spec:
+  ports:
+  - port: 3306
+    protocol: TCP
+    targetPort: 3306
+  selector:
+    app.kubernetes.io/name: mysql
+  type: ClusterIP
+status:
+  loadBalancer: {}
+---
+# v1/Service iam
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: iam
+    kind: service
+  name: iam
+  namespace: default
+spec:
+  ports:
+  - name: grpc
+    port: 9001
+    protocol: TCP
+    targetPort: 9001
+  - name: http
+    port: 9002
+    protocol: TCP
+    targetPort: 9002
+  selector:
+    app: gitpod
+    component: iam
+  type: ClusterIP
+status:
+  loadBalancer: {}
+---
+# v1/Service ide-metrics
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ide-metrics
+    kind: service
+  name: ide-metrics
+  namespace: default
+spec:
+  ports:
+  - name: http
+    port: 3000
+    protocol: TCP
+    targetPort: 3000
+  selector:
+    app: gitpod
+    component: ide-metrics
+  type: ClusterIP
+status:
+  loadBalancer: {}
+---
+# v1/Service ide-proxy
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ide-proxy
+    kind: service
+  name: ide-proxy
+  namespace: default
+spec:
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    app: gitpod
+    component: ide-proxy
+  type: ClusterIP
+status:
+  loadBalancer: {}
+---
+# v1/Service ide-service
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ide-service
+    kind: service
+  name: ide-service
+  namespace: default
+spec:
+  ports:
+  - name: grpc
+    port: 9001
+    protocol: TCP
+    targetPort: 9001
+  selector:
+    app: gitpod
+    component: ide-service
+  type: ClusterIP
+status:
+  loadBalancer: {}
+---
+# v1/Service image-builder-mk3
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: image-builder-mk3
+    kind: service
+  name: image-builder-mk3
+  namespace: default
+spec:
+  ports:
+  - name: service
+    port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: gitpod
+    component: image-builder-mk3
+  type: ClusterIP
+status:
+  loadBalancer: {}
+---
+# v1/Service messagebus
+# Source: rabbitmq/charts/rabbitmq/templates/svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: messagebus
+  namespace: "default"
+  labels:
+    app.kubernetes.io/name: rabbitmq
+    helm.sh/chart: rabbitmq-10.1.1
+    app.kubernetes.io/instance: rabbitmq
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  sessionAffinity: None
+  ports:
+    - name: amqp
+      port: 5672
+      targetPort: amqp
+      nodePort: null
+    - name: amqp-ssl
+      port: 5671
+      targetPort: amqp-ssl
+      nodePort: null
+    - name: epmd
+      port: 4369
+      targetPort: epmd
+      nodePort: null
+    - name: dist
+      port: 25672
+      targetPort: dist
+      nodePort: null
+    - name: http-stats
+      port: 15672
+      targetPort: stats
+      nodePort: null
+    - name: metrics
+      port: 9419
+      targetPort: metrics
+      nodePort: null
+  selector: 
+    app.kubernetes.io/name: rabbitmq
+    app.kubernetes.io/instance: rabbitmq
+---
+# v1/Service messagebus-headless
+# Source: rabbitmq/charts/rabbitmq/templates/svc-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: messagebus-headless
+  namespace: "default"
+  labels:
+    app.kubernetes.io/name: rabbitmq
+    helm.sh/chart: rabbitmq-10.1.1
+    app.kubernetes.io/instance: rabbitmq
+    app.kubernetes.io/managed-by: Helm
+spec:
+  clusterIP: None
+  ports:
+    - name: epmd
+      port: 4369
+      targetPort: epmd
+    - name: amqp
+      port: 5672
+      targetPort: amqp
+    - name: amqp-ssl
+      port: 5671
+      targetPort: amqp-tls
+    - name: dist
+      port: 25672
+      targetPort: dist
+    - name: http-stats
+      port: 15672
+      targetPort: stats
+  selector: 
+    app.kubernetes.io/name: rabbitmq
+    app.kubernetes.io/instance: rabbitmq
+  publishNotReadyAddresses: true
+---
+# v1/Service minio
+# Source: minio/charts/minio/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio
+  namespace: "default"
+  labels:
+    app.kubernetes.io/name: minio
+    helm.sh/chart: minio-11.6.3
+    app.kubernetes.io/instance: minio
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - name: minio-api
+      port: 9000
+      targetPort: minio-api
+      nodePort: null
+    - name: minio-console
+      port: 9001
+      targetPort: minio-console
+      nodePort: null
+  selector:
+    app.kubernetes.io/name: minio
+    app.kubernetes.io/instance: minio
+---
+# v1/Service mysql
+# Source: mysql/charts/mysql/templates/primary/svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: mysql
+  namespace: "default"
+  labels:
+    app.kubernetes.io/name: mysql
+    helm.sh/chart: mysql-9.1.2
+    app.kubernetes.io/instance: mysql
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: primary
+  annotations:
+spec:
+  type: ClusterIP
+  sessionAffinity: None
+  ports:
+    - name: mysql
+      port: 3306
+      protocol: TCP
+      targetPort: mysql
+      nodePort: null
+  selector: 
+    app.kubernetes.io/name: mysql
+    app.kubernetes.io/instance: mysql
+    app.kubernetes.io/component: primary
+---
+# v1/Service mysql-headless
+# Source: mysql/charts/mysql/templates/primary/svc-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: mysql-headless
+  namespace: "default"
+  labels:
+    app.kubernetes.io/name: mysql
+    helm.sh/chart: mysql-9.1.2
+    app.kubernetes.io/instance: mysql
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: primary
+  annotations:
+spec:
+  type: ClusterIP
+  clusterIP: None
+  publishNotReadyAddresses: true
+  ports:
+    - name: mysql
+      port: 3306
+      targetPort: mysql
+  selector: 
+    app.kubernetes.io/name: mysql
+    app.kubernetes.io/instance: mysql
+    app.kubernetes.io/component: primary
+---
+# v1/Service openvsx-proxy
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: openvsx-proxy
+    kind: service
+  name: openvsx-proxy
+  namespace: default
+spec:
+  ports:
+  - name: http
+    port: 8080
+    protocol: TCP
+    targetPort: 8080
+  - name: metrics
+    port: 9500
+    protocol: TCP
+    targetPort: 9500
+  selector:
+    app: gitpod
+    component: openvsx-proxy
+  type: ClusterIP
+status:
+  loadBalancer: {}
+---
+# v1/Service proxy
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    cloud.google.com/neg: '{"exposed_ports": {"80":{},"443": {}}}'
+    external-dns.alpha.kubernetes.io/hostname: gitpod.example.com,*.gitpod.example.com,*.ws.gitpod.example.com
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: proxy
+    kind: service
+  name: proxy
+  namespace: default
+spec:
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  - name: https
+    port: 443
+    protocol: TCP
+    targetPort: 443
+  - name: metrics
+    port: 9500
+    protocol: TCP
+    targetPort: 9500
+  selector:
+    app: gitpod
+    component: proxy
+  type: LoadBalancer
+status:
+  loadBalancer: {}
+---
+# v1/Service public-api-server
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: public-api-server
+    kind: service
+  name: public-api-server
+  namespace: default
+spec:
+  ports:
+  - name: grpc
+    port: 9001
+    protocol: TCP
+    targetPort: 9001
+  - name: http
+    port: 9002
+    protocol: TCP
+    targetPort: 9002
+  selector:
+    app: gitpod
+    component: public-api-server
+  type: ClusterIP
+status:
+  loadBalancer: {}
+---
+# v1/Service registry
+# Source: docker-registry/charts/docker-registry/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: registry
+  namespace: default
+  labels:
+    app: docker-registry
+    chart: docker-registry-1.16.0
+    release: docker-registry
+    heritage: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 443
+      protocol: TCP
+      name: https-443
+      targetPort: 5000
+  selector:
+    app: docker-registry
+    release: docker-registry
+---
+# v1/Service registry-facade
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: registry-facade
+    kind: service
+  name: registry-facade
+  namespace: default
+spec:
+  ports:
+  - name: registry
+    port: 20000
+    protocol: TCP
+    targetPort: 32223
+  selector:
+    app: gitpod
+    component: registry-facade
+  type: ClusterIP
+status:
+  loadBalancer: {}
+---
+# v1/Service server
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: server
+    kind: service
+  name: server
+  namespace: default
+spec:
+  ports:
+  - name: http
+    port: 3000
+    protocol: TCP
+    targetPort: 3000
+  - name: metrics
+    port: 9500
+    protocol: TCP
+    targetPort: 9500
+  - name: install-admin
+    port: 9000
+    protocol: TCP
+    targetPort: 9000
+  - name: session
+    port: 9876
+    protocol: TCP
+    targetPort: 9876
+  - name: debug
+    port: 6060
+    protocol: TCP
+    targetPort: 6060
+  - name: debugnode
+    port: 9229
+    protocol: TCP
+    targetPort: 9229
+  selector:
+    app: gitpod
+    component: server
+  type: ClusterIP
+status:
+  loadBalancer: {}
+---
+# v1/Service ws-daemon
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ws-daemon
+    kind: service
+  name: ws-daemon
+  namespace: default
+spec:
+  clusterIP: None
+  selector:
+    app: gitpod
+    component: ws-daemon
+  type: ClusterIP
+status:
+  loadBalancer: {}
+---
+# v1/Service ws-manager
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ws-manager
+    kind: service
+  name: ws-manager
+  namespace: default
+spec:
+  ports:
+  - name: rpc
+    port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: gitpod
+    component: ws-manager
+  type: ClusterIP
+status:
+  loadBalancer: {}
+---
+# v1/Service ws-proxy
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ws-proxy
+    kind: service
+  name: ws-proxy
+  namespace: default
+spec:
+  ports:
+  - name: http-proxy
+    port: 8080
+    protocol: TCP
+    targetPort: 8080
+  - name: https-proxy
+    port: 9090
+    protocol: TCP
+    targetPort: 9090
+  - name: metrics
+    port: 9500
+    protocol: TCP
+    targetPort: 9500
+  - name: ssh
+    port: 22
+    protocol: TCP
+    targetPort: 2200
+  selector:
+    app: gitpod
+    component: ws-proxy
+  type: ClusterIP
+status:
+  loadBalancer: {}
+---
+# apps/v1/DaemonSet agent-smith
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  annotations:
+    gitpod.io/checksum_config: e5f1dd2a1327394b4bef4172c43487842026ef965fe8cec2475f00b1588de01f
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: agent-smith
+  name: agent-smith
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      app: gitpod
+      component: agent-smith
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: agent-smith
+      name: agent-smith
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: gitpod.io/workload_workspace_regular
+                operator: Exists
+            - matchExpressions:
+              - key: gitpod.io/workload_workspace_headless
+                operator: Exists
+      containers:
+      - args:
+        - run
+        - --config
+        - /config/config.json
+        env:
+        - name: GITPOD_DOMAIN
+          value: gitpod.example.com
+        - name: GITPOD_INSTALLATION_SHORTNAME
+          value: default
+        - name: GITPOD_REGION
+          value: local
+        - name: HOST_URL
+          value: https://gitpod.example.com
+        - name: KUBE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: KUBE_DOMAIN
+          value: svc.cluster.local
+        - name: LOG_LEVEL
+          value: info
+        - name: JAEGER_DISABLED
+          value: "true"
+        - name: NODENAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        image: registry.mydomain.com/namespace/agent-smith:test
+        imagePullPolicy: IfNotPresent
+        name: agent-smith
+        resources:
+          requests:
+            cpu: 100m
+            memory: 32Mi
+        securityContext:
+          privileged: true
+          procMount: Default
+        volumeMounts:
+        - mountPath: /config
+          name: config
+      - args:
+        - --logtostderr
+        - --insecure-listen-address=[$(IP)]:9500
+        - --upstream=http://127.0.0.1:9500/
+        env:
+        - name: IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: registry.mydomain.com/namespace/brancz/kube-rbac-proxy:v0.12.0
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 9500
+          name: metrics
+        resources:
+          requests:
+            cpu: 1m
+            memory: 30Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
+        terminationMessagePolicy: FallbackToLogsOnError
+      dnsPolicy: ClusterFirst
+      enableServiceLinks: false
+      hostPID: true
+      restartPolicy: Always
+      serviceAccountName: agent-smith
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - configMap:
+          name: agent-smith
+        name: config
+  updateStrategy: {}
+status:
+  currentNumberScheduled: 0
+  desiredNumberScheduled: 0
+  numberMisscheduled: 0
+  numberReady: 0
+---
+# apps/v1/DaemonSet registry-facade
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: registry-facade
+  name: registry-facade
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      app: gitpod
+      component: registry-facade
+  template:
+    metadata:
+      annotations:
+        gitpod.io/checksum_config: 68e15719c683f7d74cb1f3c076690c92ee58595cd163dea3446ec8962e0e1e2c
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: registry-facade
+      name: registry-facade
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: gitpod.io/workload_workspace_regular
+                operator: Exists
+            - matchExpressions:
+              - key: gitpod.io/workload_workspace_headless
+                operator: Exists
+      containers:
+      - args:
+        - run
+        - /mnt/config/config.json
+        env:
+        - name: GITPOD_DOMAIN
+          value: gitpod.example.com
+        - name: GITPOD_INSTALLATION_SHORTNAME
+          value: default
+        - name: GITPOD_REGION
+          value: local
+        - name: HOST_URL
+          value: https://gitpod.example.com
+        - name: KUBE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: KUBE_DOMAIN
+          value: svc.cluster.local
+        - name: LOG_LEVEL
+          value: info
+        - name: JAEGER_DISABLED
+          value: "true"
+        - name: GRPC_GO_RETRY
+          value: "on"
+        - name: NODENAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        image: registry.mydomain.com/namespace/registry-facade:test
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /live
+            port: 8086
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 2
+        name: registry-facade
+        ports:
+        - containerPort: 32223
+          hostPort: 20000
+          name: registry
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /ready
+            port: 8086
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          successThreshold: 2
+          timeoutSeconds: 2
+        resources:
+          requests:
+            cpu: 100m
+            memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          privileged: false
+          runAsUser: 1000
+        volumeMounts:
+        - mountPath: /mnt/cache
+          name: cache
+        - mountPath: /mnt/config
+          name: config
+          readOnly: true
+        - mountPath: /ws-manager-client-tls-certs
+          name: ws-manager-client-tls-certs
+          readOnly: true
+        - mountPath: /mnt/pull-secret
+          name: pull-secret
+        - mountPath: /mnt/certificates
+          name: config-certificates
+      - args:
+        - --logtostderr
+        - --insecure-listen-address=[$(IP)]:9500
+        - --upstream=http://127.0.0.1:9500/
+        env:
+        - name: IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: registry.mydomain.com/namespace/brancz/kube-rbac-proxy:v0.12.0
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 9500
+          name: metrics
+        resources:
+          requests:
+            cpu: 1m
+            memory: 30Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
+        terminationMessagePolicy: FallbackToLogsOnError
+      - command:
+        - /app/ready-probe-labeler
+        - --label=gitpod.io/registry-facade_ready_ns_default
+        - --probe-url=http://localhost:8086/ready
+        env:
+        - name: NODENAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        image: registry.mydomain.com/namespace/registry-facade:test
+        imagePullPolicy: IfNotPresent
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /app/ready-probe-labeler
+              - --label=gitpod.io/registry-facade_ready_ns_default
+              - --shutdown
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /ready
+            port: 8086
+          initialDelaySeconds: 5
+          periodSeconds: 2
+          successThreshold: 1
+          timeoutSeconds: 2
+        name: node-labeler
+        resources: {}
+      dnsPolicy: ClusterFirst
+      enableServiceLinks: false
+      initContainers:
+      - command:
+        - bash
+        - -c
+        - set -e; update-ca-certificates -f; cp /etc/ssl/certs/* /ssl-certs; echo
+          'OK'
+        image: registry.mydomain.com/namespace/ca-updater:test
+        imagePullPolicy: IfNotPresent
+        name: update-ca-certificates
+        resources: {}
+        volumeMounts:
+        - mountPath: /ssl-certs
+          name: cacerts
+        - mountPath: /usr/local/share/ca-certificates/gitpod-ca.crt
+          name: gitpod-ca-certificate
+          subPath: ca.crt
+      priorityClassName: system-node-critical
+      restartPolicy: Always
+      serviceAccountName: registry-facade
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - emptyDir: {}
+        name: cache
+      - configMap:
+          name: registry-facade
+        name: config
+      - name: ws-manager-client-tls-certs
+        secret:
+          secretName: ws-manager-client-tls
+      - name: pull-secret
+        secret:
+          items:
+          - key: .dockerconfigjson
+            path: pull-secret.json
+          secretName: builtin-registry-auth
+      - hostPath:
+          path: /
+        name: hostfs
+      - emptyDir: {}
+        name: gitpod-ca-certificate
+      - emptyDir: {}
+        name: cacerts
+      - name: config-certificates
+        secret:
+          secretName: https-certificates
+  updateStrategy: {}
+status:
+  currentNumberScheduled: 0
+  desiredNumberScheduled: 0
+  numberMisscheduled: 0
+  numberReady: 0
+---
+# apps/v1/DaemonSet ws-daemon
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ws-daemon
+  name: ws-daemon
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      app: gitpod
+      component: ws-daemon
+  template:
+    metadata:
+      annotations:
+        gitpod.io/checksum_config: b938c6e286051c22b503c29f5de266741c2045a3ed69be85d7fd9f22a9346254
+        seccomp.security.alpha.kubernetes.io/shiftfs-module-loader: unconfined
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ws-daemon
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: gitpod.io/workload_workspace_regular
+                operator: Exists
+            - matchExpressions:
+              - key: gitpod.io/workload_workspace_headless
+                operator: Exists
+      containers:
+      - args:
+        - run
+        - --config
+        - /config/config.json
+        env:
+        - name: GITPOD_DOMAIN
+          value: gitpod.example.com
+        - name: GITPOD_INSTALLATION_SHORTNAME
+          value: default
+        - name: GITPOD_REGION
+          value: local
+        - name: HOST_URL
+          value: https://gitpod.example.com
+        - name: KUBE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: KUBE_DOMAIN
+          value: svc.cluster.local
+        - name: LOG_LEVEL
+          value: info
+        - name: JAEGER_DISABLED
+          value: "true"
+        - name: NODENAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        image: registry.mydomain.com/namespace/ws-daemon:test
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /live
+            port: 9501
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: ws-daemon
+        ports:
+        - containerPort: 8080
+          hostPort: 8080
+          name: rpc
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /ready
+            port: 9501
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          successThreshold: 2
+          timeoutSeconds: 1
+        resources:
+          requests:
+            cpu: 500m
+            memory: 4Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /mnt/workingarea
+          mountPropagation: Bidirectional
+          name: working-area
+        - mountPath: /config
+          name: config
+        - mountPath: /mnt/containerd.sock
+          name: containerd-socket
+        - mountPath: /mnt/node0
+          name: node-fs0
+        - mountPath: /mnt/mounts
+          mountPropagation: HostToContainer
+          name: node-mounts
+          readOnly: true
+        - mountPath: /mnt/node-cgroups
+          mountPropagation: HostToContainer
+          name: node-cgroups
+        - mountPath: /mnt/hosts
+          name: node-hosts
+        - mountPath: /certs
+          name: tls-certs
+        - mountPath: /mnt/sync-tmp
+          name: gcloud-tmp
+      - args:
+        - --logtostderr
+        - --insecure-listen-address=[$(IP)]:9500
+        - --upstream=http://127.0.0.1:9500/
+        env:
+        - name: IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: registry.mydomain.com/namespace/brancz/kube-rbac-proxy:v0.12.0
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 9500
+          name: metrics
+        resources:
+          requests:
+            cpu: 1m
+            memory: 30Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
+        terminationMessagePolicy: FallbackToLogsOnError
+      - command:
+        - /app/ready-probe-labeler
+        - --label=gitpod.io/ws-daemon_ready_ns_default
+        - --probe-url=http://localhost:9501/ready
+        env:
+        - name: NODENAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        image: registry.mydomain.com/namespace/ws-daemon:test
+        imagePullPolicy: IfNotPresent
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /app/ready-probe-labeler
+              - --label=gitpod.io/ws-daemon_ready_ns_default
+              - --shutdown
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /ready
+            port: 9501
+          initialDelaySeconds: 5
+          periodSeconds: 2
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: node-labeler
+        resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
+      dnsPolicy: ClusterFirst
+      enableServiceLinks: false
+      hostPID: true
+      initContainers:
+      - args:
+        - "exec {BASH_XTRACEFD}>&1 # this causes 'set -x' to write to stdout insted
+          of stderr\nset -euExo pipefail\nsystemctl status kube-container-runtime-monitor.service
+          || true\nif [ \"$(systemctl is-active kube-container-runtime-monitor.service)\"
+          == \"active\" ]\nthen\n\techo \"kube-container-runtime-monitor.service is
+          active\"\n\tsystemctl stop kube-container-runtime-monitor.service\n\tsystemctl
+          disable kube-container-runtime-monitor.service\n\tsystemctl status kube-container-runtime-monitor.service
+          || true\nelse\n\techo \"kube-container-runtime-monitor.service is not active,
+          not doing anything\"\nfi\n"
+        command:
+        - /usr/bin/nsenter
+        - -t
+        - "1"
+        - -a
+        - /bin/bash
+        - -c
+        image: registry.mydomain.com/namespace/library/ubuntu:20.04
+        name: disable-kube-health-monitor
+        resources: {}
+        securityContext:
+          privileged: true
+          procMount: Default
+      - command:
+        - /bin/sh
+        - -c
+        - cp -f /installer/workspace_default.json /mnt/dst/workspace_default_pd-ide-metrics.23.json
+        image: registry.mydomain.com/namespace/seccomp-profile-installer:test
+        name: seccomp-profile-installer
+        resources: {}
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /mnt/dst
+          name: hostseccomp
+      - command:
+        - sh
+        - -c
+        - "(\n\techo \"running sysctls\" &&\n\tsysctl -w net.core.somaxconn=4096 &&\n\tsysctl
+          -w \"net.ipv4.ip_local_port_range=5000 65000\" &&\n\tsysctl -w \"net.ipv4.tcp_tw_reuse=1\"
+          &&\n\tsysctl -w fs.inotify.max_user_watches=1000000 &&\n\tsysctl -w \"kernel.dmesg_restrict=1\"
+          &&\n\tsysctl -w vm.unprivileged_userfaultfd=0\n) && echo \"done!\" || echo
+          \"failed!\"\n"
+        image: registry.mydomain.com/namespace/ws-daemon:test
+        name: sysctl
+        resources: {}
+        securityContext:
+          privileged: true
+      priorityClassName: system-node-critical
+      restartPolicy: Always
+      serviceAccountName: ws-daemon
+      terminationGracePeriodSeconds: 30
+      tolerations:
+      - effect: NoExecute
+        key: node.kubernetes.io/disk-pressure
+        operator: Exists
+      - effect: NoExecute
+        key: node.kubernetes.io/memory-pressure
+        operator: Exists
+      - effect: NoExecute
+        key: node.kubernetes.io/out-of-disk
+        operator: Exists
+      volumes:
+      - hostPath:
+          path: /
+        name: hostfs
+      - hostPath:
+          path: /var/gitpod/workspaces
+          type: DirectoryOrCreate
+        name: working-area
+      - name: tls-certs
+        secret:
+          secretName: ws-daemon-tls
+      - configMap:
+          name: ws-daemon
+        name: config
+      - hostPath:
+          path: /run/containerd/containerd.sock
+          type: Socket
+        name: containerd-socket
+      - hostPath:
+          path: /var/lib/containerd/io.containerd.runtime.v2.task/k8s.io
+          type: Directory
+        name: node-fs0
+      - hostPath:
+          path: /proc/mounts
+          type: File
+        name: node-mounts
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: node-cgroups
+      - hostPath:
+          path: /etc/hosts
+          type: File
+        name: node-hosts
+      - hostPath:
+          path: /usr/src
+          type: Directory
+        name: node-linux-src
+      - hostPath:
+          path: /var/lib/kubelet/seccomp
+        name: hostseccomp
+      - hostPath:
+          path: /var/gitpod/tmp/backup
+          type: DirectoryOrCreate
+        name: gcloud-tmp
+  updateStrategy: {}
+status:
+  currentNumberScheduled: 0
+  desiredNumberScheduled: 0
+  numberMisscheduled: 0
+  numberReady: 0
+---
+# apps/v1/StatefulSet messagebus
+# Source: rabbitmq/charts/rabbitmq/templates/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: messagebus
+  namespace: "default"
+  labels:
+    app.kubernetes.io/name: rabbitmq
+    helm.sh/chart: rabbitmq-10.1.1
+    app.kubernetes.io/instance: rabbitmq
+    app.kubernetes.io/managed-by: Helm
+spec:
+  serviceName: messagebus-headless
+  podManagementPolicy: OrderedReady
+  replicas: 1
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: rabbitmq
+      app.kubernetes.io/instance: rabbitmq
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: rabbitmq
+        helm.sh/chart: rabbitmq-10.1.1
+        app.kubernetes.io/instance: rabbitmq
+        app.kubernetes.io/managed-by: Helm
+      annotations:
+        checksum/config: 2ca9db593e4ca6cdd01f7a65cce1ae90d0d45ecdf0049edfaa4ec72302fcbe8f
+        checksum/secret: c231bbb08185305defa8c4da0f3ee0f5e7a16795362a2133f74e53eb9a40453d
+        prometheus.io/port: '9419'
+        prometheus.io/scrape: "true"
+    spec:
+      
+      serviceAccountName: rabbitmq
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: gitpod.io/workload_meta
+                operator: Exists
+        
+      securityContext:
+        fsGroup: 1001
+      terminationGracePeriodSeconds: 120
+      initContainers:
+      containers:
+        - name: rabbitmq
+          image: registry.mydomain.com/namespace/bitnami/rabbitmq:3.10.2-debian-10-r7
+          imagePullPolicy: "IfNotPresent"
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1001
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - /bin/bash
+                  - -ec
+                  - |
+                    if [[ -f /opt/bitnami/scripts/rabbitmq/nodeshutdown.sh ]]; then
+                        /opt/bitnami/scripts/rabbitmq/nodeshutdown.sh -t "120" -d "false"
+                    else
+                        rabbitmqctl stop_app
+                    fi
+          env:
+            - name: BITNAMI_DEBUG
+              value: "false"
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: MY_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: K8S_SERVICE_NAME
+              value: messagebus-headless
+            - name: K8S_ADDRESS_TYPE
+              value: hostname
+            - name: RABBITMQ_FORCE_BOOT
+              value: "no"
+            - name: RABBITMQ_NODE_NAME
+              value: "rabbit@$(MY_POD_NAME).$(K8S_SERVICE_NAME).$(MY_POD_NAMESPACE).svc.cluster.local"
+            - name: K8S_HOSTNAME_SUFFIX
+              value: ".$(K8S_SERVICE_NAME).$(MY_POD_NAMESPACE).svc.cluster.local"
+            - name: RABBITMQ_MNESIA_DIR
+              value: "/bitnami/rabbitmq/mnesia/$(RABBITMQ_NODE_NAME)"
+            - name: RABBITMQ_LDAP_ENABLE
+              value: "no"
+            - name: RABBITMQ_LOGS
+              value: "-"
+            - name: RABBITMQ_ULIMIT_NOFILES
+              value: "65536"
+            - name: RABBITMQ_USE_LONGNAME
+              value: "true"
+            - name: RABBITMQ_ERL_COOKIE
+              valueFrom:
+                secretKeyRef:
+                  name: messagebus-erlang-cookie
+                  key: rabbitmq-erlang-cookie
+            - name: RABBITMQ_LOAD_DEFINITIONS
+              value: "yes"
+            - name: RABBITMQ_DEFINITIONS_FILE
+              value: "/app/load_definition.json"
+            - name: RABBITMQ_SECURE_PASSWORD
+              value: "yes"
+            - name: RABBITMQ_USERNAME
+              value: "gitpod"
+            - name: RABBITMQ_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: messagebus
+                  key: rabbitmq-password
+            - name: RABBITMQ_PLUGINS
+              value: "rabbitmq_management, rabbitmq_peer_discovery_k8s, rabbitmq_prometheus"
+            - name: RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS
+              value: +sbwt none +sbwtdcpu none +sbwtdio none
+          envFrom:
+          ports:
+            - name: amqp
+              containerPort: 5672
+            - name: dist
+              containerPort: 25672
+            - name: stats
+              containerPort: 15672
+            - name: epmd
+              containerPort: 4369
+            - name: metrics
+              containerPort: 9419
+            - name: amqp-ssl
+              containerPort: 5671
+          livenessProbe:
+            failureThreshold: 6
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 20
+            exec:
+              command:
+                - /bin/bash
+                - -ec
+                - rabbitmq-diagnostics -q ping
+          readinessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 20
+            exec:
+              command:
+                - /bin/bash
+                - -ec
+                - rabbitmq-diagnostics -q check_running && rabbitmq-diagnostics -q check_local_alarms
+          resources:
+            limits: {}
+            requests: {}
+          volumeMounts:
+            - name: configuration
+              mountPath: /bitnami/rabbitmq/conf
+            - name: data
+              mountPath: /bitnami/rabbitmq/mnesia
+            - name: certs
+              mountPath: /opt/bitnami/rabbitmq/certs
+            - name: load-definition-volume
+              mountPath: /app
+              readOnly: true
+      volumes:
+        - name: certs
+          secret:
+            secretName: messagebus-certificates-secret-core
+            items:
+              - key: tls.crt
+                path: ca_certificate.pem
+              - key: tls.crt
+                path: server_certificate.pem
+              - key: tls.key
+                path: server_key.pem
+        - name: configuration
+          secret:
+            secretName: messagebus-config
+            items:
+              - key: rabbitmq.conf
+                path: rabbitmq.conf
+        - name: load-definition-volume
+          secret:
+            secretName: "load-definition"
+        - name: data
+          emptyDir: {}
+---
+# apps/v1/StatefulSet mysql
+# Source: mysql/charts/mysql/templates/primary/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: mysql
+  namespace: "default"
+  labels:
+    app.kubernetes.io/name: mysql
+    helm.sh/chart: mysql-9.1.2
+    app.kubernetes.io/instance: mysql
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: primary
+spec:
+  replicas: 1
+  podManagementPolicy: ""
+  selector:
+    matchLabels: 
+      app.kubernetes.io/name: mysql
+      app.kubernetes.io/instance: mysql
+      app.kubernetes.io/component: primary
+  serviceName: mysql
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        checksum/configuration: 11b8361c0fbf695cec6ec7f47ed4118ad3c7d71a391ca246df129803d3e205a5
+      labels:
+        app.kubernetes.io/name: mysql
+        helm.sh/chart: mysql-9.1.2
+        app.kubernetes.io/instance: mysql
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: primary
+    spec:
+      serviceAccountName: db
+      
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: gitpod.io/workload_meta
+                operator: Exists
+        
+      securityContext:
+        fsGroup: 1001
+      initContainers:
+        - name: volume-permissions
+          image: registry.mydomain.com/namespace/bitnami/bitnami-shell:10-debian-10-r431
+          imagePullPolicy: "IfNotPresent"
+          command:
+            - /bin/bash
+            - -ec
+            - |
+              mkdir -p "/bitnami/mysql"
+              chown "1001:1001" "/bitnami/mysql"
+              find "/bitnami/mysql" -mindepth 1 -maxdepth 1 -not -name ".snapshot" -not -name "lost+found" | xargs -r chown -R "1001:1001"
+          securityContext:
+            runAsUser: 0
+          volumeMounts:
+            - name: data
+              mountPath: /bitnami/mysql
+      containers:
+        - name: mysql
+          image: registry.mydomain.com/namespace/bitnami/mysql:5.7.34-debian-10-r55
+          imagePullPolicy: "IfNotPresent"
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1001
+          env:
+            - name: BITNAMI_DEBUG
+              value: "false"
+            - name: MYSQL_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: db-password
+                  key: mysql-root-password
+            - name: MYSQL_USER
+              value: "gitpod"
+            - name: MYSQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: db-password
+                  key: mysql-password
+            - name: MYSQL_DATABASE
+              value: "gitpod"
+            - name: MYSQL_EXTRA_FLAGS
+              value: --explicit-defaults-for-timestamp=OFF
+          envFrom:
+          ports:
+            - name: mysql
+              containerPort: 3306
+          livenessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+            exec:
+              command:
+                - /bin/bash
+                - -ec
+                - |
+                  password_aux="${MYSQL_ROOT_PASSWORD:-}"
+                  if [[ -f "${MYSQL_ROOT_PASSWORD_FILE:-}" ]]; then
+                      password_aux=$(cat "$MYSQL_ROOT_PASSWORD_FILE")
+                  fi
+                  mysqladmin status -uroot -p"${password_aux}"
+          readinessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+            exec:
+              command:
+                - /bin/bash
+                - -ec
+                - |
+                  password_aux="${MYSQL_ROOT_PASSWORD:-}"
+                  if [[ -f "${MYSQL_ROOT_PASSWORD_FILE:-}" ]]; then
+                      password_aux=$(cat "$MYSQL_ROOT_PASSWORD_FILE")
+                  fi
+                  mysqladmin status -uroot -p"${password_aux}"
+          resources: 
+            limits: {}
+            requests:
+              memory: 128Mi
+          volumeMounts:
+            - name: data
+              mountPath: /bitnami/mysql
+            - name: custom-init-scripts
+              mountPath: /docker-entrypoint-initdb.d
+            - name: config
+              mountPath: /opt/bitnami/mysql/conf/my.cnf
+              subPath: my.cnf
+      volumes:
+        - name: config
+          configMap:
+            name: mysql
+        - name: custom-init-scripts
+          configMap:
+            name: db-init-scripts
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+        labels: 
+          app.kubernetes.io/name: mysql
+          app.kubernetes.io/instance: mysql
+          app.kubernetes.io/component: primary
+        annotations:
+      spec:
+        accessModes:
+          - "ReadWriteOnce"
+        resources:
+          requests:
+            storage: "8Gi"
+---
+# apps/v1/StatefulSet openvsx-proxy
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: openvsx-proxy
+  name: openvsx-proxy
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gitpod
+      component: openvsx-proxy
+  serviceName: openvsx-proxy
+  template:
+    metadata:
+      annotations:
+        gitpod.io/checksum_config: abc77df6fd99cdbb10a25a4e54f17ad9407f29b9bf966edab17a15024359c560
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: openvsx-proxy
+      name: openvsx-proxy
+      namespace: default
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: gitpod.io/workload_ide
+                    operator: Exists
+      containers:
+        - args:
+            - /config/config.json
+          env:
+            - name: GITPOD_DOMAIN
+              value: gitpod.example.com
+            - name: GITPOD_INSTALLATION_SHORTNAME
+              value: default
+            - name: GITPOD_REGION
+              value: local
+            - name: HOST_URL
+              value: https://gitpod.example.com
+            - name: KUBE_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: KUBE_DOMAIN
+              value: svc.cluster.local
+            - name: LOG_LEVEL
+              value: info
+          image: registry.mydomain.com/namespace/openvsx-proxy:test
+          imagePullPolicy: IfNotPresent
+          name: openvsx-proxy
+          ports:
+            - containerPort: 8080
+              name: http
+            - containerPort: 9500
+              name: metrics
+          readinessProbe:
+            httpGet:
+              path: /openvsx-proxy-status
+              port: 8080
+          resources:
+            requests:
+              cpu: 1m
+              memory: 150Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+          volumeMounts:
+            - mountPath: /config
+              name: config
+        - command:
+            - redis-server
+            - /config/redis.conf
+          env:
+            - name: MASTER
+              value: "true"
+          image: registry.mydomain.com/namespace/library/redis:6.2
+          imagePullPolicy: IfNotPresent
+          name: redis
+          ports:
+            - containerPort: 6379
+          resources:
+            requests:
+              cpu: 1m
+              memory: 150Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+          volumeMounts:
+            - mountPath: /config
+              name: config
+            - mountPath: /data
+              name: redis-data
+        - args:
+            - --logtostderr
+            - --insecure-listen-address=[$(IP)]:9500
+            - --upstream=http://127.0.0.1:9500/
+          env:
+            - name: IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+          image: registry.mydomain.com/namespace/brancz/kube-rbac-proxy:v0.12.0
+          name: kube-rbac-proxy
+          ports:
+            - containerPort: 9500
+              name: metrics
+          resources:
+            requests:
+              cpu: 1m
+              memory: 30Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsGroup: 65532
+            runAsNonRoot: true
+            runAsUser: 65532
+          terminationMessagePolicy: FallbackToLogsOnError
+      dnsPolicy: ClusterFirst
+      enableServiceLinks: false
+      restartPolicy: Always
+      serviceAccountName: openvsx-proxy
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - configMap:
+            name: openvsx-proxy-config
+          name: config
+  updateStrategy: {}
+  volumeClaimTemplates:
+    - metadata:
+        creationTimestamp: null
+        labels:
+          app: gitpod
+          component: openvsx-proxy
+        name: redis-data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 8Gi
+      status: {}
+
+---
+# apps/v1/Deployment blobserve
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: blobserve
+  name: blobserve
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gitpod
+      component: blobserve
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        gitpod.io/checksum_config: 27119b1d1b269fec9f51d6d6be3af57db521e2ce9d30391c96a8fe306a8e74df
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: blobserve
+      name: blobserve
+      namespace: default
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: gitpod.io/workload_ide
+                operator: Exists
+      containers:
+      - args:
+        - run
+        - /mnt/config/config.json
+        env:
+        - name: GITPOD_DOMAIN
+          value: gitpod.example.com
+        - name: GITPOD_INSTALLATION_SHORTNAME
+          value: default
+        - name: GITPOD_REGION
+          value: local
+        - name: HOST_URL
+          value: https://gitpod.example.com
+        - name: KUBE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: KUBE_DOMAIN
+          value: svc.cluster.local
+        - name: LOG_LEVEL
+          value: info
+        - name: JAEGER_DISABLED
+          value: "true"
+        image: registry.mydomain.com/namespace/blobserve:test
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /live
+            port: 8086
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 2
+        name: blobserve
+        ports:
+        - containerPort: 32224
+          name: service
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /ready
+            port: 8086
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 2
+        resources:
+          requests:
+            cpu: 100m
+            memory: 32Mi
+        securityContext:
+          privileged: false
+          runAsUser: 1000
+        volumeMounts:
+        - mountPath: /mnt/config
+          name: config
+          readOnly: true
+        - mountPath: /mnt/cache
+          name: cache
+        - mountPath: /mnt/pull-secret
+          name: pull-secret
+      - args:
+        - --logtostderr
+        - --insecure-listen-address=[$(IP)]:9500
+        - --upstream=http://127.0.0.1:9500/
+        env:
+        - name: IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: registry.mydomain.com/namespace/brancz/kube-rbac-proxy:v0.12.0
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 9500
+          name: metrics
+        resources:
+          requests:
+            cpu: 1m
+            memory: 30Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
+        terminationMessagePolicy: FallbackToLogsOnError
+      enableServiceLinks: false
+      serviceAccountName: blobserve
+      volumes:
+      - emptyDir: {}
+        name: cache
+      - configMap:
+          name: blobserve
+        name: config
+      - name: pull-secret
+        secret:
+          items:
+          - key: .dockerconfigjson
+            path: pull-secret.json
+          secretName: builtin-registry-auth
+status: {}
+---
+# apps/v1/Deployment content-service
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: content-service
+  name: content-service
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gitpod
+      component: content-service
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        gitpod.io/checksum_config: 20782435cc6d6e080cf720b57dca8d4d5cfe40942fc71c4bfd54934fdc34c766
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: content-service
+      name: content-service
+      namespace: default
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: gitpod.io/workload_meta
+                operator: Exists
+      containers:
+      - args:
+        - run
+        - --config
+        - /config/config.json
+        env:
+        - name: GITPOD_DOMAIN
+          value: gitpod.example.com
+        - name: GITPOD_INSTALLATION_SHORTNAME
+          value: default
+        - name: GITPOD_REGION
+          value: local
+        - name: HOST_URL
+          value: https://gitpod.example.com
+        - name: KUBE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: KUBE_DOMAIN
+          value: svc.cluster.local
+        - name: LOG_LEVEL
+          value: info
+        - name: JAEGER_DISABLED
+          value: "true"
+        - name: GRPC_GO_RETRY
+          value: "on"
+        image: registry.mydomain.com/namespace/content-service:test
+        imagePullPolicy: IfNotPresent
+        name: content-service
+        ports:
+        - containerPort: 8080
+          name: rpc
+        - containerPort: 9500
+          name: metrics
+        resources:
+          requests:
+            cpu: 100m
+            memory: 32Mi
+        securityContext:
+          privileged: false
+          runAsUser: 1000
+        volumeMounts:
+        - mountPath: /config
+          name: config
+          readOnly: true
+      - args:
+        - --logtostderr
+        - --insecure-listen-address=[$(IP)]:9500
+        - --upstream=http://127.0.0.1:9500/
+        env:
+        - name: IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: registry.mydomain.com/namespace/brancz/kube-rbac-proxy:v0.12.0
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 9500
+          name: metrics
+        resources:
+          requests:
+            cpu: 1m
+            memory: 30Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
+        terminationMessagePolicy: FallbackToLogsOnError
+      dnsPolicy: ClusterFirst
+      enableServiceLinks: false
+      restartPolicy: Always
+      serviceAccountName: content-service
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - configMap:
+          name: content-service
+        name: config
+status: {}
+---
+# apps/v1/Deployment dashboard
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: dashboard
+  name: dashboard
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gitpod
+      component: dashboard
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: dashboard
+      name: dashboard
+      namespace: default
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: gitpod.io/workload_meta
+                operator: Exists
+      containers:
+      - env:
+        - name: GITPOD_DOMAIN
+          value: gitpod.example.com
+        - name: GITPOD_INSTALLATION_SHORTNAME
+          value: default
+        - name: GITPOD_REGION
+          value: local
+        - name: HOST_URL
+          value: https://gitpod.example.com
+        - name: KUBE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: KUBE_DOMAIN
+          value: svc.cluster.local
+        - name: LOG_LEVEL
+          value: info
+        image: registry.mydomain.com/namespace/dashboard:test
+        imagePullPolicy: IfNotPresent
+        name: dashboard
+        ports:
+        - containerPort: 80
+          name: http
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /ready
+            port: 8080
+            scheme: HTTP
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          requests:
+            cpu: 100m
+            memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          privileged: false
+      dnsPolicy: ClusterFirst
+      enableServiceLinks: false
+      restartPolicy: Always
+      serviceAccountName: dashboard
+      terminationGracePeriodSeconds: 30
+status: {}
+---
+# apps/v1/Deployment iam
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    gitpod.io/checksum_config: 7346723d23891c253f282241ed24e225e16dd2ddafa9b7c90d1da928a4923f4b
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: iam
+  name: iam
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gitpod
+      component: iam
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: iam
+      name: iam
+      namespace: default
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: gitpod.io/workload_meta
+                operator: Exists
+      containers:
+      - args:
+        - run
+        - --config=/config.json
+        - --json-log=true
+        env:
+        - name: GITPOD_DOMAIN
+          value: gitpod.example.com
+        - name: GITPOD_INSTALLATION_SHORTNAME
+          value: default
+        - name: GITPOD_REGION
+          value: local
+        - name: HOST_URL
+          value: https://gitpod.example.com
+        - name: KUBE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: KUBE_DOMAIN
+          value: svc.cluster.local
+        - name: LOG_LEVEL
+          value: info
+        - name: DB_HOST
+          valueFrom:
+            secretKeyRef:
+              key: host
+              name: mysql
+        - name: DB_PORT
+          valueFrom:
+            secretKeyRef:
+              key: port
+              name: mysql
+        - name: DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: mysql
+        - name: DB_USERNAME
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: mysql
+        - name: DB_ENCRYPTION_KEYS
+          valueFrom:
+            secretKeyRef:
+              key: encryptionKeys
+              name: mysql
+        image: registry.mydomain.com/namespace/iam:test
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /live
+            port: 9501
+            scheme: HTTP
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: iam
+        ports:
+        - containerPort: 9001
+          name: grpc
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /ready
+            port: 9501
+            scheme: HTTP
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          requests:
+            cpu: 100m
+            memory: 32Mi
+        securityContext:
+          privileged: false
+        volumeMounts:
+        - mountPath: /config.json
+          name: config
+          readOnly: true
+          subPath: config.json
+        - mountPath: /secrets/database-config
+          name: database-config
+          readOnly: true
+      - args:
+        - --logtostderr
+        - --insecure-listen-address=[$(IP)]:9500
+        - --upstream=http://127.0.0.1:9500/
+        env:
+        - name: IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: registry.mydomain.com/namespace/brancz/kube-rbac-proxy:v0.12.0
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 9500
+          name: metrics
+        resources:
+          requests:
+            cpu: 1m
+            memory: 30Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
+        terminationMessagePolicy: FallbackToLogsOnError
+      dnsPolicy: ClusterFirst
+      enableServiceLinks: false
+      initContainers:
+      - args:
+        - -v
+        - database
+        env:
+        - name: DB_HOST
+          valueFrom:
+            secretKeyRef:
+              key: host
+              name: mysql
+        - name: DB_PORT
+          valueFrom:
+            secretKeyRef:
+              key: port
+              name: mysql
+        - name: DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: mysql
+        - name: DB_USERNAME
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: mysql
+        - name: DB_ENCRYPTION_KEYS
+          valueFrom:
+            secretKeyRef:
+              key: encryptionKeys
+              name: mysql
+        image: registry.mydomain.com/namespace/service-waiter:test
+        name: database-waiter
+        resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
+          privileged: false
+          runAsUser: 31001
+      restartPolicy: Always
+      serviceAccountName: iam
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - configMap:
+          name: iam
+        name: config
+      - name: database-config
+        secret:
+          secretName: mysql
+status: {}
+---
+# apps/v1/Deployment ide-metrics
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ide-metrics
+  name: ide-metrics
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gitpod
+      component: ide-metrics
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        gitpod.io/checksum_config: d42da55c46ab5e8278c46a30a13e4f2c614ad4f340863a57c91fc6183a1068fc
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ide-metrics
+      name: ide-metrics
+      namespace: default
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: gitpod.io/workload_meta
+                operator: Exists
+      containers:
+      - args:
+        - run
+        - --config
+        - /config/config.json
+        env:
+        - name: GITPOD_DOMAIN
+          value: gitpod.example.com
+        - name: GITPOD_INSTALLATION_SHORTNAME
+          value: default
+        - name: GITPOD_REGION
+          value: local
+        - name: HOST_URL
+          value: https://gitpod.example.com
+        - name: KUBE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: KUBE_DOMAIN
+          value: svc.cluster.local
+        - name: LOG_LEVEL
+          value: info
+        image: registry.mydomain.com/namespace/ide-metrics:test
+        imagePullPolicy: IfNotPresent
+        name: ide-metrics
+        ports:
+        - containerPort: 3000
+          name: http
+        readinessProbe:
+          failureThreshold: 3
+          successThreshold: 1
+          tcpSocket:
+            port: 3000
+          timeoutSeconds: 1
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          privileged: false
+        volumeMounts:
+        - mountPath: /config
+          name: config
+          readOnly: true
+      - args:
+        - --logtostderr
+        - --insecure-listen-address=[$(IP)]:9500
+        - --upstream=http://127.0.0.1:9500/
+        env:
+        - name: IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: registry.mydomain.com/namespace/brancz/kube-rbac-proxy:v0.12.0
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 9500
+          name: metrics
+        resources:
+          requests:
+            cpu: 1m
+            memory: 30Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
+        terminationMessagePolicy: FallbackToLogsOnError
+      dnsPolicy: ClusterFirst
+      enableServiceLinks: false
+      restartPolicy: Always
+      serviceAccountName: ide-metrics
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - configMap:
+          name: ide-metrics
+        name: config
+status: {}
+---
+# apps/v1/Deployment ide-proxy
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ide-proxy
+  name: ide-proxy
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gitpod
+      component: ide-proxy
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ide-proxy
+      name: ide-proxy
+      namespace: default
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: gitpod.io/workload_meta
+                operator: Exists
+      containers:
+      - env:
+        - name: GITPOD_DOMAIN
+          value: gitpod.example.com
+        - name: GITPOD_INSTALLATION_SHORTNAME
+          value: default
+        - name: GITPOD_REGION
+          value: local
+        - name: HOST_URL
+          value: https://gitpod.example.com
+        - name: KUBE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: KUBE_DOMAIN
+          value: svc.cluster.local
+        - name: LOG_LEVEL
+          value: info
+        image: registry.mydomain.com/namespace/ide-proxy:test
+        imagePullPolicy: IfNotPresent
+        name: ide-proxy
+        ports:
+        - containerPort: 80
+          name: http
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /ready
+            port: 8080
+            scheme: HTTP
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          requests:
+            cpu: 100m
+            memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          privileged: false
+      dnsPolicy: ClusterFirst
+      enableServiceLinks: false
+      restartPolicy: Always
+      serviceAccountName: ide-proxy
+      terminationGracePeriodSeconds: 30
+status: {}
+---
+# apps/v1/Deployment ide-service
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ide-service
+  name: ide-service
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gitpod
+      component: ide-service
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        gitpod.io/checksum_config: 96f0e9e2b0ef57685361631147d448545bddf8e1230493ac99530513b2fe7783
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ide-service
+      name: ide-service
+      namespace: default
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: gitpod.io/workload_meta
+                operator: Exists
+      containers:
+      - args:
+        - run
+        - --config
+        - /config/config.json
+        env:
+        - name: GITPOD_DOMAIN
+          value: gitpod.example.com
+        - name: GITPOD_INSTALLATION_SHORTNAME
+          value: default
+        - name: GITPOD_REGION
+          value: local
+        - name: HOST_URL
+          value: https://gitpod.example.com
+        - name: KUBE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: KUBE_DOMAIN
+          value: svc.cluster.local
+        - name: LOG_LEVEL
+          value: info
+        image: registry.mydomain.com/namespace/ide-service:test
+        imagePullPolicy: IfNotPresent
+        name: ide-service
+        ports:
+        - containerPort: 9001
+          name: grpc
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /ready
+            port: 9501
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          privileged: false
+        volumeMounts:
+        - mountPath: /config
+          name: config
+          readOnly: true
+        - mountPath: /ide-config
+          name: ide-config
+          readOnly: true
+      - args:
+        - --logtostderr
+        - --insecure-listen-address=[$(IP)]:9500
+        - --upstream=http://127.0.0.1:9500/
+        env:
+        - name: IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: registry.mydomain.com/namespace/brancz/kube-rbac-proxy:v0.12.0
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 9500
+          name: metrics
+        resources:
+          requests:
+            cpu: 1m
+            memory: 30Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
+        terminationMessagePolicy: FallbackToLogsOnError
+      dnsPolicy: ClusterFirst
+      enableServiceLinks: false
+      restartPolicy: Always
+      serviceAccountName: ide-service
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - configMap:
+          name: ide-service
+        name: config
+      - configMap:
+          name: ide-config
+        name: ide-config
+status: {}
+---
+# apps/v1/Deployment image-builder-mk3
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: image-builder-mk3
+  name: image-builder-mk3
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gitpod
+      component: image-builder-mk3
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        gitpod.io/checksum_config: a42344ad04c98efcbf37f4ea2193593c0cb67c8491b37973ac6cf57fbd2d7a59
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: image-builder-mk3
+      name: image-builder-mk3
+      namespace: default
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: gitpod.io/workload_meta
+                operator: Exists
+      containers:
+      - args:
+        - run
+        - --config
+        - /config/image-builder.json
+        env:
+        - name: GITPOD_DOMAIN
+          value: gitpod.example.com
+        - name: GITPOD_INSTALLATION_SHORTNAME
+          value: default
+        - name: GITPOD_REGION
+          value: local
+        - name: HOST_URL
+          value: https://gitpod.example.com
+        - name: KUBE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: KUBE_DOMAIN
+          value: svc.cluster.local
+        - name: LOG_LEVEL
+          value: info
+        - name: JAEGER_DISABLED
+          value: "true"
+        image: registry.mydomain.com/namespace/image-builder-mk3:test
+        imagePullPolicy: IfNotPresent
+        name: image-builder-mk3
+        ports:
+        - containerPort: 8080
+          name: service
+        resources:
+          requests:
+            cpu: 100m
+            memory: 200Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          privileged: false
+          runAsUser: 33333
+        volumeMounts:
+        - mountPath: /config/image-builder.json
+          name: configuration
+          subPath: image-builder.json
+        - mountPath: /wsman-certs
+          name: wsman-tls-certs
+          readOnly: true
+        - mountPath: /config/pull-secret
+          name: pull-secret
+      - args:
+        - --logtostderr
+        - --insecure-listen-address=[$(IP)]:9500
+        - --upstream=http://127.0.0.1:9500/
+        env:
+        - name: IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: registry.mydomain.com/namespace/brancz/kube-rbac-proxy:v0.12.0
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 9500
+          name: metrics
+        resources:
+          requests:
+            cpu: 1m
+            memory: 30Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
+        terminationMessagePolicy: FallbackToLogsOnError
+      dnsPolicy: ClusterFirst
+      enableServiceLinks: false
+      initContainers:
+      - command:
+        - bash
+        - -c
+        - set -e; update-ca-certificates -f; cp /etc/ssl/certs/* /ssl-certs; echo
+          'OK'
+        image: registry.mydomain.com/namespace/ca-updater:test
+        imagePullPolicy: IfNotPresent
+        name: update-ca-certificates
+        resources: {}
+        volumeMounts:
+        - mountPath: /ssl-certs
+          name: cacerts
+        - mountPath: /usr/local/share/ca-certificates/gitpod-ca.crt
+          name: gitpod-ca-certificate
+          subPath: ca.crt
+      restartPolicy: Always
+      serviceAccountName: image-builder-mk3
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - configMap:
+          name: image-builder-mk3-config
+        name: configuration
+      - name: wsman-tls-certs
+        secret:
+          secretName: ws-manager-client-tls
+      - name: pull-secret
+        secret:
+          items:
+          - key: .dockerconfigjson
+            path: pull-secret.json
+          secretName: builtin-registry-auth
+      - emptyDir: {}
+        name: gitpod-ca-certificate
+      - emptyDir: {}
+        name: cacerts
+status: {}
+---
+# apps/v1/Deployment minio
+# Source: minio/charts/minio/templates/standalone/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio
+  namespace: "default"
+  labels:
+    app.kubernetes.io/name: minio
+    helm.sh/chart: minio-11.6.3
+    app.kubernetes.io/instance: minio
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: minio
+      app.kubernetes.io/instance: minio
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: minio
+        helm.sh/chart: minio-11.6.3
+        app.kubernetes.io/instance: minio
+        app.kubernetes.io/managed-by: Helm
+      annotations:
+        checksum/credentials-secret: 0a5790906818b3f8eeee0bd3b3e990b3ad02d79bb23c62c0d91a4ca010fb5579
+    spec:
+      
+      serviceAccountName: minio
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: gitpod.io/workload_meta
+                operator: Exists
+        
+      securityContext:
+        fsGroup: 1001
+      containers:
+        - name: minio
+          image: registry.mydomain.com/namespace/bitnami/minio:2022.5.26-debian-10-r0
+          imagePullPolicy: "IfNotPresent"
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1001
+          env:
+            - name: BITNAMI_DEBUG
+              value: "false"
+            - name: MINIO_SCHEME
+              value: "http"
+            - name: MINIO_FORCE_NEW_KEYS
+              value: "no"
+            - name: MINIO_ROOT_USER
+              valueFrom:
+                secretKeyRef:
+                  name: minio
+                  key: root-user
+            - name: MINIO_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: minio
+                  key: root-password
+            - name: MINIO_BROWSER
+              value: "on"
+            - name: MINIO_PROMETHEUS_AUTH_TYPE
+              value: "public"
+            - name: MINIO_CONSOLE_PORT_NUMBER
+              value: "9001"
+            - name: MINIO_SKIP_CLIENT
+              value: "yes"
+          envFrom:
+          ports:
+            - name: minio-api
+              containerPort: 9000
+              protocol: TCP
+            - name: minio-console
+              containerPort: 9001
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /minio/health/live
+              port: minio-api
+              scheme: "HTTP"
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 5
+            successThreshold: 1
+            failureThreshold: 5
+          readinessProbe:
+            tcpSocket:
+              port: minio-api
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 5
+          resources:
+            limits: {}
+            requests:
+              memory: 2Gi
+          volumeMounts:
+            - name: data
+              mountPath: /data
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: minio
+---
+# apps/v1/Deployment proxy
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: proxy
+  name: proxy
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gitpod
+      component: proxy
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        gitpod.io/checksum_config: c52c73e63eaa95613a8f4fe77167c754cd48eaf757dd69c2048400311a5ae0a6
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: proxy
+      name: proxy
+      namespace: default
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: gitpod.io/workload_meta
+                operator: Exists
+      containers:
+      - args:
+        - --logtostderr
+        - --insecure-listen-address=[$(IP)]:9500
+        - --upstream=http://127.0.0.1:9545/
+        env:
+        - name: IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.podIP
+        image: registry.mydomain.com/namespace/brancz/kube-rbac-proxy:v0.12.0
+        imagePullPolicy: IfNotPresent
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 9500
+          name: metrics
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 1m
+            memory: 30Mi
+        securityContext:
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
+      - env:
+        - name: GITPOD_DOMAIN
+          value: gitpod.example.com
+        - name: GITPOD_INSTALLATION_SHORTNAME
+          value: default
+        - name: GITPOD_REGION
+          value: local
+        - name: HOST_URL
+          value: https://gitpod.example.com
+        - name: KUBE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: KUBE_DOMAIN
+          value: svc.cluster.local
+        - name: LOG_LEVEL
+          value: info
+        - name: PROXY_DOMAIN
+          value: gitpod.example.com
+        image: registry.mydomain.com/namespace/proxy:test
+        imagePullPolicy: IfNotPresent
+        name: proxy
+        ports:
+        - containerPort: 80
+          name: http
+        - containerPort: 443
+          name: https
+        - containerPort: 22
+          name: ssh
+          protocol: TCP
+        - containerPort: 9500
+          name: metrics
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /ready
+            port: 8003
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          requests:
+            cpu: 100m
+            memory: 200Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          privileged: false
+        volumeMounts:
+        - mountPath: /etc/caddy/vhosts
+          name: vhosts
+        - mountPath: /etc/caddy/certificates
+          name: config-certificates
+        - mountPath: /etc/caddy/registry-auth
+          name: builtin-registry-auth
+        - mountPath: /etc/caddy/registry-certs
+          name: builtin-registry-certs
+      dnsPolicy: ClusterFirst
+      enableServiceLinks: false
+      initContainers:
+      - command:
+        - sh
+        - -c
+        - sysctl -w net.core.somaxconn=32768; sysctl -w net.ipv4.ip_local_port_range='1024
+          65000'
+        image: registry.mydomain.com/namespace/library/alpine:3.16
+        imagePullPolicy: IfNotPresent
+        name: sysctl
+        resources: {}
+        securityContext:
+          privileged: true
+      priorityClassName: system-node-critical
+      restartPolicy: Always
+      securityContext:
+        runAsNonRoot: false
+      serviceAccountName: proxy
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - configMap:
+          name: proxy-config
+        name: vhosts
+      - name: config-certificates
+        secret:
+          secretName: https-certificates
+      - name: builtin-registry-auth
+        secret:
+          secretName: builtin-registry-auth
+      - name: builtin-registry-certs
+        secret:
+          secretName: builtin-registry-certs
+status: {}
+---
+# apps/v1/Deployment public-api-server
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    gitpod.io/checksum_config: 74ab9c5d2ac7f57832d1df15f9764c3abfc450f45beb9a31d8aefb9bcf1aaea8
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: public-api-server
+  name: public-api-server
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gitpod
+      component: public-api-server
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: public-api-server
+      name: public-api-server
+      namespace: default
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: gitpod.io/workload_meta
+                operator: Exists
+      containers:
+      - args:
+        - run
+        - --config=/config.json
+        - --json-log=true
+        env:
+        - name: GITPOD_DOMAIN
+          value: gitpod.example.com
+        - name: GITPOD_INSTALLATION_SHORTNAME
+          value: default
+        - name: GITPOD_REGION
+          value: local
+        - name: HOST_URL
+          value: https://gitpod.example.com
+        - name: KUBE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: KUBE_DOMAIN
+          value: svc.cluster.local
+        - name: LOG_LEVEL
+          value: info
+        - name: DB_HOST
+          valueFrom:
+            secretKeyRef:
+              key: host
+              name: mysql
+        - name: DB_PORT
+          valueFrom:
+            secretKeyRef:
+              key: port
+              name: mysql
+        - name: DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: mysql
+        - name: DB_USERNAME
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: mysql
+        - name: DB_ENCRYPTION_KEYS
+          valueFrom:
+            secretKeyRef:
+              key: encryptionKeys
+              name: mysql
+        image: registry.mydomain.com/namespace/public-api-server:test
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /live
+            port: 9501
+            scheme: HTTP
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: public-api-server
+        ports:
+        - containerPort: 9001
+          name: grpc
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /ready
+            port: 9501
+            scheme: HTTP
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          requests:
+            cpu: 100m
+            memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          privileged: false
+        volumeMounts:
+        - mountPath: /config.json
+          name: config
+          readOnly: true
+          subPath: config.json
+      - args:
+        - --logtostderr
+        - --insecure-listen-address=[$(IP)]:9500
+        - --upstream=http://127.0.0.1:9500/
+        env:
+        - name: IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: registry.mydomain.com/namespace/brancz/kube-rbac-proxy:v0.12.0
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 9500
+          name: metrics
+        resources:
+          requests:
+            cpu: 1m
+            memory: 30Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
+        terminationMessagePolicy: FallbackToLogsOnError
+      dnsPolicy: ClusterFirst
+      enableServiceLinks: false
+      initContainers:
+      - args:
+        - -v
+        - database
+        env:
+        - name: DB_HOST
+          valueFrom:
+            secretKeyRef:
+              key: host
+              name: mysql
+        - name: DB_PORT
+          valueFrom:
+            secretKeyRef:
+              key: port
+              name: mysql
+        - name: DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: mysql
+        - name: DB_USERNAME
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: mysql
+        - name: DB_ENCRYPTION_KEYS
+          valueFrom:
+            secretKeyRef:
+              key: encryptionKeys
+              name: mysql
+        image: registry.mydomain.com/namespace/service-waiter:test
+        name: database-waiter
+        resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
+          privileged: false
+          runAsUser: 31001
+      restartPolicy: Always
+      serviceAccountName: public-api-server
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - configMap:
+          name: public-api-server
+        name: config
+status: {}
+---
+# apps/v1/Deployment registry
+# Source: docker-registry/charts/docker-registry/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: registry
+  namespace: default
+  labels:
+    app: docker-registry
+    chart: docker-registry-1.16.0
+    release: docker-registry
+    heritage: Helm
+spec:
+  selector:
+    matchLabels:
+      app: docker-registry
+      release: docker-registry
+  replicas: 1
+  minReadySeconds: 5
+  template:
+    metadata:
+      labels:
+        app: docker-registry
+        release: docker-registry
+      annotations:
+        checksum/config: 1d22b82e19bbc654e029029c4fb86ad02dc13422dc3ac52f8175ad190e52a0bb
+        gitpod.io/checksum_config: 0ce55d51677cd683df3c7a244542c6aeaaf5dd6dca0f0458e8053a713228f535
+    spec:
+      serviceAccountName: docker-registry
+      securityContext:
+        fsGroup: 1000
+        runAsUser: 1000
+      containers:
+        - name: docker-registry
+          image: "registry.mydomain.com/namespace/library/registry:2.7.1"
+          imagePullPolicy: IfNotPresent
+          command:
+          - /bin/registry
+          - serve
+          - /etc/docker/registry/config.yml
+          ports:
+            - containerPort: 5000
+          livenessProbe:
+            httpGet:
+              scheme: HTTPS
+              path: /
+              port: 5000
+          readinessProbe:
+            httpGet:
+              scheme: HTTPS
+              path: /
+              port: 5000
+          resources:
+            {}
+          env:
+            - name: REGISTRY_HTTP_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: registry-secret
+                  key: haSharedSecret
+            - name: REGISTRY_HTTP_TLS_CERTIFICATE
+              value: /etc/ssl/docker/tls.crt
+            - name: REGISTRY_HTTP_TLS_KEY
+              value: /etc/ssl/docker/tls.key
+            - name: REGISTRY_STORAGE_FILESYSTEM_ROOTDIRECTORY
+              value: "/var/lib/registry"
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/registry/
+            - name: "registry-config"
+              mountPath: "/etc/docker/registry"
+            - mountPath: /etc/ssl/docker
+              name: tls-cert
+              readOnly: true
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: registry
+        - name: registry-config
+          configMap:
+            name: registry-config
+        - name: tls-cert
+          secret:
+            secretName: builtin-registry-certs
+---
+# apps/v1/Deployment server
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: server
+  name: server
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gitpod
+      component: server
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        gitpod.io/checksum_config: f7bdf2a221081ccd3bf2588232d706ded37099dcc3e01ae0249cafaa87c29cd7
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: server
+      name: server
+      namespace: default
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: gitpod.io/workload_meta
+                operator: Exists
+      containers:
+      - env:
+        - name: GITPOD_DOMAIN
+          value: gitpod.example.com
+        - name: GITPOD_INSTALLATION_SHORTNAME
+          value: default
+        - name: GITPOD_REGION
+          value: local
+        - name: HOST_URL
+          value: https://gitpod.example.com
+        - name: KUBE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: KUBE_DOMAIN
+          value: svc.cluster.local
+        - name: LOG_LEVEL
+          value: info
+        - name: DB_HOST
+          valueFrom:
+            secretKeyRef:
+              key: host
+              name: mysql
+        - name: DB_PORT
+          valueFrom:
+            secretKeyRef:
+              key: port
+              name: mysql
+        - name: DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: mysql
+        - name: DB_USERNAME
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: mysql
+        - name: DB_ENCRYPTION_KEYS
+          valueFrom:
+            secretKeyRef:
+              key: encryptionKeys
+              name: mysql
+        - name: JAEGER_DISABLED
+          value: "true"
+        - name: MESSAGEBUS_USERNAME
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: rabbitmq
+        - name: MESSAGEBUS_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: rabbitmq
+        - name: MESSAGEBUS_CA
+          valueFrom:
+            secretKeyRef:
+              key: ca.crt
+              name: messagebus-certificates-secret-core
+        - name: MESSAGEBUS_CERT
+          valueFrom:
+            secretKeyRef:
+              key: tls.crt
+              name: messagebus-certificates-secret-core
+        - name: MESSAGEBUS_KEY
+          valueFrom:
+            secretKeyRef:
+              key: tls.key
+              name: messagebus-certificates-secret-core
+        - name: CONFIG_PATH
+          value: /config/config.json
+        - name: GITPOD_LICENSE_TYPE
+          value: gitpod
+        - name: IDE_CONFIG_PATH
+          value: /ide-config/config.json
+        - name: NODE_ENV
+          value: production
+        - name: SHLVL
+          value: "1"
+        - name: WSMAN_CFG_MANAGERS
+          value: WwogIHsKICAgICJuYW1lIjogImRlZmF1bHQiLAogICAgInVybCI6ICJkbnM6Ly8vd3MtbWFuYWdlcjo4MDgwIiwKICAgICJ0bHMiOiB7CiAgICAgICJjYSI6ICIvd3MtbWFuYWdlci1jbGllbnQtdGxzLWNlcnRzL2NhLmNydCIsCiAgICAgICJjcnQiOiAiL3dzLW1hbmFnZXItY2xpZW50LXRscy1jZXJ0cy90bHMuY3J0IiwKICAgICAgImtleSI6ICIvd3MtbWFuYWdlci1jbGllbnQtdGxzLWNlcnRzL3Rscy5rZXkiCiAgICB9LAogICAgInN0YXRlIjogImF2YWlsYWJsZSIsCiAgICAibWF4U2NvcmUiOiAxMDAsCiAgICAic2NvcmUiOiA1MCwKICAgICJnb3Zlcm4iOiB0cnVlLAogICAgImFkbWlzc2lvbkNvbnN0cmFpbnRzIjogbnVsbCwKICAgICJhcHBsaWNhdGlvbkNsdXN0ZXIiOiAiZGVmYXVsdCIKICB9Cl0=
+        image: registry.mydomain.com/namespace/server:test
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 6
+          httpGet:
+            path: /live
+            port: 3000
+          initialDelaySeconds: 120
+          periodSeconds: 10
+        name: server
+        ports:
+        - containerPort: 3000
+          name: http
+        - containerPort: 9500
+          name: metrics
+        - containerPort: 9000
+          name: install-admin
+        - containerPort: 9876
+          name: session
+        - containerPort: 6060
+          name: debug
+        - containerPort: 9229
+          name: debugnode
+        resources:
+          requests:
+            cpu: 200m
+            memory: 200Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          privileged: false
+          runAsUser: 31001
+        volumeMounts:
+        - mountPath: /config
+          name: config
+          readOnly: true
+        - mountPath: /ide-config
+          name: ide-config
+          readOnly: true
+        - mountPath: /twilio-config
+          name: twilio-secret-volume
+          readOnly: true
+        - mountPath: /ws-manager-client-tls-certs
+          name: ws-manager-client-tls-certs
+          readOnly: true
+      - args:
+        - --logtostderr
+        - --insecure-listen-address=[$(IP)]:9500
+        - --upstream=http://127.0.0.1:9500/
+        env:
+        - name: IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: registry.mydomain.com/namespace/brancz/kube-rbac-proxy:v0.12.0
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 9500
+          name: metrics
+        resources:
+          requests:
+            cpu: 1m
+            memory: 30Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
+        terminationMessagePolicy: FallbackToLogsOnError
+      enableServiceLinks: false
+      initContainers:
+      - args:
+        - -v
+        - database
+        env:
+        - name: DB_HOST
+          valueFrom:
+            secretKeyRef:
+              key: host
+              name: mysql
+        - name: DB_PORT
+          valueFrom:
+            secretKeyRef:
+              key: port
+              name: mysql
+        - name: DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: mysql
+        - name: DB_USERNAME
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: mysql
+        - name: DB_ENCRYPTION_KEYS
+          valueFrom:
+            secretKeyRef:
+              key: encryptionKeys
+              name: mysql
+        image: registry.mydomain.com/namespace/service-waiter:test
+        name: database-waiter
+        resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
+          privileged: false
+          runAsUser: 31001
+      - args:
+        - -v
+        - messagebus
+        env:
+        - name: MESSAGEBUS_USERNAME
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: rabbitmq
+        - name: MESSAGEBUS_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: rabbitmq
+        - name: MESSAGEBUS_CA
+          valueFrom:
+            secretKeyRef:
+              key: ca.crt
+              name: messagebus-certificates-secret-core
+        - name: MESSAGEBUS_CERT
+          valueFrom:
+            secretKeyRef:
+              key: tls.crt
+              name: messagebus-certificates-secret-core
+        - name: MESSAGEBUS_KEY
+          valueFrom:
+            secretKeyRef:
+              key: tls.key
+              name: messagebus-certificates-secret-core
+        image: registry.mydomain.com/namespace/service-waiter:test
+        name: msgbus-waiter
+        resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
+          privileged: false
+          runAsUser: 31001
+      priorityClassName: system-node-critical
+      serviceAccountName: server
+      volumes:
+      - configMap:
+          name: server-config
+        name: config
+      - configMap:
+          name: server-ide-config
+        name: ide-config
+      - name: twilio-secret-volume
+        secret:
+          optional: true
+          secretName: twilio-secret
+      - name: ws-manager-client-tls-certs
+        secret:
+          secretName: ws-manager-client-tls
+status: {}
+---
+# apps/v1/Deployment ws-manager
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ws-manager
+  name: ws-manager
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gitpod
+      component: ws-manager
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        gitpod.io/checksum_config: 62fb425bd7800391dca7d008cd0c86cab613afef78e188a950e367ed7429ad73
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ws-manager
+      name: ws-manager
+      namespace: default
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: gitpod.io/workload_workspace_services
+                operator: Exists
+      containers:
+      - args:
+        - run
+        - --config
+        - /config/config.json
+        env:
+        - name: GITPOD_DOMAIN
+          value: gitpod.example.com
+        - name: GITPOD_INSTALLATION_SHORTNAME
+          value: default
+        - name: GITPOD_REGION
+          value: local
+        - name: HOST_URL
+          value: https://gitpod.example.com
+        - name: KUBE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: KUBE_DOMAIN
+          value: svc.cluster.local
+        - name: LOG_LEVEL
+          value: info
+        - name: JAEGER_DISABLED
+          value: "true"
+        - name: GRPC_GO_RETRY
+          value: "on"
+        image: registry.mydomain.com/namespace/ws-manager:test
+        imagePullPolicy: IfNotPresent
+        name: ws-manager
+        ports:
+        - containerPort: 8080
+          name: rpc
+        resources:
+          requests:
+            cpu: 100m
+            memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          privileged: false
+        volumeMounts:
+        - mountPath: /config
+          name: config
+          readOnly: true
+        - mountPath: /workspace-templates
+          name: workspace-template
+          readOnly: true
+        - mountPath: /ws-daemon-tls-certs
+          name: ws-daemon-tls-certs
+          readOnly: true
+        - mountPath: /certs
+          name: tls-certs
+          readOnly: true
+      - args:
+        - --logtostderr
+        - --insecure-listen-address=[$(IP)]:9500
+        - --upstream=http://127.0.0.1:9500/
+        env:
+        - name: IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: registry.mydomain.com/namespace/brancz/kube-rbac-proxy:v0.12.0
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 9500
+          name: metrics
+        resources:
+          requests:
+            cpu: 1m
+            memory: 30Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
+        terminationMessagePolicy: FallbackToLogsOnError
+      enableServiceLinks: false
+      priorityClassName: system-node-critical
+      securityContext:
+        runAsUser: 31002
+      serviceAccountName: ws-manager
+      volumes:
+      - configMap:
+          name: ws-manager
+        name: config
+      - configMap:
+          name: workspace-templates
+        name: workspace-template
+      - name: ws-daemon-tls-certs
+        secret:
+          secretName: ws-daemon-tls
+      - name: tls-certs
+        secret:
+          secretName: ws-manager-tls
+status: {}
+---
+# apps/v1/Deployment ws-manager-bridge
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ws-manager-bridge
+  name: ws-manager-bridge
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gitpod
+      component: ws-manager-bridge
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        gitpod.io/checksum_config: c0a3088b82fda02787165a99308e1e0cd9f919c7ba88828f2c98734c22d14c64
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ws-manager-bridge
+      name: ws-manager-bridge
+      namespace: default
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: gitpod.io/workload_meta
+                operator: Exists
+      containers:
+      - env:
+        - name: GITPOD_DOMAIN
+          value: gitpod.example.com
+        - name: GITPOD_INSTALLATION_SHORTNAME
+          value: default
+        - name: GITPOD_REGION
+          value: local
+        - name: HOST_URL
+          value: https://gitpod.example.com
+        - name: KUBE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: KUBE_DOMAIN
+          value: svc.cluster.local
+        - name: LOG_LEVEL
+          value: info
+        - name: JAEGER_DISABLED
+          value: "true"
+        - name: MESSAGEBUS_USERNAME
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: rabbitmq
+        - name: MESSAGEBUS_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: rabbitmq
+        - name: MESSAGEBUS_CA
+          valueFrom:
+            secretKeyRef:
+              key: ca.crt
+              name: messagebus-certificates-secret-core
+        - name: MESSAGEBUS_CERT
+          valueFrom:
+            secretKeyRef:
+              key: tls.crt
+              name: messagebus-certificates-secret-core
+        - name: MESSAGEBUS_KEY
+          valueFrom:
+            secretKeyRef:
+              key: tls.key
+              name: messagebus-certificates-secret-core
+        - name: DB_HOST
+          valueFrom:
+            secretKeyRef:
+              key: host
+              name: mysql
+        - name: DB_PORT
+          valueFrom:
+            secretKeyRef:
+              key: port
+              name: mysql
+        - name: DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: mysql
+        - name: DB_USERNAME
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: mysql
+        - name: DB_ENCRYPTION_KEYS
+          valueFrom:
+            secretKeyRef:
+              key: encryptionKeys
+              name: mysql
+        - name: WSMAN_BRIDGE_CONFIGPATH
+          value: /config/ws-manager-bridge.json
+        image: registry.mydomain.com/namespace/ws-manager-bridge:test
+        imagePullPolicy: IfNotPresent
+        name: ws-manager-bridge
+        ports:
+        - containerPort: 9500
+          name: metrics
+        resources:
+          requests:
+            cpu: 100m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          privileged: false
+          runAsUser: 31001
+        volumeMounts:
+        - mountPath: /config
+          name: config
+          readOnly: true
+        - mountPath: /ws-manager-client-tls-certs
+          name: ws-manager-client-tls-certs
+          readOnly: true
+      - args:
+        - --logtostderr
+        - --insecure-listen-address=[$(IP)]:9500
+        - --upstream=http://127.0.0.1:9500/
+        env:
+        - name: IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: registry.mydomain.com/namespace/brancz/kube-rbac-proxy:v0.12.0
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 9500
+          name: metrics
+        resources:
+          requests:
+            cpu: 1m
+            memory: 30Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
+        terminationMessagePolicy: FallbackToLogsOnError
+      dnsPolicy: ClusterFirst
+      enableServiceLinks: false
+      initContainers:
+      - args:
+        - -v
+        - database
+        env:
+        - name: DB_HOST
+          valueFrom:
+            secretKeyRef:
+              key: host
+              name: mysql
+        - name: DB_PORT
+          valueFrom:
+            secretKeyRef:
+              key: port
+              name: mysql
+        - name: DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: mysql
+        - name: DB_USERNAME
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: mysql
+        - name: DB_ENCRYPTION_KEYS
+          valueFrom:
+            secretKeyRef:
+              key: encryptionKeys
+              name: mysql
+        image: registry.mydomain.com/namespace/service-waiter:test
+        name: database-waiter
+        resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
+          privileged: false
+          runAsUser: 31001
+      - args:
+        - -v
+        - messagebus
+        env:
+        - name: MESSAGEBUS_USERNAME
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: rabbitmq
+        - name: MESSAGEBUS_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: rabbitmq
+        - name: MESSAGEBUS_CA
+          valueFrom:
+            secretKeyRef:
+              key: ca.crt
+              name: messagebus-certificates-secret-core
+        - name: MESSAGEBUS_CERT
+          valueFrom:
+            secretKeyRef:
+              key: tls.crt
+              name: messagebus-certificates-secret-core
+        - name: MESSAGEBUS_KEY
+          valueFrom:
+            secretKeyRef:
+              key: tls.key
+              name: messagebus-certificates-secret-core
+        image: registry.mydomain.com/namespace/service-waiter:test
+        name: msgbus-waiter
+        resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
+          privileged: false
+          runAsUser: 31001
+      priorityClassName: system-node-critical
+      restartPolicy: Always
+      serviceAccountName: ws-manager-bridge
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - configMap:
+          name: ws-manager-bridge-config
+        name: config
+      - name: ws-manager-client-tls-certs
+        secret:
+          secretName: ws-manager-client-tls
+status: {}
+---
+# apps/v1/Deployment ws-proxy
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: ws-proxy
+  name: ws-proxy
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gitpod
+      component: ws-proxy
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        gitpod.io/checksum_config: 54a20d5d027f3637c14e46ec387021c29056fc293a700bd87f470fdd7d796937
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: ws-proxy
+      name: ws-proxy
+      namespace: default
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: gitpod.io/workload_workspace_services
+                operator: Exists
+      containers:
+      - args:
+        - run
+        - /config/config.json
+        env:
+        - name: GITPOD_DOMAIN
+          value: gitpod.example.com
+        - name: GITPOD_INSTALLATION_SHORTNAME
+          value: default
+        - name: GITPOD_REGION
+          value: local
+        - name: HOST_URL
+          value: https://gitpod.example.com
+        - name: KUBE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: KUBE_DOMAIN
+          value: svc.cluster.local
+        - name: LOG_LEVEL
+          value: info
+        - name: JAEGER_DISABLED
+          value: "true"
+        image: registry.mydomain.com/namespace/ws-proxy:test
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 10
+          httpGet:
+            path: /healthz
+            port: 8086
+          initialDelaySeconds: 2
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 2
+        name: ws-proxy
+        ports:
+        - containerPort: 8080
+          name: http-proxy
+        - containerPort: 9090
+          name: https-proxy
+        - containerPort: 9500
+          name: metrics
+        readinessProbe:
+          failureThreshold: 10
+          httpGet:
+            path: /readyz
+            port: 8086
+          initialDelaySeconds: 2
+          periodSeconds: 5
+        resources:
+          requests:
+            cpu: 100m
+            memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          privileged: false
+        volumeMounts:
+        - mountPath: /config
+          name: config
+          readOnly: true
+        - mountPath: /mnt/certificates
+          name: config-certificates
+        - mountPath: /ws-manager-client-tls-certs
+          name: ws-manager-client-tls-certs
+          readOnly: true
+      - args:
+        - --logtostderr
+        - --insecure-listen-address=[$(IP)]:9500
+        - --upstream=http://127.0.0.1:9500/
+        env:
+        - name: IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: registry.mydomain.com/namespace/brancz/kube-rbac-proxy:v0.12.0
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 9500
+          name: metrics
+        resources:
+          requests:
+            cpu: 1m
+            memory: 30Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
+        terminationMessagePolicy: FallbackToLogsOnError
+      enableServiceLinks: false
+      priorityClassName: system-node-critical
+      securityContext:
+        runAsUser: 31002
+      serviceAccountName: ws-proxy
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            app: gitpod
+            component: ws-proxy
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: DoNotSchedule
+      volumes:
+      - configMap:
+          name: ws-proxy
+        name: config
+      - name: config-certificates
+        secret:
+          secretName: https-certificates
+      - name: ws-manager-client-tls-certs
+        secret:
+          secretName: ws-manager-client-tls
+status: {}
+---
+# batch/v1/Job migrations
+apiVersion: batch/v1
+kind: Job
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: migrations
+  name: migrations
+  namespace: default
+spec:
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: migrations
+      name: migrations
+      namespace: default
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: gitpod.io/workload_meta
+                operator: Exists
+      containers:
+      - command:
+        - sh
+        - -c
+        - cd /app/node_modules/@gitpod/gitpod-db && yarn run wait-for-db && yarn run
+          typeorm migration:show || true && yarn run typeorm migration:run
+        env:
+        - name: DB_HOST
+          valueFrom:
+            secretKeyRef:
+              key: host
+              name: mysql
+        - name: DB_PORT
+          valueFrom:
+            secretKeyRef:
+              key: port
+              name: mysql
+        - name: DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: mysql
+        - name: DB_USERNAME
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: mysql
+        - name: DB_ENCRYPTION_KEYS
+          valueFrom:
+            secretKeyRef:
+              key: encryptionKeys
+              name: mysql
+        - name: GITPOD_DOMAIN
+          value: gitpod.example.com
+        - name: GITPOD_INSTALLATION_SHORTNAME
+          value: default
+        - name: GITPOD_REGION
+          value: local
+        - name: HOST_URL
+          value: https://gitpod.example.com
+        - name: KUBE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: KUBE_DOMAIN
+          value: svc.cluster.local
+        - name: LOG_LEVEL
+          value: info
+        image: registry.mydomain.com/namespace/db-migrations:test
+        imagePullPolicy: IfNotPresent
+        name: migrations
+        resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
+      enableServiceLinks: false
+      initContainers:
+      - args:
+        - -v
+        - database
+        env:
+        - name: DB_HOST
+          valueFrom:
+            secretKeyRef:
+              key: host
+              name: mysql
+        - name: DB_PORT
+          valueFrom:
+            secretKeyRef:
+              key: port
+              name: mysql
+        - name: DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: mysql
+        - name: DB_USERNAME
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: mysql
+        - name: DB_ENCRYPTION_KEYS
+          valueFrom:
+            secretKeyRef:
+              key: encryptionKeys
+              name: mysql
+        image: registry.mydomain.com/namespace/service-waiter:test
+        name: database-waiter
+        resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
+          privileged: false
+          runAsUser: 31001
+      restartPolicy: Never
+      serviceAccountName: migrations
+  ttlSecondsAfterFinished: 60
+status: {}
+---
+# batch/v1/CronJob gitpod-telemetry
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: gitpod
+  name: gitpod-telemetry
+  namespace: default
+spec:
+  concurrencyPolicy: Replace
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: gitpod
+      name: gitpod-telemetry
+      namespace: default
+    spec:
+      template:
+        metadata:
+          creationTimestamp: null
+          labels:
+            app: gitpod
+            component: gitpod
+          name: gitpod-telemetry
+          namespace: default
+        spec:
+          containers:
+          - args:
+            - send
+            env:
+            - name: GITPOD_INSTALLATION_VERSION
+              value: pd-ide-metrics.23
+            - name: GITPOD_INSTALLATION_PLATFORM
+              value: unknown
+            - name: SERVER_URL
+              value: http://server.default.svc.cluster.local:9000
+            image: registry.mydomain.com/namespace/installation-telemetry:test
+            imagePullPolicy: IfNotPresent
+            name: gitpod-telemetry
+            resources: {}
+            securityContext:
+              allowPrivilegeEscalation: false
+          enableServiceLinks: false
+          initContainers:
+          - args:
+            - -v
+            - database
+            env:
+            - name: DB_HOST
+              valueFrom:
+                secretKeyRef:
+                  key: host
+                  name: mysql
+            - name: DB_PORT
+              valueFrom:
+                secretKeyRef:
+                  key: port
+                  name: mysql
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: password
+                  name: mysql
+            - name: DB_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  key: username
+                  name: mysql
+            - name: DB_ENCRYPTION_KEYS
+              valueFrom:
+                secretKeyRef:
+                  key: encryptionKeys
+                  name: mysql
+            image: registry.mydomain.com/namespace/service-waiter:test
+            name: database-waiter
+            resources: {}
+            securityContext:
+              allowPrivilegeEscalation: false
+              privileged: false
+              runAsUser: 31001
+          restartPolicy: OnFailure
+          serviceAccountName: gitpod
+  schedule: '@daily'
+  successfulJobsHistoryLimit: 3
+status: {}

--- a/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
+++ b/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
@@ -208,7 +208,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -783,7 +783,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -958,7 +958,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: minio
-    helm.sh/chart: minio-11.6.3
+    helm.sh/chart: minio-11.10.24
     app.kubernetes.io/instance: minio
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
@@ -1022,7 +1022,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
@@ -1152,7 +1152,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1168,7 +1168,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1199,13 +1199,13 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
 data:
   rabbitmq.conf: |-
-    IyMgVXNlcm5hbWUgYW5kIHBhc3N3b3JkCiMjCmRlZmF1bHRfdXNlciA9IGdpdHBvZApkZWZhdWx0X3Bhc3MgPSBDSEFOR0VNRQojIyBDbHVzdGVyaW5nCiMjCmNsdXN0ZXJfZm9ybWF0aW9uLnBlZXJfZGlzY292ZXJ5X2JhY2tlbmQgID0gcmFiYml0X3BlZXJfZGlzY292ZXJ5X2s4cwpjbHVzdGVyX2Zvcm1hdGlvbi5rOHMuaG9zdCA9IGt1YmVybmV0ZXMuZGVmYXVsdApjbHVzdGVyX2Zvcm1hdGlvbi5ub2RlX2NsZWFudXAuaW50ZXJ2YWwgPSAxMApjbHVzdGVyX2Zvcm1hdGlvbi5ub2RlX2NsZWFudXAub25seV9sb2dfd2FybmluZyA9IHRydWUKY2x1c3Rlcl9wYXJ0aXRpb25faGFuZGxpbmcgPSBhdXRvaGVhbApsb2FkX2RlZmluaXRpb25zID0gL2FwcC9sb2FkX2RlZmluaXRpb24uanNvbgojIHF1ZXVlIG1hc3RlciBsb2NhdG9yCnF1ZXVlX21hc3Rlcl9sb2NhdG9yID0gbWluLW1hc3RlcnMKIyBlbmFibGUgZ3Vlc3QgdXNlcgpsb29wYmFja191c2Vycy5ndWVzdCA9IGZhbHNlCmxvYWRfZGVmaW5pdGlvbnMgPSAvYXBwL2xvYWRfZGVmaW5pdGlvbi5qc29uCiMgSW5jcmVhc2Ugc3RhdGlzdGljcyBlbWlzc2lvbiBpbnRlcnZhbCBodHRwczovL3d3dy5yYWJiaXRtcS5jb20vbWFuYWdlbWVudC5odG1sI3N0YXRpc3RpY3MtaW50ZXJ2YWwKY29sbGVjdF9zdGF0aXN0aWNzX2ludGVydmFsID0gMTUwMDAKCnNzbF9vcHRpb25zLnZlcmlmeSA9IHZlcmlmeV9wZWVyCmxpc3RlbmVycy5zc2wuZGVmYXVsdCA9IDU2NzEKc3NsX29wdGlvbnMuZmFpbF9pZl9ub19wZWVyX2NlcnQgPSB0cnVlCnNzbF9vcHRpb25zLmNhY2VydGZpbGUgPSAvb3B0L2JpdG5hbWkvcmFiYml0bXEvY2VydHMvY2FfY2VydGlmaWNhdGUucGVtCnNzbF9vcHRpb25zLmNlcnRmaWxlID0gL29wdC9iaXRuYW1pL3JhYmJpdG1xL2NlcnRzL3NlcnZlcl9jZXJ0aWZpY2F0ZS5wZW0Kc3NsX29wdGlvbnMua2V5ZmlsZSA9IC9vcHQvYml0bmFtaS9yYWJiaXRtcS9jZXJ0cy9zZXJ2ZXJfa2V5LnBlbQojIyBQcm9tZXRoZXVzIG1ldHJpY3MKIyMKcHJvbWV0aGV1cy50Y3AucG9ydCA9IDk0MTk=
+    IyMgVXNlcm5hbWUgYW5kIHBhc3N3b3JkCiMjCmRlZmF1bHRfdXNlciA9IGdpdHBvZAojIyBDbHVzdGVyaW5nCiMjCmNsdXN0ZXJfZm9ybWF0aW9uLnBlZXJfZGlzY292ZXJ5X2JhY2tlbmQgID0gcmFiYml0X3BlZXJfZGlzY292ZXJ5X2s4cwpjbHVzdGVyX2Zvcm1hdGlvbi5rOHMuaG9zdCA9IGt1YmVybmV0ZXMuZGVmYXVsdApjbHVzdGVyX2Zvcm1hdGlvbi5ub2RlX2NsZWFudXAuaW50ZXJ2YWwgPSAxMApjbHVzdGVyX2Zvcm1hdGlvbi5ub2RlX2NsZWFudXAub25seV9sb2dfd2FybmluZyA9IHRydWUKY2x1c3Rlcl9wYXJ0aXRpb25faGFuZGxpbmcgPSBhdXRvaGVhbApsb2FkX2RlZmluaXRpb25zID0gL2FwcC9sb2FkX2RlZmluaXRpb24uanNvbgojIHF1ZXVlIG1hc3RlciBsb2NhdG9yCnF1ZXVlX21hc3Rlcl9sb2NhdG9yID0gbWluLW1hc3RlcnMKIyBlbmFibGUgZ3Vlc3QgdXNlcgpsb29wYmFja191c2Vycy5ndWVzdCA9IGZhbHNlCmxvYWRfZGVmaW5pdGlvbnMgPSAvYXBwL2xvYWRfZGVmaW5pdGlvbi5qc29uCiMgSW5jcmVhc2Ugc3RhdGlzdGljcyBlbWlzc2lvbiBpbnRlcnZhbCBodHRwczovL3d3dy5yYWJiaXRtcS5jb20vbWFuYWdlbWVudC5odG1sI3N0YXRpc3RpY3MtaW50ZXJ2YWwKY29sbGVjdF9zdGF0aXN0aWNzX2ludGVydmFsID0gMTUwMDAKCnNzbF9vcHRpb25zLnZlcmlmeSA9IHZlcmlmeV9wZWVyCmxpc3RlbmVycy5zc2wuZGVmYXVsdCA9IDU2NzEKc3NsX29wdGlvbnMuZmFpbF9pZl9ub19wZWVyX2NlcnQgPSB0cnVlCnNzbF9vcHRpb25zLmNhY2VydGZpbGUgPSAvb3B0L2JpdG5hbWkvcmFiYml0bXEvY2VydHMvY2FfY2VydGlmaWNhdGUucGVtCnNzbF9vcHRpb25zLmNlcnRmaWxlID0gL29wdC9iaXRuYW1pL3JhYmJpdG1xL2NlcnRzL3NlcnZlcl9jZXJ0aWZpY2F0ZS5wZW0Kc3NsX29wdGlvbnMua2V5ZmlsZSA9IC9vcHQvYml0bmFtaS9yYWJiaXRtcS9jZXJ0cy9zZXJ2ZXJfa2V5LnBlbQojIyBQcm9tZXRoZXVzIG1ldHJpY3MKIyMKcHJvbWV0aGV1cy50Y3AucG9ydCA9IDk0MTk=
 ---
 # v1/Secret messagebus-erlang-cookie
 apiVersion: v1
@@ -1229,7 +1229,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: minio
-    helm.sh/chart: minio-11.6.3
+    helm.sh/chart: minio-11.10.24
     app.kubernetes.io/instance: minio
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1265,7 +1265,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1282,7 +1282,7 @@ metadata:
   namespace: default
   labels:
     app: docker-registry
-    chart: docker-registry-1.16.0
+    chart: docker-registry-2.2.2
     heritage: Helm
     release: docker-registry
 type: Opaque
@@ -3431,7 +3431,7 @@ data:
       creationTimestamp: null
       labels:
         app: docker-registry
-        chart: docker-registry-1.16.0
+        chart: docker-registry-2.2.2
         heritage: Helm
         release: docker-registry
       name: registry-secret
@@ -3443,7 +3443,7 @@ data:
       creationTimestamp: null
       labels:
         app: docker-registry
-        chart: docker-registry-1.16.0
+        chart: docker-registry-2.2.2
         heritage: Helm
         release: docker-registry
       name: registry-config
@@ -3455,7 +3455,7 @@ data:
       creationTimestamp: null
       labels:
         app: registry
-        chart: docker-registry-1.16.0
+        chart: docker-registry-2.2.2
         heritage: Helm
         release: docker-registry
       name: registry
@@ -3467,7 +3467,7 @@ data:
       creationTimestamp: null
       labels:
         app: docker-registry
-        chart: docker-registry-1.16.0
+        chart: docker-registry-2.2.2
         heritage: Helm
         release: docker-registry
       name: registry
@@ -3479,7 +3479,7 @@ data:
       creationTimestamp: null
       labels:
         app: docker-registry
-        chart: docker-registry-1.16.0
+        chart: docker-registry-2.2.2
         heritage: Helm
         release: docker-registry
       name: registry
@@ -3494,7 +3494,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql
       namespace: default
     ---
@@ -3507,7 +3507,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql-headless
       namespace: default
     ---
@@ -3520,7 +3520,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql
       namespace: default
     ---
@@ -3533,7 +3533,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql
       namespace: default
     ---
@@ -3545,7 +3545,7 @@ data:
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: minio
-        helm.sh/chart: minio-11.6.3
+        helm.sh/chart: minio-11.10.24
       name: minio
       namespace: default
     ---
@@ -3557,7 +3557,7 @@ data:
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: minio
-        helm.sh/chart: minio-11.6.3
+        helm.sh/chart: minio-11.10.24
       name: minio
       namespace: default
     ---
@@ -3569,7 +3569,7 @@ data:
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: minio
-        helm.sh/chart: minio-11.6.3
+        helm.sh/chart: minio-11.10.24
       name: minio
       namespace: default
     ---
@@ -3581,7 +3581,7 @@ data:
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: minio
-        helm.sh/chart: minio-11.6.3
+        helm.sh/chart: minio-11.10.24
       name: minio
       namespace: default
     ---
@@ -3593,7 +3593,7 @@ data:
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: minio
-        helm.sh/chart: minio-11.6.3
+        helm.sh/chart: minio-11.10.24
       name: minio
       namespace: default
     ---
@@ -3605,7 +3605,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus
       namespace: default
     ---
@@ -3617,7 +3617,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus
       namespace: default
     ---
@@ -3629,7 +3629,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: rabbitmq
       namespace: default
     ---
@@ -3641,7 +3641,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus-config
       namespace: default
     ---
@@ -3653,7 +3653,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus
       namespace: default
     ---
@@ -3665,7 +3665,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: load-definition
       namespace: default
     ---
@@ -3677,7 +3677,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: rabbitmq
       namespace: default
     ---
@@ -3689,7 +3689,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus-endpoint-reader
       namespace: default
     ---
@@ -3701,7 +3701,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus-endpoint-reader
       namespace: default
     ---
@@ -3713,7 +3713,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus-headless
       namespace: default
     ---
@@ -3725,7 +3725,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus
       namespace: default
     ---
@@ -3737,7 +3737,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus
       namespace: default
     ---
@@ -5095,7 +5095,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
@@ -5112,7 +5112,7 @@ data:
     datadir=/bitnami/mysql/data
     tmpdir=/opt/bitnami/mysql/tmp
     max_allowed_packet=16M
-    bind-address=0.0.0.0
+    bind-address=*
     pid-file=/opt/bitnami/mysql/tmp/mysqld.pid
     log-error=/opt/bitnami/mysql/logs/mysqld.log
     character-set-server=UTF8
@@ -5282,7 +5282,7 @@ metadata:
   namespace: default
   labels:
     app: docker-registry
-    chart: docker-registry-1.16.0
+    chart: docker-registry-2.2.2
     heritage: Helm
     release: docker-registry
 data:
@@ -6119,7 +6119,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: minio
-    helm.sh/chart: minio-11.6.3
+    helm.sh/chart: minio-11.10.24
     app.kubernetes.io/instance: minio
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -6138,7 +6138,7 @@ metadata:
   namespace: default
   labels:
     app: registry
-    chart: "docker-registry-1.16.0"
+    chart: "docker-registry-2.2.2"
     release: "docker-registry"
     heritage: "Helm"
 spec:
@@ -6665,7 +6665,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 rules:
@@ -7026,7 +7026,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 subjects:
@@ -7519,7 +7519,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -7563,7 +7563,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -7598,7 +7598,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: minio
-    helm.sh/chart: minio-11.6.3
+    helm.sh/chart: minio-11.10.24
     app.kubernetes.io/instance: minio
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -7625,7 +7625,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
@@ -7653,11 +7653,10 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
-  annotations:
 spec:
   type: ClusterIP
   clusterIP: None
@@ -7771,7 +7770,7 @@ metadata:
   namespace: default
   labels:
     app: docker-registry
-    chart: docker-registry-1.16.0
+    chart: docker-registry-2.2.2
     release: docker-registry
     heritage: Helm
 spec:
@@ -8565,7 +8564,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -8582,12 +8581,12 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/config: 2ca9db593e4ca6cdd01f7a65cce1ae90d0d45ecdf0049edfaa4ec72302fcbe8f
-        checksum/secret: c231bbb08185305defa8c4da0f3ee0f5e7a16795362a2133f74e53eb9a40453d
+        checksum/config: d5780a0c58210a2062d54feb61cfb1d5a9c076f95569c4a77076d22c9bad4190
+        checksum/secret: 64c39dd3a8570ed4b0cc71bc0402bc814d016e16f68732938722b12a57c8e82c
         prometheus.io/port: '9419'
         prometheus.io/scrape: "true"
     spec:
@@ -8607,7 +8606,7 @@ spec:
       initContainers:
       containers:
         - name: rabbitmq
-          image: registry.mydomain.com/namespace/bitnami/rabbitmq:3.10.2-debian-10-r7
+          image: registry.mydomain.com/namespace/bitnami/rabbitmq:3.11.5-debian-11-r2
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true
@@ -8742,11 +8741,10 @@ spec:
               - key: tls.key
                 path: server_key.pem
         - name: configuration
-          secret:
-            secretName: messagebus-config
-            items:
-              - key: rabbitmq.conf
-                path: rabbitmq.conf
+          projected:
+            sources:
+              - secret:
+                  name: messagebus-config
         - name: load-definition-volume
           secret:
             secretName: "load-definition"
@@ -8762,7 +8760,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
@@ -8780,10 +8778,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/configuration: 11b8361c0fbf695cec6ec7f47ed4118ad3c7d71a391ca246df129803d3e205a5
+        checksum/configuration: 0c1e0d4282c8f8f820f3c9d1d79b3f423c4676afac2e3a6de555f8553f146eb4
       labels:
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: primary
@@ -8802,7 +8800,7 @@ spec:
         fsGroup: 1001
       initContainers:
         - name: volume-permissions
-          image: registry.mydomain.com/namespace/bitnami/bitnami-shell:10-debian-10-r431
+          image: registry.mydomain.com/namespace/bitnami/bitnami-shell:11-debian-11-r60
           imagePullPolicy: "IfNotPresent"
           command:
             - /bin/bash
@@ -10087,7 +10085,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: minio
-    helm.sh/chart: minio-11.6.3
+    helm.sh/chart: minio-11.10.24
     app.kubernetes.io/instance: minio
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -10101,11 +10099,11 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: minio
-        helm.sh/chart: minio-11.6.3
+        helm.sh/chart: minio-11.10.24
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/credentials-secret: 094325f216720012cacde9f52fd71c7e8b06dd6386492f6980e0f3588f1b1e7c
+        checksum/credentials-secret: 0f3ceb92b9779df4ce0927f6faeb23e9116b85e0eabe095d903e46a2770cde42
     spec:
       
       serviceAccountName: minio
@@ -10121,7 +10119,7 @@ spec:
         fsGroup: 1001
       containers:
         - name: minio
-          image: registry.mydomain.com/namespace/bitnami/minio:2022.5.26-debian-10-r0
+          image: registry.mydomain.com/namespace/bitnami/minio:2022.12.12-debian-11-r0
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true
@@ -10547,7 +10545,7 @@ metadata:
   namespace: default
   labels:
     app: docker-registry
-    chart: docker-registry-1.16.0
+    chart: docker-registry-2.2.2
     release: docker-registry
     heritage: Helm
 spec:
@@ -10563,7 +10561,9 @@ spec:
         app: docker-registry
         release: docker-registry
       annotations:
-        checksum/config: 1d22b82e19bbc654e029029c4fb86ad02dc13422dc3ac52f8175ad190e52a0bb
+        checksum/config: 699dd382179068f3354c330fcce38625e2861d97b962074b4f57005d40497b00
+        checksum/secret: 450f59aeda22415409a87a1abd2c033c08ebd5fb54fe24d3c56560e92b0218f6
+        
         gitpod.io/checksum_config: 1c66f4ccdb7f6331da2edaecefcb40f6c1b6315c9277eb0418fef3cc584a28bd
     spec:
       serviceAccountName: docker-registry
@@ -10572,7 +10572,7 @@ spec:
         runAsUser: 1000
       containers:
         - name: docker-registry
-          image: "registry.mydomain.com/namespace/library/registry:2.7.1"
+          image: "registry.mydomain.com/namespace/library/registry:2.8.1"
           imagePullPolicy: IfNotPresent
           command:
           - /bin/registry
@@ -10590,9 +10590,9 @@ spec:
               scheme: HTTPS
               path: /
               port: 5000
-          resources:
+          resources: 
             {}
-          env:
+          env: 
             - name: REGISTRY_HTTP_SECRET
               valueFrom:
                 secretKeyRef:
@@ -10604,21 +10604,21 @@ spec:
               value: /etc/ssl/docker/tls.key
             - name: REGISTRY_STORAGE_FILESYSTEM_ROOTDIRECTORY
               value: "/var/lib/registry"
-          volumeMounts:
-            - name: data
-              mountPath: /var/lib/registry/
+          volumeMounts: 
             - name: "registry-config"
               mountPath: "/etc/docker/registry"
+            - name: data
+              mountPath: /var/lib/registry/
             - mountPath: /etc/ssl/docker
               name: tls-cert
               readOnly: true
-      volumes:
-        - name: data
-          persistentVolumeClaim:
-            claimName: registry
+      volumes: 
         - name: registry-config
           configMap:
             name: registry-config
+        - name: data
+          persistentVolumeClaim:
+            claimName: registry
         - name: tls-cert
           secret:
             secretName: builtin-registry-certs

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -1236,9 +1236,9 @@ metadata:
 # v1/Secret builtin-registry-auth
 apiVersion: v1
 data:
-  .dockerconfigjson: eyJhdXRocyI6eyJyZWdpc3RyeS5naXRwb2QuZXhhbXBsZS5jb20iOnsiYXV0aCI6ImVGTmxaRXBwUkdkS1VWRm5ORUpyVnpWNFMzVTZRMWMwUTFKQ2FtazJVakJpUjBjNE1XZDVSWGs9In19fQ==
-  password: Q1c0Q1JCamk2UjBiR0c4MWd5RXk=
-  user: eFNlZEppRGdKUVFnNEJrVzV4S3U=
+  .dockerconfigjson: eyJhdXRocyI6eyJyZWdpc3RyeS5naXRwb2QuZXhhbXBsZS5jb20iOnsiYXV0aCI6ImVIZDVRMGRsTlZVd1RrRnFObFZsYVhFM1RqQTZWbE5UYkcxaFMxZFFhaTVRVVhCdFZXWnNWR1E9In19fQ==
+  password: VlNTbG1hS1dQai5QUXBtVWZsVGQ=
+  user: eHd5Q0dlNVUwTkFqNlVlaXE3TjA=
 kind: Secret
 metadata:
   creationTimestamp: null
@@ -1354,8 +1354,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 type: Opaque
 data:
-  root-user: "OC1XR3F3Mm9UbnNQZlVETlNrMFk="
-  root-password: "RHBDLmFTQXhrV0JQdTJfYkpfQUU="
+  root-user: "UkJqaTZSMGJHRzgxZ3lFeWUyNVA="
+  root-password: "dFg2TUw4Z0NXMzFtaXcwVDhRTUk="
   key.json: ""
 ---
 # v1/Secret mysql
@@ -1560,9 +1560,9 @@ data:
         },
         "minio": {
           "endpoint": "minio.default.svc.cluster.local:9000",
-          "accessKey": "8-WGqw2oTnsPfUDNSk0Y",
+          "accessKey": "RBji6R0bGG81gyEye25P",
           "accessKeyFile": "",
-          "secretKey": "DpC.aSAxkWBPu2_bJ_AE",
+          "secretKey": "tX6ML8gCW31miw0T8QMI",
           "secretKeyFile": "",
           "region": "local",
           "parallelUpload": 6
@@ -5753,7 +5753,7 @@ data:
         import ssl_configuration
 
         basicauth bcrypt "Docker Registry" {
-            xSedJiDgJQQg4BkW5xKu JDJhJDEwJFFTRGRRMHZZY2pIS2JqUC9aMDNnVC5HbEg2Z1dOQm5TL0pySnpYSm5iNy9DeVh0ZUw2cFM2
+            xwyCGe5U0NAj6Ueiq7N0 JDJhJDEwJFFTRGRRMHZZY2pIS2JqUC9aMDNnVC5CY0M3RDZsVVg0LzBpZmdnTGovT0VVWXoxTG8ud0lX
         }
 
         reverse_proxy https://registry.default.svc.cluster.local {
@@ -6039,7 +6039,7 @@ data:
       },
       "oauthServer": {
         "enabled": true,
-        "jwtSecret": "8QMIxwyCGe5U0NAj6Uei"
+        "jwtSecret": "m30EH-M2-cWMgkgdy7pu"
       },
       "rateLimiter": {
         "groups": {
@@ -6379,9 +6379,9 @@ data:
             },
             "minio": {
               "endpoint": "minio.default.svc.cluster.local:9000",
-              "accessKey": "8-WGqw2oTnsPfUDNSk0Y",
+              "accessKey": "RBji6R0bGG81gyEye25P",
               "accessKeyFile": "",
-              "secretKey": "DpC.aSAxkWBPu2_bJ_AE",
+              "secretKey": "tX6ML8gCW31miw0T8QMI",
               "secretKeyFile": "",
               "region": "local",
               "parallelUpload": 6
@@ -6568,9 +6568,9 @@ data:
           },
           "minio": {
             "endpoint": "minio.default.svc.cluster.local:9000",
-            "accessKey": "8-WGqw2oTnsPfUDNSk0Y",
+            "accessKey": "RBji6R0bGG81gyEye25P",
             "accessKeyFile": "",
-            "secretKey": "DpC.aSAxkWBPu2_bJ_AE",
+            "secretKey": "tX6ML8gCW31miw0T8QMI",
             "secretKeyFile": "",
             "region": "local",
             "parallelUpload": 6
@@ -8798,7 +8798,7 @@ spec:
     metadata:
       annotations:
         gitpod.io: hello
-        gitpod.io/checksum_config: fd416b9d91d5650b8ddab533d0b39983c0169716448f74ad056ed5dbc5227aa7
+        gitpod.io/checksum_config: c218d6401941c1151e9352d943af91e5702230561bfe7bf6f82f98ec9b1bb4e2
         hello: world
       creationTimestamp: null
       labels:
@@ -9024,7 +9024,7 @@ spec:
     metadata:
       annotations:
         gitpod.io: hello
-        gitpod.io/checksum_config: c4545c0bedaebc30f469d70ae1a266e68d203b27ae521f8983c90a799f61a49a
+        gitpod.io/checksum_config: 6f1809fca515396f4d65c512e9307756d6e10fff8acca0498d53ad83f7f39b4b
         hello: world
         seccomp.security.alpha.kubernetes.io/shiftfs-module-loader: unconfined
       creationTimestamp: null
@@ -9841,7 +9841,7 @@ spec:
     metadata:
       annotations:
         gitpod.io: hello
-        gitpod.io/checksum_config: f53bfe17888be51da5fce1993c73c75420a1ea22a48ae12c1a1b1ba218ca416c
+        gitpod.io/checksum_config: e74e2e6cf0f4335d2ee5420aa16b09783844ae8c9c8f109ac086d2f10634fb7c
         hello: world
       creationTimestamp: null
       labels:
@@ -9991,7 +9991,7 @@ spec:
     metadata:
       annotations:
         gitpod.io: hello
-        gitpod.io/checksum_config: efaa4ecb9c874bc91c8f6000604bbbc61f5294f388703b19ec5cdb58c303ea23
+        gitpod.io/checksum_config: 4899f3940fbfcf76586ff108843223228bce2ca11fa39645581c6ecd904d4f7d
         hello: world
       creationTimestamp: null
       labels:
@@ -10774,7 +10774,7 @@ spec:
     metadata:
       annotations:
         gitpod.io: hello
-        gitpod.io/checksum_config: 3bbe78a00b2f3aebbeb9914eeb8c5e4fed6f3f71646fe10d5c5d6eb61063c719
+        gitpod.io/checksum_config: 4b33ed54c60e126484789929736e0bcbd912e1a5b4a07cf5eebdb45837813aea
         hello: world
       creationTimestamp: null
       labels:
@@ -10930,7 +10930,7 @@ spec:
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/credentials-secret: 0a5790906818b3f8eeee0bd3b3e990b3ad02d79bb23c62c0d91a4ca010fb5579
+        checksum/credentials-secret: 094325f216720012cacde9f52fd71c7e8b06dd6386492f6980e0f3588f1b1e7c
     spec:
       
       serviceAccountName: minio
@@ -11044,7 +11044,7 @@ spec:
     metadata:
       annotations:
         gitpod.io: hello
-        gitpod.io/checksum_config: 0f81d4cad6198e5d0222f29f92143d4db7e502feae211f06ed3a71978d5be7e6
+        gitpod.io/checksum_config: 7eae00bddbe605f0150e2b3c4c065084f924179153e824d7281f1c169bc7abd0
         hello: world
       creationTimestamp: null
       labels:
@@ -11410,7 +11410,7 @@ spec:
       annotations:
         checksum/config: 1d22b82e19bbc654e029029c4fb86ad02dc13422dc3ac52f8175ad190e52a0bb
         gitpod.io: hello
-        gitpod.io/checksum_config: 0ce55d51677cd683df3c7a244542c6aeaaf5dd6dca0f0458e8053a713228f535
+        gitpod.io/checksum_config: 1c66f4ccdb7f6331da2edaecefcb40f6c1b6315c9277eb0418fef3cc584a28bd
         hello: world
     spec:
       serviceAccountName: docker-registry
@@ -11500,7 +11500,7 @@ spec:
     metadata:
       annotations:
         gitpod.io: hello
-        gitpod.io/checksum_config: 6c49f0b6ac858fc4df2c16fccab97b9967d314efe7a321277f1c43b352b0023d
+        gitpod.io/checksum_config: d160a1089a804609aa6ad12e87ac23e4c76e29efd39e9ddf44796a71fc4d6b3f
         hello: world
       creationTimestamp: null
       labels:
@@ -11790,7 +11790,7 @@ spec:
     metadata:
       annotations:
         gitpod.io: hello
-        gitpod.io/checksum_config: 6be9fbe9ae8dd0aaaf625651e4db07ef2a2cb1652b6b415c46885e2c5e2355ac
+        gitpod.io/checksum_config: 73e659a7fb2aa1e8503b572ee8217f6e841db2e3ac8ebb8ca4a0ebf5beff6d9b
         hello: world
       creationTimestamp: null
       labels:

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -208,7 +208,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -783,7 +783,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1023,7 +1023,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: minio
-    helm.sh/chart: minio-11.6.3
+    helm.sh/chart: minio-11.10.24
     app.kubernetes.io/instance: minio
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
@@ -1107,7 +1107,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
@@ -1272,7 +1272,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1288,7 +1288,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1319,13 +1319,13 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
 data:
   rabbitmq.conf: |-
-    IyMgVXNlcm5hbWUgYW5kIHBhc3N3b3JkCiMjCmRlZmF1bHRfdXNlciA9IGdpdHBvZApkZWZhdWx0X3Bhc3MgPSBDSEFOR0VNRQojIyBDbHVzdGVyaW5nCiMjCmNsdXN0ZXJfZm9ybWF0aW9uLnBlZXJfZGlzY292ZXJ5X2JhY2tlbmQgID0gcmFiYml0X3BlZXJfZGlzY292ZXJ5X2s4cwpjbHVzdGVyX2Zvcm1hdGlvbi5rOHMuaG9zdCA9IGt1YmVybmV0ZXMuZGVmYXVsdApjbHVzdGVyX2Zvcm1hdGlvbi5ub2RlX2NsZWFudXAuaW50ZXJ2YWwgPSAxMApjbHVzdGVyX2Zvcm1hdGlvbi5ub2RlX2NsZWFudXAub25seV9sb2dfd2FybmluZyA9IHRydWUKY2x1c3Rlcl9wYXJ0aXRpb25faGFuZGxpbmcgPSBhdXRvaGVhbApsb2FkX2RlZmluaXRpb25zID0gL2FwcC9sb2FkX2RlZmluaXRpb24uanNvbgojIHF1ZXVlIG1hc3RlciBsb2NhdG9yCnF1ZXVlX21hc3Rlcl9sb2NhdG9yID0gbWluLW1hc3RlcnMKIyBlbmFibGUgZ3Vlc3QgdXNlcgpsb29wYmFja191c2Vycy5ndWVzdCA9IGZhbHNlCmxvYWRfZGVmaW5pdGlvbnMgPSAvYXBwL2xvYWRfZGVmaW5pdGlvbi5qc29uCiMgSW5jcmVhc2Ugc3RhdGlzdGljcyBlbWlzc2lvbiBpbnRlcnZhbCBodHRwczovL3d3dy5yYWJiaXRtcS5jb20vbWFuYWdlbWVudC5odG1sI3N0YXRpc3RpY3MtaW50ZXJ2YWwKY29sbGVjdF9zdGF0aXN0aWNzX2ludGVydmFsID0gMTUwMDAKCnNzbF9vcHRpb25zLnZlcmlmeSA9IHZlcmlmeV9wZWVyCmxpc3RlbmVycy5zc2wuZGVmYXVsdCA9IDU2NzEKc3NsX29wdGlvbnMuZmFpbF9pZl9ub19wZWVyX2NlcnQgPSB0cnVlCnNzbF9vcHRpb25zLmNhY2VydGZpbGUgPSAvb3B0L2JpdG5hbWkvcmFiYml0bXEvY2VydHMvY2FfY2VydGlmaWNhdGUucGVtCnNzbF9vcHRpb25zLmNlcnRmaWxlID0gL29wdC9iaXRuYW1pL3JhYmJpdG1xL2NlcnRzL3NlcnZlcl9jZXJ0aWZpY2F0ZS5wZW0Kc3NsX29wdGlvbnMua2V5ZmlsZSA9IC9vcHQvYml0bmFtaS9yYWJiaXRtcS9jZXJ0cy9zZXJ2ZXJfa2V5LnBlbQojIyBQcm9tZXRoZXVzIG1ldHJpY3MKIyMKcHJvbWV0aGV1cy50Y3AucG9ydCA9IDk0MTk=
+    IyMgVXNlcm5hbWUgYW5kIHBhc3N3b3JkCiMjCmRlZmF1bHRfdXNlciA9IGdpdHBvZAojIyBDbHVzdGVyaW5nCiMjCmNsdXN0ZXJfZm9ybWF0aW9uLnBlZXJfZGlzY292ZXJ5X2JhY2tlbmQgID0gcmFiYml0X3BlZXJfZGlzY292ZXJ5X2s4cwpjbHVzdGVyX2Zvcm1hdGlvbi5rOHMuaG9zdCA9IGt1YmVybmV0ZXMuZGVmYXVsdApjbHVzdGVyX2Zvcm1hdGlvbi5ub2RlX2NsZWFudXAuaW50ZXJ2YWwgPSAxMApjbHVzdGVyX2Zvcm1hdGlvbi5ub2RlX2NsZWFudXAub25seV9sb2dfd2FybmluZyA9IHRydWUKY2x1c3Rlcl9wYXJ0aXRpb25faGFuZGxpbmcgPSBhdXRvaGVhbApsb2FkX2RlZmluaXRpb25zID0gL2FwcC9sb2FkX2RlZmluaXRpb24uanNvbgojIHF1ZXVlIG1hc3RlciBsb2NhdG9yCnF1ZXVlX21hc3Rlcl9sb2NhdG9yID0gbWluLW1hc3RlcnMKIyBlbmFibGUgZ3Vlc3QgdXNlcgpsb29wYmFja191c2Vycy5ndWVzdCA9IGZhbHNlCmxvYWRfZGVmaW5pdGlvbnMgPSAvYXBwL2xvYWRfZGVmaW5pdGlvbi5qc29uCiMgSW5jcmVhc2Ugc3RhdGlzdGljcyBlbWlzc2lvbiBpbnRlcnZhbCBodHRwczovL3d3dy5yYWJiaXRtcS5jb20vbWFuYWdlbWVudC5odG1sI3N0YXRpc3RpY3MtaW50ZXJ2YWwKY29sbGVjdF9zdGF0aXN0aWNzX2ludGVydmFsID0gMTUwMDAKCnNzbF9vcHRpb25zLnZlcmlmeSA9IHZlcmlmeV9wZWVyCmxpc3RlbmVycy5zc2wuZGVmYXVsdCA9IDU2NzEKc3NsX29wdGlvbnMuZmFpbF9pZl9ub19wZWVyX2NlcnQgPSB0cnVlCnNzbF9vcHRpb25zLmNhY2VydGZpbGUgPSAvb3B0L2JpdG5hbWkvcmFiYml0bXEvY2VydHMvY2FfY2VydGlmaWNhdGUucGVtCnNzbF9vcHRpb25zLmNlcnRmaWxlID0gL29wdC9iaXRuYW1pL3JhYmJpdG1xL2NlcnRzL3NlcnZlcl9jZXJ0aWZpY2F0ZS5wZW0Kc3NsX29wdGlvbnMua2V5ZmlsZSA9IC9vcHQvYml0bmFtaS9yYWJiaXRtcS9jZXJ0cy9zZXJ2ZXJfa2V5LnBlbQojIyBQcm9tZXRoZXVzIG1ldHJpY3MKIyMKcHJvbWV0aGV1cy50Y3AucG9ydCA9IDk0MTk=
 ---
 # v1/Secret messagebus-erlang-cookie
 apiVersion: v1
@@ -1349,7 +1349,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: minio
-    helm.sh/chart: minio-11.6.3
+    helm.sh/chart: minio-11.10.24
     app.kubernetes.io/instance: minio
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1385,7 +1385,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1402,7 +1402,7 @@ metadata:
   namespace: default
   labels:
     app: docker-registry
-    chart: docker-registry-1.16.0
+    chart: docker-registry-2.2.2
     heritage: Helm
     release: docker-registry
 type: Opaque
@@ -3971,7 +3971,7 @@ data:
       creationTimestamp: null
       labels:
         app: docker-registry
-        chart: docker-registry-1.16.0
+        chart: docker-registry-2.2.2
         heritage: Helm
         release: docker-registry
       name: registry-secret
@@ -3983,7 +3983,7 @@ data:
       creationTimestamp: null
       labels:
         app: docker-registry
-        chart: docker-registry-1.16.0
+        chart: docker-registry-2.2.2
         heritage: Helm
         release: docker-registry
       name: registry-config
@@ -3995,7 +3995,7 @@ data:
       creationTimestamp: null
       labels:
         app: registry
-        chart: docker-registry-1.16.0
+        chart: docker-registry-2.2.2
         heritage: Helm
         release: docker-registry
       name: registry
@@ -4010,7 +4010,7 @@ data:
       creationTimestamp: null
       labels:
         app: docker-registry
-        chart: docker-registry-1.16.0
+        chart: docker-registry-2.2.2
         heritage: Helm
         release: docker-registry
       name: registry
@@ -4022,7 +4022,7 @@ data:
       creationTimestamp: null
       labels:
         app: docker-registry
-        chart: docker-registry-1.16.0
+        chart: docker-registry-2.2.2
         heritage: Helm
         release: docker-registry
       name: registry
@@ -4037,7 +4037,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql
       namespace: default
     ---
@@ -4050,7 +4050,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql-headless
       namespace: default
     ---
@@ -4063,7 +4063,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql
       namespace: default
     ---
@@ -4076,7 +4076,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql
       namespace: default
     ---
@@ -4088,7 +4088,7 @@ data:
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: minio
-        helm.sh/chart: minio-11.6.3
+        helm.sh/chart: minio-11.10.24
       name: minio
       namespace: default
     ---
@@ -4100,7 +4100,7 @@ data:
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: minio
-        helm.sh/chart: minio-11.6.3
+        helm.sh/chart: minio-11.10.24
       name: minio
       namespace: default
     ---
@@ -4112,7 +4112,7 @@ data:
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: minio
-        helm.sh/chart: minio-11.6.3
+        helm.sh/chart: minio-11.10.24
       name: minio
       namespace: default
     ---
@@ -4124,7 +4124,7 @@ data:
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: minio
-        helm.sh/chart: minio-11.6.3
+        helm.sh/chart: minio-11.10.24
       name: minio
       namespace: default
     ---
@@ -4136,7 +4136,7 @@ data:
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: minio
-        helm.sh/chart: minio-11.6.3
+        helm.sh/chart: minio-11.10.24
       name: minio
       namespace: default
     ---
@@ -4148,7 +4148,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus
       namespace: default
     ---
@@ -4160,7 +4160,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus
       namespace: default
     ---
@@ -4172,7 +4172,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: rabbitmq
       namespace: default
     ---
@@ -4184,7 +4184,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus-config
       namespace: default
     ---
@@ -4196,7 +4196,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus
       namespace: default
     ---
@@ -4208,7 +4208,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: load-definition
       namespace: default
     ---
@@ -4220,7 +4220,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: rabbitmq
       namespace: default
     ---
@@ -4232,7 +4232,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus-endpoint-reader
       namespace: default
     ---
@@ -4244,7 +4244,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus-endpoint-reader
       namespace: default
     ---
@@ -4256,7 +4256,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus-headless
       namespace: default
     ---
@@ -4268,7 +4268,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus
       namespace: default
     ---
@@ -4280,7 +4280,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus
       namespace: default
     ---
@@ -5673,7 +5673,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
@@ -5690,7 +5690,7 @@ data:
     datadir=/bitnami/mysql/data
     tmpdir=/opt/bitnami/mysql/tmp
     max_allowed_packet=16M
-    bind-address=0.0.0.0
+    bind-address=*
     pid-file=/opt/bitnami/mysql/tmp/mysqld.pid
     log-error=/opt/bitnami/mysql/logs/mysqld.log
     character-set-server=UTF8
@@ -5875,7 +5875,7 @@ metadata:
   namespace: default
   labels:
     app: docker-registry
-    chart: docker-registry-1.16.0
+    chart: docker-registry-2.2.2
     heritage: Helm
     release: docker-registry
 data:
@@ -6747,7 +6747,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: minio
-    helm.sh/chart: minio-11.6.3
+    helm.sh/chart: minio-11.10.24
     app.kubernetes.io/instance: minio
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -6766,7 +6766,7 @@ metadata:
   namespace: default
   labels:
     app: registry
-    chart: "docker-registry-1.16.0"
+    chart: "docker-registry-2.2.2"
     release: "docker-registry"
     heritage: "Helm"
 spec:
@@ -7293,7 +7293,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 rules:
@@ -7654,7 +7654,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 subjects:
@@ -8192,7 +8192,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -8236,7 +8236,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -8271,7 +8271,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: minio
-    helm.sh/chart: minio-11.6.3
+    helm.sh/chart: minio-11.10.24
     app.kubernetes.io/instance: minio
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -8298,7 +8298,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
@@ -8326,11 +8326,10 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
-  annotations:
 spec:
   type: ClusterIP
   clusterIP: None
@@ -8458,7 +8457,7 @@ metadata:
   namespace: default
   labels:
     app: docker-registry
-    chart: docker-registry-1.16.0
+    chart: docker-registry-2.2.2
     release: docker-registry
     heritage: Helm
   annotations:
@@ -9307,7 +9306,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -9324,12 +9323,12 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/config: 2ca9db593e4ca6cdd01f7a65cce1ae90d0d45ecdf0049edfaa4ec72302fcbe8f
-        checksum/secret: c231bbb08185305defa8c4da0f3ee0f5e7a16795362a2133f74e53eb9a40453d
+        checksum/config: d5780a0c58210a2062d54feb61cfb1d5a9c076f95569c4a77076d22c9bad4190
+        checksum/secret: 64c39dd3a8570ed4b0cc71bc0402bc814d016e16f68732938722b12a57c8e82c
         prometheus.io/port: '9419'
         prometheus.io/scrape: "true"
     spec:
@@ -9349,7 +9348,7 @@ spec:
       initContainers:
       containers:
         - name: rabbitmq
-          image: docker.io/bitnami/rabbitmq:3.10.2-debian-10-r7
+          image: docker.io/bitnami/rabbitmq:3.11.5-debian-11-r2
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true
@@ -9484,11 +9483,10 @@ spec:
               - key: tls.key
                 path: server_key.pem
         - name: configuration
-          secret:
-            secretName: messagebus-config
-            items:
-              - key: rabbitmq.conf
-                path: rabbitmq.conf
+          projected:
+            sources:
+              - secret:
+                  name: messagebus-config
         - name: load-definition-volume
           secret:
             secretName: "load-definition"
@@ -9504,7 +9502,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
@@ -9522,10 +9520,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/configuration: 11b8361c0fbf695cec6ec7f47ed4118ad3c7d71a391ca246df129803d3e205a5
+        checksum/configuration: 0c1e0d4282c8f8f820f3c9d1d79b3f423c4676afac2e3a6de555f8553f146eb4
       labels:
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: primary
@@ -9544,7 +9542,7 @@ spec:
         fsGroup: 1001
       initContainers:
         - name: volume-permissions
-          image: docker.io/bitnami/bitnami-shell:10-debian-10-r431
+          image: docker.io/bitnami/bitnami-shell:11-debian-11-r60
           imagePullPolicy: "IfNotPresent"
           command:
             - /bin/bash
@@ -10912,7 +10910,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: minio
-    helm.sh/chart: minio-11.6.3
+    helm.sh/chart: minio-11.10.24
     app.kubernetes.io/instance: minio
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -10926,11 +10924,11 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: minio
-        helm.sh/chart: minio-11.6.3
+        helm.sh/chart: minio-11.10.24
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/credentials-secret: 094325f216720012cacde9f52fd71c7e8b06dd6386492f6980e0f3588f1b1e7c
+        checksum/credentials-secret: 0f3ceb92b9779df4ce0927f6faeb23e9116b85e0eabe095d903e46a2770cde42
     spec:
       
       serviceAccountName: minio
@@ -10946,7 +10944,7 @@ spec:
         fsGroup: 1001
       containers:
         - name: minio
-          image: docker.io/bitnami/minio:2022.5.26-debian-10-r0
+          image: docker.io/bitnami/minio:2022.12.12-debian-11-r0
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true
@@ -11390,7 +11388,7 @@ metadata:
   namespace: default
   labels:
     app: docker-registry
-    chart: docker-registry-1.16.0
+    chart: docker-registry-2.2.2
     release: docker-registry
     heritage: Helm
 spec:
@@ -11405,10 +11403,13 @@ spec:
       labels:
         app: docker-registry
         release: docker-registry
+        
         gitpod.io: hello
         hello: world
       annotations:
-        checksum/config: 1d22b82e19bbc654e029029c4fb86ad02dc13422dc3ac52f8175ad190e52a0bb
+        checksum/config: 699dd382179068f3354c330fcce38625e2861d97b962074b4f57005d40497b00
+        checksum/secret: 450f59aeda22415409a87a1abd2c033c08ebd5fb54fe24d3c56560e92b0218f6
+        
         gitpod.io: hello
         gitpod.io/checksum_config: 1c66f4ccdb7f6331da2edaecefcb40f6c1b6315c9277eb0418fef3cc584a28bd
         hello: world
@@ -11419,7 +11420,7 @@ spec:
         runAsUser: 1000
       containers:
         - name: docker-registry
-          image: "docker.io/library/registry:2.7.1"
+          image: "docker.io/library/registry:2.8.1"
           imagePullPolicy: IfNotPresent
           command:
           - /bin/registry
@@ -11437,9 +11438,9 @@ spec:
               scheme: HTTPS
               path: /
               port: 5000
-          resources:
+          resources: 
             {}
-          env:
+          env: 
             - name: REGISTRY_HTTP_SECRET
               valueFrom:
                 secretKeyRef:
@@ -11451,21 +11452,21 @@ spec:
               value: /etc/ssl/docker/tls.key
             - name: REGISTRY_STORAGE_FILESYSTEM_ROOTDIRECTORY
               value: "/var/lib/registry"
-          volumeMounts:
-            - name: data
-              mountPath: /var/lib/registry/
+          volumeMounts: 
             - name: "registry-config"
               mountPath: "/etc/docker/registry"
+            - name: data
+              mountPath: /var/lib/registry/
             - mountPath: /etc/ssl/docker
               name: tls-cert
               readOnly: true
-      volumes:
-        - name: data
-          persistentVolumeClaim:
-            claimName: registry
+      volumes: 
         - name: registry-config
           configMap:
             name: registry-config
+        - name: data
+          persistentVolumeClaim:
+            claimName: registry
         - name: tls-cert
           secret:
             secretName: builtin-registry-certs

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -208,7 +208,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -758,7 +758,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -921,7 +921,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: minio
-    helm.sh/chart: minio-11.6.3
+    helm.sh/chart: minio-11.10.24
     app.kubernetes.io/instance: minio
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
@@ -985,7 +985,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
@@ -1099,7 +1099,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1115,7 +1115,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1146,13 +1146,13 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
 data:
   rabbitmq.conf: |-
-    IyMgVXNlcm5hbWUgYW5kIHBhc3N3b3JkCiMjCmRlZmF1bHRfdXNlciA9IGdpdHBvZApkZWZhdWx0X3Bhc3MgPSBDSEFOR0VNRQojIyBDbHVzdGVyaW5nCiMjCmNsdXN0ZXJfZm9ybWF0aW9uLnBlZXJfZGlzY292ZXJ5X2JhY2tlbmQgID0gcmFiYml0X3BlZXJfZGlzY292ZXJ5X2s4cwpjbHVzdGVyX2Zvcm1hdGlvbi5rOHMuaG9zdCA9IGt1YmVybmV0ZXMuZGVmYXVsdApjbHVzdGVyX2Zvcm1hdGlvbi5ub2RlX2NsZWFudXAuaW50ZXJ2YWwgPSAxMApjbHVzdGVyX2Zvcm1hdGlvbi5ub2RlX2NsZWFudXAub25seV9sb2dfd2FybmluZyA9IHRydWUKY2x1c3Rlcl9wYXJ0aXRpb25faGFuZGxpbmcgPSBhdXRvaGVhbApsb2FkX2RlZmluaXRpb25zID0gL2FwcC9sb2FkX2RlZmluaXRpb24uanNvbgojIHF1ZXVlIG1hc3RlciBsb2NhdG9yCnF1ZXVlX21hc3Rlcl9sb2NhdG9yID0gbWluLW1hc3RlcnMKIyBlbmFibGUgZ3Vlc3QgdXNlcgpsb29wYmFja191c2Vycy5ndWVzdCA9IGZhbHNlCmxvYWRfZGVmaW5pdGlvbnMgPSAvYXBwL2xvYWRfZGVmaW5pdGlvbi5qc29uCiMgSW5jcmVhc2Ugc3RhdGlzdGljcyBlbWlzc2lvbiBpbnRlcnZhbCBodHRwczovL3d3dy5yYWJiaXRtcS5jb20vbWFuYWdlbWVudC5odG1sI3N0YXRpc3RpY3MtaW50ZXJ2YWwKY29sbGVjdF9zdGF0aXN0aWNzX2ludGVydmFsID0gMTUwMDAKCnNzbF9vcHRpb25zLnZlcmlmeSA9IHZlcmlmeV9wZWVyCmxpc3RlbmVycy5zc2wuZGVmYXVsdCA9IDU2NzEKc3NsX29wdGlvbnMuZmFpbF9pZl9ub19wZWVyX2NlcnQgPSB0cnVlCnNzbF9vcHRpb25zLmNhY2VydGZpbGUgPSAvb3B0L2JpdG5hbWkvcmFiYml0bXEvY2VydHMvY2FfY2VydGlmaWNhdGUucGVtCnNzbF9vcHRpb25zLmNlcnRmaWxlID0gL29wdC9iaXRuYW1pL3JhYmJpdG1xL2NlcnRzL3NlcnZlcl9jZXJ0aWZpY2F0ZS5wZW0Kc3NsX29wdGlvbnMua2V5ZmlsZSA9IC9vcHQvYml0bmFtaS9yYWJiaXRtcS9jZXJ0cy9zZXJ2ZXJfa2V5LnBlbQojIyBQcm9tZXRoZXVzIG1ldHJpY3MKIyMKcHJvbWV0aGV1cy50Y3AucG9ydCA9IDk0MTk=
+    IyMgVXNlcm5hbWUgYW5kIHBhc3N3b3JkCiMjCmRlZmF1bHRfdXNlciA9IGdpdHBvZAojIyBDbHVzdGVyaW5nCiMjCmNsdXN0ZXJfZm9ybWF0aW9uLnBlZXJfZGlzY292ZXJ5X2JhY2tlbmQgID0gcmFiYml0X3BlZXJfZGlzY292ZXJ5X2s4cwpjbHVzdGVyX2Zvcm1hdGlvbi5rOHMuaG9zdCA9IGt1YmVybmV0ZXMuZGVmYXVsdApjbHVzdGVyX2Zvcm1hdGlvbi5ub2RlX2NsZWFudXAuaW50ZXJ2YWwgPSAxMApjbHVzdGVyX2Zvcm1hdGlvbi5ub2RlX2NsZWFudXAub25seV9sb2dfd2FybmluZyA9IHRydWUKY2x1c3Rlcl9wYXJ0aXRpb25faGFuZGxpbmcgPSBhdXRvaGVhbApsb2FkX2RlZmluaXRpb25zID0gL2FwcC9sb2FkX2RlZmluaXRpb24uanNvbgojIHF1ZXVlIG1hc3RlciBsb2NhdG9yCnF1ZXVlX21hc3Rlcl9sb2NhdG9yID0gbWluLW1hc3RlcnMKIyBlbmFibGUgZ3Vlc3QgdXNlcgpsb29wYmFja191c2Vycy5ndWVzdCA9IGZhbHNlCmxvYWRfZGVmaW5pdGlvbnMgPSAvYXBwL2xvYWRfZGVmaW5pdGlvbi5qc29uCiMgSW5jcmVhc2Ugc3RhdGlzdGljcyBlbWlzc2lvbiBpbnRlcnZhbCBodHRwczovL3d3dy5yYWJiaXRtcS5jb20vbWFuYWdlbWVudC5odG1sI3N0YXRpc3RpY3MtaW50ZXJ2YWwKY29sbGVjdF9zdGF0aXN0aWNzX2ludGVydmFsID0gMTUwMDAKCnNzbF9vcHRpb25zLnZlcmlmeSA9IHZlcmlmeV9wZWVyCmxpc3RlbmVycy5zc2wuZGVmYXVsdCA9IDU2NzEKc3NsX29wdGlvbnMuZmFpbF9pZl9ub19wZWVyX2NlcnQgPSB0cnVlCnNzbF9vcHRpb25zLmNhY2VydGZpbGUgPSAvb3B0L2JpdG5hbWkvcmFiYml0bXEvY2VydHMvY2FfY2VydGlmaWNhdGUucGVtCnNzbF9vcHRpb25zLmNlcnRmaWxlID0gL29wdC9iaXRuYW1pL3JhYmJpdG1xL2NlcnRzL3NlcnZlcl9jZXJ0aWZpY2F0ZS5wZW0Kc3NsX29wdGlvbnMua2V5ZmlsZSA9IC9vcHQvYml0bmFtaS9yYWJiaXRtcS9jZXJ0cy9zZXJ2ZXJfa2V5LnBlbQojIyBQcm9tZXRoZXVzIG1ldHJpY3MKIyMKcHJvbWV0aGV1cy50Y3AucG9ydCA9IDk0MTk=
 ---
 # v1/Secret messagebus-erlang-cookie
 apiVersion: v1
@@ -1176,7 +1176,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: minio
-    helm.sh/chart: minio-11.6.3
+    helm.sh/chart: minio-11.10.24
     app.kubernetes.io/instance: minio
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1212,7 +1212,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -3328,7 +3328,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql
       namespace: default
     ---
@@ -3341,7 +3341,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql-headless
       namespace: default
     ---
@@ -3354,7 +3354,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql
       namespace: default
     ---
@@ -3367,7 +3367,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql
       namespace: default
     ---
@@ -3379,7 +3379,7 @@ data:
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: minio
-        helm.sh/chart: minio-11.6.3
+        helm.sh/chart: minio-11.10.24
       name: minio
       namespace: default
     ---
@@ -3391,7 +3391,7 @@ data:
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: minio
-        helm.sh/chart: minio-11.6.3
+        helm.sh/chart: minio-11.10.24
       name: minio
       namespace: default
     ---
@@ -3403,7 +3403,7 @@ data:
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: minio
-        helm.sh/chart: minio-11.6.3
+        helm.sh/chart: minio-11.10.24
       name: minio
       namespace: default
     ---
@@ -3415,7 +3415,7 @@ data:
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: minio
-        helm.sh/chart: minio-11.6.3
+        helm.sh/chart: minio-11.10.24
       name: minio
       namespace: default
     ---
@@ -3427,7 +3427,7 @@ data:
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: minio
-        helm.sh/chart: minio-11.6.3
+        helm.sh/chart: minio-11.10.24
       name: minio
       namespace: default
     ---
@@ -3439,7 +3439,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus
       namespace: default
     ---
@@ -3451,7 +3451,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus
       namespace: default
     ---
@@ -3463,7 +3463,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: rabbitmq
       namespace: default
     ---
@@ -3475,7 +3475,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus-config
       namespace: default
     ---
@@ -3487,7 +3487,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus
       namespace: default
     ---
@@ -3499,7 +3499,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: load-definition
       namespace: default
     ---
@@ -3511,7 +3511,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: rabbitmq
       namespace: default
     ---
@@ -3523,7 +3523,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus-endpoint-reader
       namespace: default
     ---
@@ -3535,7 +3535,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus-endpoint-reader
       namespace: default
     ---
@@ -3547,7 +3547,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus-headless
       namespace: default
     ---
@@ -3559,7 +3559,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus
       namespace: default
     ---
@@ -3571,7 +3571,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus
       namespace: default
     ---
@@ -4929,7 +4929,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
@@ -4946,7 +4946,7 @@ data:
     datadir=/bitnami/mysql/data
     tmpdir=/opt/bitnami/mysql/tmp
     max_allowed_packet=16M
-    bind-address=0.0.0.0
+    bind-address=*
     pid-file=/opt/bitnami/mysql/tmp/mysqld.pid
     log-error=/opt/bitnami/mysql/logs/mysqld.log
     character-set-server=UTF8
@@ -5899,7 +5899,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: minio
-    helm.sh/chart: minio-11.6.3
+    helm.sh/chart: minio-11.10.24
     app.kubernetes.io/instance: minio
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -6426,7 +6426,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 rules:
@@ -6769,7 +6769,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 subjects:
@@ -7262,7 +7262,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -7306,7 +7306,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -7341,7 +7341,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: minio
-    helm.sh/chart: minio-11.6.3
+    helm.sh/chart: minio-11.10.24
     app.kubernetes.io/instance: minio
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -7368,7 +7368,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
@@ -7396,11 +7396,10 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
-  annotations:
 spec:
   type: ClusterIP
   clusterIP: None
@@ -8285,7 +8284,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -8302,12 +8301,12 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/config: 2ca9db593e4ca6cdd01f7a65cce1ae90d0d45ecdf0049edfaa4ec72302fcbe8f
-        checksum/secret: c231bbb08185305defa8c4da0f3ee0f5e7a16795362a2133f74e53eb9a40453d
+        checksum/config: d5780a0c58210a2062d54feb61cfb1d5a9c076f95569c4a77076d22c9bad4190
+        checksum/secret: 64c39dd3a8570ed4b0cc71bc0402bc814d016e16f68732938722b12a57c8e82c
         prometheus.io/port: '9419'
         prometheus.io/scrape: "true"
     spec:
@@ -8327,7 +8326,7 @@ spec:
       initContainers:
       containers:
         - name: rabbitmq
-          image: docker.io/bitnami/rabbitmq:3.10.2-debian-10-r7
+          image: docker.io/bitnami/rabbitmq:3.11.5-debian-11-r2
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true
@@ -8462,11 +8461,10 @@ spec:
               - key: tls.key
                 path: server_key.pem
         - name: configuration
-          secret:
-            secretName: messagebus-config
-            items:
-              - key: rabbitmq.conf
-                path: rabbitmq.conf
+          projected:
+            sources:
+              - secret:
+                  name: messagebus-config
         - name: load-definition-volume
           secret:
             secretName: "load-definition"
@@ -8482,7 +8480,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
@@ -8500,10 +8498,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/configuration: 11b8361c0fbf695cec6ec7f47ed4118ad3c7d71a391ca246df129803d3e205a5
+        checksum/configuration: 0c1e0d4282c8f8f820f3c9d1d79b3f423c4676afac2e3a6de555f8553f146eb4
       labels:
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: primary
@@ -8522,7 +8520,7 @@ spec:
         fsGroup: 1001
       initContainers:
         - name: volume-permissions
-          image: docker.io/bitnami/bitnami-shell:10-debian-10-r431
+          image: docker.io/bitnami/bitnami-shell:11-debian-11-r60
           imagePullPolicy: "IfNotPresent"
           command:
             - /bin/bash
@@ -9807,7 +9805,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: minio
-    helm.sh/chart: minio-11.6.3
+    helm.sh/chart: minio-11.10.24
     app.kubernetes.io/instance: minio
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -9821,11 +9819,11 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: minio
-        helm.sh/chart: minio-11.6.3
+        helm.sh/chart: minio-11.10.24
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/credentials-secret: 094325f216720012cacde9f52fd71c7e8b06dd6386492f6980e0f3588f1b1e7c
+        checksum/credentials-secret: 0f3ceb92b9779df4ce0927f6faeb23e9116b85e0eabe095d903e46a2770cde42
     spec:
       
       serviceAccountName: minio
@@ -9841,7 +9839,7 @@ spec:
         fsGroup: 1001
       containers:
         - name: minio
-          image: docker.io/bitnami/minio:2022.5.26-debian-10-r0
+          image: docker.io/bitnami/minio:2022.12.12-debian-11-r0
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -1181,8 +1181,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 type: Opaque
 data:
-  root-user: "OC1XR3F3Mm9UbnNQZlVETlNrMFk="
-  root-password: "RHBDLmFTQXhrV0JQdTJfYkpfQUU="
+  root-user: "UkJqaTZSMGJHRzgxZ3lFeWUyNVA="
+  root-password: "dFg2TUw4Z0NXMzFtaXcwVDhRTUk="
   key.json: ""
 ---
 # v1/Secret mysql
@@ -1359,9 +1359,9 @@ data:
         },
         "minio": {
           "endpoint": "minio.default.svc.cluster.local:9000",
-          "accessKey": "8-WGqw2oTnsPfUDNSk0Y",
+          "accessKey": "RBji6R0bGG81gyEye25P",
           "accessKeyFile": "",
-          "secretKey": "DpC.aSAxkWBPu2_bJ_AE",
+          "secretKey": "tX6ML8gCW31miw0T8QMI",
           "secretKeyFile": "",
           "region": "local",
           "parallelUpload": 6
@@ -5221,7 +5221,7 @@ data:
       },
       "oauthServer": {
         "enabled": true,
-        "jwtSecret": "8QMIxwyCGe5U0NAj6Uei"
+        "jwtSecret": "m30EH-M2-cWMgkgdy7pu"
       },
       "rateLimiter": {
         "groups": {
@@ -5551,9 +5551,9 @@ data:
             },
             "minio": {
               "endpoint": "minio.default.svc.cluster.local:9000",
-              "accessKey": "8-WGqw2oTnsPfUDNSk0Y",
+              "accessKey": "RBji6R0bGG81gyEye25P",
               "accessKeyFile": "",
-              "secretKey": "DpC.aSAxkWBPu2_bJ_AE",
+              "secretKey": "tX6ML8gCW31miw0T8QMI",
               "secretKeyFile": "",
               "region": "local",
               "parallelUpload": 6
@@ -5735,9 +5735,9 @@ data:
           },
           "minio": {
             "endpoint": "minio.default.svc.cluster.local:9000",
-            "accessKey": "8-WGqw2oTnsPfUDNSk0Y",
+            "accessKey": "RBji6R0bGG81gyEye25P",
             "accessKeyFile": "",
-            "secretKey": "DpC.aSAxkWBPu2_bJ_AE",
+            "secretKey": "tX6ML8gCW31miw0T8QMI",
             "secretKeyFile": "",
             "region": "local",
             "parallelUpload": 6
@@ -8005,7 +8005,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: b938c6e286051c22b503c29f5de266741c2045a3ed69be85d7fd9f22a9346254
+        gitpod.io/checksum_config: 2a29ef265c219405bda658cb21613f40ad5e692590d2779476a3ff90917ed6fb
         seccomp.security.alpha.kubernetes.io/shiftfs-module-loader: unconfined
       creationTimestamp: null
       labels:
@@ -8945,7 +8945,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 20782435cc6d6e080cf720b57dca8d4d5cfe40942fc71c4bfd54934fdc34c766
+        gitpod.io/checksum_config: 21ad538d4c7daef6619e5dda6fd71a49a5e5b551f0fc1365d3b7db1d1f38f9ce
       creationTimestamp: null
       labels:
         app: gitpod
@@ -9825,7 +9825,7 @@ spec:
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/credentials-secret: 0a5790906818b3f8eeee0bd3b3e990b3ad02d79bb23c62c0d91a4ca010fb5579
+        checksum/credentials-secret: 094325f216720012cacde9f52fd71c7e8b06dd6386492f6980e0f3588f1b1e7c
     spec:
       
       serviceAccountName: minio
@@ -10272,7 +10272,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 726dafd8c59907accd3250e873f40d6e59d6913f82b7198335bc6c24ae2e7db1
+        gitpod.io/checksum_config: f52ae23eddcf2fe15c87ec92cc3d998045c5ff491d52caed0f23a6fccc020134
       creationTimestamp: null
       labels:
         app: gitpod
@@ -10553,7 +10553,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 62fb425bd7800391dca7d008cd0c86cab613afef78e188a950e367ed7429ad73
+        gitpod.io/checksum_config: 21c3b53bac44cf0f98bc57e43353e3136dc5806409951038c2ba36aea69dd218
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/gcp-setup/output.golden
+++ b/install/installer/cmd/testdata/render/gcp-setup/output.golden
@@ -4995,7 +4995,7 @@ data:
       },
       "oauthServer": {
         "enabled": true,
-        "jwtSecret": "8QMIxwyCGe5U0NAj6Uei"
+        "jwtSecret": "m30EH-M2-cWMgkgdy7pu"
       },
       "rateLimiter": {
         "groups": {
@@ -9752,7 +9752,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 725344887ccd5c74b96673d5b9202ab10858246e89bb5620ff30074e31f932bf
+        gitpod.io/checksum_config: 09e70c56b73dd1d83f59a85cec7dc6dd2cdd18982612e885a72dde8132a61ddf
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/gcp-setup/output.golden
+++ b/install/installer/cmd/testdata/render/gcp-setup/output.golden
@@ -208,7 +208,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -758,7 +758,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -981,7 +981,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
@@ -1081,7 +1081,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1097,7 +1097,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1128,13 +1128,13 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
 data:
   rabbitmq.conf: |-
-    IyMgVXNlcm5hbWUgYW5kIHBhc3N3b3JkCiMjCmRlZmF1bHRfdXNlciA9IGdpdHBvZApkZWZhdWx0X3Bhc3MgPSBDSEFOR0VNRQojIyBDbHVzdGVyaW5nCiMjCmNsdXN0ZXJfZm9ybWF0aW9uLnBlZXJfZGlzY292ZXJ5X2JhY2tlbmQgID0gcmFiYml0X3BlZXJfZGlzY292ZXJ5X2s4cwpjbHVzdGVyX2Zvcm1hdGlvbi5rOHMuaG9zdCA9IGt1YmVybmV0ZXMuZGVmYXVsdApjbHVzdGVyX2Zvcm1hdGlvbi5ub2RlX2NsZWFudXAuaW50ZXJ2YWwgPSAxMApjbHVzdGVyX2Zvcm1hdGlvbi5ub2RlX2NsZWFudXAub25seV9sb2dfd2FybmluZyA9IHRydWUKY2x1c3Rlcl9wYXJ0aXRpb25faGFuZGxpbmcgPSBhdXRvaGVhbApsb2FkX2RlZmluaXRpb25zID0gL2FwcC9sb2FkX2RlZmluaXRpb24uanNvbgojIHF1ZXVlIG1hc3RlciBsb2NhdG9yCnF1ZXVlX21hc3Rlcl9sb2NhdG9yID0gbWluLW1hc3RlcnMKIyBlbmFibGUgZ3Vlc3QgdXNlcgpsb29wYmFja191c2Vycy5ndWVzdCA9IGZhbHNlCmxvYWRfZGVmaW5pdGlvbnMgPSAvYXBwL2xvYWRfZGVmaW5pdGlvbi5qc29uCiMgSW5jcmVhc2Ugc3RhdGlzdGljcyBlbWlzc2lvbiBpbnRlcnZhbCBodHRwczovL3d3dy5yYWJiaXRtcS5jb20vbWFuYWdlbWVudC5odG1sI3N0YXRpc3RpY3MtaW50ZXJ2YWwKY29sbGVjdF9zdGF0aXN0aWNzX2ludGVydmFsID0gMTUwMDAKCnNzbF9vcHRpb25zLnZlcmlmeSA9IHZlcmlmeV9wZWVyCmxpc3RlbmVycy5zc2wuZGVmYXVsdCA9IDU2NzEKc3NsX29wdGlvbnMuZmFpbF9pZl9ub19wZWVyX2NlcnQgPSB0cnVlCnNzbF9vcHRpb25zLmNhY2VydGZpbGUgPSAvb3B0L2JpdG5hbWkvcmFiYml0bXEvY2VydHMvY2FfY2VydGlmaWNhdGUucGVtCnNzbF9vcHRpb25zLmNlcnRmaWxlID0gL29wdC9iaXRuYW1pL3JhYmJpdG1xL2NlcnRzL3NlcnZlcl9jZXJ0aWZpY2F0ZS5wZW0Kc3NsX29wdGlvbnMua2V5ZmlsZSA9IC9vcHQvYml0bmFtaS9yYWJiaXRtcS9jZXJ0cy9zZXJ2ZXJfa2V5LnBlbQojIyBQcm9tZXRoZXVzIG1ldHJpY3MKIyMKcHJvbWV0aGV1cy50Y3AucG9ydCA9IDk0MTk=
+    IyMgVXNlcm5hbWUgYW5kIHBhc3N3b3JkCiMjCmRlZmF1bHRfdXNlciA9IGdpdHBvZAojIyBDbHVzdGVyaW5nCiMjCmNsdXN0ZXJfZm9ybWF0aW9uLnBlZXJfZGlzY292ZXJ5X2JhY2tlbmQgID0gcmFiYml0X3BlZXJfZGlzY292ZXJ5X2s4cwpjbHVzdGVyX2Zvcm1hdGlvbi5rOHMuaG9zdCA9IGt1YmVybmV0ZXMuZGVmYXVsdApjbHVzdGVyX2Zvcm1hdGlvbi5ub2RlX2NsZWFudXAuaW50ZXJ2YWwgPSAxMApjbHVzdGVyX2Zvcm1hdGlvbi5ub2RlX2NsZWFudXAub25seV9sb2dfd2FybmluZyA9IHRydWUKY2x1c3Rlcl9wYXJ0aXRpb25faGFuZGxpbmcgPSBhdXRvaGVhbApsb2FkX2RlZmluaXRpb25zID0gL2FwcC9sb2FkX2RlZmluaXRpb24uanNvbgojIHF1ZXVlIG1hc3RlciBsb2NhdG9yCnF1ZXVlX21hc3Rlcl9sb2NhdG9yID0gbWluLW1hc3RlcnMKIyBlbmFibGUgZ3Vlc3QgdXNlcgpsb29wYmFja191c2Vycy5ndWVzdCA9IGZhbHNlCmxvYWRfZGVmaW5pdGlvbnMgPSAvYXBwL2xvYWRfZGVmaW5pdGlvbi5qc29uCiMgSW5jcmVhc2Ugc3RhdGlzdGljcyBlbWlzc2lvbiBpbnRlcnZhbCBodHRwczovL3d3dy5yYWJiaXRtcS5jb20vbWFuYWdlbWVudC5odG1sI3N0YXRpc3RpY3MtaW50ZXJ2YWwKY29sbGVjdF9zdGF0aXN0aWNzX2ludGVydmFsID0gMTUwMDAKCnNzbF9vcHRpb25zLnZlcmlmeSA9IHZlcmlmeV9wZWVyCmxpc3RlbmVycy5zc2wuZGVmYXVsdCA9IDU2NzEKc3NsX29wdGlvbnMuZmFpbF9pZl9ub19wZWVyX2NlcnQgPSB0cnVlCnNzbF9vcHRpb25zLmNhY2VydGZpbGUgPSAvb3B0L2JpdG5hbWkvcmFiYml0bXEvY2VydHMvY2FfY2VydGlmaWNhdGUucGVtCnNzbF9vcHRpb25zLmNlcnRmaWxlID0gL29wdC9iaXRuYW1pL3JhYmJpdG1xL2NlcnRzL3NlcnZlcl9jZXJ0aWZpY2F0ZS5wZW0Kc3NsX29wdGlvbnMua2V5ZmlsZSA9IC9vcHQvYml0bmFtaS9yYWJiaXRtcS9jZXJ0cy9zZXJ2ZXJfa2V5LnBlbQojIyBQcm9tZXRoZXVzIG1ldHJpY3MKIyMKcHJvbWV0aGV1cy50Y3AucG9ydCA9IDk0MTk=
 ---
 # v1/Secret messagebus-erlang-cookie
 apiVersion: v1
@@ -1158,7 +1158,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -3269,7 +3269,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus
       namespace: default
     ---
@@ -3281,7 +3281,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus
       namespace: default
     ---
@@ -3293,7 +3293,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: rabbitmq
       namespace: default
     ---
@@ -3305,7 +3305,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus-config
       namespace: default
     ---
@@ -3317,7 +3317,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus
       namespace: default
     ---
@@ -3329,7 +3329,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: load-definition
       namespace: default
     ---
@@ -3341,7 +3341,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: rabbitmq
       namespace: default
     ---
@@ -3353,7 +3353,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus-endpoint-reader
       namespace: default
     ---
@@ -3365,7 +3365,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus-endpoint-reader
       namespace: default
     ---
@@ -3377,7 +3377,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus-headless
       namespace: default
     ---
@@ -3389,7 +3389,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus
       namespace: default
     ---
@@ -3401,7 +3401,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus
       namespace: default
     ---
@@ -6179,7 +6179,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 rules:
@@ -6540,7 +6540,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 subjects:
@@ -7036,7 +7036,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -7080,7 +7080,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -7983,7 +7983,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -8000,12 +8000,12 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/config: 2ca9db593e4ca6cdd01f7a65cce1ae90d0d45ecdf0049edfaa4ec72302fcbe8f
-        checksum/secret: c231bbb08185305defa8c4da0f3ee0f5e7a16795362a2133f74e53eb9a40453d
+        checksum/config: d5780a0c58210a2062d54feb61cfb1d5a9c076f95569c4a77076d22c9bad4190
+        checksum/secret: 64c39dd3a8570ed4b0cc71bc0402bc814d016e16f68732938722b12a57c8e82c
         prometheus.io/port: '9419'
         prometheus.io/scrape: "true"
     spec:
@@ -8025,7 +8025,7 @@ spec:
       initContainers:
       containers:
         - name: rabbitmq
-          image: docker.io/bitnami/rabbitmq:3.10.2-debian-10-r7
+          image: docker.io/bitnami/rabbitmq:3.11.5-debian-11-r2
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true
@@ -8160,11 +8160,10 @@ spec:
               - key: tls.key
                 path: server_key.pem
         - name: configuration
-          secret:
-            secretName: messagebus-config
-            items:
-              - key: rabbitmq.conf
-                path: rabbitmq.conf
+          projected:
+            sources:
+              - secret:
+                  name: messagebus-config
         - name: load-definition-volume
           secret:
             secretName: "load-definition"

--- a/install/installer/cmd/testdata/render/http-proxy/output.golden
+++ b/install/installer/cmd/testdata/render/http-proxy/output.golden
@@ -1116,9 +1116,9 @@ metadata:
 # v1/Secret builtin-registry-auth
 apiVersion: v1
 data:
-  .dockerconfigjson: eyJhdXRocyI6eyJyZWdpc3RyeS5naXRwb2QuZXhhbXBsZS5jb20iOnsiYXV0aCI6ImVGTmxaRXBwUkdkS1VWRm5ORUpyVnpWNFMzVTZRMWMwUTFKQ2FtazJVakJpUjBjNE1XZDVSWGs9In19fQ==
-  password: Q1c0Q1JCamk2UjBiR0c4MWd5RXk=
-  user: eFNlZEppRGdKUVFnNEJrVzV4S3U=
+  .dockerconfigjson: eyJhdXRocyI6eyJyZWdpc3RyeS5naXRwb2QuZXhhbXBsZS5jb20iOnsiYXV0aCI6ImVIZDVRMGRsTlZVd1RrRnFObFZsYVhFM1RqQTZWbE5UYkcxaFMxZFFhaTVRVVhCdFZXWnNWR1E9In19fQ==
+  password: VlNTbG1hS1dQai5QUXBtVWZsVGQ=
+  user: eHd5Q0dlNVUwTkFqNlVlaXE3TjA=
 kind: Secret
 metadata:
   creationTimestamp: null
@@ -1234,8 +1234,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 type: Opaque
 data:
-  root-user: "OC1XR3F3Mm9UbnNQZlVETlNrMFk="
-  root-password: "RHBDLmFTQXhrV0JQdTJfYkpfQUU="
+  root-user: "UkJqaTZSMGJHRzgxZ3lFeWUyNVA="
+  root-password: "dFg2TUw4Z0NXMzFtaXcwVDhRTUk="
   key.json: ""
 ---
 # v1/Secret mysql
@@ -1430,9 +1430,9 @@ data:
         },
         "minio": {
           "endpoint": "minio.default.svc.cluster.local:9000",
-          "accessKey": "8-WGqw2oTnsPfUDNSk0Y",
+          "accessKey": "RBji6R0bGG81gyEye25P",
           "accessKeyFile": "",
-          "secretKey": "DpC.aSAxkWBPu2_bJ_AE",
+          "secretKey": "tX6ML8gCW31miw0T8QMI",
           "secretKeyFile": "",
           "region": "local",
           "parallelUpload": 6
@@ -5173,7 +5173,7 @@ data:
         import ssl_configuration
 
         basicauth bcrypt "Docker Registry" {
-            xSedJiDgJQQg4BkW5xKu JDJhJDEwJFFTRGRRMHZZY2pIS2JqUC9aMDNnVC5HbEg2Z1dOQm5TL0pySnpYSm5iNy9DeVh0ZUw2cFM2
+            xwyCGe5U0NAj6Ueiq7N0 JDJhJDEwJFFTRGRRMHZZY2pIS2JqUC9aMDNnVC5CY0M3RDZsVVg0LzBpZmdnTGovT0VVWXoxTG8ud0lX
         }
 
         reverse_proxy https://registry.default.svc.cluster.local {
@@ -5444,7 +5444,7 @@ data:
       },
       "oauthServer": {
         "enabled": true,
-        "jwtSecret": "8QMIxwyCGe5U0NAj6Uei"
+        "jwtSecret": "m30EH-M2-cWMgkgdy7pu"
       },
       "rateLimiter": {
         "groups": {
@@ -5774,9 +5774,9 @@ data:
             },
             "minio": {
               "endpoint": "minio.default.svc.cluster.local:9000",
-              "accessKey": "8-WGqw2oTnsPfUDNSk0Y",
+              "accessKey": "RBji6R0bGG81gyEye25P",
               "accessKeyFile": "",
-              "secretKey": "DpC.aSAxkWBPu2_bJ_AE",
+              "secretKey": "tX6ML8gCW31miw0T8QMI",
               "secretKeyFile": "",
               "region": "local",
               "parallelUpload": 6
@@ -5958,9 +5958,9 @@ data:
           },
           "minio": {
             "endpoint": "minio.default.svc.cluster.local:9000",
-            "accessKey": "8-WGqw2oTnsPfUDNSk0Y",
+            "accessKey": "RBji6R0bGG81gyEye25P",
             "accessKeyFile": "",
-            "secretKey": "DpC.aSAxkWBPu2_bJ_AE",
+            "secretKey": "tX6ML8gCW31miw0T8QMI",
             "secretKeyFile": "",
             "region": "local",
             "parallelUpload": 6
@@ -8151,7 +8151,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3e487f9543c719b9ee3f5590a0f98cb535b4bf1b301c66de8f00f3aa9d61381d
+        gitpod.io/checksum_config: 3e7db160db71491d8d16b0423783bf99a0dc293dc723960c9308756bdde69d3b
       creationTimestamp: null
       labels:
         app: gitpod
@@ -8529,7 +8529,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: b938c6e286051c22b503c29f5de266741c2045a3ed69be85d7fd9f22a9346254
+        gitpod.io/checksum_config: 2a29ef265c219405bda658cb21613f40ad5e692590d2779476a3ff90917ed6fb
         seccomp.security.alpha.kubernetes.io/shiftfs-module-loader: unconfined
       creationTimestamp: null
       labels:
@@ -9569,7 +9569,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: cac138904f08d79e5598805683f8dc378bd52c58348489de22949ac38dd8b193
+        gitpod.io/checksum_config: 0d9d1c68723466a253996f0a96bf0682ce57b89ebcb4ae1e4a643dd788ef1cab
       creationTimestamp: null
       labels:
         app: gitpod
@@ -9790,7 +9790,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 20782435cc6d6e080cf720b57dca8d4d5cfe40942fc71c4bfd54934fdc34c766
+        gitpod.io/checksum_config: 21ad538d4c7daef6619e5dda6fd71a49a5e5b551f0fc1365d3b7db1d1f38f9ce
       creationTimestamp: null
       labels:
         app: gitpod
@@ -10957,7 +10957,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: af26ec864db5be86adfb79b972614487639aa67ad16de869e23e22e468f0bed8
+        gitpod.io/checksum_config: 3b0478b4bb4feb7b7a29bc33bf4ec99671df4dcbd9529778de375c72e78df64c
       creationTimestamp: null
       labels:
         app: gitpod
@@ -11231,7 +11231,7 @@ spec:
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/credentials-secret: 0a5790906818b3f8eeee0bd3b3e990b3ad02d79bb23c62c0d91a4ca010fb5579
+        checksum/credentials-secret: 094325f216720012cacde9f52fd71c7e8b06dd6386492f6980e0f3588f1b1e7c
     spec:
       
       serviceAccountName: minio
@@ -11339,7 +11339,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: c52c73e63eaa95613a8f4fe77167c754cd48eaf757dd69c2048400311a5ae0a6
+        gitpod.io/checksum_config: a7bd71558cb04a04656bafe7651d4192a9d37be96d2d817f9b6225f63e3a6989
       creationTimestamp: null
       labels:
         app: gitpod
@@ -11850,7 +11850,7 @@ spec:
         release: docker-registry
       annotations:
         checksum/config: 1d22b82e19bbc654e029029c4fb86ad02dc13422dc3ac52f8175ad190e52a0bb
-        gitpod.io/checksum_config: 0ce55d51677cd683df3c7a244542c6aeaaf5dd6dca0f0458e8053a713228f535
+        gitpod.io/checksum_config: 1c66f4ccdb7f6331da2edaecefcb40f6c1b6315c9277eb0418fef3cc584a28bd
     spec:
       serviceAccountName: docker-registry
       securityContext:
@@ -11933,7 +11933,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 726dafd8c59907accd3250e873f40d6e59d6913f82b7198335bc6c24ae2e7db1
+        gitpod.io/checksum_config: f52ae23eddcf2fe15c87ec92cc3d998045c5ff491d52caed0f23a6fccc020134
       creationTimestamp: null
       labels:
         app: gitpod
@@ -12376,7 +12376,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 62fb425bd7800391dca7d008cd0c86cab613afef78e188a950e367ed7429ad73
+        gitpod.io/checksum_config: 21c3b53bac44cf0f98bc57e43353e3136dc5806409951038c2ba36aea69dd218
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/http-proxy/output.golden
+++ b/install/installer/cmd/testdata/render/http-proxy/output.golden
@@ -208,7 +208,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -783,7 +783,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -958,7 +958,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: minio
-    helm.sh/chart: minio-11.6.3
+    helm.sh/chart: minio-11.10.24
     app.kubernetes.io/instance: minio
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
@@ -1022,7 +1022,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
@@ -1152,7 +1152,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1168,7 +1168,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1199,13 +1199,13 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
 data:
   rabbitmq.conf: |-
-    IyMgVXNlcm5hbWUgYW5kIHBhc3N3b3JkCiMjCmRlZmF1bHRfdXNlciA9IGdpdHBvZApkZWZhdWx0X3Bhc3MgPSBDSEFOR0VNRQojIyBDbHVzdGVyaW5nCiMjCmNsdXN0ZXJfZm9ybWF0aW9uLnBlZXJfZGlzY292ZXJ5X2JhY2tlbmQgID0gcmFiYml0X3BlZXJfZGlzY292ZXJ5X2s4cwpjbHVzdGVyX2Zvcm1hdGlvbi5rOHMuaG9zdCA9IGt1YmVybmV0ZXMuZGVmYXVsdApjbHVzdGVyX2Zvcm1hdGlvbi5ub2RlX2NsZWFudXAuaW50ZXJ2YWwgPSAxMApjbHVzdGVyX2Zvcm1hdGlvbi5ub2RlX2NsZWFudXAub25seV9sb2dfd2FybmluZyA9IHRydWUKY2x1c3Rlcl9wYXJ0aXRpb25faGFuZGxpbmcgPSBhdXRvaGVhbApsb2FkX2RlZmluaXRpb25zID0gL2FwcC9sb2FkX2RlZmluaXRpb24uanNvbgojIHF1ZXVlIG1hc3RlciBsb2NhdG9yCnF1ZXVlX21hc3Rlcl9sb2NhdG9yID0gbWluLW1hc3RlcnMKIyBlbmFibGUgZ3Vlc3QgdXNlcgpsb29wYmFja191c2Vycy5ndWVzdCA9IGZhbHNlCmxvYWRfZGVmaW5pdGlvbnMgPSAvYXBwL2xvYWRfZGVmaW5pdGlvbi5qc29uCiMgSW5jcmVhc2Ugc3RhdGlzdGljcyBlbWlzc2lvbiBpbnRlcnZhbCBodHRwczovL3d3dy5yYWJiaXRtcS5jb20vbWFuYWdlbWVudC5odG1sI3N0YXRpc3RpY3MtaW50ZXJ2YWwKY29sbGVjdF9zdGF0aXN0aWNzX2ludGVydmFsID0gMTUwMDAKCnNzbF9vcHRpb25zLnZlcmlmeSA9IHZlcmlmeV9wZWVyCmxpc3RlbmVycy5zc2wuZGVmYXVsdCA9IDU2NzEKc3NsX29wdGlvbnMuZmFpbF9pZl9ub19wZWVyX2NlcnQgPSB0cnVlCnNzbF9vcHRpb25zLmNhY2VydGZpbGUgPSAvb3B0L2JpdG5hbWkvcmFiYml0bXEvY2VydHMvY2FfY2VydGlmaWNhdGUucGVtCnNzbF9vcHRpb25zLmNlcnRmaWxlID0gL29wdC9iaXRuYW1pL3JhYmJpdG1xL2NlcnRzL3NlcnZlcl9jZXJ0aWZpY2F0ZS5wZW0Kc3NsX29wdGlvbnMua2V5ZmlsZSA9IC9vcHQvYml0bmFtaS9yYWJiaXRtcS9jZXJ0cy9zZXJ2ZXJfa2V5LnBlbQojIyBQcm9tZXRoZXVzIG1ldHJpY3MKIyMKcHJvbWV0aGV1cy50Y3AucG9ydCA9IDk0MTk=
+    IyMgVXNlcm5hbWUgYW5kIHBhc3N3b3JkCiMjCmRlZmF1bHRfdXNlciA9IGdpdHBvZAojIyBDbHVzdGVyaW5nCiMjCmNsdXN0ZXJfZm9ybWF0aW9uLnBlZXJfZGlzY292ZXJ5X2JhY2tlbmQgID0gcmFiYml0X3BlZXJfZGlzY292ZXJ5X2s4cwpjbHVzdGVyX2Zvcm1hdGlvbi5rOHMuaG9zdCA9IGt1YmVybmV0ZXMuZGVmYXVsdApjbHVzdGVyX2Zvcm1hdGlvbi5ub2RlX2NsZWFudXAuaW50ZXJ2YWwgPSAxMApjbHVzdGVyX2Zvcm1hdGlvbi5ub2RlX2NsZWFudXAub25seV9sb2dfd2FybmluZyA9IHRydWUKY2x1c3Rlcl9wYXJ0aXRpb25faGFuZGxpbmcgPSBhdXRvaGVhbApsb2FkX2RlZmluaXRpb25zID0gL2FwcC9sb2FkX2RlZmluaXRpb24uanNvbgojIHF1ZXVlIG1hc3RlciBsb2NhdG9yCnF1ZXVlX21hc3Rlcl9sb2NhdG9yID0gbWluLW1hc3RlcnMKIyBlbmFibGUgZ3Vlc3QgdXNlcgpsb29wYmFja191c2Vycy5ndWVzdCA9IGZhbHNlCmxvYWRfZGVmaW5pdGlvbnMgPSAvYXBwL2xvYWRfZGVmaW5pdGlvbi5qc29uCiMgSW5jcmVhc2Ugc3RhdGlzdGljcyBlbWlzc2lvbiBpbnRlcnZhbCBodHRwczovL3d3dy5yYWJiaXRtcS5jb20vbWFuYWdlbWVudC5odG1sI3N0YXRpc3RpY3MtaW50ZXJ2YWwKY29sbGVjdF9zdGF0aXN0aWNzX2ludGVydmFsID0gMTUwMDAKCnNzbF9vcHRpb25zLnZlcmlmeSA9IHZlcmlmeV9wZWVyCmxpc3RlbmVycy5zc2wuZGVmYXVsdCA9IDU2NzEKc3NsX29wdGlvbnMuZmFpbF9pZl9ub19wZWVyX2NlcnQgPSB0cnVlCnNzbF9vcHRpb25zLmNhY2VydGZpbGUgPSAvb3B0L2JpdG5hbWkvcmFiYml0bXEvY2VydHMvY2FfY2VydGlmaWNhdGUucGVtCnNzbF9vcHRpb25zLmNlcnRmaWxlID0gL29wdC9iaXRuYW1pL3JhYmJpdG1xL2NlcnRzL3NlcnZlcl9jZXJ0aWZpY2F0ZS5wZW0Kc3NsX29wdGlvbnMua2V5ZmlsZSA9IC9vcHQvYml0bmFtaS9yYWJiaXRtcS9jZXJ0cy9zZXJ2ZXJfa2V5LnBlbQojIyBQcm9tZXRoZXVzIG1ldHJpY3MKIyMKcHJvbWV0aGV1cy50Y3AucG9ydCA9IDk0MTk=
 ---
 # v1/Secret messagebus-erlang-cookie
 apiVersion: v1
@@ -1229,7 +1229,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: minio
-    helm.sh/chart: minio-11.6.3
+    helm.sh/chart: minio-11.10.24
     app.kubernetes.io/instance: minio
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1265,7 +1265,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1282,7 +1282,7 @@ metadata:
   namespace: default
   labels:
     app: docker-registry
-    chart: docker-registry-1.16.0
+    chart: docker-registry-2.2.2
     heritage: Helm
     release: docker-registry
 type: Opaque
@@ -3434,7 +3434,7 @@ data:
       creationTimestamp: null
       labels:
         app: docker-registry
-        chart: docker-registry-1.16.0
+        chart: docker-registry-2.2.2
         heritage: Helm
         release: docker-registry
       name: registry-secret
@@ -3446,7 +3446,7 @@ data:
       creationTimestamp: null
       labels:
         app: docker-registry
-        chart: docker-registry-1.16.0
+        chart: docker-registry-2.2.2
         heritage: Helm
         release: docker-registry
       name: registry-config
@@ -3458,7 +3458,7 @@ data:
       creationTimestamp: null
       labels:
         app: registry
-        chart: docker-registry-1.16.0
+        chart: docker-registry-2.2.2
         heritage: Helm
         release: docker-registry
       name: registry
@@ -3470,7 +3470,7 @@ data:
       creationTimestamp: null
       labels:
         app: docker-registry
-        chart: docker-registry-1.16.0
+        chart: docker-registry-2.2.2
         heritage: Helm
         release: docker-registry
       name: registry
@@ -3482,7 +3482,7 @@ data:
       creationTimestamp: null
       labels:
         app: docker-registry
-        chart: docker-registry-1.16.0
+        chart: docker-registry-2.2.2
         heritage: Helm
         release: docker-registry
       name: registry
@@ -3497,7 +3497,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql
       namespace: default
     ---
@@ -3510,7 +3510,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql-headless
       namespace: default
     ---
@@ -3523,7 +3523,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql
       namespace: default
     ---
@@ -3536,7 +3536,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql
       namespace: default
     ---
@@ -3548,7 +3548,7 @@ data:
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: minio
-        helm.sh/chart: minio-11.6.3
+        helm.sh/chart: minio-11.10.24
       name: minio
       namespace: default
     ---
@@ -3560,7 +3560,7 @@ data:
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: minio
-        helm.sh/chart: minio-11.6.3
+        helm.sh/chart: minio-11.10.24
       name: minio
       namespace: default
     ---
@@ -3572,7 +3572,7 @@ data:
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: minio
-        helm.sh/chart: minio-11.6.3
+        helm.sh/chart: minio-11.10.24
       name: minio
       namespace: default
     ---
@@ -3584,7 +3584,7 @@ data:
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: minio
-        helm.sh/chart: minio-11.6.3
+        helm.sh/chart: minio-11.10.24
       name: minio
       namespace: default
     ---
@@ -3596,7 +3596,7 @@ data:
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: minio
-        helm.sh/chart: minio-11.6.3
+        helm.sh/chart: minio-11.10.24
       name: minio
       namespace: default
     ---
@@ -3608,7 +3608,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus
       namespace: default
     ---
@@ -3620,7 +3620,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus
       namespace: default
     ---
@@ -3632,7 +3632,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: rabbitmq
       namespace: default
     ---
@@ -3644,7 +3644,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus-config
       namespace: default
     ---
@@ -3656,7 +3656,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus
       namespace: default
     ---
@@ -3668,7 +3668,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: load-definition
       namespace: default
     ---
@@ -3680,7 +3680,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: rabbitmq
       namespace: default
     ---
@@ -3692,7 +3692,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus-endpoint-reader
       namespace: default
     ---
@@ -3704,7 +3704,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus-endpoint-reader
       namespace: default
     ---
@@ -3716,7 +3716,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus-headless
       namespace: default
     ---
@@ -3728,7 +3728,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus
       namespace: default
     ---
@@ -3740,7 +3740,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus
       namespace: default
     ---
@@ -5098,7 +5098,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
@@ -5115,7 +5115,7 @@ data:
     datadir=/bitnami/mysql/data
     tmpdir=/opt/bitnami/mysql/tmp
     max_allowed_packet=16M
-    bind-address=0.0.0.0
+    bind-address=*
     pid-file=/opt/bitnami/mysql/tmp/mysqld.pid
     log-error=/opt/bitnami/mysql/logs/mysqld.log
     character-set-server=UTF8
@@ -5285,7 +5285,7 @@ metadata:
   namespace: default
   labels:
     app: docker-registry
-    chart: docker-registry-1.16.0
+    chart: docker-registry-2.2.2
     heritage: Helm
     release: docker-registry
 data:
@@ -6122,7 +6122,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: minio
-    helm.sh/chart: minio-11.6.3
+    helm.sh/chart: minio-11.10.24
     app.kubernetes.io/instance: minio
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -6141,7 +6141,7 @@ metadata:
   namespace: default
   labels:
     app: registry
-    chart: "docker-registry-1.16.0"
+    chart: "docker-registry-2.2.2"
     release: "docker-registry"
     heritage: "Helm"
 spec:
@@ -6668,7 +6668,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 rules:
@@ -7029,7 +7029,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 subjects:
@@ -7522,7 +7522,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -7566,7 +7566,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -7601,7 +7601,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: minio
-    helm.sh/chart: minio-11.6.3
+    helm.sh/chart: minio-11.10.24
     app.kubernetes.io/instance: minio
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -7628,7 +7628,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
@@ -7656,11 +7656,10 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
-  annotations:
 spec:
   type: ClusterIP
   clusterIP: None
@@ -7774,7 +7773,7 @@ metadata:
   namespace: default
   labels:
     app: docker-registry
-    chart: docker-registry-1.16.0
+    chart: docker-registry-2.2.2
     release: docker-registry
     heritage: Helm
 spec:
@@ -8970,7 +8969,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -8987,12 +8986,12 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/config: 2ca9db593e4ca6cdd01f7a65cce1ae90d0d45ecdf0049edfaa4ec72302fcbe8f
-        checksum/secret: c231bbb08185305defa8c4da0f3ee0f5e7a16795362a2133f74e53eb9a40453d
+        checksum/config: d5780a0c58210a2062d54feb61cfb1d5a9c076f95569c4a77076d22c9bad4190
+        checksum/secret: 64c39dd3a8570ed4b0cc71bc0402bc814d016e16f68732938722b12a57c8e82c
         prometheus.io/port: '9419'
         prometheus.io/scrape: "true"
     spec:
@@ -9012,7 +9011,7 @@ spec:
       initContainers:
       containers:
         - name: rabbitmq
-          image: docker.io/bitnami/rabbitmq:3.10.2-debian-10-r7
+          image: docker.io/bitnami/rabbitmq:3.11.5-debian-11-r2
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true
@@ -9147,11 +9146,10 @@ spec:
               - key: tls.key
                 path: server_key.pem
         - name: configuration
-          secret:
-            secretName: messagebus-config
-            items:
-              - key: rabbitmq.conf
-                path: rabbitmq.conf
+          projected:
+            sources:
+              - secret:
+                  name: messagebus-config
         - name: load-definition-volume
           secret:
             secretName: "load-definition"
@@ -9167,7 +9165,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
@@ -9185,10 +9183,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/configuration: 11b8361c0fbf695cec6ec7f47ed4118ad3c7d71a391ca246df129803d3e205a5
+        checksum/configuration: 0c1e0d4282c8f8f820f3c9d1d79b3f423c4676afac2e3a6de555f8553f146eb4
       labels:
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: primary
@@ -9207,7 +9205,7 @@ spec:
         fsGroup: 1001
       initContainers:
         - name: volume-permissions
-          image: docker.io/bitnami/bitnami-shell:10-debian-10-r431
+          image: docker.io/bitnami/bitnami-shell:11-debian-11-r60
           imagePullPolicy: "IfNotPresent"
           command:
             - /bin/bash
@@ -11213,7 +11211,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: minio
-    helm.sh/chart: minio-11.6.3
+    helm.sh/chart: minio-11.10.24
     app.kubernetes.io/instance: minio
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -11227,11 +11225,11 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: minio
-        helm.sh/chart: minio-11.6.3
+        helm.sh/chart: minio-11.10.24
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/credentials-secret: 094325f216720012cacde9f52fd71c7e8b06dd6386492f6980e0f3588f1b1e7c
+        checksum/credentials-secret: 0f3ceb92b9779df4ce0927f6faeb23e9116b85e0eabe095d903e46a2770cde42
     spec:
       
       serviceAccountName: minio
@@ -11247,7 +11245,7 @@ spec:
         fsGroup: 1001
       containers:
         - name: minio
-          image: docker.io/bitnami/minio:2022.5.26-debian-10-r0
+          image: docker.io/bitnami/minio:2022.12.12-debian-11-r0
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true
@@ -11833,7 +11831,7 @@ metadata:
   namespace: default
   labels:
     app: docker-registry
-    chart: docker-registry-1.16.0
+    chart: docker-registry-2.2.2
     release: docker-registry
     heritage: Helm
 spec:
@@ -11849,7 +11847,9 @@ spec:
         app: docker-registry
         release: docker-registry
       annotations:
-        checksum/config: 1d22b82e19bbc654e029029c4fb86ad02dc13422dc3ac52f8175ad190e52a0bb
+        checksum/config: 699dd382179068f3354c330fcce38625e2861d97b962074b4f57005d40497b00
+        checksum/secret: 450f59aeda22415409a87a1abd2c033c08ebd5fb54fe24d3c56560e92b0218f6
+        
         gitpod.io/checksum_config: 1c66f4ccdb7f6331da2edaecefcb40f6c1b6315c9277eb0418fef3cc584a28bd
     spec:
       serviceAccountName: docker-registry
@@ -11858,7 +11858,7 @@ spec:
         runAsUser: 1000
       containers:
         - name: docker-registry
-          image: "docker.io/library/registry:2.7.1"
+          image: "docker.io/library/registry:2.8.1"
           imagePullPolicy: IfNotPresent
           command:
           - /bin/registry
@@ -11876,9 +11876,9 @@ spec:
               scheme: HTTPS
               path: /
               port: 5000
-          resources:
+          resources: 
             {}
-          env:
+          env: 
             - name: REGISTRY_HTTP_SECRET
               valueFrom:
                 secretKeyRef:
@@ -11890,21 +11890,21 @@ spec:
               value: /etc/ssl/docker/tls.key
             - name: REGISTRY_STORAGE_FILESYSTEM_ROOTDIRECTORY
               value: "/var/lib/registry"
-          volumeMounts:
-            - name: data
-              mountPath: /var/lib/registry/
+          volumeMounts: 
             - name: "registry-config"
               mountPath: "/etc/docker/registry"
+            - name: data
+              mountPath: /var/lib/registry/
             - mountPath: /etc/ssl/docker
               name: tls-cert
               readOnly: true
-      volumes:
-        - name: data
-          persistentVolumeClaim:
-            claimName: registry
+      volumes: 
         - name: registry-config
           configMap:
             name: registry-config
+        - name: data
+          persistentVolumeClaim:
+            claimName: registry
         - name: tls-cert
           secret:
             secretName: builtin-registry-certs

--- a/install/installer/cmd/testdata/render/kind-ide/output.golden
+++ b/install/installer/cmd/testdata/render/kind-ide/output.golden
@@ -305,9 +305,9 @@ metadata:
 # v1/Secret builtin-registry-auth
 apiVersion: v1
 data:
-  .dockerconfigjson: eyJhdXRocyI6eyJyZWdpc3RyeS5naXRwb2QuZXhhbXBsZS5jb20iOnsiYXV0aCI6ImVGTmxaRXBwUkdkS1VWRm5ORUpyVnpWNFMzVTZRMWMwUTFKQ2FtazJVakJpUjBjNE1XZDVSWGs9In19fQ==
-  password: Q1c0Q1JCamk2UjBiR0c4MWd5RXk=
-  user: eFNlZEppRGdKUVFnNEJrVzV4S3U=
+  .dockerconfigjson: eyJhdXRocyI6eyJyZWdpc3RyeS5naXRwb2QuZXhhbXBsZS5jb20iOnsiYXV0aCI6ImVIZDVRMGRsTlZVd1RrRnFObFZsYVhFM1RqQTZWbE5UYkcxaFMxZFFhaTVRVVhCdFZXWnNWR1E9In19fQ==
+  password: VlNTbG1hS1dQai5QUXBtVWZsVGQ=
+  user: eHd5Q0dlNVUwTkFqNlVlaXE3TjA=
 kind: Secret
 metadata:
   creationTimestamp: null
@@ -3410,7 +3410,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: cac138904f08d79e5598805683f8dc378bd52c58348489de22949ac38dd8b193
+        gitpod.io/checksum_config: 0d9d1c68723466a253996f0a96bf0682ce57b89ebcb4ae1e4a643dd788ef1cab
       creationTimestamp: null
       labels:
         app: gitpod
@@ -3881,7 +3881,7 @@ spec:
         release: docker-registry
       annotations:
         checksum/config: 1d22b82e19bbc654e029029c4fb86ad02dc13422dc3ac52f8175ad190e52a0bb
-        gitpod.io/checksum_config: 0ce55d51677cd683df3c7a244542c6aeaaf5dd6dca0f0458e8053a713228f535
+        gitpod.io/checksum_config: 1c66f4ccdb7f6331da2edaecefcb40f6c1b6315c9277eb0418fef3cc584a28bd
     spec:
       serviceAccountName: docker-registry
       securityContext:

--- a/install/installer/cmd/testdata/render/kind-ide/output.golden
+++ b/install/installer/cmd/testdata/render/kind-ide/output.golden
@@ -327,7 +327,7 @@ metadata:
   namespace: default
   labels:
     app: docker-registry
-    chart: docker-registry-1.16.0
+    chart: docker-registry-2.2.2
     heritage: Helm
     release: docker-registry
 type: Opaque
@@ -1185,7 +1185,7 @@ data:
       creationTimestamp: null
       labels:
         app: docker-registry
-        chart: docker-registry-1.16.0
+        chart: docker-registry-2.2.2
         heritage: Helm
         release: docker-registry
       name: registry-secret
@@ -1197,7 +1197,7 @@ data:
       creationTimestamp: null
       labels:
         app: docker-registry
-        chart: docker-registry-1.16.0
+        chart: docker-registry-2.2.2
         heritage: Helm
         release: docker-registry
       name: registry-config
@@ -1209,7 +1209,7 @@ data:
       creationTimestamp: null
       labels:
         app: registry
-        chart: docker-registry-1.16.0
+        chart: docker-registry-2.2.2
         heritage: Helm
         release: docker-registry
       name: registry
@@ -1221,7 +1221,7 @@ data:
       creationTimestamp: null
       labels:
         app: docker-registry
-        chart: docker-registry-1.16.0
+        chart: docker-registry-2.2.2
         heritage: Helm
         release: docker-registry
       name: registry
@@ -1233,7 +1233,7 @@ data:
       creationTimestamp: null
       labels:
         app: docker-registry
-        chart: docker-registry-1.16.0
+        chart: docker-registry-2.2.2
         heritage: Helm
         release: docker-registry
       name: registry
@@ -2552,7 +2552,7 @@ metadata:
   namespace: default
   labels:
     app: docker-registry
-    chart: docker-registry-1.16.0
+    chart: docker-registry-2.2.2
     heritage: Helm
     release: docker-registry
 data:
@@ -2811,7 +2811,7 @@ metadata:
   namespace: default
   labels:
     app: registry
-    chart: "docker-registry-1.16.0"
+    chart: "docker-registry-2.2.2"
     release: "docker-registry"
     heritage: "Helm"
 spec:
@@ -3224,7 +3224,7 @@ metadata:
   namespace: default
   labels:
     app: docker-registry
-    chart: docker-registry-1.16.0
+    chart: docker-registry-2.2.2
     release: docker-registry
     heritage: Helm
 spec:
@@ -3864,7 +3864,7 @@ metadata:
   namespace: default
   labels:
     app: docker-registry
-    chart: docker-registry-1.16.0
+    chart: docker-registry-2.2.2
     release: docker-registry
     heritage: Helm
 spec:
@@ -3880,7 +3880,9 @@ spec:
         app: docker-registry
         release: docker-registry
       annotations:
-        checksum/config: 1d22b82e19bbc654e029029c4fb86ad02dc13422dc3ac52f8175ad190e52a0bb
+        checksum/config: 699dd382179068f3354c330fcce38625e2861d97b962074b4f57005d40497b00
+        checksum/secret: 6fe5d819b2ea20bf72ad31384d4886d6f64dd1f0d237703ac3aff11c1e0737fd
+        
         gitpod.io/checksum_config: 1c66f4ccdb7f6331da2edaecefcb40f6c1b6315c9277eb0418fef3cc584a28bd
     spec:
       serviceAccountName: docker-registry
@@ -3889,7 +3891,7 @@ spec:
         runAsUser: 1000
       containers:
         - name: docker-registry
-          image: "docker.io/library/registry:2.7.1"
+          image: "docker.io/library/registry:2.8.1"
           imagePullPolicy: IfNotPresent
           command:
           - /bin/registry
@@ -3907,9 +3909,9 @@ spec:
               scheme: HTTPS
               path: /
               port: 5000
-          resources:
+          resources: 
             {}
-          env:
+          env: 
             - name: REGISTRY_HTTP_SECRET
               valueFrom:
                 secretKeyRef:
@@ -3921,21 +3923,21 @@ spec:
               value: /etc/ssl/docker/tls.key
             - name: REGISTRY_STORAGE_FILESYSTEM_ROOTDIRECTORY
               value: "/var/lib/registry"
-          volumeMounts:
-            - name: data
-              mountPath: /var/lib/registry/
+          volumeMounts: 
             - name: "registry-config"
               mountPath: "/etc/docker/registry"
+            - name: data
+              mountPath: /var/lib/registry/
             - mountPath: /etc/ssl/docker
               name: tls-cert
               readOnly: true
-      volumes:
-        - name: data
-          persistentVolumeClaim:
-            claimName: registry
+      volumes: 
         - name: registry-config
           configMap:
             name: registry-config
+        - name: data
+          persistentVolumeClaim:
+            claimName: registry
         - name: tls-cert
           secret:
             secretName: builtin-registry-certs

--- a/install/installer/cmd/testdata/render/kind-meta/output.golden
+++ b/install/installer/cmd/testdata/render/kind-meta/output.golden
@@ -689,9 +689,9 @@ metadata:
 # v1/Secret builtin-registry-auth
 apiVersion: v1
 data:
-  .dockerconfigjson: eyJhdXRocyI6eyJyZWdpc3RyeS5naXRwb2QuZXhhbXBsZS5jb20iOnsiYXV0aCI6ImVGTmxaRXBwUkdkS1VWRm5ORUpyVnpWNFMzVTZRMWMwUTFKQ2FtazJVakJpUjBjNE1XZDVSWGs9In19fQ==
-  password: Q1c0Q1JCamk2UjBiR0c4MWd5RXk=
-  user: eFNlZEppRGdKUVFnNEJrVzV4S3U=
+  .dockerconfigjson: eyJhdXRocyI6eyJyZWdpc3RyeS5naXRwb2QuZXhhbXBsZS5jb20iOnsiYXV0aCI6ImVIZDVRMGRsTlZVd1RrRnFObFZsYVhFM1RqQTZWbE5UYkcxaFMxZFFhaTVRVVhCdFZXWnNWR1E9In19fQ==
+  password: VlNTbG1hS1dQai5QUXBtVWZsVGQ=
+  user: eHd5Q0dlNVUwTkFqNlVlaXE3TjA=
 kind: Secret
 metadata:
   creationTimestamp: null
@@ -807,8 +807,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 type: Opaque
 data:
-  root-user: "OC1XR3F3Mm9UbnNQZlVETlNrMFk="
-  root-password: "RHBDLmFTQXhrV0JQdTJfYkpfQUU="
+  root-user: "UkJqaTZSMGJHRzgxZ3lFeWUyNVA="
+  root-password: "dFg2TUw4Z0NXMzFtaXcwVDhRTUk="
   key.json: ""
 ---
 # v1/Secret mysql
@@ -977,9 +977,9 @@ data:
         },
         "minio": {
           "endpoint": "minio.default.svc.cluster.local:9000",
-          "accessKey": "8-WGqw2oTnsPfUDNSk0Y",
+          "accessKey": "RBji6R0bGG81gyEye25P",
           "accessKeyFile": "",
-          "secretKey": "DpC.aSAxkWBPu2_bJ_AE",
+          "secretKey": "tX6ML8gCW31miw0T8QMI",
           "secretKeyFile": "",
           "region": "local",
           "parallelUpload": 6
@@ -4098,7 +4098,7 @@ data:
         import ssl_configuration
 
         basicauth bcrypt "Docker Registry" {
-            xSedJiDgJQQg4BkW5xKu JDJhJDEwJFFTRGRRMHZZY2pIS2JqUC9aMDNnVC5HbEg2Z1dOQm5TL0pySnpYSm5iNy9DeVh0ZUw2cFM2
+            xwyCGe5U0NAj6Ueiq7N0 JDJhJDEwJFFTRGRRMHZZY2pIS2JqUC9aMDNnVC5CY0M3RDZsVVg0LzBpZmdnTGovT0VVWXoxTG8ud0lX
         }
 
         reverse_proxy https://registry.default.svc.cluster.local {
@@ -4317,7 +4317,7 @@ data:
       },
       "oauthServer": {
         "enabled": true,
-        "jwtSecret": "8QMIxwyCGe5U0NAj6Uei"
+        "jwtSecret": "m30EH-M2-cWMgkgdy7pu"
       },
       "rateLimiter": {
         "groups": {
@@ -6400,7 +6400,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: cac138904f08d79e5598805683f8dc378bd52c58348489de22949ac38dd8b193
+        gitpod.io/checksum_config: 0d9d1c68723466a253996f0a96bf0682ce57b89ebcb4ae1e4a643dd788ef1cab
       creationTimestamp: null
       labels:
         app: gitpod
@@ -6541,7 +6541,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 20782435cc6d6e080cf720b57dca8d4d5cfe40942fc71c4bfd54934fdc34c766
+        gitpod.io/checksum_config: 21ad538d4c7daef6619e5dda6fd71a49a5e5b551f0fc1365d3b7db1d1f38f9ce
       creationTimestamp: null
       labels:
         app: gitpod
@@ -7271,7 +7271,7 @@ spec:
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/credentials-secret: 0a5790906818b3f8eeee0bd3b3e990b3ad02d79bb23c62c0d91a4ca010fb5579
+        checksum/credentials-secret: 094325f216720012cacde9f52fd71c7e8b06dd6386492f6980e0f3588f1b1e7c
     spec:
       
       serviceAccountName: minio
@@ -7379,7 +7379,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: c52c73e63eaa95613a8f4fe77167c754cd48eaf757dd69c2048400311a5ae0a6
+        gitpod.io/checksum_config: a7bd71558cb04a04656bafe7651d4192a9d37be96d2d817f9b6225f63e3a6989
       creationTimestamp: null
       labels:
         app: gitpod
@@ -7730,7 +7730,7 @@ spec:
         release: docker-registry
       annotations:
         checksum/config: 1d22b82e19bbc654e029029c4fb86ad02dc13422dc3ac52f8175ad190e52a0bb
-        gitpod.io/checksum_config: 0ce55d51677cd683df3c7a244542c6aeaaf5dd6dca0f0458e8053a713228f535
+        gitpod.io/checksum_config: 1c66f4ccdb7f6331da2edaecefcb40f6c1b6315c9277eb0418fef3cc584a28bd
     spec:
       serviceAccountName: docker-registry
       securityContext:
@@ -7813,7 +7813,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 726dafd8c59907accd3250e873f40d6e59d6913f82b7198335bc6c24ae2e7db1
+        gitpod.io/checksum_config: f52ae23eddcf2fe15c87ec92cc3d998045c5ff491d52caed0f23a6fccc020134
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/kind-meta/output.golden
+++ b/install/installer/cmd/testdata/render/kind-meta/output.golden
@@ -159,7 +159,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -440,7 +440,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -591,7 +591,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: minio
-    helm.sh/chart: minio-11.6.3
+    helm.sh/chart: minio-11.10.24
     app.kubernetes.io/instance: minio
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
@@ -655,7 +655,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
@@ -725,7 +725,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -741,7 +741,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -772,13 +772,13 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
 data:
   rabbitmq.conf: |-
-    IyMgVXNlcm5hbWUgYW5kIHBhc3N3b3JkCiMjCmRlZmF1bHRfdXNlciA9IGdpdHBvZApkZWZhdWx0X3Bhc3MgPSBDSEFOR0VNRQojIyBDbHVzdGVyaW5nCiMjCmNsdXN0ZXJfZm9ybWF0aW9uLnBlZXJfZGlzY292ZXJ5X2JhY2tlbmQgID0gcmFiYml0X3BlZXJfZGlzY292ZXJ5X2s4cwpjbHVzdGVyX2Zvcm1hdGlvbi5rOHMuaG9zdCA9IGt1YmVybmV0ZXMuZGVmYXVsdApjbHVzdGVyX2Zvcm1hdGlvbi5ub2RlX2NsZWFudXAuaW50ZXJ2YWwgPSAxMApjbHVzdGVyX2Zvcm1hdGlvbi5ub2RlX2NsZWFudXAub25seV9sb2dfd2FybmluZyA9IHRydWUKY2x1c3Rlcl9wYXJ0aXRpb25faGFuZGxpbmcgPSBhdXRvaGVhbApsb2FkX2RlZmluaXRpb25zID0gL2FwcC9sb2FkX2RlZmluaXRpb24uanNvbgojIHF1ZXVlIG1hc3RlciBsb2NhdG9yCnF1ZXVlX21hc3Rlcl9sb2NhdG9yID0gbWluLW1hc3RlcnMKIyBlbmFibGUgZ3Vlc3QgdXNlcgpsb29wYmFja191c2Vycy5ndWVzdCA9IGZhbHNlCmxvYWRfZGVmaW5pdGlvbnMgPSAvYXBwL2xvYWRfZGVmaW5pdGlvbi5qc29uCiMgSW5jcmVhc2Ugc3RhdGlzdGljcyBlbWlzc2lvbiBpbnRlcnZhbCBodHRwczovL3d3dy5yYWJiaXRtcS5jb20vbWFuYWdlbWVudC5odG1sI3N0YXRpc3RpY3MtaW50ZXJ2YWwKY29sbGVjdF9zdGF0aXN0aWNzX2ludGVydmFsID0gMTUwMDAKCnNzbF9vcHRpb25zLnZlcmlmeSA9IHZlcmlmeV9wZWVyCmxpc3RlbmVycy5zc2wuZGVmYXVsdCA9IDU2NzEKc3NsX29wdGlvbnMuZmFpbF9pZl9ub19wZWVyX2NlcnQgPSB0cnVlCnNzbF9vcHRpb25zLmNhY2VydGZpbGUgPSAvb3B0L2JpdG5hbWkvcmFiYml0bXEvY2VydHMvY2FfY2VydGlmaWNhdGUucGVtCnNzbF9vcHRpb25zLmNlcnRmaWxlID0gL29wdC9iaXRuYW1pL3JhYmJpdG1xL2NlcnRzL3NlcnZlcl9jZXJ0aWZpY2F0ZS5wZW0Kc3NsX29wdGlvbnMua2V5ZmlsZSA9IC9vcHQvYml0bmFtaS9yYWJiaXRtcS9jZXJ0cy9zZXJ2ZXJfa2V5LnBlbQojIyBQcm9tZXRoZXVzIG1ldHJpY3MKIyMKcHJvbWV0aGV1cy50Y3AucG9ydCA9IDk0MTk=
+    IyMgVXNlcm5hbWUgYW5kIHBhc3N3b3JkCiMjCmRlZmF1bHRfdXNlciA9IGdpdHBvZAojIyBDbHVzdGVyaW5nCiMjCmNsdXN0ZXJfZm9ybWF0aW9uLnBlZXJfZGlzY292ZXJ5X2JhY2tlbmQgID0gcmFiYml0X3BlZXJfZGlzY292ZXJ5X2s4cwpjbHVzdGVyX2Zvcm1hdGlvbi5rOHMuaG9zdCA9IGt1YmVybmV0ZXMuZGVmYXVsdApjbHVzdGVyX2Zvcm1hdGlvbi5ub2RlX2NsZWFudXAuaW50ZXJ2YWwgPSAxMApjbHVzdGVyX2Zvcm1hdGlvbi5ub2RlX2NsZWFudXAub25seV9sb2dfd2FybmluZyA9IHRydWUKY2x1c3Rlcl9wYXJ0aXRpb25faGFuZGxpbmcgPSBhdXRvaGVhbApsb2FkX2RlZmluaXRpb25zID0gL2FwcC9sb2FkX2RlZmluaXRpb24uanNvbgojIHF1ZXVlIG1hc3RlciBsb2NhdG9yCnF1ZXVlX21hc3Rlcl9sb2NhdG9yID0gbWluLW1hc3RlcnMKIyBlbmFibGUgZ3Vlc3QgdXNlcgpsb29wYmFja191c2Vycy5ndWVzdCA9IGZhbHNlCmxvYWRfZGVmaW5pdGlvbnMgPSAvYXBwL2xvYWRfZGVmaW5pdGlvbi5qc29uCiMgSW5jcmVhc2Ugc3RhdGlzdGljcyBlbWlzc2lvbiBpbnRlcnZhbCBodHRwczovL3d3dy5yYWJiaXRtcS5jb20vbWFuYWdlbWVudC5odG1sI3N0YXRpc3RpY3MtaW50ZXJ2YWwKY29sbGVjdF9zdGF0aXN0aWNzX2ludGVydmFsID0gMTUwMDAKCnNzbF9vcHRpb25zLnZlcmlmeSA9IHZlcmlmeV9wZWVyCmxpc3RlbmVycy5zc2wuZGVmYXVsdCA9IDU2NzEKc3NsX29wdGlvbnMuZmFpbF9pZl9ub19wZWVyX2NlcnQgPSB0cnVlCnNzbF9vcHRpb25zLmNhY2VydGZpbGUgPSAvb3B0L2JpdG5hbWkvcmFiYml0bXEvY2VydHMvY2FfY2VydGlmaWNhdGUucGVtCnNzbF9vcHRpb25zLmNlcnRmaWxlID0gL29wdC9iaXRuYW1pL3JhYmJpdG1xL2NlcnRzL3NlcnZlcl9jZXJ0aWZpY2F0ZS5wZW0Kc3NsX29wdGlvbnMua2V5ZmlsZSA9IC9vcHQvYml0bmFtaS9yYWJiaXRtcS9jZXJ0cy9zZXJ2ZXJfa2V5LnBlbQojIyBQcm9tZXRoZXVzIG1ldHJpY3MKIyMKcHJvbWV0aGV1cy50Y3AucG9ydCA9IDk0MTk=
 ---
 # v1/Secret messagebus-erlang-cookie
 apiVersion: v1
@@ -802,7 +802,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: minio
-    helm.sh/chart: minio-11.6.3
+    helm.sh/chart: minio-11.10.24
     app.kubernetes.io/instance: minio
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -838,7 +838,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -855,7 +855,7 @@ metadata:
   namespace: default
   labels:
     app: docker-registry
-    chart: docker-registry-1.16.0
+    chart: docker-registry-2.2.2
     heritage: Helm
     release: docker-registry
 type: Opaque
@@ -2402,7 +2402,7 @@ data:
       creationTimestamp: null
       labels:
         app: docker-registry
-        chart: docker-registry-1.16.0
+        chart: docker-registry-2.2.2
         heritage: Helm
         release: docker-registry
       name: registry-secret
@@ -2414,7 +2414,7 @@ data:
       creationTimestamp: null
       labels:
         app: docker-registry
-        chart: docker-registry-1.16.0
+        chart: docker-registry-2.2.2
         heritage: Helm
         release: docker-registry
       name: registry-config
@@ -2426,7 +2426,7 @@ data:
       creationTimestamp: null
       labels:
         app: registry
-        chart: docker-registry-1.16.0
+        chart: docker-registry-2.2.2
         heritage: Helm
         release: docker-registry
       name: registry
@@ -2438,7 +2438,7 @@ data:
       creationTimestamp: null
       labels:
         app: docker-registry
-        chart: docker-registry-1.16.0
+        chart: docker-registry-2.2.2
         heritage: Helm
         release: docker-registry
       name: registry
@@ -2450,7 +2450,7 @@ data:
       creationTimestamp: null
       labels:
         app: docker-registry
-        chart: docker-registry-1.16.0
+        chart: docker-registry-2.2.2
         heritage: Helm
         release: docker-registry
       name: registry
@@ -2465,7 +2465,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql
       namespace: default
     ---
@@ -2478,7 +2478,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql-headless
       namespace: default
     ---
@@ -2491,7 +2491,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql
       namespace: default
     ---
@@ -2504,7 +2504,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql
       namespace: default
     ---
@@ -2516,7 +2516,7 @@ data:
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: minio
-        helm.sh/chart: minio-11.6.3
+        helm.sh/chart: minio-11.10.24
       name: minio
       namespace: default
     ---
@@ -2528,7 +2528,7 @@ data:
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: minio
-        helm.sh/chart: minio-11.6.3
+        helm.sh/chart: minio-11.10.24
       name: minio
       namespace: default
     ---
@@ -2540,7 +2540,7 @@ data:
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: minio
-        helm.sh/chart: minio-11.6.3
+        helm.sh/chart: minio-11.10.24
       name: minio
       namespace: default
     ---
@@ -2552,7 +2552,7 @@ data:
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: minio
-        helm.sh/chart: minio-11.6.3
+        helm.sh/chart: minio-11.10.24
       name: minio
       namespace: default
     ---
@@ -2564,7 +2564,7 @@ data:
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: minio
-        helm.sh/chart: minio-11.6.3
+        helm.sh/chart: minio-11.10.24
       name: minio
       namespace: default
     ---
@@ -2576,7 +2576,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus
       namespace: default
     ---
@@ -2588,7 +2588,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus
       namespace: default
     ---
@@ -2600,7 +2600,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: rabbitmq
       namespace: default
     ---
@@ -2612,7 +2612,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus-config
       namespace: default
     ---
@@ -2624,7 +2624,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus
       namespace: default
     ---
@@ -2636,7 +2636,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: load-definition
       namespace: default
     ---
@@ -2648,7 +2648,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: rabbitmq
       namespace: default
     ---
@@ -2660,7 +2660,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus-endpoint-reader
       namespace: default
     ---
@@ -2672,7 +2672,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus-endpoint-reader
       namespace: default
     ---
@@ -2684,7 +2684,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus-headless
       namespace: default
     ---
@@ -2696,7 +2696,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus
       namespace: default
     ---
@@ -2708,7 +2708,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus
       namespace: default
     ---
@@ -4023,7 +4023,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
@@ -4040,7 +4040,7 @@ data:
     datadir=/bitnami/mysql/data
     tmpdir=/opt/bitnami/mysql/tmp
     max_allowed_packet=16M
-    bind-address=0.0.0.0
+    bind-address=*
     pid-file=/opt/bitnami/mysql/tmp/mysqld.pid
     log-error=/opt/bitnami/mysql/logs/mysqld.log
     character-set-server=UTF8
@@ -4210,7 +4210,7 @@ metadata:
   namespace: default
   labels:
     app: docker-registry
-    chart: docker-registry-1.16.0
+    chart: docker-registry-2.2.2
     heritage: Helm
     release: docker-registry
 data:
@@ -4658,7 +4658,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: minio
-    helm.sh/chart: minio-11.6.3
+    helm.sh/chart: minio-11.10.24
     app.kubernetes.io/instance: minio
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -4677,7 +4677,7 @@ metadata:
   namespace: default
   labels:
     app: registry
-    chart: "docker-registry-1.16.0"
+    chart: "docker-registry-2.2.2"
     release: "docker-registry"
     heritage: "Helm"
 spec:
@@ -4932,7 +4932,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 rules:
@@ -5183,7 +5183,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 subjects:
@@ -5562,7 +5562,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -5606,7 +5606,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -5641,7 +5641,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: minio
-    helm.sh/chart: minio-11.6.3
+    helm.sh/chart: minio-11.10.24
     app.kubernetes.io/instance: minio
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -5668,7 +5668,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
@@ -5696,11 +5696,10 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
-  annotations:
 spec:
   type: ClusterIP
   clusterIP: None
@@ -5814,7 +5813,7 @@ metadata:
   namespace: default
   labels:
     app: docker-registry
-    chart: docker-registry-1.16.0
+    chart: docker-registry-2.2.2
     release: docker-registry
     heritage: Helm
 spec:
@@ -5881,7 +5880,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -5898,12 +5897,12 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/config: 2ca9db593e4ca6cdd01f7a65cce1ae90d0d45ecdf0049edfaa4ec72302fcbe8f
-        checksum/secret: c231bbb08185305defa8c4da0f3ee0f5e7a16795362a2133f74e53eb9a40453d
+        checksum/config: d5780a0c58210a2062d54feb61cfb1d5a9c076f95569c4a77076d22c9bad4190
+        checksum/secret: 64c39dd3a8570ed4b0cc71bc0402bc814d016e16f68732938722b12a57c8e82c
         prometheus.io/port: '9419'
         prometheus.io/scrape: "true"
     spec:
@@ -5923,7 +5922,7 @@ spec:
       initContainers:
       containers:
         - name: rabbitmq
-          image: docker.io/bitnami/rabbitmq:3.10.2-debian-10-r7
+          image: docker.io/bitnami/rabbitmq:3.11.5-debian-11-r2
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true
@@ -6058,11 +6057,10 @@ spec:
               - key: tls.key
                 path: server_key.pem
         - name: configuration
-          secret:
-            secretName: messagebus-config
-            items:
-              - key: rabbitmq.conf
-                path: rabbitmq.conf
+          projected:
+            sources:
+              - secret:
+                  name: messagebus-config
         - name: load-definition-volume
           secret:
             secretName: "load-definition"
@@ -6078,7 +6076,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
@@ -6096,10 +6094,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/configuration: 11b8361c0fbf695cec6ec7f47ed4118ad3c7d71a391ca246df129803d3e205a5
+        checksum/configuration: 0c1e0d4282c8f8f820f3c9d1d79b3f423c4676afac2e3a6de555f8553f146eb4
       labels:
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: primary
@@ -6118,7 +6116,7 @@ spec:
         fsGroup: 1001
       initContainers:
         - name: volume-permissions
-          image: docker.io/bitnami/bitnami-shell:10-debian-10-r431
+          image: docker.io/bitnami/bitnami-shell:11-debian-11-r60
           imagePullPolicy: "IfNotPresent"
           command:
             - /bin/bash
@@ -7253,7 +7251,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: minio
-    helm.sh/chart: minio-11.6.3
+    helm.sh/chart: minio-11.10.24
     app.kubernetes.io/instance: minio
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -7267,11 +7265,11 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: minio
-        helm.sh/chart: minio-11.6.3
+        helm.sh/chart: minio-11.10.24
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/credentials-secret: 094325f216720012cacde9f52fd71c7e8b06dd6386492f6980e0f3588f1b1e7c
+        checksum/credentials-secret: 0f3ceb92b9779df4ce0927f6faeb23e9116b85e0eabe095d903e46a2770cde42
     spec:
       
       serviceAccountName: minio
@@ -7287,7 +7285,7 @@ spec:
         fsGroup: 1001
       containers:
         - name: minio
-          image: docker.io/bitnami/minio:2022.5.26-debian-10-r0
+          image: docker.io/bitnami/minio:2022.12.12-debian-11-r0
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true
@@ -7713,7 +7711,7 @@ metadata:
   namespace: default
   labels:
     app: docker-registry
-    chart: docker-registry-1.16.0
+    chart: docker-registry-2.2.2
     release: docker-registry
     heritage: Helm
 spec:
@@ -7729,7 +7727,9 @@ spec:
         app: docker-registry
         release: docker-registry
       annotations:
-        checksum/config: 1d22b82e19bbc654e029029c4fb86ad02dc13422dc3ac52f8175ad190e52a0bb
+        checksum/config: 699dd382179068f3354c330fcce38625e2861d97b962074b4f57005d40497b00
+        checksum/secret: 450f59aeda22415409a87a1abd2c033c08ebd5fb54fe24d3c56560e92b0218f6
+        
         gitpod.io/checksum_config: 1c66f4ccdb7f6331da2edaecefcb40f6c1b6315c9277eb0418fef3cc584a28bd
     spec:
       serviceAccountName: docker-registry
@@ -7738,7 +7738,7 @@ spec:
         runAsUser: 1000
       containers:
         - name: docker-registry
-          image: "docker.io/library/registry:2.7.1"
+          image: "docker.io/library/registry:2.8.1"
           imagePullPolicy: IfNotPresent
           command:
           - /bin/registry
@@ -7756,9 +7756,9 @@ spec:
               scheme: HTTPS
               path: /
               port: 5000
-          resources:
+          resources: 
             {}
-          env:
+          env: 
             - name: REGISTRY_HTTP_SECRET
               valueFrom:
                 secretKeyRef:
@@ -7770,21 +7770,21 @@ spec:
               value: /etc/ssl/docker/tls.key
             - name: REGISTRY_STORAGE_FILESYSTEM_ROOTDIRECTORY
               value: "/var/lib/registry"
-          volumeMounts:
-            - name: data
-              mountPath: /var/lib/registry/
+          volumeMounts: 
             - name: "registry-config"
               mountPath: "/etc/docker/registry"
+            - name: data
+              mountPath: /var/lib/registry/
             - mountPath: /etc/ssl/docker
               name: tls-cert
               readOnly: true
-      volumes:
-        - name: data
-          persistentVolumeClaim:
-            claimName: registry
+      volumes: 
         - name: registry-config
           configMap:
             name: registry-config
+        - name: data
+          persistentVolumeClaim:
+            claimName: registry
         - name: tls-cert
           secret:
             secretName: builtin-registry-certs

--- a/install/installer/cmd/testdata/render/kind-webapp/output.golden
+++ b/install/installer/cmd/testdata/render/kind-webapp/output.golden
@@ -85,7 +85,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -333,7 +333,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -436,7 +436,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: minio
-    helm.sh/chart: minio-11.6.3
+    helm.sh/chart: minio-11.10.24
     app.kubernetes.io/instance: minio
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
@@ -488,7 +488,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
@@ -558,7 +558,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -574,7 +574,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -605,13 +605,13 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
 data:
   rabbitmq.conf: |-
-    IyMgVXNlcm5hbWUgYW5kIHBhc3N3b3JkCiMjCmRlZmF1bHRfdXNlciA9IGdpdHBvZApkZWZhdWx0X3Bhc3MgPSBDSEFOR0VNRQojIyBDbHVzdGVyaW5nCiMjCmNsdXN0ZXJfZm9ybWF0aW9uLnBlZXJfZGlzY292ZXJ5X2JhY2tlbmQgID0gcmFiYml0X3BlZXJfZGlzY292ZXJ5X2s4cwpjbHVzdGVyX2Zvcm1hdGlvbi5rOHMuaG9zdCA9IGt1YmVybmV0ZXMuZGVmYXVsdApjbHVzdGVyX2Zvcm1hdGlvbi5ub2RlX2NsZWFudXAuaW50ZXJ2YWwgPSAxMApjbHVzdGVyX2Zvcm1hdGlvbi5ub2RlX2NsZWFudXAub25seV9sb2dfd2FybmluZyA9IHRydWUKY2x1c3Rlcl9wYXJ0aXRpb25faGFuZGxpbmcgPSBhdXRvaGVhbApsb2FkX2RlZmluaXRpb25zID0gL2FwcC9sb2FkX2RlZmluaXRpb24uanNvbgojIHF1ZXVlIG1hc3RlciBsb2NhdG9yCnF1ZXVlX21hc3Rlcl9sb2NhdG9yID0gbWluLW1hc3RlcnMKIyBlbmFibGUgZ3Vlc3QgdXNlcgpsb29wYmFja191c2Vycy5ndWVzdCA9IGZhbHNlCmxvYWRfZGVmaW5pdGlvbnMgPSAvYXBwL2xvYWRfZGVmaW5pdGlvbi5qc29uCiMgSW5jcmVhc2Ugc3RhdGlzdGljcyBlbWlzc2lvbiBpbnRlcnZhbCBodHRwczovL3d3dy5yYWJiaXRtcS5jb20vbWFuYWdlbWVudC5odG1sI3N0YXRpc3RpY3MtaW50ZXJ2YWwKY29sbGVjdF9zdGF0aXN0aWNzX2ludGVydmFsID0gMTUwMDAKCnNzbF9vcHRpb25zLnZlcmlmeSA9IHZlcmlmeV9wZWVyCmxpc3RlbmVycy5zc2wuZGVmYXVsdCA9IDU2NzEKc3NsX29wdGlvbnMuZmFpbF9pZl9ub19wZWVyX2NlcnQgPSB0cnVlCnNzbF9vcHRpb25zLmNhY2VydGZpbGUgPSAvb3B0L2JpdG5hbWkvcmFiYml0bXEvY2VydHMvY2FfY2VydGlmaWNhdGUucGVtCnNzbF9vcHRpb25zLmNlcnRmaWxlID0gL29wdC9iaXRuYW1pL3JhYmJpdG1xL2NlcnRzL3NlcnZlcl9jZXJ0aWZpY2F0ZS5wZW0Kc3NsX29wdGlvbnMua2V5ZmlsZSA9IC9vcHQvYml0bmFtaS9yYWJiaXRtcS9jZXJ0cy9zZXJ2ZXJfa2V5LnBlbQojIyBQcm9tZXRoZXVzIG1ldHJpY3MKIyMKcHJvbWV0aGV1cy50Y3AucG9ydCA9IDk0MTk=
+    IyMgVXNlcm5hbWUgYW5kIHBhc3N3b3JkCiMjCmRlZmF1bHRfdXNlciA9IGdpdHBvZAojIyBDbHVzdGVyaW5nCiMjCmNsdXN0ZXJfZm9ybWF0aW9uLnBlZXJfZGlzY292ZXJ5X2JhY2tlbmQgID0gcmFiYml0X3BlZXJfZGlzY292ZXJ5X2s4cwpjbHVzdGVyX2Zvcm1hdGlvbi5rOHMuaG9zdCA9IGt1YmVybmV0ZXMuZGVmYXVsdApjbHVzdGVyX2Zvcm1hdGlvbi5ub2RlX2NsZWFudXAuaW50ZXJ2YWwgPSAxMApjbHVzdGVyX2Zvcm1hdGlvbi5ub2RlX2NsZWFudXAub25seV9sb2dfd2FybmluZyA9IHRydWUKY2x1c3Rlcl9wYXJ0aXRpb25faGFuZGxpbmcgPSBhdXRvaGVhbApsb2FkX2RlZmluaXRpb25zID0gL2FwcC9sb2FkX2RlZmluaXRpb24uanNvbgojIHF1ZXVlIG1hc3RlciBsb2NhdG9yCnF1ZXVlX21hc3Rlcl9sb2NhdG9yID0gbWluLW1hc3RlcnMKIyBlbmFibGUgZ3Vlc3QgdXNlcgpsb29wYmFja191c2Vycy5ndWVzdCA9IGZhbHNlCmxvYWRfZGVmaW5pdGlvbnMgPSAvYXBwL2xvYWRfZGVmaW5pdGlvbi5qc29uCiMgSW5jcmVhc2Ugc3RhdGlzdGljcyBlbWlzc2lvbiBpbnRlcnZhbCBodHRwczovL3d3dy5yYWJiaXRtcS5jb20vbWFuYWdlbWVudC5odG1sI3N0YXRpc3RpY3MtaW50ZXJ2YWwKY29sbGVjdF9zdGF0aXN0aWNzX2ludGVydmFsID0gMTUwMDAKCnNzbF9vcHRpb25zLnZlcmlmeSA9IHZlcmlmeV9wZWVyCmxpc3RlbmVycy5zc2wuZGVmYXVsdCA9IDU2NzEKc3NsX29wdGlvbnMuZmFpbF9pZl9ub19wZWVyX2NlcnQgPSB0cnVlCnNzbF9vcHRpb25zLmNhY2VydGZpbGUgPSAvb3B0L2JpdG5hbWkvcmFiYml0bXEvY2VydHMvY2FfY2VydGlmaWNhdGUucGVtCnNzbF9vcHRpb25zLmNlcnRmaWxlID0gL29wdC9iaXRuYW1pL3JhYmJpdG1xL2NlcnRzL3NlcnZlcl9jZXJ0aWZpY2F0ZS5wZW0Kc3NsX29wdGlvbnMua2V5ZmlsZSA9IC9vcHQvYml0bmFtaS9yYWJiaXRtcS9jZXJ0cy9zZXJ2ZXJfa2V5LnBlbQojIyBQcm9tZXRoZXVzIG1ldHJpY3MKIyMKcHJvbWV0aGV1cy50Y3AucG9ydCA9IDk0MTk=
 ---
 # v1/Secret messagebus-erlang-cookie
 apiVersion: v1
@@ -635,7 +635,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: minio
-    helm.sh/chart: minio-11.6.3
+    helm.sh/chart: minio-11.10.24
     app.kubernetes.io/instance: minio
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -671,7 +671,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -688,7 +688,7 @@ metadata:
   namespace: default
   labels:
     app: docker-registry
-    chart: docker-registry-1.16.0
+    chart: docker-registry-2.2.2
     heritage: Helm
     release: docker-registry
 type: Opaque
@@ -1781,7 +1781,7 @@ data:
       creationTimestamp: null
       labels:
         app: docker-registry
-        chart: docker-registry-1.16.0
+        chart: docker-registry-2.2.2
         heritage: Helm
         release: docker-registry
       name: registry-secret
@@ -1793,7 +1793,7 @@ data:
       creationTimestamp: null
       labels:
         app: docker-registry
-        chart: docker-registry-1.16.0
+        chart: docker-registry-2.2.2
         heritage: Helm
         release: docker-registry
       name: registry-config
@@ -1805,7 +1805,7 @@ data:
       creationTimestamp: null
       labels:
         app: registry
-        chart: docker-registry-1.16.0
+        chart: docker-registry-2.2.2
         heritage: Helm
         release: docker-registry
       name: registry
@@ -1817,7 +1817,7 @@ data:
       creationTimestamp: null
       labels:
         app: docker-registry
-        chart: docker-registry-1.16.0
+        chart: docker-registry-2.2.2
         heritage: Helm
         release: docker-registry
       name: registry
@@ -1829,7 +1829,7 @@ data:
       creationTimestamp: null
       labels:
         app: docker-registry
-        chart: docker-registry-1.16.0
+        chart: docker-registry-2.2.2
         heritage: Helm
         release: docker-registry
       name: registry
@@ -1844,7 +1844,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql
       namespace: default
     ---
@@ -1857,7 +1857,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql-headless
       namespace: default
     ---
@@ -1870,7 +1870,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql
       namespace: default
     ---
@@ -1883,7 +1883,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql
       namespace: default
     ---
@@ -1895,7 +1895,7 @@ data:
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: minio
-        helm.sh/chart: minio-11.6.3
+        helm.sh/chart: minio-11.10.24
       name: minio
       namespace: default
     ---
@@ -1907,7 +1907,7 @@ data:
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: minio
-        helm.sh/chart: minio-11.6.3
+        helm.sh/chart: minio-11.10.24
       name: minio
       namespace: default
     ---
@@ -1919,7 +1919,7 @@ data:
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: minio
-        helm.sh/chart: minio-11.6.3
+        helm.sh/chart: minio-11.10.24
       name: minio
       namespace: default
     ---
@@ -1931,7 +1931,7 @@ data:
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: minio
-        helm.sh/chart: minio-11.6.3
+        helm.sh/chart: minio-11.10.24
       name: minio
       namespace: default
     ---
@@ -1943,7 +1943,7 @@ data:
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: minio
-        helm.sh/chart: minio-11.6.3
+        helm.sh/chart: minio-11.10.24
       name: minio
       namespace: default
     ---
@@ -1955,7 +1955,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus
       namespace: default
     ---
@@ -1967,7 +1967,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus
       namespace: default
     ---
@@ -1979,7 +1979,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: rabbitmq
       namespace: default
     ---
@@ -1991,7 +1991,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus-config
       namespace: default
     ---
@@ -2003,7 +2003,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus
       namespace: default
     ---
@@ -2015,7 +2015,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: load-definition
       namespace: default
     ---
@@ -2027,7 +2027,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: rabbitmq
       namespace: default
     ---
@@ -2039,7 +2039,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus-endpoint-reader
       namespace: default
     ---
@@ -2051,7 +2051,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus-endpoint-reader
       namespace: default
     ---
@@ -2063,7 +2063,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus-headless
       namespace: default
     ---
@@ -2075,7 +2075,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus
       namespace: default
     ---
@@ -2087,7 +2087,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus
       namespace: default
     ---
@@ -2145,7 +2145,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
@@ -2162,7 +2162,7 @@ data:
     datadir=/bitnami/mysql/data
     tmpdir=/opt/bitnami/mysql/tmp
     max_allowed_packet=16M
-    bind-address=0.0.0.0
+    bind-address=*
     pid-file=/opt/bitnami/mysql/tmp/mysqld.pid
     log-error=/opt/bitnami/mysql/logs/mysqld.log
     character-set-server=UTF8
@@ -2304,7 +2304,7 @@ metadata:
   namespace: default
   labels:
     app: docker-registry
-    chart: docker-registry-1.16.0
+    chart: docker-registry-2.2.2
     heritage: Helm
     release: docker-registry
 data:
@@ -2530,7 +2530,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: minio
-    helm.sh/chart: minio-11.6.3
+    helm.sh/chart: minio-11.10.24
     app.kubernetes.io/instance: minio
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -2549,7 +2549,7 @@ metadata:
   namespace: default
   labels:
     app: registry
-    chart: "docker-registry-1.16.0"
+    chart: "docker-registry-2.2.2"
     release: "docker-registry"
     heritage: "Helm"
 spec:
@@ -2696,7 +2696,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 rules:
@@ -2875,7 +2875,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 subjects:
@@ -3140,7 +3140,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -3184,7 +3184,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -3219,7 +3219,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: minio
-    helm.sh/chart: minio-11.6.3
+    helm.sh/chart: minio-11.10.24
     app.kubernetes.io/instance: minio
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -3246,7 +3246,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
@@ -3274,11 +3274,10 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
-  annotations:
 spec:
   type: ClusterIP
   clusterIP: None
@@ -3364,7 +3363,7 @@ metadata:
   namespace: default
   labels:
     app: docker-registry
-    chart: docker-registry-1.16.0
+    chart: docker-registry-2.2.2
     release: docker-registry
     heritage: Helm
 spec:
@@ -3431,7 +3430,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -3448,12 +3447,12 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/config: 2ca9db593e4ca6cdd01f7a65cce1ae90d0d45ecdf0049edfaa4ec72302fcbe8f
-        checksum/secret: c231bbb08185305defa8c4da0f3ee0f5e7a16795362a2133f74e53eb9a40453d
+        checksum/config: d5780a0c58210a2062d54feb61cfb1d5a9c076f95569c4a77076d22c9bad4190
+        checksum/secret: 64c39dd3a8570ed4b0cc71bc0402bc814d016e16f68732938722b12a57c8e82c
         prometheus.io/port: '9419'
         prometheus.io/scrape: "true"
     spec:
@@ -3473,7 +3472,7 @@ spec:
       initContainers:
       containers:
         - name: rabbitmq
-          image: docker.io/bitnami/rabbitmq:3.10.2-debian-10-r7
+          image: docker.io/bitnami/rabbitmq:3.11.5-debian-11-r2
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true
@@ -3608,11 +3607,10 @@ spec:
               - key: tls.key
                 path: server_key.pem
         - name: configuration
-          secret:
-            secretName: messagebus-config
-            items:
-              - key: rabbitmq.conf
-                path: rabbitmq.conf
+          projected:
+            sources:
+              - secret:
+                  name: messagebus-config
         - name: load-definition-volume
           secret:
             secretName: "load-definition"
@@ -3628,7 +3626,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
@@ -3646,10 +3644,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/configuration: 11b8361c0fbf695cec6ec7f47ed4118ad3c7d71a391ca246df129803d3e205a5
+        checksum/configuration: 0c1e0d4282c8f8f820f3c9d1d79b3f423c4676afac2e3a6de555f8553f146eb4
       labels:
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: primary
@@ -3668,7 +3666,7 @@ spec:
         fsGroup: 1001
       initContainers:
         - name: volume-permissions
-          image: docker.io/bitnami/bitnami-shell:10-debian-10-r431
+          image: docker.io/bitnami/bitnami-shell:11-debian-11-r60
           imagePullPolicy: "IfNotPresent"
           command:
             - /bin/bash
@@ -4186,7 +4184,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: minio
-    helm.sh/chart: minio-11.6.3
+    helm.sh/chart: minio-11.10.24
     app.kubernetes.io/instance: minio
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -4200,11 +4198,11 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: minio
-        helm.sh/chart: minio-11.6.3
+        helm.sh/chart: minio-11.10.24
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/credentials-secret: 094325f216720012cacde9f52fd71c7e8b06dd6386492f6980e0f3588f1b1e7c
+        checksum/credentials-secret: 0f3ceb92b9779df4ce0927f6faeb23e9116b85e0eabe095d903e46a2770cde42
     spec:
       
       serviceAccountName: minio
@@ -4220,7 +4218,7 @@ spec:
         fsGroup: 1001
       containers:
         - name: minio
-          image: docker.io/bitnami/minio:2022.5.26-debian-10-r0
+          image: docker.io/bitnami/minio:2022.12.12-debian-11-r0
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true
@@ -4646,7 +4644,7 @@ metadata:
   namespace: default
   labels:
     app: docker-registry
-    chart: docker-registry-1.16.0
+    chart: docker-registry-2.2.2
     release: docker-registry
     heritage: Helm
 spec:
@@ -4662,7 +4660,9 @@ spec:
         app: docker-registry
         release: docker-registry
       annotations:
-        checksum/config: 1d22b82e19bbc654e029029c4fb86ad02dc13422dc3ac52f8175ad190e52a0bb
+        checksum/config: 699dd382179068f3354c330fcce38625e2861d97b962074b4f57005d40497b00
+        checksum/secret: 450f59aeda22415409a87a1abd2c033c08ebd5fb54fe24d3c56560e92b0218f6
+        
         gitpod.io/checksum_config: 1c66f4ccdb7f6331da2edaecefcb40f6c1b6315c9277eb0418fef3cc584a28bd
     spec:
       serviceAccountName: docker-registry
@@ -4671,7 +4671,7 @@ spec:
         runAsUser: 1000
       containers:
         - name: docker-registry
-          image: "docker.io/library/registry:2.7.1"
+          image: "docker.io/library/registry:2.8.1"
           imagePullPolicy: IfNotPresent
           command:
           - /bin/registry
@@ -4689,9 +4689,9 @@ spec:
               scheme: HTTPS
               path: /
               port: 5000
-          resources:
+          resources: 
             {}
-          env:
+          env: 
             - name: REGISTRY_HTTP_SECRET
               valueFrom:
                 secretKeyRef:
@@ -4703,21 +4703,21 @@ spec:
               value: /etc/ssl/docker/tls.key
             - name: REGISTRY_STORAGE_FILESYSTEM_ROOTDIRECTORY
               value: "/var/lib/registry"
-          volumeMounts:
-            - name: data
-              mountPath: /var/lib/registry/
+          volumeMounts: 
             - name: "registry-config"
               mountPath: "/etc/docker/registry"
+            - name: data
+              mountPath: /var/lib/registry/
             - mountPath: /etc/ssl/docker
               name: tls-cert
               readOnly: true
-      volumes:
-        - name: data
-          persistentVolumeClaim:
-            claimName: registry
+      volumes: 
         - name: registry-config
           configMap:
             name: registry-config
+        - name: data
+          persistentVolumeClaim:
+            claimName: registry
         - name: tls-cert
           secret:
             secretName: builtin-registry-certs

--- a/install/installer/cmd/testdata/render/kind-webapp/output.golden
+++ b/install/installer/cmd/testdata/render/kind-webapp/output.golden
@@ -522,9 +522,9 @@ metadata:
 # v1/Secret builtin-registry-auth
 apiVersion: v1
 data:
-  .dockerconfigjson: eyJhdXRocyI6eyJyZWdpc3RyeS5naXRwb2QuZXhhbXBsZS5jb20iOnsiYXV0aCI6ImVGTmxaRXBwUkdkS1VWRm5ORUpyVnpWNFMzVTZRMWMwUTFKQ2FtazJVakJpUjBjNE1XZDVSWGs9In19fQ==
-  password: Q1c0Q1JCamk2UjBiR0c4MWd5RXk=
-  user: eFNlZEppRGdKUVFnNEJrVzV4S3U=
+  .dockerconfigjson: eyJhdXRocyI6eyJyZWdpc3RyeS5naXRwb2QuZXhhbXBsZS5jb20iOnsiYXV0aCI6ImVIZDVRMGRsTlZVd1RrRnFObFZsYVhFM1RqQTZWbE5UYkcxaFMxZFFhaTVRVVhCdFZXWnNWR1E9In19fQ==
+  password: VlNTbG1hS1dQai5QUXBtVWZsVGQ=
+  user: eHd5Q0dlNVUwTkFqNlVlaXE3TjA=
 kind: Secret
 metadata:
   creationTimestamp: null
@@ -640,8 +640,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 type: Opaque
 data:
-  root-user: "OC1XR3F3Mm9UbnNQZlVETlNrMFk="
-  root-password: "RHBDLmFTQXhrV0JQdTJfYkpfQUU="
+  root-user: "UkJqaTZSMGJHRzgxZ3lFeWUyNVA="
+  root-password: "dFg2TUw4Z0NXMzFtaXcwVDhRTUk="
   key.json: ""
 ---
 # v1/Secret mysql
@@ -715,9 +715,9 @@ data:
         },
         "minio": {
           "endpoint": "minio.default.svc.cluster.local:9000",
-          "accessKey": "8-WGqw2oTnsPfUDNSk0Y",
+          "accessKey": "RBji6R0bGG81gyEye25P",
           "accessKeyFile": "",
-          "secretKey": "DpC.aSAxkWBPu2_bJ_AE",
+          "secretKey": "tX6ML8gCW31miw0T8QMI",
           "secretKeyFile": "",
           "region": "local",
           "parallelUpload": 6
@@ -2192,7 +2192,7 @@ data:
         import ssl_configuration
 
         basicauth bcrypt "Docker Registry" {
-            xSedJiDgJQQg4BkW5xKu JDJhJDEwJFFTRGRRMHZZY2pIS2JqUC9aMDNnVC5HbEg2Z1dOQm5TL0pySnpYSm5iNy9DeVh0ZUw2cFM2
+            xwyCGe5U0NAj6Ueiq7N0 JDJhJDEwJFFTRGRRMHZZY2pIS2JqUC9aMDNnVC5CY0M3RDZsVVg0LzBpZmdnTGovT0VVWXoxTG8ud0lX
         }
 
         reverse_proxy https://registry.default.svc.cluster.local {
@@ -2411,7 +2411,7 @@ data:
       },
       "oauthServer": {
         "enabled": true,
-        "jwtSecret": "8QMIxwyCGe5U0NAj6Uei"
+        "jwtSecret": "m30EH-M2-cWMgkgdy7pu"
       },
       "rateLimiter": {
         "groups": {
@@ -3802,7 +3802,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 20782435cc6d6e080cf720b57dca8d4d5cfe40942fc71c4bfd54934fdc34c766
+        gitpod.io/checksum_config: 21ad538d4c7daef6619e5dda6fd71a49a5e5b551f0fc1365d3b7db1d1f38f9ce
       creationTimestamp: null
       labels:
         app: gitpod
@@ -4204,7 +4204,7 @@ spec:
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/credentials-secret: 0a5790906818b3f8eeee0bd3b3e990b3ad02d79bb23c62c0d91a4ca010fb5579
+        checksum/credentials-secret: 094325f216720012cacde9f52fd71c7e8b06dd6386492f6980e0f3588f1b1e7c
     spec:
       
       serviceAccountName: minio
@@ -4312,7 +4312,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: c52c73e63eaa95613a8f4fe77167c754cd48eaf757dd69c2048400311a5ae0a6
+        gitpod.io/checksum_config: a7bd71558cb04a04656bafe7651d4192a9d37be96d2d817f9b6225f63e3a6989
       creationTimestamp: null
       labels:
         app: gitpod
@@ -4663,7 +4663,7 @@ spec:
         release: docker-registry
       annotations:
         checksum/config: 1d22b82e19bbc654e029029c4fb86ad02dc13422dc3ac52f8175ad190e52a0bb
-        gitpod.io/checksum_config: 0ce55d51677cd683df3c7a244542c6aeaaf5dd6dca0f0458e8053a713228f535
+        gitpod.io/checksum_config: 1c66f4ccdb7f6331da2edaecefcb40f6c1b6315c9277eb0418fef3cc584a28bd
     spec:
       serviceAccountName: docker-registry
       securityContext:
@@ -4746,7 +4746,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 726dafd8c59907accd3250e873f40d6e59d6913f82b7198335bc6c24ae2e7db1
+        gitpod.io/checksum_config: f52ae23eddcf2fe15c87ec92cc3d998045c5ff491d52caed0f23a6fccc020134
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/kind-workspace/output.golden
+++ b/install/installer/cmd/testdata/render/kind-workspace/output.golden
@@ -584,9 +584,9 @@ metadata:
 # v1/Secret builtin-registry-auth
 apiVersion: v1
 data:
-  .dockerconfigjson: eyJhdXRocyI6eyJyZWdpc3RyeS5naXRwb2QuZXhhbXBsZS5jb20iOnsiYXV0aCI6ImVGTmxaRXBwUkdkS1VWRm5ORUpyVnpWNFMzVTZRMWMwUTFKQ2FtazJVakJpUjBjNE1XZDVSWGs9In19fQ==
-  password: Q1c0Q1JCamk2UjBiR0c4MWd5RXk=
-  user: eFNlZEppRGdKUVFnNEJrVzV4S3U=
+  .dockerconfigjson: eyJhdXRocyI6eyJyZWdpc3RyeS5naXRwb2QuZXhhbXBsZS5jb20iOnsiYXV0aCI6ImVIZDVRMGRsTlZVd1RrRnFObFZsYVhFM1RqQTZWbE5UYkcxaFMxZFFhaTVRVVhCdFZXWnNWR1E9In19fQ==
+  password: VlNTbG1hS1dQai5QUXBtVWZsVGQ=
+  user: eHd5Q0dlNVUwTkFqNlVlaXE3TjA=
 kind: Secret
 metadata:
   creationTimestamp: null
@@ -1871,9 +1871,9 @@ data:
             },
             "minio": {
               "endpoint": "minio.default.svc.cluster.local:9000",
-              "accessKey": "8-WGqw2oTnsPfUDNSk0Y",
+              "accessKey": "RBji6R0bGG81gyEye25P",
               "accessKeyFile": "",
-              "secretKey": "DpC.aSAxkWBPu2_bJ_AE",
+              "secretKey": "tX6ML8gCW31miw0T8QMI",
               "secretKeyFile": "",
               "region": "local",
               "parallelUpload": 6
@@ -2055,9 +2055,9 @@ data:
           },
           "minio": {
             "endpoint": "minio.default.svc.cluster.local:9000",
-            "accessKey": "8-WGqw2oTnsPfUDNSk0Y",
+            "accessKey": "RBji6R0bGG81gyEye25P",
             "accessKeyFile": "",
-            "secretKey": "DpC.aSAxkWBPu2_bJ_AE",
+            "secretKey": "tX6ML8gCW31miw0T8QMI",
             "secretKeyFile": "",
             "region": "local",
             "parallelUpload": 6
@@ -3012,7 +3012,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3e487f9543c719b9ee3f5590a0f98cb535b4bf1b301c66de8f00f3aa9d61381d
+        gitpod.io/checksum_config: 3e7db160db71491d8d16b0423783bf99a0dc293dc723960c9308756bdde69d3b
       creationTimestamp: null
       labels:
         app: gitpod
@@ -3229,7 +3229,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: b938c6e286051c22b503c29f5de266741c2045a3ed69be85d7fd9f22a9346254
+        gitpod.io/checksum_config: 2a29ef265c219405bda658cb21613f40ad5e692590d2779476a3ff90917ed6fb
         seccomp.security.alpha.kubernetes.io/shiftfs-module-loader: unconfined
       creationTimestamp: null
       labels:
@@ -3524,7 +3524,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 17379f665f26a7fe1e7ad830348985a5af3e35ba52bf2d8073bbdadb67c0aaeb
+        gitpod.io/checksum_config: 9be6cd6b32a0508817c7d1dadc9d574f14a8946d1c60c135954dab56ca241e29
       creationTimestamp: null
       labels:
         app: gitpod
@@ -3682,7 +3682,7 @@ spec:
         release: docker-registry
       annotations:
         checksum/config: 1d22b82e19bbc654e029029c4fb86ad02dc13422dc3ac52f8175ad190e52a0bb
-        gitpod.io/checksum_config: 0ce55d51677cd683df3c7a244542c6aeaaf5dd6dca0f0458e8053a713228f535
+        gitpod.io/checksum_config: 1c66f4ccdb7f6331da2edaecefcb40f6c1b6315c9277eb0418fef3cc584a28bd
     spec:
       serviceAccountName: docker-registry
       securityContext:
@@ -3765,7 +3765,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 8e17df1f6904718d97532e9779c3342f517ed6366049cd670c4ca158e272c1ec
+        gitpod.io/checksum_config: b7a18ab8174f569b7581efcda13a5f2ee2e35bda88559aead6bf593339a2db54
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/kind-workspace/output.golden
+++ b/install/installer/cmd/testdata/render/kind-workspace/output.golden
@@ -606,7 +606,7 @@ metadata:
   namespace: default
   labels:
     app: docker-registry
-    chart: docker-registry-1.16.0
+    chart: docker-registry-2.2.2
     heritage: Helm
     release: docker-registry
 type: Opaque
@@ -1614,7 +1614,7 @@ data:
       creationTimestamp: null
       labels:
         app: docker-registry
-        chart: docker-registry-1.16.0
+        chart: docker-registry-2.2.2
         heritage: Helm
         release: docker-registry
       name: registry-secret
@@ -1626,7 +1626,7 @@ data:
       creationTimestamp: null
       labels:
         app: docker-registry
-        chart: docker-registry-1.16.0
+        chart: docker-registry-2.2.2
         heritage: Helm
         release: docker-registry
       name: registry-config
@@ -1638,7 +1638,7 @@ data:
       creationTimestamp: null
       labels:
         app: registry
-        chart: docker-registry-1.16.0
+        chart: docker-registry-2.2.2
         heritage: Helm
         release: docker-registry
       name: registry
@@ -1650,7 +1650,7 @@ data:
       creationTimestamp: null
       labels:
         app: docker-registry
-        chart: docker-registry-1.16.0
+        chart: docker-registry-2.2.2
         heritage: Helm
         release: docker-registry
       name: registry
@@ -1662,7 +1662,7 @@ data:
       creationTimestamp: null
       labels:
         app: docker-registry
-        chart: docker-registry-1.16.0
+        chart: docker-registry-2.2.2
         heritage: Helm
         release: docker-registry
       name: registry
@@ -1744,7 +1744,7 @@ metadata:
   namespace: default
   labels:
     app: docker-registry
-    chart: docker-registry-1.16.0
+    chart: docker-registry-2.2.2
     heritage: Helm
     release: docker-registry
 data:
@@ -2170,7 +2170,7 @@ metadata:
   namespace: default
   labels:
     app: registry
-    chart: "docker-registry-1.16.0"
+    chart: "docker-registry-2.2.2"
     release: "docker-registry"
     heritage: "Helm"
 spec:
@@ -2757,7 +2757,7 @@ metadata:
   namespace: default
   labels:
     app: docker-registry
-    chart: docker-registry-1.16.0
+    chart: docker-registry-2.2.2
     release: docker-registry
     heritage: Helm
 spec:
@@ -3665,7 +3665,7 @@ metadata:
   namespace: default
   labels:
     app: docker-registry
-    chart: docker-registry-1.16.0
+    chart: docker-registry-2.2.2
     release: docker-registry
     heritage: Helm
 spec:
@@ -3681,7 +3681,9 @@ spec:
         app: docker-registry
         release: docker-registry
       annotations:
-        checksum/config: 1d22b82e19bbc654e029029c4fb86ad02dc13422dc3ac52f8175ad190e52a0bb
+        checksum/config: 699dd382179068f3354c330fcce38625e2861d97b962074b4f57005d40497b00
+        checksum/secret: 6fe5d819b2ea20bf72ad31384d4886d6f64dd1f0d237703ac3aff11c1e0737fd
+        
         gitpod.io/checksum_config: 1c66f4ccdb7f6331da2edaecefcb40f6c1b6315c9277eb0418fef3cc584a28bd
     spec:
       serviceAccountName: docker-registry
@@ -3690,7 +3692,7 @@ spec:
         runAsUser: 1000
       containers:
         - name: docker-registry
-          image: "docker.io/library/registry:2.7.1"
+          image: "docker.io/library/registry:2.8.1"
           imagePullPolicy: IfNotPresent
           command:
           - /bin/registry
@@ -3708,9 +3710,9 @@ spec:
               scheme: HTTPS
               path: /
               port: 5000
-          resources:
+          resources: 
             {}
-          env:
+          env: 
             - name: REGISTRY_HTTP_SECRET
               valueFrom:
                 secretKeyRef:
@@ -3722,21 +3724,21 @@ spec:
               value: /etc/ssl/docker/tls.key
             - name: REGISTRY_STORAGE_FILESYSTEM_ROOTDIRECTORY
               value: "/var/lib/registry"
-          volumeMounts:
-            - name: data
-              mountPath: /var/lib/registry/
+          volumeMounts: 
             - name: "registry-config"
               mountPath: "/etc/docker/registry"
+            - name: data
+              mountPath: /var/lib/registry/
             - mountPath: /etc/ssl/docker
               name: tls-cert
               readOnly: true
-      volumes:
-        - name: data
-          persistentVolumeClaim:
-            claimName: registry
+      volumes: 
         - name: registry-config
           configMap:
             name: registry-config
+        - name: data
+          persistentVolumeClaim:
+            claimName: registry
         - name: tls-cert
           secret:
             secretName: builtin-registry-certs

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -1116,9 +1116,9 @@ metadata:
 # v1/Secret builtin-registry-auth
 apiVersion: v1
 data:
-  .dockerconfigjson: eyJhdXRocyI6eyJyZWdpc3RyeS5naXRwb2QuZXhhbXBsZS5jb20iOnsiYXV0aCI6ImVGTmxaRXBwUkdkS1VWRm5ORUpyVnpWNFMzVTZRMWMwUTFKQ2FtazJVakJpUjBjNE1XZDVSWGs9In19fQ==
-  password: Q1c0Q1JCamk2UjBiR0c4MWd5RXk=
-  user: eFNlZEppRGdKUVFnNEJrVzV4S3U=
+  .dockerconfigjson: eyJhdXRocyI6eyJyZWdpc3RyeS5naXRwb2QuZXhhbXBsZS5jb20iOnsiYXV0aCI6ImVIZDVRMGRsTlZVd1RrRnFObFZsYVhFM1RqQTZWbE5UYkcxaFMxZFFhaTVRVVhCdFZXWnNWR1E9In19fQ==
+  password: VlNTbG1hS1dQai5QUXBtVWZsVGQ=
+  user: eHd5Q0dlNVUwTkFqNlVlaXE3TjA=
 kind: Secret
 metadata:
   creationTimestamp: null
@@ -1234,8 +1234,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 type: Opaque
 data:
-  root-user: "OC1XR3F3Mm9UbnNQZlVETlNrMFk="
-  root-password: "RHBDLmFTQXhrV0JQdTJfYkpfQUU="
+  root-user: "UkJqaTZSMGJHRzgxZ3lFeWUyNVA="
+  root-password: "dFg2TUw4Z0NXMzFtaXcwVDhRTUk="
   key.json: ""
 ---
 # v1/Secret mysql
@@ -1430,9 +1430,9 @@ data:
         },
         "minio": {
           "endpoint": "minio.default.svc.cluster.local:9000",
-          "accessKey": "8-WGqw2oTnsPfUDNSk0Y",
+          "accessKey": "RBji6R0bGG81gyEye25P",
           "accessKeyFile": "",
-          "secretKey": "DpC.aSAxkWBPu2_bJ_AE",
+          "secretKey": "tX6ML8gCW31miw0T8QMI",
           "secretKeyFile": "",
           "region": "local",
           "parallelUpload": 6
@@ -5170,7 +5170,7 @@ data:
         import ssl_configuration
 
         basicauth bcrypt "Docker Registry" {
-            xSedJiDgJQQg4BkW5xKu JDJhJDEwJFFTRGRRMHZZY2pIS2JqUC9aMDNnVC5HbEg2Z1dOQm5TL0pySnpYSm5iNy9DeVh0ZUw2cFM2
+            xwyCGe5U0NAj6Ueiq7N0 JDJhJDEwJFFTRGRRMHZZY2pIS2JqUC9aMDNnVC5CY0M3RDZsVVg0LzBpZmdnTGovT0VVWXoxTG8ud0lX
         }
 
         reverse_proxy https://registry.default.svc.cluster.local {
@@ -5441,7 +5441,7 @@ data:
       },
       "oauthServer": {
         "enabled": true,
-        "jwtSecret": "8QMIxwyCGe5U0NAj6Uei"
+        "jwtSecret": "m30EH-M2-cWMgkgdy7pu"
       },
       "rateLimiter": {
         "groups": {
@@ -5771,9 +5771,9 @@ data:
             },
             "minio": {
               "endpoint": "minio.default.svc.cluster.local:9000",
-              "accessKey": "8-WGqw2oTnsPfUDNSk0Y",
+              "accessKey": "RBji6R0bGG81gyEye25P",
               "accessKeyFile": "",
-              "secretKey": "DpC.aSAxkWBPu2_bJ_AE",
+              "secretKey": "tX6ML8gCW31miw0T8QMI",
               "secretKeyFile": "",
               "region": "local",
               "parallelUpload": 6
@@ -5955,9 +5955,9 @@ data:
           },
           "minio": {
             "endpoint": "minio.default.svc.cluster.local:9000",
-            "accessKey": "8-WGqw2oTnsPfUDNSk0Y",
+            "accessKey": "RBji6R0bGG81gyEye25P",
             "accessKeyFile": "",
-            "secretKey": "DpC.aSAxkWBPu2_bJ_AE",
+            "secretKey": "tX6ML8gCW31miw0T8QMI",
             "secretKeyFile": "",
             "region": "local",
             "parallelUpload": 6
@@ -8068,7 +8068,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3e487f9543c719b9ee3f5590a0f98cb535b4bf1b301c66de8f00f3aa9d61381d
+        gitpod.io/checksum_config: 3e7db160db71491d8d16b0423783bf99a0dc293dc723960c9308756bdde69d3b
       creationTimestamp: null
       labels:
         app: gitpod
@@ -8285,7 +8285,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: b938c6e286051c22b503c29f5de266741c2045a3ed69be85d7fd9f22a9346254
+        gitpod.io/checksum_config: 2a29ef265c219405bda658cb21613f40ad5e692590d2779476a3ff90917ed6fb
         seccomp.security.alpha.kubernetes.io/shiftfs-module-loader: unconfined
       creationTimestamp: null
       labels:
@@ -9084,7 +9084,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: cac138904f08d79e5598805683f8dc378bd52c58348489de22949ac38dd8b193
+        gitpod.io/checksum_config: 0d9d1c68723466a253996f0a96bf0682ce57b89ebcb4ae1e4a643dd788ef1cab
       creationTimestamp: null
       labels:
         app: gitpod
@@ -9225,7 +9225,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 20782435cc6d6e080cf720b57dca8d4d5cfe40942fc71c4bfd54934fdc34c766
+        gitpod.io/checksum_config: 21ad538d4c7daef6619e5dda6fd71a49a5e5b551f0fc1365d3b7db1d1f38f9ce
       creationTimestamp: null
       labels:
         app: gitpod
@@ -9952,7 +9952,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: af26ec864db5be86adfb79b972614487639aa67ad16de869e23e22e468f0bed8
+        gitpod.io/checksum_config: 3b0478b4bb4feb7b7a29bc33bf4ec99671df4dcbd9529778de375c72e78df64c
       creationTimestamp: null
       labels:
         app: gitpod
@@ -10105,7 +10105,7 @@ spec:
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/credentials-secret: 0a5790906818b3f8eeee0bd3b3e990b3ad02d79bb23c62c0d91a4ca010fb5579
+        checksum/credentials-secret: 094325f216720012cacde9f52fd71c7e8b06dd6386492f6980e0f3588f1b1e7c
     spec:
       
       serviceAccountName: minio
@@ -10213,7 +10213,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: c52c73e63eaa95613a8f4fe77167c754cd48eaf757dd69c2048400311a5ae0a6
+        gitpod.io/checksum_config: a7bd71558cb04a04656bafe7651d4192a9d37be96d2d817f9b6225f63e3a6989
       creationTimestamp: null
       labels:
         app: gitpod
@@ -10564,7 +10564,7 @@ spec:
         release: docker-registry
       annotations:
         checksum/config: 1d22b82e19bbc654e029029c4fb86ad02dc13422dc3ac52f8175ad190e52a0bb
-        gitpod.io/checksum_config: 0ce55d51677cd683df3c7a244542c6aeaaf5dd6dca0f0458e8053a713228f535
+        gitpod.io/checksum_config: 1c66f4ccdb7f6331da2edaecefcb40f6c1b6315c9277eb0418fef3cc584a28bd
     spec:
       serviceAccountName: docker-registry
       securityContext:
@@ -10647,7 +10647,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 726dafd8c59907accd3250e873f40d6e59d6913f82b7198335bc6c24ae2e7db1
+        gitpod.io/checksum_config: f52ae23eddcf2fe15c87ec92cc3d998045c5ff491d52caed0f23a6fccc020134
       creationTimestamp: null
       labels:
         app: gitpod
@@ -10928,7 +10928,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 62fb425bd7800391dca7d008cd0c86cab613afef78e188a950e367ed7429ad73
+        gitpod.io/checksum_config: 21c3b53bac44cf0f98bc57e43353e3136dc5806409951038c2ba36aea69dd218
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -208,7 +208,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -783,7 +783,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -958,7 +958,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: minio
-    helm.sh/chart: minio-11.6.3
+    helm.sh/chart: minio-11.10.24
     app.kubernetes.io/instance: minio
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
@@ -1022,7 +1022,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
@@ -1152,7 +1152,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1168,7 +1168,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1199,13 +1199,13 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
 data:
   rabbitmq.conf: |-
-    IyMgVXNlcm5hbWUgYW5kIHBhc3N3b3JkCiMjCmRlZmF1bHRfdXNlciA9IGdpdHBvZApkZWZhdWx0X3Bhc3MgPSBDSEFOR0VNRQojIyBDbHVzdGVyaW5nCiMjCmNsdXN0ZXJfZm9ybWF0aW9uLnBlZXJfZGlzY292ZXJ5X2JhY2tlbmQgID0gcmFiYml0X3BlZXJfZGlzY292ZXJ5X2s4cwpjbHVzdGVyX2Zvcm1hdGlvbi5rOHMuaG9zdCA9IGt1YmVybmV0ZXMuZGVmYXVsdApjbHVzdGVyX2Zvcm1hdGlvbi5ub2RlX2NsZWFudXAuaW50ZXJ2YWwgPSAxMApjbHVzdGVyX2Zvcm1hdGlvbi5ub2RlX2NsZWFudXAub25seV9sb2dfd2FybmluZyA9IHRydWUKY2x1c3Rlcl9wYXJ0aXRpb25faGFuZGxpbmcgPSBhdXRvaGVhbApsb2FkX2RlZmluaXRpb25zID0gL2FwcC9sb2FkX2RlZmluaXRpb24uanNvbgojIHF1ZXVlIG1hc3RlciBsb2NhdG9yCnF1ZXVlX21hc3Rlcl9sb2NhdG9yID0gbWluLW1hc3RlcnMKIyBlbmFibGUgZ3Vlc3QgdXNlcgpsb29wYmFja191c2Vycy5ndWVzdCA9IGZhbHNlCmxvYWRfZGVmaW5pdGlvbnMgPSAvYXBwL2xvYWRfZGVmaW5pdGlvbi5qc29uCiMgSW5jcmVhc2Ugc3RhdGlzdGljcyBlbWlzc2lvbiBpbnRlcnZhbCBodHRwczovL3d3dy5yYWJiaXRtcS5jb20vbWFuYWdlbWVudC5odG1sI3N0YXRpc3RpY3MtaW50ZXJ2YWwKY29sbGVjdF9zdGF0aXN0aWNzX2ludGVydmFsID0gMTUwMDAKCnNzbF9vcHRpb25zLnZlcmlmeSA9IHZlcmlmeV9wZWVyCmxpc3RlbmVycy5zc2wuZGVmYXVsdCA9IDU2NzEKc3NsX29wdGlvbnMuZmFpbF9pZl9ub19wZWVyX2NlcnQgPSB0cnVlCnNzbF9vcHRpb25zLmNhY2VydGZpbGUgPSAvb3B0L2JpdG5hbWkvcmFiYml0bXEvY2VydHMvY2FfY2VydGlmaWNhdGUucGVtCnNzbF9vcHRpb25zLmNlcnRmaWxlID0gL29wdC9iaXRuYW1pL3JhYmJpdG1xL2NlcnRzL3NlcnZlcl9jZXJ0aWZpY2F0ZS5wZW0Kc3NsX29wdGlvbnMua2V5ZmlsZSA9IC9vcHQvYml0bmFtaS9yYWJiaXRtcS9jZXJ0cy9zZXJ2ZXJfa2V5LnBlbQojIyBQcm9tZXRoZXVzIG1ldHJpY3MKIyMKcHJvbWV0aGV1cy50Y3AucG9ydCA9IDk0MTk=
+    IyMgVXNlcm5hbWUgYW5kIHBhc3N3b3JkCiMjCmRlZmF1bHRfdXNlciA9IGdpdHBvZAojIyBDbHVzdGVyaW5nCiMjCmNsdXN0ZXJfZm9ybWF0aW9uLnBlZXJfZGlzY292ZXJ5X2JhY2tlbmQgID0gcmFiYml0X3BlZXJfZGlzY292ZXJ5X2s4cwpjbHVzdGVyX2Zvcm1hdGlvbi5rOHMuaG9zdCA9IGt1YmVybmV0ZXMuZGVmYXVsdApjbHVzdGVyX2Zvcm1hdGlvbi5ub2RlX2NsZWFudXAuaW50ZXJ2YWwgPSAxMApjbHVzdGVyX2Zvcm1hdGlvbi5ub2RlX2NsZWFudXAub25seV9sb2dfd2FybmluZyA9IHRydWUKY2x1c3Rlcl9wYXJ0aXRpb25faGFuZGxpbmcgPSBhdXRvaGVhbApsb2FkX2RlZmluaXRpb25zID0gL2FwcC9sb2FkX2RlZmluaXRpb24uanNvbgojIHF1ZXVlIG1hc3RlciBsb2NhdG9yCnF1ZXVlX21hc3Rlcl9sb2NhdG9yID0gbWluLW1hc3RlcnMKIyBlbmFibGUgZ3Vlc3QgdXNlcgpsb29wYmFja191c2Vycy5ndWVzdCA9IGZhbHNlCmxvYWRfZGVmaW5pdGlvbnMgPSAvYXBwL2xvYWRfZGVmaW5pdGlvbi5qc29uCiMgSW5jcmVhc2Ugc3RhdGlzdGljcyBlbWlzc2lvbiBpbnRlcnZhbCBodHRwczovL3d3dy5yYWJiaXRtcS5jb20vbWFuYWdlbWVudC5odG1sI3N0YXRpc3RpY3MtaW50ZXJ2YWwKY29sbGVjdF9zdGF0aXN0aWNzX2ludGVydmFsID0gMTUwMDAKCnNzbF9vcHRpb25zLnZlcmlmeSA9IHZlcmlmeV9wZWVyCmxpc3RlbmVycy5zc2wuZGVmYXVsdCA9IDU2NzEKc3NsX29wdGlvbnMuZmFpbF9pZl9ub19wZWVyX2NlcnQgPSB0cnVlCnNzbF9vcHRpb25zLmNhY2VydGZpbGUgPSAvb3B0L2JpdG5hbWkvcmFiYml0bXEvY2VydHMvY2FfY2VydGlmaWNhdGUucGVtCnNzbF9vcHRpb25zLmNlcnRmaWxlID0gL29wdC9iaXRuYW1pL3JhYmJpdG1xL2NlcnRzL3NlcnZlcl9jZXJ0aWZpY2F0ZS5wZW0Kc3NsX29wdGlvbnMua2V5ZmlsZSA9IC9vcHQvYml0bmFtaS9yYWJiaXRtcS9jZXJ0cy9zZXJ2ZXJfa2V5LnBlbQojIyBQcm9tZXRoZXVzIG1ldHJpY3MKIyMKcHJvbWV0aGV1cy50Y3AucG9ydCA9IDk0MTk=
 ---
 # v1/Secret messagebus-erlang-cookie
 apiVersion: v1
@@ -1229,7 +1229,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: minio
-    helm.sh/chart: minio-11.6.3
+    helm.sh/chart: minio-11.10.24
     app.kubernetes.io/instance: minio
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1265,7 +1265,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1282,7 +1282,7 @@ metadata:
   namespace: default
   labels:
     app: docker-registry
-    chart: docker-registry-1.16.0
+    chart: docker-registry-2.2.2
     heritage: Helm
     release: docker-registry
 type: Opaque
@@ -3431,7 +3431,7 @@ data:
       creationTimestamp: null
       labels:
         app: docker-registry
-        chart: docker-registry-1.16.0
+        chart: docker-registry-2.2.2
         heritage: Helm
         release: docker-registry
       name: registry-secret
@@ -3443,7 +3443,7 @@ data:
       creationTimestamp: null
       labels:
         app: docker-registry
-        chart: docker-registry-1.16.0
+        chart: docker-registry-2.2.2
         heritage: Helm
         release: docker-registry
       name: registry-config
@@ -3455,7 +3455,7 @@ data:
       creationTimestamp: null
       labels:
         app: registry
-        chart: docker-registry-1.16.0
+        chart: docker-registry-2.2.2
         heritage: Helm
         release: docker-registry
       name: registry
@@ -3467,7 +3467,7 @@ data:
       creationTimestamp: null
       labels:
         app: docker-registry
-        chart: docker-registry-1.16.0
+        chart: docker-registry-2.2.2
         heritage: Helm
         release: docker-registry
       name: registry
@@ -3479,7 +3479,7 @@ data:
       creationTimestamp: null
       labels:
         app: docker-registry
-        chart: docker-registry-1.16.0
+        chart: docker-registry-2.2.2
         heritage: Helm
         release: docker-registry
       name: registry
@@ -3494,7 +3494,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql
       namespace: default
     ---
@@ -3507,7 +3507,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql-headless
       namespace: default
     ---
@@ -3520,7 +3520,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql
       namespace: default
     ---
@@ -3533,7 +3533,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql
       namespace: default
     ---
@@ -3545,7 +3545,7 @@ data:
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: minio
-        helm.sh/chart: minio-11.6.3
+        helm.sh/chart: minio-11.10.24
       name: minio
       namespace: default
     ---
@@ -3557,7 +3557,7 @@ data:
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: minio
-        helm.sh/chart: minio-11.6.3
+        helm.sh/chart: minio-11.10.24
       name: minio
       namespace: default
     ---
@@ -3569,7 +3569,7 @@ data:
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: minio
-        helm.sh/chart: minio-11.6.3
+        helm.sh/chart: minio-11.10.24
       name: minio
       namespace: default
     ---
@@ -3581,7 +3581,7 @@ data:
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: minio
-        helm.sh/chart: minio-11.6.3
+        helm.sh/chart: minio-11.10.24
       name: minio
       namespace: default
     ---
@@ -3593,7 +3593,7 @@ data:
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: minio
-        helm.sh/chart: minio-11.6.3
+        helm.sh/chart: minio-11.10.24
       name: minio
       namespace: default
     ---
@@ -3605,7 +3605,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus
       namespace: default
     ---
@@ -3617,7 +3617,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus
       namespace: default
     ---
@@ -3629,7 +3629,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: rabbitmq
       namespace: default
     ---
@@ -3641,7 +3641,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus-config
       namespace: default
     ---
@@ -3653,7 +3653,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus
       namespace: default
     ---
@@ -3665,7 +3665,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: load-definition
       namespace: default
     ---
@@ -3677,7 +3677,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: rabbitmq
       namespace: default
     ---
@@ -3689,7 +3689,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus-endpoint-reader
       namespace: default
     ---
@@ -3701,7 +3701,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus-endpoint-reader
       namespace: default
     ---
@@ -3713,7 +3713,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus-headless
       namespace: default
     ---
@@ -3725,7 +3725,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus
       namespace: default
     ---
@@ -3737,7 +3737,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus
       namespace: default
     ---
@@ -5095,7 +5095,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
@@ -5112,7 +5112,7 @@ data:
     datadir=/bitnami/mysql/data
     tmpdir=/opt/bitnami/mysql/tmp
     max_allowed_packet=16M
-    bind-address=0.0.0.0
+    bind-address=*
     pid-file=/opt/bitnami/mysql/tmp/mysqld.pid
     log-error=/opt/bitnami/mysql/logs/mysqld.log
     character-set-server=UTF8
@@ -5282,7 +5282,7 @@ metadata:
   namespace: default
   labels:
     app: docker-registry
-    chart: docker-registry-1.16.0
+    chart: docker-registry-2.2.2
     heritage: Helm
     release: docker-registry
 data:
@@ -6119,7 +6119,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: minio
-    helm.sh/chart: minio-11.6.3
+    helm.sh/chart: minio-11.10.24
     app.kubernetes.io/instance: minio
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -6138,7 +6138,7 @@ metadata:
   namespace: default
   labels:
     app: registry
-    chart: "docker-registry-1.16.0"
+    chart: "docker-registry-2.2.2"
     release: "docker-registry"
     heritage: "Helm"
 spec:
@@ -6665,7 +6665,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 rules:
@@ -7026,7 +7026,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 subjects:
@@ -7519,7 +7519,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -7563,7 +7563,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -7598,7 +7598,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: minio
-    helm.sh/chart: minio-11.6.3
+    helm.sh/chart: minio-11.10.24
     app.kubernetes.io/instance: minio
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -7625,7 +7625,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
@@ -7653,11 +7653,10 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
-  annotations:
 spec:
   type: ClusterIP
   clusterIP: None
@@ -7771,7 +7770,7 @@ metadata:
   namespace: default
   labels:
     app: docker-registry
-    chart: docker-registry-1.16.0
+    chart: docker-registry-2.2.2
     release: docker-registry
     heritage: Helm
 spec:
@@ -8565,7 +8564,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -8582,12 +8581,12 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/config: 2ca9db593e4ca6cdd01f7a65cce1ae90d0d45ecdf0049edfaa4ec72302fcbe8f
-        checksum/secret: c231bbb08185305defa8c4da0f3ee0f5e7a16795362a2133f74e53eb9a40453d
+        checksum/config: d5780a0c58210a2062d54feb61cfb1d5a9c076f95569c4a77076d22c9bad4190
+        checksum/secret: 64c39dd3a8570ed4b0cc71bc0402bc814d016e16f68732938722b12a57c8e82c
         prometheus.io/port: '9419'
         prometheus.io/scrape: "true"
     spec:
@@ -8607,7 +8606,7 @@ spec:
       initContainers:
       containers:
         - name: rabbitmq
-          image: docker.io/bitnami/rabbitmq:3.10.2-debian-10-r7
+          image: docker.io/bitnami/rabbitmq:3.11.5-debian-11-r2
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true
@@ -8742,11 +8741,10 @@ spec:
               - key: tls.key
                 path: server_key.pem
         - name: configuration
-          secret:
-            secretName: messagebus-config
-            items:
-              - key: rabbitmq.conf
-                path: rabbitmq.conf
+          projected:
+            sources:
+              - secret:
+                  name: messagebus-config
         - name: load-definition-volume
           secret:
             secretName: "load-definition"
@@ -8762,7 +8760,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
@@ -8780,10 +8778,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/configuration: 11b8361c0fbf695cec6ec7f47ed4118ad3c7d71a391ca246df129803d3e205a5
+        checksum/configuration: 0c1e0d4282c8f8f820f3c9d1d79b3f423c4676afac2e3a6de555f8553f146eb4
       labels:
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: primary
@@ -8802,7 +8800,7 @@ spec:
         fsGroup: 1001
       initContainers:
         - name: volume-permissions
-          image: docker.io/bitnami/bitnami-shell:10-debian-10-r431
+          image: docker.io/bitnami/bitnami-shell:11-debian-11-r60
           imagePullPolicy: "IfNotPresent"
           command:
             - /bin/bash
@@ -10087,7 +10085,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: minio
-    helm.sh/chart: minio-11.6.3
+    helm.sh/chart: minio-11.10.24
     app.kubernetes.io/instance: minio
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -10101,11 +10099,11 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: minio
-        helm.sh/chart: minio-11.6.3
+        helm.sh/chart: minio-11.10.24
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/credentials-secret: 094325f216720012cacde9f52fd71c7e8b06dd6386492f6980e0f3588f1b1e7c
+        checksum/credentials-secret: 0f3ceb92b9779df4ce0927f6faeb23e9116b85e0eabe095d903e46a2770cde42
     spec:
       
       serviceAccountName: minio
@@ -10121,7 +10119,7 @@ spec:
         fsGroup: 1001
       containers:
         - name: minio
-          image: docker.io/bitnami/minio:2022.5.26-debian-10-r0
+          image: docker.io/bitnami/minio:2022.12.12-debian-11-r0
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true
@@ -10547,7 +10545,7 @@ metadata:
   namespace: default
   labels:
     app: docker-registry
-    chart: docker-registry-1.16.0
+    chart: docker-registry-2.2.2
     release: docker-registry
     heritage: Helm
 spec:
@@ -10563,7 +10561,9 @@ spec:
         app: docker-registry
         release: docker-registry
       annotations:
-        checksum/config: 1d22b82e19bbc654e029029c4fb86ad02dc13422dc3ac52f8175ad190e52a0bb
+        checksum/config: 699dd382179068f3354c330fcce38625e2861d97b962074b4f57005d40497b00
+        checksum/secret: 450f59aeda22415409a87a1abd2c033c08ebd5fb54fe24d3c56560e92b0218f6
+        
         gitpod.io/checksum_config: 1c66f4ccdb7f6331da2edaecefcb40f6c1b6315c9277eb0418fef3cc584a28bd
     spec:
       serviceAccountName: docker-registry
@@ -10572,7 +10572,7 @@ spec:
         runAsUser: 1000
       containers:
         - name: docker-registry
-          image: "docker.io/library/registry:2.7.1"
+          image: "docker.io/library/registry:2.8.1"
           imagePullPolicy: IfNotPresent
           command:
           - /bin/registry
@@ -10590,9 +10590,9 @@ spec:
               scheme: HTTPS
               path: /
               port: 5000
-          resources:
+          resources: 
             {}
-          env:
+          env: 
             - name: REGISTRY_HTTP_SECRET
               valueFrom:
                 secretKeyRef:
@@ -10604,21 +10604,21 @@ spec:
               value: /etc/ssl/docker/tls.key
             - name: REGISTRY_STORAGE_FILESYSTEM_ROOTDIRECTORY
               value: "/var/lib/registry"
-          volumeMounts:
-            - name: data
-              mountPath: /var/lib/registry/
+          volumeMounts: 
             - name: "registry-config"
               mountPath: "/etc/docker/registry"
+            - name: data
+              mountPath: /var/lib/registry/
             - mountPath: /etc/ssl/docker
               name: tls-cert
               readOnly: true
-      volumes:
-        - name: data
-          persistentVolumeClaim:
-            claimName: registry
+      volumes: 
         - name: registry-config
           configMap:
             name: registry-config
+        - name: data
+          persistentVolumeClaim:
+            claimName: registry
         - name: tls-cert
           secret:
             secretName: builtin-registry-certs

--- a/install/installer/cmd/testdata/render/shortname/output.golden
+++ b/install/installer/cmd/testdata/render/shortname/output.golden
@@ -1116,9 +1116,9 @@ metadata:
 # v1/Secret builtin-registry-auth
 apiVersion: v1
 data:
-  .dockerconfigjson: eyJhdXRocyI6eyJyZWdpc3RyeS5naXRwb2QuZXhhbXBsZS5jb20iOnsiYXV0aCI6ImVGTmxaRXBwUkdkS1VWRm5ORUpyVnpWNFMzVTZRMWMwUTFKQ2FtazJVakJpUjBjNE1XZDVSWGs9In19fQ==
-  password: Q1c0Q1JCamk2UjBiR0c4MWd5RXk=
-  user: eFNlZEppRGdKUVFnNEJrVzV4S3U=
+  .dockerconfigjson: eyJhdXRocyI6eyJyZWdpc3RyeS5naXRwb2QuZXhhbXBsZS5jb20iOnsiYXV0aCI6ImVIZDVRMGRsTlZVd1RrRnFObFZsYVhFM1RqQTZWbE5UYkcxaFMxZFFhaTVRVVhCdFZXWnNWR1E9In19fQ==
+  password: VlNTbG1hS1dQai5QUXBtVWZsVGQ=
+  user: eHd5Q0dlNVUwTkFqNlVlaXE3TjA=
 kind: Secret
 metadata:
   creationTimestamp: null
@@ -1234,8 +1234,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 type: Opaque
 data:
-  root-user: "OC1XR3F3Mm9UbnNQZlVETlNrMFk="
-  root-password: "RHBDLmFTQXhrV0JQdTJfYkpfQUU="
+  root-user: "UkJqaTZSMGJHRzgxZ3lFeWUyNVA="
+  root-password: "dFg2TUw4Z0NXMzFtaXcwVDhRTUk="
   key.json: ""
 ---
 # v1/Secret mysql
@@ -1430,9 +1430,9 @@ data:
         },
         "minio": {
           "endpoint": "minio.default.svc.cluster.local:9000",
-          "accessKey": "8-WGqw2oTnsPfUDNSk0Y",
+          "accessKey": "RBji6R0bGG81gyEye25P",
           "accessKeyFile": "",
-          "secretKey": "DpC.aSAxkWBPu2_bJ_AE",
+          "secretKey": "tX6ML8gCW31miw0T8QMI",
           "secretKeyFile": "",
           "region": "local",
           "parallelUpload": 6
@@ -5170,7 +5170,7 @@ data:
         import ssl_configuration
 
         basicauth bcrypt "Docker Registry" {
-            xSedJiDgJQQg4BkW5xKu JDJhJDEwJFFTRGRRMHZZY2pIS2JqUC9aMDNnVC5HbEg2Z1dOQm5TL0pySnpYSm5iNy9DeVh0ZUw2cFM2
+            xwyCGe5U0NAj6Ueiq7N0 JDJhJDEwJFFTRGRRMHZZY2pIS2JqUC9aMDNnVC5CY0M3RDZsVVg0LzBpZmdnTGovT0VVWXoxTG8ud0lX
         }
 
         reverse_proxy https://registry.default.svc.cluster.local {
@@ -5441,7 +5441,7 @@ data:
       },
       "oauthServer": {
         "enabled": true,
-        "jwtSecret": "8QMIxwyCGe5U0NAj6Uei"
+        "jwtSecret": "m30EH-M2-cWMgkgdy7pu"
       },
       "rateLimiter": {
         "groups": {
@@ -5771,9 +5771,9 @@ data:
             },
             "minio": {
               "endpoint": "minio.default.svc.cluster.local:9000",
-              "accessKey": "8-WGqw2oTnsPfUDNSk0Y",
+              "accessKey": "RBji6R0bGG81gyEye25P",
               "accessKeyFile": "",
-              "secretKey": "DpC.aSAxkWBPu2_bJ_AE",
+              "secretKey": "tX6ML8gCW31miw0T8QMI",
               "secretKeyFile": "",
               "region": "local",
               "parallelUpload": 6
@@ -5955,9 +5955,9 @@ data:
           },
           "minio": {
             "endpoint": "minio.default.svc.cluster.local:9000",
-            "accessKey": "8-WGqw2oTnsPfUDNSk0Y",
+            "accessKey": "RBji6R0bGG81gyEye25P",
             "accessKeyFile": "",
-            "secretKey": "DpC.aSAxkWBPu2_bJ_AE",
+            "secretKey": "tX6ML8gCW31miw0T8QMI",
             "secretKeyFile": "",
             "region": "local",
             "parallelUpload": 6
@@ -8068,7 +8068,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3e487f9543c719b9ee3f5590a0f98cb535b4bf1b301c66de8f00f3aa9d61381d
+        gitpod.io/checksum_config: 3e7db160db71491d8d16b0423783bf99a0dc293dc723960c9308756bdde69d3b
       creationTimestamp: null
       labels:
         app: gitpod
@@ -8285,7 +8285,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: b938c6e286051c22b503c29f5de266741c2045a3ed69be85d7fd9f22a9346254
+        gitpod.io/checksum_config: 2a29ef265c219405bda658cb21613f40ad5e692590d2779476a3ff90917ed6fb
         seccomp.security.alpha.kubernetes.io/shiftfs-module-loader: unconfined
       creationTimestamp: null
       labels:
@@ -9084,7 +9084,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: cac138904f08d79e5598805683f8dc378bd52c58348489de22949ac38dd8b193
+        gitpod.io/checksum_config: 0d9d1c68723466a253996f0a96bf0682ce57b89ebcb4ae1e4a643dd788ef1cab
       creationTimestamp: null
       labels:
         app: gitpod
@@ -9225,7 +9225,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 20782435cc6d6e080cf720b57dca8d4d5cfe40942fc71c4bfd54934fdc34c766
+        gitpod.io/checksum_config: 21ad538d4c7daef6619e5dda6fd71a49a5e5b551f0fc1365d3b7db1d1f38f9ce
       creationTimestamp: null
       labels:
         app: gitpod
@@ -9952,7 +9952,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: af26ec864db5be86adfb79b972614487639aa67ad16de869e23e22e468f0bed8
+        gitpod.io/checksum_config: 3b0478b4bb4feb7b7a29bc33bf4ec99671df4dcbd9529778de375c72e78df64c
       creationTimestamp: null
       labels:
         app: gitpod
@@ -10105,7 +10105,7 @@ spec:
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/credentials-secret: 0a5790906818b3f8eeee0bd3b3e990b3ad02d79bb23c62c0d91a4ca010fb5579
+        checksum/credentials-secret: 094325f216720012cacde9f52fd71c7e8b06dd6386492f6980e0f3588f1b1e7c
     spec:
       
       serviceAccountName: minio
@@ -10213,7 +10213,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: c52c73e63eaa95613a8f4fe77167c754cd48eaf757dd69c2048400311a5ae0a6
+        gitpod.io/checksum_config: a7bd71558cb04a04656bafe7651d4192a9d37be96d2d817f9b6225f63e3a6989
       creationTimestamp: null
       labels:
         app: gitpod
@@ -10564,7 +10564,7 @@ spec:
         release: docker-registry
       annotations:
         checksum/config: 1d22b82e19bbc654e029029c4fb86ad02dc13422dc3ac52f8175ad190e52a0bb
-        gitpod.io/checksum_config: 0ce55d51677cd683df3c7a244542c6aeaaf5dd6dca0f0458e8053a713228f535
+        gitpod.io/checksum_config: 1c66f4ccdb7f6331da2edaecefcb40f6c1b6315c9277eb0418fef3cc584a28bd
     spec:
       serviceAccountName: docker-registry
       securityContext:
@@ -10647,7 +10647,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 014f406b734b4529cd004af285cbef7951637359f10150a98bc83bfa1a231cac
+        gitpod.io/checksum_config: 112e8aa62e3e63f4756819d1ecee48aa807111855d857f0703a3aba91f8507b9
       creationTimestamp: null
       labels:
         app: gitpod
@@ -10928,7 +10928,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: b1913e713ab1ed0f8a96ed0e9b4c655902e55087aba7f44268d34d0c111ad9c7
+        gitpod.io/checksum_config: 4c65a42ef4d94121901b843e258a390d10752fd720f83788ac0a184199a7643d
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/shortname/output.golden
+++ b/install/installer/cmd/testdata/render/shortname/output.golden
@@ -208,7 +208,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -783,7 +783,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -958,7 +958,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: minio
-    helm.sh/chart: minio-11.6.3
+    helm.sh/chart: minio-11.10.24
     app.kubernetes.io/instance: minio
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
@@ -1022,7 +1022,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
@@ -1152,7 +1152,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1168,7 +1168,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1199,13 +1199,13 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
 data:
   rabbitmq.conf: |-
-    IyMgVXNlcm5hbWUgYW5kIHBhc3N3b3JkCiMjCmRlZmF1bHRfdXNlciA9IGdpdHBvZApkZWZhdWx0X3Bhc3MgPSBDSEFOR0VNRQojIyBDbHVzdGVyaW5nCiMjCmNsdXN0ZXJfZm9ybWF0aW9uLnBlZXJfZGlzY292ZXJ5X2JhY2tlbmQgID0gcmFiYml0X3BlZXJfZGlzY292ZXJ5X2s4cwpjbHVzdGVyX2Zvcm1hdGlvbi5rOHMuaG9zdCA9IGt1YmVybmV0ZXMuZGVmYXVsdApjbHVzdGVyX2Zvcm1hdGlvbi5ub2RlX2NsZWFudXAuaW50ZXJ2YWwgPSAxMApjbHVzdGVyX2Zvcm1hdGlvbi5ub2RlX2NsZWFudXAub25seV9sb2dfd2FybmluZyA9IHRydWUKY2x1c3Rlcl9wYXJ0aXRpb25faGFuZGxpbmcgPSBhdXRvaGVhbApsb2FkX2RlZmluaXRpb25zID0gL2FwcC9sb2FkX2RlZmluaXRpb24uanNvbgojIHF1ZXVlIG1hc3RlciBsb2NhdG9yCnF1ZXVlX21hc3Rlcl9sb2NhdG9yID0gbWluLW1hc3RlcnMKIyBlbmFibGUgZ3Vlc3QgdXNlcgpsb29wYmFja191c2Vycy5ndWVzdCA9IGZhbHNlCmxvYWRfZGVmaW5pdGlvbnMgPSAvYXBwL2xvYWRfZGVmaW5pdGlvbi5qc29uCiMgSW5jcmVhc2Ugc3RhdGlzdGljcyBlbWlzc2lvbiBpbnRlcnZhbCBodHRwczovL3d3dy5yYWJiaXRtcS5jb20vbWFuYWdlbWVudC5odG1sI3N0YXRpc3RpY3MtaW50ZXJ2YWwKY29sbGVjdF9zdGF0aXN0aWNzX2ludGVydmFsID0gMTUwMDAKCnNzbF9vcHRpb25zLnZlcmlmeSA9IHZlcmlmeV9wZWVyCmxpc3RlbmVycy5zc2wuZGVmYXVsdCA9IDU2NzEKc3NsX29wdGlvbnMuZmFpbF9pZl9ub19wZWVyX2NlcnQgPSB0cnVlCnNzbF9vcHRpb25zLmNhY2VydGZpbGUgPSAvb3B0L2JpdG5hbWkvcmFiYml0bXEvY2VydHMvY2FfY2VydGlmaWNhdGUucGVtCnNzbF9vcHRpb25zLmNlcnRmaWxlID0gL29wdC9iaXRuYW1pL3JhYmJpdG1xL2NlcnRzL3NlcnZlcl9jZXJ0aWZpY2F0ZS5wZW0Kc3NsX29wdGlvbnMua2V5ZmlsZSA9IC9vcHQvYml0bmFtaS9yYWJiaXRtcS9jZXJ0cy9zZXJ2ZXJfa2V5LnBlbQojIyBQcm9tZXRoZXVzIG1ldHJpY3MKIyMKcHJvbWV0aGV1cy50Y3AucG9ydCA9IDk0MTk=
+    IyMgVXNlcm5hbWUgYW5kIHBhc3N3b3JkCiMjCmRlZmF1bHRfdXNlciA9IGdpdHBvZAojIyBDbHVzdGVyaW5nCiMjCmNsdXN0ZXJfZm9ybWF0aW9uLnBlZXJfZGlzY292ZXJ5X2JhY2tlbmQgID0gcmFiYml0X3BlZXJfZGlzY292ZXJ5X2s4cwpjbHVzdGVyX2Zvcm1hdGlvbi5rOHMuaG9zdCA9IGt1YmVybmV0ZXMuZGVmYXVsdApjbHVzdGVyX2Zvcm1hdGlvbi5ub2RlX2NsZWFudXAuaW50ZXJ2YWwgPSAxMApjbHVzdGVyX2Zvcm1hdGlvbi5ub2RlX2NsZWFudXAub25seV9sb2dfd2FybmluZyA9IHRydWUKY2x1c3Rlcl9wYXJ0aXRpb25faGFuZGxpbmcgPSBhdXRvaGVhbApsb2FkX2RlZmluaXRpb25zID0gL2FwcC9sb2FkX2RlZmluaXRpb24uanNvbgojIHF1ZXVlIG1hc3RlciBsb2NhdG9yCnF1ZXVlX21hc3Rlcl9sb2NhdG9yID0gbWluLW1hc3RlcnMKIyBlbmFibGUgZ3Vlc3QgdXNlcgpsb29wYmFja191c2Vycy5ndWVzdCA9IGZhbHNlCmxvYWRfZGVmaW5pdGlvbnMgPSAvYXBwL2xvYWRfZGVmaW5pdGlvbi5qc29uCiMgSW5jcmVhc2Ugc3RhdGlzdGljcyBlbWlzc2lvbiBpbnRlcnZhbCBodHRwczovL3d3dy5yYWJiaXRtcS5jb20vbWFuYWdlbWVudC5odG1sI3N0YXRpc3RpY3MtaW50ZXJ2YWwKY29sbGVjdF9zdGF0aXN0aWNzX2ludGVydmFsID0gMTUwMDAKCnNzbF9vcHRpb25zLnZlcmlmeSA9IHZlcmlmeV9wZWVyCmxpc3RlbmVycy5zc2wuZGVmYXVsdCA9IDU2NzEKc3NsX29wdGlvbnMuZmFpbF9pZl9ub19wZWVyX2NlcnQgPSB0cnVlCnNzbF9vcHRpb25zLmNhY2VydGZpbGUgPSAvb3B0L2JpdG5hbWkvcmFiYml0bXEvY2VydHMvY2FfY2VydGlmaWNhdGUucGVtCnNzbF9vcHRpb25zLmNlcnRmaWxlID0gL29wdC9iaXRuYW1pL3JhYmJpdG1xL2NlcnRzL3NlcnZlcl9jZXJ0aWZpY2F0ZS5wZW0Kc3NsX29wdGlvbnMua2V5ZmlsZSA9IC9vcHQvYml0bmFtaS9yYWJiaXRtcS9jZXJ0cy9zZXJ2ZXJfa2V5LnBlbQojIyBQcm9tZXRoZXVzIG1ldHJpY3MKIyMKcHJvbWV0aGV1cy50Y3AucG9ydCA9IDk0MTk=
 ---
 # v1/Secret messagebus-erlang-cookie
 apiVersion: v1
@@ -1229,7 +1229,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: minio
-    helm.sh/chart: minio-11.6.3
+    helm.sh/chart: minio-11.10.24
     app.kubernetes.io/instance: minio
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1265,7 +1265,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1282,7 +1282,7 @@ metadata:
   namespace: default
   labels:
     app: docker-registry
-    chart: docker-registry-1.16.0
+    chart: docker-registry-2.2.2
     heritage: Helm
     release: docker-registry
 type: Opaque
@@ -3431,7 +3431,7 @@ data:
       creationTimestamp: null
       labels:
         app: docker-registry
-        chart: docker-registry-1.16.0
+        chart: docker-registry-2.2.2
         heritage: Helm
         release: docker-registry
       name: registry-secret
@@ -3443,7 +3443,7 @@ data:
       creationTimestamp: null
       labels:
         app: docker-registry
-        chart: docker-registry-1.16.0
+        chart: docker-registry-2.2.2
         heritage: Helm
         release: docker-registry
       name: registry-config
@@ -3455,7 +3455,7 @@ data:
       creationTimestamp: null
       labels:
         app: registry
-        chart: docker-registry-1.16.0
+        chart: docker-registry-2.2.2
         heritage: Helm
         release: docker-registry
       name: registry
@@ -3467,7 +3467,7 @@ data:
       creationTimestamp: null
       labels:
         app: docker-registry
-        chart: docker-registry-1.16.0
+        chart: docker-registry-2.2.2
         heritage: Helm
         release: docker-registry
       name: registry
@@ -3479,7 +3479,7 @@ data:
       creationTimestamp: null
       labels:
         app: docker-registry
-        chart: docker-registry-1.16.0
+        chart: docker-registry-2.2.2
         heritage: Helm
         release: docker-registry
       name: registry
@@ -3494,7 +3494,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql
       namespace: default
     ---
@@ -3507,7 +3507,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql-headless
       namespace: default
     ---
@@ -3520,7 +3520,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql
       namespace: default
     ---
@@ -3533,7 +3533,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql
       namespace: default
     ---
@@ -3545,7 +3545,7 @@ data:
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: minio
-        helm.sh/chart: minio-11.6.3
+        helm.sh/chart: minio-11.10.24
       name: minio
       namespace: default
     ---
@@ -3557,7 +3557,7 @@ data:
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: minio
-        helm.sh/chart: minio-11.6.3
+        helm.sh/chart: minio-11.10.24
       name: minio
       namespace: default
     ---
@@ -3569,7 +3569,7 @@ data:
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: minio
-        helm.sh/chart: minio-11.6.3
+        helm.sh/chart: minio-11.10.24
       name: minio
       namespace: default
     ---
@@ -3581,7 +3581,7 @@ data:
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: minio
-        helm.sh/chart: minio-11.6.3
+        helm.sh/chart: minio-11.10.24
       name: minio
       namespace: default
     ---
@@ -3593,7 +3593,7 @@ data:
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: minio
-        helm.sh/chart: minio-11.6.3
+        helm.sh/chart: minio-11.10.24
       name: minio
       namespace: default
     ---
@@ -3605,7 +3605,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus
       namespace: default
     ---
@@ -3617,7 +3617,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus
       namespace: default
     ---
@@ -3629,7 +3629,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: rabbitmq
       namespace: default
     ---
@@ -3641,7 +3641,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus-config
       namespace: default
     ---
@@ -3653,7 +3653,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus
       namespace: default
     ---
@@ -3665,7 +3665,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: load-definition
       namespace: default
     ---
@@ -3677,7 +3677,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: rabbitmq
       namespace: default
     ---
@@ -3689,7 +3689,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus-endpoint-reader
       namespace: default
     ---
@@ -3701,7 +3701,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus-endpoint-reader
       namespace: default
     ---
@@ -3713,7 +3713,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus-headless
       namespace: default
     ---
@@ -3725,7 +3725,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus
       namespace: default
     ---
@@ -3737,7 +3737,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus
       namespace: default
     ---
@@ -5095,7 +5095,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
@@ -5112,7 +5112,7 @@ data:
     datadir=/bitnami/mysql/data
     tmpdir=/opt/bitnami/mysql/tmp
     max_allowed_packet=16M
-    bind-address=0.0.0.0
+    bind-address=*
     pid-file=/opt/bitnami/mysql/tmp/mysqld.pid
     log-error=/opt/bitnami/mysql/logs/mysqld.log
     character-set-server=UTF8
@@ -5282,7 +5282,7 @@ metadata:
   namespace: default
   labels:
     app: docker-registry
-    chart: docker-registry-1.16.0
+    chart: docker-registry-2.2.2
     heritage: Helm
     release: docker-registry
 data:
@@ -6119,7 +6119,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: minio
-    helm.sh/chart: minio-11.6.3
+    helm.sh/chart: minio-11.10.24
     app.kubernetes.io/instance: minio
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -6138,7 +6138,7 @@ metadata:
   namespace: default
   labels:
     app: registry
-    chart: "docker-registry-1.16.0"
+    chart: "docker-registry-2.2.2"
     release: "docker-registry"
     heritage: "Helm"
 spec:
@@ -6665,7 +6665,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 rules:
@@ -7026,7 +7026,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 subjects:
@@ -7519,7 +7519,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -7563,7 +7563,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -7598,7 +7598,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: minio
-    helm.sh/chart: minio-11.6.3
+    helm.sh/chart: minio-11.10.24
     app.kubernetes.io/instance: minio
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -7625,7 +7625,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
@@ -7653,11 +7653,10 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
-  annotations:
 spec:
   type: ClusterIP
   clusterIP: None
@@ -7771,7 +7770,7 @@ metadata:
   namespace: default
   labels:
     app: docker-registry
-    chart: docker-registry-1.16.0
+    chart: docker-registry-2.2.2
     release: docker-registry
     heritage: Helm
 spec:
@@ -8565,7 +8564,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -8582,12 +8581,12 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/config: 2ca9db593e4ca6cdd01f7a65cce1ae90d0d45ecdf0049edfaa4ec72302fcbe8f
-        checksum/secret: c231bbb08185305defa8c4da0f3ee0f5e7a16795362a2133f74e53eb9a40453d
+        checksum/config: d5780a0c58210a2062d54feb61cfb1d5a9c076f95569c4a77076d22c9bad4190
+        checksum/secret: 64c39dd3a8570ed4b0cc71bc0402bc814d016e16f68732938722b12a57c8e82c
         prometheus.io/port: '9419'
         prometheus.io/scrape: "true"
     spec:
@@ -8607,7 +8606,7 @@ spec:
       initContainers:
       containers:
         - name: rabbitmq
-          image: docker.io/bitnami/rabbitmq:3.10.2-debian-10-r7
+          image: docker.io/bitnami/rabbitmq:3.11.5-debian-11-r2
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true
@@ -8742,11 +8741,10 @@ spec:
               - key: tls.key
                 path: server_key.pem
         - name: configuration
-          secret:
-            secretName: messagebus-config
-            items:
-              - key: rabbitmq.conf
-                path: rabbitmq.conf
+          projected:
+            sources:
+              - secret:
+                  name: messagebus-config
         - name: load-definition-volume
           secret:
             secretName: "load-definition"
@@ -8762,7 +8760,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
@@ -8780,10 +8778,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/configuration: 11b8361c0fbf695cec6ec7f47ed4118ad3c7d71a391ca246df129803d3e205a5
+        checksum/configuration: 0c1e0d4282c8f8f820f3c9d1d79b3f423c4676afac2e3a6de555f8553f146eb4
       labels:
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: primary
@@ -8802,7 +8800,7 @@ spec:
         fsGroup: 1001
       initContainers:
         - name: volume-permissions
-          image: docker.io/bitnami/bitnami-shell:10-debian-10-r431
+          image: docker.io/bitnami/bitnami-shell:11-debian-11-r60
           imagePullPolicy: "IfNotPresent"
           command:
             - /bin/bash
@@ -10087,7 +10085,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: minio
-    helm.sh/chart: minio-11.6.3
+    helm.sh/chart: minio-11.10.24
     app.kubernetes.io/instance: minio
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -10101,11 +10099,11 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: minio
-        helm.sh/chart: minio-11.6.3
+        helm.sh/chart: minio-11.10.24
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/credentials-secret: 094325f216720012cacde9f52fd71c7e8b06dd6386492f6980e0f3588f1b1e7c
+        checksum/credentials-secret: 0f3ceb92b9779df4ce0927f6faeb23e9116b85e0eabe095d903e46a2770cde42
     spec:
       
       serviceAccountName: minio
@@ -10121,7 +10119,7 @@ spec:
         fsGroup: 1001
       containers:
         - name: minio
-          image: docker.io/bitnami/minio:2022.5.26-debian-10-r0
+          image: docker.io/bitnami/minio:2022.12.12-debian-11-r0
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true
@@ -10547,7 +10545,7 @@ metadata:
   namespace: default
   labels:
     app: docker-registry
-    chart: docker-registry-1.16.0
+    chart: docker-registry-2.2.2
     release: docker-registry
     heritage: Helm
 spec:
@@ -10563,7 +10561,9 @@ spec:
         app: docker-registry
         release: docker-registry
       annotations:
-        checksum/config: 1d22b82e19bbc654e029029c4fb86ad02dc13422dc3ac52f8175ad190e52a0bb
+        checksum/config: 699dd382179068f3354c330fcce38625e2861d97b962074b4f57005d40497b00
+        checksum/secret: 450f59aeda22415409a87a1abd2c033c08ebd5fb54fe24d3c56560e92b0218f6
+        
         gitpod.io/checksum_config: 1c66f4ccdb7f6331da2edaecefcb40f6c1b6315c9277eb0418fef3cc584a28bd
     spec:
       serviceAccountName: docker-registry
@@ -10572,7 +10572,7 @@ spec:
         runAsUser: 1000
       containers:
         - name: docker-registry
-          image: "docker.io/library/registry:2.7.1"
+          image: "docker.io/library/registry:2.8.1"
           imagePullPolicy: IfNotPresent
           command:
           - /bin/registry
@@ -10590,9 +10590,9 @@ spec:
               scheme: HTTPS
               path: /
               port: 5000
-          resources:
+          resources: 
             {}
-          env:
+          env: 
             - name: REGISTRY_HTTP_SECRET
               valueFrom:
                 secretKeyRef:
@@ -10604,21 +10604,21 @@ spec:
               value: /etc/ssl/docker/tls.key
             - name: REGISTRY_STORAGE_FILESYSTEM_ROOTDIRECTORY
               value: "/var/lib/registry"
-          volumeMounts:
-            - name: data
-              mountPath: /var/lib/registry/
+          volumeMounts: 
             - name: "registry-config"
               mountPath: "/etc/docker/registry"
+            - name: data
+              mountPath: /var/lib/registry/
             - mountPath: /etc/ssl/docker
               name: tls-cert
               readOnly: true
-      volumes:
-        - name: data
-          persistentVolumeClaim:
-            claimName: registry
+      volumes: 
         - name: registry-config
           configMap:
             name: registry-config
+        - name: data
+          persistentVolumeClaim:
+            claimName: registry
         - name: tls-cert
           secret:
             secretName: builtin-registry-certs

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -1116,9 +1116,9 @@ metadata:
 # v1/Secret builtin-registry-auth
 apiVersion: v1
 data:
-  .dockerconfigjson: eyJhdXRocyI6eyJyZWdpc3RyeS5naXRwb2QuZXhhbXBsZS5jb20iOnsiYXV0aCI6ImVGTmxaRXBwUkdkS1VWRm5ORUpyVnpWNFMzVTZRMWMwUTFKQ2FtazJVakJpUjBjNE1XZDVSWGs9In19fQ==
-  password: Q1c0Q1JCamk2UjBiR0c4MWd5RXk=
-  user: eFNlZEppRGdKUVFnNEJrVzV4S3U=
+  .dockerconfigjson: eyJhdXRocyI6eyJyZWdpc3RyeS5naXRwb2QuZXhhbXBsZS5jb20iOnsiYXV0aCI6ImVIZDVRMGRsTlZVd1RrRnFObFZsYVhFM1RqQTZWbE5UYkcxaFMxZFFhaTVRVVhCdFZXWnNWR1E9In19fQ==
+  password: VlNTbG1hS1dQai5QUXBtVWZsVGQ=
+  user: eHd5Q0dlNVUwTkFqNlVlaXE3TjA=
 kind: Secret
 metadata:
   creationTimestamp: null
@@ -1234,8 +1234,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 type: Opaque
 data:
-  root-user: "OC1XR3F3Mm9UbnNQZlVETlNrMFk="
-  root-password: "RHBDLmFTQXhrV0JQdTJfYkpfQUU="
+  root-user: "UkJqaTZSMGJHRzgxZ3lFeWUyNVA="
+  root-password: "dFg2TUw4Z0NXMzFtaXcwVDhRTUk="
   key.json: ""
 ---
 # v1/Secret mysql
@@ -1430,9 +1430,9 @@ data:
         },
         "minio": {
           "endpoint": "minio.default.svc.cluster.local:9000",
-          "accessKey": "8-WGqw2oTnsPfUDNSk0Y",
+          "accessKey": "RBji6R0bGG81gyEye25P",
           "accessKeyFile": "",
-          "secretKey": "DpC.aSAxkWBPu2_bJ_AE",
+          "secretKey": "tX6ML8gCW31miw0T8QMI",
           "secretKeyFile": "",
           "region": "local",
           "parallelUpload": 6
@@ -5182,7 +5182,7 @@ data:
         import ssl_configuration
 
         basicauth bcrypt "Docker Registry" {
-            xSedJiDgJQQg4BkW5xKu JDJhJDEwJFFTRGRRMHZZY2pIS2JqUC9aMDNnVC5HbEg2Z1dOQm5TL0pySnpYSm5iNy9DeVh0ZUw2cFM2
+            xwyCGe5U0NAj6Ueiq7N0 JDJhJDEwJFFTRGRRMHZZY2pIS2JqUC9aMDNnVC5CY0M3RDZsVVg0LzBpZmdnTGovT0VVWXoxTG8ud0lX
         }
 
         reverse_proxy https://registry.default.svc.cluster.local {
@@ -5453,7 +5453,7 @@ data:
       },
       "oauthServer": {
         "enabled": true,
-        "jwtSecret": "8QMIxwyCGe5U0NAj6Uei"
+        "jwtSecret": "m30EH-M2-cWMgkgdy7pu"
       },
       "rateLimiter": {
         "groups": {
@@ -5783,9 +5783,9 @@ data:
             },
             "minio": {
               "endpoint": "minio.default.svc.cluster.local:9000",
-              "accessKey": "8-WGqw2oTnsPfUDNSk0Y",
+              "accessKey": "RBji6R0bGG81gyEye25P",
               "accessKeyFile": "",
-              "secretKey": "DpC.aSAxkWBPu2_bJ_AE",
+              "secretKey": "tX6ML8gCW31miw0T8QMI",
               "secretKeyFile": "",
               "region": "local",
               "parallelUpload": 6
@@ -5967,9 +5967,9 @@ data:
           },
           "minio": {
             "endpoint": "minio.default.svc.cluster.local:9000",
-            "accessKey": "8-WGqw2oTnsPfUDNSk0Y",
+            "accessKey": "RBji6R0bGG81gyEye25P",
             "accessKeyFile": "",
-            "secretKey": "DpC.aSAxkWBPu2_bJ_AE",
+            "secretKey": "tX6ML8gCW31miw0T8QMI",
             "secretKeyFile": "",
             "region": "local",
             "parallelUpload": 6
@@ -8080,7 +8080,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3e487f9543c719b9ee3f5590a0f98cb535b4bf1b301c66de8f00f3aa9d61381d
+        gitpod.io/checksum_config: 3e7db160db71491d8d16b0423783bf99a0dc293dc723960c9308756bdde69d3b
       creationTimestamp: null
       labels:
         app: gitpod
@@ -8297,7 +8297,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: b938c6e286051c22b503c29f5de266741c2045a3ed69be85d7fd9f22a9346254
+        gitpod.io/checksum_config: 2a29ef265c219405bda658cb21613f40ad5e692590d2779476a3ff90917ed6fb
         seccomp.security.alpha.kubernetes.io/shiftfs-module-loader: unconfined
       creationTimestamp: null
       labels:
@@ -9096,7 +9096,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: cac138904f08d79e5598805683f8dc378bd52c58348489de22949ac38dd8b193
+        gitpod.io/checksum_config: 0d9d1c68723466a253996f0a96bf0682ce57b89ebcb4ae1e4a643dd788ef1cab
       creationTimestamp: null
       labels:
         app: gitpod
@@ -9237,7 +9237,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 20782435cc6d6e080cf720b57dca8d4d5cfe40942fc71c4bfd54934fdc34c766
+        gitpod.io/checksum_config: 21ad538d4c7daef6619e5dda6fd71a49a5e5b551f0fc1365d3b7db1d1f38f9ce
       creationTimestamp: null
       labels:
         app: gitpod
@@ -9964,7 +9964,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: af26ec864db5be86adfb79b972614487639aa67ad16de869e23e22e468f0bed8
+        gitpod.io/checksum_config: 3b0478b4bb4feb7b7a29bc33bf4ec99671df4dcbd9529778de375c72e78df64c
       creationTimestamp: null
       labels:
         app: gitpod
@@ -10117,7 +10117,7 @@ spec:
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/credentials-secret: 0a5790906818b3f8eeee0bd3b3e990b3ad02d79bb23c62c0d91a4ca010fb5579
+        checksum/credentials-secret: 094325f216720012cacde9f52fd71c7e8b06dd6386492f6980e0f3588f1b1e7c
     spec:
       
       serviceAccountName: minio
@@ -10225,7 +10225,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: c52c73e63eaa95613a8f4fe77167c754cd48eaf757dd69c2048400311a5ae0a6
+        gitpod.io/checksum_config: a7bd71558cb04a04656bafe7651d4192a9d37be96d2d817f9b6225f63e3a6989
       creationTimestamp: null
       labels:
         app: gitpod
@@ -10576,7 +10576,7 @@ spec:
         release: docker-registry
       annotations:
         checksum/config: 1d22b82e19bbc654e029029c4fb86ad02dc13422dc3ac52f8175ad190e52a0bb
-        gitpod.io/checksum_config: 0ce55d51677cd683df3c7a244542c6aeaaf5dd6dca0f0458e8053a713228f535
+        gitpod.io/checksum_config: 1c66f4ccdb7f6331da2edaecefcb40f6c1b6315c9277eb0418fef3cc584a28bd
     spec:
       serviceAccountName: docker-registry
       securityContext:
@@ -10659,7 +10659,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 726dafd8c59907accd3250e873f40d6e59d6913f82b7198335bc6c24ae2e7db1
+        gitpod.io/checksum_config: f52ae23eddcf2fe15c87ec92cc3d998045c5ff491d52caed0f23a6fccc020134
       creationTimestamp: null
       labels:
         app: gitpod
@@ -10940,7 +10940,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 62fb425bd7800391dca7d008cd0c86cab613afef78e188a950e367ed7429ad73
+        gitpod.io/checksum_config: 21c3b53bac44cf0f98bc57e43353e3136dc5806409951038c2ba36aea69dd218
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -208,7 +208,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -783,7 +783,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -958,7 +958,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: minio
-    helm.sh/chart: minio-11.6.3
+    helm.sh/chart: minio-11.10.24
     app.kubernetes.io/instance: minio
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
@@ -1022,7 +1022,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
@@ -1152,7 +1152,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1168,7 +1168,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1199,13 +1199,13 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
 data:
   rabbitmq.conf: |-
-    IyMgVXNlcm5hbWUgYW5kIHBhc3N3b3JkCiMjCmRlZmF1bHRfdXNlciA9IGdpdHBvZApkZWZhdWx0X3Bhc3MgPSBDSEFOR0VNRQojIyBDbHVzdGVyaW5nCiMjCmNsdXN0ZXJfZm9ybWF0aW9uLnBlZXJfZGlzY292ZXJ5X2JhY2tlbmQgID0gcmFiYml0X3BlZXJfZGlzY292ZXJ5X2s4cwpjbHVzdGVyX2Zvcm1hdGlvbi5rOHMuaG9zdCA9IGt1YmVybmV0ZXMuZGVmYXVsdApjbHVzdGVyX2Zvcm1hdGlvbi5ub2RlX2NsZWFudXAuaW50ZXJ2YWwgPSAxMApjbHVzdGVyX2Zvcm1hdGlvbi5ub2RlX2NsZWFudXAub25seV9sb2dfd2FybmluZyA9IHRydWUKY2x1c3Rlcl9wYXJ0aXRpb25faGFuZGxpbmcgPSBhdXRvaGVhbApsb2FkX2RlZmluaXRpb25zID0gL2FwcC9sb2FkX2RlZmluaXRpb24uanNvbgojIHF1ZXVlIG1hc3RlciBsb2NhdG9yCnF1ZXVlX21hc3Rlcl9sb2NhdG9yID0gbWluLW1hc3RlcnMKIyBlbmFibGUgZ3Vlc3QgdXNlcgpsb29wYmFja191c2Vycy5ndWVzdCA9IGZhbHNlCmxvYWRfZGVmaW5pdGlvbnMgPSAvYXBwL2xvYWRfZGVmaW5pdGlvbi5qc29uCiMgSW5jcmVhc2Ugc3RhdGlzdGljcyBlbWlzc2lvbiBpbnRlcnZhbCBodHRwczovL3d3dy5yYWJiaXRtcS5jb20vbWFuYWdlbWVudC5odG1sI3N0YXRpc3RpY3MtaW50ZXJ2YWwKY29sbGVjdF9zdGF0aXN0aWNzX2ludGVydmFsID0gMTUwMDAKCnNzbF9vcHRpb25zLnZlcmlmeSA9IHZlcmlmeV9wZWVyCmxpc3RlbmVycy5zc2wuZGVmYXVsdCA9IDU2NzEKc3NsX29wdGlvbnMuZmFpbF9pZl9ub19wZWVyX2NlcnQgPSB0cnVlCnNzbF9vcHRpb25zLmNhY2VydGZpbGUgPSAvb3B0L2JpdG5hbWkvcmFiYml0bXEvY2VydHMvY2FfY2VydGlmaWNhdGUucGVtCnNzbF9vcHRpb25zLmNlcnRmaWxlID0gL29wdC9iaXRuYW1pL3JhYmJpdG1xL2NlcnRzL3NlcnZlcl9jZXJ0aWZpY2F0ZS5wZW0Kc3NsX29wdGlvbnMua2V5ZmlsZSA9IC9vcHQvYml0bmFtaS9yYWJiaXRtcS9jZXJ0cy9zZXJ2ZXJfa2V5LnBlbQojIyBQcm9tZXRoZXVzIG1ldHJpY3MKIyMKcHJvbWV0aGV1cy50Y3AucG9ydCA9IDk0MTk=
+    IyMgVXNlcm5hbWUgYW5kIHBhc3N3b3JkCiMjCmRlZmF1bHRfdXNlciA9IGdpdHBvZAojIyBDbHVzdGVyaW5nCiMjCmNsdXN0ZXJfZm9ybWF0aW9uLnBlZXJfZGlzY292ZXJ5X2JhY2tlbmQgID0gcmFiYml0X3BlZXJfZGlzY292ZXJ5X2s4cwpjbHVzdGVyX2Zvcm1hdGlvbi5rOHMuaG9zdCA9IGt1YmVybmV0ZXMuZGVmYXVsdApjbHVzdGVyX2Zvcm1hdGlvbi5ub2RlX2NsZWFudXAuaW50ZXJ2YWwgPSAxMApjbHVzdGVyX2Zvcm1hdGlvbi5ub2RlX2NsZWFudXAub25seV9sb2dfd2FybmluZyA9IHRydWUKY2x1c3Rlcl9wYXJ0aXRpb25faGFuZGxpbmcgPSBhdXRvaGVhbApsb2FkX2RlZmluaXRpb25zID0gL2FwcC9sb2FkX2RlZmluaXRpb24uanNvbgojIHF1ZXVlIG1hc3RlciBsb2NhdG9yCnF1ZXVlX21hc3Rlcl9sb2NhdG9yID0gbWluLW1hc3RlcnMKIyBlbmFibGUgZ3Vlc3QgdXNlcgpsb29wYmFja191c2Vycy5ndWVzdCA9IGZhbHNlCmxvYWRfZGVmaW5pdGlvbnMgPSAvYXBwL2xvYWRfZGVmaW5pdGlvbi5qc29uCiMgSW5jcmVhc2Ugc3RhdGlzdGljcyBlbWlzc2lvbiBpbnRlcnZhbCBodHRwczovL3d3dy5yYWJiaXRtcS5jb20vbWFuYWdlbWVudC5odG1sI3N0YXRpc3RpY3MtaW50ZXJ2YWwKY29sbGVjdF9zdGF0aXN0aWNzX2ludGVydmFsID0gMTUwMDAKCnNzbF9vcHRpb25zLnZlcmlmeSA9IHZlcmlmeV9wZWVyCmxpc3RlbmVycy5zc2wuZGVmYXVsdCA9IDU2NzEKc3NsX29wdGlvbnMuZmFpbF9pZl9ub19wZWVyX2NlcnQgPSB0cnVlCnNzbF9vcHRpb25zLmNhY2VydGZpbGUgPSAvb3B0L2JpdG5hbWkvcmFiYml0bXEvY2VydHMvY2FfY2VydGlmaWNhdGUucGVtCnNzbF9vcHRpb25zLmNlcnRmaWxlID0gL29wdC9iaXRuYW1pL3JhYmJpdG1xL2NlcnRzL3NlcnZlcl9jZXJ0aWZpY2F0ZS5wZW0Kc3NsX29wdGlvbnMua2V5ZmlsZSA9IC9vcHQvYml0bmFtaS9yYWJiaXRtcS9jZXJ0cy9zZXJ2ZXJfa2V5LnBlbQojIyBQcm9tZXRoZXVzIG1ldHJpY3MKIyMKcHJvbWV0aGV1cy50Y3AucG9ydCA9IDk0MTk=
 ---
 # v1/Secret messagebus-erlang-cookie
 apiVersion: v1
@@ -1229,7 +1229,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: minio
-    helm.sh/chart: minio-11.6.3
+    helm.sh/chart: minio-11.10.24
     app.kubernetes.io/instance: minio
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1265,7 +1265,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1282,7 +1282,7 @@ metadata:
   namespace: default
   labels:
     app: docker-registry
-    chart: docker-registry-1.16.0
+    chart: docker-registry-2.2.2
     heritage: Helm
     release: docker-registry
 type: Opaque
@@ -3443,7 +3443,7 @@ data:
       creationTimestamp: null
       labels:
         app: docker-registry
-        chart: docker-registry-1.16.0
+        chart: docker-registry-2.2.2
         heritage: Helm
         release: docker-registry
       name: registry-secret
@@ -3455,7 +3455,7 @@ data:
       creationTimestamp: null
       labels:
         app: docker-registry
-        chart: docker-registry-1.16.0
+        chart: docker-registry-2.2.2
         heritage: Helm
         release: docker-registry
       name: registry-config
@@ -3467,7 +3467,7 @@ data:
       creationTimestamp: null
       labels:
         app: registry
-        chart: docker-registry-1.16.0
+        chart: docker-registry-2.2.2
         heritage: Helm
         release: docker-registry
       name: registry
@@ -3479,7 +3479,7 @@ data:
       creationTimestamp: null
       labels:
         app: docker-registry
-        chart: docker-registry-1.16.0
+        chart: docker-registry-2.2.2
         heritage: Helm
         release: docker-registry
       name: registry
@@ -3491,7 +3491,7 @@ data:
       creationTimestamp: null
       labels:
         app: docker-registry
-        chart: docker-registry-1.16.0
+        chart: docker-registry-2.2.2
         heritage: Helm
         release: docker-registry
       name: registry
@@ -3506,7 +3506,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql
       namespace: default
     ---
@@ -3519,7 +3519,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql-headless
       namespace: default
     ---
@@ -3532,7 +3532,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql
       namespace: default
     ---
@@ -3545,7 +3545,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql
       namespace: default
     ---
@@ -3557,7 +3557,7 @@ data:
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: minio
-        helm.sh/chart: minio-11.6.3
+        helm.sh/chart: minio-11.10.24
       name: minio
       namespace: default
     ---
@@ -3569,7 +3569,7 @@ data:
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: minio
-        helm.sh/chart: minio-11.6.3
+        helm.sh/chart: minio-11.10.24
       name: minio
       namespace: default
     ---
@@ -3581,7 +3581,7 @@ data:
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: minio
-        helm.sh/chart: minio-11.6.3
+        helm.sh/chart: minio-11.10.24
       name: minio
       namespace: default
     ---
@@ -3593,7 +3593,7 @@ data:
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: minio
-        helm.sh/chart: minio-11.6.3
+        helm.sh/chart: minio-11.10.24
       name: minio
       namespace: default
     ---
@@ -3605,7 +3605,7 @@ data:
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: minio
-        helm.sh/chart: minio-11.6.3
+        helm.sh/chart: minio-11.10.24
       name: minio
       namespace: default
     ---
@@ -3617,7 +3617,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus
       namespace: default
     ---
@@ -3629,7 +3629,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus
       namespace: default
     ---
@@ -3641,7 +3641,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: rabbitmq
       namespace: default
     ---
@@ -3653,7 +3653,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus-config
       namespace: default
     ---
@@ -3665,7 +3665,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus
       namespace: default
     ---
@@ -3677,7 +3677,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: load-definition
       namespace: default
     ---
@@ -3689,7 +3689,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: rabbitmq
       namespace: default
     ---
@@ -3701,7 +3701,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus-endpoint-reader
       namespace: default
     ---
@@ -3713,7 +3713,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus-endpoint-reader
       namespace: default
     ---
@@ -3725,7 +3725,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus-headless
       namespace: default
     ---
@@ -3737,7 +3737,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus
       namespace: default
     ---
@@ -3749,7 +3749,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus
       namespace: default
     ---
@@ -5107,7 +5107,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
@@ -5124,7 +5124,7 @@ data:
     datadir=/bitnami/mysql/data
     tmpdir=/opt/bitnami/mysql/tmp
     max_allowed_packet=16M
-    bind-address=0.0.0.0
+    bind-address=*
     pid-file=/opt/bitnami/mysql/tmp/mysqld.pid
     log-error=/opt/bitnami/mysql/logs/mysqld.log
     character-set-server=UTF8
@@ -5294,7 +5294,7 @@ metadata:
   namespace: default
   labels:
     app: docker-registry
-    chart: docker-registry-1.16.0
+    chart: docker-registry-2.2.2
     heritage: Helm
     release: docker-registry
 data:
@@ -6131,7 +6131,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: minio
-    helm.sh/chart: minio-11.6.3
+    helm.sh/chart: minio-11.10.24
     app.kubernetes.io/instance: minio
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -6150,7 +6150,7 @@ metadata:
   namespace: default
   labels:
     app: registry
-    chart: "docker-registry-1.16.0"
+    chart: "docker-registry-2.2.2"
     release: "docker-registry"
     heritage: "Helm"
 spec:
@@ -6677,7 +6677,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 rules:
@@ -7038,7 +7038,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 subjects:
@@ -7531,7 +7531,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -7575,7 +7575,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -7610,7 +7610,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: minio
-    helm.sh/chart: minio-11.6.3
+    helm.sh/chart: minio-11.10.24
     app.kubernetes.io/instance: minio
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -7637,7 +7637,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
@@ -7665,11 +7665,10 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
-  annotations:
 spec:
   type: ClusterIP
   clusterIP: None
@@ -7783,7 +7782,7 @@ metadata:
   namespace: default
   labels:
     app: docker-registry
-    chart: docker-registry-1.16.0
+    chart: docker-registry-2.2.2
     release: docker-registry
     heritage: Helm
 spec:
@@ -8577,7 +8576,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -8594,12 +8593,12 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/config: 2ca9db593e4ca6cdd01f7a65cce1ae90d0d45ecdf0049edfaa4ec72302fcbe8f
-        checksum/secret: c231bbb08185305defa8c4da0f3ee0f5e7a16795362a2133f74e53eb9a40453d
+        checksum/config: d5780a0c58210a2062d54feb61cfb1d5a9c076f95569c4a77076d22c9bad4190
+        checksum/secret: 64c39dd3a8570ed4b0cc71bc0402bc814d016e16f68732938722b12a57c8e82c
         prometheus.io/port: '9419'
         prometheus.io/scrape: "true"
     spec:
@@ -8619,7 +8618,7 @@ spec:
       initContainers:
       containers:
         - name: rabbitmq
-          image: docker.io/bitnami/rabbitmq:3.10.2-debian-10-r7
+          image: docker.io/bitnami/rabbitmq:3.11.5-debian-11-r2
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true
@@ -8754,11 +8753,10 @@ spec:
               - key: tls.key
                 path: server_key.pem
         - name: configuration
-          secret:
-            secretName: messagebus-config
-            items:
-              - key: rabbitmq.conf
-                path: rabbitmq.conf
+          projected:
+            sources:
+              - secret:
+                  name: messagebus-config
         - name: load-definition-volume
           secret:
             secretName: "load-definition"
@@ -8774,7 +8772,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
@@ -8792,10 +8790,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/configuration: 11b8361c0fbf695cec6ec7f47ed4118ad3c7d71a391ca246df129803d3e205a5
+        checksum/configuration: 0c1e0d4282c8f8f820f3c9d1d79b3f423c4676afac2e3a6de555f8553f146eb4
       labels:
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: primary
@@ -8814,7 +8812,7 @@ spec:
         fsGroup: 1001
       initContainers:
         - name: volume-permissions
-          image: docker.io/bitnami/bitnami-shell:10-debian-10-r431
+          image: docker.io/bitnami/bitnami-shell:11-debian-11-r60
           imagePullPolicy: "IfNotPresent"
           command:
             - /bin/bash
@@ -10099,7 +10097,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: minio
-    helm.sh/chart: minio-11.6.3
+    helm.sh/chart: minio-11.10.24
     app.kubernetes.io/instance: minio
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -10113,11 +10111,11 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: minio
-        helm.sh/chart: minio-11.6.3
+        helm.sh/chart: minio-11.10.24
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/credentials-secret: 094325f216720012cacde9f52fd71c7e8b06dd6386492f6980e0f3588f1b1e7c
+        checksum/credentials-secret: 0f3ceb92b9779df4ce0927f6faeb23e9116b85e0eabe095d903e46a2770cde42
     spec:
       
       serviceAccountName: minio
@@ -10133,7 +10131,7 @@ spec:
         fsGroup: 1001
       containers:
         - name: minio
-          image: docker.io/bitnami/minio:2022.5.26-debian-10-r0
+          image: docker.io/bitnami/minio:2022.12.12-debian-11-r0
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true
@@ -10559,7 +10557,7 @@ metadata:
   namespace: default
   labels:
     app: docker-registry
-    chart: docker-registry-1.16.0
+    chart: docker-registry-2.2.2
     release: docker-registry
     heritage: Helm
 spec:
@@ -10575,7 +10573,9 @@ spec:
         app: docker-registry
         release: docker-registry
       annotations:
-        checksum/config: 1d22b82e19bbc654e029029c4fb86ad02dc13422dc3ac52f8175ad190e52a0bb
+        checksum/config: 699dd382179068f3354c330fcce38625e2861d97b962074b4f57005d40497b00
+        checksum/secret: 450f59aeda22415409a87a1abd2c033c08ebd5fb54fe24d3c56560e92b0218f6
+        
         gitpod.io/checksum_config: 1c66f4ccdb7f6331da2edaecefcb40f6c1b6315c9277eb0418fef3cc584a28bd
     spec:
       serviceAccountName: docker-registry
@@ -10584,7 +10584,7 @@ spec:
         runAsUser: 1000
       containers:
         - name: docker-registry
-          image: "docker.io/library/registry:2.7.1"
+          image: "docker.io/library/registry:2.8.1"
           imagePullPolicy: IfNotPresent
           command:
           - /bin/registry
@@ -10602,9 +10602,9 @@ spec:
               scheme: HTTPS
               path: /
               port: 5000
-          resources:
+          resources: 
             {}
-          env:
+          env: 
             - name: REGISTRY_HTTP_SECRET
               valueFrom:
                 secretKeyRef:
@@ -10616,21 +10616,21 @@ spec:
               value: /etc/ssl/docker/tls.key
             - name: REGISTRY_STORAGE_FILESYSTEM_ROOTDIRECTORY
               value: "/var/lib/registry"
-          volumeMounts:
-            - name: data
-              mountPath: /var/lib/registry/
+          volumeMounts: 
             - name: "registry-config"
               mountPath: "/etc/docker/registry"
+            - name: data
+              mountPath: /var/lib/registry/
             - mountPath: /etc/ssl/docker
               name: tls-cert
               readOnly: true
-      volumes:
-        - name: data
-          persistentVolumeClaim:
-            claimName: registry
+      volumes: 
         - name: registry-config
           configMap:
             name: registry-config
+        - name: data
+          persistentVolumeClaim:
+            claimName: registry
         - name: tls-cert
           secret:
             secretName: builtin-registry-certs

--- a/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
+++ b/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
@@ -1338,9 +1338,9 @@ metadata:
 # v1/Secret builtin-registry-auth
 apiVersion: v1
 data:
-  .dockerconfigjson: eyJhdXRocyI6eyJyZWdpc3RyeS5naXRwb2QuZXhhbXBsZS5jb20iOnsiYXV0aCI6ImVGTmxaRXBwUkdkS1VWRm5ORUpyVnpWNFMzVTZRMWMwUTFKQ2FtazJVakJpUjBjNE1XZDVSWGs9In19fQ==
-  password: Q1c0Q1JCamk2UjBiR0c4MWd5RXk=
-  user: eFNlZEppRGdKUVFnNEJrVzV4S3U=
+  .dockerconfigjson: eyJhdXRocyI6eyJyZWdpc3RyeS5naXRwb2QuZXhhbXBsZS5jb20iOnsiYXV0aCI6ImVIZDVRMGRsTlZVd1RrRnFObFZsYVhFM1RqQTZWbE5UYkcxaFMxZFFhaTVRVVhCdFZXWnNWR1E9In19fQ==
+  password: VlNTbG1hS1dQai5QUXBtVWZsVGQ=
+  user: eHd5Q0dlNVUwTkFqNlVlaXE3TjA=
 kind: Secret
 metadata:
   creationTimestamp: null
@@ -1456,8 +1456,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 type: Opaque
 data:
-  root-user: "OC1XR3F3Mm9UbnNQZlVETlNrMFk="
-  root-password: "RHBDLmFTQXhrV0JQdTJfYkpfQUU="
+  root-user: "UkJqaTZSMGJHRzgxZ3lFeWUyNVA="
+  root-password: "dFg2TUw4Z0NXMzFtaXcwVDhRTUk="
   key.json: ""
 ---
 # v1/Secret mysql
@@ -1652,9 +1652,9 @@ data:
         },
         "minio": {
           "endpoint": "minio.default.svc.cluster.local:9000",
-          "accessKey": "8-WGqw2oTnsPfUDNSk0Y",
+          "accessKey": "RBji6R0bGG81gyEye25P",
           "accessKeyFile": "",
-          "secretKey": "DpC.aSAxkWBPu2_bJ_AE",
+          "secretKey": "tX6ML8gCW31miw0T8QMI",
           "secretKeyFile": "",
           "region": "local",
           "parallelUpload": 6
@@ -5503,7 +5503,7 @@ data:
         import ssl_configuration
 
         basicauth bcrypt "Docker Registry" {
-            xSedJiDgJQQg4BkW5xKu JDJhJDEwJFFTRGRRMHZZY2pIS2JqUC9aMDNnVC5HbEg2Z1dOQm5TL0pySnpYSm5iNy9DeVh0ZUw2cFM2
+            xwyCGe5U0NAj6Ueiq7N0 JDJhJDEwJFFTRGRRMHZZY2pIS2JqUC9aMDNnVC5CY0M3RDZsVVg0LzBpZmdnTGovT0VVWXoxTG8ud0lX
         }
 
         reverse_proxy https://registry.default.svc.cluster.local {
@@ -5774,7 +5774,7 @@ data:
       },
       "oauthServer": {
         "enabled": true,
-        "jwtSecret": "8QMIxwyCGe5U0NAj6Uei"
+        "jwtSecret": "m30EH-M2-cWMgkgdy7pu"
       },
       "rateLimiter": {
         "groups": {
@@ -6104,9 +6104,9 @@ data:
             },
             "minio": {
               "endpoint": "minio.default.svc.cluster.local:9000",
-              "accessKey": "8-WGqw2oTnsPfUDNSk0Y",
+              "accessKey": "RBji6R0bGG81gyEye25P",
               "accessKeyFile": "",
-              "secretKey": "DpC.aSAxkWBPu2_bJ_AE",
+              "secretKey": "tX6ML8gCW31miw0T8QMI",
               "secretKeyFile": "",
               "region": "local",
               "parallelUpload": 6
@@ -6288,9 +6288,9 @@ data:
           },
           "minio": {
             "endpoint": "minio.default.svc.cluster.local:9000",
-            "accessKey": "8-WGqw2oTnsPfUDNSk0Y",
+            "accessKey": "RBji6R0bGG81gyEye25P",
             "accessKeyFile": "",
-            "secretKey": "DpC.aSAxkWBPu2_bJ_AE",
+            "secretKey": "tX6ML8gCW31miw0T8QMI",
             "secretKeyFile": "",
             "region": "local",
             "parallelUpload": 6
@@ -8512,7 +8512,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3e487f9543c719b9ee3f5590a0f98cb535b4bf1b301c66de8f00f3aa9d61381d
+        gitpod.io/checksum_config: 3e7db160db71491d8d16b0423783bf99a0dc293dc723960c9308756bdde69d3b
       creationTimestamp: null
       labels:
         app: gitpod
@@ -8729,7 +8729,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: b938c6e286051c22b503c29f5de266741c2045a3ed69be85d7fd9f22a9346254
+        gitpod.io/checksum_config: 2a29ef265c219405bda658cb21613f40ad5e692590d2779476a3ff90917ed6fb
         seccomp.security.alpha.kubernetes.io/shiftfs-module-loader: unconfined
       creationTimestamp: null
       labels:
@@ -9528,7 +9528,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: cac138904f08d79e5598805683f8dc378bd52c58348489de22949ac38dd8b193
+        gitpod.io/checksum_config: 0d9d1c68723466a253996f0a96bf0682ce57b89ebcb4ae1e4a643dd788ef1cab
       creationTimestamp: null
       labels:
         app: gitpod
@@ -9669,7 +9669,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 20782435cc6d6e080cf720b57dca8d4d5cfe40942fc71c4bfd54934fdc34c766
+        gitpod.io/checksum_config: 21ad538d4c7daef6619e5dda6fd71a49a5e5b551f0fc1365d3b7db1d1f38f9ce
       creationTimestamp: null
       labels:
         app: gitpod
@@ -10396,7 +10396,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: af26ec864db5be86adfb79b972614487639aa67ad16de869e23e22e468f0bed8
+        gitpod.io/checksum_config: 3b0478b4bb4feb7b7a29bc33bf4ec99671df4dcbd9529778de375c72e78df64c
       creationTimestamp: null
       labels:
         app: gitpod
@@ -10549,7 +10549,7 @@ spec:
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/credentials-secret: 0a5790906818b3f8eeee0bd3b3e990b3ad02d79bb23c62c0d91a4ca010fb5579
+        checksum/credentials-secret: 094325f216720012cacde9f52fd71c7e8b06dd6386492f6980e0f3588f1b1e7c
     spec:
       
       serviceAccountName: minio
@@ -10657,7 +10657,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: c52c73e63eaa95613a8f4fe77167c754cd48eaf757dd69c2048400311a5ae0a6
+        gitpod.io/checksum_config: a7bd71558cb04a04656bafe7651d4192a9d37be96d2d817f9b6225f63e3a6989
       creationTimestamp: null
       labels:
         app: gitpod
@@ -11008,7 +11008,7 @@ spec:
         release: docker-registry
       annotations:
         checksum/config: 1d22b82e19bbc654e029029c4fb86ad02dc13422dc3ac52f8175ad190e52a0bb
-        gitpod.io/checksum_config: 0ce55d51677cd683df3c7a244542c6aeaaf5dd6dca0f0458e8053a713228f535
+        gitpod.io/checksum_config: 1c66f4ccdb7f6331da2edaecefcb40f6c1b6315c9277eb0418fef3cc584a28bd
     spec:
       serviceAccountName: docker-registry
       securityContext:
@@ -11091,7 +11091,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 726dafd8c59907accd3250e873f40d6e59d6913f82b7198335bc6c24ae2e7db1
+        gitpod.io/checksum_config: f52ae23eddcf2fe15c87ec92cc3d998045c5ff491d52caed0f23a6fccc020134
       creationTimestamp: null
       labels:
         app: gitpod
@@ -11372,7 +11372,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 62fb425bd7800391dca7d008cd0c86cab613afef78e188a950e367ed7429ad73
+        gitpod.io/checksum_config: 21c3b53bac44cf0f98bc57e43353e3136dc5806409951038c2ba36aea69dd218
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
+++ b/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
@@ -208,7 +208,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1005,7 +1005,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -1180,7 +1180,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: minio
-    helm.sh/chart: minio-11.6.3
+    helm.sh/chart: minio-11.10.24
     app.kubernetes.io/instance: minio
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
@@ -1244,7 +1244,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
@@ -1374,7 +1374,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1390,7 +1390,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1421,13 +1421,13 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
 data:
   rabbitmq.conf: |-
-    IyMgVXNlcm5hbWUgYW5kIHBhc3N3b3JkCiMjCmRlZmF1bHRfdXNlciA9IGdpdHBvZApkZWZhdWx0X3Bhc3MgPSBDSEFOR0VNRQojIyBDbHVzdGVyaW5nCiMjCmNsdXN0ZXJfZm9ybWF0aW9uLnBlZXJfZGlzY292ZXJ5X2JhY2tlbmQgID0gcmFiYml0X3BlZXJfZGlzY292ZXJ5X2s4cwpjbHVzdGVyX2Zvcm1hdGlvbi5rOHMuaG9zdCA9IGt1YmVybmV0ZXMuZGVmYXVsdApjbHVzdGVyX2Zvcm1hdGlvbi5ub2RlX2NsZWFudXAuaW50ZXJ2YWwgPSAxMApjbHVzdGVyX2Zvcm1hdGlvbi5ub2RlX2NsZWFudXAub25seV9sb2dfd2FybmluZyA9IHRydWUKY2x1c3Rlcl9wYXJ0aXRpb25faGFuZGxpbmcgPSBhdXRvaGVhbApsb2FkX2RlZmluaXRpb25zID0gL2FwcC9sb2FkX2RlZmluaXRpb24uanNvbgojIHF1ZXVlIG1hc3RlciBsb2NhdG9yCnF1ZXVlX21hc3Rlcl9sb2NhdG9yID0gbWluLW1hc3RlcnMKIyBlbmFibGUgZ3Vlc3QgdXNlcgpsb29wYmFja191c2Vycy5ndWVzdCA9IGZhbHNlCmxvYWRfZGVmaW5pdGlvbnMgPSAvYXBwL2xvYWRfZGVmaW5pdGlvbi5qc29uCiMgSW5jcmVhc2Ugc3RhdGlzdGljcyBlbWlzc2lvbiBpbnRlcnZhbCBodHRwczovL3d3dy5yYWJiaXRtcS5jb20vbWFuYWdlbWVudC5odG1sI3N0YXRpc3RpY3MtaW50ZXJ2YWwKY29sbGVjdF9zdGF0aXN0aWNzX2ludGVydmFsID0gMTUwMDAKCnNzbF9vcHRpb25zLnZlcmlmeSA9IHZlcmlmeV9wZWVyCmxpc3RlbmVycy5zc2wuZGVmYXVsdCA9IDU2NzEKc3NsX29wdGlvbnMuZmFpbF9pZl9ub19wZWVyX2NlcnQgPSB0cnVlCnNzbF9vcHRpb25zLmNhY2VydGZpbGUgPSAvb3B0L2JpdG5hbWkvcmFiYml0bXEvY2VydHMvY2FfY2VydGlmaWNhdGUucGVtCnNzbF9vcHRpb25zLmNlcnRmaWxlID0gL29wdC9iaXRuYW1pL3JhYmJpdG1xL2NlcnRzL3NlcnZlcl9jZXJ0aWZpY2F0ZS5wZW0Kc3NsX29wdGlvbnMua2V5ZmlsZSA9IC9vcHQvYml0bmFtaS9yYWJiaXRtcS9jZXJ0cy9zZXJ2ZXJfa2V5LnBlbQojIyBQcm9tZXRoZXVzIG1ldHJpY3MKIyMKcHJvbWV0aGV1cy50Y3AucG9ydCA9IDk0MTk=
+    IyMgVXNlcm5hbWUgYW5kIHBhc3N3b3JkCiMjCmRlZmF1bHRfdXNlciA9IGdpdHBvZAojIyBDbHVzdGVyaW5nCiMjCmNsdXN0ZXJfZm9ybWF0aW9uLnBlZXJfZGlzY292ZXJ5X2JhY2tlbmQgID0gcmFiYml0X3BlZXJfZGlzY292ZXJ5X2s4cwpjbHVzdGVyX2Zvcm1hdGlvbi5rOHMuaG9zdCA9IGt1YmVybmV0ZXMuZGVmYXVsdApjbHVzdGVyX2Zvcm1hdGlvbi5ub2RlX2NsZWFudXAuaW50ZXJ2YWwgPSAxMApjbHVzdGVyX2Zvcm1hdGlvbi5ub2RlX2NsZWFudXAub25seV9sb2dfd2FybmluZyA9IHRydWUKY2x1c3Rlcl9wYXJ0aXRpb25faGFuZGxpbmcgPSBhdXRvaGVhbApsb2FkX2RlZmluaXRpb25zID0gL2FwcC9sb2FkX2RlZmluaXRpb24uanNvbgojIHF1ZXVlIG1hc3RlciBsb2NhdG9yCnF1ZXVlX21hc3Rlcl9sb2NhdG9yID0gbWluLW1hc3RlcnMKIyBlbmFibGUgZ3Vlc3QgdXNlcgpsb29wYmFja191c2Vycy5ndWVzdCA9IGZhbHNlCmxvYWRfZGVmaW5pdGlvbnMgPSAvYXBwL2xvYWRfZGVmaW5pdGlvbi5qc29uCiMgSW5jcmVhc2Ugc3RhdGlzdGljcyBlbWlzc2lvbiBpbnRlcnZhbCBodHRwczovL3d3dy5yYWJiaXRtcS5jb20vbWFuYWdlbWVudC5odG1sI3N0YXRpc3RpY3MtaW50ZXJ2YWwKY29sbGVjdF9zdGF0aXN0aWNzX2ludGVydmFsID0gMTUwMDAKCnNzbF9vcHRpb25zLnZlcmlmeSA9IHZlcmlmeV9wZWVyCmxpc3RlbmVycy5zc2wuZGVmYXVsdCA9IDU2NzEKc3NsX29wdGlvbnMuZmFpbF9pZl9ub19wZWVyX2NlcnQgPSB0cnVlCnNzbF9vcHRpb25zLmNhY2VydGZpbGUgPSAvb3B0L2JpdG5hbWkvcmFiYml0bXEvY2VydHMvY2FfY2VydGlmaWNhdGUucGVtCnNzbF9vcHRpb25zLmNlcnRmaWxlID0gL29wdC9iaXRuYW1pL3JhYmJpdG1xL2NlcnRzL3NlcnZlcl9jZXJ0aWZpY2F0ZS5wZW0Kc3NsX29wdGlvbnMua2V5ZmlsZSA9IC9vcHQvYml0bmFtaS9yYWJiaXRtcS9jZXJ0cy9zZXJ2ZXJfa2V5LnBlbQojIyBQcm9tZXRoZXVzIG1ldHJpY3MKIyMKcHJvbWV0aGV1cy50Y3AucG9ydCA9IDk0MTk=
 ---
 # v1/Secret messagebus-erlang-cookie
 apiVersion: v1
@@ -1451,7 +1451,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: minio
-    helm.sh/chart: minio-11.6.3
+    helm.sh/chart: minio-11.10.24
     app.kubernetes.io/instance: minio
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1487,7 +1487,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1504,7 +1504,7 @@ metadata:
   namespace: default
   labels:
     app: docker-registry
-    chart: docker-registry-1.16.0
+    chart: docker-registry-2.2.2
     heritage: Helm
     release: docker-registry
 type: Opaque
@@ -3764,7 +3764,7 @@ data:
       creationTimestamp: null
       labels:
         app: docker-registry
-        chart: docker-registry-1.16.0
+        chart: docker-registry-2.2.2
         heritage: Helm
         release: docker-registry
       name: registry-secret
@@ -3776,7 +3776,7 @@ data:
       creationTimestamp: null
       labels:
         app: docker-registry
-        chart: docker-registry-1.16.0
+        chart: docker-registry-2.2.2
         heritage: Helm
         release: docker-registry
       name: registry-config
@@ -3788,7 +3788,7 @@ data:
       creationTimestamp: null
       labels:
         app: registry
-        chart: docker-registry-1.16.0
+        chart: docker-registry-2.2.2
         heritage: Helm
         release: docker-registry
       name: registry
@@ -3800,7 +3800,7 @@ data:
       creationTimestamp: null
       labels:
         app: docker-registry
-        chart: docker-registry-1.16.0
+        chart: docker-registry-2.2.2
         heritage: Helm
         release: docker-registry
       name: registry
@@ -3812,7 +3812,7 @@ data:
       creationTimestamp: null
       labels:
         app: docker-registry
-        chart: docker-registry-1.16.0
+        chart: docker-registry-2.2.2
         heritage: Helm
         release: docker-registry
       name: registry
@@ -3827,7 +3827,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql
       namespace: default
     ---
@@ -3840,7 +3840,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql-headless
       namespace: default
     ---
@@ -3853,7 +3853,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql
       namespace: default
     ---
@@ -3866,7 +3866,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql
       namespace: default
     ---
@@ -3878,7 +3878,7 @@ data:
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: minio
-        helm.sh/chart: minio-11.6.3
+        helm.sh/chart: minio-11.10.24
       name: minio
       namespace: default
     ---
@@ -3890,7 +3890,7 @@ data:
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: minio
-        helm.sh/chart: minio-11.6.3
+        helm.sh/chart: minio-11.10.24
       name: minio
       namespace: default
     ---
@@ -3902,7 +3902,7 @@ data:
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: minio
-        helm.sh/chart: minio-11.6.3
+        helm.sh/chart: minio-11.10.24
       name: minio
       namespace: default
     ---
@@ -3914,7 +3914,7 @@ data:
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: minio
-        helm.sh/chart: minio-11.6.3
+        helm.sh/chart: minio-11.10.24
       name: minio
       namespace: default
     ---
@@ -3926,7 +3926,7 @@ data:
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: minio
-        helm.sh/chart: minio-11.6.3
+        helm.sh/chart: minio-11.10.24
       name: minio
       namespace: default
     ---
@@ -3938,7 +3938,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus
       namespace: default
     ---
@@ -3950,7 +3950,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus
       namespace: default
     ---
@@ -3962,7 +3962,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: rabbitmq
       namespace: default
     ---
@@ -3974,7 +3974,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus-config
       namespace: default
     ---
@@ -3986,7 +3986,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus
       namespace: default
     ---
@@ -3998,7 +3998,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: load-definition
       namespace: default
     ---
@@ -4010,7 +4010,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: rabbitmq
       namespace: default
     ---
@@ -4022,7 +4022,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus-endpoint-reader
       namespace: default
     ---
@@ -4034,7 +4034,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus-endpoint-reader
       namespace: default
     ---
@@ -4046,7 +4046,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus-headless
       namespace: default
     ---
@@ -4058,7 +4058,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus
       namespace: default
     ---
@@ -4070,7 +4070,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus
       namespace: default
     ---
@@ -5428,7 +5428,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
@@ -5445,7 +5445,7 @@ data:
     datadir=/bitnami/mysql/data
     tmpdir=/opt/bitnami/mysql/tmp
     max_allowed_packet=16M
-    bind-address=0.0.0.0
+    bind-address=*
     pid-file=/opt/bitnami/mysql/tmp/mysqld.pid
     log-error=/opt/bitnami/mysql/logs/mysqld.log
     character-set-server=UTF8
@@ -5615,7 +5615,7 @@ metadata:
   namespace: default
   labels:
     app: docker-registry
-    chart: docker-registry-1.16.0
+    chart: docker-registry-2.2.2
     heritage: Helm
     release: docker-registry
 data:
@@ -6452,7 +6452,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: minio
-    helm.sh/chart: minio-11.6.3
+    helm.sh/chart: minio-11.10.24
     app.kubernetes.io/instance: minio
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -6471,7 +6471,7 @@ metadata:
   namespace: default
   labels:
     app: registry
-    chart: "docker-registry-1.16.0"
+    chart: "docker-registry-2.2.2"
     release: "docker-registry"
     heritage: "Helm"
 spec:
@@ -7089,7 +7089,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 rules:
@@ -7470,7 +7470,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 subjects:
@@ -7963,7 +7963,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -8007,7 +8007,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -8042,7 +8042,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: minio
-    helm.sh/chart: minio-11.6.3
+    helm.sh/chart: minio-11.10.24
     app.kubernetes.io/instance: minio
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -8069,7 +8069,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
@@ -8097,11 +8097,10 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
-  annotations:
 spec:
   type: ClusterIP
   clusterIP: None
@@ -8215,7 +8214,7 @@ metadata:
   namespace: default
   labels:
     app: docker-registry
-    chart: docker-registry-1.16.0
+    chart: docker-registry-2.2.2
     release: docker-registry
     heritage: Helm
 spec:
@@ -9009,7 +9008,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -9026,12 +9025,12 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/config: 2ca9db593e4ca6cdd01f7a65cce1ae90d0d45ecdf0049edfaa4ec72302fcbe8f
-        checksum/secret: c231bbb08185305defa8c4da0f3ee0f5e7a16795362a2133f74e53eb9a40453d
+        checksum/config: d5780a0c58210a2062d54feb61cfb1d5a9c076f95569c4a77076d22c9bad4190
+        checksum/secret: 64c39dd3a8570ed4b0cc71bc0402bc814d016e16f68732938722b12a57c8e82c
         prometheus.io/port: '9419'
         prometheus.io/scrape: "true"
     spec:
@@ -9051,7 +9050,7 @@ spec:
       initContainers:
       containers:
         - name: rabbitmq
-          image: docker.io/bitnami/rabbitmq:3.10.2-debian-10-r7
+          image: docker.io/bitnami/rabbitmq:3.11.5-debian-11-r2
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true
@@ -9186,11 +9185,10 @@ spec:
               - key: tls.key
                 path: server_key.pem
         - name: configuration
-          secret:
-            secretName: messagebus-config
-            items:
-              - key: rabbitmq.conf
-                path: rabbitmq.conf
+          projected:
+            sources:
+              - secret:
+                  name: messagebus-config
         - name: load-definition-volume
           secret:
             secretName: "load-definition"
@@ -9206,7 +9204,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
@@ -9224,10 +9222,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/configuration: 11b8361c0fbf695cec6ec7f47ed4118ad3c7d71a391ca246df129803d3e205a5
+        checksum/configuration: 0c1e0d4282c8f8f820f3c9d1d79b3f423c4676afac2e3a6de555f8553f146eb4
       labels:
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: primary
@@ -9246,7 +9244,7 @@ spec:
         fsGroup: 1001
       initContainers:
         - name: volume-permissions
-          image: docker.io/bitnami/bitnami-shell:10-debian-10-r431
+          image: docker.io/bitnami/bitnami-shell:11-debian-11-r60
           imagePullPolicy: "IfNotPresent"
           command:
             - /bin/bash
@@ -10531,7 +10529,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: minio
-    helm.sh/chart: minio-11.6.3
+    helm.sh/chart: minio-11.10.24
     app.kubernetes.io/instance: minio
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -10545,11 +10543,11 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: minio
-        helm.sh/chart: minio-11.6.3
+        helm.sh/chart: minio-11.10.24
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/credentials-secret: 094325f216720012cacde9f52fd71c7e8b06dd6386492f6980e0f3588f1b1e7c
+        checksum/credentials-secret: 0f3ceb92b9779df4ce0927f6faeb23e9116b85e0eabe095d903e46a2770cde42
     spec:
       
       serviceAccountName: minio
@@ -10565,7 +10563,7 @@ spec:
         fsGroup: 1001
       containers:
         - name: minio
-          image: docker.io/bitnami/minio:2022.5.26-debian-10-r0
+          image: docker.io/bitnami/minio:2022.12.12-debian-11-r0
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true
@@ -10991,7 +10989,7 @@ metadata:
   namespace: default
   labels:
     app: docker-registry
-    chart: docker-registry-1.16.0
+    chart: docker-registry-2.2.2
     release: docker-registry
     heritage: Helm
 spec:
@@ -11007,7 +11005,9 @@ spec:
         app: docker-registry
         release: docker-registry
       annotations:
-        checksum/config: 1d22b82e19bbc654e029029c4fb86ad02dc13422dc3ac52f8175ad190e52a0bb
+        checksum/config: 699dd382179068f3354c330fcce38625e2861d97b962074b4f57005d40497b00
+        checksum/secret: 450f59aeda22415409a87a1abd2c033c08ebd5fb54fe24d3c56560e92b0218f6
+        
         gitpod.io/checksum_config: 1c66f4ccdb7f6331da2edaecefcb40f6c1b6315c9277eb0418fef3cc584a28bd
     spec:
       serviceAccountName: docker-registry
@@ -11016,7 +11016,7 @@ spec:
         runAsUser: 1000
       containers:
         - name: docker-registry
-          image: "docker.io/library/registry:2.7.1"
+          image: "docker.io/library/registry:2.8.1"
           imagePullPolicy: IfNotPresent
           command:
           - /bin/registry
@@ -11034,9 +11034,9 @@ spec:
               scheme: HTTPS
               path: /
               port: 5000
-          resources:
+          resources: 
             {}
-          env:
+          env: 
             - name: REGISTRY_HTTP_SECRET
               valueFrom:
                 secretKeyRef:
@@ -11048,21 +11048,21 @@ spec:
               value: /etc/ssl/docker/tls.key
             - name: REGISTRY_STORAGE_FILESYSTEM_ROOTDIRECTORY
               value: "/var/lib/registry"
-          volumeMounts:
-            - name: data
-              mountPath: /var/lib/registry/
+          volumeMounts: 
             - name: "registry-config"
               mountPath: "/etc/docker/registry"
+            - name: data
+              mountPath: /var/lib/registry/
             - mountPath: /etc/ssl/docker
               name: tls-cert
               readOnly: true
-      volumes:
-        - name: data
-          persistentVolumeClaim:
-            claimName: registry
+      volumes: 
         - name: registry-config
           configMap:
             name: registry-config
+        - name: data
+          persistentVolumeClaim:
+            claimName: registry
         - name: tls-cert
           secret:
             secretName: builtin-registry-certs

--- a/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
+++ b/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
@@ -208,7 +208,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -783,7 +783,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -958,7 +958,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: minio
-    helm.sh/chart: minio-11.6.3
+    helm.sh/chart: minio-11.10.24
     app.kubernetes.io/instance: minio
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
@@ -1022,7 +1022,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
@@ -1152,7 +1152,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1168,7 +1168,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1199,13 +1199,13 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
 data:
   rabbitmq.conf: |-
-    IyMgVXNlcm5hbWUgYW5kIHBhc3N3b3JkCiMjCmRlZmF1bHRfdXNlciA9IGdpdHBvZApkZWZhdWx0X3Bhc3MgPSBDSEFOR0VNRQojIyBDbHVzdGVyaW5nCiMjCmNsdXN0ZXJfZm9ybWF0aW9uLnBlZXJfZGlzY292ZXJ5X2JhY2tlbmQgID0gcmFiYml0X3BlZXJfZGlzY292ZXJ5X2s4cwpjbHVzdGVyX2Zvcm1hdGlvbi5rOHMuaG9zdCA9IGt1YmVybmV0ZXMuZGVmYXVsdApjbHVzdGVyX2Zvcm1hdGlvbi5ub2RlX2NsZWFudXAuaW50ZXJ2YWwgPSAxMApjbHVzdGVyX2Zvcm1hdGlvbi5ub2RlX2NsZWFudXAub25seV9sb2dfd2FybmluZyA9IHRydWUKY2x1c3Rlcl9wYXJ0aXRpb25faGFuZGxpbmcgPSBhdXRvaGVhbApsb2FkX2RlZmluaXRpb25zID0gL2FwcC9sb2FkX2RlZmluaXRpb24uanNvbgojIHF1ZXVlIG1hc3RlciBsb2NhdG9yCnF1ZXVlX21hc3Rlcl9sb2NhdG9yID0gbWluLW1hc3RlcnMKIyBlbmFibGUgZ3Vlc3QgdXNlcgpsb29wYmFja191c2Vycy5ndWVzdCA9IGZhbHNlCmxvYWRfZGVmaW5pdGlvbnMgPSAvYXBwL2xvYWRfZGVmaW5pdGlvbi5qc29uCiMgSW5jcmVhc2Ugc3RhdGlzdGljcyBlbWlzc2lvbiBpbnRlcnZhbCBodHRwczovL3d3dy5yYWJiaXRtcS5jb20vbWFuYWdlbWVudC5odG1sI3N0YXRpc3RpY3MtaW50ZXJ2YWwKY29sbGVjdF9zdGF0aXN0aWNzX2ludGVydmFsID0gMTUwMDAKCnNzbF9vcHRpb25zLnZlcmlmeSA9IHZlcmlmeV9wZWVyCmxpc3RlbmVycy5zc2wuZGVmYXVsdCA9IDU2NzEKc3NsX29wdGlvbnMuZmFpbF9pZl9ub19wZWVyX2NlcnQgPSB0cnVlCnNzbF9vcHRpb25zLmNhY2VydGZpbGUgPSAvb3B0L2JpdG5hbWkvcmFiYml0bXEvY2VydHMvY2FfY2VydGlmaWNhdGUucGVtCnNzbF9vcHRpb25zLmNlcnRmaWxlID0gL29wdC9iaXRuYW1pL3JhYmJpdG1xL2NlcnRzL3NlcnZlcl9jZXJ0aWZpY2F0ZS5wZW0Kc3NsX29wdGlvbnMua2V5ZmlsZSA9IC9vcHQvYml0bmFtaS9yYWJiaXRtcS9jZXJ0cy9zZXJ2ZXJfa2V5LnBlbQojIyBQcm9tZXRoZXVzIG1ldHJpY3MKIyMKcHJvbWV0aGV1cy50Y3AucG9ydCA9IDk0MTk=
+    IyMgVXNlcm5hbWUgYW5kIHBhc3N3b3JkCiMjCmRlZmF1bHRfdXNlciA9IGdpdHBvZAojIyBDbHVzdGVyaW5nCiMjCmNsdXN0ZXJfZm9ybWF0aW9uLnBlZXJfZGlzY292ZXJ5X2JhY2tlbmQgID0gcmFiYml0X3BlZXJfZGlzY292ZXJ5X2s4cwpjbHVzdGVyX2Zvcm1hdGlvbi5rOHMuaG9zdCA9IGt1YmVybmV0ZXMuZGVmYXVsdApjbHVzdGVyX2Zvcm1hdGlvbi5ub2RlX2NsZWFudXAuaW50ZXJ2YWwgPSAxMApjbHVzdGVyX2Zvcm1hdGlvbi5ub2RlX2NsZWFudXAub25seV9sb2dfd2FybmluZyA9IHRydWUKY2x1c3Rlcl9wYXJ0aXRpb25faGFuZGxpbmcgPSBhdXRvaGVhbApsb2FkX2RlZmluaXRpb25zID0gL2FwcC9sb2FkX2RlZmluaXRpb24uanNvbgojIHF1ZXVlIG1hc3RlciBsb2NhdG9yCnF1ZXVlX21hc3Rlcl9sb2NhdG9yID0gbWluLW1hc3RlcnMKIyBlbmFibGUgZ3Vlc3QgdXNlcgpsb29wYmFja191c2Vycy5ndWVzdCA9IGZhbHNlCmxvYWRfZGVmaW5pdGlvbnMgPSAvYXBwL2xvYWRfZGVmaW5pdGlvbi5qc29uCiMgSW5jcmVhc2Ugc3RhdGlzdGljcyBlbWlzc2lvbiBpbnRlcnZhbCBodHRwczovL3d3dy5yYWJiaXRtcS5jb20vbWFuYWdlbWVudC5odG1sI3N0YXRpc3RpY3MtaW50ZXJ2YWwKY29sbGVjdF9zdGF0aXN0aWNzX2ludGVydmFsID0gMTUwMDAKCnNzbF9vcHRpb25zLnZlcmlmeSA9IHZlcmlmeV9wZWVyCmxpc3RlbmVycy5zc2wuZGVmYXVsdCA9IDU2NzEKc3NsX29wdGlvbnMuZmFpbF9pZl9ub19wZWVyX2NlcnQgPSB0cnVlCnNzbF9vcHRpb25zLmNhY2VydGZpbGUgPSAvb3B0L2JpdG5hbWkvcmFiYml0bXEvY2VydHMvY2FfY2VydGlmaWNhdGUucGVtCnNzbF9vcHRpb25zLmNlcnRmaWxlID0gL29wdC9iaXRuYW1pL3JhYmJpdG1xL2NlcnRzL3NlcnZlcl9jZXJ0aWZpY2F0ZS5wZW0Kc3NsX29wdGlvbnMua2V5ZmlsZSA9IC9vcHQvYml0bmFtaS9yYWJiaXRtcS9jZXJ0cy9zZXJ2ZXJfa2V5LnBlbQojIyBQcm9tZXRoZXVzIG1ldHJpY3MKIyMKcHJvbWV0aGV1cy50Y3AucG9ydCA9IDk0MTk=
 ---
 # v1/Secret messagebus-erlang-cookie
 apiVersion: v1
@@ -1229,7 +1229,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: minio
-    helm.sh/chart: minio-11.6.3
+    helm.sh/chart: minio-11.10.24
     app.kubernetes.io/instance: minio
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1265,7 +1265,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1282,7 +1282,7 @@ metadata:
   namespace: default
   labels:
     app: docker-registry
-    chart: docker-registry-1.16.0
+    chart: docker-registry-2.2.2
     heritage: Helm
     release: docker-registry
 type: Opaque
@@ -3433,7 +3433,7 @@ data:
       creationTimestamp: null
       labels:
         app: docker-registry
-        chart: docker-registry-1.16.0
+        chart: docker-registry-2.2.2
         heritage: Helm
         release: docker-registry
       name: registry-secret
@@ -3445,7 +3445,7 @@ data:
       creationTimestamp: null
       labels:
         app: docker-registry
-        chart: docker-registry-1.16.0
+        chart: docker-registry-2.2.2
         heritage: Helm
         release: docker-registry
       name: registry-config
@@ -3457,7 +3457,7 @@ data:
       creationTimestamp: null
       labels:
         app: registry
-        chart: docker-registry-1.16.0
+        chart: docker-registry-2.2.2
         heritage: Helm
         release: docker-registry
       name: registry
@@ -3469,7 +3469,7 @@ data:
       creationTimestamp: null
       labels:
         app: docker-registry
-        chart: docker-registry-1.16.0
+        chart: docker-registry-2.2.2
         heritage: Helm
         release: docker-registry
       name: registry
@@ -3481,7 +3481,7 @@ data:
       creationTimestamp: null
       labels:
         app: docker-registry
-        chart: docker-registry-1.16.0
+        chart: docker-registry-2.2.2
         heritage: Helm
         release: docker-registry
       name: registry
@@ -3496,7 +3496,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql
       namespace: default
     ---
@@ -3509,7 +3509,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql-headless
       namespace: default
     ---
@@ -3522,7 +3522,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql
       namespace: default
     ---
@@ -3535,7 +3535,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql
       namespace: default
     ---
@@ -3547,7 +3547,7 @@ data:
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: minio
-        helm.sh/chart: minio-11.6.3
+        helm.sh/chart: minio-11.10.24
       name: minio
       namespace: default
     ---
@@ -3559,7 +3559,7 @@ data:
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: minio
-        helm.sh/chart: minio-11.6.3
+        helm.sh/chart: minio-11.10.24
       name: minio
       namespace: default
     ---
@@ -3571,7 +3571,7 @@ data:
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: minio
-        helm.sh/chart: minio-11.6.3
+        helm.sh/chart: minio-11.10.24
       name: minio
       namespace: default
     ---
@@ -3583,7 +3583,7 @@ data:
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: minio
-        helm.sh/chart: minio-11.6.3
+        helm.sh/chart: minio-11.10.24
       name: minio
       namespace: default
     ---
@@ -3595,7 +3595,7 @@ data:
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: minio
-        helm.sh/chart: minio-11.6.3
+        helm.sh/chart: minio-11.10.24
       name: minio
       namespace: default
     ---
@@ -3607,7 +3607,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus
       namespace: default
     ---
@@ -3619,7 +3619,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus
       namespace: default
     ---
@@ -3631,7 +3631,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: rabbitmq
       namespace: default
     ---
@@ -3643,7 +3643,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus-config
       namespace: default
     ---
@@ -3655,7 +3655,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus
       namespace: default
     ---
@@ -3667,7 +3667,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: load-definition
       namespace: default
     ---
@@ -3679,7 +3679,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: rabbitmq
       namespace: default
     ---
@@ -3691,7 +3691,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus-endpoint-reader
       namespace: default
     ---
@@ -3703,7 +3703,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus-endpoint-reader
       namespace: default
     ---
@@ -3715,7 +3715,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus-headless
       namespace: default
     ---
@@ -3727,7 +3727,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus
       namespace: default
     ---
@@ -3739,7 +3739,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus
       namespace: default
     ---
@@ -5097,7 +5097,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
@@ -5114,7 +5114,7 @@ data:
     datadir=/bitnami/mysql/data
     tmpdir=/opt/bitnami/mysql/tmp
     max_allowed_packet=16M
-    bind-address=0.0.0.0
+    bind-address=*
     pid-file=/opt/bitnami/mysql/tmp/mysqld.pid
     log-error=/opt/bitnami/mysql/logs/mysqld.log
     character-set-server=UTF8
@@ -5284,7 +5284,7 @@ metadata:
   namespace: default
   labels:
     app: docker-registry
-    chart: docker-registry-1.16.0
+    chart: docker-registry-2.2.2
     heritage: Helm
     release: docker-registry
 data:
@@ -6121,7 +6121,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: minio
-    helm.sh/chart: minio-11.6.3
+    helm.sh/chart: minio-11.10.24
     app.kubernetes.io/instance: minio
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -6140,7 +6140,7 @@ metadata:
   namespace: default
   labels:
     app: registry
-    chart: "docker-registry-1.16.0"
+    chart: "docker-registry-2.2.2"
     release: "docker-registry"
     heritage: "Helm"
 spec:
@@ -6667,7 +6667,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 rules:
@@ -7028,7 +7028,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 subjects:
@@ -7521,7 +7521,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -7565,7 +7565,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -7600,7 +7600,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: minio
-    helm.sh/chart: minio-11.6.3
+    helm.sh/chart: minio-11.10.24
     app.kubernetes.io/instance: minio
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -7627,7 +7627,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
@@ -7655,11 +7655,10 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
-  annotations:
 spec:
   type: ClusterIP
   clusterIP: None
@@ -7773,7 +7772,7 @@ metadata:
   namespace: default
   labels:
     app: docker-registry
-    chart: docker-registry-1.16.0
+    chart: docker-registry-2.2.2
     release: docker-registry
     heritage: Helm
 spec:
@@ -8567,7 +8566,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -8584,12 +8583,12 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/config: 2ca9db593e4ca6cdd01f7a65cce1ae90d0d45ecdf0049edfaa4ec72302fcbe8f
-        checksum/secret: c231bbb08185305defa8c4da0f3ee0f5e7a16795362a2133f74e53eb9a40453d
+        checksum/config: d5780a0c58210a2062d54feb61cfb1d5a9c076f95569c4a77076d22c9bad4190
+        checksum/secret: 64c39dd3a8570ed4b0cc71bc0402bc814d016e16f68732938722b12a57c8e82c
         prometheus.io/port: '9419'
         prometheus.io/scrape: "true"
     spec:
@@ -8609,7 +8608,7 @@ spec:
       initContainers:
       containers:
         - name: rabbitmq
-          image: docker.io/bitnami/rabbitmq:3.10.2-debian-10-r7
+          image: docker.io/bitnami/rabbitmq:3.11.5-debian-11-r2
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true
@@ -8744,11 +8743,10 @@ spec:
               - key: tls.key
                 path: server_key.pem
         - name: configuration
-          secret:
-            secretName: messagebus-config
-            items:
-              - key: rabbitmq.conf
-                path: rabbitmq.conf
+          projected:
+            sources:
+              - secret:
+                  name: messagebus-config
         - name: load-definition-volume
           secret:
             secretName: "load-definition"
@@ -8764,7 +8762,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
@@ -8782,10 +8780,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/configuration: 11b8361c0fbf695cec6ec7f47ed4118ad3c7d71a391ca246df129803d3e205a5
+        checksum/configuration: 0c1e0d4282c8f8f820f3c9d1d79b3f423c4676afac2e3a6de555f8553f146eb4
       labels:
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: primary
@@ -8804,7 +8802,7 @@ spec:
         fsGroup: 1001
       initContainers:
         - name: volume-permissions
-          image: docker.io/bitnami/bitnami-shell:10-debian-10-r431
+          image: docker.io/bitnami/bitnami-shell:11-debian-11-r60
           imagePullPolicy: "IfNotPresent"
           command:
             - /bin/bash
@@ -10077,7 +10075,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: minio
-    helm.sh/chart: minio-11.6.3
+    helm.sh/chart: minio-11.10.24
     app.kubernetes.io/instance: minio
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -10091,11 +10089,11 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: minio
-        helm.sh/chart: minio-11.6.3
+        helm.sh/chart: minio-11.10.24
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/credentials-secret: 094325f216720012cacde9f52fd71c7e8b06dd6386492f6980e0f3588f1b1e7c
+        checksum/credentials-secret: 0f3ceb92b9779df4ce0927f6faeb23e9116b85e0eabe095d903e46a2770cde42
     spec:
       
       serviceAccountName: minio
@@ -10111,7 +10109,7 @@ spec:
         fsGroup: 1001
       containers:
         - name: minio
-          image: docker.io/bitnami/minio:2022.5.26-debian-10-r0
+          image: docker.io/bitnami/minio:2022.12.12-debian-11-r0
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true
@@ -10537,7 +10535,7 @@ metadata:
   namespace: default
   labels:
     app: docker-registry
-    chart: docker-registry-1.16.0
+    chart: docker-registry-2.2.2
     release: docker-registry
     heritage: Helm
 spec:
@@ -10553,7 +10551,9 @@ spec:
         app: docker-registry
         release: docker-registry
       annotations:
-        checksum/config: 1d22b82e19bbc654e029029c4fb86ad02dc13422dc3ac52f8175ad190e52a0bb
+        checksum/config: 699dd382179068f3354c330fcce38625e2861d97b962074b4f57005d40497b00
+        checksum/secret: 450f59aeda22415409a87a1abd2c033c08ebd5fb54fe24d3c56560e92b0218f6
+        
         gitpod.io/checksum_config: 1c66f4ccdb7f6331da2edaecefcb40f6c1b6315c9277eb0418fef3cc584a28bd
     spec:
       serviceAccountName: docker-registry
@@ -10562,7 +10562,7 @@ spec:
         runAsUser: 1000
       containers:
         - name: docker-registry
-          image: "docker.io/library/registry:2.7.1"
+          image: "docker.io/library/registry:2.8.1"
           imagePullPolicy: IfNotPresent
           command:
           - /bin/registry
@@ -10580,9 +10580,9 @@ spec:
               scheme: HTTPS
               path: /
               port: 5000
-          resources:
+          resources: 
             {}
-          env:
+          env: 
             - name: REGISTRY_HTTP_SECRET
               valueFrom:
                 secretKeyRef:
@@ -10594,21 +10594,21 @@ spec:
               value: /etc/ssl/docker/tls.key
             - name: REGISTRY_STORAGE_FILESYSTEM_ROOTDIRECTORY
               value: "/var/lib/registry"
-          volumeMounts:
-            - name: data
-              mountPath: /var/lib/registry/
+          volumeMounts: 
             - name: "registry-config"
               mountPath: "/etc/docker/registry"
+            - name: data
+              mountPath: /var/lib/registry/
             - mountPath: /etc/ssl/docker
               name: tls-cert
               readOnly: true
-      volumes:
-        - name: data
-          persistentVolumeClaim:
-            claimName: registry
+      volumes: 
         - name: registry-config
           configMap:
             name: registry-config
+        - name: data
+          persistentVolumeClaim:
+            claimName: registry
         - name: tls-cert
           secret:
             secretName: builtin-registry-certs

--- a/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
+++ b/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
@@ -1116,9 +1116,9 @@ metadata:
 # v1/Secret builtin-registry-auth
 apiVersion: v1
 data:
-  .dockerconfigjson: eyJhdXRocyI6eyJyZWdpc3RyeS5naXRwb2QuZXhhbXBsZS5jb20iOnsiYXV0aCI6ImVGTmxaRXBwUkdkS1VWRm5ORUpyVnpWNFMzVTZRMWMwUTFKQ2FtazJVakJpUjBjNE1XZDVSWGs9In19fQ==
-  password: Q1c0Q1JCamk2UjBiR0c4MWd5RXk=
-  user: eFNlZEppRGdKUVFnNEJrVzV4S3U=
+  .dockerconfigjson: eyJhdXRocyI6eyJyZWdpc3RyeS5naXRwb2QuZXhhbXBsZS5jb20iOnsiYXV0aCI6ImVIZDVRMGRsTlZVd1RrRnFObFZsYVhFM1RqQTZWbE5UYkcxaFMxZFFhaTVRVVhCdFZXWnNWR1E9In19fQ==
+  password: VlNTbG1hS1dQai5QUXBtVWZsVGQ=
+  user: eHd5Q0dlNVUwTkFqNlVlaXE3TjA=
 kind: Secret
 metadata:
   creationTimestamp: null
@@ -1234,8 +1234,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 type: Opaque
 data:
-  root-user: "OC1XR3F3Mm9UbnNQZlVETlNrMFk="
-  root-password: "RHBDLmFTQXhrV0JQdTJfYkpfQUU="
+  root-user: "UkJqaTZSMGJHRzgxZ3lFeWUyNVA="
+  root-password: "dFg2TUw4Z0NXMzFtaXcwVDhRTUk="
   key.json: ""
 ---
 # v1/Secret mysql
@@ -1430,9 +1430,9 @@ data:
         },
         "minio": {
           "endpoint": "minio.default.svc.cluster.local:9000",
-          "accessKey": "8-WGqw2oTnsPfUDNSk0Y",
+          "accessKey": "RBji6R0bGG81gyEye25P",
           "accessKeyFile": "",
-          "secretKey": "DpC.aSAxkWBPu2_bJ_AE",
+          "secretKey": "tX6ML8gCW31miw0T8QMI",
           "secretKeyFile": "",
           "region": "local",
           "parallelUpload": 6
@@ -5172,7 +5172,7 @@ data:
         import ssl_configuration
 
         basicauth bcrypt "Docker Registry" {
-            xSedJiDgJQQg4BkW5xKu JDJhJDEwJFFTRGRRMHZZY2pIS2JqUC9aMDNnVC5HbEg2Z1dOQm5TL0pySnpYSm5iNy9DeVh0ZUw2cFM2
+            xwyCGe5U0NAj6Ueiq7N0 JDJhJDEwJFFTRGRRMHZZY2pIS2JqUC9aMDNnVC5CY0M3RDZsVVg0LzBpZmdnTGovT0VVWXoxTG8ud0lX
         }
 
         reverse_proxy https://registry.default.svc.cluster.local {
@@ -5443,7 +5443,7 @@ data:
       },
       "oauthServer": {
         "enabled": true,
-        "jwtSecret": "8QMIxwyCGe5U0NAj6Uei"
+        "jwtSecret": "m30EH-M2-cWMgkgdy7pu"
       },
       "rateLimiter": {
         "groups": {
@@ -5773,9 +5773,9 @@ data:
             },
             "minio": {
               "endpoint": "minio.default.svc.cluster.local:9000",
-              "accessKey": "8-WGqw2oTnsPfUDNSk0Y",
+              "accessKey": "RBji6R0bGG81gyEye25P",
               "accessKeyFile": "",
-              "secretKey": "DpC.aSAxkWBPu2_bJ_AE",
+              "secretKey": "tX6ML8gCW31miw0T8QMI",
               "secretKeyFile": "",
               "region": "local",
               "parallelUpload": 6
@@ -5957,9 +5957,9 @@ data:
           },
           "minio": {
             "endpoint": "minio.default.svc.cluster.local:9000",
-            "accessKey": "8-WGqw2oTnsPfUDNSk0Y",
+            "accessKey": "RBji6R0bGG81gyEye25P",
             "accessKeyFile": "",
-            "secretKey": "DpC.aSAxkWBPu2_bJ_AE",
+            "secretKey": "tX6ML8gCW31miw0T8QMI",
             "secretKeyFile": "",
             "region": "local",
             "parallelUpload": 6
@@ -8070,7 +8070,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3e487f9543c719b9ee3f5590a0f98cb535b4bf1b301c66de8f00f3aa9d61381d
+        gitpod.io/checksum_config: 3e7db160db71491d8d16b0423783bf99a0dc293dc723960c9308756bdde69d3b
       creationTimestamp: null
       labels:
         app: gitpod
@@ -8287,7 +8287,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: b938c6e286051c22b503c29f5de266741c2045a3ed69be85d7fd9f22a9346254
+        gitpod.io/checksum_config: 2a29ef265c219405bda658cb21613f40ad5e692590d2779476a3ff90917ed6fb
         seccomp.security.alpha.kubernetes.io/shiftfs-module-loader: unconfined
       creationTimestamp: null
       labels:
@@ -9074,7 +9074,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: cac138904f08d79e5598805683f8dc378bd52c58348489de22949ac38dd8b193
+        gitpod.io/checksum_config: 0d9d1c68723466a253996f0a96bf0682ce57b89ebcb4ae1e4a643dd788ef1cab
       creationTimestamp: null
       labels:
         app: gitpod
@@ -9215,7 +9215,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 20782435cc6d6e080cf720b57dca8d4d5cfe40942fc71c4bfd54934fdc34c766
+        gitpod.io/checksum_config: 21ad538d4c7daef6619e5dda6fd71a49a5e5b551f0fc1365d3b7db1d1f38f9ce
       creationTimestamp: null
       labels:
         app: gitpod
@@ -9942,7 +9942,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: af26ec864db5be86adfb79b972614487639aa67ad16de869e23e22e468f0bed8
+        gitpod.io/checksum_config: 3b0478b4bb4feb7b7a29bc33bf4ec99671df4dcbd9529778de375c72e78df64c
       creationTimestamp: null
       labels:
         app: gitpod
@@ -10095,7 +10095,7 @@ spec:
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/credentials-secret: 0a5790906818b3f8eeee0bd3b3e990b3ad02d79bb23c62c0d91a4ca010fb5579
+        checksum/credentials-secret: 094325f216720012cacde9f52fd71c7e8b06dd6386492f6980e0f3588f1b1e7c
     spec:
       
       serviceAccountName: minio
@@ -10203,7 +10203,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: c52c73e63eaa95613a8f4fe77167c754cd48eaf757dd69c2048400311a5ae0a6
+        gitpod.io/checksum_config: a7bd71558cb04a04656bafe7651d4192a9d37be96d2d817f9b6225f63e3a6989
       creationTimestamp: null
       labels:
         app: gitpod
@@ -10554,7 +10554,7 @@ spec:
         release: docker-registry
       annotations:
         checksum/config: 1d22b82e19bbc654e029029c4fb86ad02dc13422dc3ac52f8175ad190e52a0bb
-        gitpod.io/checksum_config: 0ce55d51677cd683df3c7a244542c6aeaaf5dd6dca0f0458e8053a713228f535
+        gitpod.io/checksum_config: 1c66f4ccdb7f6331da2edaecefcb40f6c1b6315c9277eb0418fef3cc584a28bd
     spec:
       serviceAccountName: docker-registry
       securityContext:
@@ -10637,7 +10637,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 726dafd8c59907accd3250e873f40d6e59d6913f82b7198335bc6c24ae2e7db1
+        gitpod.io/checksum_config: f52ae23eddcf2fe15c87ec92cc3d998045c5ff491d52caed0f23a6fccc020134
       creationTimestamp: null
       labels:
         app: gitpod
@@ -10918,7 +10918,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 62fb425bd7800391dca7d008cd0c86cab613afef78e188a950e367ed7429ad73
+        gitpod.io/checksum_config: 21c3b53bac44cf0f98bc57e43353e3136dc5806409951038c2ba36aea69dd218
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
+++ b/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
@@ -1116,9 +1116,9 @@ metadata:
 # v1/Secret builtin-registry-auth
 apiVersion: v1
 data:
-  .dockerconfigjson: eyJhdXRocyI6eyJyZWdpc3RyeS5naXRwb2QuZXhhbXBsZS5jb20iOnsiYXV0aCI6ImVGTmxaRXBwUkdkS1VWRm5ORUpyVnpWNFMzVTZRMWMwUTFKQ2FtazJVakJpUjBjNE1XZDVSWGs9In19fQ==
-  password: Q1c0Q1JCamk2UjBiR0c4MWd5RXk=
-  user: eFNlZEppRGdKUVFnNEJrVzV4S3U=
+  .dockerconfigjson: eyJhdXRocyI6eyJyZWdpc3RyeS5naXRwb2QuZXhhbXBsZS5jb20iOnsiYXV0aCI6ImVIZDVRMGRsTlZVd1RrRnFObFZsYVhFM1RqQTZWbE5UYkcxaFMxZFFhaTVRVVhCdFZXWnNWR1E9In19fQ==
+  password: VlNTbG1hS1dQai5QUXBtVWZsVGQ=
+  user: eHd5Q0dlNVUwTkFqNlVlaXE3TjA=
 kind: Secret
 metadata:
   creationTimestamp: null
@@ -1234,8 +1234,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 type: Opaque
 data:
-  root-user: "OC1XR3F3Mm9UbnNQZlVETlNrMFk="
-  root-password: "RHBDLmFTQXhrV0JQdTJfYkpfQUU="
+  root-user: "UkJqaTZSMGJHRzgxZ3lFeWUyNVA="
+  root-password: "dFg2TUw4Z0NXMzFtaXcwVDhRTUk="
   key.json: ""
 ---
 # v1/Secret mysql
@@ -1430,9 +1430,9 @@ data:
         },
         "minio": {
           "endpoint": "minio.default.svc.cluster.local:9000",
-          "accessKey": "8-WGqw2oTnsPfUDNSk0Y",
+          "accessKey": "RBji6R0bGG81gyEye25P",
           "accessKeyFile": "",
-          "secretKey": "DpC.aSAxkWBPu2_bJ_AE",
+          "secretKey": "tX6ML8gCW31miw0T8QMI",
           "secretKeyFile": "",
           "region": "local",
           "parallelUpload": 6
@@ -5173,7 +5173,7 @@ data:
         import ssl_configuration
 
         basicauth bcrypt "Docker Registry" {
-            xSedJiDgJQQg4BkW5xKu JDJhJDEwJFFTRGRRMHZZY2pIS2JqUC9aMDNnVC5HbEg2Z1dOQm5TL0pySnpYSm5iNy9DeVh0ZUw2cFM2
+            xwyCGe5U0NAj6Ueiq7N0 JDJhJDEwJFFTRGRRMHZZY2pIS2JqUC9aMDNnVC5CY0M3RDZsVVg0LzBpZmdnTGovT0VVWXoxTG8ud0lX
         }
 
         reverse_proxy https://registry.default.svc.cluster.local {
@@ -5444,7 +5444,7 @@ data:
       },
       "oauthServer": {
         "enabled": true,
-        "jwtSecret": "8QMIxwyCGe5U0NAj6Uei"
+        "jwtSecret": "m30EH-M2-cWMgkgdy7pu"
       },
       "rateLimiter": {
         "groups": {
@@ -5774,9 +5774,9 @@ data:
             },
             "minio": {
               "endpoint": "minio.default.svc.cluster.local:9000",
-              "accessKey": "8-WGqw2oTnsPfUDNSk0Y",
+              "accessKey": "RBji6R0bGG81gyEye25P",
               "accessKeyFile": "",
-              "secretKey": "DpC.aSAxkWBPu2_bJ_AE",
+              "secretKey": "tX6ML8gCW31miw0T8QMI",
               "secretKeyFile": "",
               "region": "local",
               "parallelUpload": 6
@@ -5958,9 +5958,9 @@ data:
           },
           "minio": {
             "endpoint": "minio.default.svc.cluster.local:9000",
-            "accessKey": "8-WGqw2oTnsPfUDNSk0Y",
+            "accessKey": "RBji6R0bGG81gyEye25P",
             "accessKeyFile": "",
-            "secretKey": "DpC.aSAxkWBPu2_bJ_AE",
+            "secretKey": "tX6ML8gCW31miw0T8QMI",
             "secretKeyFile": "",
             "region": "local",
             "parallelUpload": 6
@@ -8071,7 +8071,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3e487f9543c719b9ee3f5590a0f98cb535b4bf1b301c66de8f00f3aa9d61381d
+        gitpod.io/checksum_config: 3e7db160db71491d8d16b0423783bf99a0dc293dc723960c9308756bdde69d3b
       creationTimestamp: null
       labels:
         app: gitpod
@@ -8288,7 +8288,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: b938c6e286051c22b503c29f5de266741c2045a3ed69be85d7fd9f22a9346254
+        gitpod.io/checksum_config: 2a29ef265c219405bda658cb21613f40ad5e692590d2779476a3ff90917ed6fb
         seccomp.security.alpha.kubernetes.io/shiftfs-module-loader: unconfined
       creationTimestamp: null
       labels:
@@ -9087,7 +9087,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: cac138904f08d79e5598805683f8dc378bd52c58348489de22949ac38dd8b193
+        gitpod.io/checksum_config: 0d9d1c68723466a253996f0a96bf0682ce57b89ebcb4ae1e4a643dd788ef1cab
       creationTimestamp: null
       labels:
         app: gitpod
@@ -9228,7 +9228,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 20782435cc6d6e080cf720b57dca8d4d5cfe40942fc71c4bfd54934fdc34c766
+        gitpod.io/checksum_config: 21ad538d4c7daef6619e5dda6fd71a49a5e5b551f0fc1365d3b7db1d1f38f9ce
       creationTimestamp: null
       labels:
         app: gitpod
@@ -9955,7 +9955,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: af26ec864db5be86adfb79b972614487639aa67ad16de869e23e22e468f0bed8
+        gitpod.io/checksum_config: 3b0478b4bb4feb7b7a29bc33bf4ec99671df4dcbd9529778de375c72e78df64c
       creationTimestamp: null
       labels:
         app: gitpod
@@ -10108,7 +10108,7 @@ spec:
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/credentials-secret: 0a5790906818b3f8eeee0bd3b3e990b3ad02d79bb23c62c0d91a4ca010fb5579
+        checksum/credentials-secret: 094325f216720012cacde9f52fd71c7e8b06dd6386492f6980e0f3588f1b1e7c
     spec:
       
       serviceAccountName: minio
@@ -10216,7 +10216,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: c52c73e63eaa95613a8f4fe77167c754cd48eaf757dd69c2048400311a5ae0a6
+        gitpod.io/checksum_config: a7bd71558cb04a04656bafe7651d4192a9d37be96d2d817f9b6225f63e3a6989
       creationTimestamp: null
       labels:
         app: gitpod
@@ -10567,7 +10567,7 @@ spec:
         release: docker-registry
       annotations:
         checksum/config: 1d22b82e19bbc654e029029c4fb86ad02dc13422dc3ac52f8175ad190e52a0bb
-        gitpod.io/checksum_config: 0ce55d51677cd683df3c7a244542c6aeaaf5dd6dca0f0458e8053a713228f535
+        gitpod.io/checksum_config: 1c66f4ccdb7f6331da2edaecefcb40f6c1b6315c9277eb0418fef3cc584a28bd
     spec:
       serviceAccountName: docker-registry
       securityContext:
@@ -10650,7 +10650,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 726dafd8c59907accd3250e873f40d6e59d6913f82b7198335bc6c24ae2e7db1
+        gitpod.io/checksum_config: f52ae23eddcf2fe15c87ec92cc3d998045c5ff491d52caed0f23a6fccc020134
       creationTimestamp: null
       labels:
         app: gitpod
@@ -10931,7 +10931,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 298563e7c37240295bf1c4e80327389892858aa3339c84b06de7cc454947cafb
+        gitpod.io/checksum_config: 94faf3d35267d731390a04ac48ef44a66d93a2308c6d41b78fb238a7e78ecdf2
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
+++ b/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
@@ -208,7 +208,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -783,7 +783,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -958,7 +958,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: minio
-    helm.sh/chart: minio-11.6.3
+    helm.sh/chart: minio-11.10.24
     app.kubernetes.io/instance: minio
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
@@ -1022,7 +1022,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
@@ -1152,7 +1152,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1168,7 +1168,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1199,13 +1199,13 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
 data:
   rabbitmq.conf: |-
-    IyMgVXNlcm5hbWUgYW5kIHBhc3N3b3JkCiMjCmRlZmF1bHRfdXNlciA9IGdpdHBvZApkZWZhdWx0X3Bhc3MgPSBDSEFOR0VNRQojIyBDbHVzdGVyaW5nCiMjCmNsdXN0ZXJfZm9ybWF0aW9uLnBlZXJfZGlzY292ZXJ5X2JhY2tlbmQgID0gcmFiYml0X3BlZXJfZGlzY292ZXJ5X2s4cwpjbHVzdGVyX2Zvcm1hdGlvbi5rOHMuaG9zdCA9IGt1YmVybmV0ZXMuZGVmYXVsdApjbHVzdGVyX2Zvcm1hdGlvbi5ub2RlX2NsZWFudXAuaW50ZXJ2YWwgPSAxMApjbHVzdGVyX2Zvcm1hdGlvbi5ub2RlX2NsZWFudXAub25seV9sb2dfd2FybmluZyA9IHRydWUKY2x1c3Rlcl9wYXJ0aXRpb25faGFuZGxpbmcgPSBhdXRvaGVhbApsb2FkX2RlZmluaXRpb25zID0gL2FwcC9sb2FkX2RlZmluaXRpb24uanNvbgojIHF1ZXVlIG1hc3RlciBsb2NhdG9yCnF1ZXVlX21hc3Rlcl9sb2NhdG9yID0gbWluLW1hc3RlcnMKIyBlbmFibGUgZ3Vlc3QgdXNlcgpsb29wYmFja191c2Vycy5ndWVzdCA9IGZhbHNlCmxvYWRfZGVmaW5pdGlvbnMgPSAvYXBwL2xvYWRfZGVmaW5pdGlvbi5qc29uCiMgSW5jcmVhc2Ugc3RhdGlzdGljcyBlbWlzc2lvbiBpbnRlcnZhbCBodHRwczovL3d3dy5yYWJiaXRtcS5jb20vbWFuYWdlbWVudC5odG1sI3N0YXRpc3RpY3MtaW50ZXJ2YWwKY29sbGVjdF9zdGF0aXN0aWNzX2ludGVydmFsID0gMTUwMDAKCnNzbF9vcHRpb25zLnZlcmlmeSA9IHZlcmlmeV9wZWVyCmxpc3RlbmVycy5zc2wuZGVmYXVsdCA9IDU2NzEKc3NsX29wdGlvbnMuZmFpbF9pZl9ub19wZWVyX2NlcnQgPSB0cnVlCnNzbF9vcHRpb25zLmNhY2VydGZpbGUgPSAvb3B0L2JpdG5hbWkvcmFiYml0bXEvY2VydHMvY2FfY2VydGlmaWNhdGUucGVtCnNzbF9vcHRpb25zLmNlcnRmaWxlID0gL29wdC9iaXRuYW1pL3JhYmJpdG1xL2NlcnRzL3NlcnZlcl9jZXJ0aWZpY2F0ZS5wZW0Kc3NsX29wdGlvbnMua2V5ZmlsZSA9IC9vcHQvYml0bmFtaS9yYWJiaXRtcS9jZXJ0cy9zZXJ2ZXJfa2V5LnBlbQojIyBQcm9tZXRoZXVzIG1ldHJpY3MKIyMKcHJvbWV0aGV1cy50Y3AucG9ydCA9IDk0MTk=
+    IyMgVXNlcm5hbWUgYW5kIHBhc3N3b3JkCiMjCmRlZmF1bHRfdXNlciA9IGdpdHBvZAojIyBDbHVzdGVyaW5nCiMjCmNsdXN0ZXJfZm9ybWF0aW9uLnBlZXJfZGlzY292ZXJ5X2JhY2tlbmQgID0gcmFiYml0X3BlZXJfZGlzY292ZXJ5X2s4cwpjbHVzdGVyX2Zvcm1hdGlvbi5rOHMuaG9zdCA9IGt1YmVybmV0ZXMuZGVmYXVsdApjbHVzdGVyX2Zvcm1hdGlvbi5ub2RlX2NsZWFudXAuaW50ZXJ2YWwgPSAxMApjbHVzdGVyX2Zvcm1hdGlvbi5ub2RlX2NsZWFudXAub25seV9sb2dfd2FybmluZyA9IHRydWUKY2x1c3Rlcl9wYXJ0aXRpb25faGFuZGxpbmcgPSBhdXRvaGVhbApsb2FkX2RlZmluaXRpb25zID0gL2FwcC9sb2FkX2RlZmluaXRpb24uanNvbgojIHF1ZXVlIG1hc3RlciBsb2NhdG9yCnF1ZXVlX21hc3Rlcl9sb2NhdG9yID0gbWluLW1hc3RlcnMKIyBlbmFibGUgZ3Vlc3QgdXNlcgpsb29wYmFja191c2Vycy5ndWVzdCA9IGZhbHNlCmxvYWRfZGVmaW5pdGlvbnMgPSAvYXBwL2xvYWRfZGVmaW5pdGlvbi5qc29uCiMgSW5jcmVhc2Ugc3RhdGlzdGljcyBlbWlzc2lvbiBpbnRlcnZhbCBodHRwczovL3d3dy5yYWJiaXRtcS5jb20vbWFuYWdlbWVudC5odG1sI3N0YXRpc3RpY3MtaW50ZXJ2YWwKY29sbGVjdF9zdGF0aXN0aWNzX2ludGVydmFsID0gMTUwMDAKCnNzbF9vcHRpb25zLnZlcmlmeSA9IHZlcmlmeV9wZWVyCmxpc3RlbmVycy5zc2wuZGVmYXVsdCA9IDU2NzEKc3NsX29wdGlvbnMuZmFpbF9pZl9ub19wZWVyX2NlcnQgPSB0cnVlCnNzbF9vcHRpb25zLmNhY2VydGZpbGUgPSAvb3B0L2JpdG5hbWkvcmFiYml0bXEvY2VydHMvY2FfY2VydGlmaWNhdGUucGVtCnNzbF9vcHRpb25zLmNlcnRmaWxlID0gL29wdC9iaXRuYW1pL3JhYmJpdG1xL2NlcnRzL3NlcnZlcl9jZXJ0aWZpY2F0ZS5wZW0Kc3NsX29wdGlvbnMua2V5ZmlsZSA9IC9vcHQvYml0bmFtaS9yYWJiaXRtcS9jZXJ0cy9zZXJ2ZXJfa2V5LnBlbQojIyBQcm9tZXRoZXVzIG1ldHJpY3MKIyMKcHJvbWV0aGV1cy50Y3AucG9ydCA9IDk0MTk=
 ---
 # v1/Secret messagebus-erlang-cookie
 apiVersion: v1
@@ -1229,7 +1229,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: minio
-    helm.sh/chart: minio-11.6.3
+    helm.sh/chart: minio-11.10.24
     app.kubernetes.io/instance: minio
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1265,7 +1265,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 type: Opaque
@@ -1282,7 +1282,7 @@ metadata:
   namespace: default
   labels:
     app: docker-registry
-    chart: docker-registry-1.16.0
+    chart: docker-registry-2.2.2
     heritage: Helm
     release: docker-registry
 type: Opaque
@@ -3434,7 +3434,7 @@ data:
       creationTimestamp: null
       labels:
         app: docker-registry
-        chart: docker-registry-1.16.0
+        chart: docker-registry-2.2.2
         heritage: Helm
         release: docker-registry
       name: registry-secret
@@ -3446,7 +3446,7 @@ data:
       creationTimestamp: null
       labels:
         app: docker-registry
-        chart: docker-registry-1.16.0
+        chart: docker-registry-2.2.2
         heritage: Helm
         release: docker-registry
       name: registry-config
@@ -3458,7 +3458,7 @@ data:
       creationTimestamp: null
       labels:
         app: registry
-        chart: docker-registry-1.16.0
+        chart: docker-registry-2.2.2
         heritage: Helm
         release: docker-registry
       name: registry
@@ -3470,7 +3470,7 @@ data:
       creationTimestamp: null
       labels:
         app: docker-registry
-        chart: docker-registry-1.16.0
+        chart: docker-registry-2.2.2
         heritage: Helm
         release: docker-registry
       name: registry
@@ -3482,7 +3482,7 @@ data:
       creationTimestamp: null
       labels:
         app: docker-registry
-        chart: docker-registry-1.16.0
+        chart: docker-registry-2.2.2
         heritage: Helm
         release: docker-registry
       name: registry
@@ -3497,7 +3497,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql
       namespace: default
     ---
@@ -3510,7 +3510,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql-headless
       namespace: default
     ---
@@ -3523,7 +3523,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql
       namespace: default
     ---
@@ -3536,7 +3536,7 @@ data:
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
       name: mysql
       namespace: default
     ---
@@ -3548,7 +3548,7 @@ data:
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: minio
-        helm.sh/chart: minio-11.6.3
+        helm.sh/chart: minio-11.10.24
       name: minio
       namespace: default
     ---
@@ -3560,7 +3560,7 @@ data:
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: minio
-        helm.sh/chart: minio-11.6.3
+        helm.sh/chart: minio-11.10.24
       name: minio
       namespace: default
     ---
@@ -3572,7 +3572,7 @@ data:
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: minio
-        helm.sh/chart: minio-11.6.3
+        helm.sh/chart: minio-11.10.24
       name: minio
       namespace: default
     ---
@@ -3584,7 +3584,7 @@ data:
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: minio
-        helm.sh/chart: minio-11.6.3
+        helm.sh/chart: minio-11.10.24
       name: minio
       namespace: default
     ---
@@ -3596,7 +3596,7 @@ data:
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: minio
-        helm.sh/chart: minio-11.6.3
+        helm.sh/chart: minio-11.10.24
       name: minio
       namespace: default
     ---
@@ -3608,7 +3608,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus
       namespace: default
     ---
@@ -3620,7 +3620,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus
       namespace: default
     ---
@@ -3632,7 +3632,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: rabbitmq
       namespace: default
     ---
@@ -3644,7 +3644,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus-config
       namespace: default
     ---
@@ -3656,7 +3656,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus
       namespace: default
     ---
@@ -3668,7 +3668,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: load-definition
       namespace: default
     ---
@@ -3680,7 +3680,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: rabbitmq
       namespace: default
     ---
@@ -3692,7 +3692,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus-endpoint-reader
       namespace: default
     ---
@@ -3704,7 +3704,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus-endpoint-reader
       namespace: default
     ---
@@ -3716,7 +3716,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus-headless
       namespace: default
     ---
@@ -3728,7 +3728,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus
       namespace: default
     ---
@@ -3740,7 +3740,7 @@ data:
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
       name: messagebus
       namespace: default
     ---
@@ -5098,7 +5098,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
@@ -5115,7 +5115,7 @@ data:
     datadir=/bitnami/mysql/data
     tmpdir=/opt/bitnami/mysql/tmp
     max_allowed_packet=16M
-    bind-address=0.0.0.0
+    bind-address=*
     pid-file=/opt/bitnami/mysql/tmp/mysqld.pid
     log-error=/opt/bitnami/mysql/logs/mysqld.log
     character-set-server=UTF8
@@ -5285,7 +5285,7 @@ metadata:
   namespace: default
   labels:
     app: docker-registry
-    chart: docker-registry-1.16.0
+    chart: docker-registry-2.2.2
     heritage: Helm
     release: docker-registry
 data:
@@ -6122,7 +6122,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: minio
-    helm.sh/chart: minio-11.6.3
+    helm.sh/chart: minio-11.10.24
     app.kubernetes.io/instance: minio
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -6141,7 +6141,7 @@ metadata:
   namespace: default
   labels:
     app: registry
-    chart: "docker-registry-1.16.0"
+    chart: "docker-registry-2.2.2"
     release: "docker-registry"
     heritage: "Helm"
 spec:
@@ -6668,7 +6668,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 rules:
@@ -7029,7 +7029,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 subjects:
@@ -7522,7 +7522,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -7566,7 +7566,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -7601,7 +7601,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: minio
-    helm.sh/chart: minio-11.6.3
+    helm.sh/chart: minio-11.10.24
     app.kubernetes.io/instance: minio
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -7628,7 +7628,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
@@ -7656,11 +7656,10 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
-  annotations:
 spec:
   type: ClusterIP
   clusterIP: None
@@ -7774,7 +7773,7 @@ metadata:
   namespace: default
   labels:
     app: docker-registry
-    chart: docker-registry-1.16.0
+    chart: docker-registry-2.2.2
     release: docker-registry
     heritage: Helm
 spec:
@@ -8568,7 +8567,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: rabbitmq
-    helm.sh/chart: rabbitmq-10.1.1
+    helm.sh/chart: rabbitmq-11.3.0
     app.kubernetes.io/instance: rabbitmq
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -8585,12 +8584,12 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: rabbitmq
-        helm.sh/chart: rabbitmq-10.1.1
+        helm.sh/chart: rabbitmq-11.3.0
         app.kubernetes.io/instance: rabbitmq
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/config: 2ca9db593e4ca6cdd01f7a65cce1ae90d0d45ecdf0049edfaa4ec72302fcbe8f
-        checksum/secret: c231bbb08185305defa8c4da0f3ee0f5e7a16795362a2133f74e53eb9a40453d
+        checksum/config: d5780a0c58210a2062d54feb61cfb1d5a9c076f95569c4a77076d22c9bad4190
+        checksum/secret: 64c39dd3a8570ed4b0cc71bc0402bc814d016e16f68732938722b12a57c8e82c
         prometheus.io/port: '9419'
         prometheus.io/scrape: "true"
     spec:
@@ -8610,7 +8609,7 @@ spec:
       initContainers:
       containers:
         - name: rabbitmq
-          image: docker.io/bitnami/rabbitmq:3.10.2-debian-10-r7
+          image: docker.io/bitnami/rabbitmq:3.11.5-debian-11-r2
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true
@@ -8745,11 +8744,10 @@ spec:
               - key: tls.key
                 path: server_key.pem
         - name: configuration
-          secret:
-            secretName: messagebus-config
-            items:
-              - key: rabbitmq.conf
-                path: rabbitmq.conf
+          projected:
+            sources:
+              - secret:
+                  name: messagebus-config
         - name: load-definition-volume
           secret:
             secretName: "load-definition"
@@ -8765,7 +8763,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: mysql
-    helm.sh/chart: mysql-9.1.2
+    helm.sh/chart: mysql-9.4.5
     app.kubernetes.io/instance: mysql
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: primary
@@ -8783,10 +8781,10 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/configuration: 11b8361c0fbf695cec6ec7f47ed4118ad3c7d71a391ca246df129803d3e205a5
+        checksum/configuration: 0c1e0d4282c8f8f820f3c9d1d79b3f423c4676afac2e3a6de555f8553f146eb4
       labels:
         app.kubernetes.io/name: mysql
-        helm.sh/chart: mysql-9.1.2
+        helm.sh/chart: mysql-9.4.5
         app.kubernetes.io/instance: mysql
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: primary
@@ -8805,7 +8803,7 @@ spec:
         fsGroup: 1001
       initContainers:
         - name: volume-permissions
-          image: docker.io/bitnami/bitnami-shell:10-debian-10-r431
+          image: docker.io/bitnami/bitnami-shell:11-debian-11-r60
           imagePullPolicy: "IfNotPresent"
           command:
             - /bin/bash
@@ -10090,7 +10088,7 @@ metadata:
   namespace: "default"
   labels:
     app.kubernetes.io/name: minio
-    helm.sh/chart: minio-11.6.3
+    helm.sh/chart: minio-11.10.24
     app.kubernetes.io/instance: minio
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -10104,11 +10102,11 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: minio
-        helm.sh/chart: minio-11.6.3
+        helm.sh/chart: minio-11.10.24
         app.kubernetes.io/instance: minio
         app.kubernetes.io/managed-by: Helm
       annotations:
-        checksum/credentials-secret: 094325f216720012cacde9f52fd71c7e8b06dd6386492f6980e0f3588f1b1e7c
+        checksum/credentials-secret: 0f3ceb92b9779df4ce0927f6faeb23e9116b85e0eabe095d903e46a2770cde42
     spec:
       
       serviceAccountName: minio
@@ -10124,7 +10122,7 @@ spec:
         fsGroup: 1001
       containers:
         - name: minio
-          image: docker.io/bitnami/minio:2022.5.26-debian-10-r0
+          image: docker.io/bitnami/minio:2022.12.12-debian-11-r0
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsNonRoot: true
@@ -10550,7 +10548,7 @@ metadata:
   namespace: default
   labels:
     app: docker-registry
-    chart: docker-registry-1.16.0
+    chart: docker-registry-2.2.2
     release: docker-registry
     heritage: Helm
 spec:
@@ -10566,7 +10564,9 @@ spec:
         app: docker-registry
         release: docker-registry
       annotations:
-        checksum/config: 1d22b82e19bbc654e029029c4fb86ad02dc13422dc3ac52f8175ad190e52a0bb
+        checksum/config: 699dd382179068f3354c330fcce38625e2861d97b962074b4f57005d40497b00
+        checksum/secret: 450f59aeda22415409a87a1abd2c033c08ebd5fb54fe24d3c56560e92b0218f6
+        
         gitpod.io/checksum_config: 1c66f4ccdb7f6331da2edaecefcb40f6c1b6315c9277eb0418fef3cc584a28bd
     spec:
       serviceAccountName: docker-registry
@@ -10575,7 +10575,7 @@ spec:
         runAsUser: 1000
       containers:
         - name: docker-registry
-          image: "docker.io/library/registry:2.7.1"
+          image: "docker.io/library/registry:2.8.1"
           imagePullPolicy: IfNotPresent
           command:
           - /bin/registry
@@ -10593,9 +10593,9 @@ spec:
               scheme: HTTPS
               path: /
               port: 5000
-          resources:
+          resources: 
             {}
-          env:
+          env: 
             - name: REGISTRY_HTTP_SECRET
               valueFrom:
                 secretKeyRef:
@@ -10607,21 +10607,21 @@ spec:
               value: /etc/ssl/docker/tls.key
             - name: REGISTRY_STORAGE_FILESYSTEM_ROOTDIRECTORY
               value: "/var/lib/registry"
-          volumeMounts:
-            - name: data
-              mountPath: /var/lib/registry/
+          volumeMounts: 
             - name: "registry-config"
               mountPath: "/etc/docker/registry"
+            - name: data
+              mountPath: /var/lib/registry/
             - mountPath: /etc/ssl/docker
               name: tls-cert
               readOnly: true
-      volumes:
-        - name: data
-          persistentVolumeClaim:
-            claimName: registry
+      volumes: 
         - name: registry-config
           configMap:
             name: registry-config
+        - name: data
+          persistentVolumeClaim:
+            claimName: registry
         - name: tls-cert
           secret:
             secretName: builtin-registry-certs

--- a/install/installer/go.mod
+++ b/install/installer/go.mod
@@ -133,7 +133,7 @@ require (
 	github.com/gitpod-io/gitpod/usage-api v0.0.0-00010101000000-000000000000 // indirect
 	github.com/gitpod-io/golang-crypto v0.0.0-20220823040820-b59f56dfbab3 // indirect
 	github.com/go-errors/errors v1.0.1 // indirect
-	github.com/go-gorp/gorp/v3 v3.0.2 // indirect
+	github.com/go-gorp/gorp/v3 v3.1.0 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
@@ -215,15 +215,15 @@ require (
 	github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 // indirect
 	github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 // indirect
 	github.com/leodido/go-urn v1.2.1 // indirect
-	github.com/lib/pq v1.10.6 // indirect
+	github.com/lib/pq v1.10.7 // indirect
 	github.com/libp2p/go-buffer-pool v0.0.2 // indirect
 	github.com/libp2p/go-libp2p-core v0.8.6 // indirect
 	github.com/libp2p/go-openssl v0.0.7 // indirect
 	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de // indirect
 	github.com/magiconair/properties v1.8.6 // indirect
 	github.com/mailru/easyjson v0.7.6 // indirect
-	github.com/mattn/go-colorable v0.1.12 // indirect
-	github.com/mattn/go-isatty v0.0.14 // indirect
+	github.com/mattn/go-colorable v0.1.13 // indirect
+	github.com/mattn/go-isatty v0.0.16 // indirect
 	github.com/mattn/go-runewidth v0.0.13 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
 	github.com/mdlayher/netlink v1.4.2 // indirect

--- a/install/installer/go.sum
+++ b/install/installer/go.sum
@@ -651,6 +651,8 @@ github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gorp/gorp/v3 v3.0.2 h1:ULqJXIekoqMx29FI5ekXXFoH1dT2Vc8UhnRzBg+Emz4=
 github.com/go-gorp/gorp/v3 v3.0.2/go.mod h1:BJ3q1ejpV8cVALtcXvXaXyTOlMmJhWDxTmncaR6rwBY=
+github.com/go-gorp/gorp/v3 v3.1.0 h1:ItKF/Vbuj31dmV4jxA1qblpSwkl9g1typ24xoe70IGs=
+github.com/go-gorp/gorp/v3 v3.1.0/go.mod h1:dLEjIyyRNiXvNZ8PSmzpt1GsWAUK8kjVhEpjH8TixEw=
 github.com/go-ini/ini v1.25.4/go.mod h1:ByCAeIL28uOIIG0E3PJtZPDL8WnHpFKFOtgjp+3Ies8=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
@@ -1323,6 +1325,8 @@ github.com/lib/pq v1.10.0/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/lib/pq v1.10.2/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/lib/pq v1.10.6 h1:jbk+ZieJ0D7EVGJYpL9QTz7/YW6UHbmdnZWYyK5cdBs=
 github.com/lib/pq v1.10.6/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
+github.com/lib/pq v1.10.7 h1:p7ZhMD+KsSRozJr34udlUrhboJwWAgCg34+/ZZNvZZw=
+github.com/lib/pq v1.10.7/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/libp2p/go-addr-util v0.0.1/go.mod h1:4ac6O7n9rIAKB1dnd+s8IbbMXkt+oBpzX4/+RACcnlQ=
 github.com/libp2p/go-addr-util v0.0.2 h1:7cWK5cdA5x72jX0g8iLrQWm5TRJZ6CzGdPEhWj7plWU=
 github.com/libp2p/go-addr-util v0.0.2/go.mod h1:Ecd6Fb3yIuLzq4bD7VcywcVSBtefcAwnUISBM3WG15E=
@@ -1549,6 +1553,8 @@ github.com/mattn/go-colorable v0.1.8/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope
 github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.12 h1:jF+Du6AlPIjs2BiUiQlKOX0rt3SujHxPnksPKZbaA40=
 github.com/mattn/go-colorable v0.1.12/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
+github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
+github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.5/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
@@ -1560,6 +1566,8 @@ github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Ky
 github.com/mattn/go-isatty v0.0.13/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-isatty v0.0.14 h1:yVuAays6BHfxijgZPzw+3Zlu5yQgKGP2/hcQbHb7S9Y=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
+github.com/mattn/go-isatty v0.0.16 h1:bq3VjFmv/sOjHtdEhmkEV4x1AJtvUvOJ2PFAZ5+peKQ=
+github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-oci8 v0.0.7/go.mod h1:wjDx6Xm9q7dFtHJvIlrI99JytznLw5wQ4R+9mNXJwGI=
 github.com/mattn/go-oci8 v0.1.1/go.mod h1:wjDx6Xm9q7dFtHJvIlrI99JytznLw5wQ4R+9mNXJwGI=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
@@ -2652,6 +2660,7 @@ golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220610221304-9f5ed59c137d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.3.0 h1:w8ZOecv6NaNa/zC8944JTU3vz4u6Lagfk4RPQxv92NQ=
 golang.org/x/sys v0.3.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=

--- a/install/installer/pkg/components/database/incluster/helm.go
+++ b/install/installer/pkg/components/database/incluster/helm.go
@@ -24,6 +24,8 @@ var Helm = common.CompositeHelmFunc(
 			return nil, err
 		}
 
+		imageRegistry := common.ThirdPartyContainerRepo(cfg.Config.Repository, common.DockerRegistryURL)
+
 		return &common.HelmConfig{
 			Enabled: true,
 			Values: &values.Options{
@@ -34,15 +36,12 @@ var Helm = common.CompositeHelmFunc(
 					helm.KeyValue("mysql.initdbScriptsConfigMap", SQLInitScripts),
 					helm.KeyValue("mysql.serviceAccount.name", Component),
 					helm.ImagePullSecrets("mysql.image.pullSecrets", cfg),
-					helm.KeyValue("mysql.image.registry", ""),
-					helm.KeyValue("mysql.image.repository", cfg.RepoName(common.ThirdPartyContainerRepo(cfg.Config.Repository, common.DockerRegistryURL), "bitnami/mysql")),
+					helm.KeyValue("mysql.image.registry", imageRegistry),
 					helm.ImagePullSecrets("mysql.metrics.image.pullSecrets", cfg),
-					helm.KeyValue("mysql.metrics.image.registry", ""),
-					helm.KeyValue("mysql.metrics.image.repository", cfg.RepoName(common.ThirdPartyContainerRepo(cfg.Config.Repository, common.DockerRegistryURL), "bitnami/mysqld-exporter")),
+					helm.KeyValue("mysql.metrics.image.registry", imageRegistry),
 					helm.ImagePullSecrets("mysql.volumePermissions.image.pullSecrets", cfg),
 					helm.KeyValue("mysql.volumePermissions.image.pullPolicy", "IfNotPresent"),
-					helm.KeyValue("mysql.volumePermissions.image.registry", ""),
-					helm.KeyValue("mysql.volumePermissions.image.repository", cfg.RepoName(common.ThirdPartyContainerRepo(cfg.Config.Repository, common.DockerRegistryURL), "bitnami/bitnami-shell")),
+					helm.KeyValue("mysql.volumePermissions.image.registry", imageRegistry),
 
 					// improve start time
 					helm.KeyValue("mysql.primary.startupProbe.enabled", "false"),

--- a/install/installer/pkg/components/minio/helm.go
+++ b/install/installer/pkg/components/minio/helm.go
@@ -17,13 +17,13 @@ import (
 
 var Helm = common.CompositeHelmFunc(
 	func(cfg *common.RenderContext) ([]string, error) {
+		imageRegistry := common.ThirdPartyContainerRepo(cfg.Config.Repository, common.DockerRegistryURL)
+
 		commonHelmValues := []string{
 			helm.ImagePullSecrets("minio.image.pullSecrets", cfg),
-			helm.KeyValue("minio.image.registry", ""),
-			helm.KeyValue("minio.image.repository", cfg.RepoName(common.ThirdPartyContainerRepo(cfg.Config.Repository, common.DockerRegistryURL), "bitnami/minio")),
+			helm.KeyValue("minio.image.registry", imageRegistry),
 			helm.ImagePullSecrets("minio.volumePermissions.image.pullSecrets", cfg),
-			helm.KeyValue("minio.volumePermissions.image.registry", ""),
-			helm.KeyValue("minio.volumePermissions.image.repository", cfg.RepoName(common.ThirdPartyContainerRepo(cfg.Config.Repository, common.DockerRegistryURL), "bitnami/bitnami-shell")),
+			helm.KeyValue("minio.volumePermissions.image.registry", imageRegistry),
 		}
 
 		if cfg.Config.ObjectStorage.Resources != nil && cfg.Config.ObjectStorage.Resources.Requests.Memory() != nil {

--- a/install/installer/pkg/components/rabbitmq/helm.go
+++ b/install/installer/pkg/components/rabbitmq/helm.go
@@ -184,6 +184,8 @@ var Helm = common.CompositeHelmFunc(
 			return nil, err
 		}
 
+		imageRegistry := common.ThirdPartyContainerRepo(cfg.Config.Repository, common.DockerRegistryURL)
+
 		return &common.HelmConfig{
 			Enabled: true,
 			Values: &values.Options{
@@ -196,11 +198,9 @@ var Helm = common.CompositeHelmFunc(
 					helm.KeyValue(fmt.Sprintf("rabbitmq.extraSecrets.%s.username", InClusterDbSecret), username),
 					helm.KeyValue(fmt.Sprintf("rabbitmq.extraSecrets.%s.password", InClusterDbSecret), password),
 					helm.ImagePullSecrets("rabbitmq.image.pullSecrets", cfg),
-					helm.KeyValue("rabbitmq.image.registry", ""),
-					helm.KeyValue("rabbitmq.image.repository", cfg.RepoName(common.ThirdPartyContainerRepo(cfg.Config.Repository, common.DockerRegistryURL), "bitnami/rabbitmq")),
+					helm.KeyValue("rabbitmq.image.registry", imageRegistry),
 					helm.ImagePullSecrets("volumePermissions.image.pullSecrets", cfg),
-					helm.KeyValue("rabbitmq.volumePermissions.image.registry", ""),
-					helm.KeyValue("rabbitmq.volumePermissions.image.repository", cfg.RepoName(common.ThirdPartyContainerRepo(cfg.Config.Repository, common.DockerRegistryURL), "bitnami/bitnami-shell")),
+					helm.KeyValue("rabbitmq.volumePermissions.image.registry", imageRegistry),
 
 					helm.KeyValue("rabbitmq.livenessProbe.initialDelaySeconds", "30"),
 				},

--- a/install/installer/third_party/charts/docker-registry/Chart.yaml
+++ b/install/installer/third_party/charts/docker-registry/Chart.yaml
@@ -8,5 +8,5 @@ name: docker-registry
 version: 1.0.0
 dependencies:
   - name: docker-registry
-    version: 1.16.0
+    version: 2.2.2
     repository: https://helm.twun.io

--- a/install/installer/third_party/charts/minio/Chart.yaml
+++ b/install/installer/third_party/charts/minio/Chart.yaml
@@ -8,5 +8,5 @@ name: minio
 version: 1.0.0
 dependencies:
   - name: minio
-    version: 11.6.3
+    version: 11.10.24
     repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami

--- a/install/installer/third_party/charts/mysql/Chart.yaml
+++ b/install/installer/third_party/charts/mysql/Chart.yaml
@@ -8,5 +8,5 @@ name: mysql
 version: 1.0.0
 dependencies:
   - name: mysql
-    version: 9.1.2
+    version: 9.4.5
     repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami

--- a/install/installer/third_party/charts/rabbitmq/Chart.yaml
+++ b/install/installer/third_party/charts/rabbitmq/Chart.yaml
@@ -8,5 +8,5 @@ name: rabbitmq
 version: 1.0.0
 dependencies:
   - name: rabbitmq
-    version: 10.1.1
+    version: 11.3.0
     repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This updates all Helm dependencies in the Installer (Docker registry, Minio, MySQL, RabbitMQ) to the latest versions. This PR has more commits than is strictly necessary, but have done it like this to ensure that the changes to the golden files are human-readable.

All of these dependency upgrade change the major version of the Helm chart. The Bitnami charts change how the image block works, so the previous way of defining the custom pull registry no longer works - in retrospect, I wish I'd done the original definition in the way I've done it here. The first two commits ([1](https://github.com/gitpod-io/gitpod/pull/15568/commits/0a9c537b854b971017c67b59e23be02720b63c9e) and [2](https://github.com/gitpod-io/gitpod/pull/15568/commits/853b6fd9a0835cf2bbdced5d0d81032fb6fb3986)) address this by adding a new golden file to handle a custom pull repo and change the image block in the Helm dependencies.

The [third commit](https://github.com/gitpod-io/gitpod/pull/15568/commits/09068b829fe4fc2d916ac6e6290d2c32cb820c2d) exists because the Docker registry [introduced a checksum on the secret.yaml](https://github.com/twuni/docker-registry.helm/pull/49) in the template. This uses the Helm `randAlphaNum` function, which breaks the random seed - 64 bits wasn't enough random data, so increased to 128 bits.

The [fourth commit](https://github.com/gitpod-io/gitpod/pull/15568/commits/631f0e54cb22eb6296c1b20e7237655271211ef2) is the actual update of the Helm dependencies and the associated golden files.

Finally, there is an update made to `go-gorp` as warning "Versions prior to 3.0.4 had a vulnerability in the dependency graph" reported (this could be a separate PR, but it's all part of the same area so I've put it in here).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/security/issues/95

## How to test
<!-- Provide steps to test this PR -->
Use [preview environment](https://sje-instal6626b9bf74.preview.gitpod-dev.com/workspaces)/self-hosted instance and do normal smoke-tests:
- build image
- start workspace
- use `gp stop`
- ensure that backups are saved to storage

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Update Helm dependencies in Installer
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
