### PR TITLE
Optional GHA-Builds via argument '/werft with-github-actions'

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -29,8 +29,10 @@ Does this PR require updates to the documentation at www.gitpod.io/docs?
   * Are you sure? If so, nothing to do here.
 -->
 
-## Werft options:
+## Build Options:
 
+- [ ] /werft with-github-actions
+      Experimental feature to run the build with GitHub Actions (and not in Werft).
 - [ ] /werft with-local-preview
       If enabled this will build `install/preview`
 - [ ] /werft with-preview

--- a/.github/workflows/poc-build.yml
+++ b/.github/workflows/poc-build.yml
@@ -1,205 +1,209 @@
 name: PoC-Build
-on: workflow_dispatch
+on:
+  pull_request:
+    types: [opened, synchronize, edited]
 
 jobs:
-    previewctl:
-        runs-on: [self-hosted]
-        container:
-            image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-leeway-v0.7.3.4
-        steps:
-            - uses: actions/checkout@v3
-            - name: Configure workspace
-              run: cp -r /__w/gitpod/gitpod /workspace
-            - name: Build previewctl
-              shell: bash
-              working-directory: /workspace/gitpod
-              run: |
-                  leeway run dev/preview/previewctl:install --dont-test
-                  cp /workspace/bin/previewctl /__w/gitpod/gitpod/previewctl
-            - name: "Upload Installer artifacts"
-              uses: actions/upload-artifact@v3
-              with:
-                  name: previewctl
-                  path: previewctl
+  previewctl:
+    if: ${{ contains(github.event.pull_request.body, '[x] /werft with-github-actions') && contains(github.event.pull_request.body, '[x] /werft with-preview') }}
+    runs-on: [self-hosted]
+    container:
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-leeway-v0.7.3.4
+    steps:
+      - uses: actions/checkout@v3
+      - name: Configure workspace
+        run: cp -r /__w/gitpod/gitpod /workspace
+      - name: Build previewctl
+        shell: bash
+        working-directory: /workspace/gitpod
+        run: |
+          leeway run dev/preview/previewctl:install --dont-test
+          cp /workspace/bin/previewctl /__w/gitpod/gitpod/previewctl
+      - name: "Upload Installer artifacts"
+        uses: actions/upload-artifact@v3
+        with:
+          name: previewctl
+          path: previewctl
 
-    infrastructure:
-        runs-on: [self-hosted]
-        needs: [previewctl]
-        container:
-            image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-leeway-v0.7.3.4
-        steps:
-            - uses: actions/checkout@v3
-            - uses: actions/download-artifact@v3
-              with:
-                  name: previewctl
-            - name: Configure workspace
-              run: |
-                  cp -r /__w/gitpod/gitpod /workspace
-                  chmod +x ./previewctl
-                  sudo mv ./previewctl /usr/local/bin/
-            - name: Terraform
-              id: terraform
-              shell: bash
-              working-directory: /workspace/gitpod
-              env:
-                  HOME: /home/gitpod
-                  PREVIEW_ENV_DEV_SA_KEY: ${{ secrets.GCP_CREDENTIALS }}
-                  PREVIEW_ENV_DEV_SA_KEY_PATH: /home/gitpod/.config/gcloud/preview-environment-dev-sa.json
-                  # Don't prompt user before terraform apply
-                  TF_INPUT: 0
-                  TF_IN_AUTOMATION: true
-              run: |
-                  echo "${PREVIEW_ENV_DEV_SA_KEY}" > "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
-                  gcloud auth activate-service-account --key-file "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
+  infrastructure:
+    runs-on: [self-hosted]
+    needs: [previewctl]
+    container:
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-leeway-v0.7.3.4
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
+        with:
+          name: previewctl
+      - name: Configure workspace
+        run: |
+          cp -r /__w/gitpod/gitpod /workspace
+          chmod +x ./previewctl
+          sudo mv ./previewctl /usr/local/bin/
+      - name: Terraform
+        id: terraform
+        shell: bash
+        working-directory: /workspace/gitpod
+        env:
+          HOME: /home/gitpod
+          PREVIEW_ENV_DEV_SA_KEY: ${{ secrets.GCP_CREDENTIALS }}
+          PREVIEW_ENV_DEV_SA_KEY_PATH: /home/gitpod/.config/gcloud/preview-environment-dev-sa.json
+          # Don't prompt user before terraform apply
+          TF_INPUT: 0
+          TF_IN_AUTOMATION: true
+        run: |
+          echo "${PREVIEW_ENV_DEV_SA_KEY}" > "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
+          gcloud auth activate-service-account --key-file "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
 
