### PR TITLE
[server] redirect to /teams/new after /login/ots/admin-user

### DIFF
--- a/components/server/src/user/user-controller.ts
+++ b/components/server/src/user/user-controller.ts
@@ -162,7 +162,7 @@ export class UserController {
                 });
 
                 // Simply redirect to the app for now
-                res.redirect("/", 307);
+                res.redirect("/teams/new", 307);
             }, BUILTIN_INSTLLATION_ADMIN_USER_ID),
         );
         router.get(


### PR DESCRIPTION
In context of the OTS-based login into the pre-seeded admin account on Dedicated previews, this changes the redirect to `/teams/new`. Reasons are:
* Currently, that's the first move an installer would take anyway, so let's automate.
* We want to avoid to be bothered with onboarding that happens for new users, e.g. config of IDE preferences.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all-ci
- [ ] /werft no-test
      Run Leeway with `--dont-test`
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-dedicated-emulation
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
