### PR TITLE
[server] Validate userID, teamID is a UUID on team operations

### DIFF
--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -2046,6 +2046,11 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
 
     public async getTeam(ctx: TraceContext, teamId: string): Promise<Team> {
         traceAPIParams(ctx, { teamId });
+
+        if (!uuidValidate(teamId)) {
+            throw new ResponseError(ErrorCodes.BAD_REQUEST, "team ID must be a valid UUID");
+        }
+
         this.checkAndBlockUser("getTeam");
 
         const team = await this.teamDB.findTeamById(teamId);
@@ -2058,6 +2063,10 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
 
     public async getTeamMembers(ctx: TraceContext, teamId: string): Promise<TeamMemberInfo[]> {
         traceAPIParams(ctx, { teamId });
+
+        if (!uuidValidate(teamId)) {
+            throw new ResponseError(ErrorCodes.BAD_REQUEST, "team ID must be a valid UUID");
+        }
 
         this.checkUser("getTeamMembers");
         const team = await this.getTeam(ctx, teamId);
@@ -2145,6 +2154,14 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
     public async removeTeamMember(ctx: TraceContext, teamId: string, userId: string): Promise<void> {
         traceAPIParams(ctx, { teamId, userId });
 
+        if (!uuidValidate(teamId)) {
+            throw new ResponseError(ErrorCodes.BAD_REQUEST, "team ID must be a valid UUID");
+        }
+
+        if (!uuidValidate(userId)) {
+            throw new ResponseError(ErrorCodes.BAD_REQUEST, "user ID must be a valid UUID");
+        }
+
         const user = this.checkAndBlockUser("removeTeamMember");
         // Users are free to leave any team themselves, but only owners can remove others from their teams.
         await this.guardTeamOperation(teamId, user.id === userId ? "get" : "update");
@@ -2167,6 +2184,10 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
     public async getGenericInvite(ctx: TraceContext, teamId: string): Promise<TeamMembershipInvite> {
         traceAPIParams(ctx, { teamId });
 
+        if (!uuidValidate(teamId)) {
+            throw new ResponseError(ErrorCodes.BAD_REQUEST, "team ID must be a valid UUID");
+        }
+
         this.checkUser("getGenericInvite");
         await this.guardTeamOperation(teamId, "get");
         const invite = await this.teamDB.findGenericInviteByTeamId(teamId);
@@ -2178,6 +2199,10 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
 
     public async resetGenericInvite(ctx: TraceContext, teamId: string): Promise<TeamMembershipInvite> {
         traceAPIParams(ctx, { teamId });
+
+        if (!uuidValidate(teamId)) {
+            throw new ResponseError(ErrorCodes.BAD_REQUEST, "team ID must be a valid UUID");
+        }
 
         this.checkAndBlockUser("resetGenericInvite");
         await this.guardTeamOperation(teamId, "update");


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

To ensure we fail early on bogus values. This is also a necessary pre-cursor to use an authorization system as we need to guarantee consistency of records

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
1. Interact with teams in preview
2. Make a request using the ws protocol with non-uuid values


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[server] Validate userID and teamID is a UUID on Team operations
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