-                  previewctl get-credentials --gcp-service-account "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
-                  leeway run dev/preview:create-preview
+          previewctl get-credentials --gcp-service-account "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
+          leeway run dev/preview:create-preview
 
-    build:
-        runs-on: [self-hosted]
-        outputs:
-            version: ${{ steps.leeway.outputs.version }}
-        container:
-            image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-leeway-v0.7.3.4
-        steps:
-            - uses: actions/checkout@v3
-            - name: Configure workspace
-              run: |
-                  cp -r /__w/gitpod/gitpod /workspace
-                  # Needed by google-github-actions/setup-gcloud
-                  sudo chown -R gitpod:gitpod /__t
-                  # Needed by docker/login-action
-                  sudo chmod goa+rw /var/run/docker.sock
-            - id: auth
-              uses: google-github-actions/auth@v1
-              with:
-                  token_format: access_token
-                  credentials_json: "${{ secrets.GCP_CREDENTIALS }}"
-            - name: Set up Cloud SDK
-              uses: google-github-actions/setup-gcloud@v1
-            - uses: docker/login-action@v2
-              with:
-                  registry: eu.gcr.io
-                  username: oauth2accesstoken
-                  password: "${{ steps.auth.outputs.access_token }}"
-            - name: "Determine Branch"
-              id: branches
-              uses: transferwise/sanitize-branch-name@v1
-            - name: Leeway
-              id: leeway
-              shell: bash
-              working-directory: /workspace/gitpod
-              env:
-                  JAVA_HOME: /home/gitpod/.sdkman/candidates/java/current
-                  VERSION: "${{ steps.branches.outputs.sanitized-branch-name }}.${{github.run_number}}"
-              run: |
-                  echo "version=$VERSION" >> $GITHUB_OUTPUT
+  build:
+    if: ${{ contains(github.event.pull_request.body, '[x] /werft with-github-actions') }}
+    runs-on: [self-hosted]
+    outputs:
+      version: ${{ steps.leeway.outputs.version }}
+    container:
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-leeway-v0.7.3.4
+    steps:
+      - uses: actions/checkout@v3
+      - name: Configure workspace
+        run: |
+          cp -r /__w/gitpod/gitpod /workspace
+          # Needed by google-github-actions/setup-gcloud
+          sudo chown -R gitpod:gitpod /__t
+          # Needed by docker/login-action
+          sudo chmod goa+rw /var/run/docker.sock
+      - id: auth
+        uses: google-github-actions/auth@v1
+        with:
+          token_format: access_token
+          credentials_json: "${{ secrets.GCP_CREDENTIALS }}"
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v1
+      - uses: docker/login-action@v2
+        with:
+          registry: eu.gcr.io
+          username: oauth2accesstoken
+          password: "${{ steps.auth.outputs.access_token }}"
+      - name: "Determine Branch"
+        id: branches
+        uses: transferwise/sanitize-branch-name@v1
+      - name: Leeway
+        id: leeway
+        shell: bash
+        working-directory: /workspace/gitpod
+        env:
+          JAVA_HOME: /home/gitpod/.sdkman/candidates/java/current
+          VERSION: "${{ steps.branches.outputs.sanitized-branch-name }}.${{github.run_number}}"
+        run: |
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
 
-                  RESULT=0
-                  leeway build dev/preview:deploy-dependencies \
-                    -Dversion=$VERSION \
-                    -DSEGMENT_IO_TOKEN=value \
-                    -DpublishToNPM=false \
-                    --dont-test \
-                    --report report.html || RESULT=$?
+          RESULT=0
+          leeway build dev/preview:deploy-dependencies \
+            -Dversion=$VERSION \
+            -DSEGMENT_IO_TOKEN=value \
+            -DpublishToNPM=false \
+            --dont-test \
+            --report report.html || RESULT=$?
 
