### PR TITLE
[webapp] Group CPU alerts by deployment

### DIFF
--- a/operations/observability/mixins/meta/rules/content-service.yaml
+++ b/operations/observability/mixins/meta/rules/content-service.yaml
@@ -1,0 +1,24 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: k8s
+    role: alert-rules
+  name: server-monitoring-rules
+spec:
+  groups:
+  - name: content-service
+    rules:
+    - alert: ContentServiceHighCPUUsage
+      # Reasoning: high rates of CPU consumption should only be temporary.
+      expr: sum(rate(container_cpu_usage_seconds_total{container!="POD", pod=~"content-service-.*"}[5m])) by (cluster) > 0.80
+      for: 10m
+      labels:
+        # sent to the team internal channel until we fine tuned it
+        severity: warning
+        team: webapp
+      annotations:
+        runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/WebAppServicesHighCPUUsage.md
+        summary: Content Service has excessive CPU usage.
+        description: Content Service is consumming too much CPU. Please investigate.
+        dashboard_url: https://grafana.gitpod.io/d/6581e46e4e5c7ba40a07646395ef7b23/kubernetes-compute-resources-pod?var-cluster={{ $labels.cluster }}&var-namespace=default

--- a/operations/observability/mixins/meta/rules/dashboard.yaml
+++ b/operations/observability/mixins/meta/rules/dashboard.yaml
@@ -1,0 +1,24 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: k8s
+    role: alert-rules
+  name: server-monitoring-rules
+spec:
+  groups:
+  - name: dashboard
+    rules:
+    - alert: DashboardHighCPUUsage
+      # Reasoning: high rates of CPU consumption should only be temporary.
+      expr: sum(rate(container_cpu_usage_seconds_total{container!="POD", pod=~"dashboard-.*"}[5m])) by (cluster) > 0.80
+      for: 10m
+      labels:
+        # sent to the team internal channel until we fine tuned it
+        severity: warning
+        team: webapp
+      annotations:
+        runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/WebAppServicesHighCPUUsage.md
+        summary: Dashboard has excessive CPU usage.
+        description: Dashboard is consumming too much CPU. Please investigate.
+        dashboard_url: https://grafana.gitpod.io/d/6581e46e4e5c7ba40a07646395ef7b23/kubernetes-compute-resources-pod?var-cluster={{ $labels.cluster }}&var-namespace=default

--- a/operations/observability/mixins/meta/rules/db-sync.yaml
+++ b/operations/observability/mixins/meta/rules/db-sync.yaml
@@ -1,0 +1,24 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: k8s
+    role: alert-rules
+  name: server-monitoring-rules
+spec:
+  groups:
+  - name: db-sync
+    rules:
+    - alert: DBSyncHighCPUUsage
+      # Reasoning: high rates of CPU consumption should only be temporary.
+      expr: sum(rate(container_cpu_usage_seconds_total{container!="POD", pod=~"db-sync-.*"}[5m])) by (cluster) > 0.80
+      for: 10m
+      labels:
+        # sent to the team internal channel until we fine tuned it
+        severity: warning
+        team: webapp
+      annotations:
+        runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/WebAppServicesHighCPUUsage.md
+        summary: DB Sync has excessive CPU usage.
+        description: DB Sync is consumming too much CPU. Please investigate.
+        dashboard_url: https://grafana.gitpod.io/d/6581e46e4e5c7ba40a07646395ef7b23/kubernetes-compute-resources-pod?var-cluster={{ $labels.cluster }}&var-namespace=default

--- a/operations/observability/mixins/meta/rules/db.yaml
+++ b/operations/observability/mixins/meta/rules/db.yaml
@@ -1,0 +1,24 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: k8s
+    role: alert-rules
+  name: server-monitoring-rules
+spec:
+  groups:
+  - name: db
+    rules:
+    - alert: DBHighCPUUsage
+      # Reasoning: high rates of CPU consumption should only be temporary.
+      expr: sum(rate(container_cpu_usage_seconds_total{container!="POD", pod=~"db-.*"}[5m])) by (cluster) > 0.80
+      for: 10m
+      labels:
+        # sent to the team internal channel until we fine tuned it
+        severity: warning
+        team: webapp
+      annotations:
+        runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/WebAppServicesHighCPUUsage.md
+        summary: DB has excessive CPU usage.
+        description: DB is consumming too much CPU. Please investigate.
+        dashboard_url: https://grafana.gitpod.io/d/6581e46e4e5c7ba40a07646395ef7b23/kubernetes-compute-resources-pod?var-cluster={{ $labels.cluster }}&var-namespace=default

