### PR TITLE
[obs] Adjust CPU alert thresholds for webapp services

### DIFF
--- a/operations/observability/mixins/meta/rules/content-service.yaml
+++ b/operations/observability/mixins/meta/rules/content-service.yaml
@@ -11,7 +11,7 @@ spec:
     rules:
     - alert: ContentServiceHighCPUUsage
       # Reasoning: high rates of CPU consumption should only be temporary.
-      expr: sum(rate(container_cpu_usage_seconds_total{container!="POD", pod=~"content-service-.*"}[5m])) by (cluster) > 0.80
+      expr: avg(rate(container_cpu_usage_seconds_total{container!="POD", pod=~"content-service-.*"}[5m])) by (cluster) > 0.1
       for: 10m
       labels:
         # sent to the team internal channel until we fine tuned it

--- a/operations/observability/mixins/meta/rules/dashboard.yaml
+++ b/operations/observability/mixins/meta/rules/dashboard.yaml
@@ -11,7 +11,7 @@ spec:
     rules:
     - alert: DashboardHighCPUUsage
       # Reasoning: high rates of CPU consumption should only be temporary.
-      expr: sum(rate(container_cpu_usage_seconds_total{container!="POD", pod=~"dashboard-.*"}[5m])) by (cluster) > 0.80
+      expr: avg(rate(container_cpu_usage_seconds_total{container!="POD", pod=~"dashboard-.*"}[5m])) by (cluster) > 0.1
       for: 10m
       labels:
         # sent to the team internal channel until we fine tuned it

--- a/operations/observability/mixins/meta/rules/db-sync.yaml
+++ b/operations/observability/mixins/meta/rules/db-sync.yaml
@@ -11,7 +11,7 @@ spec:
     rules:
     - alert: DBSyncHighCPUUsage
       # Reasoning: high rates of CPU consumption should only be temporary.
-      expr: sum(rate(container_cpu_usage_seconds_total{container!="POD", pod=~"db-sync-.*"}[5m])) by (cluster) > 0.80
+      expr: avg(rate(container_cpu_usage_seconds_total{container!="POD", pod=~"db-sync-.*"}[5m])) by (cluster) > 0.1
       for: 10m
       labels:
         # sent to the team internal channel until we fine tuned it

--- a/operations/observability/mixins/meta/rules/db.yaml
+++ b/operations/observability/mixins/meta/rules/db.yaml
@@ -11,7 +11,7 @@ spec:
     rules:
     - alert: DBHighCPUUsage
       # Reasoning: high rates of CPU consumption should only be temporary.
-      expr: sum(rate(container_cpu_usage_seconds_total{container!="POD", pod=~"db-.*"}[5m])) by (cluster) > 0.80
+      expr: avg(rate(container_cpu_usage_seconds_total{container!="POD", pod=~"db-.*"}[5m])) by (cluster) > 0.4
       for: 10m
       labels:
         # sent to the team internal channel until we fine tuned it

--- a/operations/observability/mixins/meta/rules/messagebus.yaml
+++ b/operations/observability/mixins/meta/rules/messagebus.yaml
@@ -25,7 +25,7 @@ spec:
 
     - alert: MessageBusHighCPUUsage
       # Reasoning: high rates of CPU consumption should only be temporary.
-      expr: sum(rate(container_cpu_usage_seconds_total{container!="POD", pod=~"messagebus-.*"}[5m])) by (cluster) > 0.80
+      expr: avg(rate(container_cpu_usage_seconds_total{container!="POD", pod=~"messagebus-.*"}[5m])) by (cluster) > 0.4
       for: 10m
       labels:
         # sent to the team internal channel until we fine tuned it

--- a/operations/observability/mixins/meta/rules/payment-endpoint.yaml
+++ b/operations/observability/mixins/meta/rules/payment-endpoint.yaml
@@ -11,7 +11,7 @@ spec:
     rules:
     - alert: PaymentEndpointHighCPUUsage
       # Reasoning: high rates of CPU consumption should only be temporary.
