### PR TITLE
Add MySQL service

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,8 +41,16 @@ jobs:
     runs-on: [self-hosted]
     outputs:
       version: ${{ steps.leeway.outputs.version }}
+    services:
+      mysql:
+        image: mysql:5.7
+        env:
+          MYSQL_ROOT_PASSWORD: test
+          MYSQL_TCP_PORT: 23306
     container:
       image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-leeway-v0.7.3.4
+      env:
+        DB_HOST: mysql
     steps:
       - uses: actions/checkout@v3
       - name: Configure workspace

--- a/.werft/build.yaml
+++ b/.werft/build.yaml
@@ -115,6 +115,8 @@ pod:
     #   mountPath: /mnt/secrets/github-ssh-key
     #   readOnly: true
     env:
+    - name: DB_HOST
+      value: 127.0.0.1
     - name: LEEWAY_WORKSPACE_ROOT
       value: /workspace
     - name: LEEWAY_REMOTE_CACHE_BUCKET

--- a/components/gitpod-db/BUILD.yaml
+++ b/components/gitpod-db/BUILD.yaml
@@ -50,7 +50,6 @@ packages:
       - :migrations
       - install/installer/pkg/components/database/incluster/init:init-scripts
     env:
-      - DB_HOST=127.0.0.1
       - DB_PORT=23306
       - DB_USER=root
       - DB_PASSWORD=test


### PR DESCRIPTION
## Description
Start a MySQL-Container alongside the GHA build. It's used by Database-Unit-Test.

## Related Issue(s)
Fixes #15823

## How to test
Successful Werft build: https://werft.gitpod-dev.com/job/gitpod-build-meysholdt-support-running-tests-15823.15/logs
Successful GHA build: https://github.com/gitpod-io/gitpod/actions/runs/3968144594/jobs/6800934542

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [x] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [x] leeway-no-cache
      leeway-target=components/gitpod-db:dbtest-init 
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
