### PR TITLE
Open start workspace in modal from projects list

### DIFF
--- a/components/dashboard/src/components/RepositoryFinder.tsx
+++ b/components/dashboard/src/components/RepositoryFinder.tsx
@@ -31,7 +31,7 @@ export default function RepositoryFinder(props: RepositoryFinderProps) {
                 setSuggestedContextURLs(urls);
                 saveSearchData(urls);
             });
-    }, [suggestedContextURLs]);
+    }, []);
 
     const getElements = useCallback(
         (searchString: string) => {

--- a/components/dashboard/src/projects/Project.tsx
+++ b/components/dashboard/src/projects/Project.tsx
@@ -21,6 +21,7 @@ import { openAuthorizeWindow } from "../provider-utils";
 import Alert from "../components/Alert";
 import { listAllProjects } from "../service/public-api";
 import { UserContext } from "../user-context";
+import { StartWorkspaceModalContext } from "../workspaces/start-workspace-modal-context";
 
 export default function () {
     const location = useLocation();
@@ -29,6 +30,7 @@ export default function () {
     const { teams } = useContext(TeamsContext);
     const { user } = useContext(UserContext);
     const team = getCurrentTeam(location, teams);
+    const { setStartWorkspaceModalProps } = useContext(StartWorkspaceModalContext);
 
     const match = useRouteMatch<{ team: string; resource: string }>("/(t/)?:team/:resource");
     const projectSlug = match?.params?.resource;
@@ -395,9 +397,11 @@ export default function () {
                                                     menuEntries={[
                                                         {
                                                             title: "New Workspace ...",
-                                                            href: gitpodHostUrl
-                                                                .withContext(`${branch.url}`, { showOptions: true })
-                                                                .toString(),
+                                                            onClick: () =>
+                                                                setStartWorkspaceModalProps({
+                                                                    contextUrl: branch.url,
+                                                                    allowContextUrlChange: true,
+                                                                }),
                                                             separator: true,
                                                         },
                                                         prebuild?.status === "queued" || prebuild?.status === "building"

--- a/components/dashboard/src/projects/ProjectListItem.tsx
+++ b/components/dashboard/src/projects/ProjectListItem.tsx
@@ -4,7 +4,7 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { FunctionComponent, useMemo, useState } from "react";
+import { FunctionComponent, useContext, useMemo, useState } from "react";
 import dayjs from "dayjs";
 import { Project } from "@gitpod/gitpod-protocol";
 import { Link } from "react-router-dom";
@@ -15,6 +15,7 @@ import { toRemoteURL } from "./render-utils";
 import { prebuildStatusIcon } from "./Prebuilds";
 import { gitpodHostUrl } from "../service/service";
 import { useLatestProjectPrebuildQuery } from "../data/prebuilds/latest-project-prebuild-query";
+import { StartWorkspaceModalContext } from "../workspaces/start-workspace-modal-context";
 
 type ProjectListItemProps = {
     project: Project;
@@ -25,6 +26,7 @@ export const ProjectListItem: FunctionComponent<ProjectListItemProps> = ({ proje
     const team = useCurrentTeam();
     const [showRemoveModal, setShowRemoveModal] = useState(false);
     const { data: prebuild, isLoading } = useLatestProjectPrebuildQuery({ projectId: project.id });
+    const { setStartWorkspaceModalProps } = useContext(StartWorkspaceModalContext);
 
     const teamOrUserSlug = useMemo(() => {
         return !!team ? "t/" + team.slug : "projects";
@@ -47,9 +49,11 @@ export const ProjectListItem: FunctionComponent<ProjectListItemProps> = ({ proje
                                     },
                                     {
                                         title: "New Workspace ...",
-                                        href: gitpodHostUrl
-                                            .withContext(`${project.cloneUrl}`, { showOptions: true })
-                                            .toString(),
+                                        onClick: () =>
+                                            setStartWorkspaceModalProps({
+                                                contextUrl: project.cloneUrl,
+                                                allowContextUrlChange: true,
+                                            }),
                                         separator: true,
                                     },
                                     {

--- a/components/dashboard/src/workspaces/StartWorkspaceModal.tsx
+++ b/components/dashboard/src/workspaces/StartWorkspaceModal.tsx
@@ -17,6 +17,8 @@ export interface StartWorkspaceModalProps {
     ide?: string;
     workspaceClass?: string;
     contextUrl?: string;
+    // If contextUrl is provided, setting `allowContextUrlChange` to true will allow it to be changed still
+    allowContextUrlChange?: boolean;
     onClose?: () => void;
 }
 
@@ -88,7 +90,10 @@ export function StartWorkspaceModal(props: StartWorkspaceModalProps) {
             <div className="-mx-6 px-6">
                 <div className="text-xs text-gray-500">Start a new workspace with the following options.</div>
                 <div className="pt-3">
-                    <RepositoryFinder setSelection={props.contextUrl ? undefined : setRepo} initialValue={repo} />
+                    <RepositoryFinder
+                        setSelection={props.contextUrl && !props.allowContextUrlChange ? undefined : setRepo}
+                        initialValue={repo}
+                    />
                 </div>
                 <div className="pt-3">
                     {errorIde && <div className="text-red-500 text-sm">{errorIde}</div>}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This adjusts the Start Workspace UI from the Projects list page and Branches page to open in a modal vs. redirecting to a new page. This allows the modal to be closed, and avoids losing your context of what you were doing when you opened it.

While in here, I also noticed the RepositoryFinder component was continuously making calls to `getSuggestedContextURLs` due to a `useEffect()` dep that it mutate, so I corrected that was well.

I added an option to the StartWorkspaceModal to allow the `contextUrl` to be changed even if passed in, as locking it felt unnecessary here, although we do default it to the project's url.

![image](https://user-images.githubusercontent.com/367275/213609151-76dbea29-bb92-44e8-ace3-30ae37048448.png)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #15696

## How to test
<!-- Provide steps to test this PR -->
* On the preview environment, create a new team and project
* On the Projects list page, click the overflow menu, and select `New Workspace...`
* It should open the Start Workspace modal instead of navigating to a new page
* It should default the context url based on the project you selected
* You should still be able to change the context url even though it defaulted

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
