### PR TITLE
[iam] don't fail if test config is missing

### DIFF
--- a/components/iam/pkg/oidc/service.go
+++ b/components/iam/pkg/oidc/service.go
@@ -17,6 +17,8 @@ import (
 	"github.com/coreos/go-oidc/v3/oidc"
 	goidc "github.com/coreos/go-oidc/v3/oidc"
 	"golang.org/x/oauth2"
+
+	"github.com/gitpod-io/gitpod/common-go/log"
 )
 
 type Service struct {
@@ -43,29 +45,31 @@ type AuthFlowResult struct {
 }
 
 func NewServiceWithTestConfig(configPath string) (*Service, error) {
+	s := NewService()
+
 	testConfig, err := readDemoConfigFromFile(configPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read test config: %w", err)
 	}
+	if testConfig != nil {
+		clientConfig := &ClientConfig{
+			Issuer: testConfig.Issuer,
+			ID:     "R4ND0M1D",
+			OAuth2Config: &oauth2.Config{
+				ClientID:     testConfig.ClientID,
+				ClientSecret: testConfig.ClientSecret,
+				RedirectURL:  testConfig.RedirectURL,
+				Scopes:       []string{goidc.ScopeOpenID, "profile", "email"},
+			},
+			VerifierConfig: &goidc.Config{
+				ClientID: testConfig.ClientID,
+			},
+		}
 
-	clientConfig := &ClientConfig{
-		Issuer: testConfig.Issuer,
-		ID:     "R4ND0M1D",
-		OAuth2Config: &oauth2.Config{
-			ClientID:     testConfig.ClientID,
-			ClientSecret: testConfig.ClientSecret,
-			RedirectURL:  testConfig.RedirectURL,
-			Scopes:       []string{goidc.ScopeOpenID, "profile", "email"},
-		},
-		VerifierConfig: &goidc.Config{
-			ClientID: testConfig.ClientID,
-		},
-	}
-
-	s := NewService()
-	err = s.AddClientConfig(clientConfig)
-	if err != nil {
-		return nil, fmt.Errorf("failed to add client config: %w", err)
+		err = s.AddClientConfig(clientConfig)
+		if err != nil {
+			log.Errorf("failed to add client config: %v", err)
+		}
 	}
 
 	return s, nil


### PR DESCRIPTION
This is a quick fix for the `iam` component to not crash if the test config is not present.

## How to test
Verify that the `iam` component is not crash-looping.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
