### PR TITLE
[obs] Fix webapp monitoring rule names

### DIFF
--- a/operations/observability/mixins/meta/rules/dashboard.yaml
+++ b/operations/observability/mixins/meta/rules/dashboard.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     prometheus: k8s
     role: alert-rules
-  name: server-monitoring-rules
+  name: dashboard-monitoring-rules
 spec:
   groups:
   - name: dashboard

--- a/operations/observability/mixins/meta/rules/db-sync.yaml
+++ b/operations/observability/mixins/meta/rules/db-sync.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     prometheus: k8s
     role: alert-rules
-  name: server-monitoring-rules
+  name: db-sync-monitoring-rules
 spec:
   groups:
   - name: db-sync

--- a/operations/observability/mixins/meta/rules/db.yaml
+++ b/operations/observability/mixins/meta/rules/db.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     prometheus: k8s
     role: alert-rules
-  name: server-monitoring-rules
+  name: db-monitoring-rules
 spec:
   groups:
   - name: db

--- a/operations/observability/mixins/meta/rules/payment-endpoint.yaml
+++ b/operations/observability/mixins/meta/rules/payment-endpoint.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     prometheus: k8s
     role: alert-rules
-  name: server-monitoring-rules
+  name: payment-endpoint-monitoring-rules
 spec:
   groups:
   - name: payment-endpoint

--- a/operations/observability/mixins/meta/rules/proxy.yaml
+++ b/operations/observability/mixins/meta/rules/proxy.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     prometheus: k8s
     role: alert-rules
-  name: server-monitoring-rules
+  name: proxy-monitoring-rules
 spec:
   groups:
   - name: dashboard

--- a/operations/observability/mixins/meta/rules/ws-manager-bridge.yaml
+++ b/operations/observability/mixins/meta/rules/ws-manager-bridge.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     prometheus: k8s
     role: alert-rules
-  name: server-monitoring-rules
+  name: ws-manager-bridge-monitoring-rules
 spec:
   groups:
   - name: ws-manager-bridge


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Names clashed with each other, copy-paste mistake 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
