### PR TITLE
[oidc] Propagate OrganizationID to IAM component

### DIFF
--- a/components/public-api-server/pkg/apiv1/oidc.go
+++ b/components/public-api-server/pkg/apiv1/oidc.go
@@ -38,6 +38,10 @@ type OIDCService struct {
 }
 
 func (s *OIDCService) CreateClientConfig(ctx context.Context, req *connect.Request[v1.CreateClientConfigRequest]) (*connect.Response[v1.CreateClientConfigResponse], error) {
+	_, err := validateOrganizationID(req.Msg.Config.GetOrganizationId())
+	if err != nil {
+		return nil, err
+	}
 
 	conn, err := s.getConnection(ctx)
 	if err != nil {
@@ -64,6 +68,7 @@ func (s *OIDCService) CreateClientConfig(ctx context.Context, req *connect.Reque
 
 func papiConfigToIAM(c *v1.OIDCClientConfig) *iam.OIDCClientConfig {
 	return &iam.OIDCClientConfig{
+		OrganizationId: c.GetOrganizationId(),
 		OidcConfig: &iam.OIDCConfig{
 			Issuer: c.OidcConfig.GetIssuer(),
 		},
@@ -75,7 +80,8 @@ func papiConfigToIAM(c *v1.OIDCClientConfig) *iam.OIDCClientConfig {
 }
 func iamConfigToPAPI(c *iam.OIDCClientConfig) *v1.OIDCClientConfig {
 	return &v1.OIDCClientConfig{
-		Id: c.GetId(),
+		Id:             c.GetId(),
+		OrganizationId: c.GetOrganizationId(),
 		OidcConfig: &v1.OIDCConfig{
 			Issuer: c.OidcConfig.GetIssuer(),
 		},

--- a/components/public-api-server/pkg/apiv1/validation.go
+++ b/components/public-api-server/pkg/apiv1/validation.go
@@ -89,6 +89,20 @@ func validatePersonalAccessTokenID(id string) (uuid.UUID, error) {
 	return tokenID, nil
 }
 
+func validateOrganizationID(id string) (uuid.UUID, error) {
+	trimmed := strings.TrimSpace(id)
+	if trimmed == "" {
+		return uuid.Nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("OrganizationID is a required argument."))
+	}
+
+	organizationID, err := uuid.Parse(trimmed)
+	if err != nil {
+		return uuid.Nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("OrganizationID must be a valid UUID"))
+	}
+
+	return organizationID, nil
+}
+
 func validateFieldMask(mask *fieldmaskpb.FieldMask, message proto.Message) (*fieldmaskpb.FieldMask, error) {
 	if mask == nil {
 		return &fieldmaskpb.FieldMask{}, nil


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Forwards Organization ID to IAM OIDC service

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Part of https://github.com/gitpod-io/gitpod/issues/15708

## How to test
<!-- Provide steps to test this PR -->
Unit tests

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
