### PR TITLE
[oidc] Implement Get OIDC Client Config API

### DIFF
--- a/components/gitpod-db/go/oidc_client_config_test.go
+++ b/components/gitpod-db/go/oidc_client_config_test.go
@@ -83,3 +83,30 @@ func TestDeleteOIDCClientConfig(t *testing.T) {
 	})
 
 }
+
+func TestGetOIDCClientConfigForOrganization(t *testing.T) {
+
+	t.Run("not found when config does not exist", func(t *testing.T) {
+		conn := dbtest.ConnectForTests(t)
+
+		_, err := db.GetOIDCClientConfigForOrganization(context.Background(), conn, uuid.New(), uuid.New())
+		require.Error(t, err)
+		require.ErrorIs(t, err, db.ErrorNotFound)
+	})
+
+	t.Run("retrieves config which exists", func(t *testing.T) {
+		conn := dbtest.ConnectForTests(t)
+
+		orgID := uuid.New()
+
+		created := dbtest.CreateOIDCClientConfigs(t, conn, db.OIDCClientConfig{
+			OrganizationID: &orgID,
+		})[0]
+
+		retrieved, err := db.GetOIDCClientConfigForOrganization(context.Background(), conn, created.ID, *created.OrganizationID)
+		require.NoError(t, err)
+
+		require.Equal(t, created, retrieved)
+	})
+
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Implements Get OIDC Client Config API

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Fixes https://github.com/gitpod-io/gitpod/issues/15152
* Depends on https://github.com/gitpod-io/gitpod/pull/15925

## How to test
<!-- Provide steps to test this PR -->
* Unit tests

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all-ci
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold for dependency on https://github.com/gitpod-io/gitpod/pull/15925