### PR TITLE
[server, cli] Allow flexible workspace timeouts

### DIFF
--- a/components/gitpod-cli/cmd/timeout-set.go
+++ b/components/gitpod-cli/cmd/timeout-set.go
@@ -15,10 +15,16 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// extendTimeoutCmd extend timeout of current workspace
-var extendTimeoutCmd = &cobra.Command{
-	Use:   "extend",
-	Short: "Extend timeout of current workspace",
+// setTimeoutCmd sets the timeout of current workspace
+var setTimeoutCmd = &cobra.Command{
+	Use:   "set <duration>",
+	Args:  cobra.ExactArgs(1),
+	Short: "Set timeout of current workspace",
+	Long: `Set timeout of current workspace.
+
+Duration must be in the format of <n>m (minutes), <n>h (hours), or <n>d (days).
+For example, 30m, 1h, 2d, etc.`,
+	Example: `gitpod timeout set 1h`,
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
@@ -33,16 +39,20 @@ var extendTimeoutCmd = &cobra.Command{
 		if err != nil {
 			fail(err.Error())
 		}
-		if _, err := client.SetWorkspaceTimeout(ctx, wsInfo.WorkspaceId, time.Minute*180); err != nil {
+		duration, err := time.ParseDuration(args[0])
+		if err != nil {
+			fail(err.Error())
+		}
+		if _, err := client.SetWorkspaceTimeout(ctx, wsInfo.WorkspaceId, duration); err != nil {
 			if err, ok := err.(*jsonrpc2.Error); ok && err.Code == serverapi.PLAN_PROFESSIONAL_REQUIRED {
 				fail("Cannot extend workspace timeout for current plan, please upgrade your plan")
 			}
 			fail(err.Error())
 		}
-		fmt.Println("Workspace timeout has been extended to three hours.")
+		fmt.Printf("Workspace timeout has been set to %d minutes.\n", int(duration.Minutes()))
 	},
 }
 
 func init() {
-	timeoutCmd.AddCommand(extendTimeoutCmd)
+	timeoutCmd.AddCommand(setTimeoutCmd)
 }

--- a/components/gitpod-cli/cmd/timeout-show.go
+++ b/components/gitpod-cli/cmd/timeout-show.go
@@ -37,13 +37,11 @@ var showTimeoutCommand = &cobra.Command{
 			fail(err.Error())
 		}
 
-		// Try to use `DurationRaw` but fall back to `Duration` in case of
-		// old server component versions that don't expose it.
-		if res.DurationRaw != "" {
-			fmt.Println("Timeout for current workspace is", res.DurationRaw)
-		} else {
-			fmt.Println("Timeout for current workspace is", res.Duration)
+		duration, err := time.ParseDuration(res.Duration)
+		if err != nil {
+			fail(err.Error())
 		}
+		fmt.Printf("Workspace timeout is set to %d minutes.\n", int(duration.Minutes()))
 	},
 }
 

--- a/components/gitpod-protocol/go/mock.go
+++ b/components/gitpod-protocol/go/mock.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Copyright (c) 2023 Gitpod GmbH. All rights reserved.
 // Licensed under the GNU Affero General Public License (AGPL).
 // See License.AGPL.txt in the project root for license information.
 
@@ -11,6 +11,7 @@ package protocol
 import (
 	context "context"
 	reflect "reflect"
+	time "time"
 
 	gomock "github.com/golang/mock/gomock"
 )
@@ -951,7 +952,7 @@ func (mr *MockAPIInterfaceMockRecorder) SetWorkspaceDescription(ctx, id, desc in
 }
 
 // SetWorkspaceTimeout mocks base method.
-func (m *MockAPIInterface) SetWorkspaceTimeout(ctx context.Context, workspaceID string, duration *WorkspaceTimeoutDuration) (*SetWorkspaceTimeoutResult, error) {
+func (m *MockAPIInterface) SetWorkspaceTimeout(ctx context.Context, workspaceID string, duration time.Duration) (*SetWorkspaceTimeoutResult, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetWorkspaceTimeout", ctx, workspaceID, duration)
 	ret0, _ := ret[0].(*SetWorkspaceTimeoutResult)

--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -353,16 +353,24 @@ export interface ClientHeaderFields {
     clientRegion?: string;
 }
 
-export const WORKSPACE_TIMEOUT_DEFAULT_SHORT = "short";
-export const WORKSPACE_TIMEOUT_DEFAULT_LONG = "long";
-export const WORKSPACE_TIMEOUT_EXTENDED = "extended";
-export const WORKSPACE_TIMEOUT_EXTENDED_ALT = "180m"; // for backwards compatibility since the IDE uses this
-export const WorkspaceTimeoutValues = [
-    WORKSPACE_TIMEOUT_DEFAULT_SHORT,
-    WORKSPACE_TIMEOUT_DEFAULT_LONG,
-    WORKSPACE_TIMEOUT_EXTENDED,
-    WORKSPACE_TIMEOUT_EXTENDED_ALT,
-] as const;
+export type WorkspaceTimeoutDuration = string;
+export namespace WorkspaceTimeoutDuration {
+    export function validate(duration: string): WorkspaceTimeoutDuration {
+        const unit = duration.slice(-1);
+        if (!["m", "h", "d"].includes(unit)) {
+            throw new Error(`Invalid timeout unit: ${unit}`);
+        }
+        const value = parseInt(duration.slice(0, -1));
+        if (isNaN(value) || value <= 0) {
+            throw new Error(`Invalid timeout value: ${duration}`);
+        }
+        return duration;
+    }
+}
+
+export const WORKSPACE_TIMEOUT_DEFAULT_SHORT: WorkspaceTimeoutDuration = "30m";
+export const WORKSPACE_TIMEOUT_DEFAULT_LONG: WorkspaceTimeoutDuration = "60m";
+export const WORKSPACE_TIMEOUT_EXTENDED: WorkspaceTimeoutDuration = "180m";
 
 export const createServiceMock = function <C extends GitpodClient, S extends GitpodServer>(
     methods: Partial<JsonRpcProxy<S>>,
@@ -387,16 +395,12 @@ export const createServerMock = function <C extends GitpodClient, S extends Gitp
     });
 };
 
-type WorkspaceTimeoutDurationTuple = typeof WorkspaceTimeoutValues;
-export type WorkspaceTimeoutDuration = WorkspaceTimeoutDurationTuple[number];
-
 export interface SetWorkspaceTimeoutResult {
     resetTimeoutOnWorkspaces: string[];
 }
 
 export interface GetWorkspaceTimeoutResult {
     duration: WorkspaceTimeoutDuration;
-    durationRaw: string;
     canChange: boolean;
 }
 

--- a/components/server/ee/src/user/user-service.ts
+++ b/components/server/ee/src/user/user-service.ts
@@ -5,14 +5,7 @@
  */
 
 import { UserService, CheckSignUpParams, CheckTermsParams } from "../../../src/user/user-service";
-import {
-    User,
-    WorkspaceTimeoutDuration,
-    WORKSPACE_TIMEOUT_EXTENDED,
-    WORKSPACE_TIMEOUT_EXTENDED_ALT,
-    WORKSPACE_TIMEOUT_DEFAULT_LONG,
-    WORKSPACE_TIMEOUT_DEFAULT_SHORT,
-} from "@gitpod/gitpod-protocol";
+import { User } from "@gitpod/gitpod-protocol";
 import { inject } from "inversify";
 import { LicenseEvaluator } from "@gitpod/licensor/lib";
 import { AuthException } from "../../../src/auth/errors";
@@ -27,31 +20,6 @@ export class UserServiceEE extends UserService {
     @inject(OssAllowListDB) protected readonly OssAllowListDb: OssAllowListDB;
     @inject(HostContextProvider) protected readonly hostContextProvider: HostContextProvider;
     @inject(Config) protected readonly config: Config;
-
-    public workspaceTimeoutToDuration(timeout: WorkspaceTimeoutDuration): string {
-        switch (timeout) {
-            case WORKSPACE_TIMEOUT_DEFAULT_SHORT:
-                return "30m";
-            case WORKSPACE_TIMEOUT_DEFAULT_LONG:
-                return this.config.workspaceDefaults.timeoutDefault || "60m";
-            case WORKSPACE_TIMEOUT_EXTENDED:
-            case WORKSPACE_TIMEOUT_EXTENDED_ALT:
-                return this.config.workspaceDefaults.timeoutExtended || "180m";
-        }
-    }
-
-    public durationToWorkspaceTimeout(duration: string): WorkspaceTimeoutDuration {
-        switch (duration) {
-            case "30m":
-                return WORKSPACE_TIMEOUT_DEFAULT_SHORT;
-            case this.config.workspaceDefaults.timeoutDefault || "60m":
-                return WORKSPACE_TIMEOUT_DEFAULT_LONG;
-            case this.config.workspaceDefaults.timeoutExtended || "180m":
-                return WORKSPACE_TIMEOUT_EXTENDED_ALT;
-            default:
-                return WORKSPACE_TIMEOUT_DEFAULT_SHORT;
-        }
-    }
 
     async checkSignUp(params: CheckSignUpParams) {
         // todo@at: check if we need an optimization for SaaS here. used to be a no-op there.

--- a/components/server/src/user/user-service.ts
+++ b/components/server/src/user/user-service.ts
@@ -5,18 +5,7 @@
  */
 
 import { injectable, inject } from "inversify";
-import {
-    User,
-    Identity,
-    WorkspaceTimeoutDuration,
-    UserEnvVarValue,
-    Token,
-    WORKSPACE_TIMEOUT_DEFAULT_SHORT,
-    WORKSPACE_TIMEOUT_DEFAULT_LONG,
-    WORKSPACE_TIMEOUT_EXTENDED,
-    WORKSPACE_TIMEOUT_EXTENDED_ALT,
-    Workspace,
-} from "@gitpod/gitpod-protocol";
+import { User, Identity, UserEnvVarValue, Token, Workspace } from "@gitpod/gitpod-protocol";
 import { ProjectDB, TeamDB, TermsAcceptanceDB, UserDB } from "@gitpod/gitpod-db/lib";
 import { HostContextProvider } from "../auth/host-context-provider";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
@@ -165,31 +154,6 @@ export class UserService {
         }
         if (!newUser.blocked && (isFirstUser || this.config.makeNewUsersAdmin)) {
             newUser.rolesOrPermissions = ["admin"];
-        }
-    }
-
-    public workspaceTimeoutToDuration(timeout: WorkspaceTimeoutDuration): string {
-        switch (timeout) {
-            case WORKSPACE_TIMEOUT_DEFAULT_SHORT:
-                return "30m";
-            case WORKSPACE_TIMEOUT_DEFAULT_LONG:
-                return "60m";
-            case WORKSPACE_TIMEOUT_EXTENDED:
-            case WORKSPACE_TIMEOUT_EXTENDED_ALT:
-                return "180m";
-        }
-    }
-
-    public durationToWorkspaceTimeout(duration: string): WorkspaceTimeoutDuration {
-        switch (duration) {
-            case "30m":
-                return WORKSPACE_TIMEOUT_DEFAULT_SHORT;
-            case "60m":
-                return WORKSPACE_TIMEOUT_DEFAULT_LONG;
-            case "180m":
-                return WORKSPACE_TIMEOUT_EXTENDED_ALT;
-            default:
-                return WORKSPACE_TIMEOUT_DEFAULT_SHORT;
         }
     }
 

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -1483,7 +1483,7 @@ export class WorkspaceStarter {
         spec.setClass(instance.workspaceClass!);
 
         if (workspace.type === "regular") {
-            spec.setTimeout(this.userService.workspaceTimeoutToDuration(await userTimeoutPromise));
+            spec.setTimeout(await userTimeoutPromise);
         }
         spec.setAdmission(admissionLevel);
         const sshKeys = await this.userDB.trace(traceCtx).getSSHPublicKeys(user.id);


### PR DESCRIPTION
## Description
Makes setWorkspaceTimout handle arbitrary poistive duration strings, matching the format <\D+[mhd]>, which is compatible with go's time Duration.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #9038

## How to test
<!-- Provide steps to test this PR -->
- Verify that extending timouts still work as before
- try `gp timeout set 4h` 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
A new CLI command `gp timeout set` allows to set the workspace timeout to arbitrary durations.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-payment
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
