### PR TITLE
[Gitpod CLI] Add analytics

### DIFF
--- a/components/gitpod-cli/.gitignore
+++ b/components/gitpod-cli/.gitignore
@@ -1,0 +1,1 @@
+gitpod-cli

--- a/components/gitpod-cli/cmd/docs.go
+++ b/components/gitpod-cli/cmd/docs.go
@@ -5,6 +5,8 @@
 package cmd
 
 import (
+	"context"
+
 	"github.com/spf13/cobra"
 )
 
@@ -15,7 +17,12 @@ var docsCmd = &cobra.Command{
 	Use:   "docs",
 	Short: "Open Gitpod Documentation in default browser",
 	Run: func(cmd *cobra.Command, args []string) {
-		openPreview("GP_EXTERNAL_BROWSER", DocsUrl)
+		ctx := cmd.Context()
+		err := openPreview("GP_EXTERNAL_BROWSER", DocsUrl)
+		if err != nil {
+			errorCtx := context.WithValue(ctx, ctxKeyError, err)
+			cmd.SetContext(errorCtx)
+		}
 	},
 }
 

--- a/components/gitpod-cli/cmd/env.go
+++ b/components/gitpod-cli/cmd/env.go
@@ -59,15 +59,18 @@ delete environment variables with a repository pattern of */foo, foo/* or */*.
 			log.SetOutput(f)
 		}
 
+		ctx, cancel := context.WithTimeout(cmd.Context(), 1*time.Minute)
+		defer cancel()
+
 		if len(args) > 0 {
 			if unsetEnvs {
 				deleteEnvs(args)
 				return
 			}
 
-			setEnvs(args)
+			setEnvs(ctx, args)
 		} else {
-			getEnvs()
+			getEnvs(ctx)
 		}
 	},
 }
@@ -120,9 +123,7 @@ func connectToServer(ctx context.Context) (*connectToServerResult, error) {
 	return &connectToServerResult{repositoryPattern, client}, nil
 }
 
