### PR TITLE
[alerts] Fix WebAppServicesHighCPUUsage dashboard link

### DIFF
--- a/operations/observability/mixins/meta/rules/server.yaml
+++ b/operations/observability/mixins/meta/rules/server.yaml
@@ -109,7 +109,7 @@ spec:
         runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/WebAppServicesHighCPUUsage.md
         summary: WebApp Services excessive CPU usage.
         description: Pod {{ $labels.pod }} is consumming too much CPU. Please investigate.
-        dashboard_url: https://grafana.gitpod.io/d/6581e46e4e5c7ba40a07646395ef7b23/kubernetes-compute-resources-pod?var-cluster={{ $labels.cluster }}&var-namespace=default&var-pod={{ $labels.pod }}
+        dashboard_url: https://grafana.gitpod.io/d/gitpod-services/meta-services?orgId=1&var-datasource=VictoriaMetrics&var-cluster={{ $labels.cluster }}&var-node=All&var-component=All&from=now-1h&to=now
 
     - alert: WebAppServicesCrashlooping
       # Reasoning: alert if any pod is restarting more than 3 times / 5 minutes.


### PR DESCRIPTION
## Description
The old link would point to a very generic Dashboard that showed different data.

Old:
![image](https://user-images.githubusercontent.com/32448529/212022718-0c58ac6a-5a71-4593-ab88-86c449b57667.png)

New:
![image](https://user-images.githubusercontent.com/32448529/212022757-e511cff1-4ea8-4c89-9cc6-08c7107ca8d0.png)


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related to #15704

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
