### PR TITLE
Use separate folders for caching Gradle dependencies from Stable and Latest JetBrains Gateway Plugin

### DIFF
--- a/components/ide/jetbrains/gateway-plugin/BUILD.yaml
+++ b/components/ide/jetbrains/gateway-plugin/BUILD.yaml
@@ -17,7 +17,7 @@ packages:
       - DO_PUBLISH=${publishToJBMarketplace}
     config:
       commands:
-        - [ "./gradlew", "-PpluginVersion=0.0.1-${version}", "-PgitpodProtocolProjectPath=components-gitpod-protocol-java--lib/", "-PenvironmentName=stable", "buildFromLeeway" ]
+        - [ "./gradlew", "-PpluginVersion=0.0.1-${version}", "-PgitpodProtocolProjectPath=components-gitpod-protocol-java--lib/", "-PenvironmentName=stable", "-Dgradle.user.home=/workspace/.gradle-stable", "-Dplugin.verifier.home.dir=$HOME/.cache/pluginVerifier-stable", "buildFromLeeway" ]
   - name: publish-latest
     type: generic
     deps:
@@ -36,4 +36,4 @@ packages:
       - DO_PUBLISH=${publishToJBMarketplace}
     config:
       commands:
-        - [ "./gradlew", "-PpluginVersion=0.0.1-${version}", "-PgitpodProtocolProjectPath=components-gitpod-protocol-java--lib/", "-PenvironmentName=latest", "buildFromLeeway" ]
+        - [ "./gradlew", "-PpluginVersion=0.0.1-${version}", "-PgitpodProtocolProjectPath=components-gitpod-protocol-java--lib/", "-PenvironmentName=latest", "-Dgradle.user.home=/workspace/.gradle-latest", "-Dplugin.verifier.home.dir=$HOME/.cache/pluginVerifier-latest", "buildFromLeeway" ]


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Use separate folders for caching Gradle dependencies from Stable and Latest JetBrains Gateway Plugin.

This prevents failures on Werft Build when the Stable and Latest have the same platform version (which happens after every major release from JetBrains IntelliJ) [[1](https://github.com/gitpod-io/gitpod/pull/15646#issuecomment-1378460217)].

It's the same strategy we used on JetBrains Backend Plugin [[1](https://github.com/gitpod-io/gitpod/blob/245cb43a7d48aa40c32d9ffb4c530b98ac5420b8/components/ide/jetbrains/backend-plugin/build.sh#L13)].

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
- https://github.com/gitpod-io/gitpod/pull/15646#issuecomment-1378460217

## How to test
<!-- Provide steps to test this PR -->
Confirm if Werft Build passes.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=jetbrains
