### PR TITLE
[dashboard] add "with-options" buttons

### DIFF
--- a/components/dashboard/src/projects/Project.tsx
+++ b/components/dashboard/src/projects/Project.tsx
@@ -398,26 +398,29 @@ export default function () {
                                                 </a>
                                                 <ItemFieldContextMenu
                                                     className="py-0.5"
-                                                    menuEntries={
+                                                    menuEntries={[
+                                                        {
+                                                            title: "New Workspace ...",
+                                                            href: gitpodHostUrl
+                                                                .withContext(`${branch.url}`, { showOptions: true })
+                                                                .toString(),
+                                                            separator: true,
+                                                        },
                                                         prebuild?.status === "queued" || prebuild?.status === "building"
-                                                            ? [
-                                                                  {
-                                                                      title: "Cancel Prebuild",
-                                                                      customFontStyle:
-                                                                          "text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-300",
-                                                                      onClick: () =>
-                                                                          prebuild && cancelPrebuild(prebuild.info.id),
-                                                                  },
-                                                              ]
-                                                            : [
-                                                                  {
-                                                                      title: `${prebuild ? "Rerun" : "Run"} Prebuild (${
-                                                                          branch.name
-                                                                      })`,
-                                                                      onClick: () => triggerPrebuild(branch),
-                                                                  },
-                                                              ]
-                                                    }
+                                                            ? {
+                                                                  title: "Cancel Prebuild",
+                                                                  customFontStyle:
+                                                                      "text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-300",
+                                                                  onClick: () =>
+                                                                      prebuild && cancelPrebuild(prebuild.info.id),
+                                                              }
+                                                            : {
+                                                                  title: `${prebuild ? "Rerun" : "Run"} Prebuild (${
+                                                                      branch.name
+                                                                  })`,
+                                                                  onClick: () => triggerPrebuild(branch),
+                                                              },
+                                                    ]}
                                                 />
                                             </ItemField>
                                         </Item>

--- a/components/dashboard/src/projects/ProjectListItem.tsx
+++ b/components/dashboard/src/projects/ProjectListItem.tsx
@@ -13,6 +13,7 @@ import { useCurrentTeam } from "../teams/teams-context";
 import { RemoveProjectModal } from "./RemoveProjectModal";
 import { toRemoteURL } from "./render-utils";
 import { prebuildStatusIcon } from "./Prebuilds";
+import { gitpodHostUrl } from "../service/service";
 
 type ProjectListItemProps = {
     project: Project;
@@ -40,7 +41,14 @@ export const ProjectListItem: FunctionComponent<ProjectListItemProps> = ({ proje
                                 menuEntries={[
                                     {
                                         title: "New Workspace",
-                                        href: `/#${project.cloneUrl}`,
+                                        href: gitpodHostUrl.withContext(`${project.cloneUrl}`).toString(),
+                                        separator: true,
+                                    },
+                                    {
+                                        title: "New Workspace ...",
+                                        href: gitpodHostUrl
+                                            .withContext(`${project.cloneUrl}`, { showOptions: true })
+                                            .toString(),
                                         separator: true,
                                     },
                                     {

--- a/components/gitpod-protocol/src/util/gitpod-host-url.ts
+++ b/components/gitpod-protocol/src/util/gitpod-host-url.ts
@@ -77,8 +77,15 @@ export class GitpodHostUrl {
         return updated.with((url) => ({ pathname: `/api${url.pathname}` }));
     }
 
-    withContext(contextUrl: string) {
-        return this.with((url) => ({ hash: contextUrl }));
+    withContext(
+        contextUrl: string,
+        startOptions?: { showOptions?: boolean; editor?: string; workspaceClass?: string },
+    ) {
+        const searchParams = new URLSearchParams();
+        if (startOptions?.showOptions) {
+            searchParams.append("showOptions", "true");
+        }
+        return this.with((url) => ({ hash: contextUrl, search: searchParams.toString() }));
     }
 
     asWebsocket(): GitpodHostUrl {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Adds a secondary "New Workspace ..." button the projects list on a team and the branches list on a project.


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Added a secondary button to start workspaces on projects and branches with options.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
