### PR TITLE
[supervisor] improve instance updates

### DIFF
--- a/components/supervisor/pkg/ports/exposed-ports.go
+++ b/components/supervisor/pkg/ports/exposed-ports.go
@@ -121,7 +121,7 @@ func (g *GitpodExposedPorts) Observe(ctx context.Context) (<-chan []ExposedPort,
 		defer close(reschan)
 		defer close(errchan)
 
-		updates, err := g.gitpodService.InstanceUpdates(ctx, g.InstanceID, g.WorkspaceID)
+		updates, err := g.gitpodService.InstanceUpdates(ctx)
 		if err != nil {
 			errchan <- err
 			return
@@ -205,7 +205,7 @@ func (g *GitpodExposedPorts) doExpose(req *exposePortRequest) {
 	exp.Reset()
 	attempt := 0
 	for {
-		_, err = g.gitpodService.OpenPort(req.ctx, g.WorkspaceID, req.port)
+		_, err = g.gitpodService.OpenPort(req.ctx, req.port)
 		if err == nil || req.ctx.Err() != nil || attempt == 5 {
 			return
 		}

--- a/components/supervisor/pkg/supervisor/supervisor.go
+++ b/components/supervisor/pkg/supervisor/supervisor.go
@@ -1616,7 +1616,7 @@ func (a *PerfAnalyzer) analyze(used float64) bool {
 }
 
 func analysePerfChanges(ctx context.Context, wscfg *Config, w analytics.Writer, topService *TopService, gitpodAPI serverapi.APIInterface) {
-	ownerID, err := gitpodAPI.GetOwnerID(ctx, wscfg.WorkspaceID)
+	ownerID, err := gitpodAPI.GetOwnerID(ctx)
 	if err != nil {
 		log.WithError(err).Error("gitpod perf analytics: failed to resolve workspace info")
 		return
@@ -1658,7 +1658,7 @@ func analysePerfChanges(ctx context.Context, wscfg *Config, w analytics.Writer, 
 }
 
 func analyseConfigChanges(ctx context.Context, wscfg *Config, w analytics.Writer, cfgobs config.ConfigInterface, gitpodAPI serverapi.APIInterface) {
-	ownerID, err := gitpodAPI.GetOwnerID(ctx, wscfg.WorkspaceID)
+	ownerID, err := gitpodAPI.GetOwnerID(ctx)
 	if err != nil {
 		log.WithError(err).Error("gitpod config analytics: failed to resolve workspace info")
 		return


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Address plan https://github.com/gitpod-io/gitpod/pull/15723#issuecomment-1381444444

- Change our interface -> we don't need instanceID or workspaceID in supervisor as it only works for current workspace itself.
- Listen to server/pubcli API instanceUpdates inside, once Service created.
- Add subscriber once outside call InstanceUpdates

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #
Related https://github.com/gitpod-io/gitpod/issues/15383

## How to test
<!-- Provide steps to test this PR -->
Check if instance updates works as before (check **How to Test** section of PR https://github.com/gitpod-io/gitpod/pull/15723)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
