### PR TITLE
ws-manager: add new reason `out-of-space` for workspace_stops_total metric

### DIFF
--- a/components/ws-manager/pkg/manager/metrics.go
+++ b/components/ws-manager/pkg/manager/metrics.go
@@ -292,6 +292,10 @@ func (m *metrics) OnChange(status *api.WorkspaceStatus) {
 			reason = "aborted"
 		} else if status.Conditions.Failed != "" {
 			reason = "failed"
+
+			if strings.Contains(status.Conditions.Failed, "Pod ephemeral local storage usage exceeds the total limit of containers") {
+				reason = "out-of-space"
+			}
 		} else {
 			reason = "regular-stop"
 		}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
The ephemeral local storage out of space should not be counted in `workspace_stops_total{reason="failed"}`.
Adding a new reason `out-of-space` to track the number of workspace pods ever running into an out-of-space error.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Partial #15562

## How to test
<!-- Provide steps to test this PR -->
1. Open the workspace, and make the ephemeral local storage out of space.
   ```console
   fallocate -l 25G /var/tmp/test1
   ```
2. Port-forward ws-manager metric port 9500
    ```console
    kubectl port-forward <ws-manager-pod-name> 9500:9500
    ```
3. Get the metric, the metric `gitpod_ws_manager_workspace_stops_total{reason="out-of-space"}` should increase by one.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-integration-tests=workspace
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
