### PR TITLE
increase buildkit log size to 4MB

### DIFF
--- a/components/image-builder-bob/pkg/builder/builder.go
+++ b/components/image-builder-bob/pkg/builder/builder.go
@@ -157,6 +157,8 @@ func buildImage(ctx context.Context, contextDir, dockerfile, authLayer, target s
 
 	env := os.Environ()
 	env = append(env, "DOCKER_CONFIG=/tmp")
+	// set log max size to 4MB from 2MB default (to prevent log clipping for large builds)
+	env = append(env, "BUILDKIT_STEP_LOG_MAX_SIZE=4194304")
 	buildctlCmd.Env = env
 
 	if err := buildctlCmd.Start(); err != nil {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Increase log size to 4MB to prevent log clipping. See #7147  for details and discussion.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #7147 

## How to test
<!-- Provide steps to test this PR -->
See issue #7147 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
none
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
