### PR TITLE
Accessibility improvements on the New Workspace modal

### DIFF
--- a/components/dashboard/src/components/DropDown2.tsx
+++ b/components/dashboard/src/components/DropDown2.tsx
@@ -158,12 +158,14 @@ export const DropDown2: FunctionComponent<DropDown2Props> = (props) => {
                                 />
                             </div>
                         )}
-                        <ul>
+                        <ul role="listbox" aria-activedescendant={selectedElementTemp} tabIndex={0}>
                             {filteredOptions.length > 0 ? (
                                 filteredOptions.map((element) => {
                                     let selectionClasses = `dark:bg-gray-800 cursor-pointer`;
-                                    if (element.id === selectedElementTemp) {
-                                        selectionClasses = `bg-gray-200 dark:bg-gray-700 cursor-pointer  focus:outline-none focus:ring-0`;
+                                    const active = element.id === selectedElementTemp;
+
+                                    if (active) {
+                                        selectionClasses = `bg-gray-200 dark:bg-gray-700 cursor-pointer focus:outline-none focus:ring-0`;
                                     }
                                     if (!element.isSelectable) {
                                         selectionClasses = ``;
@@ -173,6 +175,8 @@ export const DropDown2: FunctionComponent<DropDown2Props> = (props) => {
                                             key={element.id}
                                             id={element.id}
                                             tabIndex={0}
+                                            role="option"
+                                            aria-selected={active}
                                             className={"h-16 rounded-lg flex items-center px-2 " + selectionClasses}
                                             onMouseDown={() => {
                                                 if (element.isSelectable) {

--- a/components/dashboard/src/components/DropDown2.tsx
+++ b/components/dashboard/src/components/DropDown2.tsx
@@ -88,7 +88,7 @@ export const DropDown2: FunctionComponent<DropDown2Props> = (props) => {
                 setShowDropDown(false);
                 e.preventDefault();
             }
-            if (e.key === "Enter") {
+            if (e.key === "Enter" || e.key === "Space") {
                 if (showDropDown && selectedElementTemp && filteredOptions.some((e) => e.id === selectedElementTemp)) {
                     e.preventDefault();
                     props.onSelectionChange(selectedElementTemp);

--- a/components/dashboard/src/components/Modal.tsx
+++ b/components/dashboard/src/components/Modal.tsx
@@ -82,15 +82,15 @@ export default function Modal(props: {
                     )}
                 >
                     {props.closeable !== false && (
-                        <div
-                            className="absolute right-7 top-6 cursor-pointer text-gray-800 dark:text-gray-100 hover:bg-gray-200 dark:hover:bg-gray-700 rounded-md p-2"
+                        <button
+                            className="absolute right-7 top-6 cursor-pointer text-gray-800 bg-transparent dark:text-gray-100 hover:bg-gray-200 dark:hover:bg-gray-700 rounded-md p-2"
                             onClick={() => closeModal("x")}
                         >
                             <svg version="1.1" width="14px" height="14px" viewBox="0 0 100 100">
                                 <line x1="0" y1="0" x2="100" y2="100" stroke="currentColor" strokeWidth="10px" />
                                 <line x1="0" y1="100" x2="100" y2="0" stroke="currentColor" strokeWidth="10px" />
                             </svg>
-                        </div>
+                        </button>
                     )}
                     {props.title ? (
                         <>

--- a/components/dashboard/src/components/Modal.tsx
+++ b/components/dashboard/src/components/Modal.tsx
@@ -84,6 +84,13 @@ export default function Modal(props: {
                     {props.closeable !== false && (
                         <button
                             className="absolute right-7 top-6 cursor-pointer text-gray-800 bg-transparent dark:text-gray-100 hover:bg-gray-200 dark:hover:bg-gray-700 rounded-md p-2"
+                            onKeyDown={(e) => {
+                                // Prevent the modal from submitting when attempting to close it
+                                if (e.key === "Enter" || e.key === "Space") {
+                                    e.preventDefault();
+                                    closeModal("x");
+                                }
+                            }}
                             onClick={() => closeModal("x")}
                         >
                             <svg version="1.1" width="14px" height="14px" viewBox="0 0 100 100">

--- a/components/dashboard/src/components/Modal.tsx
+++ b/components/dashboard/src/components/Modal.tsx
@@ -73,7 +73,11 @@ export default function Modal(props: {
     }
 
     return (
-        <div className="fixed top-0 left-0 bg-black bg-opacity-70 z-50 w-screen h-screen">
+        <div
+            className="fixed top-0 left-0 bg-black bg-opacity-70 z-50 w-screen h-screen"
+            aria-labelledby="modal-title"
+            role="alertdialog"
+        >
             <div className="w-screen h-screen align-middle" style={{ display: "table-cell" }}>
                 <div
                     className={cn(
@@ -84,6 +88,7 @@ export default function Modal(props: {
                     {props.closeable !== false && (
                         <button
                             className="absolute right-7 top-6 cursor-pointer text-gray-800 bg-transparent dark:text-gray-100 hover:bg-gray-200 dark:hover:bg-gray-700 rounded-md p-2"
+                            aria-label="Close this modal"
                             onKeyDown={(e) => {
                                 // Prevent the modal from submitting when attempting to close it
                                 if (e.key === "Enter" || e.key === "Space") {
@@ -119,7 +124,11 @@ type ModalHeaderProps = {
 };
 
 export const ModalHeader = ({ children }: ModalHeaderProps) => {
-    return <h3 className="pb-2">{children}</h3>;
+    return (
+        <h3 className="pb-2" id="modal-title">
+            {children}
+        </h3>
+    );
 };
 
 type ModalBodyProps = {


### PR DESCRIPTION
## Description

The <kbd>X</kbd> modal-closing button is focusable via subsequent keyboard navigation

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test

Open the preview environment, hit <kbd>Cmd+O</kbd> and try to navigate via <kbd>Tab</kbd> onto the closing button - and try to close the modal with it using <kbd>Space</kbd> or <kbd>Enter</kbd>.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
