### PR TITLE
obs: Make AutoscaleFailure ago down to warning level

### DIFF
--- a/operations/observability/mixins/workspace/rules/central/nodes.yaml
+++ b/operations/observability/mixins/workspace/rules/central/nodes.yaml
@@ -47,7 +47,8 @@ spec:
 
     - alert: AutoscaleFailure
       labels:
-        severity: critical
+        severity: warning
+        team: workspace
       annotations:
         runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/AutoscaleFailure.md
         summary: Automatic scale-up failed for some reason.


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This alert has no direct impact on the user, so it should be at the WARN level.

e.g. If a scale-up failure is affecting users, the InstanceStartFailures alert should go off because users' workspace cannot launch any cluster due to a lack of resources.
https://github.com/gitpod-io/gitpod/blob/7706df3313e91bb36d4e51915f3fd8d6595b0d3e/operations/observability/mixins/meta/rules/server.yaml#L36-L45

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/15863

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
