### PR TITLE
[dedicated] Never show the self-hosted setup modal (by adding option showSetupModal: true)

### DIFF
--- a/components/server/src/config.ts
+++ b/components/server/src/config.ts
@@ -143,6 +143,8 @@ export interface ConfigSerialized {
         passlist: string[];
     };
 
+    showSetupModal: boolean;
+
     adminLoginKeyFile: string;
     admin: {
         grantFirstUserAdminRole: boolean;

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -408,6 +408,9 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
     protected async doUpdateUser(): Promise<void> {
         // execute the check for the setup to be shown until the setup is not required.
         // cf. evaluation of the condition in `checkUser`
+        if (!this.config.showSetupModal) {
+            this.showSetupCondition = { value: false };
+        }
         if (!this.showSetupCondition || this.showSetupCondition.value === true) {
             const hasAnyStaticProviders = this.hostContextProvider
                 .getAll()

--- a/dev/preview/workflow/preview/deploy-gitpod.sh
+++ b/dev/preview/workflow/preview/deploy-gitpod.sh
@@ -355,6 +355,9 @@ then
           --dry-run=client -o yaml | \
           kubectl --kubeconfig "${PREVIEW_K3S_KUBE_PATH}" --context "${PREVIEW_K3S_KUBE_CONTEXT}" replace --force -f -
   done
+
+  # Suppress the Self-Hosted setup modal
+  yq w -i "${INSTALLER_CONFIG_PATH}" experimental.webapp.server.showSetupModal "false"
 fi
 
 

--- a/install/installer/cmd/testdata/render/agent-smith/output.golden
+++ b/install/installer/cmd/testdata/render/agent-smith/output.golden
@@ -5611,6 +5611,7 @@ data:
       "enablePayment": false,
       "patSigningKeyFile": "",
       "withoutWorkspaceComponents": false,
+      "showSetupModal": true,
       "workspaceHeartbeat": {
         "intervalSeconds": 60,
         "timeoutSeconds": 300
@@ -10856,7 +10857,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 550e02430b4a042f739e7c0d1baa862ef615c832e308bd185227308e596dec0d
+        gitpod.io/checksum_config: 3cbf6419cc635586dee0590dba116c7928b8a5c9fd21253ca53e7a246940e369
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/aws-setup/output.golden
+++ b/install/installer/cmd/testdata/render/aws-setup/output.golden
@@ -4956,6 +4956,7 @@ data:
       "enablePayment": false,
       "patSigningKeyFile": "",
       "withoutWorkspaceComponents": false,
+      "showSetupModal": true,
       "workspaceHeartbeat": {
         "intervalSeconds": 60,
         "timeoutSeconds": 300
@@ -9673,7 +9674,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 5269d9fc5c6b73baff49aac56fba12707ad3a7e30252fdcba506ef27fb1afebf
+        gitpod.io/checksum_config: 3d4047140424b6cc95f77ac2f3b141defad051e86f4671a39f7f31d7a2104e86
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/azure-setup/output.golden
+++ b/install/installer/cmd/testdata/render/azure-setup/output.golden
@@ -5022,6 +5022,7 @@ data:
       "enablePayment": false,
       "patSigningKeyFile": "",
       "withoutWorkspaceComponents": false,
+      "showSetupModal": true,
       "workspaceHeartbeat": {
         "intervalSeconds": 60,
         "timeoutSeconds": 300
@@ -9870,7 +9871,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 5269d9fc5c6b73baff49aac56fba12707ad3a7e30252fdcba506ef27fb1afebf
+        gitpod.io/checksum_config: 3d4047140424b6cc95f77ac2f3b141defad051e86f4671a39f7f31d7a2104e86
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
+++ b/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
@@ -5429,6 +5429,7 @@ data:
       "enablePayment": false,
       "patSigningKeyFile": "",
       "withoutWorkspaceComponents": false,
+      "showSetupModal": true,
       "workspaceHeartbeat": {
         "intervalSeconds": 60,
         "timeoutSeconds": 300
@@ -10674,7 +10675,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 4da63a919ee3c1a5536eb78fdca63be3ce849c20d4e8f8a0d7c90381be844753
+        gitpod.io/checksum_config: a650c4798487d5b4bfddae5466f28d9990d216a5e0be8ec832228a3e0ae48331
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -6027,6 +6027,7 @@ data:
       "enablePayment": false,
       "patSigningKeyFile": "",
       "withoutWorkspaceComponents": false,
+      "showSetupModal": true,
       "workspaceHeartbeat": {
         "intervalSeconds": 60,
         "timeoutSeconds": 300
@@ -11528,7 +11529,7 @@ spec:
     metadata:
       annotations:
         gitpod.io: hello
-        gitpod.io/checksum_config: c3b0b1bc8f51ba9af5abeb508dcba2952067d9f94e0acf102ccf0caf178dfc92
+        gitpod.io/checksum_config: 05ea415d86820cdebe10c6e25e8dc68addab2f02c272900fafe82cb5b63eb729
         hello: world
       creationTimestamp: null
       labels:

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -5209,6 +5209,7 @@ data:
       "enablePayment": false,
       "patSigningKeyFile": "",
       "withoutWorkspaceComponents": false,
+      "showSetupModal": true,
       "workspaceHeartbeat": {
         "intervalSeconds": 60,
         "timeoutSeconds": 300
@@ -10297,7 +10298,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 550e02430b4a042f739e7c0d1baa862ef615c832e308bd185227308e596dec0d
+        gitpod.io/checksum_config: 3cbf6419cc635586dee0590dba116c7928b8a5c9fd21253ca53e7a246940e369
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/gcp-setup/output.golden
+++ b/install/installer/cmd/testdata/render/gcp-setup/output.golden
@@ -4983,6 +4983,7 @@ data:
       "enablePayment": false,
       "patSigningKeyFile": "",
       "withoutWorkspaceComponents": false,
+      "showSetupModal": true,
       "workspaceHeartbeat": {
         "intervalSeconds": 60,
         "timeoutSeconds": 300
@@ -9778,7 +9779,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 9515c439aaad606d1301d3c1476ccf4cabfd9bea5dd81920a0be269eb2b7400f
+        gitpod.io/checksum_config: 63ef1bddf21762d0e8860832e3af6df082fdc2328e0693bfe1966291ebc0591c
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/http-proxy/output.golden
+++ b/install/installer/cmd/testdata/render/http-proxy/output.golden
@@ -5432,6 +5432,7 @@ data:
       "enablePayment": false,
       "patSigningKeyFile": "",
       "withoutWorkspaceComponents": false,
+      "showSetupModal": true,
       "workspaceHeartbeat": {
         "intervalSeconds": 60,
         "timeoutSeconds": 300
@@ -11919,7 +11920,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 550e02430b4a042f739e7c0d1baa862ef615c832e308bd185227308e596dec0d
+        gitpod.io/checksum_config: 3cbf6419cc635586dee0590dba116c7928b8a5c9fd21253ca53e7a246940e369
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/kind-meta/output.golden
+++ b/install/installer/cmd/testdata/render/kind-meta/output.golden
@@ -4305,6 +4305,7 @@ data:
       "enablePayment": false,
       "patSigningKeyFile": "",
       "withoutWorkspaceComponents": false,
+      "showSetupModal": true,
       "workspaceHeartbeat": {
         "intervalSeconds": 60,
         "timeoutSeconds": 300
@@ -7860,7 +7861,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 550e02430b4a042f739e7c0d1baa862ef615c832e308bd185227308e596dec0d
+        gitpod.io/checksum_config: 3cbf6419cc635586dee0590dba116c7928b8a5c9fd21253ca53e7a246940e369
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/kind-webapp/output.golden
+++ b/install/installer/cmd/testdata/render/kind-webapp/output.golden
@@ -2395,6 +2395,7 @@ data:
       "enablePayment": false,
       "patSigningKeyFile": "",
       "withoutWorkspaceComponents": false,
+      "showSetupModal": true,
       "workspaceHeartbeat": {
         "intervalSeconds": 60,
         "timeoutSeconds": 300
@@ -4789,7 +4790,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 550e02430b4a042f739e7c0d1baa862ef615c832e308bd185227308e596dec0d
+        gitpod.io/checksum_config: 3cbf6419cc635586dee0590dba116c7928b8a5c9fd21253ca53e7a246940e369
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -5429,6 +5429,7 @@ data:
       "enablePayment": false,
       "patSigningKeyFile": "",
       "withoutWorkspaceComponents": false,
+      "showSetupModal": true,
       "workspaceHeartbeat": {
         "intervalSeconds": 60,
         "timeoutSeconds": 300
@@ -10674,7 +10675,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 550e02430b4a042f739e7c0d1baa862ef615c832e308bd185227308e596dec0d
+        gitpod.io/checksum_config: 3cbf6419cc635586dee0590dba116c7928b8a5c9fd21253ca53e7a246940e369
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/overrides-inline/output.golden
+++ b/install/installer/cmd/testdata/render/overrides-inline/output.golden
@@ -5427,6 +5427,7 @@ data:
       "enablePayment": false,
       "patSigningKeyFile": "",
       "withoutWorkspaceComponents": false,
+      "showSetupModal": true,
       "workspaceHeartbeat": {
         "intervalSeconds": 60,
         "timeoutSeconds": 300
@@ -10684,7 +10685,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 550e02430b4a042f739e7c0d1baa862ef615c832e308bd185227308e596dec0d
+        gitpod.io/checksum_config: 3cbf6419cc635586dee0590dba116c7928b8a5c9fd21253ca53e7a246940e369
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/pod-config/output.golden
+++ b/install/installer/cmd/testdata/render/pod-config/output.golden
@@ -5435,6 +5435,7 @@ data:
       "enablePayment": false,
       "patSigningKeyFile": "",
       "withoutWorkspaceComponents": false,
+      "showSetupModal": true,
       "workspaceHeartbeat": {
         "intervalSeconds": 60,
         "timeoutSeconds": 300
@@ -10680,7 +10681,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 550e02430b4a042f739e7c0d1baa862ef615c832e308bd185227308e596dec0d
+        gitpod.io/checksum_config: 3cbf6419cc635586dee0590dba116c7928b8a5c9fd21253ca53e7a246940e369
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/shortname/output.golden
+++ b/install/installer/cmd/testdata/render/shortname/output.golden
@@ -5429,6 +5429,7 @@ data:
       "enablePayment": false,
       "patSigningKeyFile": "",
       "withoutWorkspaceComponents": false,
+      "showSetupModal": true,
       "workspaceHeartbeat": {
         "intervalSeconds": 60,
         "timeoutSeconds": 300
@@ -10674,7 +10675,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: eed4f3be26ac38b3598e53761f29965c23fa3495b5eb37d2e78381ec9623335f
+        gitpod.io/checksum_config: 3512f4b3372b440eefbdfad14b214086bd0b03ff949aafa0350322340a19ef29
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -5441,6 +5441,7 @@ data:
       "enablePayment": false,
       "patSigningKeyFile": "",
       "withoutWorkspaceComponents": false,
+      "showSetupModal": true,
       "workspaceHeartbeat": {
         "intervalSeconds": 60,
         "timeoutSeconds": 300
@@ -10686,7 +10687,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 550e02430b4a042f739e7c0d1baa862ef615c832e308bd185227308e596dec0d
+        gitpod.io/checksum_config: 3cbf6419cc635586dee0590dba116c7928b8a5c9fd21253ca53e7a246940e369
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/telemetry/output.golden
+++ b/install/installer/cmd/testdata/render/telemetry/output.golden
@@ -5432,6 +5432,7 @@ data:
       "enablePayment": false,
       "patSigningKeyFile": "",
       "withoutWorkspaceComponents": false,
+      "showSetupModal": true,
       "workspaceHeartbeat": {
         "intervalSeconds": 60,
         "timeoutSeconds": 300
@@ -10677,7 +10678,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 550e02430b4a042f739e7c0d1baa862ef615c832e308bd185227308e596dec0d
+        gitpod.io/checksum_config: 3cbf6419cc635586dee0590dba116c7928b8a5c9fd21253ca53e7a246940e369
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
+++ b/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
@@ -5762,6 +5762,7 @@ data:
       "enablePayment": false,
       "patSigningKeyFile": "",
       "withoutWorkspaceComponents": false,
+      "showSetupModal": true,
       "workspaceHeartbeat": {
         "intervalSeconds": 60,
         "timeoutSeconds": 300
@@ -11118,7 +11119,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 550e02430b4a042f739e7c0d1baa862ef615c832e308bd185227308e596dec0d
+        gitpod.io/checksum_config: 3cbf6419cc635586dee0590dba116c7928b8a5c9fd21253ca53e7a246940e369
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
+++ b/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
@@ -5431,6 +5431,7 @@ data:
       "enablePayment": false,
       "patSigningKeyFile": "",
       "withoutWorkspaceComponents": false,
+      "showSetupModal": true,
       "workspaceHeartbeat": {
         "intervalSeconds": 60,
         "timeoutSeconds": 300
@@ -10664,7 +10665,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 550e02430b4a042f739e7c0d1baa862ef615c832e308bd185227308e596dec0d
+        gitpod.io/checksum_config: 3cbf6419cc635586dee0590dba116c7928b8a5c9fd21253ca53e7a246940e369
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
+++ b/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
@@ -5432,6 +5432,7 @@ data:
       "enablePayment": false,
       "patSigningKeyFile": "",
       "withoutWorkspaceComponents": false,
+      "showSetupModal": true,
       "workspaceHeartbeat": {
         "intervalSeconds": 60,
         "timeoutSeconds": 300
@@ -10677,7 +10678,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 550e02430b4a042f739e7c0d1baa862ef615c832e308bd185227308e596dec0d
+        gitpod.io/checksum_config: 3cbf6419cc635586dee0590dba116c7928b8a5c9fd21253ca53e7a246940e369
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/pkg/components/server/configmap.go
+++ b/install/installer/pkg/components/server/configmap.go
@@ -184,6 +184,14 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		return nil
 	})
 
+	showSetupModal := true // old default to make self-hosted continue to work!
+	_ = ctx.WithExperimental(func(cfg *experimental.Config) error {
+		if cfg.WebApp != nil && cfg.WebApp.Server != nil && cfg.WebApp.Server.ShowSetupModal != nil {
+			showSetupModal = *cfg.WebApp.Server.ShowSetupModal
+		}
+		return nil
+	})
+
 	// todo(sje): all these values are configurable
 	scfg := ConfigSerialized{
 		Version:               ctx.VersionManifest.Version,
@@ -280,6 +288,7 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 			GrantFirstUserAdminRole: true, // existing default
 		},
 		AdminLoginKeyFile: fmt.Sprintf("%s/%s", AdminSecretMountPath, AdminSecretLoginKeyName),
+		ShowSetupModal:    showSetupModal,
 	}
 
 	fc, err := common.ToJSONString(scfg)

--- a/install/installer/pkg/components/server/types.go
+++ b/install/installer/pkg/components/server/types.go
@@ -40,6 +40,7 @@ type ConfigSerialized struct {
 	EnablePayment                     bool     `json:"enablePayment"`
 	PATSigningKeyFile                 string   `json:"patSigningKeyFile"`
 	WithoutWorkspaceComponents        bool     `json:"withoutWorkspaceComponents"`
+	ShowSetupModal                    bool     `json:"showSetupModal"`
 
 	WorkspaceHeartbeat         WorkspaceHeartbeat         `json:"workspaceHeartbeat"`
 	WorkspaceDefaults          WorkspaceDefaults          `json:"workspaceDefaults"`

--- a/install/installer/pkg/config/v1/experimental/experimental.go
+++ b/install/installer/pkg/config/v1/experimental/experimental.go
@@ -265,6 +265,7 @@ type ServerConfig struct {
 	RunDbDeleter                      *bool             `json:"runDbDeleter"`
 	DisableWorkspaceGarbageCollection bool              `json:"disableWorkspaceGarbageCollection"`
 	InactivityPeriodForReposInDays    *int              `json:"inactivityPeriodForReposInDays"`
+	ShowSetupModal                    *bool             `json:"showSetupModal"`
 
 	// @deprecated use containerRegistry.privateBaseImageAllowList instead
 	DefaultBaseImageRegistryWhiteList []string `json:"defaultBaseImageRegistryWhitelist"`


### PR DESCRIPTION
## Description
Add option `showSetupModal` (default: true) to suppress the self-hosted setup-modal. Defaults to `true` for backwards compatibility.

Hopefully we can fade out that thing entirely at some point. :crossed_fingers: 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test

1. Start [workspace on this branch](https://gitpod-io/#https://github.com/gitpod-io/gitpod/pull/15929) and `kubectl port-forward deployment/server 9000:9000 &`
2. Obtain OTS key: `curl -X POST localhost:9000/admin-user/login-token/create`
3. Use the result to construct your login URL: `https://gpl-test-dedicated.preview.gitpod-dev.com/api/login/ots/admin-user/:yourOtsKey` and visit it
4. You should be logged in as `admin-user` :checkered_flag: (and not blocked by the setup modal)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all-ci
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-dedicated-emulation
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
