### PR TITLE
[Dashboard] Suggest using `gp rebuild` when image build fails

### DIFF
--- a/components/dashboard/src/start/StartWorkspace.tsx
+++ b/components/dashboard/src/start/StartWorkspace.tsx
@@ -799,9 +799,25 @@ function ImageBuildView(props: ImageBuildViewProps) {
                 <WorkspaceLogs logsEmitter={logsEmitter} errorMessage={props.error?.message} />
             </Suspense>
             {!!props.onStartWithDefaultImage && (
-                <button className="mt-6 secondary" onClick={props.onStartWithDefaultImage}>
-                    Continue with Default Image
-                </button>
+                <>
+                    <div className="mt-6 w-11/12 lg:w-3/5">
+                        <p className="text-center text-gray-400 dark:text-gray-500">
+                            💡 You can use <code>gp rebuild</code> to validate and debug your workspace configuration
+                            &nbsp;&middot;&nbsp;
+                            <a
+                                href="https://www.gitpod.io/docs/configure/workspaces/workspace-image#trying-out-changes-to-your-dockerfile"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="gp-link"
+                            >
+                                Learn More
+                            </a>
+                        </p>
+                    </div>
+                    <button className="mt-6 secondary" onClick={props.onStartWithDefaultImage}>
+                        Continue with Default Image
+                    </button>
+                </>
             )}
         </StartPage>
     );


### PR DESCRIPTION
## Description
We've recently introduced `gp rebuild` to help users debug their custom workspace image. In the future it will do more. We hope to reduce the number of image build failures caused by config changes that could have been caught in a workspace, before pushing.

<img width="200" alt="Screenshot 2023-01-17 at 12 02 42" src="https://user-images.githubusercontent.com/2318450/212964016-94e8ef77-6020-47fe-9668-cdc4d45c4474.png">


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Relates #7671

## How to test
1. Start a workspace for https://ide-gp-rebbd1841bbcb.preview.gitpod-dev.com/?workspaceClass=default&editor=code#https://github.com/andreafalzetti/gitpod-experiments/tree/imagebuild-broken
2. Observe the message educating about the use of `gp rebuild` underneath the logs 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
