### PR TITLE
[dashboard] list latest editor if available

### DIFF
--- a/components/dashboard/src/components/SelectIDEComponent.tsx
+++ b/components/dashboard/src/components/SelectIDEComponent.tsx
@@ -37,7 +37,7 @@ export default function SelectIDEComponent(props: SelectIDEComponentProps) {
                     element: <IdeOptionElementInDropDown option={ide} useLatest={false} />,
                     isSelectable: true,
                 });
-                if (ide.imageVersion !== ide.latestImageVersion) {
+                if (ide.latestImage) {
                     result.push({
                         id: ide.id + "-latest",
                         element: <IdeOptionElementInDropDown option={ide} useLatest={true} />,


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Fixes the missing entry for latest editors.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #15693

## How to test
<!-- Provide steps to test this PR -->
Start a worksapce from workspaces dashboard and verify you see the latest editors in the drop down.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
