### PR TITLE
Update services node pool labels

### DIFF
--- a/dev/preview/infrastructure/scripts/bootstrap-k3s.sh
+++ b/dev/preview/infrastructure/scripts/bootstrap-k3s.sh
@@ -32,6 +32,7 @@ kubectl label nodes ${vm_name} \
   gitpod.io/workload_meta=true \
   gitpod.io/workload_ide=true \
   gitpod.io/workload_workspace_services=true \
+  gitpod.io/workload_services=true \
   gitpod.io/workload_workspace_regular=true \
   gitpod.io/workload_workspace_headless=true \
   gitpod.io/workspace_0=true \

--- a/install/infra/modules/aks/kubernetes.tf
+++ b/install/infra/modules/aks/kubernetes.tf
@@ -42,6 +42,7 @@ resource "azurerm_kubernetes_cluster" "k8s" {
       "gitpod.io/workload_meta"               = true
       "gitpod.io/workload_ide"                = true
       "gitpod.io/workload_workspace_services" = true
+      "gitpod.io/workload_services"           = true
     }
 
     type           = "VirtualMachineScaleSets"

--- a/install/infra/modules/eks/kubernetes.tf
+++ b/install/infra/modules/eks/kubernetes.tf
@@ -142,6 +142,7 @@ module "eks" {
         "gitpod.io/workload_meta"               = true
         "gitpod.io/workload_ide"                = true
         "gitpod.io/workload_workspace_services" = true
+        "gitpod.io/workload_services"           = true
       }
 
       tags = {

--- a/install/infra/modules/gke/cluster.tf
+++ b/install/infra/modules/gke/cluster.tf
@@ -70,6 +70,7 @@ resource "google_container_node_pool" "services" {
       "gitpod.io/workload_meta"               = true
       "gitpod.io/workload_ide"                = true
       "gitpod.io/workload_workspace_services" = true
+      "gitpod.io/workload_services"           = true
     }
 
     preemptible  = false

--- a/install/infra/modules/k3s/main.tf
+++ b/install/infra/modules/k3s/main.tf
@@ -115,6 +115,7 @@ resource "null_resource" "k3sup_install" {
               --local-path ${var.kubeconfig} \
               --k3s-version ${var.cluster_version} \
               --k3s-extra-args=" --disable=traefik --node-label=gitpod.io/workload_meta=true --node-label=gitpod.io/workload_ide=true --node-label=gitpod.io/workload_workspace_services=true --node-label=gitpod.io/workload_workspace_regular=true --node-label=gitpod.io/workload_workspace_headless=true" \
+              --node-label gitpod.io/workload_services=true \
           EOT
   }
 }

--- a/install/installer/docs/overview.md
+++ b/install/installer/docs/overview.md
@@ -432,7 +432,7 @@ have a containerd runtime.
 Your Kubernetes nodes must have the following labels applied to them:
 - `gitpod.io/workload_meta`
 - `gitpod.io/workload_ide`
-- `gitpod.io/workload_workspace_services`
+- `gitpod.io/workload_services`
 - `gitpod.io/workload_workspace_regular`
 - `gitpod.io/workload_workspace_headless`
 

--- a/install/installer/pkg/config/README.md
+++ b/install/installer/pkg/config/README.md
@@ -169,6 +169,6 @@ The configuration has a required `kind` parameter, which is used to generate dif
 | Meta      | This is the `WebApp` and `IDE` components combined. This exists for historical reasons and should be considered deprecated. Used for multi-cluster deployments.          |
 | WebApp    | Components deployed to nodes with the `gitpod.io/workload_meta` label.                                                                                                   |
 | IDE       | Components deployed to nodes with the `gitpod.io/workload_ide` label.                                                                                                    |
-| Workspace | Components deployed to nodes with the `gitpod.io/workload_workspace_headless`, `gitpod.io/workload_workspace_regular` or `gitpod.io/workload_workspace_services` labels. |
+| Workspace | Components deployed to nodes with the `gitpod.io/workload_workspace_headless`, `gitpod.io/workload_workspace_regular` or `gitpod.io/workload_services` labels. |
 
 ---

--- a/install/preview/entrypoint.sh
+++ b/install/preview/entrypoint.sh
@@ -261,5 +261,6 @@ run_telemetry 2>&1 &
   --node-label gitpod.io/workload_meta=true \
   --node-label gitpod.io/workload_ide=true \
   --node-label gitpod.io/workload_workspace_services=true \
+  --node-label gitpod.io/workload_services=true \
   --node-label gitpod.io/workload_workspace_regular=true \
   --node-label gitpod.io/workload_workspace_headless=true


### PR DESCRIPTION
## Description

Required after https://github.com/gitpod-io/gitpod/pull/15132

## Release Notes
```release-note
NONE
```

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
