### PR TITLE
[common-go] Clear `GITPOD_HOST` environment variable before test

### DIFF
--- a/components/common-go/experiments/types_test.go
+++ b/components/common-go/experiments/types_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestNewClient_WithoutEnvSet(t *testing.T) {
+	t.Setenv("GITPOD_HOST", "")
 	client := NewClient()
 	require.IsType(t, &alwaysReturningDefaultValueClient{}, client)
 }


### PR DESCRIPTION
## Description

The `TestNewClient_WithoutEnvSet`  test fails when run (via `go test`) from a gitpod workspace because gitpod workspaces have the `GITPOD_HOST` env var set, causing the `NewClient` call to return a `ConfigCatClient` rather than a `alwaysReturningDefaultValueClient` struct as expected.

Having the test fail from within a workspace means that running `telepresence` for components that have `common-go` as a dependency doesn't work as `common-go` can't be built.

Clear the env var before the test runs to avoid this.

## Related Issue(s)
Fixes #

## How to test

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
