### PR TITLE
Option to choose between infra provider when running `leeway run dev:preview`

### DIFF
--- a/dev/preview/infrastructure/outputs.tf
+++ b/dev/preview/infrastructure/outputs.tf
@@ -1,0 +1,3 @@
+output "infra_provider" {
+  value = var.infra_provider
+}

--- a/dev/preview/workflow/lib/common.sh
+++ b/dev/preview/workflow/lib/common.sh
@@ -2,7 +2,7 @@
 
 # this script is meant to be sourced
 
-SCRIPT_PATH=$(dirname "${BASH_SOURCE[0]}")
+FILE_PATH=$(dirname "${BASH_SOURCE[0]}")
 
 # predefined exit codes for checks
 export ERROR_WRONG_WORKSPACE=30
@@ -13,7 +13,7 @@ export ERROR_NO_PLAN=34
 export ERROR_PLAN_FAIL=35
 
 function import() {
-  local file="${SCRIPT_PATH}/${1}"
+  local file="${FILE_PATH}/${1}"
   if [ -f "${file}" ]; then
     # shellcheck disable=SC1090
     source "${file}"
@@ -59,5 +59,19 @@ function ask() {
             [Yy]*) return 0  ;;
             [Nn]*) echo "Aborted" ; return  1 ;;
         esac
+    done
+}
+
+function choose() {
+    local text=$1
+    shift
+    local choices=("$@")
+
+    echo -e "${text}" 1>&2
+    select choice in "${choices[@]}"; do
+       case $choice in
+             *) echo "${choice}"
+                break ;;
+       esac
     done
 }

--- a/dev/preview/workflow/lib/terraform.sh
+++ b/dev/preview/workflow/lib/terraform.sh
@@ -2,10 +2,10 @@
 
 # this script is meant to be sourced
 
-SCRIPT_PATH=$(dirname "${BASH_SOURCE[0]}")
+FILE_PATH=$(dirname "${BASH_SOURCE[0]}")
 
 # shellcheck source=./common.sh
-source "${SCRIPT_PATH}/common.sh"
+source "${FILE_PATH}/common.sh"
 
 TF_CLI_ARGS_plan=${TF_CLI_ARGS_plan:-""}
 TF_CLI_ARGS_apply=${TF_CLI_ARGS_apply:-""}
@@ -96,4 +96,20 @@ function terraform_apply() {
   timeout --signal=INT --foreground 10m terraform apply "${plan_location}"
 
   popd || return "${ERROR_CHANGE_DIR}"
+}
+
+function terraform_output() {
+  local var=${1:-}
+  local format=${2:-raw}
+
+  if [ -z "${TARGET_DIR-}" ]; then
+    log_error "Must provide TARGET_DIR"
+    return "${ERROR_NO_DIR}"
+  fi
+
+  pushd "${TARGET_DIR}" >/dev/null || return "${ERROR_CHANGE_DIR}"
+
+  terraform output -${format} "${var}" 2>/dev/null
+
+  popd >/dev/null || return "${ERROR_CHANGE_DIR}"
 }

--- a/dev/preview/workflow/preview/deploy-harvester.sh
+++ b/dev/preview/workflow/preview/deploy-harvester.sh
@@ -33,6 +33,8 @@ shopt -os allexport
 
 terraform_init
 
+source "${SCRIPT_PATH}/determine-env.sh"
+
 PLAN_EXIT_CODE=0
 terraform_plan || PLAN_EXIT_CODE=$?
 

--- a/dev/preview/workflow/preview/determine-env.sh
+++ b/dev/preview/workflow/preview/determine-env.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+# this is meant to be sourced by the deploy script
+
+# If we're IN CI, quit for now
+if [ -n "${GITHUB_ACTIONS-}" ] || [ -n "${WERFT_SERVICE_HOST-}" ]; then
+  return
+fi
+
+if [ -n "${TF_VAR_infra_provider-}" ]; then
+  return
+fi
+
+state_output=$(terraform_output "infra_provider")
+# If we don't have the provider_choice in the outputs, bail. This is temporary until all envs have it set
+if [[ -z "${state_output}" ]]; then
+  return
+fi
+
+# Reuse the one we set in the state and exit
+# Otherwise if we haven't set it, the default value of the variable will be reused and might overwrite a change
+# A bit hacky for now, but will prevent destruction if you run it once with GCE, and next time you don't set the var explicitly
+export TF_VAR_infra_provider=$state_output
+return
+
+# Leaving this unreachable for now
+options=("harvester" "gce")
+provider_choice=$(choose "Choose your infra provider" "${options[@]}")
+
+if [ "${state_output}" != "${provider_choice}" ]; then
+  ask "You have chosen [${provider_choice}], but in the state we have [${state_output}]. Continuing will destroy and recreate your environment. Are you sure?"
+  export TF_VAR_infra_provider=${provider_choice}
+  return
+fi


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
```
Choose your infra provider
1) harvester
2) gce
#? 2
You have chosen [gce], but in the state we have [harvester]. Continuing will destroy and recreate your environment. Are you sure? [y/n]: n
Aborted
```

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/ops/issues/7802

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
