### PR TITLE
[db] Add OrganisationID to OIDCClientConfig model in Go

### DIFF
--- a/components/gitpod-db/go/dbtest/oidc_client_config.go
+++ b/components/gitpod-db/go/dbtest/oidc_client_config.go
@@ -34,6 +34,10 @@ func NewOIDCClientConfig(t *testing.T, record db.OIDCClientConfig) db.OIDCClient
 		result.ID = record.ID
 	}
 
+	if record.OrganisationID != uuid.Nil {
+		result.OrganisationID = record.OrganisationID
+	}
+
 	if record.Issuer != "" {
 		result.Issuer = record.Issuer
 	}

--- a/components/gitpod-db/go/oidc_client_config.go
+++ b/components/gitpod-db/go/oidc_client_config.go
@@ -17,6 +17,8 @@ import (
 type OIDCClientConfig struct {
 	ID uuid.UUID `gorm:"primary_key;column:id;type:char;size:36;" json:"id"`
 
+	OrganisationID uuid.UUID `gorm:"column:organisationId;type:char;size:36;" json:"organisationId"`
+
 	Issuer string `gorm:"column:issuer;type:char;size:255;" json:"issuer"`
 
 	Data EncryptedJSON[OIDCSpec] `gorm:"column:data;type:text;size:65535" json:"data"`
@@ -50,11 +52,11 @@ type OIDCSpec struct {
 
 func CreateOIDCCLientConfig(ctx context.Context, conn *gorm.DB, cfg OIDCClientConfig) (OIDCClientConfig, error) {
 	if cfg.ID == uuid.Nil {
-		return OIDCClientConfig{}, errors.New("OIDC Client Config ID must be set")
+		return OIDCClientConfig{}, errors.New("id must be set")
 	}
 
 	if cfg.Issuer == "" {
-		return OIDCClientConfig{}, errors.New("OIDC Client Config issuer must be set")
+		return OIDCClientConfig{}, errors.New("issuer must be set")
 	}
 
 	tx := conn.

--- a/components/gitpod-db/src/typeorm/migration/1673944879912-AddOrganisationIDToOIDCClientConfig.ts
+++ b/components/gitpod-db/src/typeorm/migration/1673944879912-AddOrganisationIDToOIDCClientConfig.ts
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { columnExists, indexExists } from "./helper/helper";
+
+const table = "d_b_oidc_client_config";
+const column = "organisationId";
+const orgIndex = "idx_organisationId";
+const idOrgCompositeIndex = "idx_id_organisationId";
+
+export class AddOrganisationIDToOIDCClientConfig1673944879912 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        if (!(await columnExists(queryRunner, table, column))) {
+            await queryRunner.query(
+                `ALTER TABLE ${table} ADD COLUMN ${column} varchar(255) NOT NULL, ALGORITHM=INPLACE, LOCK=NONE`,
+            );
+        }
+
+        if (!(await indexExists(queryRunner, table, orgIndex))) {
+            await queryRunner.query(`CREATE INDEX \`${orgIndex}\` ON \`${table}\` (${column})`);
+        }
+
+        if (!(await indexExists(queryRunner, table, idOrgCompositeIndex))) {
+            await queryRunner.query(`CREATE INDEX \`${idOrgCompositeIndex}\` ON \`${table}\` (id, ${column})`);
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {}
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Extends the go model, and test structs with the field

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Depends on https://github.com/gitpod-io/gitpod/pull/15778
* Part of https://github.com/gitpod-io/gitpod/issues/15708

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold for dependency