### PR TITLE
[oidc] find/create User account

### DIFF
--- a/components/server/src/iam/iam-oidc-create-session-payload.ts
+++ b/components/server/src/iam/iam-oidc-create-session-payload.ts
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+export namespace OIDCCreateSessionPayload {
+    export function is(payload: any): payload is OIDCCreateSessionPayload {
+        return (
+            typeof payload === "object" &&
+            "idToken" in payload &&
+            "claims" in payload &&
+            "iss" in payload.claims &&
+            "sub" in payload.claims &&
+            "name" in payload.claims &&
+            "email" in payload.claims
+        );
+    }
+
+    export function validate(payload: OIDCCreateSessionPayload) {
+        if (isEmpty(payload.claims.iss)) {
+            throw new Error("Issuer is missing");
+        }
+        if (isEmpty(payload.claims.sub)) {
+            throw new Error("Subject is missing");
+        }
+        if (isEmpty(payload.claims.name)) {
+            throw new Error("Name is missing");
+        }
+        if (isEmpty(payload.claims.email)) {
+            throw new Error("Email is missing");
+        }
+    }
+
+    function isEmpty(attribute: any) {
+        return typeof attribute !== "string" || attribute.length < 1;
+    }
+}
+
+export interface OIDCCreateSessionPayload {
+    idToken: {
+        Issuer: string; // "https://accounts.google.com",
+        Audience: string[];
+        Subject: string; // "1234567890",
+        Expiry: string; // "2023-01-10T12:00:00Z",
+        IssuedAt: string; // "2023-01-01T12:00:00Z",
+    };
+    claims: {
+        aud: string;
+        email: string;
+        email_verified: true;
+        family_name: string;
+        given_name: string;
+        hd?: string; // accepted domain, e.g. "gitpod.io"
+        iss: string; // "https://accounts.google.com"
+        locale: string; // e.g. "de"
+        name: string;
+        picture: string; // URL of avatar
+        sub: string; // "1234567890"
+    };
+}


### PR DESCRIPTION
During the OIDC flow, the `iam` component does a `POST` request to the server internally which should ensure a HTTP session is created to proceed with. This PR comes with the implementation of an account look-up.

To simplify things, I decided to map `authProviderId` to `issuerID` and `authId` to `subject`. There is no complete mapping of auth providers to OIDC clients included, as it might be not required and potentially wrong.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Based on #15629
Part of #7761
Fixes #14954


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
