### PR TITLE
show user friendly error if git is not found

### DIFF
--- a/components/supervisor/cmd/init.go
+++ b/components/supervisor/cmd/init.go
@@ -38,6 +38,13 @@ var initCmd = &cobra.Command{
 		)
 		signal.Notify(sigInput, os.Interrupt, syscall.SIGTERM)
 
+		// check if git executable exists, supervisor will fail if it doesn't
+		// checking for it here allows to bubble up this error to the user
+		_, err = exec.LookPath("git")
+		if err != nil {
+			log.WithError(err).Fatal("cannot find git executable, make sure it is installed as part of gitpod image")
+		}
+
 		supervisorPath, err := os.Executable()
 		if err != nil {
 			supervisorPath = "/.supervisor/supervisor"

--- a/components/supervisor/pkg/supervisor/supervisor.go
+++ b/components/supervisor/pkg/supervisor/supervisor.go
@@ -188,6 +188,7 @@ func Run(options ...RunOption) {
 		log.WithError(err).Fatal("cannot ensure Gitpod user exists")
 	}
 	symlinkBinaries(cfg)
+
 	configureGit(cfg, childProcEnvvars)
 
 	tokenService := NewInMemoryTokenService()


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Show user friendly error and reason for failure if user uses base image that does not include `git`.
Otherwise workspace will be stuck in `content initialization` phase forever, which is a bad user experience.
(We do require base image to have git and gitpod user, but end user may forget about those requirements).
This is how the error will be presented to the user:
![image](https://user-images.githubusercontent.com/18602811/210661954-d7096c80-abe1-4562-96ea-83e5e44f8cba.png)


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
Open a repo that uses this gitpod dockerfile:
```
FROM ubuntu

RUN apt update
```
Notice it will fail with user friendly error explaining why.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
none
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-integration-tests=workspace
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
