### PR TITLE
Fix preview environment deletion

### DIFF
--- a/.werft/util/preview.ts
+++ b/.werft/util/preview.ts
@@ -90,7 +90,7 @@ export async function configureAccess(werft: Werft) {
     try {
         await installPreviewCTL()
     } catch (e) {
-        throw new Error("Failed to install Previewctl")
+        werft.fail(SLICES.INSTALL_PREVIEWCTL, e)
     }
 
     try {
@@ -123,10 +123,10 @@ export async function configureAccess(werft: Werft) {
 export async function installPreviewCTL() {
     try {
         await execStream(`leeway run dev/preview/previewctl:install`, {
-            slice: "Install previewctl",
+            slice: SLICES.INSTALL_PREVIEWCTL,
         })
     } catch (e) {
-        throw new Error("Failed to install previewctl.");
+        throw new Error(`Failed to install previewctl: ${e}`);
     }
 }
 

--- a/.werft/vm/vm.ts
+++ b/.werft/vm/vm.ts
@@ -16,7 +16,7 @@ export async function destroyPreview(options: { name: string }) {
             {slice: "Deleting VM."})
     } catch (err) {
         werft.currentPhaseSpan.setAttribute("preview.deleted_vm", false);
-        werft.fail("Deleting VM.", new Error(`Failed creating VM: ${err}`))
+        werft.fail("Deleting VM.", new Error(`Failed deleting VM: ${err}`))
         return;
     }
 

--- a/dev/preview/infrastructure/harvester/variables.tf
+++ b/dev/preview/infrastructure/harvester/variables.tf
@@ -47,7 +47,7 @@ variable "harvester_ingress_ip" {
 
 variable "cert_issuer" {
   type        = string
-  default     = "zerossl-issuer-gitpod-core-dev"
+  default     = "letsencrypt-issuer-gitpod-core-dev"
   description = "Certificate issuer"
 }
 


### PR DESCRIPTION
## Description

The terraform variable defaulted to zerossl but it should have been letsencrypt. This PR fixes that. Also contains minor improvements around error diagnostics.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

Part of https://github.com/gitpod-io/gitpod/issues/15146

## How to test
<!-- Provide steps to test this PR -->

Triggered manually:

https://werft.gitpod-dev.com/job/gitpod-custom-mads-fix-delete-preview.2

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
