### PR TITLE
[dashboard] never redirect to projects from /

### DIFF
--- a/components/dashboard/src/hooks/use-user-and-teams-loader.ts
+++ b/components/dashboard/src/hooks/use-user-and-teams-loader.ts
@@ -6,21 +6,18 @@
 
 import { useState, useContext, useEffect } from "react";
 import { User } from "@gitpod/gitpod-protocol";
-import { useHistory } from "react-router-dom";
 import { UserContext } from "../user-context";
-import { getSelectedTeamSlug, TeamsContext } from "../teams/teams-context";
+import { TeamsContext } from "../teams/teams-context";
 import { getGitpodService } from "../service/service";
 import { publicApiTeamsToProtocol, teamsService } from "../service/public-api";
 import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
 import { trackLocation } from "../Analytics";
 import { refreshSearchData } from "../components/RepositoryFinder";
-import { getURLHash } from "../utils";
 
 export const useUserAndTeamsLoader = () => {
     const [loading, setLoading] = useState<boolean>(true);
     const { user, setUser, refreshUserBillingMode } = useContext(UserContext);
     const { teams, setTeams } = useContext(TeamsContext);
-    const history = useHistory();
     const [isSetupRequired, setSetupRequired] = useState(false);
 
     useEffect(() => {
@@ -31,24 +28,7 @@ export const useUserAndTeamsLoader = () => {
                 setUser(loggedInUser);
                 refreshSearchData();
 
-                // TODO: atm this feature-flag won't have been set yet, as it's dependant on user/teams
-                // so it will always be false when this runs
                 const loadedTeams = publicApiTeamsToProtocol((await teamsService.listTeams({})).teams);
-
-                {
-                    // if a team was selected previously and we call the root URL (e.g. "gitpod.io"),
-                    // let's continue with the team page
-                    const hash = getURLHash();
-                    const isRoot = window.location.pathname === "/" && hash === "";
-                    if (isRoot) {
-                        try {
-                            const teamSlug = getSelectedTeamSlug();
-                            if (loadedTeams.some((t) => t.slug === teamSlug)) {
-                                history.push(`/t/${teamSlug}`);
-                            }
-                        } catch {}
-                    }
-                }
                 setTeams(loadedTeams);
             } catch (error) {
                 console.error(error);


### PR DESCRIPTION
## Description
Fixes a bad redirect that is happening when you've had a team selected in a previous session and you then load the page on gitpod.io.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
Create a team and select it (go to its projects page).
reload te page on the preview environments default route (`/`) and verify that you end up on /workspaces and not get send back to the team's projects list.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
