### PR TITLE
[server] added UpdateTeam

### DIFF
--- a/components/gitpod-db/src/team-db.ts
+++ b/components/gitpod-db/src/team-db.ts
@@ -23,6 +23,7 @@ export interface TeamDB {
     findTeamsByUser(userId: string): Promise<Team[]>;
     findTeamsByUserAsSoleOwner(userId: string): Promise<Team[]>;
     createTeam(userId: string, name: string): Promise<Team>;
+    updateTeam(teamId: string, team: Partial<Pick<Team, "name">>): Promise<Team>;
     addMemberToTeam(userId: string, teamId: string): Promise<"added" | "already_member">;
     setTeamMemberRole(userId: string, teamId: string, role: TeamMemberRole): Promise<void>;
     setTeamMemberSubscription(userId: string, teamId: string, subscriptionId: string): Promise<void>;

--- a/components/gitpod-db/src/typeorm/team-db-impl.spec.db.ts
+++ b/components/gitpod-db/src/typeorm/team-db-impl.spec.db.ts
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { suite, test, timeout } from "mocha-typescript";
+import { testContainer } from "../test-container";
+import { UserDB } from "../user-db";
+import { TypeORM } from "./typeorm";
+import { DBUser } from "./entity/db-user";
+import * as chai from "chai";
+import { TeamDB } from "../team-db";
+import { DBTeam } from "./entity/db-team";
+const expect = chai.expect;
+
+@suite(timeout(10000))
+export class TeamDBSpec {
+    private readonly teamDB = testContainer.get<TeamDB>(TeamDB);
+    private readonly userDB = testContainer.get<UserDB>(UserDB);
+
+    async before() {
+        await this.wipeRepo();
+    }
+
+    async after() {
+        await this.wipeRepo();
+    }
+
+    async wipeRepo() {
+        const typeorm = testContainer.get<TypeORM>(TypeORM);
+        const manager = await typeorm.getConnection();
+        await manager.getRepository(DBTeam).delete({});
+        await manager.getRepository(DBUser).delete({});
+    }
+
+    @test()
+    async testPersistAndUpdate(): Promise<void> {
+        const user = await this.userDB.newUser();
+        let team = await this.teamDB.createTeam(user.id, "Test Team");
+        team.name = "Test Team 2";
+        team = await this.teamDB.updateTeam(team.id, team);
+        expect(team.name).to.be.eq("Test Team 2");
+    }
+}

--- a/components/gitpod-db/src/typeorm/team-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/team-db-impl.ts
@@ -122,6 +122,20 @@ export class TeamDBImpl implements TeamDB {
         return soleOwnedTeams;
     }
 
+    public async updateTeam(teamId: string, team: Partial<Pick<Team, "name">>): Promise<Team> {
+        const teamRepo = await this.getTeamRepo();
+        const existingTeam = await teamRepo.findOne({ id: teamId, deleted: false, markedDeleted: false });
+        if (!existingTeam) {
+            throw new ResponseError(ErrorCodes.NOT_FOUND, "Team not found");
+        }
+        const name = team.name && team.name.trim();
+        if (!name || name.length === 0 || name.length > 32) {
+            throw new ResponseError(ErrorCodes.INVALID_VALUE, "A team's name must be between 1 and 32 characters long");
+        }
+        existingTeam.name = name;
+        return teamRepo.save(existingTeam);
+    }
+
     public async createTeam(userId: string, name: string): Promise<Team> {
         if (!name) {
             throw new ResponseError(ErrorCodes.BAD_REQUEST, "Team name cannot be empty");

--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -165,6 +165,7 @@ export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, 
 
     // Teams
     getTeam(teamId: string): Promise<Team>;
+    updateTeam(teamId: string, team: Partial<Pick<Team, "name">>): Promise<Team>;
     getTeams(): Promise<Team[]>;
     getTeamMembers(teamId: string): Promise<TeamMemberInfo[]>;
     createTeam(name: string): Promise<Team>;

--- a/components/server/src/auth/rate-limiter.ts
+++ b/components/server/src/auth/rate-limiter.ts
@@ -97,6 +97,7 @@ const defaultFunctions: FunctionsConfig = {
     getProjectEnvironmentVariables: { group: "default", points: 1 },
     deleteProjectEnvironmentVariable: { group: "default", points: 1 },
     getTeam: { group: "default", points: 1 },
+    updateTeam: { group: "default", points: 1 },
     getTeams: { group: "default", points: 1 },
     getTeamMembers: { group: "default", points: 1 },
     createTeam: { group: "default", points: 1 },


### PR DESCRIPTION
## Description
Adds an updateTeam call to the server component.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
See #5067

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`