-                  cat report.html >> $GITHUB_STEP_SUMMARY
-                  cp /tmp/versions.yaml /__w/gitpod/gitpod/versions.yaml
-                  cp /usr/local/bin/installer /__w/gitpod/gitpod/installer
+          cat report.html >> $GITHUB_STEP_SUMMARY
+          cp /tmp/versions.yaml /__w/gitpod/gitpod/versions.yaml
+          cp /usr/local/bin/installer /__w/gitpod/gitpod/installer
 
-                  exit $RESULT
-            - name: "Upload Installer artifacts"
-              uses: actions/upload-artifact@v3
-              with:
-                  name: installer-artifacts
-                  path: |
-                      versions.yaml
-                      installer
+          exit $RESULT
+      - name: "Upload Installer artifacts"
+        uses: actions/upload-artifact@v3
+        with:
+          name: installer-artifacts
+          path: |
+            versions.yaml
+            installer
 
-    install:
-        needs: [previewctl, build, infrastructure]
-        runs-on: [self-hosted]
-        container:
-            image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-leeway-v0.7.3.4
-        steps:
-            - uses: actions/checkout@v3
-            - name: Configure workspace
-              run: |
-                  cp -r /__w/gitpod/gitpod /workspace
-                  # Needed by google-github-actions/setup-gcloud
-                  sudo chown -R gitpod:gitpod /__t
-            - uses: actions/download-artifact@v3
-              with:
-                  name: installer-artifacts
-            - uses: actions/download-artifact@v3
-              with:
-                  name: previewctl
-            - name: Install artifacts
-              run: |
-                  cp versions.yaml /tmp/versions.yaml
-                  chmod +x ./installer
-                  sudo mv ./installer /usr/local/bin/
-                  chmod +x ./previewctl
-                  sudo mv ./previewctl /usr/local/bin/
-            - id: auth
-              uses: google-github-actions/auth@v1
-              with:
-                  token_format: access_token
-                  credentials_json: "${{ secrets.GCP_CREDENTIALS }}"
-            - name: Set up Cloud SDK
-              uses: google-github-actions/setup-gcloud@v1
-            - name: Install
-              shell: bash
-              working-directory: /workspace/gitpod
-              env:
-                  VERSION: ${{needs.build.outputs.version}}
-                  HOME: /home/gitpod
-                  PREVIEW_ENV_DEV_SA_KEY: ${{ secrets.GCP_CREDENTIALS }}
-                  PREVIEW_ENV_DEV_SA_KEY_PATH: /home/gitpod/.config/gcloud/preview-environment-dev-sa.json
-              run: |
-                  echo "${PREVIEW_ENV_DEV_SA_KEY}" > "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
-                  previewctl install-context --timeout 10m --gcp-service-account "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
-                  leeway run dev/preview:deploy-gitpod
-                  previewctl report >> $GITHUB_STEP_SUMMARY
+  install:
+    needs: [previewctl, build, infrastructure]
+    runs-on: [self-hosted]
+    container:
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-leeway-v0.7.3.4
+    steps:
+      - uses: actions/checkout@v3
+      - name: Configure workspace
+        run: |
+          cp -r /__w/gitpod/gitpod /workspace
+          # Needed by google-github-actions/setup-gcloud
+          sudo chown -R gitpod:gitpod /__t
+      - uses: actions/download-artifact@v3
+        with:
+          name: installer-artifacts
+      - uses: actions/download-artifact@v3
+        with:
+          name: previewctl
+      - name: Install artifacts
+        run: |
+          cp versions.yaml /tmp/versions.yaml
+          chmod +x ./installer
+          sudo mv ./installer /usr/local/bin/
+          chmod +x ./previewctl
+          sudo mv ./previewctl /usr/local/bin/
+      - id: auth
+        uses: google-github-actions/auth@v1
+        with:
+          token_format: access_token
+          credentials_json: "${{ secrets.GCP_CREDENTIALS }}"
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v1
+      - name: Install
+        shell: bash
+        working-directory: /workspace/gitpod
+        env:
+          VERSION: ${{needs.build.outputs.version}}
+          HOME: /home/gitpod
+          PREVIEW_ENV_DEV_SA_KEY: ${{ secrets.GCP_CREDENTIALS }}
+          PREVIEW_ENV_DEV_SA_KEY_PATH: /home/gitpod/.config/gcloud/preview-environment-dev-sa.json
+        run: |
+          echo "${PREVIEW_ENV_DEV_SA_KEY}" > "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
+          previewctl install-context --timeout 10m --gcp-service-account "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
+          leeway run dev/preview:deploy-gitpod
+          previewctl report >> $GITHUB_STEP_SUMMARY
 
