### PR TITLE
[server] Correctly record client IP for analytics purposes 

### DIFF
--- a/components/server/src/express-util.ts
+++ b/components/server/src/express-util.ts
@@ -171,11 +171,9 @@ export const takeFirst = (h: string | string[] | undefined): string | undefined 
 };
 
 export function clientIp(req: express.Request): string | undefined {
-    const forwardedFor = takeFirst(req.headers["x-forwarded-for"]);
-    if (!forwardedFor) {
+    const clientIp = takeFirst(req.headers["x-real-ip"]);
+    if (!clientIp) {
         return undefined;
     }
-
-    // We now have a ,-separated string of IPs, where the first one is the (closest to) client IP
-    return forwardedFor.split(",")[0];
+    return clientIp.split(",")[0];
 }


### PR DESCRIPTION
## Description

Use a new `X-Real-IP` header for cookieless tracking rather than relying on the `X-Forwarded-For` header that the GCP loadbalancer sets by default. The `X-Forwarded-For` header is truncated by Caddy [[1](https://caddyserver.com/docs/caddyfile/directives/reverse_proxy#defaults)], removing the true client IP and leaving just the IP of the GCP LB.

By defining a new custom header at the LB and setting it to the client IP, we ensure that Caddy forwards it to `server` without modification.

If we decide to go ahead with this approach we need to configure the `X-Real-IP` header on the production loadbalancer just as has already been done for the staging loadbalancer.

## Related Issue(s)
Fixes #15600

## How to test

* Take the image of `server` built on this branch and use it to update the `image` of the `server` deployment in staging.
* Change `server`'s log level to `debug`:
```bash
kubectl get pods | rg '^server' | awk '{ print $1 }' | xargs -I@ kubectl exec @ -c server -- curl -H "Content-Type: application/json" localhost:6060/debug/logging -d '{"level": "debug"}'
```
* Open a browser and visit https://gitpod-staging.com/workspaces.
* Server logs should contain the (masked) client IP address when the websocket connection was established:
```
{"component":"server","severity":"DEBUG","time":"2023-01-13T12:38:40.354Z","message":"masked wss client IP","payload":{"maskedClientIp":"185.118.207.0"}}
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
