### PR TITLE
test: Add some stub tests for ws-daemon

### DIFF
--- a/test/tests/components/ws-daemon/cpu_burst_test.go
+++ b/test/tests/components/ws-daemon/cpu_burst_test.go
@@ -32,7 +32,7 @@ type DaemonConfig struct {
 }
 
 func TestCpuBurst(t *testing.T) {
-	f := features.New("cpulimiting").WithLabel("component", "ws-manager").Assess("check cpu limiting", func(_ context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+	f := features.New("cpulimiting").WithLabel("component", "ws-daemon").Assess("check cpu limiting", func(_ context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 		t.Parallel()
 
 		ctx, cancel := context.WithTimeout(context.Background(), 8*time.Minute)

--- a/test/tests/components/ws-daemon/fuse_device_test.go
+++ b/test/tests/components/ws-daemon/fuse_device_test.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package wsdaemon
+
+import (
+	"context"
+	"testing"
+
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+)
+
+func TestFuseDevice(t *testing.T) {
+	f := features.New("fuse devive").
+		WithLabel("component", "ws-daemon").
+		Assess("verify fuse device", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			t.Parallel()
+			// TODO(toru): check if this code works fine
+			// #define _GNU_SOURCE
+			// #include <unistd.h>
+
+			// #include <sys/syscall.h>
+			// #include <linux/fs.h>
+			// #include <sys/types.h>
+			// #include <sys/stat.h>
+			// #include <fcntl.h>
+			// #include <stdio.h>
+
+			// int main() {
+			//   const char* src_path = "/dev/fuse";
+			//   unsigned int flags = O_RDWR;
+			//   printf("RET: %ld\n", syscall(SYS_openat, AT_FDCWD, src_path, flags));
+			// }
+			t.Skip("unimplemented")
+			return ctx
+		}).Feature()
+
+	testEnv.Test(t, f)
+}

--- a/test/tests/components/ws-daemon/io_limiting_test.go
+++ b/test/tests/components/ws-daemon/io_limiting_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package wsdaemon
+
+import (
+	"context"
+	"testing"
+
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+)
+
+func TestIOLimiting(t *testing.T) {
+	f := features.New("IO limiting").
+		WithLabel("component", "ws-daemon").
+		Assess("verify if io limiting works fine", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			t.Parallel()
+			// TODO(toru): check it with dd command
+			// Note(toru): this feature is disable on a default preview env
+			t.Skip("unimplemented")
+			return ctx
+		}).Feature()
+
+	testEnv.Test(t, f)
+}

--- a/test/tests/components/ws-daemon/network_limiting_test.go
+++ b/test/tests/components/ws-daemon/network_limiting_test.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package wsdaemon
+
+import (
+	"context"
+	"testing"
+
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+)
+
+func TestNetworkdLimiting(t *testing.T) {
+	f := features.New("network limiting").
+		WithLabel("component", "ws-daemon").
+		Assess("verify if network limiting works fine", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			t.Parallel()
+			t.Skip("unimplemented")
+			return ctx
+		}).Feature()
+
+	testEnv.Test(t, f)
+}

--- a/test/tests/components/ws-daemon/process_priority_test.go
+++ b/test/tests/components/ws-daemon/process_priority_test.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package wsdaemon
+
+import (
+	"context"
+	"testing"
+
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+)
+
+func TestProcessPriority(t *testing.T) {
+	f := features.New("process priority").
+		WithLabel("component", "ws-daemon").
+		Assess("check process priority of some processes of importance", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			t.Parallel()
+			t.Skip("unimplemented")
+			return ctx
+		}).Feature()
+
+	testEnv.Test(t, f)
+}

--- a/test/tests/components/ws-daemon/workspace_resource_info_test.go
+++ b/test/tests/components/ws-daemon/workspace_resource_info_test.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package wsdaemon
+
+import (
+	"context"
+	"testing"
+
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+)
+
+func TestIWSWorkspaceInfo(t *testing.T) {
+	f := features.New("/iws.InWorkspaceService/WorkspaceInfo").
+		WithLabel("component", "ws-daemon").
+		Assess("check /iws.InWorkspaceService/WorkspaceInfo", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			t.Parallel()
+			// TODO(toru): we can implement this case with `gp top`
+			t.Skip("unimplemented")
+			return ctx
+		}).Feature()
+
+	testEnv.Test(t, f)
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

test: Add some stub tests for ws-daemon

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Follow-up https://github.com/gitpod-io/gitpod/pull/15494

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
