### PR TITLE
[openfga] Deploy when experimental.webapp.openfga.enabled is true

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -51,6 +51,7 @@
 /install/installer/pkg/components/proxy @gitpod-io/engineering-webapp
 /install/installer/pkg/components/refresh-credential @gitpod-io/engineering-workspace
 /install/installer/pkg/components/registry-facade @gitpod-io/engineering-workspace
+/install/installer/pkg/components/openfga @gitpod-io/engineering-webapp
 /install/installer/pkg/components/public-api-server @gitpod-io/engineering-webapp
 /install/installer/pkg/components/iam @gitpod-io/engineering-webapp
 /install/installer/pkg/components/iam-api @gitpod-io/engineering-webapp

--- a/dev/preview/workflow/preview/deploy-gitpod.sh
+++ b/dev/preview/workflow/preview/deploy-gitpod.sh
@@ -450,6 +450,11 @@ yq w -i "${INSTALLER_CONFIG_PATH}" "experimental.webapp.server.stripeConfig" "st
 # IAM
 #
 
+#
+# OpenFGA
+#
+yq w -i "${INSTALLER_CONFIG_PATH}" experimental.webapp.openfga.enabled "true"
+
 # copy secret from werft's space
 kubectl --kubeconfig "${DEV_KUBE_PATH}" --context "${DEV_KUBE_CONTEXT}" -n werft get secret preview-envs-oidc-clients-config-secret -o yaml > preview-envs-oidc-clients-config-secret.secret.yaml
 yq d -i preview-envs-oidc-clients-config-secret.secret.yaml metadata.name

--- a/install/installer/pkg/components/components-webapp/components.go
+++ b/install/installer/pkg/components/components-webapp/components.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gitpod-io/gitpod/installer/pkg/components/iam"
 	"github.com/gitpod-io/gitpod/installer/pkg/components/migrations"
 	"github.com/gitpod-io/gitpod/installer/pkg/components/minio"
+	"github.com/gitpod-io/gitpod/installer/pkg/components/openfga"
 	"github.com/gitpod-io/gitpod/installer/pkg/components/proxy"
 	public_api_server "github.com/gitpod-io/gitpod/installer/pkg/components/public-api-server"
 	"github.com/gitpod-io/gitpod/installer/pkg/components/rabbitmq"
@@ -37,6 +38,7 @@ var Objects = common.CompositeRenderFunc(
 	public_api_server.Objects,
 	usage.Objects,
 	toxiproxy.Objects,
+	openfga.Objects,
 )
 
 var Helm = common.CompositeHelmFunc(

--- a/install/installer/pkg/components/openfga/constants.go
+++ b/install/installer/pkg/components/openfga/constants.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package openfga
+
+const (
+	Component = "openfga"
+
+	ContainerHTTPPort = 8080
+	ContainerHTTPName = "http"
+
+	ContainerGRPCPort = 8081
+	ContainerGRPCName = "grpc"
+
+	ContainerPlaygroundPort = 3000
+	ContainerPlaygroundName = "playground"
+
+	RegistryRepo  = "registry.hub.docker.com"
+	RegistryImage = "openfga/openfga"
+	ImageTag      = "v0.3.1"
+
+	ContainerName = "openfga"
+)

--- a/install/installer/pkg/components/openfga/deployment.go
+++ b/install/installer/pkg/components/openfga/deployment.go
@@ -1,0 +1,124 @@
+// Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package openfga
+
+import (
+	"github.com/gitpod-io/gitpod/installer/pkg/cluster"
+	"github.com/gitpod-io/gitpod/installer/pkg/common"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/pointer"
+)
+
+func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
+	labels := common.CustomizeLabel(ctx, Component, common.TypeMetaDeployment)
+
+	return []runtime.Object{
+		&appsv1.Deployment{
+			TypeMeta: common.TypeMetaDeployment,
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        Component,
+				Namespace:   ctx.Namespace,
+				Labels:      labels,
+				Annotations: common.CustomizeAnnotation(ctx, Component, common.TypeMetaDeployment),
+			},
+			Spec: appsv1.DeploymentSpec{
+				Selector: &metav1.LabelSelector{MatchLabels: common.DefaultLabels(Component)},
+				Replicas: common.Replicas(ctx, Component),
+				Strategy: common.DeploymentStrategy,
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        Component,
+						Namespace:   ctx.Namespace,
+						Labels:      labels,
+						Annotations: common.CustomizeAnnotation(ctx, Component, common.TypeMetaDeployment),
+					},
+					Spec: corev1.PodSpec{
+						Affinity:                      common.NodeAffinity(cluster.AffinityLabelMeta),
+						PriorityClassName:             common.SystemNodeCritical,
+						ServiceAccountName:            Component,
+						EnableServiceLinks:            pointer.Bool(false),
+						DNSPolicy:                     "ClusterFirst",
+						RestartPolicy:                 "Always",
+						TerminationGracePeriodSeconds: pointer.Int64(30),
+						SecurityContext: &corev1.PodSecurityContext{
+							RunAsNonRoot: pointer.Bool(false),
+						},
+						Containers: []corev1.Container{{
+							Name:            ContainerName,
+							Image:           ctx.ImageName(common.ThirdPartyContainerRepo(ctx.Config.Repository, RegistryRepo), RegistryImage, ImageTag),
+							ImagePullPolicy: corev1.PullIfNotPresent,
+							Args: []string{
+								"run",
+								"--log-format=json",
+								"--log-level=warn",
+							},
+							Env: common.CustomizeEnvvar(ctx, Component, common.MergeEnv(
+								common.DefaultEnv(&ctx.Config),
+							)),
+							Ports: []corev1.ContainerPort{
+								{
+									ContainerPort: ContainerGRPCPort,
+									Name:          ContainerGRPCName,
+									Protocol:      *common.TCPProtocol,
+								},
+								{
+									ContainerPort: ContainerHTTPPort,
+									Name:          ContainerHTTPName,
+									Protocol:      *common.TCPProtocol,
+								},
+								{
+									ContainerPort: ContainerPlaygroundPort,
+									Name:          ContainerPlaygroundName,
+									Protocol:      *common.TCPProtocol,
+								},
+							},
+							Resources: common.ResourceRequirements(ctx, Component, ContainerName, corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									"cpu":    resource.MustParse("1m"),
+									"memory": resource.MustParse("30Mi"),
+								},
+							}),
+							SecurityContext: &corev1.SecurityContext{
+								RunAsGroup:   pointer.Int64(65532),
+								RunAsNonRoot: pointer.Bool(true),
+								RunAsUser:    pointer.Int64(65532),
+							},
+							LivenessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									HTTPGet: &corev1.HTTPGetAction{
+										Path:   "/healthz",
+										Port:   intstr.IntOrString{IntVal: ContainerHTTPPort},
+										Scheme: corev1.URISchemeHTTP,
+									},
+								},
+								FailureThreshold: 3,
+								SuccessThreshold: 1,
+								TimeoutSeconds:   1,
+							},
+							ReadinessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									HTTPGet: &corev1.HTTPGetAction{
+										Path:   "/healthz",
+										Port:   intstr.IntOrString{IntVal: ContainerHTTPPort},
+										Scheme: corev1.URISchemeHTTP,
+									},
+								},
+								FailureThreshold: 3,
+								SuccessThreshold: 1,
+								TimeoutSeconds:   1,
+							},
+						}},
+					},
+				},
+			},
+		},
+	}, nil
+}