--- a/operations/observability/mixins/meta/rules/messagebus.yaml
+++ b/operations/observability/mixins/meta/rules/messagebus.yaml
@@ -22,3 +22,17 @@ spec:
         summary: A messagebus has too many queues in total.
         description: messagebus {{ $labels.pod }} is reporting {{ printf "%.2f" $value }} queues in total.
       expr: sum by (instance) (rabbitmq_queues) > 10000
+
+    - alert: MessageBusHighCPUUsage
+      # Reasoning: high rates of CPU consumption should only be temporary.
+      expr: sum(rate(container_cpu_usage_seconds_total{container!="POD", pod=~"messagebus-.*"}[5m])) by (cluster) > 0.80
+      for: 10m
+      labels:
+        # sent to the team internal channel until we fine tuned it
+        severity: warning
+        team: webapp
+      annotations:
+        runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/WebAppServicesHighCPUUsage.md
+        summary: MessageBus has excessive CPU usage.
+        description: MessageBus is consumming too much CPU. Please investigate.
+        dashboard_url: https://grafana.gitpod.io/d/6581e46e4e5c7ba40a07646395ef7b23/kubernetes-compute-resources-pod?var-cluster={{ $labels.cluster }}&var-namespace=default

--- a/operations/observability/mixins/meta/rules/payment-endpoint.yaml
+++ b/operations/observability/mixins/meta/rules/payment-endpoint.yaml
@@ -1,0 +1,24 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: k8s
+    role: alert-rules
+  name: server-monitoring-rules
+spec:
+  groups:
+  - name: payment-endpoint
+    rules:
+    - alert: PaymentEndpointHighCPUUsage
+      # Reasoning: high rates of CPU consumption should only be temporary.
+      expr: sum(rate(container_cpu_usage_seconds_total{container!="POD", pod=~"payment-endpoint-.*"}[5m])) by (cluster) > 0.80
+      for: 10m
+      labels:
+        # sent to the team internal channel until we fine tuned it
+        severity: warning
+        team: webapp
+      annotations:
+        runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/WebAppServicesHighCPUUsage.md
+        summary: Payment Endpoint has excessive CPU usage.
+        description: Payment Endpoint is consumming too much CPU. Please investigate.
+        dashboard_url: https://grafana.gitpod.io/d/6581e46e4e5c7ba40a07646395ef7b23/kubernetes-compute-resources-pod?var-cluster={{ $labels.cluster }}&var-namespace=default

--- a/operations/observability/mixins/meta/rules/proxy.yaml
+++ b/operations/observability/mixins/meta/rules/proxy.yaml
@@ -1,0 +1,24 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: k8s
+    role: alert-rules
+  name: server-monitoring-rules
+spec:
+  groups:
+  - name: dashboard
+    rules:
+    - alert: ProxyHighCPUUsage
+      # Reasoning: high rates of CPU consumption should only be temporary.
+      expr: sum(rate(container_cpu_usage_seconds_total{container!="POD", pod=~"proxy-.*"}[5m])) by (cluster) > 0.80
+      for: 10m
+      labels:
+        # sent to the team internal channel until we fine tuned it
+        severity: warning
+        team: webapp
+      annotations:
+        runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/WebAppServicesHighCPUUsage.md
+        summary: Proxy has excessive CPU usage.
+        description: Proxy is consumming too much CPU. Please investigate.
+        dashboard_url: https://grafana.gitpod.io/d/6581e46e4e5c7ba40a07646395ef7b23/kubernetes-compute-resources-pod?var-cluster={{ $labels.cluster }}&var-namespace=default

--- a/operations/observability/mixins/meta/rules/server.yaml
+++ b/operations/observability/mixins/meta/rules/server.yaml
@@ -97,9 +97,9 @@ spec:
         summary: The messagebus pod is not running in {{ $labels.cluster }}. Workspace information is not being correctly propagated into web app clusters. Investigation required.
         description: Messagebus pod not running
 
-    - alert: WebAppServicesHighCPUUsage
+    - alert: ServerHighCPUUsage
       # Reasoning: high rates of CPU consumption should only be temporary.
