### PR TITLE
[ws-proxy] support ports location for debug workspace

### DIFF
--- a/components/ws-proxy/pkg/proxy/config.go
+++ b/components/ws-proxy/pkg/proxy/config.go
@@ -71,10 +71,11 @@ func (c *HostBasedIngressConfig) Validate() error {
 
 // WorkspacePodConfig contains config around the workspace pod.
 type WorkspacePodConfig struct {
-	TheiaPort           uint16 `json:"theiaPort"`
-	IDEDebugPort        uint16 `json:"ideDebugPort"`
-	SupervisorPort      uint16 `json:"supervisorPort"`
-	SupervisorDebugPort uint16 `json:"supervisorDebugPort"`
+	TheiaPort               uint16 `json:"theiaPort"`
+	IDEDebugPort            uint16 `json:"ideDebugPort"`
+	SupervisorPort          uint16 `json:"supervisorPort"`
+	SupervisorDebugPort     uint16 `json:"supervisorDebugPort"`
+	DebugWorkspaceProxyPort uint16 `json:"debugWorkspaceProxyPort"`
 	// SupervisorImage is deprecated
 	SupervisorImage string `json:"supervisorImage"`
 }
@@ -90,6 +91,7 @@ func (c *WorkspacePodConfig) Validate() error {
 		validation.Field(&c.IDEDebugPort, validation.Required),
 		validation.Field(&c.SupervisorPort, validation.Required),
 		validation.Field(&c.SupervisorDebugPort, validation.Required),
+		validation.Field(&c.DebugWorkspaceProxyPort, validation.Required),
 	)
 	if len(c.SupervisorImage) > 0 {
 		log.Warn("config value 'workspacePodConfig.supervisorImage' is deprected, use it only to be backwards compatible")

--- a/components/ws-proxy/pkg/proxy/workspacerouter_test.go
+++ b/components/ws-proxy/pkg/proxy/workspacerouter_test.go
@@ -78,6 +78,22 @@ func TestWorkspaceRouter(t *testing.T) {
 				URL:           "http://1234-amaranth-smelt-9ba20cc1.ws.gitpod.dev/",
 			},
 		},
+		{
+			Name: "host-based debug port access",
+			URL:  "http://1234-debug-amaranth-smelt-9ba20cc1.ws.gitpod.dev/",
+			Headers: map[string]string{
+				forwardedHostnameHeader: "1234-debug-amaranth-smelt-9ba20cc1.ws.gitpod.dev",
+			},
+			Router:       HostBasedRouter(forwardedHostnameHeader, wsHostSuffix, wsHostRegex),
+			WSHostSuffix: wsHostSuffix,
+			Expected: Expectation{
+				DebugWorkspace: "true",
+				WorkspaceID:    "amaranth-smelt-9ba20cc1",
+				WorkspacePort:  "1234",
+				Status:         http.StatusOK,
+				URL:            "http://1234-debug-amaranth-smelt-9ba20cc1.ws.gitpod.dev/",
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/install/installer/cmd/testdata/render/agent-smith/output.golden
+++ b/install/installer/cmd/testdata/render/agent-smith/output.golden
@@ -6278,6 +6278,7 @@ data:
           "ideDebugPort": 25000,
           "supervisorPort": 22999,
           "supervisorDebugPort": 24999,
+          "debugWorkspaceProxyPort": 25003,
           "supervisorImage": "eu.gcr.io/gitpod-core-dev/build/supervisor:test"
         },
         "builtinPages": {
@@ -11488,7 +11489,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 714740065966c437ee71b41e8953aa6bb77ac83596e2326b267a2b954f60242d
+        gitpod.io/checksum_config: 50975660db033ea3555b3ced8dcb5e88a95b63142b5402732d0bc8355f3daaed
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/aws-setup/output.golden
+++ b/install/installer/cmd/testdata/render/aws-setup/output.golden
@@ -5631,6 +5631,7 @@ data:
           "ideDebugPort": 25000,
           "supervisorPort": 22999,
           "supervisorDebugPort": 24999,
+          "debugWorkspaceProxyPort": 25003,
           "supervisorImage": "eu.gcr.io/gitpod-core-dev/build/supervisor:test"
         },
         "builtinPages": {
@@ -10311,7 +10312,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 714740065966c437ee71b41e8953aa6bb77ac83596e2326b267a2b954f60242d
+        gitpod.io/checksum_config: 50975660db033ea3555b3ced8dcb5e88a95b63142b5402732d0bc8355f3daaed
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/azure-setup/output.golden
+++ b/install/installer/cmd/testdata/render/azure-setup/output.golden
@@ -5689,6 +5689,7 @@ data:
           "ideDebugPort": 25000,
           "supervisorPort": 22999,
           "supervisorDebugPort": 24999,
+          "debugWorkspaceProxyPort": 25003,
           "supervisorImage": "eu.gcr.io/gitpod-core-dev/build/supervisor:test"
         },
         "builtinPages": {
@@ -10502,7 +10503,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 714740065966c437ee71b41e8953aa6bb77ac83596e2326b267a2b954f60242d
+        gitpod.io/checksum_config: 50975660db033ea3555b3ced8dcb5e88a95b63142b5402732d0bc8355f3daaed
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
+++ b/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
@@ -6096,6 +6096,7 @@ data:
           "ideDebugPort": 25000,
           "supervisorPort": 22999,
           "supervisorDebugPort": 24999,
+          "debugWorkspaceProxyPort": 25003,
           "supervisorImage": "registry.mydomain.com/namespace/supervisor:test"
         },
         "builtinPages": {
@@ -11306,7 +11307,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: f0a077b5cee652ccf128621f7f7cc23ae4cdb4225b4aa32942eccaa2be4e528e
+        gitpod.io/checksum_config: 8d2c99a864e5f9f28f96628cf5f56f5abae0de8a43206e0523784ce039d20a90
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -6719,6 +6719,7 @@ data:
           "ideDebugPort": 25000,
           "supervisorPort": 22999,
           "supervisorDebugPort": 24999,
+          "debugWorkspaceProxyPort": 25003,
           "supervisorImage": "eu.gcr.io/gitpod-core-dev/build/supervisor:test"
         },
         "builtinPages": {
@@ -12187,7 +12188,7 @@ spec:
     metadata:
       annotations:
         gitpod.io: hello
-        gitpod.io/checksum_config: be61210a63646185a45ed41810fa0ff56fb433059593b7eaea7a23d9a3cc4bdf
+        gitpod.io/checksum_config: 91f8cea7c5bfea1b90f1426ef89c453853e01b7c692851fc25af41491d5734a7
         hello: world
       creationTimestamp: null
       labels:

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -5876,6 +5876,7 @@ data:
           "ideDebugPort": 25000,
           "supervisorPort": 22999,
           "supervisorDebugPort": 24999,
+          "debugWorkspaceProxyPort": 25003,
           "supervisorImage": "eu.gcr.io/gitpod-core-dev/build/supervisor:test"
         },
         "builtinPages": {
@@ -10929,7 +10930,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 714740065966c437ee71b41e8953aa6bb77ac83596e2326b267a2b954f60242d
+        gitpod.io/checksum_config: 50975660db033ea3555b3ced8dcb5e88a95b63142b5402732d0bc8355f3daaed
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/gcp-setup/output.golden
+++ b/install/installer/cmd/testdata/render/gcp-setup/output.golden
@@ -5648,6 +5648,7 @@ data:
           "ideDebugPort": 25000,
           "supervisorPort": 22999,
           "supervisorDebugPort": 24999,
+          "debugWorkspaceProxyPort": 25003,
           "supervisorImage": "eu.gcr.io/gitpod-core-dev/build/supervisor:test"
         },
         "builtinPages": {
@@ -10392,7 +10393,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 714740065966c437ee71b41e8953aa6bb77ac83596e2326b267a2b954f60242d
+        gitpod.io/checksum_config: 50975660db033ea3555b3ced8dcb5e88a95b63142b5402732d0bc8355f3daaed
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/http-proxy/output.golden
+++ b/install/installer/cmd/testdata/render/http-proxy/output.golden
@@ -6099,6 +6099,7 @@ data:
           "ideDebugPort": 25000,
           "supervisorPort": 22999,
           "supervisorDebugPort": 24999,
+          "debugWorkspaceProxyPort": 25003,
           "supervisorImage": "eu.gcr.io/gitpod-core-dev/build/supervisor:test"
         },
         "builtinPages": {
@@ -12953,7 +12954,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 714740065966c437ee71b41e8953aa6bb77ac83596e2326b267a2b954f60242d
+        gitpod.io/checksum_config: 50975660db033ea3555b3ced8dcb5e88a95b63142b5402732d0bc8355f3daaed
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/kind-workspace/output.golden
+++ b/install/installer/cmd/testdata/render/kind-workspace/output.golden
@@ -2132,6 +2132,7 @@ data:
           "ideDebugPort": 25000,
           "supervisorPort": 22999,
           "supervisorDebugPort": 24999,
+          "debugWorkspaceProxyPort": 25003,
           "supervisorImage": "eu.gcr.io/gitpod-core-dev/build/supervisor:test"
         },
         "builtinPages": {
@@ -3884,7 +3885,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 714740065966c437ee71b41e8953aa6bb77ac83596e2326b267a2b954f60242d
+        gitpod.io/checksum_config: 50975660db033ea3555b3ced8dcb5e88a95b63142b5402732d0bc8355f3daaed
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -6096,6 +6096,7 @@ data:
           "ideDebugPort": 25000,
           "supervisorPort": 22999,
           "supervisorDebugPort": 24999,
+          "debugWorkspaceProxyPort": 25003,
           "supervisorImage": "eu.gcr.io/gitpod-core-dev/build/supervisor:test"
         },
         "builtinPages": {
@@ -11306,7 +11307,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 714740065966c437ee71b41e8953aa6bb77ac83596e2326b267a2b954f60242d
+        gitpod.io/checksum_config: 50975660db033ea3555b3ced8dcb5e88a95b63142b5402732d0bc8355f3daaed
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/overrides-inline/output.golden
+++ b/install/installer/cmd/testdata/render/overrides-inline/output.golden
@@ -6094,6 +6094,7 @@ data:
           "ideDebugPort": 25000,
           "supervisorPort": 22999,
           "supervisorDebugPort": 24999,
+          "debugWorkspaceProxyPort": 25003,
           "supervisorImage": "eu.gcr.io/gitpod-core-dev/build/supervisor:test"
         },
         "builtinPages": {
@@ -11316,7 +11317,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 714740065966c437ee71b41e8953aa6bb77ac83596e2326b267a2b954f60242d
+        gitpod.io/checksum_config: 50975660db033ea3555b3ced8dcb5e88a95b63142b5402732d0bc8355f3daaed
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/shortname/output.golden
+++ b/install/installer/cmd/testdata/render/shortname/output.golden
@@ -6096,6 +6096,7 @@ data:
           "ideDebugPort": 25000,
           "supervisorPort": 22999,
           "supervisorDebugPort": 24999,
+          "debugWorkspaceProxyPort": 25003,
           "supervisorImage": "eu.gcr.io/gitpod-core-dev/build/supervisor:test"
         },
         "builtinPages": {
@@ -11306,7 +11307,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 1d3e519239eb23a1e2f00e30f73abf47a1a18a74052043e6dc8d1196eed4fd1f
+        gitpod.io/checksum_config: 9a39727d1f0fad7df2a842459983ecd049b262fa12be3a72b29809d844b3365b
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -6108,6 +6108,7 @@ data:
           "ideDebugPort": 25000,
           "supervisorPort": 22999,
           "supervisorDebugPort": 24999,
+          "debugWorkspaceProxyPort": 25003,
           "supervisorImage": "eu.gcr.io/gitpod-core-dev/build/supervisor:test"
         },
         "builtinPages": {
@@ -11318,7 +11319,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 714740065966c437ee71b41e8953aa6bb77ac83596e2326b267a2b954f60242d
+        gitpod.io/checksum_config: 50975660db033ea3555b3ced8dcb5e88a95b63142b5402732d0bc8355f3daaed
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/telemetry/output.golden
+++ b/install/installer/cmd/testdata/render/telemetry/output.golden
@@ -6099,6 +6099,7 @@ data:
           "ideDebugPort": 25000,
           "supervisorPort": 22999,
           "supervisorDebugPort": 24999,
+          "debugWorkspaceProxyPort": 25003,
           "supervisorImage": "eu.gcr.io/gitpod-core-dev/build/supervisor:test"
         },
         "builtinPages": {
@@ -11309,7 +11310,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 714740065966c437ee71b41e8953aa6bb77ac83596e2326b267a2b954f60242d
+        gitpod.io/checksum_config: 50975660db033ea3555b3ced8dcb5e88a95b63142b5402732d0bc8355f3daaed
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
+++ b/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
@@ -6429,6 +6429,7 @@ data:
           "ideDebugPort": 25000,
           "supervisorPort": 22999,
           "supervisorDebugPort": 24999,
+          "debugWorkspaceProxyPort": 25003,
           "supervisorImage": "eu.gcr.io/gitpod-core-dev/build/supervisor:test"
         },
         "builtinPages": {
@@ -11750,7 +11751,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 714740065966c437ee71b41e8953aa6bb77ac83596e2326b267a2b954f60242d
+        gitpod.io/checksum_config: 50975660db033ea3555b3ced8dcb5e88a95b63142b5402732d0bc8355f3daaed
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
+++ b/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
@@ -6098,6 +6098,7 @@ data:
           "ideDebugPort": 25000,
           "supervisorPort": 22999,
           "supervisorDebugPort": 24999,
+          "debugWorkspaceProxyPort": 25003,
           "supervisorImage": "eu.gcr.io/gitpod-core-dev/build/supervisor:test"
         },
         "builtinPages": {
@@ -11296,7 +11297,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 714740065966c437ee71b41e8953aa6bb77ac83596e2326b267a2b954f60242d
+        gitpod.io/checksum_config: 50975660db033ea3555b3ced8dcb5e88a95b63142b5402732d0bc8355f3daaed
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
+++ b/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
@@ -6099,6 +6099,7 @@ data:
           "ideDebugPort": 25000,
           "supervisorPort": 22999,
           "supervisorDebugPort": 24999,
+          "debugWorkspaceProxyPort": 25003,
           "supervisorImage": "eu.gcr.io/gitpod-core-dev/build/supervisor:test"
         },
         "builtinPages": {
@@ -11309,7 +11310,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 714740065966c437ee71b41e8953aa6bb77ac83596e2326b267a2b954f60242d
+        gitpod.io/checksum_config: 50975660db033ea3555b3ced8dcb5e88a95b63142b5402732d0bc8355f3daaed
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/pkg/components/workspace/constants.go
+++ b/install/installer/pkg/components/workspace/constants.go
@@ -15,4 +15,5 @@ const (
 	SupervisorPort               = 22999
 	SupervisorDebugPort          = 24999
 	IDEDebugPort                 = 25000
+	DebugWorkspaceProxyPort      = 25003
 )

--- a/install/installer/pkg/components/ws-proxy/configmap.go
+++ b/install/installer/pkg/components/ws-proxy/configmap.go
@@ -108,11 +108,12 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 				WorkspaceHostSuffixRegex: gitpodInstallationWorkspaceHostSuffixRegex,
 			},
 			WorkspacePodConfig: &proxy.WorkspacePodConfig{
-				TheiaPort:           workspace.ContainerPort,
-				IDEDebugPort:        workspace.IDEDebugPort,
-				SupervisorPort:      workspace.SupervisorPort,
-				SupervisorDebugPort: workspace.SupervisorDebugPort,
-				SupervisorImage:     ctx.ImageName(ctx.Config.Repository, workspace.SupervisorImage, ctx.VersionManifest.Components.Workspace.Supervisor.Version),
+				TheiaPort:               workspace.ContainerPort,
+				IDEDebugPort:            workspace.IDEDebugPort,
+				SupervisorPort:          workspace.SupervisorPort,
+				SupervisorDebugPort:     workspace.SupervisorDebugPort,
+				DebugWorkspaceProxyPort: workspace.DebugWorkspaceProxyPort,
+				SupervisorImage:         ctx.ImageName(ctx.Config.Repository, workspace.SupervisorImage, ctx.VersionManifest.Components.Workspace.Supervisor.Version),
 			},
 			BuiltinPages: proxy.BuiltinPagesConfig{
 				Location: "/app/public",


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

It is a prerequisite to https://github.com/gitpod-io/gitpod/pull/15795. Based on Pudong's work from https://github.com/gitpod-io/gitpod/pull/15687.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

It is not possible to test new functionality yet. Only in context of https://github.com/gitpod-io/gitpod/pull/15795. Review code and tests. Test for regressions, i.e. start a workspace, start something inside and check that you can access it.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-integration-tests=workspace
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
