### PR TITLE
Run license header checks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,6 +90,16 @@ jobs:
             echo "::error title=The Pre-Commit Checks Failed.::Please run 'pre-commit run --show-diff-on-failure'"
           fi
           exit "$RESULT"
+      - name: Check License Headers
+        shell: bash
+        working-directory: /workspace/gitpod
+        run: |
+          RESULT=0
+          LICENCE_HEADER_CHECK_ONLY=true leeway run components:update-license-header || RESULT=$?
+          if [ $RESULT -ne 0 ]; then
+            echo "::error title=There are some license headers missing.::Please run 'leeway run components:update-license-header'"
+          fi
+          exit "$RESULT"
       - name: Get Secrets from GCP
         id: 'secrets'
         uses: 'google-github-actions/get-secretmanager-secrets@v1'


### PR DESCRIPTION
## Description
This PR adds license validation to the build and reports errors as follows:

Error on workflow-level:
<img width="525" alt="image" src="https://user-images.githubusercontent.com/239422/213144158-1f5b7cd3-bf45-48ee-8d91-1ca195c13727.png">

Error on job-level:
<img width="1006" alt="image" src="https://user-images.githubusercontent.com/239422/213144026-511bed54-d9bd-4b59-9a5e-f259e91c2e18.png">


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #15758

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [x] /werft no-test
- [x] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
