### PR TITLE
[billing] teams and individuals pay 9USD/month

### DIFF
--- a/.werft/jobs/build/payment/stripe-configmap.yaml
+++ b/.werft/jobs/build/payment/stripe-configmap.yaml
@@ -11,7 +11,7 @@ data:
         "USD": "price_1LmYWRGadRXm50o3Ym8PLqnG"
       },
       "teamUsagePriceIds": {
-        "EUR": "price_1LiId7GadRXm50o3OayAS2y4",
-        "USD": "price_1LiIdbGadRXm50o3ylg5S44r"
+        "EUR": "price_1LmYVxGadRXm50o3AiLq0Qmo",
+        "USD": "price_1LmYWRGadRXm50o3Ym8PLqnG"
       }
     }

--- a/components/dashboard/src/components/UsageBasedBillingConfig.tsx
+++ b/components/dashboard/src/components/UsageBasedBillingConfig.tsx
@@ -226,37 +226,7 @@ export default function UsageBasedBillingConfig({ attributionId }: Props) {
                         </div>
                     </div>
                 )}
-                {showUpgradeTeam && (
-                    <div className="flex flex-col mt-4 p-4 rounded-xl bg-gray-50 dark:bg-gray-800">
-                        <div className="uppercase text-sm text-gray-400 dark:text-gray-500">Upgrade Plan</div>
-                        <div className="mt-1 text-xl font-semibold flex-grow text-gray-500 dark:text-gray-400">
-                            Pay-as-you-go
-                        </div>
-                        <div className="mt-4 flex space-x-1 text-gray-400 dark:text-gray-500">
-                            <Check className="m-0.5 w-5 h-5" />
-                            <div className="flex flex-col">
-                                <span>
-                                    {currency === "EUR" ? "€" : "$"}0.36 for 10 credits or 1 hour of Standard workspace
-                                    usage, excluding VAT.{" "}
-                                    <a className="gp-link" href="https://www.gitpod.io/pricing#cost-estimator">
-                                        Estimate costs
-                                    </a>
-                                </span>
-                            </div>
-                        </div>
-                        <div className="flex justify-end mt-6 space-x-2">
-                            {stripePortalUrl && (
-                                <a href={stripePortalUrl}>
-                                    <button className="secondary" disabled={!stripePortalUrl}>
-                                        View Past Invoices ↗
-                                    </button>
-                                </a>
-                            )}
-                            <button onClick={() => setShowBillingSetupModal(true)}>Upgrade Plan</button>
-                        </div>
-                    </div>
-                )}
-                {showUpgradeUser && (
+                {(showUpgradeUser || showUpgradeTeam) && (
                     <div className="flex flex-col mt-4 p-4 rounded-xl bg-gray-50 dark:bg-gray-800">
                         <div className="uppercase text-sm text-gray-400 dark:text-gray-500">Current Plan</div>
                         <div className="mt-1 text-xl font-semibold flex-grow text-gray-600 dark:text-gray-400">
@@ -312,65 +282,24 @@ export default function UsageBasedBillingConfig({ attributionId }: Props) {
                     <div className="max-w-xl flex space-x-4">
                         <div className="flex-grow flex flex-col mt-4 p-4 rounded-xl bg-gray-50 dark:bg-gray-800">
                             <div className="uppercase text-sm text-gray-400 dark:text-gray-500">Current Plan</div>
-                            {AttributionId.parse(attributionId)?.kind === "user" ? (
-                                <>
-                                    <div className="mt-1 text-xl font-semibold flex-grow text-gray-800 dark:text-gray-100">
-                                        {currency === "EUR" ? "€" : "$"}9 / month
-                                    </div>
-                                    <div className="mt-4 flex space-x-1 text-gray-400 dark:text-gray-500">
-                                        <Check className="m-0.5 w-5 h-5 text-orange-500" />
-                                        <div className="flex flex-col">
-                                            <span className="font-bold text-gray-500 dark:text-gray-400">
-                                                1,000 credits
-                                            </span>
-                                            <span>
-                                                100 hours of Standard workspace usage.{" "}
-                                                <a
-                                                    className="gp-link"
-                                                    href="https://www.gitpod.io/docs/configure/billing/usage-based-billing"
-                                                    target="_blank"
-                                                    rel="noreferrer"
-                                                >
-                                                    Learn more about credits
-                                                </a>
-                                            </span>
-                                        </div>
-                                    </div>
-                                    <div className="mt-3 flex space-x-1 text-gray-400 dark:text-gray-500">
-                                        <Check className="m-0.5 w-5 h-5 text-orange-500" />
-                                        <div className="flex flex-col">
-                                            <span className="font-bold text-gray-500 dark:text-gray-400">
-                                                Pay-as-you-go after 1,000 credits
-                                            </span>
-                                            <span>
-                                                {currency === "EUR" ? "€" : "$"}0.36 for 10 credits or 1 hour of
-                                                Standard workspace usage, excluding VAT.
-                                            </span>
-                                        </div>
-                                    </div>
-                                </>
-                            ) : (
-                                <>
-                                    <div className="mt-1 text-xl font-semibold flex-grow text-gray-800 dark:text-gray-100">
-                                        Pay-as-you-go
-                                    </div>
-                                    <div className="mt-4 flex space-x-1 text-gray-400 dark:text-gray-500">
-                                        <Check className="m-0.5 w-5 h-5 text-orange-500" />
-                                        <div className="flex flex-col">
-                                            <span>
-                                                {currency === "EUR" ? "€" : "$"}0.36 for 10 credits or 1 hour of
-                                                Standard workspace usage, excluding VAT.{" "}
-                                                <a
-                                                    className="gp-link"
-                                                    href="https://www.gitpod.io/docs/configure/billing/usage-based-billing"
-                                                >
-                                                    Learn more about credits
-                                                </a>
-                                            </span>
-                                        </div>
-                                    </div>
-                                </>
-                            )}
+                            <div className="mt-1 text-xl font-semibold flex-grow text-gray-800 dark:text-gray-100">
+                                Pay-as-you-go
+                            </div>
+                            <div className="mt-4 flex space-x-1 text-gray-400 dark:text-gray-500">
+                                <Check className="m-0.5 w-5 h-5 text-orange-500" />
+                                <div className="flex flex-col">
+                                    <span>
+                                        {currency === "EUR" ? "€" : "$"}0.36 for 10 credits or 1 hour of Standard
+                                        workspace usage, excluding VAT.{" "}
+                                        <a
+                                            className="gp-link"
+                                            href="https://www.gitpod.io/docs/configure/billing/usage-based-billing"
+                                        >
+                                            Learn more about credits
+                                        </a>
+                                    </span>
+                                </div>
+                            </div>
                             <a className="mt-5 self-end" href={stripePortalUrl}>
                                 <button className="secondary" disabled={!stripePortalUrl}>
                                     Manage Plan ↗


### PR DESCRIPTION
## Description
Align priuces between teams and inidviudals, so that teams get the first 1000 credits for 9 USD as well.

With the changes as they are currently in this PR we wouldn't show any details on the current subscription, as that was just hard coded before and we have no information in our system which price a user has subscribed to. I'm hoping we can defer to the Stripe portal for this (to be investigated) so we can keep our system free of additional subscription details. The portal however is not very informative on this as well 😬 

Edit: I guess we are not getting around showing some simple description of the price. I'll add a service to the billing service.


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #15786

Also related 
 - https://github.com/gitpod-io/ops/pull/7799
 - https://github.com/gitpod-io/ops/pull/7800


## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Teams get the first 1000 credits for 9 USD/€
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-payment
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
