### PR TITLE
feat: `gp docs` in gitpod cli

### DIFF
--- a/components/gitpod-cli/cmd/docs.go
+++ b/components/gitpod-cli/cmd/docs.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// URL of the Gitpod documentation
+const DocsUrl = "https://www.gitpod.io/docs"
+
+var docsCmd = &cobra.Command{
+	Use:   "docs",
+	Short: "Open Gitpod Documentation in default browser",
+	Run: func(cmd *cobra.Command, args []string) {
+		openPreview("GP_EXTERNAL_BROWSER", DocsUrl)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(docsCmd)
+}


### PR DESCRIPTION
> Signed-off-by: Siddhant Khare <siddhant@gitpod.io>

## Description

Open documentation from gitpod cli: `gp docs`

**Demo Video:**

https://user-images.githubusercontent.com/55068936/212272075-0225777c-6f0a-4404-9166-02af92703141.mov



## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
- Open [Preview](https://feat-gitpod-cli.preview.gitpod-dev.com/workspaces)
- Open any workspace (`/empty`)
- run `gp docs`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
feat: `gp docs` in gitpod cli
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

- Req. Addition of [Gitpod CLI](https://www.gitpod.io/docs/references/gitpod-cli#gitpod-cli)

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
