### PR TITLE
[iam] (actually) don't fail if test config is missing

### DIFF
--- a/components/iam/pkg/oidc/service.go
+++ b/components/iam/pkg/oidc/service.go
@@ -52,7 +52,7 @@ func NewServiceWithTestConfig(configPath string, sessionServiceAddress string) (
 
 	testConfig, err := readDemoConfigFromFile(configPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read test config: %w", err)
+		log.WithError(err).Errorf("failed to read test config")
 	}
 	if testConfig != nil {
 		clientConfig := &ClientConfig{
@@ -71,7 +71,7 @@ func NewServiceWithTestConfig(configPath string, sessionServiceAddress string) (
 
 		err = s.AddClientConfig(clientConfig)
 		if err != nil {
-			log.Errorf("failed to add client config: %v", err)
+			log.WithError(err).Errorf("failed to add client config")
 		}
 	}
 


### PR DESCRIPTION
This is a fix-up for #15577, where we wanted to get rid of the returned error if test config was not found.


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
