### PR TITLE
Preview Env Bugfix

### DIFF
--- a/dev/preview/workflow/preview/determine-env.sh
+++ b/dev/preview/workflow/preview/determine-env.sh
@@ -13,7 +13,7 @@ fi
 
 state_output=$(terraform_output "infra_provider")
 # If we don't have the provider_choice in the outputs, bail. This is temporary until all envs have it set
-if [[ -z "${state_output}" ]]; then
+if [[ "${state_output}" != "harvester" && "${state_output}" != "gce" ]]; then
   return
 fi
 


### PR DESCRIPTION
## Description
Follow-up-fix for #15894:

At the initial creation of a preview env, `terraform output` outputs:
![image](https://user-images.githubusercontent.com/239422/213658911-3087170a-815a-4f6e-b323-52f42224a578.png)

Thus, the check `[[ -z "${state_output}" ]]` is true even though we're not getting a valid value.
This PR tightens the check to only accept valid values.

If did not find args for `terraform output` that would make it skip this warning message. 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #15894

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
