### PR TITLE
Preivew env GCE infra

### DIFF
--- a/dev/preview/infrastructure/gce/certificate-letsencrypt.tf
+++ b/dev/preview/infrastructure/gce/certificate-letsencrypt.tf
@@ -1,0 +1,58 @@
+locals {
+  letsencrypt_enabled = var.cert_issuer == "letsencrypt-issuer-gitpod-core-dev"
+}
+
+resource "tls_private_key" "letsencrypt" {
+  count     = local.letsencrypt_enabled ? 1 : 0
+  algorithm = "RSA"
+}
+
+resource "acme_registration" "letsencrypt" {
+  count           = local.letsencrypt_enabled ? 1 : 0
+  provider        = acme.letsencrypt
+  account_key_pem = tls_private_key.letsencrypt[0].private_key_pem
+  email_address   = "preview-environment-certificate-throwaway@gitpod.io"
+}
+
+resource "acme_certificate" "letsencrypt" {
+  count           = local.letsencrypt_enabled ? 1 : 0
+  provider        = acme.letsencrypt
+  account_key_pem = acme_registration.letsencrypt[0].account_key_pem
+  common_name     = "${var.preview_name}.${local.non_fully_qualified_dns_name}"
+  subject_alternative_names = [
+    "*.${var.preview_name}.${local.non_fully_qualified_dns_name}",
+    "*.ws-dev.${var.preview_name}.${local.non_fully_qualified_dns_name}"
+  ]
+  preferred_chain = "ISRG Root X1"
+
+  dns_challenge {
+    provider = "gcloud"
+    config = {
+      GCE_PROJECT = var.gcp_project_dns
+    }
+  }
+}
+
+resource "kubernetes_secret" "letsencrypt" {
+  count    = local.letsencrypt_enabled ? 1 : 0
+  provider = k8s.dev
+
+  type = "kubernetes.io/tls"
+
+  metadata {
+    name      = "harvester-${var.preview_name}"
+    namespace = "certs"
+    annotations = {
+      "preview/owner" = var.preview_name
+    }
+  }
+
+  data = {
+    "tls.crt" = "${lookup(acme_certificate.letsencrypt[0], "certificate_pem")}"
+    "tls.key" = "${lookup(acme_certificate.letsencrypt[0], "private_key_pem")}"
+  }
+
+  depends_on = [
+    acme_certificate.letsencrypt[0]
+  ]
+}

--- a/dev/preview/infrastructure/gce/certificate-zerossl.tf
+++ b/dev/preview/infrastructure/gce/certificate-zerossl.tf
@@ -1,0 +1,68 @@
+locals {
+  zerossl_enabled = var.cert_issuer == "zerossl-issuer-gitpod-core-dev"
+}
+
+data "google_secret_manager_secret_version" "zerossl_eab" {
+  count  = local.zerossl_enabled ? 1 : 0
+  secret = "zerossl-eab"
+}
+
+resource "tls_private_key" "zerossl" {
+  count     = local.zerossl_enabled ? 1 : 0
+  algorithm = "RSA"
+}
+
+resource "acme_registration" "zerossl" {
+  count           = local.zerossl_enabled ? 1 : 0
+  provider        = acme.zerossl
+  account_key_pem = tls_private_key.zerossl[0].private_key_pem
+  email_address   = "preview-environment-certificate-throwaway@gitpod.io"
+
+  external_account_binding {
+    key_id      = jsondecode(data.google_secret_manager_secret_version.zerossl_eab[0].secret_data).kid
+    hmac_base64 = jsondecode(data.google_secret_manager_secret_version.zerossl_eab[0].secret_data).hmac
+  }
+}
+
+resource "acme_certificate" "zerossl" {
+  count           = local.zerossl_enabled ? 1 : 0
+  provider        = acme.zerossl
+  account_key_pem = acme_registration.zerossl[0].account_key_pem
+  common_name     = "${var.preview_name}.${local.non_fully_qualified_dns_name}"
+  subject_alternative_names = [
+    "*.${var.preview_name}.${local.non_fully_qualified_dns_name}",
+    "*.ws-dev.${var.preview_name}.${local.non_fully_qualified_dns_name}"
+  ]
+  preferred_chain = ""
+
+  dns_challenge {
+    provider = "gcloud"
+    config = {
+      GCE_PROJECT = var.gcp_project_dns
+    }
+  }
+}
+
+resource "kubernetes_secret" "zerossl" {
+  count    = local.zerossl_enabled ? 1 : 0
+  provider = k8s.dev
+
+  type = "kubernetes.io/tls"
+
+  metadata {
+    name      = "harvester-${var.preview_name}"
+    namespace = "certs"
+    annotations = {
+      "preview/owner" = var.preview_name
+    }
+  }
+
+  data = {
+    "tls.crt" = "${lookup(acme_certificate.zerossl[0], "certificate_pem")}"
+    "tls.key" = "${lookup(acme_certificate.zerossl[0], "private_key_pem")}"
+  }
+
+  depends_on = [
+    acme_certificate.zerossl[0]
+  ]
+}

