### PR TITLE
cache fetched repositories to improve performance on `/new` 

### DIFF
--- a/components/dashboard/src/projects/NewProject.tsx
+++ b/components/dashboard/src/projects/NewProject.tsx
@@ -30,6 +30,8 @@ import {
 import { FeatureFlagContext } from "../contexts/FeatureFlagContext";
 import { ConnectError } from "@bufbuild/connect-web";
 
+const LOCAL_STORAGE_KEY = "new-project-search-data";
+
 export default function NewProject() {
     const location = useLocation();
     const { teams } = useContext(TeamsContext);
@@ -54,6 +56,7 @@ export default function NewProject() {
     const [isGitHubWebhooksUnauthorized, setIsGitHubWebhooksUnauthorized] = useState<boolean>();
 
     useEffect(() => {
+        loadSearchData();
         const { server } = getGitpodService();
         Promise.all([
             server.getAuthProviders().then((v) => () => setAuthProviders(v)),
@@ -140,6 +143,7 @@ export default function NewProject() {
     }, [selectedTeamOrUser, selectedRepo]);
 
     useEffect(() => {
+        saveSearchData(reposInAccounts);
         if (reposInAccounts.length === 0) {
             setSelectedAccount(undefined);
         } else {
@@ -838,4 +842,27 @@ async function openReconfigureWindow(params: { account?: string; onSuccess: (p: 
         }
     };
     window.addEventListener("message", eventListener);
+}
+
+function saveSearchData(searchData: ProviderRepository[]): void {
+    try {
+        window.localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(searchData));
+    } catch (error) {
+        console.warn("Could not save search data into local storage", error);
+    }
+}
+
+function loadSearchData(): ProviderRepository[] {
+    const string = localStorage.getItem(LOCAL_STORAGE_KEY);
+    if (!string) {
+        return [];
+    }
+    try {
+        const data = JSON.parse(string);
+        console.log("Loaded search data from local storage", data);
+        return data;
+    } catch (error) {
+        console.warn("Could not load search data from local storage", error);
+        return [];
+    }
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Performance Improvement of new project fetching repository service
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
