### PR TITLE
[feat] : Warning alert in workspace delete confirmation model for pending changes

### DIFF
--- a/components/dashboard/src/components/Alert.tsx
+++ b/components/dashboard/src/components/Alert.tsx
@@ -85,7 +85,11 @@ export default function Alert(props: AlertProps) {
     const showIcon = props.showIcon ?? true;
     const light = props.light ?? false;
     return (
-        <div className={`flex relative rounded p-4 ${info.txtCls} ${props.className || ""} ${light ? "" : info.bgCls}`}>
+        <div
+            className={`flex relative whitespace-pre-wrap rounded p-4 ${info.txtCls} ${props.className || ""} ${
+                light ? "" : info.bgCls
+            }`}
+        >
             {showIcon && <span className={`mt-1 mr-4 h-4 w-4 ${info.iconColor}`}>{props.icon ?? info.icon}</span>}
             <span className="flex-1 text-left">{props.children}</span>
             {props.closable && (

--- a/components/dashboard/src/components/ConfirmationModal.tsx
+++ b/components/dashboard/src/components/ConfirmationModal.tsx
@@ -15,6 +15,7 @@ export default function ConfirmationModal(props: {
     buttonText?: string;
     buttonDisabled?: boolean;
     visible?: boolean;
+    warningHead?: string;
     warningText?: string;
     onClose: () => void;
     onConfirm: () => void;
@@ -26,7 +27,11 @@ export default function ConfirmationModal(props: {
     ];
 
     if (props.warningText) {
-        children.unshift(<Alert type="warning">{props.warningText}</Alert>);
+        children.unshift(
+            <Alert type="warning">
+                <strong>{props.warningHead}</strong>: {props.warningText}
+            </Alert>,
+        );
     }
 
     const isEntity = (x: any): x is Entity => typeof x === "object" && "name" in x;

--- a/components/dashboard/src/components/ConfirmationModal.tsx
+++ b/components/dashboard/src/components/ConfirmationModal.tsx
@@ -28,8 +28,10 @@ export default function ConfirmationModal(props: {
 
     if (props.warningText) {
         children.unshift(
-            <Alert type="warning">
-                <strong>{props.warningHead}</strong>: {props.warningText}
+            <Alert type="warning" className="mb-4">
+                <strong>{props.warningHead}</strong>
+                {props.warningHead ? ": " : ""}
+                {props.warningText}
             </Alert>,
         );
     }

--- a/components/dashboard/src/teams/TeamSettings.tsx
+++ b/components/dashboard/src/teams/TeamSettings.tsx
@@ -97,7 +97,8 @@ export default function TeamSettings() {
                 buttonText="Delete Team"
                 buttonDisabled={teamSlug !== team!.slug}
                 visible={modal}
-                warningText="Warning: This action cannot be reversed."
+                warningHead="Warning"
+                warningText="This action cannot be reversed."
                 onClose={close}
                 onConfirm={deleteTeam}
             >

--- a/components/dashboard/src/workspaces/WorkspaceEntry.tsx
+++ b/components/dashboard/src/workspaces/WorkspaceEntry.tsx
@@ -152,6 +152,20 @@ export function WorkspaceEntry({ desc, model, isAdmin, stopWorkspace }: Props) {
         }
     };
 
+    // check for workspace changes
+    const repo = desc.latestInstance?.status?.repo;
+    let currentChanges = false;
+    if (repo) {
+        if ((repo.totalUntrackedFiles || 0) > 0) {
+            currentChanges = true;
+        }
+        if ((repo.totalUncommitedFiles || 0) > 0) {
+            currentChanges = true;
+        }
+        if ((repo.totalUnpushedCommits || 0) > 0) {
+            currentChanges = true;
+        }
+    }
     const normalizedContextUrl = ContextURL.getNormalizedURL(ws)?.toString();
     const normalizedContextUrlDescription = normalizedContextUrl || ws.contextURL; // Instead of showing nothing, we prefer to show the raw content instead
     return (
@@ -207,6 +221,8 @@ export function WorkspaceEntry({ desc, model, isAdmin, stopWorkspace }: Props) {
                     }}
                     buttonText="Delete Workspace"
                     visible={isDeleteModalVisible}
+                    warningHead="Pending Changes"
+                    warningText={currentChanges ? "Workspace contains uncommited files or unpushed commits." : ""}
                     onClose={() => setDeleteModalVisible(false)}
                     onConfirm={() => model.deleteWorkspace(ws.id, usePublicApiWorkspacesService)}
                 />


### PR DESCRIPTION
## Description
- added a variable `currentChanges` to check for pending changes, default: `false`.
- checking for latest changes and respectively update `currentChanges`
- in `ConfirmationModal`, passed a prop for alert message.
- added another property `warningHead`, to make the content bold other then `warningText` which have font-weight normal, For example `Warning`, `Pending Changes`. 

### For workspace with changes
![Screenshot from 2023-01-14 15-01-19](https://user-images.githubusercontent.com/76901313/212465502-47eccd8f-c9b3-4c1f-b37c-0b4a3bb81756.png)

### For workspace with no changes
![Screenshot from 2023-01-14 15-01-24](https://user-images.githubusercontent.com/76901313/212465498-9d737c9f-9c6d-4ada-a382-c9fe05382e59.png)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #15669 

## How to test
<!-- Provide steps to test this PR -->
- Add a workspace that contains some changes!
- try to delete the workspace

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
