### PR TITLE
support docker in rootless images

### DIFF
--- a/components/docker-up/BUILD.yaml
+++ b/components/docker-up/BUILD.yaml
@@ -40,6 +40,10 @@ packages:
       - :bin-runc-facade
     config:
       commands:
+        - ["mkdir", "unarchived"]
+        - ["tar", "-zxvf", "components-docker-up--bin-docker-up/docker.tgz", "-C", "unarchived"]
+        - ["cp", "-vaR", "unarchived/docker/.", "."]
+        - ["rm", "-r", "unarchived"]
         - ["mv", "components-docker-up--bin-docker-up/docker-up", "docker-up"]
         - ["rm", "-r", "components-docker-up--bin-docker-up"]
         - ["mv", "components-docker-up--bin-runc-facade/docker-up", "runc-facade"]


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Rootless images without docker cli don't have easy way to install, and without docker cli docker-up cannot be triggered. In fact docker cli already is a part of docker-up. This PR resolves it by preinstalling docker cli and daemon as a part of docker-up image instead of doing at runtime.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
fix #15917

## How to test
<!-- Provide steps to test this PR -->

Test in https://github.com/gitpod-samples/template-elixir

```
docker build . -f .gitpod.Dockerfile
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
