### PR TITLE
[spicedb] Set parseTime=true for mysql connection

### DIFF
--- a/install/installer/pkg/components/spicedb/deployment.go
+++ b/install/installer/pkg/components/spicedb/deployment.go
@@ -96,7 +96,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 			},
 			{
 				Name:  "SPICEDB_DATASTORE_CONN_URI",
-				Value: fmt.Sprintf("$(DB_USERNAME):$(DB_PASSWORD)@tcp(%s:%d)/%s", dbHost, CloudSQLProxyPort, cfg.CloudSQL.Database),
+				Value: fmt.Sprintf("$(DB_USERNAME):$(DB_PASSWORD)@tcp(%s:%d)/%s?parseTime=true", dbHost, CloudSQLProxyPort, cfg.CloudSQL.Database),
 			},
 			{
 				Name:  "SPICEDB_GRPC_PRESHARED_KEY",


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Without it, we get `[unsupported Scan, storing driver.Value type []uint8 into type *time.Time](https://stackoverflow.com/questions/45040319/unsupported-scan-storing-driver-value-type-uint8-into-type-time-time)` from the connection driver

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
