### PR TITLE
[iam] Store OrganizationID with OIDC Client Configs

### DIFF
--- a/components/iam/pkg/apiv1/oidc_config_test.go
+++ b/components/iam/pkg/apiv1/oidc_config_test.go
@@ -25,6 +25,7 @@ func TestOIDCClientConfig_Create(t *testing.T) {
 	client, dbConn := setupOIDCClientConfigService(t)
 
 	config := &v1.OIDCClientConfig{
+		OrganizationId: uuid.NewString(),
 		Oauth2Config: &v1.OAuth2Config{
 			ClientId:              "some-client-id",
 			ClientSecret:          "some-client-secret",


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Uses the OrganizationID from the CreateOIDCClientConfig RPC to store it in the DB.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Part of https://github.com/gitpod-io/gitpod/issues/15708

## How to test
<!-- Provide steps to test this PR -->
Unit tests

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
