### PR TITLE
polish IDEFrontendDashboardService

### DIFF
--- a/components/dashboard/src/start/StartWorkspace.tsx
+++ b/components/dashboard/src/start/StartWorkspace.tsx
@@ -458,20 +458,7 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
     }
 
     private openDesktopLink(link: string) {
-        let redirect = false;
-        try {
-            const desktopLink = new URL(link);
-            redirect = desktopLink.protocol !== "http:" && desktopLink.protocol !== "https:";
-        } catch (e) {
-            console.error("invalid desktop link:", e);
-        }
-        // redirect only if points to desktop application
-        // don't navigate browser to another page
-        if (redirect) {
-            window.location.href = link;
-        } else {
-            window.open(link, "_blank", "noopener");
-        }
+        this.ideFrontendService?.openDesktopIDE(link);
     }
 
     render() {
@@ -578,7 +565,13 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
                                     menuEntries={[
                                         {
                                             title: "Open in Browser",
-                                            onClick: () => window.parent.postMessage({ type: "openBrowserIde" }, "*"),
+                                            onClick: () => {
+                                                // TODO(ak): delete after supervisor deploy
+                                                window.parent.postMessage({ type: "openBrowserIde" }, "*");
+                                                // TODO(ak): end of delete
+
+                                                this.ideFrontendService?.openBrowserIDE();
+                                            },
                                         },
                                         {
                                             title: "Stop Workspace",

--- a/components/gitpod-protocol/src/frontend-dashboard-service.ts
+++ b/components/gitpod-protocol/src/frontend-dashboard-service.ts
@@ -6,37 +6,34 @@
 
 import { WorkspaceInstancePhase } from "./workspace-instance";
 import { RemoteTrackMessage } from "./analytics";
-import { Event } from "./util/event";
 
+/**
+ * IDEFrontendDashboardService enables IDE related communications
+ * between the workspace to gitpod origins. Use it to communicate
+ * between IDE and dashboard iframes, never use
+ * `window.postMessage` directly.
+ *
+ * **Security Note**: never expose information about other workspaces
+ * or sensitive information for the current workspace, i.e. owner token.
+ */
 export namespace IDEFrontendDashboardService {
     /**
      * IClient is the client side which is using in supervisor frontend
      */
-    export interface IClient extends IClientOn, IClientSend {}
-    interface IClientOn {
-        onStatusUpdate: Event<Status>;
-        relocate(url: string): void;
-    }
-    interface IClientSend {
+    export interface IClient {
         trackEvent(msg: RemoteTrackMessage): void;
         activeHeartbeat(): void;
         setState(state: SetStateData): void;
+        openDesktopIDE(url: string): void;
     }
 
     /**
      * IServer is the server side which is using in dashboard loading screen
      */
-    export interface IServer extends IServerOn, IServerSend {
-        auth(): Promise<void>;
-    }
-    interface IServerOn {
-        onSetState: Event<SetStateData>;
-        trackEvent(msg: RemoteTrackMessage): void;
-        activeHeartbeat(): void;
-    }
-    interface IServerSend {
+    export interface IServer {
         sendStatusUpdate(status: Status): void;
         relocate(url: string): void;
+        openBrowserIDE(): void;
     }
 
     export interface Status {
@@ -64,6 +61,8 @@ export namespace IDEFrontendDashboardService {
      * interface for post message that send status update from dashboard to supervisor
      */
     export interface StatusUpdateEventData {
+        // protocol version
+        version?: number;
         type: "ide-status-update";
         status: Status;
     }
@@ -87,6 +86,15 @@ export namespace IDEFrontendDashboardService {
         state: SetStateData;
     }
 
+    export interface OpenBrowserIDE {
+        type: "ide-open-browser";
+    }
+
+    export interface OpenDesktopIDE {
+        type: "ide-open-desktop";
+        url: string;
+    }
+
     export function isStatusUpdateEventData(obj: any): obj is StatusUpdateEventData {
         return obj != null && typeof obj === "object" && obj.type === "ide-status-update";
     }
@@ -105,5 +113,13 @@ export namespace IDEFrontendDashboardService {
 
     export function isSetStateEventData(obj: any): obj is SetStateEventData {
         return obj != null && typeof obj === "object" && obj.type === "ide-set-state";
+    }
+
+    export function isOpenBrowserIDE(obj: any): obj is OpenBrowserIDE {
+        return obj != null && typeof obj === "object" && obj.type === "ide-open-browser";
+    }
+
+    export function isOpenDesktopIDE(obj: any): obj is OpenDesktopIDE {
+        return obj != null && typeof obj === "object" && obj.type === "ide-open-desktop";
     }
 }

--- a/components/supervisor/frontend/src/regular.ts
+++ b/components/supervisor/frontend/src/regular.ts
@@ -75,16 +75,12 @@ LoadingFrame.load().then(async (loading) => {
         const supervisorServiceClient = SupervisorServiceClient.get();
 
         let hideDesktopIde = false;
-        const serverOrigin = startUrl.url.origin;
-        const hideDesktopIdeEventListener = (event: MessageEvent) => {
-            if (event.origin === serverOrigin && event.data.type == "openBrowserIde") {
-                window.removeEventListener("message", hideDesktopIdeEventListener);
-                hideDesktopIde = true;
-                toStop.push(ideService.start());
-            }
-        };
-        window.addEventListener("message", hideDesktopIdeEventListener, false);
-        toStop.push({ dispose: () => window.removeEventListener("message", hideDesktopIdeEventListener) });
+        const hideDesktopIdeEventListener = frontendDashboardServiceClient.onOpenBrowserIDE(() => {
+            hideDesktopIdeEventListener.dispose();
+            hideDesktopIde = true;
+            toStop.push(ideService.start());
+        });
+        toStop.push(hideDesktopIdeEventListener);
 
         //#region gitpod browser telemetry
         // TODO(ak) get rid of it
@@ -140,7 +136,7 @@ LoadingFrame.load().then(async (loading) => {
                             });
                             if (!desktopRedirected) {
                                 desktopRedirected = true;
-                                loading.openDesktopLink(ideStatus.desktop.link);
+                                frontendDashboardServiceClient.openDesktopIDE(ideStatus.desktop.link);
                             }
                             return loading.frame;
                         }

--- a/components/supervisor/frontend/src/shared/loading-frame.ts
+++ b/components/supervisor/frontend/src/shared/loading-frame.ts
@@ -10,7 +10,6 @@ import { startUrl } from "./urls";
 export function load(): Promise<{
     frame: HTMLIFrameElement;
     frontendDashboardServiceClient: FrontendDashboardServiceClient;
-    openDesktopLink: (link: string) => void;
 }> {
     return new Promise((resolve) => {
         const frame = document.createElement("iframe");
@@ -21,23 +20,7 @@ export function load(): Promise<{
 
         frame.onload = () => {
             const frontendDashboardServiceClient = new FrontendDashboardServiceClient(frame.contentWindow!);
-            const openDesktopLink = (link: string) => {
-                let redirect = false;
-                try {
-                    const desktopLink = new URL(link);
-                    redirect = desktopLink.protocol !== "http:" && desktopLink.protocol !== "https:";
-                } catch (e) {
-                    console.error("invalid desktop link:", e);
-                }
-                // redirect only if points to desktop application
-                // don't navigate browser to another page
-                if (redirect) {
-                    window.location.href = link;
-                } else {
-                    window.open(link, "_blank", "noopener");
-                }
-            };
-            resolve({ frame, frontendDashboardServiceClient, openDesktopLink });
+            resolve({ frame, frontendDashboardServiceClient });
         };
     });
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

- add docs and security notes
- remove implementation methods from the interface
- fix a regression with opening desktop IDEs on the workspace origin
- allow to access the interface from other locations for the same workspace, i.e. for dev and debug modes

Changes are backward compatible and does not require coordinated deployment. But a follow up clean up PR is required after both supervisor and dashboard are deployed.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

Start a workspace with IntelliJ IDEA, check that you can open VS Code Browser and IntelliJ IDEA. While redirection got IntelliJ the origin should be gitpod, not workspace.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
