### PR TITLE
Add support for unit tests

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -35,6 +35,8 @@ Does this PR require updates to the documentation at www.gitpod.io/docs?
       Experimental feature to run the build with GitHub Actions (and not in Werft).
 - [ ] leeway-no-cache
       leeway-target=components:all-ci
+- [ ] /werft no-test
+      Run Leeway with `--dont-test`
 - [ ] /werft with-local-preview
       If enabled this will build `install/preview`
 - [ ] /werft with-preview

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,9 +103,11 @@ jobs:
           PR_DESC: '${{ github.event.pull_request.body }}'
         run: |
           PR_NO_CACHE=${{ contains(github.event.pull_request.body, '[x] leeway-no-cache') }}
+          PR_NO_TEST=${{ contains(github.event.pull_request.body, '[x] /werft no-test') }}
           PR_LEEWAY_TARGET=$(echo "$PR_DESC" | sed -n -e 's/^.*leeway-target=//p' | sed 's/\r$//')
 
           echo "PR_NO_CACHE=$PR_NO_CACHE" >> $GITHUB_ENV
+          echo "PR_NO_TEST=$PR_NO_TEST"   >> $GITHUB_ENV
           echo "PR_LEEWAY_TARGET=$PR_LEEWAY_TARGET" >> $GITHUB_ENV
       - name: Leeway Build
         id: leeway
@@ -117,17 +119,21 @@ jobs:
           SEGMENT_IO_TOKEN: '${{ steps.secrets.outputs.segment-io-token }}'
         run: |
           echo "version=$VERSION" >> $GITHUB_OUTPUT
-          [[ "$PR_NO_CACHE" = "true" ]] && CACHE="none" || CACHE="remote"
+          [[ "$PR_NO_CACHE" = "true" ]] && CACHE="none"       || CACHE="remote"
+          [[ "$PR_NO_TEST"  = "true" ]] && TEST="--dont-test" || TEST=""
           [[ -z "$PR_LEEWAY_TARGET" ]] && PR_LEEWAY_TARGET="components:all-ci"
+
+          mkdir -p /__w/gitpod/gitpod/test-coverage-report
 
           RESULT=0
           set -x
           leeway build $PR_LEEWAY_TARGET \
             --cache $CACHE \
+            $TEST \
             -Dversion=$VERSION \
             -DSEGMENT_IO_TOKEN=$SEGMENT_IO_TOKEN \
             -DpublishToNPM=false \
-            --dont-test \
+            --coverage-output-path=/__w/gitpod/gitpod/test-coverage-report \
             --report report.html || RESULT=$?
           set +x
 
@@ -144,6 +150,13 @@ jobs:
           path: |
             versions.yaml
             installer
+      - name: "Upload Test Coverage Report"
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-coverage-report
+          if-no-files-found: ignore
+          path: |
+            test-coverage-report
 
   install:
     needs: [previewctl, build, infrastructure]


### PR DESCRIPTION
## Description
* Add support for the `no-test` flag.
* Export Test Coverage Reports as build artifacts.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #15769

## How to test
* Build with TestCoverageReport: https://github.com/gitpod-io/gitpod/actions/runs/3968343938 
<img width="752" alt="image" src="https://user-images.githubusercontent.com/239422/213720230-8d78260f-05e6-4782-a879-e7f41aee2d22.png">

* Build with No-test: https://github.com/gitpod-io/gitpod/actions/runs/3968284554/jobs/6801254201

<img width="535" alt="image" src="https://user-images.githubusercontent.com/239422/213720507-f8400111-a6e9-4b39-848f-1caf71e69c69.png">



## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft no-test
- [x] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [x] leeway-no-cache
      leeway-target=components/ws-manager:app
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