-    monitoring:
-        needs: [previewctl, infrastructure]
-        runs-on: [self-hosted]
-        container:
-            image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-leeway-v0.7.3.4
-        steps:
-            - uses: actions/checkout@v3
-            - name: Configure workspace
-              run: |
-                  cp -r /__w/gitpod/gitpod /workspace
-                  # Needed by google-github-actions/setup-gcloud
-                  sudo chown -R gitpod:gitpod /__t
-            - uses: actions/download-artifact@v3
-              with:
-                  name: previewctl
-            - id: auth
-              uses: google-github-actions/auth@v1
-              with:
-                  token_format: access_token
-                  credentials_json: "${{ secrets.GCP_CREDENTIALS }}"
-            - name: Set up Cloud SDK
-              uses: google-github-actions/setup-gcloud@v1
-            - name: Install artifacts
-              run: |
-                  chmod +x ./previewctl
-                  sudo mv ./previewctl /usr/local/bin/
-            - name: Install
-              shell: bash
-              working-directory: /workspace/gitpod
-              env:
-                  HOME: /home/gitpod
-                  PREVIEW_ENV_DEV_SA_KEY: ${{ secrets.GCP_CREDENTIALS }}
-                  PREVIEW_ENV_DEV_SA_KEY_PATH: /home/gitpod/.config/gcloud/preview-environment-dev-sa.json
-              run: |
-                  echo "${PREVIEW_ENV_DEV_SA_KEY}" > "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
-                  previewctl install-context --timeout 10m --gcp-service-account "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
-                  leeway run dev/preview:deploy-monitoring-satellite
-                  echo '<p>Monitoring satellite has been installed in your preview environment.</p>' >> $GITHUB_STEP_SUMMARY
-                  echo '<ul>' >> $GITHUB_STEP_SUMMARY
-                  echo '<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/f2938b2bcb0c4c8c99afe1d2b872380e" target="_blank">internal documentation</a> on how to use it.</li>' >> $GITHUB_STEP_SUMMARY
-                  echo '</ul>' >> $GITHUB_STEP_SUMMARY
+  monitoring:
+    needs: [previewctl, infrastructure]
+    runs-on: [self-hosted]
+    container:
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-leeway-v0.7.3.4
+    steps:
+      - uses: actions/checkout@v3
+      - name: Configure workspace
+        run: |
+          cp -r /__w/gitpod/gitpod /workspace
+          # Needed by google-github-actions/setup-gcloud
+          sudo chown -R gitpod:gitpod /__t
+      - uses: actions/download-artifact@v3
+        with:
+          name: previewctl
+      - id: auth
+        uses: google-github-actions/auth@v1
+        with:
+          token_format: access_token
+          credentials_json: "${{ secrets.GCP_CREDENTIALS }}"
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v1
+      - name: Install artifacts
+        run: |
+          chmod +x ./previewctl
+          sudo mv ./previewctl /usr/local/bin/
+      - name: Install
+        shell: bash
+        working-directory: /workspace/gitpod
+        env:
+          HOME: /home/gitpod
+          PREVIEW_ENV_DEV_SA_KEY: ${{ secrets.GCP_CREDENTIALS }}
+          PREVIEW_ENV_DEV_SA_KEY_PATH: /home/gitpod/.config/gcloud/preview-environment-dev-sa.json
+        run: |
+          echo "${PREVIEW_ENV_DEV_SA_KEY}" > "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
+          previewctl install-context --timeout 10m --gcp-service-account "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
+          leeway run dev/preview:deploy-monitoring-satellite
+          echo '<p>Monitoring satellite has been installed in your preview environment.</p>' >> $GITHUB_STEP_SUMMARY
+          echo '<ul>' >> $GITHUB_STEP_SUMMARY
+          echo '<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/f2938b2bcb0c4c8c99afe1d2b872380e" target="_blank">internal documentation</a> on how to use it.</li>' >> $GITHUB_STEP_SUMMARY
+          echo '</ul>' >> $GITHUB_STEP_SUMMARY

