### PR TITLE
[installer] Mount database secret to Public API

### DIFF
--- a/components/public-api/go/config/config.go
+++ b/components/public-api/go/config/config.go
@@ -19,5 +19,8 @@ type Configuration struct {
 	// Path to file which contains personal access token singing key
 	PersonalAccessTokenSigningKeyPath string `json:"personalAccessTokenSigningKeyPath"`
 
+	// Path to directory containing database configuration files
+	DatabaseConfigPath string `json:"databaseConfigPath"`
+
 	Server *baseserver.Configuration `json:"server,omitempty"`
 }

--- a/install/installer/cmd/testdata/render/aws-setup/output.golden
+++ b/install/installer/cmd/testdata/render/aws-setup/output.golden
@@ -2601,7 +2601,7 @@ data:
     kind: Deployment
     metadata:
       annotations:
-        gitpod.io/checksum_config: 82b32972a85084140320cd225c2893f0a2f22d55675f95a68e021c43e5e9b9ac
+        gitpod.io/checksum_config: 4323280d43b39ac16a1946291981c8798f4d957934a2bbc4a8161d1d4c679ac5
       creationTimestamp: null
       labels:
         app: gitpod
@@ -4828,6 +4828,7 @@ data:
       "oidcServiceAddress": "iam.default.svc.cluster.local:9001",
       "stripeWebhookSigningSecretPath": "",
       "personalAccessTokenSigningKeyPath": "",
