### PR TITLE
feat: `defaultBranch` in github app

### DIFF
--- a/components/gitpod-protocol/data/gitpod-schema.json
+++ b/components/gitpod-protocol/data/gitpod-schema.json
@@ -9,9 +9,7 @@
             "description": "List of exposed ports.",
             "items": {
                 "type": "object",
-                "required": [
-                    "port"
-                ],
+                "required": ["port"],
                 "properties": {
                     "port": {
                         "type": ["number", "string"],
@@ -20,20 +18,12 @@
                     },
                     "onOpen": {
                         "type": "string",
-                        "enum": [
-                            "open-browser",
-                            "open-preview",
-                            "notify",
-                            "ignore"
-                        ],
+                        "enum": ["open-browser", "open-preview", "notify", "ignore"],
                         "description": "What to do when a service on this port was detected. 'notify' (default) will show a notification asking the user what to do. 'open-browser' will open a new browser tab. 'open-preview' will open in the preview on the right of the IDE. 'ignore' will do nothing."
                     },
                     "visibility": {
                         "type": "string",
-                        "enum": [
-                            "private",
-                            "public"
-                        ],
+                        "enum": ["private", "public"],
                         "default": "private",
                         "description": "Whether the port visibility should be private or public. 'private' (default) will only allow users with workspace access to access the port. 'public' will allow everyone with the port URL to access the port."
                     },
@@ -43,11 +33,7 @@
                     },
                     "protocol": {
                         "type": "string",
-                        "enum": [
-                            "http",
-                            "TCP",
-                            "UDP"
-                        ],
+                        "enum": ["http", "TCP", "UDP"],
                         "deprecationMessage": "The 'protocol' property is deprecated.",
                         "description": "The protocol to be used. (deprecated)"
                     },
@@ -92,22 +78,12 @@
                     },
                     "openIn": {
                         "type": "string",
-                        "enum": [
-                            "bottom",
-                            "main",
-                            "left",
-                            "right"
-                        ],
+                        "enum": ["bottom", "main", "left", "right"],
                         "description": "The panel/area where to open the terminal. Default is 'bottom' panel."
                     },
                     "openMode": {
                         "type": "string",
-                        "enum": [
-                            "split-left",
-                            "split-right",
-                            "tab-before",
-                            "tab-after"
-                        ],
+                        "enum": ["split-left", "split-right", "tab-before", "tab-after"],
                         "description": "The opening mode. Default is 'tab-after'."
                     }
                 },
