### PR TITLE
[server] Allow to login with an instllation admin user

### DIFF
--- a/.werft/jobs/build/deploy-to-preview-environment.ts
+++ b/.werft/jobs/build/deploy-to-preview-environment.ts
@@ -5,6 +5,7 @@ import { Werft } from "../../util/werft";
 import { Analytics, JobConfig } from "./job-config";
 import * as VM from "../../vm/vm";
 import { Installer } from "./installer/installer";
+import { ChildProcess, spawn } from 'child_process';
 
 // used by Installer
 const STACKDRIVER_SERVICEACCOUNT = JSON.parse(
@@ -18,6 +19,7 @@ const phases = {
 
 const installerSlices = {
     INSTALL: "Generate, validate, and install Gitpod",
+    DEDICATED_PRESEED: "Preseed for Dedicated",
 };
 
 const vmSlices = {
@@ -113,6 +115,35 @@ export async function deployToPreviewEnvironment(werft: Werft, jobConfig: JobCon
             );
         } catch (err) {
             werft.fail(installerSlices.INSTALL, err);
+        }
+
+        if (jobConfig.withDedicatedEmulation) {
+            // After the installation is done, and everything is running, we need to prepare first-time access for the admin-user
+            let portForwardProcess: ChildProcess | undefined;
+            try {
+                werft.log(installerSlices.DEDICATED_PRESEED, "preseed for dedicated");
+                portForwardProcess = spawn("kubectl", ["port-forward", "deployment/server", "9000", "&"], {
+                    shell: true,
+                    detached: true,
+                    stdio: "overlapped",
+                });
+                await new Promise(resolve => portForwardProcess.stdout.on('data', resolve));    // wait until process is running
+
+                const adminLoginOts = exec(`curl -X POST localhost:9000/admin-user/login-token/create`, { silent: true }).stdout.trim();
+                exec(
+                    `werft log result "admin login OTS token" ${adminLoginOts}`,
+                );
+                exec(
+                    `werft log result -d "admin-user login link" url https://${deploymentConfig.domain}/api/login/ots/admin-user/${adminLoginOts}`,
+                );
+                werft.log(installerSlices.DEDICATED_PRESEED, "done preseeding for dedicated.");
+            } catch (err) {
+                werft.fail(installerSlices.DEDICATED_PRESEED, err);
+            } finally {
+                if (portForwardProcess) {
+                    portForwardProcess.kill("SIGINT");
+                }
+            }
         }
     })();
 

