### PR TITLE
[fix] : workspace options model closes on space

### DIFF
--- a/components/dashboard/src/components/DropDown2.tsx
+++ b/components/dashboard/src/components/DropDown2.tsx
@@ -99,7 +99,7 @@ export const DropDown2: FunctionComponent<DropDown2Props> = (props) => {
                     e.preventDefault();
                 }
             }
-            if (e.key === " ") {
+            if (e.key === " " && search === "") {
                 toggleDropDown();
                 e.preventDefault();
             }


### PR DESCRIPTION
## Description
- Initially work `toggleDropDown()` was called on `" "` space, removed that.
- When the input is empty, space is used to toggle the dropdown else space is getting concatenated to the input.

[Screencast from 19-01-23 06:25:46 PM IST.webm](https://user-images.githubusercontent.com/76901313/213448491-6c9c13ff-7ad9-4c2f-8be8-067f2a315e6a.webm)


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #15690 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[fix] : workspace options model closes on entering space(" ")
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
