### PR TITLE
Unblock testing of Dedicated preview envs

### DIFF
--- a/components/gitpod-db/src/typeorm/user-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/user-db-impl.ts
@@ -33,7 +33,6 @@ import { v4 as uuidv4 } from "uuid";
 import {
     BUILTIN_WORKSPACE_PROBE_USER_ID,
     BUILTIN_WORKSPACE_USER_AGENT_SMITH,
-    BUILTIN_INSTLLATION_ADMIN_USER_ID,
     MaybeUser,
     PartialUserUpdate,
     UserDB,
@@ -381,7 +380,7 @@ export class TypeORMUserDBImpl implements UserDB {
             WHERE markedDeleted != true`;
         if (excludeBuiltinUsers) {
             query = `${query}
-                AND id NOT IN ('${BUILTIN_WORKSPACE_PROBE_USER_ID}', '${BUILTIN_WORKSPACE_USER_AGENT_SMITH}', '${BUILTIN_INSTLLATION_ADMIN_USER_ID}')`;
+                AND id NOT IN ('${BUILTIN_WORKSPACE_PROBE_USER_ID}', '${BUILTIN_WORKSPACE_USER_AGENT_SMITH}')`;
         }
         const res = await userRepo.query(query);
         const count = res[0].cnt;


### PR DESCRIPTION
Alternative to https://github.com/gitpod-io/gitpod/pull/15929

This PR excludes the pre-seeded admin account from `getUserCount` computation.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-dedicated-emulation
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
