### PR TITLE
[spicedb] Make webapp codeowners of spicedb component

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -50,7 +50,7 @@
 /install/installer/pkg/components/openvsx-proxy @gitpod-io/engineering-ide
 /install/installer/pkg/components/proxy @gitpod-io/engineering-webapp
 /install/installer/pkg/components/registry-facade @gitpod-io/engineering-workspace
-/install/installer/pkg/components/openfga @gitpod-io/engineering-webapp
+/install/installer/pkg/components/spicedb @gitpod-io/engineering-webapp
 /install/installer/pkg/components/public-api-server @gitpod-io/engineering-webapp
 /install/installer/pkg/components/iam @gitpod-io/engineering-webapp
 /install/installer/pkg/components/iam-api @gitpod-io/engineering-webapp


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Makes webapp condeowners of the component

Solves https://github.com/gitpod-io/gitpod/pull/15876#pullrequestreview-1261621534

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