--- a/dev/preview/infrastructure/gce/cloudinit.yaml
+++ b/dev/preview/infrastructure/gce/cloudinit.yaml
@@ -1,0 +1,32 @@
+#cloud-config
+users:
+- name: ubuntu
+  sudo: "ALL=(ALL) NOPASSWD: ALL"
+  ssh_authorized_keys:
+    - ${ssh_authorized_keys}
+chpasswd:
+  list: |
+    ubuntu:ubuntu
+  expire: False
+write_files:
+  - path: /usr/local/bin/bootstrap.sh
+    permissions: '0744'
+    owner: root
+    content: |
+      #!/bin/bash
+
+      set -eo pipefail
+
+      # disables a service that pulls a few GBs of workspace images on every machine start
+      sudo systemctl disable load-workspace-full.service &
+      sudo systemctl stop load-workspace-full.service &
+
+      cat <<'EOF' >> /etc/containerd/config.toml
+      [plugins."io.containerd.grpc.v1.cri".registry.configs."registry-1.docker.io".auth]
+        username = "${dockerhub_user}"
+        password = "${dockerhub_passwd}"
+      EOF
+
+      sudo systemctl restart containerd.service &
+runcmd:
+ - bash /usr/local/bin/bootstrap.sh

--- a/dev/preview/infrastructure/gce/dns.tf
+++ b/dev/preview/infrastructure/gce/dns.tf
@@ -1,0 +1,54 @@
+data "google_dns_managed_zone" "preview-gitpod-dev" {
+  provider = google
+  name     = "preview-gitpod-dev-com"
+}
+
+locals {
+  # Not all consumers of the DNS name handle the fully qualified DNS name (with a dot at the end) well
+  # so for those resources, we have this local variable as a convenience. Example: acme_certificate
+  non_fully_qualified_dns_name = trim(data.google_dns_managed_zone.preview-gitpod-dev.dns_name, ".")
+}
+
+resource "google_dns_record_set" "root" {
+  provider = google
+
+  name = "${var.preview_name}.${data.google_dns_managed_zone.preview-gitpod-dev.dns_name}"
+  type = "A"
+  ttl  = 300
+
+  managed_zone = data.google_dns_managed_zone.preview-gitpod-dev.name
+  rrdatas      = [var.harvester_ingress_ip]
+}
+
+resource "google_dns_record_set" "root-wc" {
+  provider = google
+
+  name = "*.${var.preview_name}.${data.google_dns_managed_zone.preview-gitpod-dev.dns_name}"
+  type = "A"
+  ttl  = 300
+
+  managed_zone = data.google_dns_managed_zone.preview-gitpod-dev.name
+  rrdatas      = [var.harvester_ingress_ip]
+}
+
+resource "google_dns_record_set" "root-wc-ws-dev" {
+  provider = google
+
+  name = "*.ws-dev.${var.preview_name}.${data.google_dns_managed_zone.preview-gitpod-dev.dns_name}"
+  type = "A"
+  ttl  = 300
+
+  managed_zone = data.google_dns_managed_zone.preview-gitpod-dev.name
+  rrdatas      = [var.harvester_ingress_ip]
+}
+
+resource "google_dns_record_set" "root-wc-ws-dev-ssh" {
+  provider = google
+
+  name = "*.ssh.ws-dev.${var.preview_name}.${data.google_dns_managed_zone.preview-gitpod-dev.dns_name}"
+  type = "A"
+  ttl  = 300
+
+  managed_zone = data.google_dns_managed_zone.preview-gitpod-dev.name
+  rrdatas      = [google_compute_instance.default.network_interface.0.access_config.0.nat_ip]
+}

