### PR TITLE
Cleanup old code in StartWorkspace.tsx

### DIFF
--- a/components/dashboard/src/start/StartWorkspace.tsx
+++ b/components/dashboard/src/start/StartWorkspace.tsx
@@ -113,38 +113,6 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
     private readonly toDispose = new DisposableCollection();
     componentWillMount() {
         if (this.props.runsInIFrame) {
-            // TODO(hw): delete after supervisor deploy
-            window.parent.postMessage({ type: "$setSessionId", sessionId }, "*");
-            const setStateEventListener = (event: MessageEvent) => {
-                if (
-                    event.data.type === "setState" &&
-                    "state" in event.data &&
-                    typeof event.data["state"] === "object"
-                ) {
-                    if (event.data.state.ideFrontendFailureCause) {
-                        const error = { message: event.data.state.ideFrontendFailureCause };
-                        this.setState({ error });
-                    }
-                    if (event.data.state.desktopIdeLink) {
-                        const label = event.data.state.desktopIdeLabel || "Open Desktop IDE";
-                        const clientID = event.data.state.desktopIdeClientID;
-                        this.setState({ desktopIde: { link: event.data.state.desktopIdeLink, label, clientID } });
-                    }
-                }
-                if (
-                    event.data.type === "$openDesktopLink" &&
-                    "link" in event.data &&
-                    typeof event.data["link"] === "string"
-                ) {
-                    this.openDesktopLink(event.data["link"] as string);
-                }
-            };
-            window.addEventListener("message", setStateEventListener, false);
-            this.toDispose.push({
-                dispose: () => window.removeEventListener("message", setStateEventListener),
-            });
-            // TODO(hw): end of delete
-
             this.ideFrontendService = getIDEFrontendService(this.props.workspaceId, sessionId, getGitpodService());
             this.toDispose.push(
                 this.ideFrontendService.onSetState((data) => {
@@ -448,9 +416,6 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
 
     redirectTo(url: string) {
         if (this.props.runsInIFrame) {
-            // TODO(hw): delete after supervisor deploy
-            window.parent.postMessage({ type: "relocate", url }, "*");
-            // TODO(hw): end of delete
             this.ideFrontendService?.relocate(url);
         } else {
             window.location.href = url;


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Cleanup old code in StartWorkspace.tsx

## How to test
<!-- Provide steps to test this PR -->
1. Start a workspace and check vscode web ide loads sucessfully

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
