### PR TITLE
chore: descriptive output Gitpod CLI

### DIFF
--- a/components/gitpod-cli/cmd/timeout-extend.go
+++ b/components/gitpod-cli/cmd/timeout-extend.go
@@ -6,6 +6,7 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	gitpod "github.com/gitpod-io/gitpod/gitpod-cli/pkg/gitpod"
@@ -39,6 +40,7 @@ var extendTimeoutCmd = &cobra.Command{
 			}
 			fail(err.Error())
 		}
+		fmt.Println("Workspace timeout has been extended to three hours.")
 	},
 }
 

--- a/components/gitpod-cli/cmd/timeout-show.go
+++ b/components/gitpod-cli/cmd/timeout-show.go
@@ -40,9 +40,9 @@ var showTimeoutCommand = &cobra.Command{
 		// Try to use `DurationRaw` but fall back to `Duration` in case of
 		// old server component versions that don't expose it.
 		if res.DurationRaw != "" {
-			fmt.Println(res.DurationRaw)
+			fmt.Println("Timeout for current workspace is", res.DurationRaw)
 		} else {
-			fmt.Println(res.Duration)
+			fmt.Println("Timeout for current workspace is", res.Duration)
 		}
 	},
 }


### PR DESCRIPTION
> Signed-off-by: Siddhant Khare <siddhant@gitpod.io>

## Description

<img width="1387" alt="image" src="https://user-images.githubusercontent.com/55068936/211019648-b9409867-850c-4d09-b19f-19ba889291b1.png">


## How to test

- Open Preview
- Open Any Workspace
- Run `gp timeout extend` and `gp timeout show`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