--- a/dev/preview/infrastructure/gce/namespace.tf
+++ b/dev/preview/infrastructure/gce/namespace.tf
@@ -1,0 +1,6 @@
+resource "kubernetes_namespace" "preview_namespace" {
+  provider = k8s.harvester
+  metadata {
+    name = "preview-${var.preview_name}"
+  }
+}

--- a/dev/preview/infrastructure/gce/provider.tf
+++ b/dev/preview/infrastructure/gce/provider.tf
@@ -1,0 +1,49 @@
+terraform {
+
+  backend "gcs" {
+    bucket = "3f4745df-preview-tf-state"
+    prefix = "preview-gce"
+  }
+
+  required_version = ">= 1.2"
+  required_providers {
+    k8s = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.0"
+    }
+    google = {
+      source  = "hashicorp/google"
+      version = ">=4.47.0"
+    }
+    acme = {
+      source  = "vancluever/acme"
+      version = "~> 2.0"
+    }
+  }
+}
+provider "k8s" {
+  alias          = "dev"
+  config_path    = var.kubeconfig_path
+  config_context = var.dev_kube_context
+}
+
+provider "k8s" {
+  alias          = "harvester"
+  config_path    = var.kubeconfig_path
+  config_context = var.harvester_kube_context
+}
+
+provider "google" {
+  project = "gitpod-core-dev"
+  region  = "us-central1"
+}
+
+provider "acme" {
+  alias      = "letsencrypt"
+  server_url = "https://acme-v02.api.letsencrypt.org/directory"
+}
+
+provider "acme" {
+  alias      = "zerossl"
+  server_url = "https://acme.zerossl.com/v2/DV90"
+}

--- a/dev/preview/infrastructure/gce/proxy.tf
+++ b/dev/preview/infrastructure/gce/proxy.tf
@@ -1,0 +1,92 @@
+resource "kubernetes_pod" "proxy" {
+  provider = k8s.harvester
+  metadata {
+    name      = "proxy"
+    namespace = kubernetes_namespace.preview_namespace.metadata[0].name
+    labels = {
+      "preview-name" = var.preview_name
+    }
+  }
+
+  spec {
+    container {
+      name              = "socat"
+      image             = "alpine/socat"
+      image_pull_policy = "IfNotPresent"
+      command           = ["/bin/ash"]
+      # dumb port-forward directly to the machine
+      # those should be all the ports that need to be accessible in a preview env
+      # we also forward 22 to 2222, as 22 is disabled in the vm image and we don't want to change that
+      args = [
+        "-c",
+        "socat TCP-LISTEN:22,fork,reuseaddr TCP:${google_compute_instance.default.network_interface.0.access_config.0.nat_ip}:2222 & for i in 2200 80 443 6443 9090 3000; do socat TCP-LISTEN:$i,fork,reuseaddr TCP:${google_compute_instance.default.network_interface.0.access_config.0.nat_ip}:$i & done; wait"
+      ]
+    }
+  }
+}
+
+# Proxy service in the HARVESTER cluster, same namespace
+resource "kubernetes_service" "harvester-svc" {
+  provider = k8s.harvester
+  metadata {
+    name      = "proxy"
+    namespace = kubernetes_namespace.preview_namespace.metadata[0].name
+  }
+
+  spec {
+    port {
+      name        = "ssh-gateway"
+      protocol    = "TCP"
+      port        = 22
+      target_port = 22
+    }
+    port {
+      name        = "vm-ssh"
+      protocol    = "TCP"
+      port        = 2200
+      target_port = 2200
+    }
+    port {
+      name        = "gce-ssh"
+      protocol    = "TCP"
+      port        = 2222
+      target_port = 2222
+    }
+    port {
+      name        = "http"
+      protocol    = "TCP"
+      port        = 80
+      target_port = 80
+    }
+    port {
+      name        = "https"
+      protocol    = "TCP"
+      port        = 443
+      target_port = 443
+    }
+    port {
+      name        = "kube-api"
+      protocol    = "TCP"
+      port        = 6443
+      target_port = 6443
+    }
+    port {
+      name        = "prometheus"
+      protocol    = "TCP"
+      port        = 9090
+      target_port = 32001
+    }
+    port {
+      name        = "grafana"
+      protocol    = "TCP"
+      port        = 3000
+      target_port = 32000
+    }
+
+    selector = {
+      "preview-name" = var.preview_name
+    }
+
+    type = "ClusterIP"
+  }
+}