--- a/components/dashboard/src/settings/ProfileInformation.tsx
+++ b/components/dashboard/src/settings/ProfileInformation.tsx
@@ -18,6 +18,12 @@ export namespace ProfileState {
         if (!isGitpodIo()) {
             return false;
         }
+        if (user.identities.length === 0) {
+            // Special case to exclude admin-user from being asked for profile info
+            // TODO(gpl) Ideally this whole check should be done in backend, and this specific test being based on userId
+            // In addition, we should disable it for all SSO users
+            return false;
+        }
         if (!user.additionalData?.profile) {
             // never updated profile information and account is older than 24 hours (i.e. ask on second day).
             return !isDateSmaller(hoursBefore(new Date().toISOString(), 24), user.creationDate);

--- a/components/gitpod-db/src/typeorm/migration/1673963493560-AdminUser.ts
+++ b/components/gitpod-db/src/typeorm/migration/1673963493560-AdminUser.ts
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { BUILTIN_INSTLLATION_ADMIN_USER_ID } from "../../user-db";
+
+export class AdminUser1673963493560 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `INSERT IGNORE INTO d_b_user (id, creationDate, avatarUrl, name, fullName, rolesOrPermissions, blocked) VALUES ('${BUILTIN_INSTLLATION_ADMIN_USER_ID}', '${new Date().toISOString()}', '', 'admin-user', '', '["admin"]', TRUE)`,
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {}
+}

--- a/components/gitpod-db/src/typeorm/user-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/user-db-impl.ts
@@ -33,6 +33,7 @@ import { v4 as uuidv4 } from "uuid";
 import {
     BUILTIN_WORKSPACE_PROBE_USER_ID,
     BUILTIN_WORKSPACE_USER_AGENT_SMITH,
+    BUILTIN_INSTLLATION_ADMIN_USER_ID,
     MaybeUser,
     PartialUserUpdate,
     UserDB,
@@ -380,7 +381,7 @@ export class TypeORMUserDBImpl implements UserDB {
             WHERE markedDeleted != true`;
         if (excludeBuiltinUsers) {
             query = `${query}
-                AND id NOT IN ('${BUILTIN_WORKSPACE_PROBE_USER_ID}', '${BUILTIN_WORKSPACE_USER_AGENT_SMITH}')`;
+                AND id NOT IN ('${BUILTIN_WORKSPACE_PROBE_USER_ID}', '${BUILTIN_WORKSPACE_USER_AGENT_SMITH}', '${BUILTIN_INSTLLATION_ADMIN_USER_ID}')`;
         }
         const res = await userRepo.query(query);
         const count = res[0].cnt;

--- a/components/gitpod-db/src/user-db.ts
+++ b/components/gitpod-db/src/user-db.ts
@@ -155,6 +155,8 @@ export const BUILTIN_WORKSPACE_PROBE_USER_ID = "builtin-user-workspace-probe-000
 
 export const BUILTIN_WORKSPACE_USER_AGENT_SMITH = "builtin-user-agent-smith-0000000";
 
+export const BUILTIN_INSTLLATION_ADMIN_USER_ID = "builtin-installation-admin-user-0000";
+
 export interface OwnerAndRepo {
     owner: string;
     repo: string;

--- a/components/server/src/config.ts
+++ b/components/server/src/config.ts
@@ -28,6 +28,7 @@ export type Config = Omit<
     | "stripeConfigFile"
     | "licenseFile"
     | "patSigningKeyFile"
+    | "adminLoginKeyFile"
 > & {
     hostUrl: GitpodHostUrl;
     workspaceDefaults: WorkspaceDefaults;
@@ -37,6 +38,7 @@ export type Config = Omit<
     inactivityPeriodForReposInDays?: number;
 
     patSigningKey: string;
+    admin: { loginKey: string };
 };
 
 export interface WorkspaceDefaults {
@@ -141,7 +143,10 @@ export interface ConfigSerialized {
         passlist: string[];
     };
 
-    makeNewUsersAdmin: boolean;
+    adminLoginKeyFile: string;
+    admin: {
+        grantFirstUserAdminRole: boolean;
+    };
 
     /** defaultBaseImageRegistryWhitelist is the list of registryies users get acces to by default */
     defaultBaseImageRegistryWhitelist: string[];
@@ -330,6 +335,15 @@ export namespace ConfigFile {
             }
         }
 
+        let adminLoginKey = "";
+        if (config.adminLoginKeyFile) {
+            try {
+                adminLoginKey = fs.readFileSync(filePathTelepresenceAware(config.adminLoginKeyFile), "utf-8").trim();
+            } catch (error) {
+                log.error("Could not load admin login key", error);
+            }
+        }
+
         return {
             ...config,
             hostUrl,
@@ -347,6 +361,10 @@ export namespace ConfigFile {
             },
             inactivityPeriodForReposInDays,
             patSigningKey,
+            admin: {
+                ...config.admin,
+                loginKey: adminLoginKey,
+            },
         };
     }
 }

--- a/components/server/src/installation-admin/installation-admin-controller.ts
+++ b/components/server/src/installation-admin/installation-admin-controller.ts
@@ -4,15 +4,30 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
+import * as crypto from "crypto";
 import { injectable, inject } from "inversify";
 import * as express from "express";
 import * as opentracing from "opentracing";
 import { InstallationAdminTelemetryDataProvider } from "./telemetry-data-provider";
+import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
+import { OneTimeSecretServer } from "../one-time-secret-server";
+import { TraceContext } from "@gitpod/gitpod-protocol/lib/util/tracing";
+import { BUILTIN_INSTLLATION_ADMIN_USER_ID, UserDB } from "@gitpod/gitpod-db/lib/user-db";
+import { Config } from "../config";
 
 @injectable()
 export class InstallationAdminController {
     @inject(InstallationAdminTelemetryDataProvider)
     protected readonly telemetryDataProvider: InstallationAdminTelemetryDataProvider;
+
+    @inject(OneTimeSecretServer)
+    protected readonly otsServer: OneTimeSecretServer;
+
+    @inject(Config)
+    protected readonly config: Config;
+
+    @inject(UserDB)
+    protected readonly userDb: UserDB;
 
     public create(): express.Application {
         const app = express();
@@ -25,6 +40,41 @@ export class InstallationAdminController {
                 res.status(200).json(await this.telemetryDataProvider.getTelemetryData());
             } finally {
                 span.finish();
+            }
+        });
+
+        const adminUserCreateLoginTokenRoute = "/admin-user/login-token/create";
+        app.post(adminUserCreateLoginTokenRoute, async (req: express.Request, res: express.Response) => {
+            const span = TraceContext.startSpan(adminUserCreateLoginTokenRoute);
+            const ctx = { span };
+
+            log.info(`${adminUserCreateLoginTokenRoute} received.`);
+            try {
+                // Unblock the admin-user: it's blocked initially!
+                const user = await this.userDb.findUserById(BUILTIN_INSTLLATION_ADMIN_USER_ID);
+                if (!user) {
+                    throw new Error("Cannot find builint admin-user");
+                }
+                user.blocked = false;
+                await this.userDb.storeUser(user);
+
+                // Create a fresh token
+                // TODO(gpl): Would be nice if we could invalidate all other tokens here!
+                const secretHash = crypto
+                    .createHash("sha256")
+                    .update(BUILTIN_INSTLLATION_ADMIN_USER_ID + this.config.admin.loginKey)
+                    .digest("hex");
+                const oneDay = new Date();
+                oneDay.setDate(oneDay.getDate() + 1);
+                const ots = await this.otsServer.serveToken(ctx, secretHash, oneDay);
+
+                res.send(ots.token).status(200);
+                log.info(`${adminUserCreateLoginTokenRoute} done.`);
+            } catch (err) {
+                TraceContext.setError(ctx, err);
+                span.finish();
+                log.error(`${adminUserCreateLoginTokenRoute} error`, err);
+                res.sendStatus(502);
             }
         });
 

--- a/components/server/src/user/user-service.ts
+++ b/components/server/src/user/user-service.ts
@@ -152,7 +152,7 @@ export class UserService {
             // blocked = if user already blocked OR is not allowed to pass
             newUser.blocked = newUser.blocked || !canPass;
         }
-        if (!newUser.blocked && (isFirstUser || this.config.makeNewUsersAdmin)) {
+        if (!newUser.blocked && isFirstUser && this.config.admin.grantFirstUserAdminRole) {
             newUser.rolesOrPermissions = ["admin"];
         }
     }

--- a/install/installer/cmd/testdata/render/aws-setup/output.golden
+++ b/install/installer/cmd/testdata/render/aws-setup/output.golden
@@ -1164,6 +1164,19 @@ stringData:
   password: uq4KxOLtrA-QsDTfuwQ-
   username: gitpod
 ---
+# v1/Secret server-admin-secret
+apiVersion: v1
+data:
+  login-key: bTMwRUgtTTItY1dNZ2tnZHk3cHU=
+kind: Secret
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: server
+  name: server-admin-secret
+  namespace: default
+---
 # v1/ConfigMap agent-smith
 apiVersion: v1
 data:
@@ -2466,6 +2479,16 @@ data:
         app: gitpod
         component: server
       name: server
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: server
+      name: server-admin-secret
       namespace: default
     ---
     apiVersion: networking.k8s.io/v1
@@ -4980,7 +5003,7 @@ data:
       },
       "oauthServer": {
         "enabled": true,
-        "jwtSecret": "m30EH-M2-cWMgkgdy7pu"
+        "jwtSecret": "_7wODLGlsPauKCw4SBI2"
       },
       "rateLimiter": {
         "groups": {
@@ -5013,6 +5036,10 @@ data:
         "contentLimit": 0,
         "resources": null
       },
+      "admin": {
+        "grantFirstUserAdminRole": true
+      },
+      "adminLoginKeyFile": "/admin/login-key",
       "prebuildLimiter": {
         "*": {
           "limit": 100,
@@ -9645,7 +9672,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 8c05f78bde8894a461a3d382e567b6d00d34026fa916c9e7baf2c1e81e43b239
+        gitpod.io/checksum_config: 5269d9fc5c6b73baff49aac56fba12707ad3a7e30252fdcba506ef27fb1afebf
       creationTimestamp: null
       labels:
         app: gitpod
@@ -9786,6 +9813,9 @@ spec:
         - mountPath: /ws-manager-client-tls-certs
           name: ws-manager-client-tls-certs
           readOnly: true
+        - mountPath: /admin
+          name: admin-login-key
+          readOnly: true
       - args:
         - --logtostderr
         - --insecure-listen-address=[$(IP)]:9500
@@ -9900,6 +9930,9 @@ spec:
       - name: ws-manager-client-tls-certs
         secret:
           secretName: ws-manager-client-tls
+      - name: admin-login-key
+        secret:
+          secretName: server-admin-secret
 status: {}
 ---
 # apps/v1/Deployment ws-manager

--- a/install/installer/cmd/testdata/render/azure-setup/output.golden
+++ b/install/installer/cmd/testdata/render/azure-setup/output.golden
@@ -1199,6 +1199,19 @@ stringData:
   password: uq4KxOLtrA-QsDTfuwQ-
   username: gitpod
 ---
+# v1/Secret server-admin-secret
+apiVersion: v1
+data:
+  login-key: bTMwRUgtTTItY1dNZ2tnZHk3cHU=
+kind: Secret
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: server
+  name: server-admin-secret
+  namespace: default
+---
 # v1/ConfigMap agent-smith
 apiVersion: v1
 data:
@@ -2484,6 +2497,16 @@ data:
         app: gitpod
         component: server
       name: server
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: server
+      name: server-admin-secret
       namespace: default
     ---
     apiVersion: networking.k8s.io/v1
@@ -5046,7 +5069,7 @@ data:
       },
       "oauthServer": {
         "enabled": true,
-        "jwtSecret": "m30EH-M2-cWMgkgdy7pu"
+        "jwtSecret": "_7wODLGlsPauKCw4SBI2"
       },
       "rateLimiter": {
         "groups": {
@@ -5079,6 +5102,10 @@ data:
         "contentLimit": 0,
         "resources": null
       },
+      "admin": {
+        "grantFirstUserAdminRole": true
+      },
+      "adminLoginKeyFile": "/admin/login-key",
       "prebuildLimiter": {
         "*": {
           "limit": 100,
@@ -9842,7 +9869,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 8c05f78bde8894a461a3d382e567b6d00d34026fa916c9e7baf2c1e81e43b239
+        gitpod.io/checksum_config: 5269d9fc5c6b73baff49aac56fba12707ad3a7e30252fdcba506ef27fb1afebf
       creationTimestamp: null
       labels:
         app: gitpod
@@ -9983,6 +10010,9 @@ spec:
         - mountPath: /ws-manager-client-tls-certs
           name: ws-manager-client-tls-certs
           readOnly: true
+        - mountPath: /admin
+          name: admin-login-key
+          readOnly: true
       - args:
         - --logtostderr
         - --insecure-listen-address=[$(IP)]:9500
@@ -10097,6 +10127,9 @@ spec:
       - name: ws-manager-client-tls-certs
         secret:
           secretName: ws-manager-client-tls
+      - name: admin-login-key
+        secret:
+          secretName: server-admin-secret
 status: {}
 ---
 # apps/v1/Deployment ws-manager

--- a/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
+++ b/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
@@ -1301,6 +1301,19 @@ data:
   proxyUsername: ""
   proxyPassword: ""
 ---
+# v1/Secret server-admin-secret
+apiVersion: v1
+data:
+  login-key: bTMwRUgtTTItY1dNZ2tnZHk3cHU=
+kind: Secret
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: server
+  name: server-admin-secret
+  namespace: default
+---
 # v1/ConfigMap agent-smith
 apiVersion: v1
 data:
@@ -2667,6 +2680,16 @@ data:
         app: gitpod
         component: server
       name: server
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: server
+      name: server-admin-secret
       namespace: default
     ---
     apiVersion: networking.k8s.io/v1
@@ -5453,7 +5476,7 @@ data:
       },
       "oauthServer": {
         "enabled": true,
-        "jwtSecret": "m30EH-M2-cWMgkgdy7pu"
+        "jwtSecret": "_7wODLGlsPauKCw4SBI2"
       },
       "rateLimiter": {
         "groups": {
@@ -5486,6 +5509,10 @@ data:
         "contentLimit": 0,
         "resources": null
       },
+      "admin": {
+        "grantFirstUserAdminRole": true
+      },
+      "adminLoginKeyFile": "/admin/login-key",
       "prebuildLimiter": {
         "*": {
           "limit": 100,
@@ -10646,7 +10673,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 4b4c3a473e5569c39bda206c756538858ff6f5495b563c523705666ba3ec4930
+        gitpod.io/checksum_config: 4da63a919ee3c1a5536eb78fdca63be3ce849c20d4e8f8a0d7c90381be844753
       creationTimestamp: null
       labels:
         app: gitpod
@@ -10787,6 +10814,9 @@ spec:
         - mountPath: /ws-manager-client-tls-certs
           name: ws-manager-client-tls-certs
           readOnly: true
+        - mountPath: /admin
+          name: admin-login-key
+          readOnly: true
       - args:
         - --logtostderr
         - --insecure-listen-address=[$(IP)]:9500
@@ -10901,6 +10931,9 @@ spec:
       - name: ws-manager-client-tls-certs
         secret:
           secretName: ws-manager-client-tls
+      - name: admin-login-key
+        secret:
+          secretName: server-admin-secret
 status: {}
 ---
 # apps/v1/Deployment ws-manager

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -1421,6 +1421,19 @@ data:
   proxyUsername: ""
   proxyPassword: ""
 ---
+# v1/Secret server-admin-secret
+apiVersion: v1
+data:
+  login-key: bTMwRUgtTTItY1dNZ2tnZHk3cHU=
+kind: Secret
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: server
+  name: server-admin-secret
+  namespace: default
+---
 # v1/ConfigMap agent-smith
 apiVersion: v1
 data:
@@ -3044,6 +3057,16 @@ data:
         gitpod.io: hello
         hello: world
       name: server
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: server
+      name: server-admin-secret
       namespace: default
     ---
     apiVersion: networking.k8s.io/v1
@@ -6051,7 +6074,7 @@ data:
       },
       "oauthServer": {
         "enabled": true,
-        "jwtSecret": "m30EH-M2-cWMgkgdy7pu"
+        "jwtSecret": "_7wODLGlsPauKCw4SBI2"
       },
       "rateLimiter": {
         "groups": {
@@ -6084,6 +6107,10 @@ data:
         "contentLimit": 0,
         "resources": null
       },
+      "admin": {
+        "grantFirstUserAdminRole": true
+      },
+      "adminLoginKeyFile": "/admin/login-key",
       "prebuildLimiter": {
         "*": {
           "limit": 100,
@@ -11500,7 +11527,7 @@ spec:
     metadata:
       annotations:
         gitpod.io: hello
-        gitpod.io/checksum_config: d160a1089a804609aa6ad12e87ac23e4c76e29efd39e9ddf44796a71fc4d6b3f
+        gitpod.io/checksum_config: c3b0b1bc8f51ba9af5abeb508dcba2952067d9f94e0acf102ccf0caf178dfc92
         hello: world
       creationTimestamp: null
       labels:
@@ -11644,6 +11671,9 @@ spec:
         - mountPath: /ws-manager-client-tls-certs
           name: ws-manager-client-tls-certs
           readOnly: true
+        - mountPath: /admin
+          name: admin-login-key
+          readOnly: true
       - args:
         - --logtostderr
         - --insecure-listen-address=[$(IP)]:9500
@@ -11758,6 +11788,9 @@ spec:
       - name: ws-manager-client-tls-certs
         secret:
           secretName: ws-manager-client-tls
+      - name: admin-login-key
+        secret:
+          secretName: server-admin-secret
 status: {}
 ---
 # apps/v1/Deployment ws-manager

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -1230,6 +1230,19 @@ stringData:
   password: uq4KxOLtrA-QsDTfuwQ-
   username: gitpod
 ---
+# v1/Secret server-admin-secret
+apiVersion: v1
+data:
+  login-key: bTMwRUgtTTItY1dNZ2tnZHk3cHU=
+kind: Secret
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: server
+  name: server-admin-secret
+  namespace: default
+---
 # v1/ConfigMap agent-smith
 apiVersion: v1
 data:
@@ -2561,6 +2574,16 @@ data:
         app: gitpod
         component: server
       name: server
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: server
+      name: server-admin-secret
       namespace: default
     ---
     apiVersion: networking.k8s.io/v1
@@ -5233,7 +5256,7 @@ data:
       },
       "oauthServer": {
         "enabled": true,
-        "jwtSecret": "m30EH-M2-cWMgkgdy7pu"
+        "jwtSecret": "_7wODLGlsPauKCw4SBI2"
       },
       "rateLimiter": {
         "groups": {
@@ -5266,6 +5289,10 @@ data:
         "contentLimit": 0,
         "resources": null
       },
+      "admin": {
+        "grantFirstUserAdminRole": true
+      },
+      "adminLoginKeyFile": "/admin/login-key",
       "prebuildLimiter": {
         "*": {
           "limit": 100,
@@ -10269,7 +10296,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: f52ae23eddcf2fe15c87ec92cc3d998045c5ff491d52caed0f23a6fccc020134
+        gitpod.io/checksum_config: 550e02430b4a042f739e7c0d1baa862ef615c832e308bd185227308e596dec0d
       creationTimestamp: null
       labels:
         app: gitpod
@@ -10410,6 +10437,9 @@ spec:
         - mountPath: /ws-manager-client-tls-certs
           name: ws-manager-client-tls-certs
           readOnly: true
+        - mountPath: /admin
+          name: admin-login-key
+          readOnly: true
       - args:
         - --logtostderr
         - --insecure-listen-address=[$(IP)]:9500
@@ -10524,6 +10554,9 @@ spec:
       - name: ws-manager-client-tls-certs
         secret:
           secretName: ws-manager-client-tls
+      - name: admin-login-key
+        secret:
+          secretName: server-admin-secret
 status: {}
 ---
 # apps/v1/Deployment ws-manager

--- a/install/installer/cmd/testdata/render/gcp-setup/output.golden
+++ b/install/installer/cmd/testdata/render/gcp-setup/output.golden
@@ -1176,6 +1176,19 @@ stringData:
   password: uq4KxOLtrA-QsDTfuwQ-
   username: gitpod
 ---
+# v1/Secret server-admin-secret
+apiVersion: v1
+data:
+  login-key: bTMwRUgtTTItY1dNZ2tnZHk3cHU=
+kind: Secret
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: server
+  name: server-admin-secret
+  namespace: default
+---
 # v1/ConfigMap agent-smith
 apiVersion: v1
 data:
@@ -2503,6 +2516,16 @@ data:
         app: gitpod
         component: server
       name: server
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: server
+      name: server-admin-secret
       namespace: default
     ---
     apiVersion: networking.k8s.io/v1
@@ -5007,7 +5030,7 @@ data:
       },
       "oauthServer": {
         "enabled": true,
-        "jwtSecret": "m30EH-M2-cWMgkgdy7pu"
+        "jwtSecret": "_7wODLGlsPauKCw4SBI2"
       },
       "rateLimiter": {
         "groups": {
@@ -5040,6 +5063,10 @@ data:
         "contentLimit": 0,
         "resources": null
       },
+      "admin": {
+        "grantFirstUserAdminRole": true
+      },
+      "adminLoginKeyFile": "/admin/login-key",
       "prebuildLimiter": {
         "*": {
           "limit": 100,
@@ -9750,7 +9777,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 09e70c56b73dd1d83f59a85cec7dc6dd2cdd18982612e885a72dde8132a61ddf
+        gitpod.io/checksum_config: 9515c439aaad606d1301d3c1476ccf4cabfd9bea5dd81920a0be269eb2b7400f
       creationTimestamp: null
       labels:
         app: gitpod
@@ -9885,6 +9912,9 @@ spec:
         - mountPath: /ws-manager-client-tls-certs
           name: ws-manager-client-tls-certs
           readOnly: true
+        - mountPath: /admin
+          name: admin-login-key
+          readOnly: true
       - args:
         - --logtostderr
         - --insecure-listen-address=[$(IP)]:9500
@@ -9993,6 +10023,9 @@ spec:
       - name: ws-manager-client-tls-certs
         secret:
           secretName: ws-manager-client-tls
+      - name: admin-login-key
+        secret:
+          secretName: server-admin-secret
 status: {}
 ---
 # apps/v1/Deployment ws-manager

--- a/install/installer/cmd/testdata/render/http-proxy/output.golden
+++ b/install/installer/cmd/testdata/render/http-proxy/output.golden
@@ -1301,6 +1301,19 @@ data:
   proxyUsername: ""
   proxyPassword: ""
 ---
+# v1/Secret server-admin-secret
+apiVersion: v1
+data:
+  login-key: bTMwRUgtTTItY1dNZ2tnZHk3cHU=
+kind: Secret
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: server
+  name: server-admin-secret
+  namespace: default
+---
 # v1/ConfigMap agent-smith
 apiVersion: v1
 data:
@@ -2670,6 +2683,16 @@ data:
         app: gitpod
         component: server
       name: server
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: server
+      name: server-admin-secret
       namespace: default
     ---
     apiVersion: networking.k8s.io/v1
@@ -5456,7 +5479,7 @@ data:
       },
       "oauthServer": {
         "enabled": true,
-        "jwtSecret": "m30EH-M2-cWMgkgdy7pu"
+        "jwtSecret": "_7wODLGlsPauKCw4SBI2"
       },
       "rateLimiter": {
         "groups": {
@@ -5489,6 +5512,10 @@ data:
         "contentLimit": 0,
         "resources": null
       },
+      "admin": {
+        "grantFirstUserAdminRole": true
+      },
+      "adminLoginKeyFile": "/admin/login-key",
       "prebuildLimiter": {
         "*": {
           "limit": 100,
@@ -11891,7 +11918,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: f52ae23eddcf2fe15c87ec92cc3d998045c5ff491d52caed0f23a6fccc020134
+        gitpod.io/checksum_config: 550e02430b4a042f739e7c0d1baa862ef615c832e308bd185227308e596dec0d
       creationTimestamp: null
       labels:
         app: gitpod
@@ -12073,6 +12100,9 @@ spec:
           readOnly: true
         - mountPath: /ws-manager-client-tls-certs
           name: ws-manager-client-tls-certs
+          readOnly: true
+        - mountPath: /admin
+          name: admin-login-key
           readOnly: true
       - args:
         - --logtostderr
@@ -12308,6 +12338,9 @@ spec:
       - name: ws-manager-client-tls-certs
         secret:
           secretName: ws-manager-client-tls
+      - name: admin-login-key
+        secret:
+          secretName: server-admin-secret
 status: {}
 ---
 # apps/v1/Deployment ws-manager

--- a/install/installer/cmd/testdata/render/kind-meta/output.golden
+++ b/install/installer/cmd/testdata/render/kind-meta/output.golden
@@ -874,6 +874,19 @@ data:
   proxyUsername: ""
   proxyPassword: ""
 ---
+# v1/Secret server-admin-secret
+apiVersion: v1
+data:
+  login-key: bTMwRUgtTTItY1dNZ2tnZHk3cHU=
+kind: Secret
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: server
+  name: server-admin-secret
+  namespace: default
+---
 # v1/ConfigMap blobserve
 apiVersion: v1
 data:
@@ -2214,6 +2227,16 @@ data:
         app: gitpod
         component: server
       name: server
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: server
+      name: server-admin-secret
       namespace: default
     ---
     apiVersion: networking.k8s.io/v1
@@ -4329,7 +4352,7 @@ data:
       },
       "oauthServer": {
         "enabled": true,
-        "jwtSecret": "m30EH-M2-cWMgkgdy7pu"
+        "jwtSecret": "_7wODLGlsPauKCw4SBI2"
       },
       "rateLimiter": {
         "groups": {
@@ -4362,6 +4385,10 @@ data:
         "contentLimit": 0,
         "resources": null
       },
+      "admin": {
+        "grantFirstUserAdminRole": true
+      },
+      "adminLoginKeyFile": "/admin/login-key",
       "prebuildLimiter": {
         "*": {
           "limit": 100,
@@ -7833,7 +7860,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: f52ae23eddcf2fe15c87ec92cc3d998045c5ff491d52caed0f23a6fccc020134
+        gitpod.io/checksum_config: 550e02430b4a042f739e7c0d1baa862ef615c832e308bd185227308e596dec0d
       creationTimestamp: null
       labels:
         app: gitpod
@@ -7974,6 +8001,9 @@ spec:
         - mountPath: /ws-manager-client-tls-certs
           name: ws-manager-client-tls-certs
           readOnly: true
+        - mountPath: /admin
+          name: admin-login-key
+          readOnly: true
       - args:
         - --logtostderr
         - --insecure-listen-address=[$(IP)]:9500
@@ -8088,6 +8118,9 @@ spec:
       - name: ws-manager-client-tls-certs
         secret:
           secretName: ws-manager-client-tls
+      - name: admin-login-key
+        secret:
+          secretName: server-admin-secret
 status: {}
 ---
 # apps/v1/Deployment ws-manager-bridge

--- a/install/installer/cmd/testdata/render/kind-webapp/output.golden
+++ b/install/installer/cmd/testdata/render/kind-webapp/output.golden
@@ -707,6 +707,19 @@ data:
   proxyUsername: ""
   proxyPassword: ""
 ---
+# v1/Secret server-admin-secret
+apiVersion: v1
+data:
+  login-key: bTMwRUgtTTItY1dNZ2tnZHk3cHU=
+kind: Secret
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: server
+  name: server-admin-secret
+  namespace: default
+---
 # v1/ConfigMap content-service
 apiVersion: v1
 data:
@@ -1591,6 +1604,16 @@ data:
       name: server
       namespace: default
     ---
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: server
+      name: server-admin-secret
+      namespace: default
+    ---
     apiVersion: networking.k8s.io/v1
     kind: NetworkPolicy
     metadata:
@@ -2419,7 +2442,7 @@ data:
       },
       "oauthServer": {
         "enabled": true,
-        "jwtSecret": "m30EH-M2-cWMgkgdy7pu"
+        "jwtSecret": "_7wODLGlsPauKCw4SBI2"
       },
       "rateLimiter": {
         "groups": {
@@ -2452,6 +2475,10 @@ data:
         "contentLimit": 0,
         "resources": null
       },
+      "admin": {
+        "grantFirstUserAdminRole": true
+      },
+      "adminLoginKeyFile": "/admin/login-key",
       "prebuildLimiter": {
         "*": {
           "limit": 100,
@@ -4762,7 +4789,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: f52ae23eddcf2fe15c87ec92cc3d998045c5ff491d52caed0f23a6fccc020134
+        gitpod.io/checksum_config: 550e02430b4a042f739e7c0d1baa862ef615c832e308bd185227308e596dec0d
       creationTimestamp: null
       labels:
         app: gitpod
@@ -4903,6 +4930,9 @@ spec:
         - mountPath: /ws-manager-client-tls-certs
           name: ws-manager-client-tls-certs
           readOnly: true
+        - mountPath: /admin
+          name: admin-login-key
+          readOnly: true
       - args:
         - --logtostderr
         - --insecure-listen-address=[$(IP)]:9500
@@ -5017,6 +5047,9 @@ spec:
       - name: ws-manager-client-tls-certs
         secret:
           secretName: ws-manager-client-tls
+      - name: admin-login-key
+        secret:
+          secretName: server-admin-secret
 status: {}
 ---
 # apps/v1/Deployment ws-manager-bridge

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -1301,6 +1301,19 @@ data:
   proxyUsername: ""
   proxyPassword: ""
 ---
+# v1/Secret server-admin-secret
+apiVersion: v1
+data:
+  login-key: bTMwRUgtTTItY1dNZ2tnZHk3cHU=
+kind: Secret
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: server
+  name: server-admin-secret
+  namespace: default
+---
 # v1/ConfigMap agent-smith
 apiVersion: v1
 data:
@@ -2667,6 +2680,16 @@ data:
         app: gitpod
         component: server
       name: server
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: server
+      name: server-admin-secret
       namespace: default
     ---
     apiVersion: networking.k8s.io/v1
@@ -5453,7 +5476,7 @@ data:
       },
       "oauthServer": {
         "enabled": true,
-        "jwtSecret": "m30EH-M2-cWMgkgdy7pu"
+        "jwtSecret": "_7wODLGlsPauKCw4SBI2"
       },
       "rateLimiter": {
         "groups": {
@@ -5486,6 +5509,10 @@ data:
         "contentLimit": 0,
         "resources": null
       },
+      "admin": {
+        "grantFirstUserAdminRole": true
+      },
+      "adminLoginKeyFile": "/admin/login-key",
       "prebuildLimiter": {
         "*": {
           "limit": 100,
@@ -10646,7 +10673,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: f52ae23eddcf2fe15c87ec92cc3d998045c5ff491d52caed0f23a6fccc020134
+        gitpod.io/checksum_config: 550e02430b4a042f739e7c0d1baa862ef615c832e308bd185227308e596dec0d
       creationTimestamp: null
       labels:
         app: gitpod
@@ -10787,6 +10814,9 @@ spec:
         - mountPath: /ws-manager-client-tls-certs
           name: ws-manager-client-tls-certs
           readOnly: true
+        - mountPath: /admin
+          name: admin-login-key
+          readOnly: true
       - args:
         - --logtostderr
         - --insecure-listen-address=[$(IP)]:9500
@@ -10901,6 +10931,9 @@ spec:
       - name: ws-manager-client-tls-certs
         secret:
           secretName: ws-manager-client-tls
+      - name: admin-login-key
+        secret:
+          secretName: server-admin-secret
 status: {}
 ---
 # apps/v1/Deployment ws-manager

--- a/install/installer/cmd/testdata/render/overrides-inline/output.golden
+++ b/install/installer/cmd/testdata/render/overrides-inline/output.golden
@@ -1299,6 +1299,19 @@ data:
   proxyUsername: ""
   proxyPassword: ""
 ---
+# v1/Secret server-admin-secret
+apiVersion: v1
+data:
+  login-key: bTMwRUgtTTItY1dNZ2tnZHk3cHU=
+kind: Secret
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: server
+  name: server-admin-secret
+  namespace: default
+---
 # v1/ConfigMap agent-smith
 apiVersion: v1
 data:
@@ -2665,6 +2678,16 @@ data:
         app: gitpod
         component: server
       name: server
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: server
+      name: server-admin-secret
       namespace: default
     ---
     apiVersion: networking.k8s.io/v1
@@ -5451,7 +5474,7 @@ data:
       },
       "oauthServer": {
         "enabled": true,
-        "jwtSecret": "m30EH-M2-cWMgkgdy7pu"
+        "jwtSecret": "_7wODLGlsPauKCw4SBI2"
       },
       "rateLimiter": {
         "groups": {
@@ -5484,6 +5507,10 @@ data:
         "contentLimit": 0,
         "resources": null
       },
+      "admin": {
+        "grantFirstUserAdminRole": true
+      },
+      "adminLoginKeyFile": "/admin/login-key",
       "prebuildLimiter": {
         "*": {
           "limit": 100,
@@ -10272,6 +10299,8 @@ spec:
           value: info
         - name: PROXY_DOMAIN
           value: gitpod.example.com
+        - name: FRONTEND_DEV_ENABLED
+          value: "false"
         image: eu.gcr.io/gitpod-core-dev/build/proxy:test
         imagePullPolicy: IfNotPresent
         name: proxy
@@ -10654,7 +10683,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: f52ae23eddcf2fe15c87ec92cc3d998045c5ff491d52caed0f23a6fccc020134
+        gitpod.io/checksum_config: 550e02430b4a042f739e7c0d1baa862ef615c832e308bd185227308e596dec0d
       creationTimestamp: null
       labels:
         app: gitpod
@@ -10795,6 +10824,9 @@ spec:
         - mountPath: /ws-manager-client-tls-certs
           name: ws-manager-client-tls-certs
           readOnly: true
+        - mountPath: /admin
+          name: admin-login-key
+          readOnly: true
       - args:
         - --logtostderr
         - --insecure-listen-address=[$(IP)]:9500
@@ -10909,6 +10941,9 @@ spec:
       - name: ws-manager-client-tls-certs
         secret:
           secretName: ws-manager-client-tls
+      - name: admin-login-key
+        secret:
+          secretName: server-admin-secret
 status: {}
 ---
 # apps/v1/Deployment ws-manager

--- a/install/installer/cmd/testdata/render/shortname/output.golden
+++ b/install/installer/cmd/testdata/render/shortname/output.golden
@@ -1301,6 +1301,19 @@ data:
   proxyUsername: ""
   proxyPassword: ""
 ---
+# v1/Secret server-admin-secret
+apiVersion: v1
+data:
+  login-key: bTMwRUgtTTItY1dNZ2tnZHk3cHU=
+kind: Secret
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: server
+  name: server-admin-secret
+  namespace: default
+---
 # v1/ConfigMap agent-smith
 apiVersion: v1
 data:
@@ -2667,6 +2680,16 @@ data:
         app: gitpod
         component: server
       name: server
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: server
+      name: server-admin-secret
       namespace: default
     ---
     apiVersion: networking.k8s.io/v1
@@ -5453,7 +5476,7 @@ data:
       },
       "oauthServer": {
         "enabled": true,
-        "jwtSecret": "m30EH-M2-cWMgkgdy7pu"
+        "jwtSecret": "_7wODLGlsPauKCw4SBI2"
       },
       "rateLimiter": {
         "groups": {
@@ -5486,6 +5509,10 @@ data:
         "contentLimit": 0,
         "resources": null
       },
+      "admin": {
+        "grantFirstUserAdminRole": true
+      },
+      "adminLoginKeyFile": "/admin/login-key",
       "prebuildLimiter": {
         "*": {
           "limit": 100,
@@ -10646,7 +10673,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 112e8aa62e3e63f4756819d1ecee48aa807111855d857f0703a3aba91f8507b9
+        gitpod.io/checksum_config: eed4f3be26ac38b3598e53761f29965c23fa3495b5eb37d2e78381ec9623335f
       creationTimestamp: null
       labels:
         app: gitpod
@@ -10787,6 +10814,9 @@ spec:
         - mountPath: /ws-manager-client-tls-certs
           name: ws-manager-client-tls-certs
           readOnly: true
+        - mountPath: /admin
+          name: admin-login-key
+          readOnly: true
       - args:
         - --logtostderr
         - --insecure-listen-address=[$(IP)]:9500
@@ -10901,6 +10931,9 @@ spec:
       - name: ws-manager-client-tls-certs
         secret:
           secretName: ws-manager-client-tls
+      - name: admin-login-key
+        secret:
+          secretName: server-admin-secret
 status: {}
 ---
 # apps/v1/Deployment ws-manager

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -1301,6 +1301,19 @@ data:
   proxyUsername: ""
   proxyPassword: ""
 ---
+# v1/Secret server-admin-secret
+apiVersion: v1
+data:
+  login-key: bTMwRUgtTTItY1dNZ2tnZHk3cHU=
+kind: Secret
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: server
+  name: server-admin-secret
+  namespace: default
+---
 # v1/ConfigMap agent-smith
 apiVersion: v1
 data:
@@ -2679,6 +2692,16 @@ data:
         app: gitpod
         component: server
       name: server
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: server
+      name: server-admin-secret
       namespace: default
     ---
     apiVersion: networking.k8s.io/v1
@@ -5465,7 +5488,7 @@ data:
       },
       "oauthServer": {
         "enabled": true,
-        "jwtSecret": "m30EH-M2-cWMgkgdy7pu"
+        "jwtSecret": "_7wODLGlsPauKCw4SBI2"
       },
       "rateLimiter": {
         "groups": {
@@ -5498,6 +5521,10 @@ data:
         "contentLimit": 0,
         "resources": null
       },
+      "admin": {
+        "grantFirstUserAdminRole": true
+      },
+      "adminLoginKeyFile": "/admin/login-key",
       "prebuildLimiter": {
         "*": {
           "limit": 100,
@@ -10658,7 +10685,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: f52ae23eddcf2fe15c87ec92cc3d998045c5ff491d52caed0f23a6fccc020134
+        gitpod.io/checksum_config: 550e02430b4a042f739e7c0d1baa862ef615c832e308bd185227308e596dec0d
       creationTimestamp: null
       labels:
         app: gitpod
@@ -10799,6 +10826,9 @@ spec:
         - mountPath: /ws-manager-client-tls-certs
           name: ws-manager-client-tls-certs
           readOnly: true
+        - mountPath: /admin
+          name: admin-login-key
+          readOnly: true
       - args:
         - --logtostderr
         - --insecure-listen-address=[$(IP)]:9500
@@ -10913,6 +10943,9 @@ spec:
       - name: ws-manager-client-tls-certs
         secret:
           secretName: ws-manager-client-tls
+      - name: admin-login-key
+        secret:
+          secretName: server-admin-secret
 status: {}
 ---
 # apps/v1/Deployment ws-manager

--- a/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
+++ b/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
@@ -1523,6 +1523,19 @@ data:
   proxyUsername: ""
   proxyPassword: ""
 ---
+# v1/Secret server-admin-secret
+apiVersion: v1
+data:
+  login-key: bTMwRUgtTTItY1dNZ2tnZHk3cHU=
+kind: Secret
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: server
+  name: server-admin-secret
+  namespace: default
+---
 # v1/ConfigMap agent-smith
 apiVersion: v1
 data:
@@ -2955,6 +2968,16 @@ data:
         app: gitpod
         component: server
       name: server
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: server
+      name: server-admin-secret
       namespace: default
     ---
     apiVersion: networking.k8s.io/v1
@@ -5786,7 +5809,7 @@ data:
       },
       "oauthServer": {
         "enabled": true,
-        "jwtSecret": "m30EH-M2-cWMgkgdy7pu"
+        "jwtSecret": "_7wODLGlsPauKCw4SBI2"
       },
       "rateLimiter": {
         "groups": {
@@ -5819,6 +5842,10 @@ data:
         "contentLimit": 0,
         "resources": null
       },
+      "admin": {
+        "grantFirstUserAdminRole": true
+      },
+      "adminLoginKeyFile": "/admin/login-key",
       "prebuildLimiter": {
         "*": {
           "limit": 100,
@@ -11090,7 +11117,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: f52ae23eddcf2fe15c87ec92cc3d998045c5ff491d52caed0f23a6fccc020134
+        gitpod.io/checksum_config: 550e02430b4a042f739e7c0d1baa862ef615c832e308bd185227308e596dec0d
       creationTimestamp: null
       labels:
         app: gitpod
@@ -11231,6 +11258,9 @@ spec:
         - mountPath: /ws-manager-client-tls-certs
           name: ws-manager-client-tls-certs
           readOnly: true
+        - mountPath: /admin
+          name: admin-login-key
+          readOnly: true
       - args:
         - --logtostderr
         - --insecure-listen-address=[$(IP)]:9500
@@ -11345,6 +11375,9 @@ spec:
       - name: ws-manager-client-tls-certs
         secret:
           secretName: ws-manager-client-tls
+      - name: admin-login-key
+        secret:
+          secretName: server-admin-secret
 status: {}
 ---
 # apps/v1/Deployment ws-manager

--- a/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
+++ b/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
@@ -1301,6 +1301,19 @@ data:
   proxyUsername: ""
   proxyPassword: ""
 ---
+# v1/Secret server-admin-secret
+apiVersion: v1
+data:
+  login-key: bTMwRUgtTTItY1dNZ2tnZHk3cHU=
+kind: Secret
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: server
+  name: server-admin-secret
+  namespace: default
+---
 # v1/ConfigMap agent-smith
 apiVersion: v1
 data:
@@ -2669,6 +2682,16 @@ data:
         app: gitpod
         component: server
       name: server
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: server
+      name: server-admin-secret
       namespace: default
     ---
     apiVersion: networking.k8s.io/v1
@@ -5455,7 +5478,7 @@ data:
       },
       "oauthServer": {
         "enabled": true,
-        "jwtSecret": "m30EH-M2-cWMgkgdy7pu"
+        "jwtSecret": "_7wODLGlsPauKCw4SBI2"
       },
       "rateLimiter": {
         "groups": {
@@ -5488,6 +5511,10 @@ data:
         "contentLimit": 0,
         "resources": null
       },
+      "admin": {
+        "grantFirstUserAdminRole": true
+      },
+      "adminLoginKeyFile": "/admin/login-key",
       "prebuildLimiter": {
         "*": {
           "limit": 100,
@@ -10636,7 +10663,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: f52ae23eddcf2fe15c87ec92cc3d998045c5ff491d52caed0f23a6fccc020134
+        gitpod.io/checksum_config: 550e02430b4a042f739e7c0d1baa862ef615c832e308bd185227308e596dec0d
       creationTimestamp: null
       labels:
         app: gitpod
@@ -10777,6 +10804,9 @@ spec:
         - mountPath: /ws-manager-client-tls-certs
           name: ws-manager-client-tls-certs
           readOnly: true
+        - mountPath: /admin
+          name: admin-login-key
+          readOnly: true
       - args:
         - --logtostderr
         - --insecure-listen-address=[$(IP)]:9500
@@ -10891,6 +10921,9 @@ spec:
       - name: ws-manager-client-tls-certs
         secret:
           secretName: ws-manager-client-tls
+      - name: admin-login-key
+        secret:
+          secretName: server-admin-secret
 status: {}
 ---
 # apps/v1/Deployment ws-manager

--- a/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
+++ b/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
@@ -1301,6 +1301,19 @@ data:
   proxyUsername: ""
   proxyPassword: ""
 ---
+# v1/Secret server-admin-secret
+apiVersion: v1
+data:
+  login-key: bTMwRUgtTTItY1dNZ2tnZHk3cHU=
+kind: Secret
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: server
+  name: server-admin-secret
+  namespace: default
+---
 # v1/ConfigMap agent-smith
 apiVersion: v1
 data:
@@ -2670,6 +2683,16 @@ data:
         app: gitpod
         component: server
       name: server
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: server
+      name: server-admin-secret
       namespace: default
     ---
     apiVersion: networking.k8s.io/v1
@@ -5456,7 +5479,7 @@ data:
       },
       "oauthServer": {
         "enabled": true,
-        "jwtSecret": "m30EH-M2-cWMgkgdy7pu"
+        "jwtSecret": "_7wODLGlsPauKCw4SBI2"
       },
       "rateLimiter": {
         "groups": {
@@ -5489,6 +5512,10 @@ data:
         "contentLimit": 0,
         "resources": null
       },
+      "admin": {
+        "grantFirstUserAdminRole": true
+      },
+      "adminLoginKeyFile": "/admin/login-key",
       "prebuildLimiter": {
         "*": {
           "limit": 100,
@@ -10649,7 +10676,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: f52ae23eddcf2fe15c87ec92cc3d998045c5ff491d52caed0f23a6fccc020134
+        gitpod.io/checksum_config: 550e02430b4a042f739e7c0d1baa862ef615c832e308bd185227308e596dec0d
       creationTimestamp: null
       labels:
         app: gitpod
@@ -10790,6 +10817,9 @@ spec:
         - mountPath: /ws-manager-client-tls-certs
           name: ws-manager-client-tls-certs
           readOnly: true
+        - mountPath: /admin
+          name: admin-login-key
+          readOnly: true
       - args:
         - --logtostderr
         - --insecure-listen-address=[$(IP)]:9500
@@ -10904,6 +10934,9 @@ spec:
       - name: ws-manager-client-tls-certs
         secret:
           secretName: ws-manager-client-tls
+      - name: admin-login-key
+        secret:
+          secretName: server-admin-secret
 status: {}
 ---
 # apps/v1/Deployment ws-manager

--- a/install/installer/pkg/common/render.go
+++ b/install/installer/pkg/common/render.go
@@ -67,6 +67,7 @@ type GeneratedValues struct {
 	InternalRegistryPassword     string
 	InternalRegistrySharedSecret string
 	MessageBusPassword           string
+	ServerAdminLoginKey          string
 }
 
 type RenderContext struct {
@@ -168,6 +169,12 @@ func (r *RenderContext) generateValues() error {
 		messageBusPassword = "uq4KxOLtrA-QsDTfuwQ-"
 	}
 	r.Values.MessageBusPassword = messageBusPassword
+
+	serverAdminLoginKey, err := RandomString(20)
+	if err != nil {
+		return err
+	}
+	r.Values.ServerAdminLoginKey = serverAdminLoginKey
 
 	return nil
 }

--- a/install/installer/pkg/components/server/admin_secret.go
+++ b/install/installer/pkg/components/server/admin_secret.go
@@ -1,0 +1,28 @@
+// Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package server
+
+import (
+	_ "embed"
+
+	"github.com/gitpod-io/gitpod/installer/pkg/common"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func AdminSecret(ctx *common.RenderContext) ([]runtime.Object, error) {
+	return []runtime.Object{&corev1.Secret{
+		TypeMeta: common.TypeMetaSecret,
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      AdminSecretName,
+			Namespace: ctx.Namespace,
+			Labels:    common.DefaultLabels(Component),
+		},
+		Data: map[string][]byte{
+			AdminSecretLoginKeyName: []byte(ctx.Values.ServerAdminLoginKey),
+		},
+	}}, nil
+}

--- a/install/installer/pkg/components/server/configmap.go
+++ b/install/installer/pkg/components/server/configmap.go
@@ -234,7 +234,6 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		MaxConcurrentPrebuildsPerRef:      10,
 		IncrementalPrebuilds:              IncrementalPrebuilds{CommitHistory: 100, RepositoryPasslist: []string{}},
 		BlockNewUsers:                     ctx.Config.BlockNewUsers,
-		MakeNewUsersAdmin:                 false,
 		DefaultBaseImageRegistryWhitelist: defaultBaseImageRegistryWhitelist,
 		RunDbDeleter:                      runDbDeleter,
 		OAuthServer: OAuthServer{
@@ -277,6 +276,10 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		InactivityPeriodForReposInDays: inactivityPeriodForReposInDays,
 		PATSigningKeyFile:              personalAccessTokenSigningKeyPath,
 		WithoutWorkspaceComponents:     withoutWorkspaceComponents,
+		Admin: AdminConfig{
+			GrantFirstUserAdminRole: true, // existing default
+		},
+		AdminLoginKeyFile: fmt.Sprintf("%s/%s", AdminSecretMountPath, AdminSecretLoginKeyName),
 	}
 
 	fc, err := common.ToJSONString(scfg)

--- a/install/installer/pkg/components/server/constants.go
+++ b/install/installer/pkg/components/server/constants.go
@@ -25,4 +25,7 @@ const (
 	DebugNodePortName                      = "debugnode"
 	ServicePort                            = 3000
 	personalAccessTokenSigningKeyMountPath = "/secrets/personal-access-token-signing-key"
+	AdminSecretName                        = "server-admin-secret"
+	AdminSecretLoginKeyName                = "login-key"
+	AdminSecretMountPath                   = "/admin"
 )

--- a/install/installer/pkg/components/server/deployment.go
+++ b/install/installer/pkg/components/server/deployment.go
@@ -327,6 +327,21 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 		})
 	}
 
+	// admin secret
+	volumes = append(volumes, corev1.Volume{
+		Name: "admin-login-key",
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{
+				SecretName: AdminSecretName,
+			},
+		},
+	})
+	volumeMounts = append(volumeMounts, corev1.VolumeMount{
+		Name:      "admin-login-key",
+		MountPath: AdminSecretMountPath,
+		ReadOnly:  true,
+	})
+
 	return []runtime.Object{
 		&appsv1.Deployment{
 			TypeMeta: common.TypeMetaDeployment,

--- a/install/installer/pkg/components/server/objects.go
+++ b/install/installer/pkg/components/server/objects.go
@@ -14,6 +14,9 @@ var Objects = common.CompositeRenderFunc(
 	configmap,
 	deployment,
 	func(ctx *common.RenderContext) ([]runtime.Object, error) {
+		return AdminSecret(ctx)
+	},
+	func(ctx *common.RenderContext) ([]runtime.Object, error) {
 		return Networkpolicy(ctx, Component)
 	},
 	func(ctx *common.RenderContext) ([]runtime.Object, error) {

--- a/install/installer/pkg/components/server/types.go
+++ b/install/installer/pkg/components/server/types.go
@@ -52,6 +52,8 @@ type ConfigSerialized struct {
 	OAuthServer                OAuthServer                `json:"oauthServer"`
 	RateLimiter                RateLimiter                `json:"rateLimiter"`
 	CodeSync                   CodeSync                   `json:"codeSync"`
+	Admin                      AdminConfig                `json:"admin"`
+	AdminLoginKeyFile          string                     `json:"adminLoginKeyFile"`
 	// PrebuildLimiter defines the number of prebuilds allowed for each cloneURL in a given 1 minute interval
 	// Key of "*" defines the default limit, unless there exists a cloneURL in the map which overrides it.
 	PrebuildLimiter                PrebuildRateLimiters `json:"prebuildLimiter"`
@@ -164,4 +166,8 @@ type PrebuildRateLimiters = map[string]PrebuildRateLimiterConfig
 type PrebuildRateLimiterConfig struct {
 	Limit  uint32 `json:"limit"`
 	Period uint32 `json:"period"`
+}
+
+type AdminConfig struct {
+	GrantFirstUserAdminRole bool `json:"grantFirstUserAdminRole"`
 }

--- a/install/installer/pkg/components/slowserver/configmap.go
+++ b/install/installer/pkg/components/slowserver/configmap.go
@@ -249,6 +249,10 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		},
 		WorkspaceClasses:               workspaceClasses,
 		InactivityPeriodForReposInDays: inactivityPeriodForReposInDays,
+		Admin: server.AdminConfig{
+			GrantFirstUserAdminRole: true, // existing default
+		},
+		AdminLoginKeyFile: fmt.Sprintf("%s/%s", server.AdminSecretMountPath, server.AdminSecretLoginKeyName),
 	}
 
 	fc, err := common.ToJSONString(scfg)

--- a/install/installer/pkg/components/slowserver/deployment.go
+++ b/install/installer/pkg/components/slowserver/deployment.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gitpod-io/gitpod/common-go/baseserver"
 	"github.com/gitpod-io/gitpod/installer/pkg/cluster"
 	contentservice "github.com/gitpod-io/gitpod/installer/pkg/components/content-service"
+	"github.com/gitpod-io/gitpod/installer/pkg/components/server"
 	"github.com/gitpod-io/gitpod/installer/pkg/components/toxiproxy"
 	"github.com/gitpod-io/gitpod/installer/pkg/components/usage"
 	wsmanager "github.com/gitpod-io/gitpod/installer/pkg/components/ws-manager"
@@ -354,6 +355,21 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 			ReadOnly:  true,
 		})
 	}
+
+	// admin secret
+	volumes = append(volumes, corev1.Volume{
+		Name: "admin-login-key",
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{
+				SecretName: server.AdminSecretName,
+			},
+		},
+	})
+	volumeMounts = append(volumeMounts, corev1.VolumeMount{
+		Name:      "admin-login-key",
+		MountPath: server.AdminSecretMountPath,
+		ReadOnly:  true,
+	})
 
 	return []runtime.Object{
 		&appsv1.Deployment{

--- a/install/installer/pkg/components/slowserver/objects.go
+++ b/install/installer/pkg/components/slowserver/objects.go
@@ -21,6 +21,9 @@ func Objects(ctx *common.RenderContext) ([]runtime.Object, error) {
 		configmap,
 		deployment,
 		func(ctx *common.RenderContext) ([]runtime.Object, error) {
+			return server.AdminSecret(ctx)
+		},
+		func(ctx *common.RenderContext) ([]runtime.Object, error) {
 			return server.Networkpolicy(ctx, Component)
 		},
 		func(ctx *common.RenderContext) ([]runtime.Object, error) {

--- a/install/installer/pkg/components/slowserver/render_test.go
+++ b/install/installer/pkg/components/slowserver/render_test.go
@@ -36,7 +36,7 @@ func TestObjects_RenderedWhenExperimentalConfigSet(t *testing.T) {
 	objects, err := Objects(ctx)
 	require.NoError(t, err)
 	require.NotEmpty(t, objects, "must render objects because experimental config is specified")
-	require.Len(t, objects, 9, "should render expected k8s objects")
+	require.Len(t, objects, 10, "should render expected k8s objects")
 }
 
 func TestServerDeployment_UsesToxiproxyDbHost(t *testing.T) {


### PR DESCRIPTION
## Description

This PR introduces a single, per-installation `admin-user` with a predefined userId, which can login to a web session using an OTS that needs to be created using a private endpoint beforehand. 

- add a static `admin-user` that is `blocked` by default
- adds a non-exposed endpoint to create an OTS token for login purposes for that `admin-user` (`/admin-user/login-token/create`)
- adds an exposed endpoint to login into a web session using said token (`/login/ots/admin-user/:key`)
- integrate with preview deployment: if `with-dedicated-emulation` is ticked, output a fresh OTS with login link in werft

### Login flow

:information_source: Be aware this is meant as a _first version_ to get us going with _something_. Depending on product requirements (ability to re-login), and technical possibilities/constraints from Dedicated Cells (Scout Team) this might to change again in the actual implementation, especially around token generation/handling.

Current flow impl:
1. installer generates a `admin-login-key` secret that gets mounted into `server`
1. on `/admin-user/login-token/create`, `server` creates a new OTS (expiry: 24h), where the hash is sugared with that secret. Also, the `admin-user` stays `blocked` until the first call here
2. on `/login/ots/admin-user/:key`, `server` validates the OTS value using that secret, and puts the client into a web session with `admin-user`

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #15657

## How to test

1. Start [workspace on this branch](https://gitpod-io/#https://github.com/gitpod-io/gitpod/pull/15805) and `kubectl port-forward deployment/server 9000:9000 &`
2. Obtain OTS key: `curl -X POST localhost:9000/admin-user/login-token/create`
3. Use the result to construct your login URL: `https://gpl-15657-setup-user.preview.gitpod-dev.com/api/login/ots/admin-user/:yourOtsKey` and visit it
4. You should be logged in as `admin-user` :checkered_flag: 


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-dedicated-emulation
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
