### PR TITLE
Redis could be enabled without IPFS

### DIFF
--- a/components/registry-facade/pkg/registry/registry.go
+++ b/components/registry-facade/pkg/registry/registry.go
@@ -260,8 +260,12 @@ func getRedisClient(cfg *config.RedisCacheConfig) (*redis.Client, error) {
 
 	opts := &redis.Options{
 		Addr:     cfg.SingleHostAddress,
-		Username: cfg.Username,
+		Username: "default",
 		Password: cfg.Password,
+	}
+
+	if cfg.Username != "" {
+		opts.Username = cfg.Username
 	}
 
 	if cfg.UseTLS {
@@ -271,7 +275,7 @@ func getRedisClient(cfg *config.RedisCacheConfig) (*redis.Client, error) {
 		}
 	}
 
-	log.WithField("addr", cfg.SingleHostAddress).WithField("tls", cfg.UseTLS).Info("connecting to single Redis host")
+	log.WithField("addr", cfg.SingleHostAddress).WithField("username", cfg.Username).WithField("tls", cfg.UseTLS).Info("connecting to Redis")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()

--- a/install/installer/pkg/components/registry-facade/daemonset.go
+++ b/install/installer/pkg/components/registry-facade/daemonset.go
@@ -124,7 +124,7 @@ func daemonset(ctx *common.RenderContext) ([]runtime.Object, error) {
 			}
 		}
 
-		if ucfg.Workspace.RegistryFacade.IPFSCache.Enabled {
+		if ucfg.Workspace.RegistryFacade.RedisCache.Enabled {
 			if scr := ucfg.Workspace.RegistryFacade.RedisCache.PasswordSecret; scr != "" {
 				envvars = append(envvars, corev1.EnvVar{
 					Name: "REDIS_PASSWORD",


### PR DESCRIPTION
## Description

Fix configuration when only Redis is enabled

extracted from https://github.com/gitpod-io/gitpod/pull/15132

## Release Notes
```release-note
NONE
```

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
