### PR TITLE
[server] Add OneTimeSecretServer.serveToken

### DIFF
--- a/components/server/src/user/user-controller.ts
+++ b/components/server/src/user/user-controller.ts
@@ -405,7 +405,7 @@ export class UserController {
                     otsExpirationTime.setMinutes(otsExpirationTime.getMinutes() + 2);
                     const ots = await this.otsServer.serve({}, token, otsExpirationTime);
 
-                    res.redirect(`http://${rt}/?ots=${encodeURI(ots.token)}`);
+                    res.redirect(`http://${rt}/?ots=${encodeURI(ots.url)}`);
                 },
             );
         }

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -1663,7 +1663,7 @@ export class WorkspaceStarter {
                 Object.entries(context.additionalFiles).map(async ([filePath, content]) => {
                     const url = await this.otsServer.serve(traceCtx, content, tokenExpirationTime);
                     const finfo = new FileDownloadInitializer.FileInfo();
-                    finfo.setUrl(url.token);
+                    finfo.setUrl(url.url);
                     finfo.setFilePath(filePath);
                     finfo.setDigest(getDigest(content));
                     return finfo;


### PR DESCRIPTION
## Description
Add `OneTimeSecretServer.serveToken` and rename existing API.

## Related Issue(s)
Part of https://github.com/gitpod-io/gitpod/pull/15805

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
