### PR TITLE
[public-api] Reduce duplication in validation functions

### DIFF
--- a/components/public-api-server/pkg/apiv1/validation.go
+++ b/components/public-api-server/pkg/apiv1/validation.go
@@ -18,12 +18,8 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-func validateTeamID(s string) (uuid.UUID, error) {
-	if s == "" {
-		return uuid.Nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("Team ID is a required argument."))
-	}
-
-	teamID, err := uuid.Parse(s)
+func validateTeamID(id string) (uuid.UUID, error) {
+	teamID, err := validateUUID(id)
 	if err != nil {
 		return uuid.Nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("Team ID must be a valid UUID."))
 	}
@@ -61,13 +57,7 @@ func validateWorkspaceID(id string) (string, error) {
 }
 
 func validateProjectID(id string) (uuid.UUID, error) {
-	trimmed := strings.TrimSpace(id)
-
-	if trimmed == "" {
-		return uuid.Nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("Project ID is a required argument."))
-	}
-
-	projectID, err := uuid.Parse(trimmed)
+	projectID, err := validateUUID(id)
 	if err != nil {
 		return uuid.Nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("Project ID must be a valid UUID."))
 	}
@@ -76,12 +66,7 @@ func validateProjectID(id string) (uuid.UUID, error) {
 }
 
 func validatePersonalAccessTokenID(id string) (uuid.UUID, error) {
-	trimmed := strings.TrimSpace(id)
-	if trimmed == "" {
-		return uuid.Nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("Token ID is a required argument."))
-	}
-
-	tokenID, err := uuid.Parse(trimmed)
+	tokenID, err := validateUUID(id)
 	if err != nil {
 		return uuid.Nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("Token ID must be a valid UUID"))
 	}
@@ -100,4 +85,13 @@ func validateFieldMask(mask *fieldmaskpb.FieldMask, message proto.Message) (*fie
 	}
 
 	return mask, nil
+}
+
+func validateUUID(id string) (uuid.UUID, error) {
+	trimmed := strings.TrimSpace(id)
+	if trimmed == "" {
+		return uuid.Nil, errors.New("empty uuid")
+	}
+
+	return uuid.Parse(trimmed)
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Reduces duplicated validation checks, functionally remains the same

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
