### PR TITLE
[PoC] Custom GitHub Action to create preview environments

### DIFF
--- a/.github/actions/preview-create/Dockerfile
+++ b/.github/actions/preview-create/Dockerfile
@@ -1,0 +1,3 @@
+FROM eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-leeway-v0.7.3.4
+COPY entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/preview-create/entrypoint.sh
+++ b/.github/actions/preview-create/entrypoint.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+export HOME=/home/gitpod
+export PREVIEW_ENV_DEV_SA_KEY_PATH="$HOME/.config/gcloud/preview-environment-dev-sa.json"
+
+# Don't prompt user before terraform apply
+export TF_INPUT=0
+export TF_IN_AUTOMATION=true
+
+echo "${INPUT_SA_KEY}" > "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
+gcloud auth activate-service-account --key-file "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
+
+# Hack alert: We're building previewctl here until we decide how to properly distribute internal tools
+# Also, LEEWAY_WORKSPACE_ROOT is set to /workspace/gitpod in our dev image, but that's not the path GH actions use
+# shellcheck disable=SC2155
+export LEEWAY_WORKSPACE_ROOT="$(pwd)"
+leeway run dev/preview/previewctl:install --dont-test
+
+/workspace/bin/previewctl get-credentials --gcp-service-account "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
+
+leeway run dev/preview:create-preview

--- a/.github/actions/preview-create/metadata.yml
+++ b/.github/actions/preview-create/metadata.yml
@@ -1,0 +1,9 @@
+name: "Create preview environment"
+description: "Creates the infrastructure for a preview environment"
+inputs:
+    sa_key:
+        description: "The service account key to use when authenticating with GCP"
+        required: true
+runs:
+    using: "docker"
+    image: "Dockerfile"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,35 +28,13 @@ jobs:
   infrastructure:
     runs-on: [self-hosted]
     needs: [previewctl]
-    container:
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-leeway-v0.7.3.4
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/download-artifact@v3
+      - name: Create preview environment infrastructure
+        id: create
+        uses: ./.github/actions/preview-create
         with:
-          name: previewctl
-      - name: Configure workspace
-        run: |
-          cp -r /__w/gitpod/gitpod /workspace
-          chmod +x ./previewctl
-          sudo mv ./previewctl /usr/local/bin/
-      - name: Terraform
-        id: terraform
-        shell: bash
-        working-directory: /workspace/gitpod
-        env:
-          HOME: /home/gitpod
-          PREVIEW_ENV_DEV_SA_KEY: ${{ secrets.GCP_CREDENTIALS }}
-          PREVIEW_ENV_DEV_SA_KEY_PATH: /home/gitpod/.config/gcloud/preview-environment-dev-sa.json
-          # Don't prompt user before terraform apply
-          TF_INPUT: 0
-          TF_IN_AUTOMATION: true
-        run: |
-          echo "${PREVIEW_ENV_DEV_SA_KEY}" > "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
-          gcloud auth activate-service-account --key-file "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
-
-          previewctl get-credentials --gcp-service-account "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
-          leeway run dev/preview:create-preview
+          sa_key: ${{ secrets.GCP_CREDENTIALS }}
 
   build:
     if: ${{ contains(github.event.pull_request.body, '[x] /werft with-github-actions') }}


### PR DESCRIPTION
## Description

This introduces a custom action that's a wrapper around our Leeway script. This will make it easier to use as a building block in other workflows. We can then later simplify the "implementation" without requiring users of our action to change anything. See [Migration strategy for preview-dependent Werft jobs](https://www.notion.so/gitpod/Migration-strategy-for-preview-dependent-Werft-jobs-6aaeb1a22c0b4f0696827fdc27e55a3e) for more context.

## Related Issue(s)

Part of https://github.com/gitpod-io/ops/issues/7795

## How to test

See the latest Build Workflow [here](https://github.com/gitpod-io/gitpod/actions/runs/3949349883)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [x] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
