### PR TITLE
[dashboard] Remove conversion to protocol TeamMember

### DIFF
--- a/components/dashboard/src/Login.tsx
+++ b/components/dashboard/src/Login.tsx
@@ -23,7 +23,7 @@ import prebuild from "./images/welcome/prebuild.svg";
 import exclamation from "./images/exclamation.svg";
 import { getURLHash } from "./utils";
 import ErrorMessage from "./components/ErrorMessage";
-import { publicApiTeamsToProtocol, teamsService } from "./service/public-api";
+import { teamsService } from "./service/public-api";
 
 function Item(props: { icon: string; iconSize?: string; text: string }) {
     const iconSize = props.iconSize || 28;
@@ -99,7 +99,7 @@ export function Login() {
         await getGitpodService().reconnect();
         const [user, teams] = await Promise.all([
             getGitpodService().server.getLoggedInUser(),
-            publicApiTeamsToProtocol((await teamsService.listTeams({})).teams),
+            (await teamsService.listTeams({})).teams,
         ]);
         setUser(user);
         setTeams(teams);

--- a/components/dashboard/src/app/AppRoutes.tsx
+++ b/components/dashboard/src/app/AppRoutes.tsx
@@ -5,7 +5,7 @@
  */
 
 import React, { FunctionComponent, useContext, useState } from "react";
-import { ContextURL, User, Team } from "@gitpod/gitpod-protocol";
+import { ContextURL, User } from "@gitpod/gitpod-protocol";
 import SelectIDEModal from "../settings/SelectIDEModal";
 import { StartPage, StartPhase } from "../start/StartPage";
 import { getURLHash, isGitpodIo, isLocalPreview } from "../utils";
@@ -50,6 +50,7 @@ import { BlockedRepositories } from "../admin/BlockedRepositories";
 import PersonalAccessTokenCreateView from "../settings/PersonalAccessTokensCreateView";
 import { StartWorkspaceModalContext } from "../workspaces/start-workspace-modal-context";
 import { StartWorkspaceOptions } from "../start/start-workspace-options";
+import { Team } from "@gitpod/public-api/lib/gitpod/experimental/v1/teams_pb";
 
 const Setup = React.lazy(() => import(/* webpackPrefetch: true */ "../Setup"));
 const Workspaces = React.lazy(() => import(/* webpackPrefetch: true */ "../workspaces/Workspaces"));

--- a/components/dashboard/src/components/BillingAccountSelector.tsx
+++ b/components/dashboard/src/components/BillingAccountSelector.tsx
@@ -5,7 +5,6 @@
  */
 
 import { useContext, useEffect, useState } from "react";
-import { TeamMemberInfo } from "@gitpod/gitpod-protocol";
 import { AttributionId, AttributionTarget } from "@gitpod/gitpod-protocol/lib/attribution";
 import { getGitpodService } from "../service/service";
 import { TeamsContext } from "../teams/teams-context";
@@ -13,14 +12,14 @@ import { UserContext } from "../user-context";
 import SelectableCardSolid from "../components/SelectableCardSolid";
 import { ReactComponent as Spinner } from "../icons/Spinner.svg";
 import Alert from "./Alert";
-import { publicApiTeamMembersToProtocol, teamsService } from "../service/public-api";
-import { Team } from "@gitpod/public-api/lib/gitpod/experimental/v1/teams_pb";
+import { teamsService } from "../service/public-api";
+import { Team, TeamMember } from "@gitpod/public-api/lib/gitpod/experimental/v1/teams_pb";
 
 export function BillingAccountSelector(props: { onSelected?: () => void }) {
     const { user, setUser } = useContext(UserContext);
     const { teams } = useContext(TeamsContext);
     const [teamsAvailableForAttribution, setTeamsAvailableForAttribution] = useState<Team[] | undefined>();
-    const [membersByTeam, setMembersByTeam] = useState<Record<string, TeamMemberInfo[]>>({});
+    const [membersByTeam, setMembersByTeam] = useState<Record<string, TeamMember[]>>({});
     const [errorMessage, setErrorMessage] = useState<string | undefined>();
 
     useEffect(() => {
@@ -52,13 +51,11 @@ export function BillingAccountSelector(props: { onSelected?: () => void }) {
                 setErrorMessage(`Could not get list of available billing accounts. ${error?.message || String(error)}`);
             });
 
-        const members: Record<string, TeamMemberInfo[]> = {};
+        const members: Record<string, TeamMember[]> = {};
         Promise.all(
             teams.map(async (team) => {
                 try {
-                    members[team.id] = publicApiTeamMembersToProtocol(
-                        (await teamsService.getTeam({ teamId: team!.id })).team?.members || [],
-                    );
+                    members[team.id] = (await teamsService.getTeam({ teamId: team!.id })).team?.members || [];
                 } catch (error) {
                     console.warn("Could not get members of team", team, error);
                 }

--- a/components/dashboard/src/components/BillingAccountSelector.tsx
+++ b/components/dashboard/src/components/BillingAccountSelector.tsx
@@ -5,7 +5,7 @@
  */
 
 import { useContext, useEffect, useState } from "react";
-import { Team, TeamMemberInfo } from "@gitpod/gitpod-protocol";
+import { TeamMemberInfo } from "@gitpod/gitpod-protocol";
 import { AttributionId, AttributionTarget } from "@gitpod/gitpod-protocol/lib/attribution";
 import { getGitpodService } from "../service/service";
 import { TeamsContext } from "../teams/teams-context";
@@ -14,6 +14,7 @@ import SelectableCardSolid from "../components/SelectableCardSolid";
 import { ReactComponent as Spinner } from "../icons/Spinner.svg";
 import Alert from "./Alert";
 import { publicApiTeamMembersToProtocol, teamsService } from "../service/public-api";
+import { Team } from "@gitpod/public-api/lib/gitpod/experimental/v1/teams_pb";
 
 export function BillingAccountSelector(props: { onSelected?: () => void }) {
     const { user, setUser } = useContext(UserContext);

--- a/components/dashboard/src/components/UsageBasedBillingConfig.tsx
+++ b/components/dashboard/src/components/UsageBasedBillingConfig.tsx
@@ -20,7 +20,7 @@ import Modal from "../components/Modal";
 import Alert from "./Alert";
 import dayjs from "dayjs";
 import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
-import { publicApiTeamMembersToProtocol, teamsService } from "../service/public-api";
+import { teamsService } from "../service/public-api";
 
 const BASE_USAGE_LIMIT_FOR_STRIPE_USERS = 1000;
 
@@ -99,9 +99,7 @@ export default function UsageBasedBillingConfig({ attributionId }: Props) {
                 let limit = BASE_USAGE_LIMIT_FOR_STRIPE_USERS;
                 const attrId = AttributionId.parse(attributionId);
                 if (attrId?.kind === "team") {
-                    const members = publicApiTeamMembersToProtocol(
-                        (await teamsService.getTeam({ teamId: attrId.teamId })).team?.members || [],
-                    );
+                    const members = (await teamsService.getTeam({ teamId: attrId.teamId })).team?.members || [];
                     limit = BASE_USAGE_LIMIT_FOR_STRIPE_USERS * members.length;
                 }
                 const newLimit = await getGitpodService().server.subscribeToStripe(attributionId, setupIntentId, limit);

--- a/components/dashboard/src/components/UsageLimitReachedModal.tsx
+++ b/components/dashboard/src/components/UsageLimitReachedModal.tsx
@@ -4,8 +4,8 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { Team } from "@gitpod/gitpod-protocol";
 import { AttributionId } from "@gitpod/gitpod-protocol/lib/attribution";
+import { Team } from "@gitpod/public-api/lib/gitpod/experimental/v1/teams_pb";
 import { useContext, useEffect, useState } from "react";
 import { gitpodHostUrl } from "../service/service";
 import { TeamsContext } from "../teams/teams-context";

--- a/components/dashboard/src/hooks/use-user-and-teams-loader.ts
+++ b/components/dashboard/src/hooks/use-user-and-teams-loader.ts
@@ -10,7 +10,7 @@ import { useHistory } from "react-router-dom";
 import { UserContext } from "../user-context";
 import { getSelectedTeamSlug, TeamsContext } from "../teams/teams-context";
 import { getGitpodService } from "../service/service";
-import { publicApiTeamsToProtocol, teamsService } from "../service/public-api";
+import { teamsService } from "../service/public-api";
 import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
 import { trackLocation } from "../Analytics";
 import { refreshSearchData } from "../components/RepositoryFinder";
@@ -33,7 +33,7 @@ export const useUserAndTeamsLoader = () => {
 
                 // TODO: atm this feature-flag won't have been set yet, as it's dependant on user/teams
                 // so it will always be false when this runs
-                const loadedTeams = publicApiTeamsToProtocol((await teamsService.listTeams({})).teams);
+                const loadedTeams = (await teamsService.listTeams({})).teams;
 
                 {
                     // if a team was selected previously and we call the root URL (e.g. "gitpod.io"),

--- a/components/dashboard/src/projects/NewProject.tsx
+++ b/components/dashboard/src/projects/NewProject.tsx
@@ -7,7 +7,8 @@
 import { useContext, useEffect, useState } from "react";
 import { getGitpodService, gitpodHostUrl } from "../service/service";
 import { iconForAuthProvider, openAuthorizeWindow, simplifyProviderName } from "../provider-utils";
-import { AuthProviderInfo, Project, ProviderRepository, Team, TeamMemberInfo, User } from "@gitpod/gitpod-protocol";
+import { AuthProviderInfo, Project, ProviderRepository, TeamMemberInfo, User } from "@gitpod/gitpod-protocol";
+import { Team } from "@gitpod/public-api/lib/gitpod/experimental/v1/teams_pb";
 import { TeamsContext } from "../teams/teams-context";
 import { useLocation } from "react-router";
 import ContextMenu, { ContextMenuEntry } from "../components/ContextMenu";
@@ -21,12 +22,7 @@ import { trackEvent } from "../Analytics";
 import exclamation from "../images/exclamation.svg";
 import ErrorMessage from "../components/ErrorMessage";
 import Spinner from "../icons/Spinner.svg";
-import {
-    publicApiTeamMembersToProtocol,
-    publicApiTeamsToProtocol,
-    publicApiTeamToProtocol,
-    teamsService,
-} from "../service/public-api";
+import { publicApiTeamMembersToProtocol, teamsService } from "../service/public-api";
 import { ConnectError } from "@bufbuild/connect-web";
 import { useRefreshProjects } from "../data/projects/queries";
 
@@ -738,8 +734,8 @@ function NewTeam(props: { onSuccess: (team: Team) => void }) {
         }
 
         try {
-            const team = publicApiTeamToProtocol((await teamsService.createTeam({ name: teamName })).team!);
-            const teams = publicApiTeamsToProtocol((await teamsService.listTeams({})).teams);
+            const team = (await teamsService.createTeam({ name: teamName })).team!;
+            const teams = (await teamsService.listTeams({})).teams;
 
             setTeams(teams);
             props.onSuccess(team);

--- a/components/dashboard/src/projects/NewProject.tsx
+++ b/components/dashboard/src/projects/NewProject.tsx
@@ -7,8 +7,8 @@
 import { useContext, useEffect, useState } from "react";
 import { getGitpodService, gitpodHostUrl } from "../service/service";
 import { iconForAuthProvider, openAuthorizeWindow, simplifyProviderName } from "../provider-utils";
-import { AuthProviderInfo, Project, ProviderRepository, TeamMemberInfo, User } from "@gitpod/gitpod-protocol";
-import { Team } from "@gitpod/public-api/lib/gitpod/experimental/v1/teams_pb";
+import { AuthProviderInfo, Project, ProviderRepository, User } from "@gitpod/gitpod-protocol";
+import { Team, TeamMember } from "@gitpod/public-api/lib/gitpod/experimental/v1/teams_pb";
 import { TeamsContext } from "../teams/teams-context";
 import { useLocation } from "react-router";
 import ContextMenu, { ContextMenuEntry } from "../components/ContextMenu";
@@ -22,7 +22,7 @@ import { trackEvent } from "../Analytics";
 import exclamation from "../images/exclamation.svg";
 import ErrorMessage from "../components/ErrorMessage";
 import Spinner from "../icons/Spinner.svg";
-import { publicApiTeamMembersToProtocol, teamsService } from "../service/public-api";
+import { teamsService } from "../service/public-api";
 import { ConnectError } from "@bufbuild/connect-web";
 import { useRefreshProjects } from "../data/projects/queries";
 
@@ -105,19 +105,17 @@ export default function NewProject() {
         }
     }, []);
 
-    const [teamMembers, setTeamMembers] = useState<Record<string, TeamMemberInfo[]>>({});
+    const [teamMembers, setTeamMembers] = useState<Record<string, TeamMember[]>>({});
     useEffect(() => {
         if (!teams) {
             return;
         }
         (async () => {
-            const members: Record<string, TeamMemberInfo[]> = {};
+            const members: Record<string, TeamMember[]> = {};
             await Promise.all(
                 teams.map(async (team) => {
                     try {
-                        members[team.id] = publicApiTeamMembersToProtocol(
-                            (await teamsService.getTeam({ teamId: team!.id })).team?.members || [],
-                        );
+                        members[team.id] = (await teamsService.getTeam({ teamId: team!.id })).team?.members || [];
                     } catch (error) {
                         console.error("Could not get members of team", team, error);
                     }

--- a/components/dashboard/src/projects/ProjectSettings.tsx
+++ b/components/dashboard/src/projects/ProjectSettings.tsx
@@ -6,7 +6,7 @@
 
 import { useCallback, useContext, useEffect, useState } from "react";
 import { useLocation, useHistory } from "react-router";
-import { Project, ProjectSettings, Team } from "@gitpod/gitpod-protocol";
+import { Project, ProjectSettings } from "@gitpod/gitpod-protocol";
 import CheckBox from "../components/CheckBox";
 import { getGitpodService } from "../service/service";
 import { getCurrentTeam, TeamsContext } from "../teams/teams-context";
@@ -18,6 +18,7 @@ import { BillingMode } from "@gitpod/gitpod-protocol/lib/billing-mode";
 import Alert from "../components/Alert";
 import { Link } from "react-router-dom";
 import { RemoveProjectModal } from "./RemoveProjectModal";
+import { Team } from "@gitpod/public-api/lib/gitpod/experimental/v1/teams_pb";
 
 export function getProjectSettingsMenu(project?: Project, team?: Team) {
     const teamOrUserSlug = !!team ? "t/" + team.slug : "projects";

--- a/components/dashboard/src/service/public-api.ts
+++ b/components/dashboard/src/service/public-api.ts
@@ -10,8 +10,6 @@ import { TeamsService } from "@gitpod/public-api/lib/gitpod/experimental/v1/team
 import { TokensService } from "@gitpod/public-api/lib/gitpod/experimental/v1/tokens_connectweb";
 import { ProjectsService } from "@gitpod/public-api/lib/gitpod/experimental/v1/projects_connectweb";
 import { WorkspacesService } from "@gitpod/public-api/lib/gitpod/experimental/v1/workspaces_connectweb";
-import { TeamMemberInfo, TeamMemberRole } from "@gitpod/gitpod-protocol";
-import { TeamMember, TeamRole } from "@gitpod/public-api/lib/gitpod/experimental/v1/teams_pb";
 import { Project } from "@gitpod/public-api/lib/gitpod/experimental/v1/projects_pb";
 
 const transport = createConnectTransport({
@@ -22,31 +20,6 @@ export const teamsService = createPromiseClient(TeamsService, transport);
 export const personalAccessTokensService = createPromiseClient(TokensService, transport);
 export const projectsService = createPromiseClient(ProjectsService, transport);
 export const workspacesService = createPromiseClient(WorkspacesService, transport);
-
-export function publicApiTeamMembersToProtocol(members: TeamMember[]): TeamMemberInfo[] {
-    return members.map(publicApiTeamMemberToProtocol);
-}
-
-export function publicApiTeamMemberToProtocol(member: TeamMember): TeamMemberInfo {
-    return {
-        userId: member.userId,
-        fullName: member.fullName,
-        avatarUrl: member.avatarUrl,
-        memberSince: member.memberSince?.toDate().toISOString() || "",
-        role: publicApiTeamRoleToProtocol(member.role),
-        primaryEmail: member.primaryEmail,
-    };
-}
-
-export function publicApiTeamRoleToProtocol(role: TeamRole): TeamMemberRole {
-    switch (role) {
-        case TeamRole.OWNER:
-            return "owner";
-        case TeamRole.MEMBER:
-        case TeamRole.UNSPECIFIED:
-            return "member";
-    }
-}
 
 export async function listAllProjects(opts: { userId?: string; teamId?: string }): Promise<ProtocolProject[]> {
     let pagination = {

--- a/components/dashboard/src/service/public-api.ts
+++ b/components/dashboard/src/service/public-api.ts
@@ -5,12 +5,11 @@
  */
 
 import { createConnectTransport, createPromiseClient } from "@bufbuild/connect-web";
-import { Project as ProtocolProject, Team as ProtocolTeam } from "@gitpod/gitpod-protocol/lib/teams-projects-protocol";
+import { Project as ProtocolProject } from "@gitpod/gitpod-protocol/lib/teams-projects-protocol";
 import { TeamsService } from "@gitpod/public-api/lib/gitpod/experimental/v1/teams_connectweb";
 import { TokensService } from "@gitpod/public-api/lib/gitpod/experimental/v1/tokens_connectweb";
 import { ProjectsService } from "@gitpod/public-api/lib/gitpod/experimental/v1/projects_connectweb";
 import { WorkspacesService } from "@gitpod/public-api/lib/gitpod/experimental/v1/workspaces_connectweb";
-import { Team } from "@gitpod/public-api/lib/gitpod/experimental/v1/teams_pb";
 import { TeamMemberInfo, TeamMemberRole } from "@gitpod/gitpod-protocol";
 import { TeamMember, TeamRole } from "@gitpod/public-api/lib/gitpod/experimental/v1/teams_pb";
 import { Project } from "@gitpod/public-api/lib/gitpod/experimental/v1/projects_pb";
@@ -23,20 +22,6 @@ export const teamsService = createPromiseClient(TeamsService, transport);
 export const personalAccessTokensService = createPromiseClient(TokensService, transport);
 export const projectsService = createPromiseClient(ProjectsService, transport);
 export const workspacesService = createPromiseClient(WorkspacesService, transport);
-
-export function publicApiTeamToProtocol(team: Team): ProtocolTeam {
-    return {
-        id: team.id,
-        name: team.name,
-        slug: team.slug,
-        // We do not use the creationTime in the dashboard anywhere, se we keep it empty.
-        creationTime: "",
-    };
-}
-
-export function publicApiTeamsToProtocol(teams: Team[]): ProtocolTeam[] {
-    return teams.map(publicApiTeamToProtocol);
-}
 
 export function publicApiTeamMembersToProtocol(members: TeamMember[]): TeamMemberInfo[] {
     return members.map(publicApiTeamMemberToProtocol);

--- a/components/dashboard/src/teams/JoinTeam.tsx
+++ b/components/dashboard/src/teams/JoinTeam.tsx
@@ -6,7 +6,7 @@
 
 import { useContext, useEffect, useState } from "react";
 import { useHistory } from "react-router-dom";
-import { publicApiTeamsToProtocol, publicApiTeamToProtocol, teamsService } from "../service/public-api";
+import { teamsService } from "../service/public-api";
 import { TeamsContext } from "./teams-context";
 
 export default function () {
@@ -23,8 +23,8 @@ export default function () {
                     throw new Error("This invite URL is incorrect.");
                 }
 
-                const team = publicApiTeamToProtocol((await teamsService.joinTeam({ invitationId: inviteId })).team!);
-                const teams = publicApiTeamsToProtocol((await teamsService.listTeams({})).teams);
+                const team = (await teamsService.joinTeam({ invitationId: inviteId })).team!;
+                const teams = (await teamsService.listTeams({})).teams;
 
                 setTeams(teams);
 

--- a/components/dashboard/src/teams/Members.tsx
+++ b/components/dashboard/src/teams/Members.tsx
@@ -17,7 +17,7 @@ import copy from "../images/copy.svg";
 import { UserContext } from "../user-context";
 import { TeamsContext, getCurrentTeam } from "./teams-context";
 import { trackEvent } from "../Analytics";
-import { publicApiTeamMembersToProtocol, publicApiTeamsToProtocol, teamsService } from "../service/public-api";
+import { publicApiTeamMembersToProtocol, teamsService } from "../service/public-api";
 import { TeamRole } from "@gitpod/public-api/lib/gitpod/experimental/v1/teams_pb";
 
 export default function () {
@@ -102,7 +102,7 @@ export default function () {
     const removeTeamMember = async (userId: string) => {
         await teamsService.deleteTeamMember({ teamId: team!.id, teamMemberId: userId });
 
-        const newTeams = publicApiTeamsToProtocol((await teamsService.listTeams({})).teams);
+        const newTeams = (await teamsService.listTeams({})).teams;
 
         if (newTeams.some((t) => t.id === team!.id)) {
             // We're still a member of this team.

--- a/components/dashboard/src/teams/NewTeam.tsx
+++ b/components/dashboard/src/teams/NewTeam.tsx
@@ -7,7 +7,7 @@
 import { FormEvent, useContext, useEffect, useState } from "react";
 import { useHistory } from "react-router-dom";
 import { TeamsContext } from "./teams-context";
-import { publicApiTeamsToProtocol, publicApiTeamToProtocol, teamsService } from "../service/public-api";
+import { teamsService } from "../service/public-api";
 import { ConnectError } from "@bufbuild/connect-web";
 
 export default function () {
@@ -21,9 +21,9 @@ export default function () {
         event.preventDefault();
 
         try {
-            const team = publicApiTeamToProtocol((await teamsService.createTeam({ name })).team!);
+            const team = (await teamsService.createTeam({ name })).team!;
 
-            const teams = publicApiTeamsToProtocol((await teamsService.listTeams({})).teams);
+            const teams = (await teamsService.listTeams({})).teams;
 
             setTeams(teams);
             history.push(`/t/${team.slug}`);

--- a/components/dashboard/src/teams/TeamSettings.tsx
+++ b/components/dashboard/src/teams/TeamSettings.tsx
@@ -5,12 +5,12 @@
  */
 
 import { BillingMode } from "@gitpod/gitpod-protocol/lib/billing-mode";
-import { Team } from "@gitpod/public-api/lib/gitpod/experimental/v1/teams_pb";
+import { Team, TeamRole } from "@gitpod/public-api/lib/gitpod/experimental/v1/teams_pb";
 import { useContext, useEffect, useState } from "react";
 import { Redirect, useLocation } from "react-router";
 import ConfirmationModal from "../components/ConfirmationModal";
 import { PageWithSubMenu } from "../components/PageWithSubMenu";
-import { publicApiTeamMembersToProtocol, teamsService } from "../service/public-api";
+import { teamsService } from "../service/public-api";
 import { getGitpodService, gitpodHostUrl } from "../service/service";
 import { UserContext } from "../user-context";
 import { getCurrentTeam, TeamsContext } from "./teams-context";
@@ -49,12 +49,10 @@ export default function TeamSettings() {
     useEffect(() => {
         (async () => {
             if (!team) return;
-            const members = publicApiTeamMembersToProtocol(
-                (await teamsService.getTeam({ teamId: team!.id })).team?.members || [],
-            );
+            const members = (await teamsService.getTeam({ teamId: team!.id })).team?.members || [];
 
             const currentUserInTeam = members.find((member) => member.userId === user?.id);
-            setIsUserOwner(currentUserInTeam?.role === "owner");
+            setIsUserOwner(currentUserInTeam?.role === TeamRole.OWNER);
 
             // TODO(gpl) Maybe we should have TeamContext here instead of repeating ourselves...
             const billingMode = await getGitpodService().server.getBillingModeForTeam(team.id);

--- a/components/dashboard/src/teams/TeamSettings.tsx
+++ b/components/dashboard/src/teams/TeamSettings.tsx
@@ -4,8 +4,8 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { Team } from "@gitpod/gitpod-protocol";
 import { BillingMode } from "@gitpod/gitpod-protocol/lib/billing-mode";
+import { Team } from "@gitpod/public-api/lib/gitpod/experimental/v1/teams_pb";
 import { useContext, useEffect, useState } from "react";
 import { Redirect, useLocation } from "react-router";
 import ConfirmationModal from "../components/ConfirmationModal";

--- a/components/dashboard/src/teams/teams-context.tsx
+++ b/components/dashboard/src/teams/teams-context.tsx
@@ -3,8 +3,7 @@
  * Licensed under the GNU Affero General Public License (AGPL).
  * See License.AGPL.txt in the project root for license information.
  */
-
-import { Team } from "@gitpod/gitpod-protocol";
+import { Team } from "@gitpod/public-api/lib/gitpod/experimental/v1/teams_pb";
 import React, { createContext, useContext, useState } from "react";
 import { Location } from "history";
 import { useLocation } from "react-router";


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Removes conversion of TeamMembers to gitpod-protocol.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Depends on https://github.com/gitpod-io/gitpod/pull/15763

## How to test
<!-- Provide steps to test this PR -->
1. Preview
2. Check team members work as expected (use [this link](https://mp-dash-re454eefc5a1.preview.gitpod-dev.com/teams/join?inviteId=64b91c64-8b92-4c11-9bd4-49676e550489) to join a test team)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold for dependency