### PR TITLE
ws-manager: skip failure from terminated message

### DIFF
--- a/test/pkg/integration/workspace.go
+++ b/test/pkg/integration/workspace.go
@@ -729,10 +729,7 @@ func WaitForWorkspaceStop(t *testing.T, ctx context.Context, ready chan<- struct
 
 			wss = resp.GetStatus()
 			if wss.Conditions.Failed != "" {
-				// TODO(toru): we have to fix https://github.com/gitpod-io/gitpod/issues/12021
-				if wss.Conditions.Failed != "The container could not be located when the pod was deleted.  The container used to be Running" && wss.Conditions.Failed != "The container could not be located when the pod was terminated" {
-					errCh <- xerrors.Errorf("workspace instance %s failed: %s", instanceID, wss.Conditions.Failed)
-				}
+				errCh <- xerrors.Errorf("workspace instance %s failed: %s", instanceID, wss.Conditions.Failed)
 				return
 			}
 			if wss.Phase == wsmanapi.WorkspacePhase_STOPPED {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
For some reason, the pod is killed with unknown container status and no taints on the underlying node.
Therefore, we skip extracting the failure from the terminated message.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #12021

## How to test
<!-- Provide steps to test this PR -->
Ensure the workspace integration test pass.

I ran the integration test three times
- https://werft.gitpod-dev.com/job/gitpod-custom-jenting-12021.15
- https://werft.gitpod-dev.com/job/gitpod-custom-jenting-12021.16
- https://werft.gitpod-dev.com/job/gitpod-custom-jenting-12021.17

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-integration-tests=workspace
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