--- a/dev/preview/infrastructure/gce/startup-script.sh
+++ b/dev/preview/infrastructure/gce/startup-script.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+set -eo pipefail
+
+# inspired by https://github.com/gitpod-io/ops/blob/main/deploy/workspace/templates/bootstrap.sh
+
+# Install k3s
+export INSTALL_K3S_SKIP_DOWNLOAD=true
+
+/usr/local/bin/install-k3s.sh \
+  --token "1234" \
+  --node-ip "$(hostname -I | cut -d ' ' -f1)" \
+  --node-label "cloud.google.com/gke-nodepool=control-plane-pool" \
+  --container-runtime-endpoint=/var/run/containerd/containerd.sock \
+  --write-kubeconfig-mode 444 \
+  --disable traefik \
+  --disable metrics-server \
+  --flannel-backend=none \
+  --kubelet-arg config=/etc/kubernetes/kubelet-config.json \
+  --kubelet-arg cgroup-driver=systemd \
+  --kubelet-arg feature-gates=LocalStorageCapacityIsolation=true \
+  --kubelet-arg feature-gates=LocalStorageCapacityIsolationFSQuotaMonitoring=true \
+  --kube-apiserver-arg feature-gates=LocalStorageCapacityIsolation=true \
+  --kube-apiserver-arg feature-gates=LocalStorageCapacityIsolationFSQuotaMonitoring=true \
+  --cluster-init
+
+# Seems like this is a bit flaky now, with k3s not always being ready, and the labeling
+# failing occasionally. Sleeping for a bit solves it.
+sleep 10
+
+kubectl label nodes ${vm_name} \
+  gitpod.io/workload_meta=true \
+  gitpod.io/workload_ide=true \
+  gitpod.io/workload_workspace_services=true \
+  gitpod.io/workload_workspace_regular=true \
+  gitpod.io/workload_workspace_headless=true \
+  gitpod.io/workspace_0=true \
+  gitpod.io/workspace_1=true \
+  gitpod.io/workspace_2=true
+
+# apply fix from https://github.com/k3s-io/klipper-lb/issues/6 so we can use the klipper servicelb
+# this can be removed if https://github.com/gitpod-io/gitpod-packer-gcp-image/pull/20 gets merged
+cat /var/lib/gitpod/manifests/calico.yaml | sed s/__KUBERNETES_NODE_NAME__\"\,/__KUBERNETES_NODE_NAME__\",\ \"container_settings\"\:\ \{\ \"allow_ip_forwarding\"\:\ true\ \}\,/ >/var/lib/gitpod/manifests/calico2.yaml
+
+sed -i 's/docker.io/quay.io/g' /var/lib/gitpod/manifests/calico2.yaml
+sed -i 's/interface=ens/interface=en/g' /var/lib/gitpod/manifests/calico2.yaml
+sed -i 's/\$CLUSTER_IP_RANGE/10.20.0.0\/16/g' /var/lib/gitpod/manifests/calico2.yaml
+
+kubectl apply -f /var/lib/gitpod/manifests/calico2.yaml
+
+kubectl apply -f /var/lib/gitpod/manifests/cert-manager.yaml
+kubectl apply -f /var/lib/gitpod/manifests/metrics-server.yaml
+
+# install CSI snapshotter CRDs and snapshot controller
+kubectl apply -f /var/lib/gitpod/manifests/csi-driver.yaml || true
+kubectl apply -f /var/lib/gitpod/manifests/csi-config.yaml || true
+
+cat <<EOF >>/etc/bash.bashrc
+export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
+EOF

