### PR TITLE
Only load zerossl-eab secret when needed

### DIFF
--- a/dev/preview/infrastructure/harvester/certificate-zerossl.tf
+++ b/dev/preview/infrastructure/harvester/certificate-zerossl.tf
@@ -3,6 +3,7 @@ locals {
 }
 
 data "google_secret_manager_secret_version" "zerossl_eab" {
+  count  = local.zerossl_enabled ? 1 : 0
   secret = "zerossl-eab"
 }
 
@@ -18,8 +19,8 @@ resource "acme_registration" "zerossl" {
   email_address   = "preview-environment-certificate-throwaway@gitpod.io"
 
   external_account_binding {
-    key_id      = jsondecode(data.google_secret_manager_secret_version.zerossl_eab.secret_data).kid
-    hmac_base64 = jsondecode(data.google_secret_manager_secret_version.zerossl_eab.secret_data).hmac
+    key_id      = jsondecode(data.google_secret_manager_secret_version.zerossl_eab[0].secret_data).kid
+    hmac_base64 = jsondecode(data.google_secret_manager_secret_version.zerossl_eab[0].secret_data).hmac
   }
 }
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Preview environment infrastructure creating is failing off main with the following error ([example job](https://werft.gitpod-dev.com/job/gitpod-build-wv-image-build-retry-preparing.1))

```
Error: Error retrieving available secret manager secret versions: googleapi: Error 403: Permission 'secretmanager.versions.get' denied for resource 'projects/gitpod-core-dev/secrets/zerossl-eab/versions/latest' (or it may not exist).
```

As a temporary workaround I have changed the terraform definition so that it only tries to read the secret if it is needed. ZeroSSL is the fallback provider, so for normal use-cases it won't be needed.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of https://github.com/gitpod-io/gitpod/issues/15146

## How to test
<!-- Provide steps to test this PR -->

`werft job run github -a with-preview` shows that terraform is succesful. It fails at a later point which I'll fix in a follow up PR 


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
none
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