-      expr: sum(rate(container_cpu_usage_seconds_total{container!="POD", pod=~"payment-endpoint-.*"}[5m])) by (cluster) > 0.80
+      expr: avg(rate(container_cpu_usage_seconds_total{container!="POD", pod=~"payment-endpoint-.*"}[5m])) by (cluster) > 0.1
       for: 10m
       labels:
         # sent to the team internal channel until we fine tuned it

--- a/operations/observability/mixins/meta/rules/proxy.yaml
+++ b/operations/observability/mixins/meta/rules/proxy.yaml
@@ -11,7 +11,7 @@ spec:
     rules:
     - alert: ProxyHighCPUUsage
       # Reasoning: high rates of CPU consumption should only be temporary.
-      expr: sum(rate(container_cpu_usage_seconds_total{container!="POD", pod=~"proxy-.*"}[5m])) by (cluster) > 0.80
+      expr: avg(rate(container_cpu_usage_seconds_total{container!="POD", pod=~"proxy-.*"}[5m])) by (cluster) > 0.1
       for: 10m
       labels:
         # sent to the team internal channel until we fine tuned it

--- a/operations/observability/mixins/meta/rules/server.yaml
+++ b/operations/observability/mixins/meta/rules/server.yaml
@@ -99,7 +99,7 @@ spec:
 
     - alert: ServerHighCPUUsage
       # Reasoning: high rates of CPU consumption should only be temporary.
-      expr: sum(rate(container_cpu_usage_seconds_total{container!="POD", pod=~"server-.*"}[5m])) by (cluster) > 0.80
+      expr: avg(rate(container_cpu_usage_seconds_total{container!="POD", pod=~"server-.*"}[5m])) by (cluster) > 0.4
       for: 10m
       labels:
         # sent to the team internal channel until we fine tuned it

--- a/operations/observability/mixins/meta/rules/usage.yaml
+++ b/operations/observability/mixins/meta/rules/usage.yaml
@@ -70,7 +70,7 @@ spec:
 
     - alert: UsageHighCPUUsage
       # Reasoning: high rates of CPU consumption should only be temporary.
-      expr: sum(rate(container_cpu_usage_seconds_total{container!="POD", pod=~"usage-.*"}[5m])) by (cluster) > 0.80
+      expr: avg(rate(container_cpu_usage_seconds_total{container!="POD", pod=~"usage-.*"}[5m])) by (cluster) > 0.2
       for: 10m
       labels:
         # sent to the team internal channel until we fine tuned it

--- a/operations/observability/mixins/meta/rules/ws-manager-bridge.yaml
+++ b/operations/observability/mixins/meta/rules/ws-manager-bridge.yaml
@@ -11,7 +11,7 @@ spec:
     rules:
     - alert: WsManagerBridgeHighCPUUsage
       # Reasoning: high rates of CPU consumption should only be temporary.
-      expr: sum(rate(container_cpu_usage_seconds_total{container!="POD", pod=~"ws-manager-bridge-.*"}[5m])) by (cluster) > 0.80
+      expr: avg(rate(container_cpu_usage_seconds_total{container!="POD", pod=~"ws-manager-bridge-.*"}[5m])) by (cluster) > 0.1
       for: 10m
       labels:
         # sent to the team internal channel until we fine tuned it


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

* Changes the metric to `avg`. Sum was incorrect as it would add up all pods together. Average is what we're after
* Updates thresholds for each service, based on existing data over the last 30 days

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

https://grafana.gitpod.io/explore?orgId=1&left=%7B%22datasource%22:%22P4169E866C3094E38%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22datasource%22:%7B%22type%22:%22prometheus%22,%22uid%22:%22P4169E866C3094E38%22%7D,%22editorMode%22:%22code%22,%22expr%22:%22avg%28rate%28container_cpu_usage_seconds_total%7Bcontainer%21%3D%5C%22POD%5C%22,%20pod%3D~%5C%22ws-manager-bridge-.%2A%5C%22%7D%5B5m%5D%29%29%20by%20%28cluster%29%22,%22legendFormat%22:%22__auto%22,%22range%22:true,%22instant%22:true%7D%5D,%22range%22:%7B%22from%22:%22now-30d%22,%22to%22:%22now%22%7D%7D

Adjust the pod name selector as needed

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