--- a/install/installer/pkg/components/openfga/objects.go
+++ b/install/installer/pkg/components/openfga/objects.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package openfga
+
+import (
+	"github.com/gitpod-io/gitpod/installer/pkg/common"
+	"github.com/gitpod-io/gitpod/installer/pkg/config/v1/experimental"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func Objects(ctx *common.RenderContext) ([]runtime.Object, error) {
+
+	openFGAConfig := getExperimentalOpenFGAConfig(ctx)
+	if openFGAConfig == nil {
+		return nil, nil
+	}
+
+	return common.CompositeRenderFunc(
+		deployment,
+		service,
+		common.DefaultServiceAccount(Component),
+	)(ctx)
+}
+
+func getExperimentalWebAppConfig(ctx *common.RenderContext) *experimental.WebAppConfig {
+	var experimentalCfg *experimental.Config
+	_ = ctx.WithExperimental(func(ucfg *experimental.Config) error {
+		experimentalCfg = ucfg
+		return nil
+	})
+
+	if experimentalCfg == nil || experimentalCfg.WebApp == nil {
+		return nil
+	}
+
+	return experimentalCfg.WebApp
+}
+
+func getExperimentalOpenFGAConfig(ctx *common.RenderContext) *experimental.OpenFGAConfig {
+	webappCfg := getExperimentalWebAppConfig(ctx)
+
+	if webappCfg == nil || webappCfg.OpenFGA == nil {
+		return nil
+	}
+
+	return webappCfg.OpenFGA
+}

--- a/install/installer/pkg/components/openfga/service.go
+++ b/install/installer/pkg/components/openfga/service.go
@@ -1,0 +1,20 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+/// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package openfga
+
+import (
+	"github.com/gitpod-io/gitpod/installer/pkg/common"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func service(ctx *common.RenderContext) ([]runtime.Object, error) {
+	return common.GenerateService(Component, []common.ServicePort{
+		{
+			Name:          ContainerHTTPName,
+			ContainerPort: ContainerHTTPPort,
+			ServicePort:   ContainerHTTPPort,
+		},
+	})(ctx)
+}

--- a/install/installer/pkg/config/v1/experimental/experimental.go
+++ b/install/installer/pkg/config/v1/experimental/experimental.go
@@ -188,6 +188,10 @@ type IAMConfig struct {
 	OIDCClientsSecretName string `json:"oidsClientsConfigSecret,omitempty"`
 }
 
+type OpenFGAConfig struct {
+	Enabled bool `json:"enabled"`
+}
+
 type WebAppConfig struct {
 	PublicAPI                  *PublicAPIConfig       `json:"publicApi,omitempty"`
 	Server                     *ServerConfig          `json:"server,omitempty"`
@@ -203,6 +207,7 @@ type WebAppConfig struct {
 	SlowDatabase               bool                   `json:"slowDatabase,omitempty"`
 	IAM                        *IAMConfig             `json:"iam,omitempty"`
 	WithoutWorkspaceComponents bool                   `json:"withoutWorkspaceComponents,omitempty"`
+	OpenFGA                    *OpenFGAConfig         `json:"openfga,omitempty"`
 }
 
 type WorkspaceDefaults struct {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Deploys [OpenFGA](openfga.dev) when experimental.webapp.openfga.enabled is set to true.

Initially deploys OpenFGA in a `in-memory` mode.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Part of https://github.com/gitpod-io/gitpod/issues/15634

## How to test
<!-- Provide steps to test this PR -->
1. Kubectx for preview
2. Observe `openfga` deployment exists and runs

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
