### PR TITLE
[werft] add `with-dedicated-emulation` switch

### DIFF
--- a/.werft/jobs/build/deploy-to-preview-environment.ts
+++ b/.werft/jobs/build/deploy-to-preview-environment.ts
@@ -103,6 +103,7 @@ export async function deployToPreviewEnvironment(werft: Werft, jobConfig: JobCon
             withEELicense: deploymentConfig.installEELicense,
             workspaceFeatureFlags: workspaceFeatureFlags,
             withSlowDatabase: jobConfig.withSlowDatabase,
+            withDedicatedEmulation: jobConfig.withDedicatedEmulation,
         });
         try {
             werft.log(installerSlices.INSTALL, "deploying using installer");

--- a/.werft/jobs/build/installer/installer.ts
+++ b/.werft/jobs/build/installer/installer.ts
@@ -11,6 +11,7 @@ export type InstallerOptions = {
     withEELicense: boolean;
     workspaceFeatureFlags: string[];
     withSlowDatabase: boolean;
+    withDedicatedEmulation: boolean;
 };
 
 export class Installer {
@@ -31,6 +32,7 @@ export class Installer {
             GITPOD_WORKSPACE_FEATURE_FLAGS: this.options.workspaceFeatureFlags.join(" "),
             GITPOD_WITH_SLOW_DATABASE: this.options.withSlowDatabase,
             GITPOD_WITH_EE_LICENSE: this.options.withEELicense,
+            GITPOD_WITH_DEDICATED_EMU: this.options.withDedicatedEmulation,
         };
         const variables = Object.entries(environment)
             .map(([key, value]) => `${key}="${value}"`)

--- a/.werft/jobs/build/job-config.ts
+++ b/.werft/jobs/build/job-config.ts
@@ -34,6 +34,7 @@ export interface JobConfig {
     withObservability: boolean;
     withLocalPreview: boolean;
     withSlowDatabase: boolean;
+    withDedicatedEmulation: boolean;
     workspaceFeatureFlags: string[];
     previewEnvironment: PreviewEnvironmentConfig;
     repository: Repository;
@@ -107,6 +108,7 @@ export function jobConfig(werft: Werft, context: any): JobConfig {
     const recreatePreview = "recreate-preview" in buildConfig
     const recreateVm = mainBuild || "recreate-vm" in buildConfig;
     const withSlowDatabase = "with-slow-database" in buildConfig && !mainBuild;
+    const withDedicatedEmulation = "with-dedicated-emulation" in buildConfig && !mainBuild;
     const storageClass = buildConfig["storage-class"] || "";
 
     const analytics = parseAnalytics(werft, sliceId, buildConfig["analytics"])
@@ -183,6 +185,7 @@ export function jobConfig(werft: Werft, context: any): JobConfig {
         recreateVm,
         withSlowDatabase,
         withGitHubActions,
+        withDedicatedEmulation,
     };
 
     werft.logOutput(sliceId, JSON.stringify(jobConfig, null, 2));


### PR DESCRIPTION
## Description
This adds the initial step towards a setup mode trigger. The motivation is to provide a way for iterative work on Dedicated setups. 

## How to test
Trigger a new build of a preview env using `werft` from within a workspace. GH integration doesn't use the same version of `/workspace/gitpod/.werft/jobs/build/job-config.ts`, thus it wont work with the `/werft` comment. 
```
 $ werft run github -j .werft/build.yaml -a with-preview=true -a with-clean-slate-deployment=true -a with-dedicated-emulation=true
```

The custom build should not contain any auth providers, thus they'd need to be created in the app.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
