### PR TITLE
Build the dev image on-demand in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,11 +4,84 @@ on:
     types: [opened, synchronize, edited]
 
 jobs:
+  image:
+    if: ${{ contains(github.event.pull_request.body, '[x] /werft with-github-actions') }}
+    runs-on: [self-hosted]
+    container:
+      image: gitpod/workspace-full:latest
+    outputs:
+      devimage: ${{ steps.image.outputs.devimage }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 1000
+      - name: Configure workspace
+        run: |
+          cp -r /__w/gitpod/gitpod /workspace
+          # Needed by google-github-actions/setup-gcloud
+          sudo chown -R gitpod:gitpod /__t
+          # Needed by docker/login-action
+          sudo chmod goa+rw /var/run/docker.sock
+      - name: Install Leeway
+        shell: bash
+        working-directory: /workspace/gitpod
+        run: |
+          LEEWAY_VERSION=0.7.3
+          cd /usr/bin && sudo curl -fsSL https://github.com/gitpod-io/leeway/releases/download/v${LEEWAY_VERSION}/leeway_${LEEWAY_VERSION}_Linux_x86_64.tar.gz | sudo tar xz
+      - id: auth
+        uses: google-github-actions/auth@v1
+        with:
+          token_format: access_token
+          credentials_json: "${{ secrets.GCP_CREDENTIALS }}"
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v1
+      - uses: docker/login-action@v2
+        with:
+          registry: eu.gcr.io
+          username: oauth2accesstoken
+          password: "${{ steps.auth.outputs.access_token }}"
+      - name: Probe If Image Exists
+        id: image
+        shell: bash
+        working-directory: /workspace/gitpod
+        run: |
+          pwd
+          ls -l
+          RESULT=""
+          IMG_VERSION="img-$(git log -n 1 --pretty=format:%H dev/image/)"
+          IMG_BASE="eu.gcr.io/gitpod-core-dev/dev"
+          IMG_NAME="$IMG_BASE/dev-environment:$IMG_VERSION"
+
+          echo "Probing for image $IMG_NAME"
+          docker manifest inspect "$IMG_NAME" || RESULT="missing"
+
+          echo "IMG_VERSION=$IMG_VERSION" >> $GITHUB_ENV
+          echo "IMG_BASE=$IMG_BASE"       >> $GITHUB_ENV
+          echo "IMG_MISSING=$RESULT"      >> $GITHUB_ENV
+
+          echo "devimage=$IMG_NAME" >> $GITHUB_OUTPUT
+
+          # sleep 10000
+
+      - name: Build Image
+        if: ${{ env.IMG_MISSING }}
+        shell: bash
+        working-directory: /workspace/gitpod
+        run: |
+          RESULT=0
+          leeway build dev/image:docker \
+            -Dversion=$IMG_VERSION \
+            -DimageRepoBase=$IMG_BASE \
+            --report report.html || RESULT=$?
+          cat report.html >> $GITHUB_STEP_SUMMARY
+          exit $RESULT
+
   previewctl:
     if: ${{ contains(github.event.pull_request.body, '[x] /werft with-github-actions') && contains(github.event.pull_request.body, '[x] /werft with-preview') }}
     runs-on: [self-hosted]
+    needs: [image]
     container:
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-leeway-v0.7.3.4
+      image: ${{ needs.image.outputs.devimage }}
     steps:
       - uses: actions/checkout@v3
       - name: Configure workspace
@@ -29,7 +102,7 @@ jobs:
     runs-on: [self-hosted]
     needs: [previewctl]
     container:
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-leeway-v0.7.3.4
+      image: ${{ needs.image.outputs.devimage }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/download-artifact@v3
@@ -61,10 +134,11 @@ jobs:
   build:
     if: ${{ contains(github.event.pull_request.body, '[x] /werft with-github-actions') }}
     runs-on: [self-hosted]
+    needs: [image]
     outputs:
       version: ${{ steps.leeway.outputs.version }}
     container:
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-leeway-v0.7.3.4
+      image: ${{ needs.image.outputs.devimage }}
     steps:
       - uses: actions/checkout@v3
       - name: Configure workspace
@@ -129,7 +203,7 @@ jobs:
     needs: [previewctl, build, infrastructure]
     runs-on: [self-hosted]
     container:
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-leeway-v0.7.3.4
+      image: ${{ needs.image.outputs.devimage }}
     steps:
       - uses: actions/checkout@v3
       - name: Configure workspace
@@ -175,7 +249,7 @@ jobs:
     needs: [previewctl, infrastructure]
     runs-on: [self-hosted]
     container:
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-leeway-v0.7.3.4
+      image: ${{ needs.image.outputs.devimage }}
     steps:
       - uses: actions/checkout@v3
       - name: Configure workspace


### PR DESCRIPTION
## Description

I did have an idea of how to generate the dev image at the beginning of the build and then use it throughout the build. So I had to try it :)

Idea:
1. generate a version based using the commit-sha1 of the last commit that modified the image:
```
IMG_VERSION="img-$(git log -n 1 --pretty=format:%H dev/image/)"
```
2. Check if the image in the registry via 
```
docker manifest inspect "$IMG_NAME"
```
3. if the image does not exist, build it.
4. Pass the image name to downstream jobs using "job outputs".

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## TODO
* try to not run login and other steps if the image does not need to be rebuild.

## Discussion
* I think this can be great IF the happy-path (the image needs no rebuild) is super fast.
* the change detection only detects changes in the `/dev/image` folder. However, the leeway build pulls in components from other folders, too. If they change, the image will not be rebuild automatically. IMHO the image should not contain tools from the same repo; Gitpod's prebuild is better suited to make such tools available. Alternatively, pinned versions of already-compiled binaries could be downloaded. 

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [x] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
