### PR TITLE
ws-manager: avoid duplicate logs

### DIFF
--- a/components/ws-manager/pkg/manager/manager.go
+++ b/components/ws-manager/pkg/manager/manager.go
@@ -1407,24 +1407,6 @@ func (m *Manager) onChange(ctx context.Context, status *api.WorkspaceStatus) {
 	})
 
 	m.metrics.OnChange(status)
-
-	// There are some conditions we'd like to get notified about, for example while running experiements or because
-	// they represent out-of-the-ordinary situations.
-	// We attempt to use the GCP Error Reporting for this, hence log these situations as errors.
-	if status.Conditions.Failed != "" {
-		status, _ := protojson.Marshal(status)
-		safeStatus, _ := log.RedactJSON(status)
-		safeStatusLog := make(map[string]interface{})
-		_ = json.Unmarshal(safeStatus, &safeStatusLog)
-		clog.WithFields(safeStatusLog).Error("workspace failed")
-	}
-	if status.Phase == api.WorkspacePhase_UNKNOWN {
-		status, _ := protojson.Marshal(status)
-		safeStatus, _ := log.RedactJSON(status)
-		safeStatusLog := make(map[string]interface{})
-		_ = json.Unmarshal(safeStatus, &safeStatusLog)
-		clog.WithFields(safeStatusLog).Error("workspace in UNKNOWN phase")
-	}
 }
 
 // GetWorkspaces produces a list of running workspaces and their status


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

We observed that duplicated logs exist in the GCP log.
To help us analyze the log quickly and save money 💸, we output the log when there is a state change.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related to #15562

## How to test
<!-- Provide steps to test this PR -->
1. From a harvester preview VM, start a workspace, write some data, and stop the workspace.
2. After the workspace is stopped (workspace content is backed up), scale MinIO to zero.
    ```console
    kubectl scale --replicas=0 deploy/minio
    ```
3. Stream the ws-manager log
    ```console
    kubectl logs -f -l component=ws-manager
    ```
4. Reopen the workspace, and check the log message `"message":"workspace failed"` outputs when there is a state change.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=workspace
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
