### PR TITLE
Improve readability of label in billing settings

### DIFF
--- a/components/dashboard/src/components/BillingAccountSelector.tsx
+++ b/components/dashboard/src/components/BillingAccountSelector.tsx
@@ -6,7 +6,7 @@
 
 import { useContext, useEffect, useState } from "react";
 import { Team, TeamMemberInfo } from "@gitpod/gitpod-protocol";
-import { AttributionId } from "@gitpod/gitpod-protocol/lib/attribution";
+import { AttributionId, AttributionTarget } from "@gitpod/gitpod-protocol/lib/attribution";
 import { getGitpodService } from "../service/service";
 import { TeamsContext } from "../teams/teams-context";
 import { UserContext } from "../user-context";
@@ -86,6 +86,10 @@ export function BillingAccountSelector(props: { onSelected?: () => void }) {
 
     let selectedAttributionId = user?.usageAttributionId || AttributionId.render({ kind: "user", userId: user?.id! });
 
+    const isSelected = (kind: AttributionTarget, accountId: string): boolean =>
+        selectedAttributionId ===
+        AttributionId.render(kind === "user" ? { kind, userId: accountId } : { kind, teamId: accountId });
+
     return (
         <>
             {errorMessage && (
@@ -111,27 +115,32 @@ export function BillingAccountSelector(props: { onSelected?: () => void }) {
                         <SelectableCardSolid
                             className="h-18"
                             title="(myself)"
-                            selected={
-                                !!user &&
-                                selectedAttributionId === AttributionId.render({ kind: "user", userId: user.id })
-                            }
+                            selected={!!user && isSelected("user", user.id)}
                             onClick={() => setUsageAttributionTeam(undefined)}
                         >
                             <div className="flex-grow flex items-end px-1">
-                                <span className="text-sm text-gray-400">Personal Account</span>
+                                <span
+                                    className={`text-sm text-gray-400${
+                                        !!user && isSelected("user", user.id) ? " dark:text-gray-600" : ""
+                                    }`}
+                                >
+                                    Personal Account
+                                </span>
                             </div>
                         </SelectableCardSolid>
                         {teamsAvailableForAttribution.map((t) => (
                             <SelectableCardSolid
                                 className="h-18"
                                 title={t.name}
-                                selected={
-                                    selectedAttributionId === AttributionId.render({ kind: "team", teamId: t.id })
-                                }
+                                selected={isSelected("team", t.id)}
                                 onClick={() => setUsageAttributionTeam(t)}
                             >
                                 <div className="flex-grow flex items-end px-1">
-                                    <span className="text-sm text-gray-400">
+                                    <span
+                                        className={`text-sm text-gray-400${
+                                            isSelected("team", t.id) ? " dark:text-gray-600" : ""
+                                        }`}
+                                    >
                                         {!!membersByTeam[t.id]
                                             ? `${membersByTeam[t.id].length} member${
                                                   membersByTeam[t.id].length === 1 ? "" : "s"


### PR DESCRIPTION
_This PR was previously opened as https://github.com/gitpod-io/gitpod/pull/15594, read why we needed a new PR there: https://github.com/gitpod-io/gitpod/pull/15594#issuecomment-1373977394_

## Description

This improves the readability of the **Personal Account** billing account type label in dark mode if the account is selected as default billing account, because the label only had a contrast of 2.31 against the white background.

Currently, the text is actually kind of hard to read in dark mode on my 13.5" display.

Using `gray-600` here gets us a 6.99 color contrast, however we could also use `gray-500` to maintain the visual color hierarchy as seen in light mode and when not selected. While that would only get us to 4.4 contrast ratio, it’s definitely way more legible than `gray-400`.

## Screenshots

| Billing account | Before | After |
| --- | --- | --- |
| User | ![image](https://user-images.githubusercontent.com/28510368/210898712-35057620-9b2d-4213-947a-b79d13e212b2.png) | ![image](https://user-images.githubusercontent.com/28510368/210898419-1b1f5a08-a576-444f-bd57-3621844ccf70.png) |
| Team | ![image](https://user-images.githubusercontent.com/28510368/210898790-31d8226f-f9d3-4cda-b368-571818bc2702.png) | ![image](https://user-images.githubusercontent.com/28510368/210898467-59d6ea53-f7ed-43ee-974a-a7c8778395c4.png) |

There are no visual changes in the light mode.

## Related Issue(s)

None.

## How to test

1. In the navbar, click on your avatar
2. Click on **Settings**
3. In the sidebar, click on **Billing**
4. See the type text of the default billing account is better readable
5. If you have a billable team, select it
6. See that the type text of the team is likewise better readable
7. See that the type text of the user is now unchanged to `main`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