-func getEnvs() {
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
-	defer cancel()
+func getEnvs(ctx context.Context) {
 	result, err := connectToServer(ctx)
 	if err != nil {
 		fail(err.Error())
@@ -138,9 +139,7 @@ func getEnvs() {
 	}
 }
 
-func setEnvs(args []string) {
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
-	defer cancel()
+func setEnvs(ctx context.Context, args []string) {
 	result, err := connectToServer(ctx)
 	if err != nil {
 		fail(err.Error())

--- a/components/gitpod-cli/cmd/info.go
+++ b/components/gitpod-cli/cmd/info.go
@@ -43,8 +43,10 @@ var infoCmd = &cobra.Command{
 		}
 
 		if err != nil {
-			errorCtx := context.WithValue(ctx, ctxKeyError, err)
-			cmd.SetContext(errorCtx)
+			gpErr := &GpError{
+				Err: err,
+			}
+			cmd.SetContext(context.WithValue(ctx, ctxKeyError, gpErr))
 			return
 		}
 

--- a/components/gitpod-cli/cmd/init.go
+++ b/components/gitpod-cli/cmd/init.go
@@ -35,18 +35,24 @@ Create a Gitpod configuration for this project.
 		cfg := gitpodlib.GitpodFile{}
 		if interactive {
 			if err := askForDockerImage(&cfg); err != nil {
-				errorCtx := context.WithValue(ctx, ctxKeyError, err)
-				cmd.SetContext(errorCtx)
+				gpErr := &GpError{
+					Err: err,
+				}
+				cmd.SetContext(context.WithValue(ctx, ctxKeyError, gpErr))
 				return
 			}
 			if err := askForPorts(&cfg); err != nil {
-				errorCtx := context.WithValue(ctx, ctxKeyError, err)
-				cmd.SetContext(errorCtx)
+				gpErr := &GpError{
+					Err: err,
+				}
+				cmd.SetContext(context.WithValue(ctx, ctxKeyError, gpErr))
 				return
 			}
 			if err := askForTask(&cfg); err != nil {
-				errorCtx := context.WithValue(ctx, ctxKeyError, err)
-				cmd.SetContext(errorCtx)
+				gpErr := &GpError{
+					Err: err,
+				}
+				cmd.SetContext(context.WithValue(ctx, ctxKeyError, gpErr))
 				return
 			}
 		} else {
@@ -56,8 +62,10 @@ Create a Gitpod configuration for this project.
 
 		d, err := yaml.Marshal(cfg)
 		if err != nil {
-			errorCtx := context.WithValue(ctx, ctxKeyError, err)
-			cmd.SetContext(errorCtx)
+			gpErr := &GpError{
+				Err: err,
+			}
+			cmd.SetContext(context.WithValue(ctx, ctxKeyError, gpErr))
 			return
 		}
 		if !interactive {
@@ -93,8 +101,10 @@ ports:
 
 		if err := os.WriteFile(".gitpod.yml", d, 0644); err != nil {
 			// TODO(af): shall we introduce an outcome=cancelled?
-			errorCtx := context.WithValue(ctx, ctxKeyError, err)
-			cmd.SetContext(errorCtx)
+			gpErr := &GpError{
+				Err: err,
+			}
+			cmd.SetContext(context.WithValue(ctx, ctxKeyError, gpErr))
 			return
 		}
 
@@ -114,8 +124,10 @@ USER gitpod
 #
 # More information: https://www.gitpod.io/docs/config-docker/
 `), 0644); err != nil {
-					errorCtx := context.WithValue(ctx, ctxKeyError, err)
-					cmd.SetContext(errorCtx)
+					gpErr := &GpError{
+						Err: err,
+					}
+					cmd.SetContext(context.WithValue(ctx, ctxKeyError, gpErr))
 					return
 				}
 			}

--- a/components/gitpod-cli/cmd/open.go
+++ b/components/gitpod-cli/cmd/open.go
@@ -5,7 +5,6 @@
 package cmd
 
 import (
-	"context"
 	"log"
 	"os"
 	"os/exec"
@@ -25,13 +24,15 @@ var openCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		// TODO(ak) use NotificationService.NotifyActive supervisor API instead
 
-		ctx := context.Background()
+		ctx := cmd.Context()
 
-		client, err := supervisor.New(ctx)
-		if err != nil {
-			log.Fatal(err)
-		}
-		defer client.Close()
+		client := ctx.Value(ctxKeySupervisorClient).(*supervisor.SupervisorClient)
+
+		// client, err := supervisor.New(ctx)
+		// if err != nil {
+		// 	log.Fatal(err)
+		// }
+		// defer client.Close()
 
 		client.WaitForIDEReady(ctx)
 

--- a/components/gitpod-cli/cmd/open.go
+++ b/components/gitpod-cli/cmd/open.go
@@ -28,12 +28,6 @@ var openCmd = &cobra.Command{
 
 		client := ctx.Value(ctxKeySupervisorClient).(*supervisor.SupervisorClient)
 
-		// client, err := supervisor.New(ctx)
-		// if err != nil {
-		// 	log.Fatal(err)
-		// }
-		// defer client.Close()
-
 		client.WaitForIDEReady(ctx)
 
 		wait, _ := cmd.Flags().GetBool("wait")

--- a/components/gitpod-cli/cmd/preview.go
+++ b/components/gitpod-cli/cmd/preview.go
@@ -6,7 +6,6 @@ package cmd
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -52,8 +51,10 @@ var previewCmd = &cobra.Command{
 
 		err := openPreview(gpBrowserEnvVar, url)
 		if err != nil {
-			errorCtx := context.WithValue(ctx, ctxKeyError, err)
-			cmd.SetContext(errorCtx)
+			gpErr := &GpError{
+				Err: err,
+			}
+			cmd.SetContext(context.WithValue(ctx, ctxKeyError, gpErr))
 		}
 	},
 }
@@ -61,7 +62,7 @@ var previewCmd = &cobra.Command{
 func openPreview(gpBrowserEnvVar string, url string) error {
 	pcmd := os.Getenv(gpBrowserEnvVar)
 	if pcmd == "" {
-		err := errors.New(fmt.Sprintf("%s is not set", gpBrowserEnvVar))
+		err := fmt.Errorf("%s is not set", gpBrowserEnvVar)
 		return err
 	}
 	pargs, err := shlex.Split(pcmd)

--- a/components/gitpod-cli/cmd/root_test.go
+++ b/components/gitpod-cli/cmd/root_test.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestGetCommandName(t *testing.T) {
+	tests := []struct {
+		Input       string
+		Expectation []string
+	}{
+		{"gp", []string{}},
+		{"gp top", []string{"top"}},
+		{"gp tasks list", []string{"tasks", "list"}},
+		{"gp very nested command", []string{"very", "nested", "command"}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Input, func(t *testing.T) {
+			cmdName := GetCommandName(test.Input)
+
+			if diff := cmp.Diff(test.Expectation, cmdName); diff != "" {
+				t.Errorf("GetCommandName() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/components/gitpod-cli/cmd/send-analytics.go
+++ b/components/gitpod-cli/cmd/send-analytics.go
@@ -1,0 +1,92 @@
+// Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/gitpod-io/gitpod/gitpod-cli/pkg/supervisor"
+	"github.com/gitpod-io/gitpod/gitpod-cli/pkg/utils"
+	"github.com/spf13/cobra"
+)
+
+type AnalyticsData struct {
+	Command            []string `json:"command,omitempty"`
+	Duration           int64    `json:"duration,omitempty"`
+	ErrorCode          string   `json:"errorCode,omitempty"`
+	ImageBuildDuration int64    `json:"imageBuildDuration,omitempty"`
+	Outcome            string   `json:"outcome,omitempty"`
+}
+
+var sendAnalyticsCmdOpts struct {
+	data string
+}
+
+// sendAnalyticsCmd represents the send-analytics command
+var sendAnalyticsCmd = &cobra.Command{
+	Use:    "send-analytics",
+	Long:   "Sending anonymous statistics about the executed gp commands inside a workspace",
+	Hidden: true,
+	Args:   cobra.ExactArgs(0),
+	Run: func(cmd *cobra.Command, args []string) {
+		if skipAnalytics || len(args) == 0 {
+			return
+		}
+
+		var data AnalyticsData
+		err := json.Unmarshal([]byte(sendAnalyticsCmdOpts.data), &data)
+
+		if err != nil {
+			errorCtx := context.WithValue(cmd.Context(), ctxKeyError, err)
+			cmd.SetContext(errorCtx)
+			return
+		}
+
+		// if !isValidCommand(data.Command) {
+		// 	err := errors.New("send-analytics: disallowed command")
+		// 	errorCtx := context.WithValue(cmd.Context(), ctxKeyError, err)
+		// 	cmd.SetContext(errorCtx)
+		// 	return
+		// }
+
+		ctx := cmd.Context()
+
+		supervisorClient := ctx.Value(ctxKeySupervisorClient).(*supervisor.SupervisorClient)
+
+		event := utils.NewAnalyticsEvent(ctx, supervisorClient, &utils.TrackCommandUsageParams{
+			Command:   data.Command,
+			Duration:  data.Duration,
+			ErrorCode: data.ErrorCode,
+		})
+
+		if data.ImageBuildDuration != 0 {
+			event.Set("ImageBuildDuration", data.ImageBuildDuration)
+		}
+
+		if data.Outcome != "" {
+			event.Set("Outcome", data.Outcome)
+		}
+
+		// event.Send(ctx)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(sendAnalyticsCmd)
+
+	sendAnalyticsCmd.Flags().StringVarP(&sendAnalyticsCmdOpts.data, "data", "", "", "JSON encoded event data")
+	sendAnalyticsCmd.MarkFlagRequired("data")
+}
+
+// TODO: make it work with sub-commands
+// func isValidCommand(cmdName string) bool {
+// 	for _, c := range rootCmd.Commands() {
+// 		if c.Name() == cmdName {
+// 			return true
+// 		}
+// 	}
+// 	return false
+// }

--- a/components/gitpod-cli/go.mod
+++ b/components/gitpod-cli/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/prometheus/procfs v0.8.0
 	github.com/sirupsen/logrus v1.8.1
 	github.com/sourcegraph/jsonrpc2 v0.0.0-20200429184054-15c2290dcb37
-	github.com/spf13/cobra v1.1.3
+	github.com/spf13/cobra v1.6.1
 	golang.org/x/sys v0.0.0-20220610221304-9f5ed59c137d
 	golang.org/x/term v0.0.0-20220526004731-065cf7ba2467
 	golang.org/x/xerrors v0.0.0-20220609144429-65e65417b02f
@@ -34,7 +34,7 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.11.3 // indirect
-	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/inconshreveable/mousetrap v1.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.9 // indirect
 	github.com/segmentio/backo-go v0.0.0-20200129164019-23eae7c10bd3 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect

--- a/components/gitpod-cli/go.sum
+++ b/components/gitpod-cli/go.sum
@@ -40,6 +40,7 @@ github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3Ee
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
+github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.17 h1:QeVUsEDNrLBW4tMgZHvxy18sKtr6VI492kBhUfhDJNI=
 github.com/creack/pty v1.1.17/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -126,6 +127,8 @@ github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2p
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/inconshreveable/mousetrap v1.0.1 h1:U3uMjPSQEBMNp1lFxmllqCPM6P5u/Xq7Pgzkat/bFNc=
+github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
@@ -184,6 +187,7 @@ github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40T
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/segmentio/backo-go v0.0.0-20200129164019-23eae7c10bd3 h1:ZuhckGJ10ulaKkdvJtiAqsLTiPrLaXSdnVgXJKJkTxE=
@@ -202,6 +206,8 @@ github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v1.1.3 h1:xghbfqPkxzxP3C/f3n5DdpAbdKLj4ZE4BWQI362l53M=
 github.com/spf13/cobra v1.1.3/go.mod h1:pGADOWyqRD/YMrPZigI/zbliZ2wVD/23d+is3pSWzOo=
+github.com/spf13/cobra v1.6.1 h1:o94oiPyS4KD1mPy2fmcYYHHfCxLqYjJOhGsCHFZtEzA=
+github.com/spf13/cobra v1.6.1/go.mod h1:IOw/AERYS7UzyrGinqmz6HLUo219MORXGxhbaJUqzrY=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
@@ -375,6 +381,7 @@ gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/components/gitpod-cli/hot-swap.sh
+++ b/components/gitpod-cli/hot-swap.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
-# Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+# Copyright (c) 2023 Gitpod GmbH. All rights reserved.
 # Licensed under the GNU Affero General Public License (AGPL).
 # See License.AGPL.txt in the project root for license information.
 
 set -Eeuo pipefail
 
-# This script builds supervisor and swaps the old binary with the new one inside another workspace
+# This script builds gitpod-cli and swaps the old binary with the new one inside another workspace
 
 component=${PWD##*/}
 workspaceUrl=$(echo "${1}" |sed -e "s/\/$//")
@@ -38,5 +38,5 @@ uploadDest="/.supervisor/$component"
 echo "Upload Dest: $uploadDest"
 ssh -F "$sshConfig" "$workspaceId" "sudo chown -R gitpod:gitpod /.supervisor && rm $uploadDest 2> /dev/null"
 echo "Permissions granted"
-scp -F "$sshConfig" -r "./supervisor" "$workspaceId":"$uploadDest"
+scp -F "$sshConfig" -r "./$component" "$workspaceId":"$uploadDest"
 echo "Swap complete"

--- a/components/gitpod-cli/hot-swap.sh
+++ b/components/gitpod-cli/hot-swap.sh
@@ -9,6 +9,11 @@ set -Eeuo pipefail
 
 component=${PWD##*/}
 workspaceUrl=$(echo "${1}" |sed -e "s/\/$//")
+
+# build
+go build .
+echo "$component built"
+
 echo "URL: $workspaceUrl"
 
 workspaceDesc=$(gpctl workspaces describe "$workspaceUrl" -o=json)
@@ -28,10 +33,6 @@ sshConfig=$(mktemp)
 echo "Host $workspaceId" > "$sshConfig"
 echo "    Hostname \"$workspaceId.ssh.$clusterHost\"" >> "$sshConfig"
 echo "    User \"$workspaceId#$ownerToken\"" >> "$sshConfig"
-
-# build
-go build .
-echo "$component built"
 
 # upload
 uploadDest="/.supervisor/$component"

--- a/components/gitpod-cli/pkg/utils/trackEvent.go
+++ b/components/gitpod-cli/pkg/utils/trackEvent.go
@@ -7,6 +7,8 @@ package utils
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"os"
 	"time"
 
 	"github.com/gitpod-io/gitpod/common-go/analytics"
@@ -101,10 +103,21 @@ func (e *AnalyticsEvent) Set(key string, value interface{}) *AnalyticsEvent {
 	return e
 }
 
+func (e *AnalyticsEvent) ExportToJson(ctx context.Context) string {
+	fmt.Println(e.startTime)
+	e.Set("Duration", time.Since(e.startTime).Milliseconds())
+
+	data, err := json.Marshal(e.Data)
+	if err != nil {
+		LogError(ctx, err.(error), "error marshaling analytics data", e.supervisorClient)
+		os.Exit(1)
+	}
+
+	return string(data)
+}
+
 func (e *AnalyticsEvent) Send(ctx context.Context) {
 	defer e.w.Close()
-
-	e.Set("Duration", time.Since(e.startTime).Milliseconds())
 
 	data := make(map[string]interface{})
 	jsonData, err := json.Marshal(e.Data)

--- a/components/gitpod-cli/pkg/utils/trackEvent.go
+++ b/components/gitpod-cli/pkg/utils/trackEvent.go
@@ -7,7 +7,6 @@ package utils
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"os"
 	"time"
 
@@ -39,6 +38,7 @@ const (
 
 type TrackCommandUsageParams struct {
 	Command            []string `json:"command,omitempty"`
+	Flags              []string `json:"flags,omitempty"`
 	Duration           int64    `json:"duration,omitempty"`
 	ErrorCode          string   `json:"errorCode,omitempty"`
 	WorkspaceId        string   `json:"workspaceId,omitempty"`
@@ -73,6 +73,7 @@ func NewAnalyticsEvent(ctx context.Context, supervisorClient *supervisor.Supervi
 
 	event.Data = &TrackCommandUsageParams{
 		Command:     cmdParams.Command,
+		Flags:       cmdParams.Flags,
 		Duration:    cmdParams.Duration,
 		WorkspaceId: wsInfo.WorkspaceId,
 		InstanceId:  wsInfo.InstanceId,
@@ -87,6 +88,8 @@ func (e *AnalyticsEvent) Set(key string, value interface{}) *AnalyticsEvent {
 	switch key {
 	case "Command":
 		e.Data.Command = value.([]string)
+	case "Flags":
+		e.Data.Flags = value.([]string)
 	case "ErrorCode":
 		e.Data.ErrorCode = value.(string)
 	case "Duration":
@@ -104,7 +107,6 @@ func (e *AnalyticsEvent) Set(key string, value interface{}) *AnalyticsEvent {
 }
 
 func (e *AnalyticsEvent) ExportToJson(ctx context.Context) string {
-	fmt.Println(e.startTime)
 	e.Set("Duration", time.Since(e.startTime).Milliseconds())
 
 	data, err := json.Marshal(e.Data)

--- a/components/gitpod-cli/pkg/utils/trackEvent.go
+++ b/components/gitpod-cli/pkg/utils/trackEvent.go
@@ -111,7 +111,7 @@ func (e *AnalyticsEvent) ExportToJson(ctx context.Context) string {
 
 	data, err := json.Marshal(e.Data)
 	if err != nil {
-		LogError(ctx, err.(error), "error marshaling analytics data", e.supervisorClient)
+		LogError(ctx, err, "error marshaling analytics data", e.supervisorClient)
 		os.Exit(1)
 	}
 

--- a/components/gitpod-cli/pkg/utils/trackEvent.go
+++ b/components/gitpod-cli/pkg/utils/trackEvent.go
@@ -36,14 +36,14 @@ const (
 )
 
 type TrackCommandUsageParams struct {
-	Command            string `json:"command,omitempty"`
-	Duration           int64  `json:"duration,omitempty"`
-	ErrorCode          string `json:"errorCode,omitempty"`
-	WorkspaceId        string `json:"workspaceId,omitempty"`
-	InstanceId         string `json:"instanceId,omitempty"`
-	Timestamp          int64  `json:"timestamp,omitempty"`
-	ImageBuildDuration int64  `json:"imageBuildDuration,omitempty"`
-	Outcome            string `json:"outcome,omitempty"`
+	Command            []string `json:"command,omitempty"`
+	Duration           int64    `json:"duration,omitempty"`
+	ErrorCode          string   `json:"errorCode,omitempty"`
+	WorkspaceId        string   `json:"workspaceId,omitempty"`
+	InstanceId         string   `json:"instanceId,omitempty"`
+	Timestamp          int64    `json:"timestamp,omitempty"`
+	ImageBuildDuration int64    `json:"imageBuildDuration,omitempty"`
+	Outcome            string   `json:"outcome,omitempty"`
 }
 
 type AnalyticsEvent struct {
@@ -71,10 +71,10 @@ func NewAnalyticsEvent(ctx context.Context, supervisorClient *supervisor.Supervi
 
 	event.Data = &TrackCommandUsageParams{
 		Command:     cmdParams.Command,
-		Duration:    0,
+		Duration:    cmdParams.Duration,
 		WorkspaceId: wsInfo.WorkspaceId,
 		InstanceId:  wsInfo.InstanceId,
-		ErrorCode:   "",
+		ErrorCode:   cmdParams.ErrorCode,
 		Timestamp:   time.Now().UnixMilli(),
 	}
 
@@ -84,7 +84,7 @@ func NewAnalyticsEvent(ctx context.Context, supervisorClient *supervisor.Supervi
 func (e *AnalyticsEvent) Set(key string, value interface{}) *AnalyticsEvent {
 	switch key {
 	case "Command":
-		e.Data.Command = value.(string)
+		e.Data.Command = value.([]string)
 	case "ErrorCode":
 		e.Data.ErrorCode = value.(string)
 	case "Duration":


### PR DESCRIPTION
## Description
This PR adds analytics to the `gp` CLI. This will help us understand which commands are most and least useful.

I've introduced this with a pattern of relying on the command's context to share data. I've took this opportunity to also share supervisorClient and error reporting via the context. Especially for error-reporting it was a required change to make sure all commands do report back. In some instances we use Fatal errors which would exit the cli without allowing the analytics data to be flushed.

List of commands updated:

- [ ] docs
- [x] env
- [ ] help
- [ ] info
- [ ] init
- [ ] open
- [ ] ports
- [ ] preview
- [ ] rebuild
- [ ] snapshot
- [ ] stop
- [ ] sync
- [ ] sync
- [ ] tasks
- [ ] timeout
- [x] top
- [ ] url
- [ ] version

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
- [x] /werft analytics=segment