### PR TITLE
[licensor]: remove limits on licence user numbers and feature sets

### DIFF
--- a/components/licensor/ee/pkg/licensor/licensor.go
+++ b/components/licensor/ee/pkg/licensor/licensor.go
@@ -67,8 +67,7 @@ type licensePayload struct {
 type LicenseLevel int
 
 const (
-	// LevelTeam is the default license level,
-	// which is the free tier
+	// This exists for historical reasons - it is now the same as LevelEnterprise
 	LevelTeam LicenseLevel = 0
 
 	// LevelEnterprise enables enterprise features,
@@ -140,7 +139,7 @@ func (lvl LicenseLevel) allowance() allowance {
 // Fallback license is used when the instance exceeds the number of licenses - it allows limited access
 var fallbackLicense = LicensePayload{
 	ID:    "fallback-license",
-	Level: LevelTeam,
+	Level: LevelEnterprise,
 	Seats: 0,
 	// Domain, ValidUntil are free for all
 }
@@ -149,7 +148,7 @@ var fallbackLicense = LicensePayload{
 var defaultLicense = LicensePayload{
 	ID:    "default-license",
 	Level: LevelEnterprise,
-	Seats: 10,
+	Seats: 0,
 	// Domain, ValidUntil are free for all
 }
 

--- a/components/licensor/ee/pkg/licensor/licensor_test.go
+++ b/components/licensor/ee/pkg/licensor/licensor_test.go
@@ -157,7 +157,7 @@ func TestSeats(t *testing.T) {
 		{"Gitpod: invalid license", 50, 50, false, false, true, LicenseTypeGitpod, false},
 		{"Gitpod: within default license seats", 0, 7, true, true, false, LicenseTypeGitpod, false},
 		{"Gitpod: within default license seats (edge)", 0, 10, true, true, false, LicenseTypeGitpod, false},
-		{"Gitpod: beyond default license seats", 0, 11, false, true, false, LicenseTypeGitpod, false},
+		{"Gitpod: beyond default license seats", 0, 11, true, true, false, LicenseTypeGitpod, false},
 
 		// correctly missing the default license tests as Replicated always has a license
 		{"Replicated: unlimited seats", 0, 1000, true, false, false, LicenseTypeReplicated, false},
@@ -165,15 +165,15 @@ func TestSeats(t *testing.T) {
 		{"Replicated: within limited seats (edge)", 50, 50, true, false, false, LicenseTypeReplicated, false},
 		{"Replicated: beyond limited seats", 50, 150, false, false, false, LicenseTypeReplicated, false},
 		{"Replicated: beyond limited seats (edge)", 50, 51, false, false, false, LicenseTypeReplicated, false},
-		{"Replicated: invalid license", 50, 50, false, false, true, LicenseTypeReplicated, false},
-		{"Replicated: beyond default license seats", 0, 11, false, true, false, LicenseTypeReplicated, false},
+		{"Replicated: invalid license", 50, 50, true, false, true, LicenseTypeReplicated, false},
+		{"Replicated: beyond default license seats", 0, 11, true, true, false, LicenseTypeReplicated, false},
 
 		{"Replicated: unlimited seats", 0, 1000, true, false, false, LicenseTypeReplicated, true},
 		{"Replicated: within limited seats", 50, 40, true, false, false, LicenseTypeReplicated, true},
 		{"Replicated: within limited seats (edge)", 50, 50, true, false, false, LicenseTypeReplicated, true},
 		{"Replicated: beyond limited seats", 50, 150, false, false, false, LicenseTypeReplicated, true},
 		{"Replicated: beyond limited seats (edge)", 50, 51, false, false, false, LicenseTypeReplicated, true},
-		{"Replicated: invalid license", 50, 50, false, false, true, LicenseTypeReplicated, true},
+		{"Replicated: invalid license", 50, 50, true, false, true, LicenseTypeReplicated, true},
 		{"Replicated: beyond default license seats", 0, 11, false, true, false, LicenseTypeReplicated, true},
 		{"Replicated: invalid license within default seats", 50, 5, true, false, true, LicenseTypeReplicated, false},
 	}
@@ -238,7 +238,13 @@ func TestFeatures(t *testing.T) {
 			FeaturePrebuild,
 		}, LicenseTypeGitpod, seats, nil},
 
-		{"Gitpod (over seats): no license", true, LicenseLevel(0), []Feature{FeatureAdminDashboard}, LicenseTypeGitpod, 11, nil},
+		{"Gitpod (over seats): no license", true, LicenseLevel(0), []Feature{
+			FeatureAdminDashboard,
+			FeatureSetTimeout,
+			FeatureWorkspaceSharing,
+			FeatureSnapshot,
+			FeaturePrebuild,
+		}, LicenseTypeGitpod, 11, nil},
 		{"Gitpod (over seats): invalid license level", false, LicenseLevel(666), []Feature{}, LicenseTypeGitpod, seats + 1, nil},
 		{"Gitpod (over seats): enterprise license", false, LevelEnterprise, []Feature{}, LicenseTypeGitpod, seats + 1, nil},
 
@@ -272,8 +278,20 @@ func TestFeatures(t *testing.T) {
 			FeaturePrebuild,
 		}, LicenseTypeReplicated, seats + 1, &replicatedPaid},
 
-		{"Replicated (over seats - fallback): invalid license level", false, LicenseLevel(666), []Feature{FeatureAdminDashboard}, LicenseTypeReplicated, seats + 1, &replicatedCommunity},
-		{"Replicated (over seats - fallback): enterprise license", false, LevelEnterprise, []Feature{FeatureAdminDashboard}, LicenseTypeReplicated, seats + 1, &replicatedCommunity},
+		{"Replicated (over seats - fallback): invalid license level", false, LicenseLevel(666), []Feature{
+			FeatureAdminDashboard,
+			FeatureSetTimeout,
+			FeatureWorkspaceSharing,
+			FeatureSnapshot,
+			FeaturePrebuild,
+		}, LicenseTypeReplicated, seats + 1, &replicatedCommunity},
+		{"Replicated (over seats - fallback): enterprise license", false, LevelEnterprise, []Feature{
+			FeatureAdminDashboard,
+			FeatureSetTimeout,
+			FeatureWorkspaceSharing,
+			FeatureSnapshot,
+			FeaturePrebuild,
+		}, LicenseTypeReplicated, seats + 1, &replicatedCommunity},
 	}
 
 	for _, test := range tests {

--- a/components/licensor/main.go
+++ b/components/licensor/main.go
@@ -2,6 +2,8 @@
 // Licensed under the GNU Affero General Public License (AGPL).
 // See License.AGPL.txt in the project root for license information.
 
+// @deprecated
+
 package main
 
 import "github.com/gitpod-io/gitpod/licensor/ee/cmd"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This begins the deprecation of the licensor by setting the default and fallback licences to having a full complement of features and with no restrictions on the number of users.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #15640

## How to test
<!-- Provide steps to test this PR -->
Check the licence page in the preview environment. Below is proof from my own test environment

### main.6135
![image](https://user-images.githubusercontent.com/275848/211310349-b0406233-5ac2-45bb-84fb-18b4a59aea77.png)

### sje-licensor-deprecation.1
![image](https://user-images.githubusercontent.com/275848/211311091-c11ba03c-4080-4ebe-921b-da065be6e682.png)


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[licensor]: remove limits on licence user numbers and feature sets
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
