### PR TITLE
Add pin command to gp cli

### DIFF
--- a/components/gitpod-cli/cmd/pin.go
+++ b/components/gitpod-cli/cmd/pin.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2020 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package cmd
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"syscall"
+
+	gitpod "github.com/gitpod-io/gitpod/gitpod-cli/pkg/gitpod"
+	protocol "github.com/gitpod-io/gitpod/gitpod-protocol"
+	"github.com/spf13/cobra"
+)
+
+// pinCmd represents the pinCmd command
+var pinCmd = &cobra.Command{
+	Use:   "pin",
+	Short: "Toggle pinning of the current workspace",
+	Args:  cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		ctx, cancel := context.WithCancel(context.Background())
+		sigChan := make(chan os.Signal, 1)
+		signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
+		go func() {
+			<-sigChan
+			cancel()
+		}()
+		wsInfo, err := gitpod.GetWSInfo(ctx)
+		if err != nil {
+			fail(err.Error())
+		}
+		client, err := gitpod.ConnectToServer(ctx, wsInfo, []string{
+			"function:updateWorkspaceUserPin",
+			"resource:workspace::" + wsInfo.WorkspaceId + "::get/update",
+		})
+		if err != nil {
+			fail(err.Error())
+		}
+		err = client.Pin(ctx, &protocol.PinOptions{
+			WorkspaceID: wsInfo.WorkspaceId,
+		})
+		if err != nil {
+			fail(err.Error())
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(pinCmd)
+}

--- a/components/gitpod-protocol/go/gitpod-service.go
+++ b/components/gitpod-protocol/go/gitpod-service.go
@@ -1336,6 +1336,26 @@ func (gp *APIoverJSONRPC) RegisterGithubApp(ctx context.Context, installationID 
 	return
 }
 
+func (gp *APIoverJSONRPC) Pin(ctx context.Context, options *PinOptions) (err error) {
+	if gp == nil {
+		err = errNotConnected
+		return
+	}
+
+	params := []interface{}{
+		options,
+		"toggle",
+	}
+
+	var result string
+	err = gp.C.Call(ctx, "updateWorkspaceUserPin", params, &result)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
 // TakeSnapshot calls takeSnapshot on the server
 func (gp *APIoverJSONRPC) TakeSnapshot(ctx context.Context, options *TakeSnapshotOptions) (res string, err error) {
 	if gp == nil {
@@ -2014,6 +2034,11 @@ type GenerateNewGitpodTokenOptions struct {
 
 	// Scopes []string `json:"scopes,omitempty"`  float64 is the   float64 message type
 	Type float64 `json:"type,omitempty"`
+}
+
+// PinOptions is the PinOptions message type
+type PinOptions struct {
+	WorkspaceID string `json:"workspaceId,omitempty"`
 }
 
 // TakeSnapshotOptions is the TakeSnapshotOptions message type

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -1522,6 +1522,7 @@ export class WorkspaceStarter {
             "function:getTeams",
             "function:trackEvent",
             "function:getSupportedWorkspaceClasses",
+            "function:updateWorkspaceUserPin",
 
             "resource:" +
                 ScopedResourceGuard.marshalResourceScope({


### PR DESCRIPTION
## Description

:warning: This PR is still unfinished because I’m unsure how to test with the RPC server, since the scope `updateWorkspaceUserPin` is not a valid scope in production right now.

This adds a `pin` command to the CLI, which allows you to toggle the pinned state of the current workspace.

## Related Issue(s)

Fixes #13297 

Related to #6226 

## How to test

1. In the `gitpod-cli` directory, type `go run . pin` to pin the current workspace
2. Open https://gitpod.io/workspaces in your browser and see that ``

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Added `gp pin`, which pins the current workspace
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
