### PR TITLE
[server] Validate fields for setTeamMemberRole

### DIFF
--- a/components/gitpod-protocol/src/teams-projects-protocol.ts
+++ b/components/gitpod-protocol/src/teams-projects-protocol.ts
@@ -137,6 +137,12 @@ export interface Team {
 
 export type TeamMemberRole = "owner" | "member";
 
+export namespace TeamMemberRole {
+    export function isValid(role: any): role is TeamMemberRole {
+        return role === "owner" || role === "member";
+    }
+}
+
 export interface TeamMemberInfo {
     userId: string;
     fullName?: string;

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -133,7 +133,7 @@ import {
 import * as crypto from "crypto";
 import { inject, injectable } from "inversify";
 import { URL } from "url";
-import { v4 as uuidv4 } from "uuid";
+import { v4 as uuidv4, validate as uuidValidate } from "uuid";
 import { Disposable, ResponseError } from "vscode-jsonrpc";
 import { IAnalyticsWriter } from "@gitpod/gitpod-protocol/lib/analytics";
 import { AuthProviderService } from "../auth/auth-provider-service";
@@ -2124,6 +2124,18 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         role: TeamMemberRole,
     ): Promise<void> {
         traceAPIParams(ctx, { teamId, userId, role });
+
+        if (!uuidValidate(teamId)) {
+            throw new ResponseError(ErrorCodes.BAD_REQUEST, "team ID must be a valid UUID");
+        }
+
+        if (!uuidValidate(userId)) {
+            throw new ResponseError(ErrorCodes.BAD_REQUEST, "user ID must be a valid UUID");
+        }
+
+        if (!TeamMemberRole.isValid(role)) {
+            throw new ResponseError(ErrorCodes.BAD_REQUEST, "invalid role name");
+        }
 
         this.checkAndBlockUser("setTeamMemberRole");
         await this.guardTeamOperation(teamId, "update");


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Validates arguments of setTeamMemberRole call

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
