### PR TITLE
[installer] Enable service OIDC service calls from PAPI

### DIFF
--- a/components/public-api/go/config/config.go
+++ b/components/public-api/go/config/config.go
@@ -11,6 +11,8 @@ type Configuration struct {
 
 	BillingServiceAddress string `json:"billingServiceAddress,omitempty"`
 
+	OIDCServiceAddress string `json:"oidcServiceAddress,omitempty"`
+
 	// StripeWebhookSigningSecretPath is a filepath to a secret used to validate incoming webhooks from Stripe
 	StripeWebhookSigningSecretPath string `json:"stripeWebhookSigningSecretPath"`
 

--- a/install/installer/cmd/testdata/render/aws-setup/output.golden
+++ b/install/installer/cmd/testdata/render/aws-setup/output.golden
@@ -2613,7 +2613,7 @@ data:
     kind: Deployment
     metadata:
       annotations:
-        gitpod.io/checksum_config: a40753633bf3d38be4f578ad79ae07812eeda95f06fca521ce3cd3145a847f39
+        gitpod.io/checksum_config: 82b32972a85084140320cd225c2893f0a2f22d55675f95a68e021c43e5e9b9ac
       creationTimestamp: null
       labels:
         app: gitpod
@@ -4889,6 +4889,7 @@ data:
     {
       "gitpodServiceUrl": "ws://server.default.svc.cluster.local:3000",
       "billingServiceAddress": "usage.default.svc.cluster.local:9001",
+      "oidcServiceAddress": "iam.default.svc.cluster.local:9001",
       "stripeWebhookSigningSecretPath": "",
       "personalAccessTokenSigningKeyPath": "",
       "server": {
@@ -9571,7 +9572,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    gitpod.io/checksum_config: a40753633bf3d38be4f578ad79ae07812eeda95f06fca521ce3cd3145a847f39
+    gitpod.io/checksum_config: 82b32972a85084140320cd225c2893f0a2f22d55675f95a68e021c43e5e9b9ac
   creationTimestamp: null
   labels:
     app: gitpod

--- a/install/installer/cmd/testdata/render/aws-setup/output.golden
+++ b/install/installer/cmd/testdata/render/aws-setup/output.golden
@@ -103,6 +103,9 @@ spec:
         - podSelector:
             matchLabels:
               component: proxy
+        - podSelector:
+            matchLabels:
+              component: public-api-server
       ports:
         - port: 9001
           protocol: TCP

--- a/install/installer/cmd/testdata/render/azure-setup/output.golden
+++ b/install/installer/cmd/testdata/render/azure-setup/output.golden
@@ -2619,7 +2619,7 @@ data:
     kind: Deployment
     metadata:
       annotations:
-        gitpod.io/checksum_config: a40753633bf3d38be4f578ad79ae07812eeda95f06fca521ce3cd3145a847f39
+        gitpod.io/checksum_config: 82b32972a85084140320cd225c2893f0a2f22d55675f95a68e021c43e5e9b9ac
       creationTimestamp: null
       labels:
         app: gitpod
@@ -4893,6 +4893,7 @@ data:
     {
       "gitpodServiceUrl": "ws://server.default.svc.cluster.local:3000",
       "billingServiceAddress": "usage.default.svc.cluster.local:9001",
+      "oidcServiceAddress": "iam.default.svc.cluster.local:9001",
       "stripeWebhookSigningSecretPath": "",
       "personalAccessTokenSigningKeyPath": "",
       "server": {
@@ -9646,7 +9647,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    gitpod.io/checksum_config: a40753633bf3d38be4f578ad79ae07812eeda95f06fca521ce3cd3145a847f39
+    gitpod.io/checksum_config: 82b32972a85084140320cd225c2893f0a2f22d55675f95a68e021c43e5e9b9ac
   creationTimestamp: null
   labels:
     app: gitpod

--- a/install/installer/cmd/testdata/render/azure-setup/output.golden
+++ b/install/installer/cmd/testdata/render/azure-setup/output.golden
@@ -103,6 +103,9 @@ spec:
         - podSelector:
             matchLabels:
               component: proxy
+        - podSelector:
+            matchLabels:
+              component: public-api-server
       ports:
         - port: 9001
           protocol: TCP

--- a/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
+++ b/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
@@ -2802,7 +2802,7 @@ data:
     kind: Deployment
     metadata:
       annotations:
-        gitpod.io/checksum_config: a40753633bf3d38be4f578ad79ae07812eeda95f06fca521ce3cd3145a847f39
+        gitpod.io/checksum_config: 82b32972a85084140320cd225c2893f0a2f22d55675f95a68e021c43e5e9b9ac
       creationTimestamp: null
       labels:
         app: gitpod
@@ -5263,6 +5263,7 @@ data:
     {
       "gitpodServiceUrl": "ws://server.default.svc.cluster.local:3000",
       "billingServiceAddress": "usage.default.svc.cluster.local:9001",
+      "oidcServiceAddress": "iam.default.svc.cluster.local:9001",
       "stripeWebhookSigningSecretPath": "",
       "personalAccessTokenSigningKeyPath": "",
       "server": {
@@ -10363,7 +10364,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    gitpod.io/checksum_config: a40753633bf3d38be4f578ad79ae07812eeda95f06fca521ce3cd3145a847f39
+    gitpod.io/checksum_config: 82b32972a85084140320cd225c2893f0a2f22d55675f95a68e021c43e5e9b9ac
   creationTimestamp: null
   labels:
     app: gitpod

--- a/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
+++ b/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
@@ -103,6 +103,9 @@ spec:
         - podSelector:
             matchLabels:
               component: proxy
+        - podSelector:
+            matchLabels:
+              component: public-api-server
       ports:
         - port: 9001
           protocol: TCP

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -3210,7 +3210,7 @@ data:
     metadata:
       annotations:
         gitpod.io: hello
-        gitpod.io/checksum_config: 42794ba2ca883c6d462ea918350a0d347f0ce1ca14ed7672c0cd2da0bed81c6e
+        gitpod.io/checksum_config: 390485644ea26982344505a8b2194183390965b5894502fc9533222f9e7d0bbd
         hello: world
       creationTimestamp: null
       labels:
@@ -5851,6 +5851,7 @@ data:
     {
       "gitpodServiceUrl": "ws://server.default.svc.cluster.local:3000",
       "billingServiceAddress": "usage.default.svc.cluster.local:9001",
+      "oidcServiceAddress": "iam.default.svc.cluster.local:9001",
       "stripeWebhookSigningSecretPath": "",
       "personalAccessTokenSigningKeyPath": "",
       "server": {
@@ -11198,7 +11199,7 @@ kind: Deployment
 metadata:
   annotations:
     gitpod.io: hello
-    gitpod.io/checksum_config: 42794ba2ca883c6d462ea918350a0d347f0ce1ca14ed7672c0cd2da0bed81c6e
+    gitpod.io/checksum_config: 390485644ea26982344505a8b2194183390965b5894502fc9533222f9e7d0bbd
     hello: world
   creationTimestamp: null
   labels:

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -103,6 +103,9 @@ spec:
         - podSelector:
             matchLabels:
               component: proxy
+        - podSelector:
+            matchLabels:
+              component: public-api-server
       ports:
         - port: 9001
           protocol: TCP

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -2696,7 +2696,7 @@ data:
     kind: Deployment
     metadata:
       annotations:
-        gitpod.io/checksum_config: a40753633bf3d38be4f578ad79ae07812eeda95f06fca521ce3cd3145a847f39
+        gitpod.io/checksum_config: 82b32972a85084140320cd225c2893f0a2f22d55675f95a68e021c43e5e9b9ac
       creationTimestamp: null
       labels:
         app: gitpod
@@ -5080,6 +5080,7 @@ data:
     {
       "gitpodServiceUrl": "ws://server.default.svc.cluster.local:3000",
       "billingServiceAddress": "usage.default.svc.cluster.local:9001",
+      "oidcServiceAddress": "iam.default.svc.cluster.local:9001",
       "stripeWebhookSigningSecretPath": "",
       "personalAccessTokenSigningKeyPath": "",
       "server": {
@@ -10073,7 +10074,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    gitpod.io/checksum_config: a40753633bf3d38be4f578ad79ae07812eeda95f06fca521ce3cd3145a847f39
+    gitpod.io/checksum_config: 82b32972a85084140320cd225c2893f0a2f22d55675f95a68e021c43e5e9b9ac
   creationTimestamp: null
   labels:
     app: gitpod

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -103,6 +103,9 @@ spec:
         - podSelector:
             matchLabels:
               component: proxy
+        - podSelector:
+            matchLabels:
+              component: public-api-server
       ports:
         - port: 9001
           protocol: TCP

--- a/install/installer/cmd/testdata/render/gcp-setup/output.golden
+++ b/install/installer/cmd/testdata/render/gcp-setup/output.golden
@@ -2638,7 +2638,7 @@ data:
     kind: Deployment
     metadata:
       annotations:
-        gitpod.io/checksum_config: a40753633bf3d38be4f578ad79ae07812eeda95f06fca521ce3cd3145a847f39
+        gitpod.io/checksum_config: 82b32972a85084140320cd225c2893f0a2f22d55675f95a68e021c43e5e9b9ac
       creationTimestamp: null
       labels:
         app: gitpod
@@ -4854,6 +4854,7 @@ data:
     {
       "gitpodServiceUrl": "ws://server.default.svc.cluster.local:3000",
       "billingServiceAddress": "usage.default.svc.cluster.local:9001",
+      "oidcServiceAddress": "iam.default.svc.cluster.local:9001",
       "stripeWebhookSigningSecretPath": "",
       "personalAccessTokenSigningKeyPath": "",
       "server": {
@@ -9566,7 +9567,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    gitpod.io/checksum_config: a40753633bf3d38be4f578ad79ae07812eeda95f06fca521ce3cd3145a847f39
+    gitpod.io/checksum_config: 82b32972a85084140320cd225c2893f0a2f22d55675f95a68e021c43e5e9b9ac
   creationTimestamp: null
   labels:
     app: gitpod

--- a/install/installer/cmd/testdata/render/gcp-setup/output.golden
+++ b/install/installer/cmd/testdata/render/gcp-setup/output.golden
@@ -103,6 +103,9 @@ spec:
         - podSelector:
             matchLabels:
               component: proxy
+        - podSelector:
+            matchLabels:
+              component: public-api-server
       ports:
         - port: 9001
           protocol: TCP

--- a/install/installer/cmd/testdata/render/http-proxy/output.golden
+++ b/install/installer/cmd/testdata/render/http-proxy/output.golden
@@ -103,6 +103,9 @@ spec:
         - podSelector:
             matchLabels:
               component: proxy
+        - podSelector:
+            matchLabels:
+              component: public-api-server
       ports:
         - port: 9001
           protocol: TCP

--- a/install/installer/cmd/testdata/render/http-proxy/output.golden
+++ b/install/installer/cmd/testdata/render/http-proxy/output.golden
@@ -2805,7 +2805,7 @@ data:
     kind: Deployment
     metadata:
       annotations:
-        gitpod.io/checksum_config: a40753633bf3d38be4f578ad79ae07812eeda95f06fca521ce3cd3145a847f39
+        gitpod.io/checksum_config: 82b32972a85084140320cd225c2893f0a2f22d55675f95a68e021c43e5e9b9ac
       creationTimestamp: null
       labels:
         app: gitpod
@@ -5266,6 +5266,7 @@ data:
     {
       "gitpodServiceUrl": "ws://server.default.svc.cluster.local:3000",
       "billingServiceAddress": "usage.default.svc.cluster.local:9001",
+      "oidcServiceAddress": "iam.default.svc.cluster.local:9001",
       "stripeWebhookSigningSecretPath": "",
       "personalAccessTokenSigningKeyPath": "",
       "server": {
@@ -11529,7 +11530,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    gitpod.io/checksum_config: a40753633bf3d38be4f578ad79ae07812eeda95f06fca521ce3cd3145a847f39
+    gitpod.io/checksum_config: 82b32972a85084140320cd225c2893f0a2f22d55675f95a68e021c43e5e9b9ac
   creationTimestamp: null
   labels:
     app: gitpod

--- a/install/installer/cmd/testdata/render/kind-meta/output.golden
+++ b/install/installer/cmd/testdata/render/kind-meta/output.golden
@@ -2349,7 +2349,7 @@ data:
     kind: Deployment
     metadata:
       annotations:
-        gitpod.io/checksum_config: a40753633bf3d38be4f578ad79ae07812eeda95f06fca521ce3cd3145a847f39
+        gitpod.io/checksum_config: 82b32972a85084140320cd225c2893f0a2f22d55675f95a68e021c43e5e9b9ac
       creationTimestamp: null
       labels:
         app: gitpod
@@ -4191,6 +4191,7 @@ data:
     {
       "gitpodServiceUrl": "ws://server.default.svc.cluster.local:3000",
       "billingServiceAddress": "usage.default.svc.cluster.local:9001",
+      "oidcServiceAddress": "iam.default.svc.cluster.local:9001",
       "stripeWebhookSigningSecretPath": "",
       "personalAccessTokenSigningKeyPath": "",
       "server": {
@@ -7527,7 +7528,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    gitpod.io/checksum_config: a40753633bf3d38be4f578ad79ae07812eeda95f06fca521ce3cd3145a847f39
+    gitpod.io/checksum_config: 82b32972a85084140320cd225c2893f0a2f22d55675f95a68e021c43e5e9b9ac
   creationTimestamp: null
   labels:
     app: gitpod

--- a/install/installer/cmd/testdata/render/kind-meta/output.golden
+++ b/install/installer/cmd/testdata/render/kind-meta/output.golden
@@ -84,6 +84,9 @@ spec:
         - podSelector:
             matchLabels:
               component: proxy
+        - podSelector:
+            matchLabels:
+              component: public-api-server
       ports:
         - port: 9001
           protocol: TCP

--- a/install/installer/cmd/testdata/render/kind-webapp/output.golden
+++ b/install/installer/cmd/testdata/render/kind-webapp/output.golden
@@ -63,6 +63,9 @@ spec:
         - podSelector:
             matchLabels:
               component: proxy
+        - podSelector:
+            matchLabels:
+              component: public-api-server
       ports:
         - port: 9001
           protocol: TCP

--- a/install/installer/cmd/testdata/render/kind-webapp/output.golden
+++ b/install/installer/cmd/testdata/render/kind-webapp/output.golden
@@ -1724,7 +1724,7 @@ data:
     kind: Deployment
     metadata:
       annotations:
-        gitpod.io/checksum_config: a40753633bf3d38be4f578ad79ae07812eeda95f06fca521ce3cd3145a847f39
+        gitpod.io/checksum_config: 82b32972a85084140320cd225c2893f0a2f22d55675f95a68e021c43e5e9b9ac
       creationTimestamp: null
       labels:
         app: gitpod
@@ -2281,6 +2281,7 @@ data:
     {
       "gitpodServiceUrl": "ws://server.default.svc.cluster.local:3000",
       "billingServiceAddress": "usage.default.svc.cluster.local:9001",
+      "oidcServiceAddress": "iam.default.svc.cluster.local:9001",
       "stripeWebhookSigningSecretPath": "",
       "personalAccessTokenSigningKeyPath": "",
       "server": {
@@ -4456,7 +4457,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    gitpod.io/checksum_config: a40753633bf3d38be4f578ad79ae07812eeda95f06fca521ce3cd3145a847f39
+    gitpod.io/checksum_config: 82b32972a85084140320cd225c2893f0a2f22d55675f95a68e021c43e5e9b9ac
   creationTimestamp: null
   labels:
     app: gitpod

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -2802,7 +2802,7 @@ data:
     kind: Deployment
     metadata:
       annotations:
-        gitpod.io/checksum_config: a40753633bf3d38be4f578ad79ae07812eeda95f06fca521ce3cd3145a847f39
+        gitpod.io/checksum_config: 82b32972a85084140320cd225c2893f0a2f22d55675f95a68e021c43e5e9b9ac
       creationTimestamp: null
       labels:
         app: gitpod
@@ -5263,6 +5263,7 @@ data:
     {
       "gitpodServiceUrl": "ws://server.default.svc.cluster.local:3000",
       "billingServiceAddress": "usage.default.svc.cluster.local:9001",
+      "oidcServiceAddress": "iam.default.svc.cluster.local:9001",
       "stripeWebhookSigningSecretPath": "",
       "personalAccessTokenSigningKeyPath": "",
       "server": {
@@ -10363,7 +10364,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    gitpod.io/checksum_config: a40753633bf3d38be4f578ad79ae07812eeda95f06fca521ce3cd3145a847f39
+    gitpod.io/checksum_config: 82b32972a85084140320cd225c2893f0a2f22d55675f95a68e021c43e5e9b9ac
   creationTimestamp: null
   labels:
     app: gitpod

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -103,6 +103,9 @@ spec:
         - podSelector:
             matchLabels:
               component: proxy
+        - podSelector:
+            matchLabels:
+              component: public-api-server
       ports:
         - port: 9001
           protocol: TCP

--- a/install/installer/cmd/testdata/render/shortname/output.golden
+++ b/install/installer/cmd/testdata/render/shortname/output.golden
@@ -2802,7 +2802,7 @@ data:
     kind: Deployment
     metadata:
       annotations:
-        gitpod.io/checksum_config: a40753633bf3d38be4f578ad79ae07812eeda95f06fca521ce3cd3145a847f39
+        gitpod.io/checksum_config: 82b32972a85084140320cd225c2893f0a2f22d55675f95a68e021c43e5e9b9ac
       creationTimestamp: null
       labels:
         app: gitpod
@@ -5263,6 +5263,7 @@ data:
     {
       "gitpodServiceUrl": "ws://server.default.svc.cluster.local:3000",
       "billingServiceAddress": "usage.default.svc.cluster.local:9001",
+      "oidcServiceAddress": "iam.default.svc.cluster.local:9001",
       "stripeWebhookSigningSecretPath": "",
       "personalAccessTokenSigningKeyPath": "",
       "server": {
@@ -10363,7 +10364,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    gitpod.io/checksum_config: a40753633bf3d38be4f578ad79ae07812eeda95f06fca521ce3cd3145a847f39
+    gitpod.io/checksum_config: 82b32972a85084140320cd225c2893f0a2f22d55675f95a68e021c43e5e9b9ac
   creationTimestamp: null
   labels:
     app: gitpod

--- a/install/installer/cmd/testdata/render/shortname/output.golden
+++ b/install/installer/cmd/testdata/render/shortname/output.golden
@@ -103,6 +103,9 @@ spec:
         - podSelector:
             matchLabels:
               component: proxy
+        - podSelector:
+            matchLabels:
+              component: public-api-server
       ports:
         - port: 9001
           protocol: TCP

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -2814,7 +2814,7 @@ data:
     kind: Deployment
     metadata:
       annotations:
-        gitpod.io/checksum_config: a40753633bf3d38be4f578ad79ae07812eeda95f06fca521ce3cd3145a847f39
+        gitpod.io/checksum_config: 82b32972a85084140320cd225c2893f0a2f22d55675f95a68e021c43e5e9b9ac
       creationTimestamp: null
       labels:
         app: gitpod
@@ -5275,6 +5275,7 @@ data:
     {
       "gitpodServiceUrl": "ws://server.default.svc.cluster.local:3000",
       "billingServiceAddress": "usage.default.svc.cluster.local:9001",
+      "oidcServiceAddress": "iam.default.svc.cluster.local:9001",
       "stripeWebhookSigningSecretPath": "",
       "personalAccessTokenSigningKeyPath": "",
       "server": {
@@ -10375,7 +10376,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    gitpod.io/checksum_config: a40753633bf3d38be4f578ad79ae07812eeda95f06fca521ce3cd3145a847f39
+    gitpod.io/checksum_config: 82b32972a85084140320cd225c2893f0a2f22d55675f95a68e021c43e5e9b9ac
   creationTimestamp: null
   labels:
     app: gitpod

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -103,6 +103,9 @@ spec:
         - podSelector:
             matchLabels:
               component: proxy
+        - podSelector:
+            matchLabels:
+              component: public-api-server
       ports:
         - port: 9001
           protocol: TCP

--- a/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
+++ b/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
@@ -3090,7 +3090,7 @@ data:
     kind: Deployment
     metadata:
       annotations:
-        gitpod.io/checksum_config: a40753633bf3d38be4f578ad79ae07812eeda95f06fca521ce3cd3145a847f39
+        gitpod.io/checksum_config: 82b32972a85084140320cd225c2893f0a2f22d55675f95a68e021c43e5e9b9ac
       creationTimestamp: null
       labels:
         app: gitpod
@@ -5596,6 +5596,7 @@ data:
     {
       "gitpodServiceUrl": "ws://server.default.svc.cluster.local:3000",
       "billingServiceAddress": "usage.default.svc.cluster.local:9001",
+      "oidcServiceAddress": "iam.default.svc.cluster.local:9001",
       "stripeWebhookSigningSecretPath": "",
       "personalAccessTokenSigningKeyPath": "",
       "server": {
@@ -10807,7 +10808,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    gitpod.io/checksum_config: a40753633bf3d38be4f578ad79ae07812eeda95f06fca521ce3cd3145a847f39
+    gitpod.io/checksum_config: 82b32972a85084140320cd225c2893f0a2f22d55675f95a68e021c43e5e9b9ac
   creationTimestamp: null
   labels:
     app: gitpod

--- a/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
+++ b/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
@@ -103,6 +103,9 @@ spec:
         - podSelector:
             matchLabels:
               component: proxy
+        - podSelector:
+            matchLabels:
+              component: public-api-server
       ports:
         - port: 9001
           protocol: TCP

--- a/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
+++ b/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
@@ -103,6 +103,9 @@ spec:
         - podSelector:
             matchLabels:
               component: proxy
+        - podSelector:
+            matchLabels:
+              component: public-api-server
       ports:
         - port: 9001
           protocol: TCP

--- a/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
+++ b/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
@@ -2804,7 +2804,7 @@ data:
     kind: Deployment
     metadata:
       annotations:
-        gitpod.io/checksum_config: a40753633bf3d38be4f578ad79ae07812eeda95f06fca521ce3cd3145a847f39
+        gitpod.io/checksum_config: 82b32972a85084140320cd225c2893f0a2f22d55675f95a68e021c43e5e9b9ac
       creationTimestamp: null
       labels:
         app: gitpod
@@ -5265,6 +5265,7 @@ data:
     {
       "gitpodServiceUrl": "ws://server.default.svc.cluster.local:3000",
       "billingServiceAddress": "usage.default.svc.cluster.local:9001",
+      "oidcServiceAddress": "iam.default.svc.cluster.local:9001",
       "stripeWebhookSigningSecretPath": "",
       "personalAccessTokenSigningKeyPath": "",
       "server": {
@@ -10353,7 +10354,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    gitpod.io/checksum_config: a40753633bf3d38be4f578ad79ae07812eeda95f06fca521ce3cd3145a847f39
+    gitpod.io/checksum_config: 82b32972a85084140320cd225c2893f0a2f22d55675f95a68e021c43e5e9b9ac
   creationTimestamp: null
   labels:
     app: gitpod

--- a/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
+++ b/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
@@ -2805,7 +2805,7 @@ data:
     kind: Deployment
     metadata:
       annotations:
-        gitpod.io/checksum_config: a40753633bf3d38be4f578ad79ae07812eeda95f06fca521ce3cd3145a847f39
+        gitpod.io/checksum_config: 82b32972a85084140320cd225c2893f0a2f22d55675f95a68e021c43e5e9b9ac
       creationTimestamp: null
       labels:
         app: gitpod
@@ -5266,6 +5266,7 @@ data:
     {
       "gitpodServiceUrl": "ws://server.default.svc.cluster.local:3000",
       "billingServiceAddress": "usage.default.svc.cluster.local:9001",
+      "oidcServiceAddress": "iam.default.svc.cluster.local:9001",
       "stripeWebhookSigningSecretPath": "",
       "personalAccessTokenSigningKeyPath": "",
       "server": {
@@ -10366,7 +10367,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    gitpod.io/checksum_config: a40753633bf3d38be4f578ad79ae07812eeda95f06fca521ce3cd3145a847f39
+    gitpod.io/checksum_config: 82b32972a85084140320cd225c2893f0a2f22d55675f95a68e021c43e5e9b9ac
   creationTimestamp: null
   labels:
     app: gitpod

--- a/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
+++ b/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
@@ -103,6 +103,9 @@ spec:
         - podSelector:
             matchLabels:
               component: proxy
+        - podSelector:
+            matchLabels:
+              component: public-api-server
       ports:
         - port: 9001
           protocol: TCP

--- a/install/installer/pkg/components/iam/networkpolicy.go
+++ b/install/installer/pkg/components/iam/networkpolicy.go
@@ -46,6 +46,13 @@ func networkpolicy(ctx *common.RenderContext) ([]runtime.Object, error) {
 									},
 								},
 							},
+							{
+								PodSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										"component": common.PublicApiComponent,
+									},
+								},
+							},
 						},
 					},
 				},

--- a/install/installer/pkg/components/public-api-server/configmap.go
+++ b/install/installer/pkg/components/public-api-server/configmap.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gitpod-io/gitpod/components/public-api/go/config"
 
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
+	"github.com/gitpod-io/gitpod/installer/pkg/components/iam"
 	"github.com/gitpod-io/gitpod/installer/pkg/components/server"
 	"github.com/gitpod-io/gitpod/installer/pkg/components/usage"
 	corev1 "k8s.io/api/core/v1"
@@ -45,6 +46,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		GitpodServiceURL:                  fmt.Sprintf("ws://%s.%s.svc.cluster.local:%d", server.Component, ctx.Namespace, server.ContainerPort),
 		StripeWebhookSigningSecretPath:    stripeSecretPath,
 		PersonalAccessTokenSigningKeyPath: personalAccessTokenSigningKeyPath,
+		OIDCServiceAddress:                net.JoinHostPort(fmt.Sprintf("%s.%s.svc.cluster.local", iam.Component, ctx.Namespace), strconv.Itoa(iam.GRPCServicePort)),
 		BillingServiceAddress:             net.JoinHostPort(fmt.Sprintf("%s.%s.svc.cluster.local", usage.Component, ctx.Namespace), strconv.Itoa(usage.GRPCServicePort)),
 		Server: &baseserver.Configuration{
 			Services: baseserver.ServicesConfiguration{

--- a/install/installer/pkg/components/public-api-server/configmap_test.go
+++ b/install/installer/pkg/components/public-api-server/configmap_test.go
@@ -40,6 +40,7 @@ func TestConfigMap(t *testing.T) {
 	expectedConfiguration := config.Configuration{
 		GitpodServiceURL:                  fmt.Sprintf("ws://server.%s.svc.cluster.local:3000", ctx.Namespace),
 		BillingServiceAddress:             fmt.Sprintf("usage.%s.svc.cluster.local:9001", ctx.Namespace),
+		OIDCServiceAddress:                fmt.Sprintf("iam.%s.svc.cluster.local:9001", ctx.Namespace),
 		StripeWebhookSigningSecretPath:    stripeSecretPath,
 		PersonalAccessTokenSigningKeyPath: personalAccessTokenSigningKeyPath,
 		Server: &baseserver.Configuration{


### PR DESCRIPTION
This PRs comes with the installer changes for OIDC enablement:
* required ingress rule to support calling OIDC service from PAPI
* OIDC service address configuration

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of #15150


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
