### PR TITLE
Add proxy route for public-api

### DIFF
--- a/components/dashboard/src/service/public-api.ts
+++ b/components/dashboard/src/service/public-api.ts
@@ -16,8 +16,7 @@ import { TeamMember, TeamRole } from "@gitpod/public-api/lib/gitpod/experimental
 import { Project } from "@gitpod/public-api/lib/gitpod/experimental/v1/projects_pb";
 
 const transport = createConnectTransport({
-    baseUrl: `${window.location.protocol}//api.${window.location.host}`,
-    credentials: "include",
+    baseUrl: `${window.location.protocol}//${window.location.host}/public-api`,
 });
 
 export const teamsService = createPromiseClient(TeamsService, transport);

--- a/components/proxy/conf/Caddyfile
+++ b/components/proxy/conf/Caddyfile
@@ -176,6 +176,13 @@ https://{$GITPOD_DOMAIN} {
 	import ssl_configuration
 	import security_headers
 
+	@proxy_public_api path /public-api*
+	handle @proxy_public_api {
+		uri strip_prefix /public-api
+
+		reverse_proxy public-api-server.{$KUBE_NAMESPACE}.{$KUBE_DOMAIN}:9002
+	}
+
 	@workspace_download path /workspace-download*
 	handle @workspace_download {
 		import google_storage_headers


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

As step 7 for [internal chat](https://gitpod.slack.com/archives/C04HBF1GWJ0/p1673335543513649)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
- ✅  All public apis in preview env dashboard should works, and request should be like gitpod.io/public-api/xxx
- ✅  Change main cookie domain to `hw-pub-proxyy.preview.gitpod-dev.com`, public API should work still

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
