### PR TITLE
[openfga] Configure cloud-sql-proxy sidecar

### DIFF
--- a/install/installer/pkg/components/openfga/constants.go
+++ b/install/installer/pkg/components/openfga/constants.go
@@ -21,4 +21,6 @@ const (
 	ImageTag      = "v0.3.1"
 
 	ContainerName = "openfga"
+
+	CloudSQLProxyPort = 3306
 )

--- a/install/installer/pkg/config/v1/experimental/experimental.go
+++ b/install/installer/pkg/config/v1/experimental/experimental.go
@@ -190,6 +190,15 @@ type IAMConfig struct {
 
 type OpenFGAConfig struct {
 	Enabled bool `json:"enabled"`
+
+	CloudSQL *struct {
+		Instance string `json:"instance"`
+		Database string `json:"database"`
+		// Credentials for CloudSQL proxy to authenticate with GCP
+		ProxySecretRef string `json:"proxySecretRef"`
+		// Username/Password to authenticate with the database
+		DatabaseSecretRef string `json:"databaseSecretRef"`
+	} `json:"cloudSql,omitempty"`
 }
 
 type WebAppConfig struct {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Adds a cloud-sql-proxy sidecar to the `openfga` deployment, if a CloudSQL config is specified.

We require that the `openfga` deployment talks to a database in a _single_ region. That means we can't use the existing cloud-sql-proxy because that is configured to talk to a regional instance.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Part of https://github.com/gitpod-io/gitpod/issues/15634

## How to test
<!-- Provide steps to test this PR -->
Not really testable in preview, will need to validate on staging with config.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
