### PR TITLE
[code] update stable code

### DIFF
--- a/install/installer/cmd/testdata/render/aws-setup/output.golden
+++ b/install/installer/cmd/testdata/render/aws-setup/output.golden
@@ -3513,7 +3513,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-fdf6a08a681c53ddd97c7bae9acc7d49158a41a0",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2b5b022a4d10e518d55b5a893dab492f2a33ba89",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {
@@ -5149,7 +5149,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-fdf6a08a681c53ddd97c7bae9acc7d49158a41a0",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2b5b022a4d10e518d55b5a893dab492f2a33ba89",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/azure-setup/output.golden
+++ b/install/installer/cmd/testdata/render/azure-setup/output.golden
@@ -3517,7 +3517,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-fdf6a08a681c53ddd97c7bae9acc7d49158a41a0",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2b5b022a4d10e518d55b5a893dab492f2a33ba89",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {
@@ -5133,7 +5133,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-fdf6a08a681c53ddd97c7bae9acc7d49158a41a0",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2b5b022a4d10e518d55b5a893dab492f2a33ba89",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
+++ b/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
@@ -3824,7 +3824,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "registry.mydomain.com/namespace/ide/code:commit-fdf6a08a681c53ddd97c7bae9acc7d49158a41a0",
+            "image": "registry.mydomain.com/namespace/ide/code:commit-2b5b022a4d10e518d55b5a893dab492f2a33ba89",
             "latestImage": "registry.mydomain.com/namespace/ide/code:nightly"
           },
           "code-desktop": {
@@ -5540,7 +5540,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "registry.mydomain.com/namespace/ide/code:commit-fdf6a08a681c53ddd97c7bae9acc7d49158a41a0",
+            "image": "registry.mydomain.com/namespace/ide/code:commit-2b5b022a4d10e518d55b5a893dab492f2a33ba89",
             "latestImage": "registry.mydomain.com/namespace/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -4382,7 +4382,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-fdf6a08a681c53ddd97c7bae9acc7d49158a41a0",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2b5b022a4d10e518d55b5a893dab492f2a33ba89",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {
@@ -6143,7 +6143,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-fdf6a08a681c53ddd97c7bae9acc7d49158a41a0",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2b5b022a4d10e518d55b5a893dab492f2a33ba89",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -3658,7 +3658,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-fdf6a08a681c53ddd97c7bae9acc7d49158a41a0",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2b5b022a4d10e518d55b5a893dab492f2a33ba89",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {
@@ -5320,7 +5320,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-fdf6a08a681c53ddd97c7bae9acc7d49158a41a0",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2b5b022a4d10e518d55b5a893dab492f2a33ba89",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/gcp-setup/output.golden
+++ b/install/installer/cmd/testdata/render/gcp-setup/output.golden
@@ -3488,7 +3488,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-fdf6a08a681c53ddd97c7bae9acc7d49158a41a0",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2b5b022a4d10e518d55b5a893dab492f2a33ba89",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {
@@ -5094,7 +5094,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-fdf6a08a681c53ddd97c7bae9acc7d49158a41a0",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2b5b022a4d10e518d55b5a893dab492f2a33ba89",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/http-proxy/output.golden
+++ b/install/installer/cmd/testdata/render/http-proxy/output.golden
@@ -3827,7 +3827,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-fdf6a08a681c53ddd97c7bae9acc7d49158a41a0",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2b5b022a4d10e518d55b5a893dab492f2a33ba89",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {
@@ -5543,7 +5543,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-fdf6a08a681c53ddd97c7bae9acc7d49158a41a0",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2b5b022a4d10e518d55b5a893dab492f2a33ba89",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/kind-ide/output.golden
+++ b/install/installer/cmd/testdata/render/kind-ide/output.golden
@@ -1295,7 +1295,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-fdf6a08a681c53ddd97c7bae9acc7d49158a41a0",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2b5b022a4d10e518d55b5a893dab492f2a33ba89",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {
@@ -2617,7 +2617,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-fdf6a08a681c53ddd97c7bae9acc7d49158a41a0",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2b5b022a4d10e518d55b5a893dab492f2a33ba89",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/kind-meta/output.golden
+++ b/install/installer/cmd/testdata/render/kind-meta/output.golden
@@ -2795,7 +2795,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-fdf6a08a681c53ddd97c7bae9acc7d49158a41a0",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2b5b022a4d10e518d55b5a893dab492f2a33ba89",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {
@@ -4416,7 +4416,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-fdf6a08a681c53ddd97c7bae9acc7d49158a41a0",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2b5b022a4d10e518d55b5a893dab492f2a33ba89",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -3824,7 +3824,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-fdf6a08a681c53ddd97c7bae9acc7d49158a41a0",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2b5b022a4d10e518d55b5a893dab492f2a33ba89",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {
@@ -5540,7 +5540,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-fdf6a08a681c53ddd97c7bae9acc7d49158a41a0",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2b5b022a4d10e518d55b5a893dab492f2a33ba89",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/shortname/output.golden
+++ b/install/installer/cmd/testdata/render/shortname/output.golden
@@ -3824,7 +3824,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-fdf6a08a681c53ddd97c7bae9acc7d49158a41a0",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2b5b022a4d10e518d55b5a893dab492f2a33ba89",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {
@@ -5540,7 +5540,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-fdf6a08a681c53ddd97c7bae9acc7d49158a41a0",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2b5b022a4d10e518d55b5a893dab492f2a33ba89",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -3836,7 +3836,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-fdf6a08a681c53ddd97c7bae9acc7d49158a41a0",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2b5b022a4d10e518d55b5a893dab492f2a33ba89",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {
@@ -5552,7 +5552,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-fdf6a08a681c53ddd97c7bae9acc7d49158a41a0",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2b5b022a4d10e518d55b5a893dab492f2a33ba89",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
+++ b/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
@@ -4157,7 +4157,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-fdf6a08a681c53ddd97c7bae9acc7d49158a41a0",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2b5b022a4d10e518d55b5a893dab492f2a33ba89",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {
@@ -5873,7 +5873,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-fdf6a08a681c53ddd97c7bae9acc7d49158a41a0",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2b5b022a4d10e518d55b5a893dab492f2a33ba89",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
+++ b/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
@@ -3826,7 +3826,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-fdf6a08a681c53ddd97c7bae9acc7d49158a41a0",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2b5b022a4d10e518d55b5a893dab492f2a33ba89",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {
@@ -5542,7 +5542,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-fdf6a08a681c53ddd97c7bae9acc7d49158a41a0",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2b5b022a4d10e518d55b5a893dab492f2a33ba89",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
+++ b/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
@@ -3827,7 +3827,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-fdf6a08a681c53ddd97c7bae9acc7d49158a41a0",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2b5b022a4d10e518d55b5a893dab492f2a33ba89",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {
@@ -5543,7 +5543,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-fdf6a08a681c53ddd97c7bae9acc7d49158a41a0",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2b5b022a4d10e518d55b5a893dab492f2a33ba89",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/pkg/components/workspace/ide/constants.go
+++ b/install/installer/pkg/components/workspace/ide/constants.go
@@ -6,7 +6,7 @@ package ide
 
 const (
 	CodeIDEImage                = "ide/code"
-	CodeIDEImageStableVersion   = "commit-fdf6a08a681c53ddd97c7bae9acc7d49158a41a0" // stable version that will be updated manually on demand
+	CodeIDEImageStableVersion   = "commit-2b5b022a4d10e518d55b5a893dab492f2a33ba89" // stable version that will be updated manually on demand
 	CodeDesktopIDEImage         = "ide/code-desktop"
 	CodeDesktopInsidersIDEImage = "ide/code-desktop-insiders"
 	IntelliJDesktopIDEImage     = "ide/intellij"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
As step 2 of [internal chat](https://github.com/gitpod-io/openvscode-server/commit/ad9c6305383fffbb0ff2a069017e39429d05925f) 

commit hash comes from https://werft.gitpod-dev.com/job/gitpod-build-hw-build-stable.1

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
- Open workspace with **stable** code in preview env
- Make sure it works

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
