### PR TITLE
[public-api] examples: teams & workspaces examples in go

### DIFF
--- a/components/public-api/go/examples/workspaces_example.go
+++ b/components/public-api/go/examples/workspaces_example.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Copyright (c) 2023 Gitpod GmbH. All rights reserved.
 // Licensed under the GNU Affero General Public License (AGPL).
 // See License.AGPL.txt in the project root for license information.
 
@@ -7,14 +7,14 @@ package examples
 import (
 	"context"
 	"fmt"
+	"os"
+
 	"github.com/bufbuild/connect-go"
 	"github.com/gitpod-io/gitpod/components/public-api/go/client"
 	v1 "github.com/gitpod-io/gitpod/components/public-api/go/experimental/v1"
-	"os"
-	"time"
 )
 
-func ExampleListTeams() {
+func ExampleListAllWorkspaces() {
 	token := "gitpod_pat_example.personal-access-token"
 
 	gitpod, err := client.New(client.WithCredentials(token))
@@ -23,19 +23,16 @@ func ExampleListTeams() {
 		return
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
-	defer cancel()
-
-	response, err := gitpod.Teams.ListTeams(ctx, connect.NewRequest(&v1.ListTeamsRequest{}))
+	response, err := gitpod.Workspaces.ListWorkspaces(context.Background(), connect.NewRequest(&v1.ListWorkspacesRequest{}))
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to list teams %v", err)
+		fmt.Fprintf(os.Stderr, "Failed to list workspaces %v", err)
 		return
 	}
 
-	fmt.Fprintf(os.Stdout, "Retrieved teams %v", response.Msg.GetTeams())
+	fmt.Fprintf(os.Stdout, "Retrieved workspaces %v", response.Msg.GetResult())
 }
 
-func ExampleGetTeam() {
+func ExampleGetWorkspace() {
 	token := "gitpod_pat_example.personal-access-token"
 
 	gitpod, err := client.New(client.WithCredentials(token))
@@ -44,13 +41,13 @@ func ExampleGetTeam() {
 		return
 	}
 
-	response, err := gitpod.Teams.GetTeam(context.Background(), connect.NewRequest(&v1.GetTeamRequest{
-		TeamId: "<TEAM_ID>",
+	response, err := gitpod.Workspaces.GetWorkspace(context.Background(), connect.NewRequest(&v1.GetWorkspaceRequest{
+		WorkspaceId: "<WORKSPACE_ID>",
 	}))
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to get team %v", err)
+		fmt.Fprintf(os.Stderr, "Failed to get workspace %v", err)
 		return
 	}
 
-	fmt.Fprintf(os.Stdout, "Retrieved team %v", response.Msg.GetTeam())
+	fmt.Fprintf(os.Stdout, "Retrieved workspace %v", response.Msg.GetResult())
 }


### PR DESCRIPTION
## Description
Examples of `public-api` Go Client for Workspace & Teams. Also https://github.com/gitpod-io/website/pull/3196

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