--- a/.werft/build.ts
+++ b/.werft/build.ts
@@ -54,6 +54,13 @@ Tracing.initialize()
 async function run(context: any) {
     const config = jobConfig(werft, context);
 
+    if(config.withGitHubActions) {
+        werft.phase("Build Disabled");
+        werft.log("(not building)","The build is being performed via GitHub Actions; Thus, this Werft build does not run");
+        werft.done("(not building)");
+        return;
+    }
+
     await validateChanges(werft, config);
     await prepare(werft, config);
     if (config.withUpgradeTests) {

--- a/.werft/jobs/build/job-config.ts
+++ b/.werft/jobs/build/job-config.ts
@@ -43,6 +43,7 @@ export interface JobConfig {
     certIssuer: string;
     recreatePreview: boolean;
     recreateVm: boolean;
+    withGitHubActions: boolean;
 }
 
 export interface PreviewEnvironmentConfig {
@@ -111,6 +112,7 @@ export function jobConfig(werft: Werft, context: any): JobConfig {
     const analytics = parseAnalytics(werft, sliceId, buildConfig["analytics"])
     const withIntegrationTests = parseWithIntegrationTests(werft, sliceId, buildConfig["with-integration-tests"]);
     const withPreview = decideWithPreview({werft, sliceID: sliceId, buildConfig, mainBuild, withIntegrationTests})
+    const withGitHubActions = "with-github-actions" in buildConfig;
 
     switch (buildConfig["cert-issuer"]) {
         case "zerossl":
@@ -180,6 +182,7 @@ export function jobConfig(werft: Werft, context: any): JobConfig {
         recreatePreview,
         recreateVm,
         withSlowDatabase,
+        withGitHubActions,
     };
 
     werft.logOutput(sliceId, JSON.stringify(jobConfig, null, 2));


### PR DESCRIPTION
## Description
This PR aims to make it super easy to opt into running the build in GitHub Actions instead of Werft.

For this, this PR introduces the flag:
```
[ ] /werft with-github-actions
```
which gets interpreted by both GHA and Werft:

## Build in GitHub Actions (`[x]  /werft with-github-actions`)

Jobs from the GitHub Actions Workflow (named "PoC-build" in the screenshot)  will run on the PR:
<img width="566" alt="image" src="https://user-images.githubusercontent.com/239422/212684404-a2de536a-b587-4f81-9416-d65a756a5a72.png">


The Werft Build will show as "running" and "passing", but perform a no-op:
<img width="890" alt="image" src="https://user-images.githubusercontent.com/239422/212680607-766ab417-15c1-46f4-90af-2e59bbda2b18.png">

## Build in Werft (`[ ] /werft with-github-actions`)
The Werft build will run normally.
The GHA Jobs will be shown as "skipped":
<img width="446" alt="image" src="https://user-images.githubusercontent.com/239422/212680976-c4c213c4-a95f-46c3-962b-a7f770ddb1d2.png">

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes [#15748](https://github.com/gitpod-io/gitpod/issues/15748)

## How to test
* check/uncheck the `werft with-github-actions` on this PR.
* Run `werft run github -a with-github-actions=true` to test the changes in Werft. Triggering the job via CLI is necessary to make job protection happy.

## Discussion
* I'd prefer to run GHA and Werft simultaneously on the same PR, which causes collisions among build results (container images) and the preview env. Thus it's either-or for now, which is probably good enough. 
* I could not extract the GHA-expressions into ENV vars, because the `job-if` context [does not support access to env vars](https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability).
* I did not add the if-guard expressions to all jobs as their-re only needed on the upstream-jobs (in the context of the build graph). Downstream-jobs are automatically skipped if upstream jobs don't run.
* The GHA build runs whenever the PR-description is being edited to make sure new arguments are being picked up. Thus, it runs also when the edit did not intent changes to the build. This is probably good enough for now. 


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [x] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions.   
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