@@ -115,15 +91,10 @@
             }
         },
         "image": {
-            "type": [
-                "object",
-                "string"
-            ],
+            "type": ["object", "string"],
             "description": "The Docker image to run your workspace in.",
             "default": "gitpod/workspace-full",
-            "required": [
-                "file"
-            ],
+            "required": ["file"],
             "properties": {
                 "file": {
                     "type": "string",
@@ -141,9 +112,7 @@
             "description": "List of additional repositories that are part of this project.",
             "items": {
                 "type": "object",
-                "required": [
-                    "url"
-                ],
+                "required": ["url"],
                 "properties": {
                     "url": {
                         "type": ["string"],
@@ -170,9 +139,7 @@
             "description": "Path to where the IDE's workspace should be opened. Supports vscode's `*.code-workspace` files."
         },
         "gitConfig": {
-            "type": [
-                "object"
-            ],
+            "type": ["object"],
             "description": "Git config values should be provided in pairs. E.g. `core.autocrlf: input`. See https://git-scm.com/docs/git-config#_values.",
             "additionalProperties": {
                 "type": "string"
@@ -183,15 +150,17 @@
             "description": "Configures Gitpod's GitHub app",
             "properties": {
                 "prebuilds": {
-                    "type": [
-                        "boolean",
-                        "object"
-                    ],
+                    "type": ["boolean", "object"],
                     "description": "Set to true to enable workspace prebuilds, false to disable them. Defaults to true.",
                     "properties": {
                         "master": {
                             "type": "boolean",
-                            "description": "Enable prebuilds for the default branch (typically master). Defaults to true."
+                            "description": "Enable prebuilds for the default branch (typically master). Defaults to true.",
+                            "deprecationMessage": "Deprecated. Please use `defaultBranch` instead. See https://www.gitpod.io/docs/configure/projects/prebuilds#github-specific-configuration."
+                        },
+                        "defaultBranch": {
+                            "type": "boolean",
+                            "description": "Enable prebuilds for the default branch (typically main). Defaults to true."
                         },
                         "branches": {
                             "type": "boolean",
@@ -210,22 +179,12 @@
                             "description": "Add a Review in Gitpod badge to pull requests. Defaults to true."
                         },
                         "addCheck": {
-                            "type": [
-                                "boolean",
-                                "string"
-                            ],
-                            "enum": [
-                                true,
-                                false,
-                                "prevent-merge-on-error"
-                            ],
+                            "type": ["boolean", "string"],
+                            "enum": [true, false, "prevent-merge-on-error"],
                             "description": "Add a commit check to pull requests. Set to 'fail-on-error' if you want broken prebuilds to block merging. Defaults to true."
                         },
                         "addLabel": {
-                            "type": [
-                                "boolean",
-                                "string"
-                            ],
+                            "type": ["boolean", "string"],
                             "description": "Add a label to a PR when it's prebuilt. Set to true to use the default label (prebuilt-in-gitpod) or set to a string to use a different label name. This is a beta feature and may be unreliable. Defaults to false."
                         }
                     }
@@ -339,11 +298,7 @@
                     "properties": {
                         "version": {
                             "type": "string",
-                            "enum": [
-                                "stable",
-                                "latest",
-                                "both"
-                            ],
+                            "enum": ["stable", "latest", "both"],
                             "description": "Whether only stable, latest or both versions should be warmed up. Default is stable only."
                         }
                     }

--- a/components/gitpod-protocol/go/gitpod-config-types.go
+++ b/components/gitpod-protocol/go/gitpod-config-types.go
@@ -179,6 +179,9 @@ type Prebuilds_object struct {
 	// Enable prebuilds for all branches. Defaults to false.
 	Branches bool `yaml:"branches,omitempty" json:"branches,omitempty"`
 
+	// Enable prebuilds for the default branch (typically main). Defaults to true.
+	DefaultBranch bool `yaml:"defaultBranch,omitempty" json:"defaultBranch,omitempty"`
+
 	// Enable prebuilds for the default branch (typically master). Defaults to true.
 	Master bool `yaml:"master,omitempty" json:"master,omitempty"`
 

--- a/components/gitpod-protocol/go/gitpod-service.go
+++ b/components/gitpod-protocol/go/gitpod-service.go
@@ -1926,7 +1926,8 @@ type GithubAppPrebuildConfig struct {
 	AddComment            bool        `json:"addComment,omitempty"`
 	AddLabel              interface{} `json:"addLabel,omitempty"`
 	Branches              bool        `json:"branches,omitempty"`
-	Master                bool        `json:"master,omitempty"`
+	Master                bool        `json:"master,omitempty"` // Deprecated: use DefaultBranch instead
+	DefaultBranch         bool        `json:"defaultBranch,omitempty"`
 	PullRequests          bool        `json:"pullRequests,omitempty"`
 	PullRequestsFromForks bool        `json:"pullRequestsFromForks,omitempty"`
 }

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -849,7 +849,8 @@ export interface GithubAppConfig {
     prebuilds?: GithubAppPrebuildConfig;
 }
 export interface GithubAppPrebuildConfig {
-    master?: boolean;
+    master?: boolean; // Deprecated: use defaultBranch instead
+    defaultBranch?: boolean;
     branches?: boolean;
     pullRequests?: boolean;
     pullRequestsFromForks?: boolean;

--- a/components/server/ee/src/prebuilds/github-app-rules.ts
+++ b/components/server/ee/src/prebuilds/github-app-rules.ts
@@ -16,7 +16,8 @@ const defaultConfig: GithubAppConfig = {
         addComment: false,
         addLabel: false,
         branches: false,
-        master: true,
+        master: false, // Deprecated: use defaultBranch instead
+        defaultBranch: true,
         pullRequests: true,
         pullRequestsFromForks: false,
     },
@@ -52,7 +53,7 @@ export class GithubAppRules {
                 return !!prebuildCfg.pullRequests;
             }
         } else if (isDefaultBranch) {
-            return !!prebuildCfg.master;
+            return /* !!prebuildCfg.master || */ !!prebuildCfg.defaultBranch;
         } else {
             return !!prebuildCfg.branches;
         }

--- a/components/server/ee/src/prebuilds/github-app.spec.ts
+++ b/components/server/ee/src/prebuilds/github-app.spec.ts
@@ -37,10 +37,15 @@ describe("GitHub app", () => {
                 tasks: [{ init: "ls" }],
             };
 
+            // chai.assert.equal(
+            //     rules.shouldRunPrebuild(cfg, true, false, false),
+            //     expectation[0],
+            //     `master prebuild check failed with ${JSON.stringify(pbcfg)}`,
+            // );
             chai.assert.equal(
                 rules.shouldRunPrebuild(cfg, true, false, false),
                 expectation[0],
-                `master prebuild check failed with ${JSON.stringify(pbcfg)}`,
+                `defaultBranch prebuild check failed with ${JSON.stringify(pbcfg)}`,
             );
             chai.assert.equal(
                 rules.shouldRunPrebuild(cfg, false, true, false),
@@ -60,10 +65,14 @@ describe("GitHub app", () => {
         };
 
         checkConfig({ branches: true }, [true, true, true, false]);
-        checkConfig({ master: false }, [false, true, false, false]);
-        checkConfig({ master: false, branches: true }, [false, true, true, false]);
+        // checkConfig({ master: false }, [false, true, false, false]);
+        // checkConfig({ master: false, branches: true }, [false, true, true, false]);
+        checkConfig({ defaultBranch: false }, [false, true, false, false]);
+        // checkConfig({ master: false, defaultBranch: false }, [false, true, false, false]);
+        checkConfig({ defaultBranch: false, branches: true }, [false, true, true, false]);
         checkConfig({ pullRequests: false }, [true, false, false, false]);
-        checkConfig({ pullRequests: false, master: false }, [false, false, false, false]);
+        // checkConfig({ pullRequests: false, master: false }, [false, false, false, false]);
+        checkConfig({ pullRequests: false, defaultBranch: false }, [false, false, false, false]);
         checkConfig({ pullRequests: true, pullRequestsFromForks: true }, [true, true, false, true]);
         checkConfig({ pullRequestsFromForks: true }, [true, true, false, true]);
     });


### PR DESCRIPTION


## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #10358

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all-ci
- [ ] /werft no-test
      Run Leeway with `--dont-test`
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-integration-tests=workspace
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

> Signed-off-by: Siddhant Khare <siddhant@gitpod.io>