### PR TITLE
Use project creation time to sort when no prebuild

### DIFF
--- a/components/dashboard/src/data/projects/fetchers.ts
+++ b/components/dashboard/src/data/projects/fetchers.ts
@@ -64,9 +64,11 @@ export const useFetchProjects = ({ teamId, userId }: UseFetchProjectsArgs) => {
 
         // Sort projects by latest prebuild first
         projects.sort((p0: Project, p1: Project): number => {
-            return dayjs(latestPrebuilds.get(p1.id)?.info?.startedAt || "1970-01-01").diff(
-                dayjs(latestPrebuilds.get(p0.id)?.info?.startedAt || "1970-01-01"),
-            );
+            // use latest prebuild start time, then fallback to project creation if no prebuild
+            const p0Date = latestPrebuilds.get(p0.id)?.info?.startedAt || p0.creationTime || "1970-01-01";
+            const p1Date = latestPrebuilds.get(p1.id)?.info?.startedAt || p1.creationTime || "1970-01-01";
+
+            return dayjs(p1Date).diff(dayjs(p0Date));
         });
 
         return {


### PR DESCRIPTION
## Description
Fixes an issue where a new project and project sorting would get sorted to the end of the projects list if there was no prebuild yet ([found here](https://github.com/gitpod-io/gitpod/pull/15676#discussion_r1066733079)).

Now, if there's no latest prebuild for a project, the project's creation time will be used for sorting.

## How to test
**Preview Env:** https://bmh-new-pr441f0eae67.preview.gitpod-dev.com/

To test this, you have to be kinda quick 😄 .

* Create a team
* Create a project
* Create a 2nd project. After it's created, you can hit the browser back button to get back to the projects list w/o a page reload. The new project should be sorted first, even if it doesn't have a prebuild yet.



## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