--- a/dev/preview/infrastructure/gce/variables.tf
+++ b/dev/preview/infrastructure/gce/variables.tf
@@ -1,0 +1,46 @@
+variable "preview_name" {
+  type        = string
+  description = "The preview environment's name"
+}
+
+variable "kubeconfig_path" {
+  type        = string
+  default     = "/home/gitpod/.kube/config"
+  description = "The path to the kubernetes config"
+}
+
+variable "harvester_kube_context" {
+  type        = string
+  default     = "harvester"
+  description = "The name of the harvester kube context"
+}
+
+variable "dev_kube_context" {
+  type        = string
+  default     = "dev"
+  description = "The name of the dev kube context"
+}
+
+variable "harvester_ingress_ip" {
+  type        = string
+  default     = "159.69.172.117"
+  description = "Ingress IP in Harvester cluster"
+}
+
+variable "vmi" {
+  type        = string
+  description = "The storage class for the VM"
+  default     = "gitpod-k3s-202209251218"
+}
+
+variable "cert_issuer" {
+  type        = string
+  default     = "letsencrypt-issuer-gitpod-core-dev"
+  description = "Certificate issuer"
+}
+
+variable "gcp_project_dns" {
+  type        = string
+  default     = "gitpod-core-dev"
+  description = "The GCP project in which to create DNS records"
+}

