### PR TITLE
[server] Wait for image build logs in preparing state

### DIFF
--- a/components/dashboard/debug.sh
+++ b/components/dashboard/debug.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+# Licensed under the GNU Affero General Public License (AGPL).
+# See License.AGPL.txt in the project root for license information.
+
+set -Eeuo pipefail
+source /workspace/gitpod/scripts/ws-deploy.sh deployment dashboard

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -1639,7 +1639,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
             await new Promise((resolve) => setTimeout(resolve, 2000));
 
             const wsi = await this.workspaceDb.trace(ctx).findInstanceById(instance.id);
-            if (!wsi || wsi.status.phase !== "building") {
+            if (!wsi || !["preparing", "building"].includes(wsi.status.phase)) {
                 log.debug(logCtx, `imagebuild logs: instance is not/no longer in 'building' state`, {
                     phase: wsi?.status.phase,
                 });


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Fixes image build logs from showing up in the dashboard if the build is delayed.

When a workspace's image build is delayed (due to e.g. waiting for a node to scale up), the workspace instance stays in a `preparing` state, it only moves to `building` once the build is actually running. Previously, the logic would stop retrying for build logs if it's not in a `building` state, this PR changes it to also wait for build logs while in a `preparing` state

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #14862

## How to test
<!-- Provide steps to test this PR -->

In a preview environment:
- Cordon the preview environment's node
- Create a new image build (e.g. `https://<your-preview-env>.preview.gitpod-dev.com/#imagebuild/github.com/gitpod-io/gitpod`
- Wait a few minutes (an image build workspace gets created, but gets stuck in a pending state)
- Uncordon the node
- Observe that the image build runs, and logs are shown on the dashboard

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Fix image build logs not showing in the dashboard if the build is delayed.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
