### PR TITLE
Improve /auth/workspace-cookie fetching

### DIFF
--- a/components/gitpod-protocol/src/util/gitpod-host-url.ts
+++ b/components/gitpod-protocol/src/util/gitpod-host-url.ts
@@ -124,10 +124,9 @@ export class GitpodHostUrl {
         });
     }
 
-    asWorkspaceAuth(instanceID: string, redirect?: boolean): GitpodHostUrl {
+    asWorkspaceAuth(instanceID: string): GitpodHostUrl {
         return this.with((url) => ({
             pathname: `/api/auth/workspace-cookie/${instanceID}`,
-            search: redirect ? "redirect" : "",
         }));
     }
 

--- a/components/server/src/user/user-controller.ts
+++ b/components/server/src/user/user-controller.ts
@@ -267,9 +267,9 @@ export class UserController {
 
                 const token = instance.status.ownerToken;
                 if (!token) {
-                    // no token, no problem. The dashboard will try again later.
-                    res.sendStatus(200);
-                    log.debug("attempted to fetch workspace cookie, but instance has no owner token", {
+                    // There is no token to answer with, so we sent a 404. The client has to properly handle this case with retries/timeouts, etc.
+                    res.sendStatus(404);
+                    log.warn("attempted to fetch workspace cookie, but instance has no owner token", {
                         instanceId: req.params.instanceID,
                         userId: user.id,
                     });


### PR DESCRIPTION
## Description
When testing `slow-server` we noticed that sometimes fetching of workspace-cookies would not work, but sent us into a dead-end redirect.
Analysis of logs showed that this might happen to some people regularly ([link](https://github.com/gitpod-io/gitpod/issues/15328#issuecomment-1373736924)), and might be related to outdated code: e.g. the handler we use (no longer?) supports handling redirects.

This PR removes that redirect logic, and replaces it with a re-try.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Context: #15328

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
