### PR TITLE
Simplify testing leeway in GHA builds

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -33,6 +33,8 @@ Does this PR require updates to the documentation at www.gitpod.io/docs?
 
 - [ ] /werft with-github-actions
       Experimental feature to run the build with GitHub Actions (and not in Werft).
+- [ ] leeway-no-cache
+      leeway-target=components:all-ci
 - [ ] /werft with-local-preview
       If enabled this will build `install/preview`
 - [ ] /werft with-preview

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,7 +88,18 @@ jobs:
         with:
           secrets: |-
             segment-io-token:gitpod-core-dev/segment-io-token
-      - name: Leeway Build components:all-ci
+      - name: Parse PullRequest
+        shell: bash
+        working-directory: /workspace/gitpod
+        env:
+          PR_DESC: '${{ github.event.pull_request.body }}'
+        run: |
+          PR_NO_CACHE=${{ contains(github.event.pull_request.body, '[x] leeway-no-cache') }}
+          PR_LEEWAY_TARGET=$(echo "$PR_DESC" | sed -n -e 's/^.*leeway-target=//p' | sed 's/\r$//')
+
+          echo "PR_NO_CACHE=$PR_NO_CACHE" >> $GITHUB_ENV
+          echo "PR_LEEWAY_TARGET=$PR_LEEWAY_TARGET" >> $GITHUB_ENV
+      - name: Leeway Build
         id: leeway
         shell: bash
         working-directory: /workspace/gitpod
@@ -98,24 +109,30 @@ jobs:
           SEGMENT_IO_TOKEN: '${{ steps.secrets.outputs.segment-io-token }}'
         run: |
           echo "version=$VERSION" >> $GITHUB_OUTPUT
+          [[ "$PR_NO_CACHE" = "true" ]] && CACHE="none" || CACHE="remote"
+          [[ -z "$PR_LEEWAY_TARGET" ]] && PR_LEEWAY_TARGET="components:all-ci"
 
           RESULT=0
-          leeway build components:all-ci \
+          set -x
+          leeway build $PR_LEEWAY_TARGET \
+            --cache $CACHE \
             -Dversion=$VERSION \
             -DSEGMENT_IO_TOKEN=$SEGMENT_IO_TOKEN \
             -DpublishToNPM=false \
             --dont-test \
             --report report.html || RESULT=$?
+          set +x
 
           cat report.html >> $GITHUB_STEP_SUMMARY
-          cp /tmp/versions.yaml /__w/gitpod/gitpod/versions.yaml
-          cp /tmp/installer /__w/gitpod/gitpod/installer
+          [[ -f /tmp/versions.yaml ]] && cp /tmp/versions.yaml /__w/gitpod/gitpod/versions.yaml
+          [[ -f /tmp/installer ]]     && cp /tmp/installer     /__w/gitpod/gitpod/installer
 
           exit $RESULT
       - name: "Upload Installer artifacts"
         uses: actions/upload-artifact@v3
         with:
           name: installer-artifacts
+          if-no-files-found: ignore
           path: |
             versions.yaml
             installer


### PR DESCRIPTION
## Description
This PR:
* adds a flag to specify the leeway build target in the PR description.
* adds a flag to disable the leeway cache.
* adds `set -x` so the `leeway build` command is printed in full in the build logs.
* adds a step for flag parsing not to clutter the "leeway" step. Parsing is now done in bash - we may want to refactor that to something more robust later.

These changes help to test the build, because they allow building individual components explicitly, without the cache getting in the way or the large dependency tree causing long wait times.

## Discussion
* Changing the leeway target bars risks: It breaks preview environments (because `installer` and `values.yaml` are no longer available) and if the build no longer builds all components, it no longer guarantees that the main build won't fail.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

[Here is a build](https://github.com/gitpod-io/gitpod/actions/runs/3959801631/jobs/6783094181) that only builds agent smith and ignores all caches.
<img width="1260" alt="image" src="https://user-images.githubusercontent.com/239422/213481838-36afb331-cccf-4fe2-8b8b-4b9f2d393e4f.png">


[Here is a "standard" build](https://github.com/gitpod-io/gitpod/actions/runs/3959801631/jobs/6783094181): no customization to the target, no disabled cache.
<img width="1166" alt="image" src="https://user-images.githubusercontent.com/239422/213482839-ddcabc0a-9ecd-49e0-bcc0-91d1526f2209.png">


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [x] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
