### PR TITLE
[proxy] Route /iam/* to public-api-server

### DIFF
--- a/components/proxy/conf/Caddyfile
+++ b/components/proxy/conf/Caddyfile
@@ -289,7 +289,7 @@ https://{$GITPOD_DOMAIN} {
 
 		uri strip_prefix /iam
 
-		reverse_proxy iam.{$KUBE_NAMESPACE}.{$KUBE_DOMAIN}:9002 {
+		reverse_proxy public-api-server.{$KUBE_NAMESPACE}.{$KUBE_DOMAIN}:9002 {
 			import upstream_connection
 		}
 	}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Routes `/iam/*` requests to `public-api-server`. Handlers are mounted on the `public-api-server` in https://github.com/gitpod-io/gitpod/pull/15939

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Depends on https://github.com/gitpod-io/gitpod/pull/15939
* Part of https://github.com/gitpod-io/gitpod/issues/15860

## How to test
<!-- Provide steps to test this PR -->
1. Preview
2. Access preview on `https://mp-proxy-r093a737b1c.preview.gitpod-dev.com/iam/oidc/start`
3. Observe 404 - no valid config - expected as we didn't specify OIDC details, but it means the endpoint is being handled by public-api

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all-ci
- [ ] /werft no-test
      Run Leeway with `--dont-test`
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold for dependency on https://github.com/gitpod-io/gitpod/pull/15939