### PR TITLE
VS Code `1.74.3`

### DIFF
--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -7,8 +7,8 @@ defaultArgs:
   publishToNPM: true
   publishToJBMarketplace: true
   localAppVersion: unknown
-  codeCommit: 8ee664e58e31e81e9dd9da10fb31809e249f0d61
-  codeVersion: 1.75.0
+  codeCommit: 5717390f186f7f0d00fec0394ba3452b658ee169
+  codeVersion: 1.74.3
   codeQuality: stable
   noVerifyJBPlugin: false
   intellijDownloadUrl: "https://download.jetbrains.com/idea/ideaIU-2022.3.1.tar.gz"

--- a/install/installer/cmd/testdata/render/aws-setup/output.golden
+++ b/install/installer/cmd/testdata/render/aws-setup/output.golden
@@ -3513,7 +3513,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2b5b022a4d10e518d55b5a893dab492f2a33ba89",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-f861b9d093fc8cdc728a0179b3a0c43a9155d9b4",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {
@@ -5149,7 +5149,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2b5b022a4d10e518d55b5a893dab492f2a33ba89",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-f861b9d093fc8cdc728a0179b3a0c43a9155d9b4",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/azure-setup/output.golden
+++ b/install/installer/cmd/testdata/render/azure-setup/output.golden
@@ -3517,7 +3517,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2b5b022a4d10e518d55b5a893dab492f2a33ba89",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-f861b9d093fc8cdc728a0179b3a0c43a9155d9b4",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {
@@ -5133,7 +5133,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2b5b022a4d10e518d55b5a893dab492f2a33ba89",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-f861b9d093fc8cdc728a0179b3a0c43a9155d9b4",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
+++ b/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
@@ -3824,7 +3824,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "registry.mydomain.com/namespace/ide/code:commit-2b5b022a4d10e518d55b5a893dab492f2a33ba89",
+            "image": "registry.mydomain.com/namespace/ide/code:commit-f861b9d093fc8cdc728a0179b3a0c43a9155d9b4",
             "latestImage": "registry.mydomain.com/namespace/ide/code:nightly"
           },
           "code-desktop": {
@@ -5540,7 +5540,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "registry.mydomain.com/namespace/ide/code:commit-2b5b022a4d10e518d55b5a893dab492f2a33ba89",
+            "image": "registry.mydomain.com/namespace/ide/code:commit-f861b9d093fc8cdc728a0179b3a0c43a9155d9b4",
             "latestImage": "registry.mydomain.com/namespace/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -4382,7 +4382,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2b5b022a4d10e518d55b5a893dab492f2a33ba89",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-f861b9d093fc8cdc728a0179b3a0c43a9155d9b4",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {
@@ -6143,7 +6143,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2b5b022a4d10e518d55b5a893dab492f2a33ba89",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-f861b9d093fc8cdc728a0179b3a0c43a9155d9b4",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -3658,7 +3658,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2b5b022a4d10e518d55b5a893dab492f2a33ba89",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-f861b9d093fc8cdc728a0179b3a0c43a9155d9b4",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {
@@ -5320,7 +5320,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2b5b022a4d10e518d55b5a893dab492f2a33ba89",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-f861b9d093fc8cdc728a0179b3a0c43a9155d9b4",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/gcp-setup/output.golden
+++ b/install/installer/cmd/testdata/render/gcp-setup/output.golden
@@ -3488,7 +3488,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2b5b022a4d10e518d55b5a893dab492f2a33ba89",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-f861b9d093fc8cdc728a0179b3a0c43a9155d9b4",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {
@@ -5094,7 +5094,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2b5b022a4d10e518d55b5a893dab492f2a33ba89",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-f861b9d093fc8cdc728a0179b3a0c43a9155d9b4",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/http-proxy/output.golden
+++ b/install/installer/cmd/testdata/render/http-proxy/output.golden
@@ -3827,7 +3827,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2b5b022a4d10e518d55b5a893dab492f2a33ba89",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-f861b9d093fc8cdc728a0179b3a0c43a9155d9b4",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {
@@ -5543,7 +5543,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2b5b022a4d10e518d55b5a893dab492f2a33ba89",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-f861b9d093fc8cdc728a0179b3a0c43a9155d9b4",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/kind-ide/output.golden
+++ b/install/installer/cmd/testdata/render/kind-ide/output.golden
@@ -1295,7 +1295,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2b5b022a4d10e518d55b5a893dab492f2a33ba89",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-f861b9d093fc8cdc728a0179b3a0c43a9155d9b4",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {
@@ -2617,7 +2617,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2b5b022a4d10e518d55b5a893dab492f2a33ba89",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-f861b9d093fc8cdc728a0179b3a0c43a9155d9b4",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/kind-meta/output.golden
+++ b/install/installer/cmd/testdata/render/kind-meta/output.golden
@@ -2795,7 +2795,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2b5b022a4d10e518d55b5a893dab492f2a33ba89",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-f861b9d093fc8cdc728a0179b3a0c43a9155d9b4",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {
@@ -4416,7 +4416,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2b5b022a4d10e518d55b5a893dab492f2a33ba89",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-f861b9d093fc8cdc728a0179b3a0c43a9155d9b4",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -3824,7 +3824,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2b5b022a4d10e518d55b5a893dab492f2a33ba89",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-f861b9d093fc8cdc728a0179b3a0c43a9155d9b4",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {
@@ -5540,7 +5540,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2b5b022a4d10e518d55b5a893dab492f2a33ba89",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-f861b9d093fc8cdc728a0179b3a0c43a9155d9b4",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/shortname/output.golden
+++ b/install/installer/cmd/testdata/render/shortname/output.golden
@@ -3824,7 +3824,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2b5b022a4d10e518d55b5a893dab492f2a33ba89",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-f861b9d093fc8cdc728a0179b3a0c43a9155d9b4",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {
@@ -5540,7 +5540,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2b5b022a4d10e518d55b5a893dab492f2a33ba89",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-f861b9d093fc8cdc728a0179b3a0c43a9155d9b4",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -3836,7 +3836,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2b5b022a4d10e518d55b5a893dab492f2a33ba89",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-f861b9d093fc8cdc728a0179b3a0c43a9155d9b4",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {
@@ -5552,7 +5552,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2b5b022a4d10e518d55b5a893dab492f2a33ba89",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-f861b9d093fc8cdc728a0179b3a0c43a9155d9b4",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
+++ b/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
@@ -4157,7 +4157,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2b5b022a4d10e518d55b5a893dab492f2a33ba89",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-f861b9d093fc8cdc728a0179b3a0c43a9155d9b4",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {
@@ -5873,7 +5873,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2b5b022a4d10e518d55b5a893dab492f2a33ba89",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-f861b9d093fc8cdc728a0179b3a0c43a9155d9b4",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
+++ b/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
@@ -3826,7 +3826,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2b5b022a4d10e518d55b5a893dab492f2a33ba89",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-f861b9d093fc8cdc728a0179b3a0c43a9155d9b4",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {
@@ -5542,7 +5542,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2b5b022a4d10e518d55b5a893dab492f2a33ba89",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-f861b9d093fc8cdc728a0179b3a0c43a9155d9b4",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
+++ b/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
@@ -3827,7 +3827,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2b5b022a4d10e518d55b5a893dab492f2a33ba89",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-f861b9d093fc8cdc728a0179b3a0c43a9155d9b4",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {
@@ -5543,7 +5543,7 @@ data:
             "type": "browser",
             "logo": "https://ide.gitpod.example.com/image/ide-logo/vscode.svg",
             "label": "Browser",
-            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-2b5b022a4d10e518d55b5a893dab492f2a33ba89",
+            "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-f861b9d093fc8cdc728a0179b3a0c43a9155d9b4",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly"
           },
           "code-desktop": {

--- a/install/installer/pkg/components/workspace/ide/constants.go
+++ b/install/installer/pkg/components/workspace/ide/constants.go
@@ -6,7 +6,7 @@ package ide
 
 const (
 	CodeIDEImage                = "ide/code"
-	CodeIDEImageStableVersion   = "commit-2b5b022a4d10e518d55b5a893dab492f2a33ba89" // stable version that will be updated manually on demand
+	CodeIDEImageStableVersion   = "commit-f861b9d093fc8cdc728a0179b3a0c43a9155d9b4" // stable version that will be updated manually on demand
 	CodeDesktopIDEImage         = "ide/code-desktop"
 	CodeDesktopInsidersIDEImage = "ide/code-desktop-insiders"
 	IntelliJDesktopIDEImage     = "ide/intellij"


### PR DESCRIPTION
## Description
Update code to `1.74.3`

## Progress

- [x] Update Insiders  (https://github.com/gitpod-io/gitpod/blob/main/WORKSPACE.yaml)
- [x] Update Stable (https://github.com/gitpod-io/gitpod/blob/main/install/installer/pkg/components/workspace/ide/constants.go)

A part of #14977 

## How to test

- Switch to VS Code Browser Insiders in settings.
- Start a workspace.
- Test the following:
  - [x] terminals are preserved and resized properly between window reloads
  - [x] WebViews are working
  - [x] extension host process: check language smartness and debugging 
  - [x] extension management (installing/uninstalling)
  - [x] install the [VIM extension](https://open-vsx.org/extension/vscodevim/vim) to test web extensions
  - that user data is synced across workspaces as well as on workspace restarts, especially for extensions
     - [x] extensions from `.gitpod.yml` are not installed as sync
     - [x] extensions installed as sync are actually synced to all new workspaces
  - [ ] settings should not contain any mentions of MS telemetry
  - [ ] WebSockets and workers are properly proxied
     - [x] diff editor should be operable
     - [ ] trigger reconnection with `window.WebSocket.disconnectWorkspace()`, check that old WebSockets are closed and new opened of the same amount
  - [x] workspace specific commands should work, i.e. F1 → type <kbd>Gitpod</kbd> prefix
  - [ ] that a PR view is preloaded when opening a PR URL
  - [x] test `gp open` and `gp preview`
  - [ ] test open in VS Code Desktop, check `gp open` and `gp preview` in task/user terminals
  - [ ] telemetry data is collected in [Segment](https://app.segment.com/gitpod/sources/staging_trusted/debugger)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Werft options:

- [x] /werft with-preview
- [x] /werft analytics=segment