### PR TITLE
Rename OpenFGA to SpiceDB

### DIFF
--- a/dev/preview/workflow/preview/deploy-gitpod.sh
+++ b/dev/preview/workflow/preview/deploy-gitpod.sh
@@ -477,9 +477,9 @@ yq w -i "${INSTALLER_CONFIG_PATH}" "experimental.webapp.server.stripeConfig" "st
 #
 
 #
-# OpenFGA
+# SpiceDB
 #
-yq w -i "${INSTALLER_CONFIG_PATH}" experimental.webapp.openfga.enabled "true"
+yq w -i "${INSTALLER_CONFIG_PATH}" experimental.webapp.spicedb.enabled "true"
 
 # copy secret from werft's space
 kubectl --kubeconfig "${DEV_KUBE_PATH}" --context "${DEV_KUBE_CONTEXT}" -n werft get secret preview-envs-oidc-clients-config-secret -o yaml > preview-envs-oidc-clients-config-secret.secret.yaml


### PR DESCRIPTION
## Description

OpenFGA was replaced with SpiceDB in https://github.com/gitpod-io/gitpod/pull/15817 but the config option was not renamed causing Gitpod Installer config validation errors

```
error loading config: error unmarshaling JSON: while decoding JSON: json: unknown field "openfga"
```

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

No issue

## How to test
<!-- Provide steps to test this PR -->

TBD: Started Werft job [here](https://werft.gitpod-dev.com/job/gitpod-build-mads-rename-openfga-to-spicedb.1) - waiting for it to complete to see if things work.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
