### PR TITLE
[papi]  Refactor validation functions to a file

### DIFF
--- a/components/public-api-server/pkg/apiv1/oidc.go
+++ b/components/public-api-server/pkg/apiv1/oidc.go
@@ -38,6 +38,7 @@ type OIDCService struct {
 }
 
 func (s *OIDCService) CreateClientConfig(ctx context.Context, req *connect.Request[v1.CreateClientConfigRequest]) (*connect.Response[v1.CreateClientConfigResponse], error) {
+
 	conn, err := s.getConnection(ctx)
 	if err != nil {
 		return nil, err

--- a/components/public-api-server/pkg/apiv1/project.go
+++ b/components/public-api-server/pkg/apiv1/project.go
@@ -195,7 +195,7 @@ func projectToAPIResponse(p *protocol.Project) *v1.Project {
 		Name:         p.Name,
 		Slug:         p.Slug,
 		CloneUrl:     p.CloneURL,
-		CreationTime: parseTimeStamp(p.CreationTime),
+		CreationTime: parseGitpodTimeStampOrDefault(p.CreationTime),
 		Settings:     projectSettingsToAPIResponse(p.Settings),
 	}
 }
@@ -228,19 +228,4 @@ func workspaceClassesToAPIResponse(s *protocol.WorkspaceClassesSettings) *v1.Wor
 		Regular:  s.Regular,
 		Prebuild: s.Prebuild,
 	}
-}
-
-func validateProjectID(id string) (uuid.UUID, error) {
-	trimmed := strings.TrimSpace(id)
-
-	if trimmed == "" {
-		return uuid.Nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("Project ID is a required argument."))
-	}
-
-	projectID, err := uuid.Parse(trimmed)
-	if err != nil {
-		return uuid.Nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("Project ID must be a valid UUID."))
-	}
-
-	return projectID, nil
 }

--- a/components/public-api-server/pkg/apiv1/team.go
+++ b/components/public-api-server/pkg/apiv1/team.go
@@ -14,9 +14,6 @@ import (
 	"github.com/gitpod-io/gitpod/components/public-api/go/experimental/v1/v1connect"
 	protocol "github.com/gitpod-io/gitpod/gitpod-protocol"
 	"github.com/gitpod-io/gitpod/public-api-server/pkg/proxy"
-	"github.com/google/uuid"
-	"github.com/relvacode/iso8601"
-	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func NewTeamsService(pool proxy.ServerConnectionPool) *TeamService {
@@ -274,7 +271,7 @@ func teamMembersToAPIResponse(members []*protocol.TeamMemberInfo) []*v1.TeamMemb
 		result = append(result, &v1.TeamMember{
 			UserId:       m.UserId,
 			Role:         teamRoleToAPIResponse(m.Role),
-			MemberSince:  parseTimeStamp(m.MemberSince),
+			MemberSince:  parseGitpodTimeStampOrDefault(m.MemberSince),
 			AvatarUrl:    m.AvatarUrl,
 			FullName:     m.FullName,
 			PrimaryEmail: m.PrimaryEmail,
@@ -299,26 +296,4 @@ func teamInviteToAPIResponse(invite *protocol.TeamMembershipInvite) *v1.TeamInvi
 	return &v1.TeamInvitation{
 		Id: invite.ID,
 	}
-}
-
-func parseTimeStamp(s string) *timestamppb.Timestamp {
-	parsed, err := iso8601.ParseString(s)
-	if err != nil {
-		return &timestamppb.Timestamp{}
-	}
-
-	return timestamppb.New(parsed)
-}
-
-func validateTeamID(s string) (uuid.UUID, error) {
-	if s == "" {
-		return uuid.Nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("Team ID is a required argument."))
-	}
-
-	teamID, err := uuid.Parse(s)
-	if err != nil {
-		return uuid.Nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("Team ID must be a valid UUID."))
-	}
-
-	return teamID, nil
 }

--- a/components/public-api-server/pkg/apiv1/team_test.go
+++ b/components/public-api-server/pkg/apiv1/team_test.go
@@ -266,7 +266,7 @@ func TestTeamToAPIResponse(t *testing.T) {
 			{
 				UserId:       members[0].UserId,
 				Role:         teamRoleToAPIResponse(members[0].Role),
-				MemberSince:  parseTimeStamp(members[0].MemberSince),
+				MemberSince:  parseGitpodTimeStampOrDefault(members[0].MemberSince),
 				AvatarUrl:    members[0].AvatarUrl,
 				FullName:     members[0].FullName,
 				PrimaryEmail: members[0].PrimaryEmail,
@@ -274,7 +274,7 @@ func TestTeamToAPIResponse(t *testing.T) {
 			{
 				UserId:       members[1].UserId,
 				Role:         teamRoleToAPIResponse(members[1].Role),
-				MemberSince:  parseTimeStamp(members[1].MemberSince),
+				MemberSince:  parseGitpodTimeStampOrDefault(members[1].MemberSince),
 				AvatarUrl:    members[1].AvatarUrl,
 				FullName:     members[1].FullName,
 				PrimaryEmail: members[1].PrimaryEmail,

--- a/components/public-api-server/pkg/apiv1/user.go
+++ b/components/public-api-server/pkg/apiv1/user.go
@@ -95,7 +95,7 @@ func userToAPIResponse(user *protocol.User) *v1.User {
 		Id:        user.ID,
 		Name:      name,
 		AvatarUrl: user.AvatarURL,
-		CreatedAt: parseTimeStamp(user.CreationDate),
+		CreatedAt: parseGitpodTimeStampOrDefault(user.CreationDate),
 	}
 }
 
@@ -104,7 +104,7 @@ func sshKeyToAPIResponse(key *protocol.UserSSHPublicKeyValue) *v1.SSHKey {
 		Id:        key.ID,
 		Name:      key.Name,
 		Key:       key.Key,
-		CreatedAt: parseTimeStamp(key.CreationTime),
+		CreatedAt: parseGitpodTimeStampOrDefault(key.CreationTime),
 	}
 }
 

--- a/components/public-api-server/pkg/apiv1/validation.go
+++ b/components/public-api-server/pkg/apiv1/validation.go
@@ -1,0 +1,103 @@
+// Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package apiv1
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	connect "github.com/bufbuild/connect-go"
+	"github.com/gitpod-io/gitpod/common-go/namegen"
+	"github.com/google/uuid"
+	"github.com/relvacode/iso8601"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func validateTeamID(s string) (uuid.UUID, error) {
+	if s == "" {
+		return uuid.Nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("Team ID is a required argument."))
+	}
+
+	teamID, err := uuid.Parse(s)
+	if err != nil {
+		return uuid.Nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("Team ID must be a valid UUID."))
+	}
+
+	return teamID, nil
+}
+
+func parseGitpodTimeStampOrDefault(s string) *timestamppb.Timestamp {
+	parsed, err := parseGitpodTimestamp(s)
+	if err != nil {
+		return &timestamppb.Timestamp{}
+	}
+	return parsed
+}
+
+func parseGitpodTimestamp(input string) (*timestamppb.Timestamp, error) {
+	parsed, err := iso8601.ParseString(input)
+	if err != nil {
+		return nil, err
+	}
+	return timestamppb.New(parsed), nil
+}
+
+func validateWorkspaceID(id string) (string, error) {
+	if id == "" {
+		return "", connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("Empty workspace id specified"))
+	}
+
+	err := namegen.ValidateWorkspaceID(id)
+	if err != nil {
+		return "", connect.NewError(connect.CodeInvalidArgument, err)
+	}
+
+	return id, nil
+}
+
+func validateProjectID(id string) (uuid.UUID, error) {
+	trimmed := strings.TrimSpace(id)
+
+	if trimmed == "" {
+		return uuid.Nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("Project ID is a required argument."))
+	}
+
+	projectID, err := uuid.Parse(trimmed)
+	if err != nil {
+		return uuid.Nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("Project ID must be a valid UUID."))
+	}
+
+	return projectID, nil
+}
+
+func validatePersonalAccessTokenID(id string) (uuid.UUID, error) {
+	trimmed := strings.TrimSpace(id)
+	if trimmed == "" {
+		return uuid.Nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("Token ID is a required argument."))
+	}
+
+	tokenID, err := uuid.Parse(trimmed)
+	if err != nil {
+		return uuid.Nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("Token ID must be a valid UUID"))
+	}
+
+	return tokenID, nil
+}
+
+func validateFieldMask(mask *fieldmaskpb.FieldMask, message proto.Message) (*fieldmaskpb.FieldMask, error) {
+	if mask == nil {
+		return &fieldmaskpb.FieldMask{}, nil
+	}
+
+	mask.Normalize()
+	if !mask.IsValid(message) {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("Invalid field mask specified."))
+	}
+
+	return mask, nil
+}

