### PR TITLE
[installer] regenerate render tests

### DIFF
--- a/install/installer/cmd/testdata/render/agent-smith/output.golden
+++ b/install/installer/cmd/testdata/render/agent-smith/output.golden
@@ -1301,6 +1301,19 @@ data:
   proxyUsername: ""
   proxyPassword: ""
 ---
+# v1/Secret server-admin-secret
+apiVersion: v1
+data:
+  login-key: bTMwRUgtTTItY1dNZ2tnZHk3cHU=
+kind: Secret
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: server
+  name: server-admin-secret
+  namespace: default
+---
 # v1/ConfigMap agent-smith
 apiVersion: v1
 data:
@@ -2849,6 +2862,16 @@ data:
         app: gitpod
         component: server
       name: server
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: server
+      name: server-admin-secret
       namespace: default
     ---
     apiVersion: networking.k8s.io/v1
@@ -5635,7 +5658,7 @@ data:
       },
       "oauthServer": {
         "enabled": true,
-        "jwtSecret": "m30EH-M2-cWMgkgdy7pu"
+        "jwtSecret": "_7wODLGlsPauKCw4SBI2"
       },
       "rateLimiter": {
         "groups": {
@@ -5668,6 +5691,10 @@ data:
         "contentLimit": 0,
         "resources": null
       },
+      "admin": {
+        "grantFirstUserAdminRole": true
+      },
+      "adminLoginKeyFile": "/admin/login-key",
       "prebuildLimiter": {
         "*": {
           "limit": 100,
@@ -10829,7 +10856,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: f52ae23eddcf2fe15c87ec92cc3d998045c5ff491d52caed0f23a6fccc020134
+        gitpod.io/checksum_config: 550e02430b4a042f739e7c0d1baa862ef615c832e308bd185227308e596dec0d
       creationTimestamp: null
       labels:
         app: gitpod
@@ -10970,6 +10997,9 @@ spec:
         - mountPath: /ws-manager-client-tls-certs
           name: ws-manager-client-tls-certs
           readOnly: true
+        - mountPath: /admin
+          name: admin-login-key
+          readOnly: true
       - args:
         - --logtostderr
         - --insecure-listen-address=[$(IP)]:9500
@@ -11084,6 +11114,9 @@ spec:
       - name: ws-manager-client-tls-certs
         secret:
           secretName: ws-manager-client-tls
+      - name: admin-login-key
+        secret:
+          secretName: server-admin-secret
 status: {}
 ---
 # apps/v1/Deployment ws-manager

--- a/install/installer/cmd/testdata/render/pod-config/output.golden
+++ b/install/installer/cmd/testdata/render/pod-config/output.golden
@@ -1301,6 +1301,19 @@ data:
   proxyUsername: ""
   proxyPassword: ""
 ---
+# v1/Secret server-admin-secret
+apiVersion: v1
+data:
+  login-key: bTMwRUgtTTItY1dNZ2tnZHk3cHU=
+kind: Secret
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: server
+  name: server-admin-secret
+  namespace: default
+---
 # v1/ConfigMap agent-smith
 apiVersion: v1
 data:
@@ -2673,6 +2686,16 @@ data:
         app: gitpod
         component: server
       name: server
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: server
+      name: server-admin-secret
       namespace: default
     ---
     apiVersion: networking.k8s.io/v1
@@ -5459,7 +5482,7 @@ data:
       },
       "oauthServer": {
         "enabled": true,
-        "jwtSecret": "m30EH-M2-cWMgkgdy7pu"
+        "jwtSecret": "_7wODLGlsPauKCw4SBI2"
       },
       "rateLimiter": {
         "groups": {
@@ -5492,6 +5515,10 @@ data:
         "contentLimit": 0,
         "resources": null
       },
+      "admin": {
+        "grantFirstUserAdminRole": true
+      },
+      "adminLoginKeyFile": "/admin/login-key",
       "prebuildLimiter": {
         "*": {
           "limit": 100,
@@ -10653,7 +10680,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: f52ae23eddcf2fe15c87ec92cc3d998045c5ff491d52caed0f23a6fccc020134
+        gitpod.io/checksum_config: 550e02430b4a042f739e7c0d1baa862ef615c832e308bd185227308e596dec0d
       creationTimestamp: null
       labels:
         app: gitpod
@@ -10794,6 +10821,9 @@ spec:
         - mountPath: /ws-manager-client-tls-certs
           name: ws-manager-client-tls-certs
           readOnly: true
+        - mountPath: /admin
+          name: admin-login-key
+          readOnly: true
       - args:
         - --logtostderr
         - --insecure-listen-address=[$(IP)]:9500
@@ -10908,6 +10938,9 @@ spec:
       - name: ws-manager-client-tls-certs
         secret:
           secretName: ws-manager-client-tls
+      - name: admin-login-key
+        secret:
+          secretName: server-admin-secret
 status: {}
 ---
 # apps/v1/Deployment ws-manager

--- a/install/installer/cmd/testdata/render/telemetry/output.golden
+++ b/install/installer/cmd/testdata/render/telemetry/output.golden
@@ -1301,6 +1301,19 @@ data:
   proxyUsername: ""
   proxyPassword: ""
 ---
+# v1/Secret server-admin-secret
+apiVersion: v1
+data:
+  login-key: bTMwRUgtTTItY1dNZ2tnZHk3cHU=
+kind: Secret
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: server
+  name: server-admin-secret
+  namespace: default
+---
 # v1/ConfigMap agent-smith
 apiVersion: v1
 data:
@@ -2670,6 +2683,16 @@ data:
         app: gitpod
         component: server
       name: server
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: server
+      name: server-admin-secret
       namespace: default
     ---
     apiVersion: networking.k8s.io/v1
@@ -5456,7 +5479,7 @@ data:
       },
       "oauthServer": {
         "enabled": true,
-        "jwtSecret": "m30EH-M2-cWMgkgdy7pu"
+        "jwtSecret": "_7wODLGlsPauKCw4SBI2"
       },
       "rateLimiter": {
         "groups": {
@@ -5489,6 +5512,10 @@ data:
         "contentLimit": 0,
         "resources": null
       },
+      "admin": {
+        "grantFirstUserAdminRole": true
+      },
+      "adminLoginKeyFile": "/admin/login-key",
       "prebuildLimiter": {
         "*": {
           "limit": 100,
@@ -10650,7 +10677,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: f52ae23eddcf2fe15c87ec92cc3d998045c5ff491d52caed0f23a6fccc020134
+        gitpod.io/checksum_config: 550e02430b4a042f739e7c0d1baa862ef615c832e308bd185227308e596dec0d
       creationTimestamp: null
       labels:
         app: gitpod
@@ -10791,6 +10818,9 @@ spec:
         - mountPath: /ws-manager-client-tls-certs
           name: ws-manager-client-tls-certs
           readOnly: true
+        - mountPath: /admin
+          name: admin-login-key
+          readOnly: true
       - args:
         - --logtostderr
         - --insecure-listen-address=[$(IP)]:9500
@@ -10905,6 +10935,9 @@ spec:
       - name: ws-manager-client-tls-certs
         secret:
           secretName: ws-manager-client-tls
+      - name: admin-login-key
+        secret:
+          secretName: server-admin-secret
 status: {}
 ---
 # apps/v1/Deployment ws-manager


### PR DESCRIPTION
This should fix the build.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