-      expr: sum(rate(container_cpu_usage_seconds_total{container!="POD", node=~".*", pod=~"(content-service|dashboard|db|db-sync|messagebus|payment-endpoint|proxy|server|ws-manager-bridge|usage)-.*"}[5m])) by (pod, node, cluster) > 0.80
+      expr: sum(rate(container_cpu_usage_seconds_total{container!="POD", pod=~"server-.*"}[5m])) by (cluster) > 0.80
       for: 10m
       labels:
         # sent to the team internal channel until we fine tuned it
@@ -107,9 +107,9 @@ spec:
         team: webapp
       annotations:
         runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/WebAppServicesHighCPUUsage.md
-        summary: WebApp Services excessive CPU usage.
-        description: Pod {{ $labels.pod }} is consumming too much CPU. Please investigate.
-        dashboard_url: https://grafana.gitpod.io/d/6581e46e4e5c7ba40a07646395ef7b23/kubernetes-compute-resources-pod?var-cluster={{ $labels.cluster }}&var-namespace=default&var-pod={{ $labels.pod }}
+        summary: Server has excessive CPU usage.
+        description: Server is consumming too much CPU. Please investigate.
+        dashboard_url: https://grafana.gitpod.io/d/6581e46e4e5c7ba40a07646395ef7b23/kubernetes-compute-resources-pod?var-cluster={{ $labels.cluster }}&var-namespace=default
 
     - alert: WebAppServicesCrashlooping
       # Reasoning: alert if any pod is restarting more than 3 times / 5 minutes.

--- a/operations/observability/mixins/meta/rules/usage.yaml
+++ b/operations/observability/mixins/meta/rules/usage.yaml
@@ -67,3 +67,17 @@ spec:
         runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodUsageStripeWebhookFailures.md
         summary: Detected {{ printf "%.2f" $value }} errors handling Stripe webhook.
         description: Stripe is sending us webhooks but we are failing to handle them. Inconsistent usage data very likely.
+
+    - alert: UsageHighCPUUsage
+      # Reasoning: high rates of CPU consumption should only be temporary.
+      expr: sum(rate(container_cpu_usage_seconds_total{container!="POD", pod=~"usage-.*"}[5m])) by (cluster) > 0.80
+      for: 10m
+      labels:
+        # sent to the team internal channel until we fine tuned it
+        severity: warning
+        team: webapp
+      annotations:
+        runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/WebAppServicesHighCPUUsage.md
+        summary: Usage has excessive CPU usage.
+        description: Usage is consumming too much CPU. Please investigate.
+        dashboard_url: https://grafana.gitpod.io/d/6581e46e4e5c7ba40a07646395ef7b23/kubernetes-compute-resources-pod?var-cluster={{ $labels.cluster }}&var-namespace=default

--- a/operations/observability/mixins/meta/rules/ws-manager-bridge.yaml
+++ b/operations/observability/mixins/meta/rules/ws-manager-bridge.yaml
@@ -1,0 +1,24 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: k8s
+    role: alert-rules
+  name: server-monitoring-rules
+spec:
+  groups:
+  - name: ws-manager-bridge
+    rules:
+    - alert: WsManagerBridgeHighCPUUsage
+      # Reasoning: high rates of CPU consumption should only be temporary.
+      expr: sum(rate(container_cpu_usage_seconds_total{container!="POD", pod=~"ws-manager-bridge-.*"}[5m])) by (cluster) > 0.80
+      for: 10m
+      labels:
+        # sent to the team internal channel until we fine tuned it
+        severity: warning
+        team: webapp
+      annotations:
+        runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/WebAppServicesHighCPUUsage.md
+        summary: WS Manager Bridge has excessive CPU usage.
+        description: WS Manager Bridge is consumming too much CPU. Please investigate.
+        dashboard_url: https://grafana.gitpod.io/d/6581e46e4e5c7ba40a07646395ef7b23/kubernetes-compute-resources-pod?var-cluster={{ $labels.cluster }}&var-namespace=default


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Groups CPU alerts by their deployment. To do this, a new alert is introduced for each of the original selectors as we cannot target a deployment as a collection of resources for an aggregate metric.

This change should reduce noise in the alerts channel, as we only consider it as firing if the aggregate of the pods has increased.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
