### PR TITLE
[iam/sso] select config by ID on /start

### DIFF
--- a/components/iam/pkg/oidc/service.go
+++ b/components/iam/pkg/oidc/service.go
@@ -159,17 +159,27 @@ func randString(size int) (string, error) {
 
 func (s *Service) GetClientConfigFromStartRequest(r *http.Request) (*ClientConfig, error) {
 	issuerParam := r.URL.Query().Get("issuer")
-	if issuerParam == "" {
-		return nil, fmt.Errorf("missing issuer parameter")
+	idParam := r.URL.Query().Get("id")
+	if issuerParam == "" && idParam == "" {
+		return nil, fmt.Errorf("missing parameters")
 	}
 
-	for _, value := range s.configsById {
-		if value.Issuer == issuerParam {
-			return value, nil
+	if idParam != "" {
+		config := s.configsById[idParam]
+		if config != nil {
+			return config, nil
+		}
+		return nil, fmt.Errorf("failed to find OIDC config by ID")
+	}
+	if issuerParam != "" {
+		for _, value := range s.configsById {
+			if value.Issuer == issuerParam {
+				return value, nil
+			}
 		}
 	}
 
-	return nil, fmt.Errorf("failed to find OIDC config for start request")
+	return nil, fmt.Errorf("failed to find OIDC config")
 }
 
 func (s *Service) GetClientConfigFromCallbackRequest(r *http.Request) (*ClientConfig, error) {
@@ -187,7 +197,7 @@ func (s *Service) GetClientConfigFromCallbackRequest(r *http.Request) (*ClientCo
 		return config, nil
 	}
 
-	return nil, fmt.Errorf("failed to find OIDC config for request")
+	return nil, fmt.Errorf("failed to find OIDC config on callback")
 }
 
 type AuthenticateParams struct {

--- a/components/iam/pkg/oidc/service_test.go
+++ b/components/iam/pkg/oidc/service_test.go
@@ -85,6 +85,16 @@ func TestGetClientConfigFromStartRequest(t *testing.T) {
 			ExpectedError: true,
 			ExpectedId:    "",
 		},
+		{
+			Location:      "/start?id=UNKNOWN",
+			ExpectedError: true,
+			ExpectedId:    "",
+		},
+		{
+			Location:      "/start?id=" + clientID,
+			ExpectedError: false,
+			ExpectedId:    clientID,
+		},
 	}
 
 	sessionServerAddress := newFakeSessionServer(t)


### PR DESCRIPTION
Given that some OIDC client configurations will be fetched on frontend to render a login page, it makes sense to allow direct selection of the OIDC client by id: `GET /iam/oidc/start?id=UUID`



## Related Issue(s)
Depends on #15628
Part of #7761

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
