### PR TITLE
[db] Implement basic list oidc client configs

### DIFF
--- a/components/gitpod-db/go/oidc_client_config.go
+++ b/components/gitpod-db/go/oidc_client_config.go
@@ -90,3 +90,22 @@ func GetOIDCClientConfig(ctx context.Context, conn *gorm.DB, id uuid.UUID) (OIDC
 
 	return config, nil
 }
+
+func ListOIDCClientConfigsForOrganization(ctx context.Context, conn *gorm.DB, organizationID uuid.UUID) ([]OIDCClientConfig, error) {
+	if organizationID == uuid.Nil {
+		return nil, errors.New("organization ID is a required argument")
+	}
+
+	var results []OIDCClientConfig
+
+	tx := conn.
+		WithContext(ctx).
+		Where("organizationId = ?", organizationID).
+		Where("deleted = ?", 0).
+		Find(&results)
+	if tx.Error != nil {
+		return nil, fmt.Errorf("failed to list oidc client configs for organization %s: %w", organizationID.String(), tx.Error)
+	}
+
+	return results, nil
+}

--- a/components/gitpod-db/go/oidc_client_config_test.go
+++ b/components/gitpod-db/go/oidc_client_config_test.go
@@ -6,10 +6,12 @@ package db_test
 
 import (
 	"context"
+	"testing"
+
 	db "github.com/gitpod-io/gitpod/components/gitpod-db/go"
 	"github.com/gitpod-io/gitpod/components/gitpod-db/go/dbtest"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestCreateOIDCClientConfig_Create(t *testing.T) {
@@ -19,4 +21,35 @@ func TestCreateOIDCClientConfig_Create(t *testing.T) {
 	retrieved, err := db.GetOIDCClientConfig(context.Background(), conn, created.ID)
 	require.NoError(t, err)
 	require.Equal(t, created, retrieved)
+}
+
+func TestListOIDCClientConfigsForOrganization(t *testing.T) {
+	ctx := context.Background()
+	conn := dbtest.ConnectForTests(t)
+
+	orgA, orgB := uuid.New(), uuid.New()
+
+	dbtest.CreateOIDCClientConfigs(t, conn,
+		dbtest.NewOIDCClientConfig(t, db.OIDCClientConfig{
+			OrganizationID: &orgA,
+		}),
+		dbtest.NewOIDCClientConfig(t, db.OIDCClientConfig{
+			OrganizationID: &orgA,
+		}),
+		dbtest.NewOIDCClientConfig(t, db.OIDCClientConfig{
+			OrganizationID: &orgB,
+		}),
+	)
+
+	configsForOrgA, err := db.ListOIDCClientConfigsForOrganization(ctx, conn, orgA)
+	require.NoError(t, err)
+	require.Len(t, configsForOrgA, 2)
+
+	configsForOrgB, err := db.ListOIDCClientConfigsForOrganization(ctx, conn, orgB)
+	require.NoError(t, err)
+	require.Len(t, configsForOrgB, 1)
+
+	configsForRandomOrg, err := db.ListOIDCClientConfigsForOrganization(ctx, conn, uuid.New())
+	require.NoError(t, err)
+	require.Len(t, configsForRandomOrg, 0)
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Initial, basic unpaginated implementation of list oidc client configs. Pagination will be added in subsequent PR.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Part of https://github.com/gitpod-io/gitpod/issues/15153
* Used in https://github.com/gitpod-io/gitpod/pull/15852

## How to test
<!-- Provide steps to test this PR -->
Unit tests

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
