### PR TITLE
feat: `gp validate` in Gitpod CLI

### DIFF
--- a/components/gitpod-cli/cmd/validate.go
+++ b/components/gitpod-cli/cmd/validate.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	gitpod "github.com/gitpod-io/gitpod/gitpod-protocol"
+	"github.com/spf13/cobra"
+	"github.com/xeipuuv/gojsonschema"
+	yaml "gopkg.in/yaml.v2"
+)
+
+var validateCommand = &cobra.Command{
+	Use:   "validate",
+	Short: "Validate your .gitpod.yml file is valid or not",
+	Run: func(_ *cobra.Command, _ []string) {
+
+		// Load .gitpod.yml schema
+		schemaLoader := gojsonschema.NewReferenceLoader("https://gitpod.io/schemas/gitpod-schema.json")
+
+		// Load .gitpod.yml file
+		filePathOfGitpodConfig := os.Getenv("GITPOD_REPO_ROOT") + "/.gitpod.yml"
+
+		data, err := os.ReadFile(filePathOfGitpodConfig)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				fmt.Println(".gitpod.yml file does not exist")
+				return
+			}
+			panic(errors.New("read .gitpod.yml file failed: " + err.Error() + "\n"))
+		}
+
+		// TODO: Better error handling messages.
+		var config *gitpod.GitpodConfig
+		if err = yaml.Unmarshal(data, &config); err != nil {
+			fmt.Println(".gitpod.yml is invalid. see errors :\n" + err.Error() + "\n")
+			return
+		}
+
+		documentLoader := gojsonschema.NewGoLoader(config)
+
+		result, err := gojsonschema.Validate(schemaLoader, documentLoader)
+		if err != nil {
+			panic(err.Error())
+		}
+
+		if result.Valid() {
+			fmt.Println(".gitpod.yml is valid")
+		} else {
+			fmt.Println(".gitpod.yml is invalid")
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(validateCommand)
+}

--- a/components/gitpod-cli/go.mod
+++ b/components/gitpod-cli/go.mod
@@ -37,6 +37,9 @@ require (
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/mattn/go-runewidth v0.0.9 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
+	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
+	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
 	golang.org/x/net v0.0.0-20220624214902-1bab6f366d9e // indirect
 	golang.org/x/text v0.3.7 // indirect
 	google.golang.org/genproto v0.0.0-20220822174746-9e6da59bd2fc // indirect

--- a/components/gitpod-cli/go.sum
+++ b/components/gitpod-cli/go.sum
@@ -211,6 +211,12 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
+github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f h1:J9EGpcZtP0E/raorCMxlFGSTBrsSlaDGf3jU/qvAE2c=
+github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
+github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0=
+github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
+github.com/xeipuuv/gojsonschema v1.2.0 h1:LhYJRs+L4fBtjZUfuSZIKGeVu0QRy8e5Xi7D17UxZ74=
+github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=


### PR DESCRIPTION
Signed-off-by: Siddhant Khare <siddhant@gitpod.io>

## Description

:tada: Validate your `.gitpod.yml` using `gp validate`

|No `.gitpod.yml` file|Valid File|Invalid File _(this can be improved)_|
|:---:|:---:|:---:|
|<img width="1102" alt="image" src="https://user-images.githubusercontent.com/55068936/211155856-4eace31b-063a-4378-b039-dcf49a813ebc.png">|<img width="1117" alt="image" src="https://user-images.githubusercontent.com/55068936/211155900-afbbe690-d5e4-42d9-a0c1-8d7f93ab2955.png"> |<img width="1156" alt="image" src="https://user-images.githubusercontent.com/55068936/211155961-fad3d7df-49d8-4fa8-ab34-915a4d4be9af.png">|

### TODO:

- Better error handling of error messages

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #9025

## How to test
<!-- Provide steps to test this PR -->
- Open Preview
- Open workspace with any repo.
-  Add a `.gitpod.yml` file:

```yml
# List the start up tasks. Learn more https://www.gitpod.io/docs/config-start-tasks/
tasks:
  - init: echo 'init script' # runs during prebuild
    command: echo 'start script'

# List the ports to expose. Learn more https://www.gitpod.io/docs/config-ports/
ports:
  - port: 3000
    onOpen: open-preview
```
- Open Terminal & run `gp validate`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Validate your .gitpod.yml from Gitpod CLI using `gp validate`
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