--- a/components/public-api-server/pkg/apiv1/workspace.go
+++ b/components/public-api-server/pkg/apiv1/workspace.go
@@ -10,13 +10,11 @@ import (
 
 	connect "github.com/bufbuild/connect-go"
 	"github.com/gitpod-io/gitpod/common-go/log"
-	"github.com/gitpod-io/gitpod/common-go/namegen"
 	v1 "github.com/gitpod-io/gitpod/components/public-api/go/experimental/v1"
 	"github.com/gitpod-io/gitpod/components/public-api/go/experimental/v1/v1connect"
 	protocol "github.com/gitpod-io/gitpod/gitpod-protocol"
 	"github.com/gitpod-io/gitpod/public-api-server/pkg/proxy"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/logrus/ctxlogrus"
-	"github.com/relvacode/iso8601"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -384,25 +382,4 @@ func convertWorkspaceInstance(wsi *protocol.WorkspaceInstance, shareable bool) (
 			Ports: ports,
 		},
 	}, nil
-}
-
-func parseGitpodTimestamp(input string) (*timestamppb.Timestamp, error) {
-	parsed, err := iso8601.ParseString(input)
-	if err != nil {
-		return nil, err
-	}
-	return timestamppb.New(parsed), nil
-}
-
-func validateWorkspaceID(id string) (string, error) {
-	if id == "" {
-		return "", connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("Empty workspace id specified"))
-	}
-
-	err := namegen.ValidateWorkspaceID(id)
-	if err != nil {
-		return "", connect.NewError(connect.CodeInvalidArgument, err)
-	}
-
-	return id, nil
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

So far the validation functions have been largely co-located with the handler implementation. This change moves them to a dedicated file. This allows for re-use across packages, where relevant, and makes it slightly more discoverable. Subsequent PR will unify UUID parsing a bit to reduce repetition.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
unit tests

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
