### PR TITLE
[JetBrains-Gateway] Menu Options for Usage, Feedback, Help in JB Gateway Plugin

### DIFF
--- a/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodWorkspacesView.kt
+++ b/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodWorkspacesView.kt
@@ -120,13 +120,25 @@ class GitpodWorkspacesView(
                     }
                     label("").resizableColumn().horizontalAlign(HorizontalAlign.FILL)
                     actionsButton(object :
-                        DumbAwareAction("Open Dashboard", "Open Dashboard", AllIcons.Nodes.Servlet) {
+                        DumbAwareAction("Dashboard", "Dashboard", AllIcons.Nodes.Servlet) {
                         override fun actionPerformed(e: AnActionEvent) {
                             BrowserUtil.browse("https://${settings.gitpodHost}")
                         }
+                    }, object : DumbAwareAction("Usage", "Usage", AllIcons.Actions.DynamicUsages) {
+                        override fun actionPerformed(e: AnActionEvent) {
+                            BrowserUtil.browse("https://${settings.gitpodHost}/usage")
+                        }
                     }, object : DumbAwareAction("Documentation", "Documentation", AllIcons.Toolwindows.Documentation) {
                         override fun actionPerformed(e: AnActionEvent) {
-                            BrowserUtil.browse("https://www.gitpod.io/docs/ides-and-editors/jetbrains-gateway")
+                            BrowserUtil.browse("https://www.gitpod.io/docs/integrations/jetbrains-gateway")
+                        }
+                    }, object : DumbAwareAction("Feedback", "Feedback", AllIcons.Actions.IntentionBulb) {
+                        override fun actionPerformed(e: AnActionEvent) {
+                            BrowserUtil.browse("https://github.com/gitpod-io/gitpod/issues/6576")
+                        }
+                    }, object : DumbAwareAction("Help", "Help", AllIcons.Actions.Help) {
+                        override fun actionPerformed(e: AnActionEvent) {
+                            BrowserUtil.browse("https://www.gitpod.io/contact/support?subject=technical%20support")
                         }
                     }, object : DumbAwareAction("Log Out", "Log out", AllIcons.Actions.Exit) {
                         override fun actionPerformed(e: AnActionEvent) {


### PR DESCRIPTION
> Signed-off-by: Siddhant Khare <siddhant@gitpod.io>

## Description
This PR propose changes to providing user options to open Usage Page, Open Feedback Issue, Help page of website directly from JetBrains Gateway.

|Old|New|
|:---:|:---:|
|<img width="928" alt="image" src="https://user-images.githubusercontent.com/55068936/211487681-02944cc8-0f23-467c-b603-c2733d02a223.png">|<img width="951" alt="image" src="https://user-images.githubusercontent.com/55068936/211484102-14f3c2f6-2514-4ea7-a29d-0cce32052184.png">|


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test

- Open JetBrains Gateway
- Install [Dev Version of this preview for Open Gitpod Plugin](https://plugins.jetbrains.com/plugin/18438-gitpod-gateway/versions/Dev/275087)
- Click on Settings Gear Icon above `New Worksapce` Button
- See :eyes: new options :sparkles:

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Menu Options for Usage, Feedback & Help in Gitpod's JetBrains Gateway Plugin
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
