### PR TITLE
[dashboard - login] align login page product desc.

### DIFF
--- a/components/dashboard/src/Login.tsx
+++ b/components/dashboard/src/Login.tsx
@@ -151,7 +151,8 @@ export function Login() {
                             <div className="mb-10">
                                 <h1 className="text-5xl mb-3">Welcome to Gitpod</h1>
                                 <div className="text-gray-400 text-lg">
-                                    Spin up fresh, automated dev environments for each task in the cloud, in seconds.
+                                    Spin up fresh cloud development environments for each task, fully automated, in
+                                    seconds.
                                 </div>
                             </div>
                             <div className="flex mb-10">


### PR DESCRIPTION
## Description

Align the new updated message on Login Page with new product description with [website message](https://www.gitpod.io/#:~:text=Spin%20up%20fresh%20cloud%20development%20environments%0Afor%20each%20task%2C%20fully%20automated%2C%20in%20seconds.)

|Old|New|
|:---:|:---:|
|![image](https://user-images.githubusercontent.com/55068936/211495303-0430c54f-2a21-4e53-8f55-66beef1d4b52.png)|![image](https://user-images.githubusercontent.com/55068936/211495350-05f751c1-5bce-43c0-b1c0-997de963cf03.png)|

## How to test
<!-- Provide steps to test this PR -->
- Open Preview 
- Go to `/login` or `workspaces` (if you are not logged in)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