+      "databaseConfigPath": "/secrets/database-config",
       "server": {
         "services": {
           "grpc": {
@@ -9425,7 +9426,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    gitpod.io/checksum_config: 82b32972a85084140320cd225c2893f0a2f22d55675f95a68e021c43e5e9b9ac
+    gitpod.io/checksum_config: 4323280d43b39ac16a1946291981c8798f4d957934a2bbc4a8161d1d4c679ac5
   creationTimestamp: null
   labels:
     app: gitpod
@@ -9540,6 +9541,9 @@ spec:
           name: config
           readOnly: true
           subPath: config.json
+        - mountPath: /secrets/database-config
+          name: database-config
+          readOnly: true
       - args:
         - --logtostderr
         - --insecure-listen-address=[$(IP)]:9500
@@ -9610,6 +9614,9 @@ spec:
       - configMap:
           name: public-api-server
         name: config
+      - name: database-config
+        secret:
+          secretName: aws-database
 status: {}
 ---
 # apps/v1/Deployment server

--- a/install/installer/cmd/testdata/render/azure-setup/output.golden
+++ b/install/installer/cmd/testdata/render/azure-setup/output.golden
@@ -2619,7 +2619,7 @@ data:
     kind: Deployment
     metadata:
       annotations:
-        gitpod.io/checksum_config: 82b32972a85084140320cd225c2893f0a2f22d55675f95a68e021c43e5e9b9ac
+        gitpod.io/checksum_config: 4323280d43b39ac16a1946291981c8798f4d957934a2bbc4a8161d1d4c679ac5
       creationTimestamp: null
       labels:
         app: gitpod
@@ -4894,6 +4894,7 @@ data:
       "oidcServiceAddress": "iam.default.svc.cluster.local:9001",
       "stripeWebhookSigningSecretPath": "",
       "personalAccessTokenSigningKeyPath": "",
+      "databaseConfigPath": "/secrets/database-config",
       "server": {
         "services": {
           "grpc": {
@@ -9622,7 +9623,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    gitpod.io/checksum_config: 82b32972a85084140320cd225c2893f0a2f22d55675f95a68e021c43e5e9b9ac
+    gitpod.io/checksum_config: 4323280d43b39ac16a1946291981c8798f4d957934a2bbc4a8161d1d4c679ac5
   creationTimestamp: null
   labels:
     app: gitpod
@@ -9737,6 +9738,9 @@ spec:
           name: config
           readOnly: true
           subPath: config.json
+        - mountPath: /secrets/database-config
+          name: database-config
+          readOnly: true
       - args:
         - --logtostderr
         - --insecure-listen-address=[$(IP)]:9500
@@ -9807,6 +9811,9 @@ spec:
       - configMap:
           name: public-api-server
         name: config
+      - name: database-config
+        secret:
+          secretName: azure-database
 status: {}
 ---
 # apps/v1/Deployment server

--- a/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
+++ b/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
@@ -2802,7 +2802,7 @@ data:
     kind: Deployment
     metadata:
       annotations:
-        gitpod.io/checksum_config: 82b32972a85084140320cd225c2893f0a2f22d55675f95a68e021c43e5e9b9ac
+        gitpod.io/checksum_config: 4323280d43b39ac16a1946291981c8798f4d957934a2bbc4a8161d1d4c679ac5
       creationTimestamp: null
       labels:
         app: gitpod
@@ -5264,6 +5264,7 @@ data:
       "oidcServiceAddress": "iam.default.svc.cluster.local:9001",
       "stripeWebhookSigningSecretPath": "",
       "personalAccessTokenSigningKeyPath": "",
+      "databaseConfigPath": "/secrets/database-config",
       "server": {
         "services": {
           "grpc": {
@@ -10339,7 +10340,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    gitpod.io/checksum_config: 82b32972a85084140320cd225c2893f0a2f22d55675f95a68e021c43e5e9b9ac
+    gitpod.io/checksum_config: 4323280d43b39ac16a1946291981c8798f4d957934a2bbc4a8161d1d4c679ac5
   creationTimestamp: null
   labels:
     app: gitpod
@@ -10454,6 +10455,9 @@ spec:
           name: config
           readOnly: true
           subPath: config.json
+        - mountPath: /secrets/database-config
+          name: database-config
+          readOnly: true
       - args:
         - --logtostderr
         - --insecure-listen-address=[$(IP)]:9500
@@ -10524,6 +10528,9 @@ spec:
       - configMap:
           name: public-api-server
         name: config
+      - name: database-config
+        secret:
+          secretName: mysql
 status: {}
 ---
 # apps/v1/Deployment registry

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -3210,7 +3210,7 @@ data:
     metadata:
       annotations:
         gitpod.io: hello
-        gitpod.io/checksum_config: 390485644ea26982344505a8b2194183390965b5894502fc9533222f9e7d0bbd
+        gitpod.io/checksum_config: b09816dd82ee4d6fa891c0975d2c4794a0d0f1c8d1fd40ff85fd550237e54064
         hello: world
       creationTimestamp: null
       labels:
@@ -5852,6 +5852,7 @@ data:
       "oidcServiceAddress": "iam.default.svc.cluster.local:9001",
       "stripeWebhookSigningSecretPath": "",
       "personalAccessTokenSigningKeyPath": "",
+      "databaseConfigPath": "/secrets/database-config",
       "server": {
         "services": {
           "grpc": {
@@ -11174,7 +11175,7 @@ kind: Deployment
 metadata:
   annotations:
     gitpod.io: hello
-    gitpod.io/checksum_config: 390485644ea26982344505a8b2194183390965b5894502fc9533222f9e7d0bbd
+    gitpod.io/checksum_config: b09816dd82ee4d6fa891c0975d2c4794a0d0f1c8d1fd40ff85fd550237e54064
     hello: world
   creationTimestamp: null
   labels:
@@ -11297,6 +11298,9 @@ spec:
           name: config
           readOnly: true
           subPath: config.json
+        - mountPath: /secrets/database-config
+          name: database-config
+          readOnly: true
       - args:
         - --logtostderr
         - --insecure-listen-address=[$(IP)]:9500
@@ -11367,6 +11371,9 @@ spec:
       - configMap:
           name: public-api-server
         name: config
+      - name: database-config
+        secret:
+          secretName: mysql
 status: {}
 ---
 # apps/v1/Deployment registry

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -2696,7 +2696,7 @@ data:
     kind: Deployment
     metadata:
       annotations:
-        gitpod.io/checksum_config: 82b32972a85084140320cd225c2893f0a2f22d55675f95a68e021c43e5e9b9ac
+        gitpod.io/checksum_config: 4323280d43b39ac16a1946291981c8798f4d957934a2bbc4a8161d1d4c679ac5
       creationTimestamp: null
       labels:
         app: gitpod
@@ -5081,6 +5081,7 @@ data:
       "oidcServiceAddress": "iam.default.svc.cluster.local:9001",
       "stripeWebhookSigningSecretPath": "",
       "personalAccessTokenSigningKeyPath": "",
+      "databaseConfigPath": "/secrets/database-config",
       "server": {
         "services": {
           "grpc": {
@@ -10049,7 +10050,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    gitpod.io/checksum_config: 82b32972a85084140320cd225c2893f0a2f22d55675f95a68e021c43e5e9b9ac
+    gitpod.io/checksum_config: 4323280d43b39ac16a1946291981c8798f4d957934a2bbc4a8161d1d4c679ac5
   creationTimestamp: null
   labels:
     app: gitpod
@@ -10164,6 +10165,9 @@ spec:
           name: config
           readOnly: true
           subPath: config.json
+        - mountPath: /secrets/database-config
+          name: database-config
+          readOnly: true
       - args:
         - --logtostderr
         - --insecure-listen-address=[$(IP)]:9500
@@ -10234,6 +10238,9 @@ spec:
       - configMap:
           name: public-api-server
         name: config
+      - name: database-config
+        secret:
+          secretName: mysql
 status: {}
 ---
 # apps/v1/Deployment server

--- a/install/installer/cmd/testdata/render/gcp-setup/output.golden
+++ b/install/installer/cmd/testdata/render/gcp-setup/output.golden
@@ -2638,7 +2638,7 @@ data:
     kind: Deployment
     metadata:
       annotations:
-        gitpod.io/checksum_config: 82b32972a85084140320cd225c2893f0a2f22d55675f95a68e021c43e5e9b9ac
+        gitpod.io/checksum_config: 4323280d43b39ac16a1946291981c8798f4d957934a2bbc4a8161d1d4c679ac5
       creationTimestamp: null
       labels:
         app: gitpod
@@ -4855,6 +4855,7 @@ data:
       "oidcServiceAddress": "iam.default.svc.cluster.local:9001",
       "stripeWebhookSigningSecretPath": "",
       "personalAccessTokenSigningKeyPath": "",
+      "databaseConfigPath": "/secrets/database-config",
       "server": {
         "services": {
           "grpc": {
@@ -9542,7 +9543,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    gitpod.io/checksum_config: 82b32972a85084140320cd225c2893f0a2f22d55675f95a68e021c43e5e9b9ac
+    gitpod.io/checksum_config: 4323280d43b39ac16a1946291981c8798f4d957934a2bbc4a8161d1d4c679ac5
   creationTimestamp: null
   labels:
     app: gitpod
@@ -9651,6 +9652,9 @@ spec:
           name: config
           readOnly: true
           subPath: config.json
+        - mountPath: /secrets/database-config
+          name: database-config
+          readOnly: true
       - args:
         - --logtostderr
         - --insecure-listen-address=[$(IP)]:9500
@@ -9715,6 +9719,9 @@ spec:
       - configMap:
           name: public-api-server
         name: config
+      - name: database-config
+        secret:
+          secretName: gcp-database
 status: {}
 ---
 # apps/v1/Deployment server

--- a/install/installer/cmd/testdata/render/http-proxy/output.golden
+++ b/install/installer/cmd/testdata/render/http-proxy/output.golden
@@ -2805,7 +2805,7 @@ data:
     kind: Deployment
     metadata:
       annotations:
-        gitpod.io/checksum_config: 82b32972a85084140320cd225c2893f0a2f22d55675f95a68e021c43e5e9b9ac
+        gitpod.io/checksum_config: 4323280d43b39ac16a1946291981c8798f4d957934a2bbc4a8161d1d4c679ac5
       creationTimestamp: null
       labels:
         app: gitpod
@@ -5267,6 +5267,7 @@ data:
       "oidcServiceAddress": "iam.default.svc.cluster.local:9001",
       "stripeWebhookSigningSecretPath": "",
       "personalAccessTokenSigningKeyPath": "",
+      "databaseConfigPath": "/secrets/database-config",
       "server": {
         "services": {
           "grpc": {
@@ -11464,7 +11465,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    gitpod.io/checksum_config: 82b32972a85084140320cd225c2893f0a2f22d55675f95a68e021c43e5e9b9ac
+    gitpod.io/checksum_config: 4323280d43b39ac16a1946291981c8798f4d957934a2bbc4a8161d1d4c679ac5
   creationTimestamp: null
   labels:
     app: gitpod
@@ -11619,6 +11620,9 @@ spec:
           name: config
           readOnly: true
           subPath: config.json
+        - mountPath: /secrets/database-config
+          name: database-config
+          readOnly: true
       - args:
         - --logtostderr
         - --insecure-listen-address=[$(IP)]:9500
@@ -11769,6 +11773,9 @@ spec:
       - configMap:
           name: public-api-server
         name: config
+      - name: database-config
+        secret:
+          secretName: mysql
 status: {}
 ---
 # apps/v1/Deployment registry

--- a/install/installer/cmd/testdata/render/kind-meta/output.golden
+++ b/install/installer/cmd/testdata/render/kind-meta/output.golden
@@ -2349,7 +2349,7 @@ data:
     kind: Deployment
     metadata:
       annotations:
-        gitpod.io/checksum_config: 82b32972a85084140320cd225c2893f0a2f22d55675f95a68e021c43e5e9b9ac
+        gitpod.io/checksum_config: 4323280d43b39ac16a1946291981c8798f4d957934a2bbc4a8161d1d4c679ac5
       creationTimestamp: null
       labels:
         app: gitpod
@@ -4192,6 +4192,7 @@ data:
       "oidcServiceAddress": "iam.default.svc.cluster.local:9001",
       "stripeWebhookSigningSecretPath": "",
       "personalAccessTokenSigningKeyPath": "",
+      "databaseConfigPath": "/secrets/database-config",
       "server": {
         "services": {
           "grpc": {
@@ -7526,7 +7527,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    gitpod.io/checksum_config: 82b32972a85084140320cd225c2893f0a2f22d55675f95a68e021c43e5e9b9ac
+    gitpod.io/checksum_config: 4323280d43b39ac16a1946291981c8798f4d957934a2bbc4a8161d1d4c679ac5
   creationTimestamp: null
   labels:
     app: gitpod
@@ -7641,6 +7642,9 @@ spec:
           name: config
           readOnly: true
           subPath: config.json
+        - mountPath: /secrets/database-config
+          name: database-config
+          readOnly: true
       - args:
         - --logtostderr
         - --insecure-listen-address=[$(IP)]:9500
@@ -7711,6 +7715,9 @@ spec:
       - configMap:
           name: public-api-server
         name: config
+      - name: database-config
+        secret:
+          secretName: mysql
 status: {}
 ---
 # apps/v1/Deployment registry

--- a/install/installer/cmd/testdata/render/kind-webapp/output.golden
+++ b/install/installer/cmd/testdata/render/kind-webapp/output.golden
@@ -1724,7 +1724,7 @@ data:
     kind: Deployment
     metadata:
       annotations:
-        gitpod.io/checksum_config: 82b32972a85084140320cd225c2893f0a2f22d55675f95a68e021c43e5e9b9ac
+        gitpod.io/checksum_config: 4323280d43b39ac16a1946291981c8798f4d957934a2bbc4a8161d1d4c679ac5
       creationTimestamp: null
       labels:
         app: gitpod
@@ -2282,6 +2282,7 @@ data:
       "oidcServiceAddress": "iam.default.svc.cluster.local:9001",
       "stripeWebhookSigningSecretPath": "",
       "personalAccessTokenSigningKeyPath": "",
+      "databaseConfigPath": "/secrets/database-config",
       "server": {
         "services": {
           "grpc": {
@@ -4455,7 +4456,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    gitpod.io/checksum_config: 82b32972a85084140320cd225c2893f0a2f22d55675f95a68e021c43e5e9b9ac
+    gitpod.io/checksum_config: 4323280d43b39ac16a1946291981c8798f4d957934a2bbc4a8161d1d4c679ac5
   creationTimestamp: null
   labels:
     app: gitpod
@@ -4570,6 +4571,9 @@ spec:
           name: config
           readOnly: true
           subPath: config.json
+        - mountPath: /secrets/database-config
+          name: database-config
+          readOnly: true
       - args:
         - --logtostderr
         - --insecure-listen-address=[$(IP)]:9500
@@ -4640,6 +4644,9 @@ spec:
       - configMap:
           name: public-api-server
         name: config
+      - name: database-config
+        secret:
+          secretName: mysql
 status: {}
 ---
 # apps/v1/Deployment registry

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -2802,7 +2802,7 @@ data:
     kind: Deployment
     metadata:
       annotations:
-        gitpod.io/checksum_config: 82b32972a85084140320cd225c2893f0a2f22d55675f95a68e021c43e5e9b9ac
+        gitpod.io/checksum_config: 4323280d43b39ac16a1946291981c8798f4d957934a2bbc4a8161d1d4c679ac5
       creationTimestamp: null
       labels:
         app: gitpod
@@ -5264,6 +5264,7 @@ data:
       "oidcServiceAddress": "iam.default.svc.cluster.local:9001",
       "stripeWebhookSigningSecretPath": "",
       "personalAccessTokenSigningKeyPath": "",
+      "databaseConfigPath": "/secrets/database-config",
       "server": {
         "services": {
           "grpc": {
@@ -10339,7 +10340,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    gitpod.io/checksum_config: 82b32972a85084140320cd225c2893f0a2f22d55675f95a68e021c43e5e9b9ac
+    gitpod.io/checksum_config: 4323280d43b39ac16a1946291981c8798f4d957934a2bbc4a8161d1d4c679ac5
   creationTimestamp: null
   labels:
     app: gitpod
@@ -10454,6 +10455,9 @@ spec:
           name: config
           readOnly: true
           subPath: config.json
+        - mountPath: /secrets/database-config
+          name: database-config
+          readOnly: true
       - args:
         - --logtostderr
         - --insecure-listen-address=[$(IP)]:9500
@@ -10524,6 +10528,9 @@ spec:
       - configMap:
           name: public-api-server
         name: config
+      - name: database-config
+        secret:
+          secretName: mysql
 status: {}
 ---
 # apps/v1/Deployment registry

--- a/install/installer/cmd/testdata/render/shortname/output.golden
+++ b/install/installer/cmd/testdata/render/shortname/output.golden
@@ -2802,7 +2802,7 @@ data:
     kind: Deployment
     metadata:
       annotations:
-        gitpod.io/checksum_config: 82b32972a85084140320cd225c2893f0a2f22d55675f95a68e021c43e5e9b9ac
+        gitpod.io/checksum_config: 4323280d43b39ac16a1946291981c8798f4d957934a2bbc4a8161d1d4c679ac5
       creationTimestamp: null
       labels:
         app: gitpod
@@ -5264,6 +5264,7 @@ data:
       "oidcServiceAddress": "iam.default.svc.cluster.local:9001",
       "stripeWebhookSigningSecretPath": "",
       "personalAccessTokenSigningKeyPath": "",
+      "databaseConfigPath": "/secrets/database-config",
       "server": {
         "services": {
           "grpc": {
@@ -10339,7 +10340,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    gitpod.io/checksum_config: 82b32972a85084140320cd225c2893f0a2f22d55675f95a68e021c43e5e9b9ac
+    gitpod.io/checksum_config: 4323280d43b39ac16a1946291981c8798f4d957934a2bbc4a8161d1d4c679ac5
   creationTimestamp: null
   labels:
     app: gitpod
@@ -10454,6 +10455,9 @@ spec:
           name: config
           readOnly: true
           subPath: config.json
+        - mountPath: /secrets/database-config
+          name: database-config
+          readOnly: true
       - args:
         - --logtostderr
         - --insecure-listen-address=[$(IP)]:9500
@@ -10524,6 +10528,9 @@ spec:
       - configMap:
           name: public-api-server
         name: config
+      - name: database-config
+        secret:
+          secretName: mysql
 status: {}
 ---
 # apps/v1/Deployment registry

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -2814,7 +2814,7 @@ data:
     kind: Deployment
     metadata:
       annotations:
-        gitpod.io/checksum_config: 82b32972a85084140320cd225c2893f0a2f22d55675f95a68e021c43e5e9b9ac
+        gitpod.io/checksum_config: 4323280d43b39ac16a1946291981c8798f4d957934a2bbc4a8161d1d4c679ac5
       creationTimestamp: null
       labels:
         app: gitpod
@@ -5276,6 +5276,7 @@ data:
       "oidcServiceAddress": "iam.default.svc.cluster.local:9001",
       "stripeWebhookSigningSecretPath": "",
       "personalAccessTokenSigningKeyPath": "",
+      "databaseConfigPath": "/secrets/database-config",
       "server": {
         "services": {
           "grpc": {
@@ -10351,7 +10352,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    gitpod.io/checksum_config: 82b32972a85084140320cd225c2893f0a2f22d55675f95a68e021c43e5e9b9ac
+    gitpod.io/checksum_config: 4323280d43b39ac16a1946291981c8798f4d957934a2bbc4a8161d1d4c679ac5
   creationTimestamp: null
   labels:
     app: gitpod
@@ -10466,6 +10467,9 @@ spec:
           name: config
           readOnly: true
           subPath: config.json
+        - mountPath: /secrets/database-config
+          name: database-config
+          readOnly: true
       - args:
         - --logtostderr
         - --insecure-listen-address=[$(IP)]:9500
@@ -10536,6 +10540,9 @@ spec:
       - configMap:
           name: public-api-server
         name: config
+      - name: database-config
+        secret:
+          secretName: mysql
 status: {}
 ---
 # apps/v1/Deployment registry

--- a/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
+++ b/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
@@ -3090,7 +3090,7 @@ data:
     kind: Deployment
     metadata:
       annotations:
-        gitpod.io/checksum_config: 82b32972a85084140320cd225c2893f0a2f22d55675f95a68e021c43e5e9b9ac
+        gitpod.io/checksum_config: 4323280d43b39ac16a1946291981c8798f4d957934a2bbc4a8161d1d4c679ac5
       creationTimestamp: null
       labels:
         app: gitpod
@@ -5597,6 +5597,7 @@ data:
       "oidcServiceAddress": "iam.default.svc.cluster.local:9001",
       "stripeWebhookSigningSecretPath": "",
       "personalAccessTokenSigningKeyPath": "",
+      "databaseConfigPath": "/secrets/database-config",
       "server": {
         "services": {
           "grpc": {
@@ -10783,7 +10784,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    gitpod.io/checksum_config: 82b32972a85084140320cd225c2893f0a2f22d55675f95a68e021c43e5e9b9ac
+    gitpod.io/checksum_config: 4323280d43b39ac16a1946291981c8798f4d957934a2bbc4a8161d1d4c679ac5
   creationTimestamp: null
   labels:
     app: gitpod
@@ -10898,6 +10899,9 @@ spec:
           name: config
           readOnly: true
           subPath: config.json
+        - mountPath: /secrets/database-config
+          name: database-config
+          readOnly: true
       - args:
         - --logtostderr
         - --insecure-listen-address=[$(IP)]:9500
@@ -10968,6 +10972,9 @@ spec:
       - configMap:
           name: public-api-server
         name: config
+      - name: database-config
+        secret:
+          secretName: mysql
 status: {}
 ---
 # apps/v1/Deployment registry

--- a/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
+++ b/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
@@ -2804,7 +2804,7 @@ data:
     kind: Deployment
     metadata:
       annotations:
-        gitpod.io/checksum_config: 82b32972a85084140320cd225c2893f0a2f22d55675f95a68e021c43e5e9b9ac
+        gitpod.io/checksum_config: 4323280d43b39ac16a1946291981c8798f4d957934a2bbc4a8161d1d4c679ac5
       creationTimestamp: null
       labels:
         app: gitpod
@@ -5266,6 +5266,7 @@ data:
       "oidcServiceAddress": "iam.default.svc.cluster.local:9001",
       "stripeWebhookSigningSecretPath": "",
       "personalAccessTokenSigningKeyPath": "",
+      "databaseConfigPath": "/secrets/database-config",
       "server": {
         "services": {
           "grpc": {
@@ -10329,7 +10330,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    gitpod.io/checksum_config: 82b32972a85084140320cd225c2893f0a2f22d55675f95a68e021c43e5e9b9ac
+    gitpod.io/checksum_config: 4323280d43b39ac16a1946291981c8798f4d957934a2bbc4a8161d1d4c679ac5
   creationTimestamp: null
   labels:
     app: gitpod
@@ -10444,6 +10445,9 @@ spec:
           name: config
           readOnly: true
           subPath: config.json
+        - mountPath: /secrets/database-config
+          name: database-config
+          readOnly: true
       - args:
         - --logtostderr
         - --insecure-listen-address=[$(IP)]:9500
@@ -10514,6 +10518,9 @@ spec:
       - configMap:
           name: public-api-server
         name: config
+      - name: database-config
+        secret:
+          secretName: mysql
 status: {}
 ---
 # apps/v1/Deployment registry

--- a/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
+++ b/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
@@ -2805,7 +2805,7 @@ data:
     kind: Deployment
     metadata:
       annotations:
-        gitpod.io/checksum_config: 82b32972a85084140320cd225c2893f0a2f22d55675f95a68e021c43e5e9b9ac
+        gitpod.io/checksum_config: 4323280d43b39ac16a1946291981c8798f4d957934a2bbc4a8161d1d4c679ac5
       creationTimestamp: null
       labels:
         app: gitpod
@@ -5267,6 +5267,7 @@ data:
       "oidcServiceAddress": "iam.default.svc.cluster.local:9001",
       "stripeWebhookSigningSecretPath": "",
       "personalAccessTokenSigningKeyPath": "",
+      "databaseConfigPath": "/secrets/database-config",
       "server": {
         "services": {
           "grpc": {
@@ -10342,7 +10343,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    gitpod.io/checksum_config: 82b32972a85084140320cd225c2893f0a2f22d55675f95a68e021c43e5e9b9ac
+    gitpod.io/checksum_config: 4323280d43b39ac16a1946291981c8798f4d957934a2bbc4a8161d1d4c679ac5
   creationTimestamp: null
   labels:
     app: gitpod
@@ -10457,6 +10458,9 @@ spec:
           name: config
           readOnly: true
           subPath: config.json
+        - mountPath: /secrets/database-config
+          name: database-config
+          readOnly: true
       - args:
         - --logtostderr
         - --insecure-listen-address=[$(IP)]:9500
@@ -10527,6 +10531,9 @@ spec:
       - configMap:
           name: public-api-server
         name: config
+      - name: database-config
+        secret:
+          secretName: mysql
 status: {}
 ---
 # apps/v1/Deployment registry

--- a/install/installer/pkg/components/public-api-server/configmap.go
+++ b/install/installer/pkg/components/public-api-server/configmap.go
@@ -42,12 +42,15 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		return nil
 	})
 
+	_, _, databaseSecretMountPath := common.DatabaseEnvSecret(ctx.Config)
+
 	cfg := config.Configuration{
 		GitpodServiceURL:                  fmt.Sprintf("ws://%s.%s.svc.cluster.local:%d", server.Component, ctx.Namespace, server.ContainerPort),
 		StripeWebhookSigningSecretPath:    stripeSecretPath,
 		PersonalAccessTokenSigningKeyPath: personalAccessTokenSigningKeyPath,
 		OIDCServiceAddress:                net.JoinHostPort(fmt.Sprintf("%s.%s.svc.cluster.local", iam.Component, ctx.Namespace), strconv.Itoa(iam.GRPCServicePort)),
 		BillingServiceAddress:             net.JoinHostPort(fmt.Sprintf("%s.%s.svc.cluster.local", usage.Component, ctx.Namespace), strconv.Itoa(usage.GRPCServicePort)),
+		DatabaseConfigPath:                databaseSecretMountPath,
 		Server: &baseserver.Configuration{
 			Services: baseserver.ServicesConfiguration{
 				GRPC: &baseserver.ServerConfiguration{

--- a/install/installer/pkg/components/public-api-server/configmap_test.go
+++ b/install/installer/pkg/components/public-api-server/configmap_test.go
@@ -43,6 +43,7 @@ func TestConfigMap(t *testing.T) {
 		OIDCServiceAddress:                fmt.Sprintf("iam.%s.svc.cluster.local:9001", ctx.Namespace),
 		StripeWebhookSigningSecretPath:    stripeSecretPath,
 		PersonalAccessTokenSigningKeyPath: personalAccessTokenSigningKeyPath,
+		DatabaseConfigPath:                "/secrets/database-config",
 		Server: &baseserver.Configuration{
 			Services: baseserver.ServicesConfiguration{
 				GRPC: &baseserver.ServerConfiguration{

--- a/install/installer/pkg/components/public-api-server/deployment.go
+++ b/install/installer/pkg/components/public-api-server/deployment.go
@@ -33,6 +33,8 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 		return nil, err
 	}
 
+	databaseSecretVolume, databaseSecretMount, _ := common.DatabaseEnvSecret(ctx.Config)
+
 	volumes := []corev1.Volume{
 		{
 			Name: configmapVolume,
@@ -44,6 +46,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 				},
 			},
 		},
+		databaseSecretVolume,
 	}
 	volumeMounts := []corev1.VolumeMount{
 		{
@@ -52,6 +55,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 			MountPath: configMountPath,
 			SubPath:   configJSONFilename,
 		},
+		databaseSecretMount,
 	}
 
 	_ = ctx.WithExperimental(func(cfg *experimental.Config) error {

--- a/install/installer/pkg/components/public-api-server/deployment_test.go
+++ b/install/installer/pkg/components/public-api-server/deployment_test.go
@@ -57,6 +57,14 @@ func TestDeployment_ServerArguments(t *testing.T) {
 			},
 		},
 		{
+			Name: "database-config",
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: "gcp-db-creds-service-account-name",
+				},
+			},
+		},
+		{
 			Name: "stripe-secret",
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Mounts database secret as a volume/volume-mount onto Public API. This will allow the public-api to access the secret from files, including the db-decryption key which can then be used to merge the `iam` component with `public-api` ([thread](https://gitpod.slack.com/archives/C02EN94AEPL/p1674073546820559))

Config remains unused, will be used in subsequent PRs

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
* Unit tests
* Preview deploys public-api and the deployment starts

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