--- a/dev/preview/infrastructure/gce/vm.tf
+++ b/dev/preview/infrastructure/gce/vm.tf
@@ -1,0 +1,72 @@
+data "google_compute_default_service_account" "default" {
+  provider = google
+}
+
+resource "google_compute_instance" "default" {
+  provider     = google
+  name         = var.preview_name
+  machine_type = "n2-standard-8"
+  zone         = "us-central1-a"
+
+  boot_disk {
+    initialize_params {
+      image = "projects/workspace-clusters/global/images/${var.vmi}"
+    }
+  }
+
+  tags = ["preview"]
+
+  #  scheduling {
+  #    provisioning_model          = "SPOT"
+  #    preemptible                 = true
+  #    automatic_restart           = false
+  #    instance_termination_action = "STOP"
+  #  }
+
+  metadata = {
+    ssh-keys           = "dev:${file(pathexpand("~/.ssh/vm_id_rsa.pub"))}"
+    serial-port-enable = true
+    user-data          = local.cloudinit_user_data
+  }
+
+  network_interface {
+    network = "default"
+
+    access_config {
+      // Ephemeral public IP
+    }
+  }
+
+  metadata_startup_script = local.startup_script
+
+  service_account {
+    # Google recommends custom service accounts that have cloud-platform scope and permissions granted via IAM Roles.
+    email  = data.google_compute_default_service_account.default.email
+    scopes = ["cloud-platform"]
+  }
+}
+
+data "kubernetes_secret" "harvester-k3s-dockerhub-pull-account" {
+  provider = k8s.dev
+  metadata {
+    name      = "harvester-k3s-dockerhub-pull-account"
+    namespace = "werft"
+  }
+}
+
+locals {
+  startup_script = templatefile("${path.module}/startup-script.sh", {
+    dockerhub_user   = data.kubernetes_secret.harvester-k3s-dockerhub-pull-account.data["username"]
+    dockerhub_passwd = data.kubernetes_secret.harvester-k3s-dockerhub-pull-account.data["password"]
+    vm_name          = var.preview_name
+  })
+
+  cloudinit_user_data = templatefile("${path.module}/cloudinit.yaml", {
+    dockerhub_user      = data.kubernetes_secret.harvester-k3s-dockerhub-pull-account.data["username"]
+    dockerhub_passwd    = data.kubernetes_secret.harvester-k3s-dockerhub-pull-account.data["password"]
+    vm_name             = var.preview_name
+    ssh_authorized_keys = local.ssh_key
+  })
+
+  ssh_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC/aB/HYsb56V0NBOEab6j33v3LIxRiGqG4fmidAryAXevLyTANJPF8m44KSzSQg7AI7PMy6egxQp/JqH2b+3z1cItWuHZSU+klsKNuf5HxK7AOrND3ahbejZfyYewtKFQ3X9rv5Sk8TAR5gw5oPbkTR61jiLa58Sw7UkhLm2EDguGASb6mBal8iboiF8Wpl8QIvPmJaGIOY2YwXLepwFA3S3kVqW88eh2WFmjTMre5ASLguYNkHXjyb/TuhVFzAvphzpl84RAaEyjKYnk45fh4xRXx+oKqlfKRJJ/Owxa7SmGO+/4rWb3chdnpodHeu7XjERmjYLY+r46sf6n6ySgEht1xAWjMb1uqZqkDx+fDDsjFSeaN3ncX6HSoDOrphFmXYSwaMpZ8v67A791fuUPrMLC+YMckhTuX2g4i3XUdumIWvhaMvKhy/JRRMsfUH0h+KAkBLI6tn5ozoXiQhgM4SAE5HsMr6CydSIzab0yY3sq0avmZgeoc78+8PKPkZG1zRMEspV/hKKBC8hq7nm0bu4IgzuEIYHowOD8svqA0ufhDWxTt6A4Jo0xDzhFyKme7KfmW7SIhpejf3T1Wlf+QINs1hURr8LSOZEyY2SzYmAoQ49N0SSPb5xyG44cptpKcj0WCAJjBJoZqz0F5x9TjJ8XToB5obyJfRHD1JjxoMQ== dev@gitpod.io"
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This PR adds GCE Infra required to run preview envs. Other PRs will follow with leeway/werft integration and a tidying up of the terraform for both harvester/gce and a small change in `previewctl install-context`

* The VM is created directly from the VMI from ws clusters
* Separated the original cloud-init into 2 (gce only for now):
    * cloud-init to set-up the machine (docker, disable services)
    * startup-script to install k3s - will try to get this one to execute in tf with remote exec - so k3s installation is synchronous
* Disable and stop `load-workspace-full.service` for both harvester and gce
    * This seems that has been running always, and pulls a couple of GB of images (workspace-full) on every machine start. Should considerably speed up preview env startup as we don't need those images by default
* An ugly hack - `proxy` pod/svc in harvester - It runs `socat` and port-forwards directly to the VM. This is required because:
    * The auth callback for gh log-in is set to `preview.gitpod-dev.com`, which is an ingress in the harvester cluster, which in turn proxies requests to the `proxy` service in every preview namespace based on a url param matching the preview env name(space)
    * `{preview}.kube.gitpod-dev.com`, is a wildcard dns that points to a proxy somewhere, which forwards 6443 (k8s api) to the same proxy service. This one can be solved with a literal record directly to the machine, but keeping it the same for now.

<img width="1693" alt="image" src="https://user-images.githubusercontent.com/5501705/210837061-d7ddc2fc-c2cf-4119-aac0-71024ece3fe1.png">

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
