### PR TITLE
Narrow cookie scope to gitpod domain only

### DIFF
--- a/components/server/src/session-handler.ts
+++ b/components/server/src/session-handler.ts
@@ -43,33 +43,14 @@ export class SessionHandlerProvider {
     }
 
     protected getCookieOptions(config: Config): express.CookieOptions {
-        const hostName = config.hostUrl.url.host;
-
-        let domain = hostName;
-        if (config.devBranch) {
-            // Use cookie for base domain to allow cookies being sent via ingress proxy in preview environments
-            //
-            // Otherwise, clients (in this case Chrome) may ignore (as in: save it, but don't send it on consequent requests) the 'Set-Cookie:...' send with a redirect (302, to github oauth)
-            // For details, see:
-            // - RFC draft sameSite: http://httpwg.org/http-extensions/draft-ietf-httpbis-cookie-same-site.html
-            // - https://bugs.chromium.org/p/chromium/issues/detail?id=150066
-            // - google: chromium not sending cookies set with redirect
-
-            const hostParts = hostName.split(".");
-            const baseDomain = hostParts.slice(hostParts.length - 2).join(".");
-            domain = `.${baseDomain}`;
-        }
-        if (this.config.insecureNoDomain) {
-            domain = hostName.split(":")[0];
-        }
-
+        // Do not set `domain` attribute so only the base domain (e.g. only gitpod.io) has the Gitpod cookie.
+        // If `domain` is specified, then subdomains are always included. Therefore, specifying `domain` is less restrictive than omitting it.
         return {
             path: "/", // default
             httpOnly: true, // default
             secure: false, // default, TODO SSL! Config proxy
             maxAge: config.session.maxAgeMs, // configured in Helm chart, defaults to 3 days.
             sameSite: "lax", // default: true. "Lax" needed for OAuth.
-            domain: `${domain}`,
         };
     }
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Narrow cookie scope to gitpod domain only

## How to test
<!-- Provide steps to test this PR -->
1. Check public api still works in dashboard
2. Check you cannot create a ws connection from workspace origin

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
