### PR TITLE
[ws-manager-bridge] Stop logging workspacestatus.auth for prebuilds

### DIFF
--- a/components/ws-manager-bridge/ee/src/prebuild-updater-db.ts
+++ b/components/ws-manager-bridge/ee/src/prebuild-updater-db.ts
@@ -15,6 +15,7 @@ import { DBWithTracing, TracedWorkspaceDB } from "@gitpod/gitpod-db/lib/traced-d
 import { WorkspaceDB } from "@gitpod/gitpod-db/lib/workspace-db";
 import { MessageBusIntegration } from "../../src/messagebus-integration";
 import { PrometheusMetricsExporter } from "../../src/prometheus-metrics-exporter";
+import { filterStatus } from "../../src/bridge";
 
 @injectable()
 export class PrebuildUpdaterDB implements PrebuildUpdater {
@@ -44,7 +45,7 @@ export class PrebuildUpdaterDB implements PrebuildUpdater {
         const workspaceId = status.metadata!.metaId!;
         const logCtx: LogContext = { instanceId, workspaceId, userId };
 
-        log.info(logCtx, "Handling prebuild workspace update.", status);
+        log.info(logCtx, "Handling prebuild workspace update.", filterStatus(status));
 
         const span = TraceContext.startSpan("updatePrebuiltWorkspace", ctx);
         try {

--- a/components/ws-manager-bridge/src/bridge.ts
+++ b/components/ws-manager-bridge/src/bridge.ts
@@ -436,7 +436,7 @@ const mapPortVisibility = (visibility: WsManPortVisibility | undefined): PortVis
  * Filter here to avoid overloading spans
  * @param status
  */
-const filterStatus = (status: WorkspaceStatus.AsObject): Partial<WorkspaceStatus.AsObject> => {
+export const filterStatus = (status: WorkspaceStatus.AsObject): Partial<WorkspaceStatus.AsObject> => {
     return {
         id: status.id,
         metadata: status.metadata,


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/security/issues/113

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
