### PR TITLE
[iam/oidc] Read OIDC config from DB

### DIFF
--- a/components/iam/pkg/oidc/oauth2.go
+++ b/components/iam/pkg/oidc/oauth2.go
@@ -78,6 +78,7 @@ func (s *Service) OAuth2Middleware(next http.Handler) http.Handler {
 			return
 		}
 
+		config.OAuth2Config.RedirectURL = getCallbackURL(r.Host)
 		oauth2Token, err := config.OAuth2Config.Exchange(r.Context(), code)
 		if err != nil {
 			http.Error(rw, "failed to exchange token: "+err.Error(), http.StatusInternalServerError)

--- a/components/iam/pkg/oidc/oauth2.go
+++ b/components/iam/pkg/oidc/oauth2.go
@@ -21,8 +21,7 @@ type OAuth2Result struct {
 type StateParam struct {
 	// Internal client ID
 	ClientConfigID string `json:"clientId"`
-
-	ReturnToURL string `json:"returnTo"`
+	ReturnToURL    string `json:"returnTo"`
 }
 
 type keyOAuth2Result struct{}

--- a/components/iam/pkg/oidc/router.go
+++ b/components/iam/pkg/oidc/router.go
@@ -6,6 +6,7 @@ package oidc
 
 import (
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/gitpod-io/gitpod/common-go/log"
@@ -41,7 +42,8 @@ func (s *Service) getStartHandler() http.HandlerFunc {
 			return
 		}
 
-		startParams, err := s.GetStartParams(config)
+		redirectURL := getCallbackURL(r.Host)
+		startParams, err := s.GetStartParams(config, redirectURL)
 		if err != nil {
 			http.Error(rw, "failed to start auth flow", http.StatusInternalServerError)
 			return
@@ -52,6 +54,11 @@ func (s *Service) getStartHandler() http.HandlerFunc {
 
 		http.Redirect(rw, r, startParams.AuthCodeURL, http.StatusTemporaryRedirect)
 	}
+}
+
+func getCallbackURL(host string) string {
+	callbackURL := url.URL{Scheme: "https", Path: "/iam/oidc/callback", Host: host}
+	return callbackURL.String()
 }
 
 func newCallbackCookie(r *http.Request, name string, value string) *http.Cookie {

--- a/components/iam/pkg/oidc/router_test.go
+++ b/components/iam/pkg/oidc/router_test.go
@@ -110,7 +110,6 @@ func newTestServer(t *testing.T, params testServerParams) (url string, state *St
 	oauth2Config := &oauth2.Config{
 		ClientID:     params.clientID,
 		ClientSecret: "secret",
-		RedirectURL:  url + "/callback",
 		Scopes:       []string{goidc.ScopeOpenID, "profile", "email"},
 	}
 	clientConfig := &ClientConfig{

--- a/components/iam/pkg/oidc/service.go
+++ b/components/iam/pkg/oidc/service.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"strings"
 
@@ -272,5 +273,7 @@ func (s *Service) CreateSession(ctx context.Context, flowResult *AuthFlowResult)
 		}
 		return nil, fmt.Errorf("unexpected count of cookies: %v", len(cookies))
 	}
+	message, _ := ioutil.ReadAll(res.Body)
+	log.WithField("create-session-error", message).Error("Failed to create session (via server)")
 	return nil, fmt.Errorf("unexpected status code: %v", res.StatusCode)
 }

--- a/components/iam/pkg/oidc/service.go
+++ b/components/iam/pkg/oidc/service.go
@@ -195,8 +195,12 @@ func (s *Service) getConfigById(id string) (*ClientConfig, error) {
 			s.verifierByIssuer[dbEntry.Issuer] = provider.Verifier(&goidc.Config{
 				ClientID: spec.ClientID,
 			})
-
 		}
+	}
+
+	scopes := spec.Scopes
+	if len(scopes) < 1 {
+		scopes = []string{"openid"}
 	}
 
 	return &ClientConfig{
@@ -206,6 +210,7 @@ func (s *Service) getConfigById(id string) (*ClientConfig, error) {
 			ClientID:     spec.ClientID,
 			ClientSecret: spec.ClientSecret,
 			Endpoint:     provider.Endpoint(),
+			Scopes:       scopes,
 		},
 		VerifierConfig: &goidc.Config{
 			ClientID: spec.ClientID,

--- a/components/iam/pkg/oidc/service.go
+++ b/components/iam/pkg/oidc/service.go
@@ -124,10 +124,9 @@ func randString(size int) (string, error) {
 }
 
 func (s *Service) GetClientConfigFromStartRequest(r *http.Request) (*ClientConfig, error) {
-	issuerParam := r.URL.Query().Get("issuer")
 	idParam := r.URL.Query().Get("id")
-	if issuerParam == "" && idParam == "" {
-		return nil, fmt.Errorf("missing parameters")
+	if idParam == "" {
+		return nil, fmt.Errorf("missing id parameter")
 	}
 
 	if idParam != "" {
@@ -136,13 +135,6 @@ func (s *Service) GetClientConfigFromStartRequest(r *http.Request) (*ClientConfi
 			return config, nil
 		}
 		return nil, fmt.Errorf("failed to find OIDC config by ID")
-	}
-	if issuerParam != "" {
-		for _, value := range s.configsById {
-			if value.Issuer == issuerParam {
-				return value, nil
-			}
-		}
 	}
 
 	return nil, fmt.Errorf("failed to find OIDC config")

--- a/components/iam/pkg/oidc/service.go
+++ b/components/iam/pkg/oidc/service.go
@@ -71,7 +71,7 @@ func newTestService(sessionServiceAddress string, dbConn *gorm.DB, cipher db.Cip
 	return service
 }
 
-func (s *Service) GetStartParams(config *ClientConfig) (*StartParams, error) {
+func (s *Service) GetStartParams(config *ClientConfig, redirectURL string) (*StartParams, error) {
 	// state is supposed to a) be present on client request as cookie header
 	// and b) to be mirrored by the IdP on callback requests.
 	stateParam := StateParam{
@@ -92,6 +92,7 @@ func (s *Service) GetStartParams(config *ClientConfig) (*StartParams, error) {
 	}
 
 	// Nonce is the single option passed on to configure the consent page ATM.
+	config.OAuth2Config.RedirectURL = redirectURL
 	authCodeURL := config.OAuth2Config.AuthCodeURL(state, goidc.Nonce(nonce))
 
 	return &StartParams{

--- a/components/iam/pkg/oidc/service_test.go
+++ b/components/iam/pkg/oidc/service_test.go
@@ -28,8 +28,9 @@ import (
 
 func TestGetStartParams(t *testing.T) {
 	const (
-		issuerG  = "https://accounts.google.com"
-		clientID = "client-id-123"
+		issuerG     = "https://accounts.google.com"
+		clientID    = "client-id-123"
+		redirectURL = "https://test.local/iam/oidc/callback"
 	)
 	service, _ := setupOIDCServiceForTests(t)
 	config := &ClientConfig{
@@ -43,7 +44,7 @@ func TestGetStartParams(t *testing.T) {
 		},
 	}
 
-	params, err := service.GetStartParams(config)
+	params, err := service.GetStartParams(config, redirectURL)
 
 	require.NoError(t, err)
 	require.NotNil(t, params.Nonce)
@@ -54,10 +55,12 @@ func TestGetStartParams(t *testing.T) {
 	// ?client_id=client-id-123
 	// &nonce=UFTMxxUtc5jVZbp2a2R9XEoRwpfzs-04FcmVQ-HdCsw
 	// &response_type=code
+	// &redirect_url=https...
 	// &state=Q4XzRcdo4jtOYeRbF17T9LHHwX-4HacT1_5pZH8mXLI
 	require.NotNil(t, params.AuthCodeURL)
 	require.Contains(t, params.AuthCodeURL, issuerG)
 	require.Contains(t, params.AuthCodeURL, clientID)
+	require.Contains(t, params.AuthCodeURL, url.QueryEscape(redirectURL))
 	require.Contains(t, params.AuthCodeURL, url.QueryEscape(params.Nonce))
 	require.Contains(t, params.AuthCodeURL, url.QueryEscape(params.State))
 }

--- a/components/iam/pkg/oidc/service_test.go
+++ b/components/iam/pkg/oidc/service_test.go
@@ -76,16 +76,6 @@ func TestGetClientConfigFromStartRequest(t *testing.T) {
 			ExpectedId:    "",
 		},
 		{
-			Location:      "/start?issuer=" + issuer,
-			ExpectedError: false,
-			ExpectedId:    clientID,
-		},
-		{
-			Location:      "/start?issuer=UNKNOWN",
-			ExpectedError: true,
-			ExpectedId:    "",
-		},
-		{
 			Location:      "/start?id=UNKNOWN",
 			ExpectedError: true,
 			ExpectedId:    "",

--- a/components/iam/pkg/server/server.go
+++ b/components/iam/pkg/server/server.go
@@ -41,7 +41,7 @@ func Start(logger *logrus.Entry, version string, cfg *config.ServiceConfig) erro
 		return fmt.Errorf("failed to initialize IAM server: %w", err)
 	}
 
-	oidcService := oidc.NewService(cfg.SessionServiceAddress)
+	oidcService := oidc.NewService(cfg.SessionServiceAddress, dbConn, cipherSet)
 	oidcClientConfigService := apiv1.NewOIDCClientConfigService(dbConn, cipherSet)
 
 	err = register(srv, &dependencies{

--- a/components/server/src/iam/iam-session-app.ts
+++ b/components/server/src/iam/iam-session-app.ts
@@ -10,6 +10,7 @@ import { SessionHandlerProvider } from "../session-handler";
 import { Authenticator } from "../auth/authenticator";
 import { UserService } from "../user/user-service";
 import { OIDCCreateSessionPayload } from "./iam-oidc-create-session-payload";
+import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 
 @injectable()
 export class IamSessionApp {
@@ -35,6 +36,7 @@ export class IamSessionApp {
                 const result = await this.doCreateSession(req);
                 res.status(200).json(result);
             } catch (error) {
+                log.error("Error creating session on behalf of IAM", error, { error });
                 // we treat all errors as bad request here and forward the error message to the caller
                 res.status(400).json({ error, message: error.message });
             }


### PR DESCRIPTION
## Description

With DB persistence of OIDC client configs in place, these changes enable actually using them after creation via API.

1. API calls look like this (curl style) 
```sh
curl 'https://api.at-oidc-proxy.preview.gitpod-dev.com/gitpod.experimental.v1.OIDCService/CreateClientConfig' \
  -H 'content-type: application/json' \
  -H 'Authorization: Bearer gitpod_pat_READACTED' \
  --data '{"config": { "organizationId": "d3b6708c-360f-41d0-8d1a-cc716b8cf686", "oidcConfig": {"issuer": "https://accounts.google.com"}, "oauth2Config": {"scopesSupported": ["openid", "email", "profile"], "clientId": "REDACTED.apps.googleusercontent.com", "clientSecret": "GOCSPX-REDACTED-t"} }}'
```

2. Responses look like this
```json
{"config":{"id":"b8da1816-e45c-49a7-ab45-f56297123861","organizationId":"d3b6708c-360f-41d0-8d1a-cc716b8cf686","oidcConfig":{},"oauth2Config":{"clientSecret":"REDACTED"}}}       
```

3. To initiate the OIDC flow for this OIDC client, navigate your browser the `/iam/oidc/start` URL which has to provide the `id` of the created client config:
```
https://at-oidc-proxy.preview.gitpod-dev.com/iam/oidc/start?id=b8da1816-e45c-49a7-ab45-f56297123861
```


## How to test
* see unit tests
* parallel deployment at https://at-oidc-proxy.preview.gitpod-dev.com/iam/oidc/start?id=b8da1816-e45c-49a7-ab45-f56297123861
   * requires a gitpodder account 😛 

## Related issues
Fixes https://github.com/gitpod-io/gitpod/issues/14955

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
