### PR TITLE
[server] Cleanup movedImageBuilder flag

### DIFF
--- a/components/server/src/container-module.ts
+++ b/components/server/src/container-module.ts
@@ -54,7 +54,6 @@ import { StorageClient } from "./storage/storage-client";
 import {
     ImageBuilderClientConfig,
     ImageBuilderClientProvider,
-    CachingImageBuilderClientProvider,
     ImageBuilderClientCallMetrics,
 } from "@gitpod/image-builder/lib";
 import { ImageSourceProvider } from "./workspace/image-source-provider";
@@ -178,9 +177,8 @@ export const productionContainerModule = new ContainerModule((bind, unbind, isBo
         const config = ctx.container.get<Config>(Config);
         return { address: config.imageBuilderAddr };
     });
-    bind(CachingImageBuilderClientProvider).toSelf().inSingletonScope();
-    bind(WorkspaceClusterImagebuilderClientProvider).toSelf().inSingletonScope(); // during the transition period, we have two kinds of image builder client providers
-    bind(ImageBuilderClientProvider).toService(CachingImageBuilderClientProvider);
+    bind(WorkspaceClusterImagebuilderClientProvider).toSelf().inSingletonScope();
+    bind(ImageBuilderClientProvider).toService(WorkspaceClusterImagebuilderClientProvider);
     bind(ImageBuilderClientCallMetrics).toService(IClientCallMetrics);
 
     /* The binding order of the context parser does not configure preference/a working order. Each context parser must be able


### PR DESCRIPTION
## Description

Removes the `movedImageBuilder` ConfigCat flag, always building images in workspace clusters, as the flag has been enabled at 100% for over a week now.

Also updates dependency injection to bind `ImageBuilderClientProvider ` to a `WorkspaceClusterImagebuilderClientProvider`.

Tested that this still works for single-install clusters (i.e. a `full` install), as the `WorkspaceClusterImagebuilderClientProvider` will create a client for its own cluster (tested below).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/9143

## How to test

Tested as follows:
* Create `-f full` [workspace-preview](https://github.com/gitpod-io/workspace-preview) cluster, and ran a successful image build.
* Create a `-f meta` (doesn't contain ws components) with a `-f workspace` workspace-preview cluster, and ran a successful image build.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [x] /werft with-large-vm
- [ ] /werft with-integration-tests=webapp
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
