### PR TITLE
Build all components

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,7 +94,7 @@ jobs:
         working-directory: /workspace/gitpod
         run: |
           leeway vet --ignore-warnings
-      - name: Leeway
+      - name: Leeway Build components:all-ci
         id: leeway
         shell: bash
         working-directory: /workspace/gitpod
@@ -105,7 +105,7 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
           RESULT=0
-          leeway build dev/preview:deploy-dependencies \
+          leeway build components:all-ci \
             -Dversion=$VERSION \
             -DSEGMENT_IO_TOKEN=value \
             -DpublishToNPM=false \
@@ -114,7 +114,7 @@ jobs:
 
           cat report.html >> $GITHUB_STEP_SUMMARY
           cp /tmp/versions.yaml /__w/gitpod/gitpod/versions.yaml
-          cp /usr/local/bin/installer /__w/gitpod/gitpod/installer
+          cp /tmp/installer /__w/gitpod/gitpod/installer
 
           exit $RESULT
       - name: "Upload Installer artifacts"

--- a/components/BUILD.yaml
+++ b/components/BUILD.yaml
@@ -15,6 +15,19 @@ packages:
       - install/installer:docker
       - install/kots:lint
       - components/gitpod-protocol:all
+
+  - name: all-ci
+  # like components:all + dev:all + exports files for .github/workflows/build.yml
+    type: generic
+    deps:
+      - :all
+      - dev:all
+      - :all-docker
+      - install/installer:raw-app
+    config:
+      commands:
+        - [ "sh", "-c", "mv install-installer--raw-app/installer /tmp/installer" ]
+        - [ "sh", "-c", "cat components--all-docker/versions.yaml > /tmp/versions.yaml" ]
   - name: docker-versions
     type: docker
     config:


### PR DESCRIPTION
## Description
This PR modified the GHA build to build the same components as the Werft build.

Instead of calling the [Leeway default target](https://github.com/gitpod-io/gitpod/blob/main/WORKSPACE.yaml#L2), it introduces a new target named `components:all-ci` so it can:
* also build `dev:all` (The Werft job does this with an [additional call of `leeway build`](https://github.com/gitpod-io/gitpod/blob/ef72a6901cc756bdf58478d3094d846fc90558d2/.werft/jobs/build/build-and-publish.ts#L37-L40).
* export files `previewctl` and `versions.yaml`.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/15759

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [x] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
