### PR TITLE
[fix] :Preselect editor and class on the new workspace modal on first load

### DIFF
--- a/components/dashboard/src/components/DropDown2.tsx
+++ b/components/dashboard/src/components/DropDown2.tsx
@@ -19,6 +19,7 @@ export interface DropDown2Props {
     disableSearch?: boolean;
     expanded?: boolean;
     onSelectionChange: (id: string) => void;
+    allOptions?: string;
 }
 
 export const DropDown2: FunctionComponent<DropDown2Props> = (props) => {
@@ -38,6 +39,9 @@ export const DropDown2: FunctionComponent<DropDown2Props> = (props) => {
     // reset search when the drop down is expanded or closed
     useEffect(() => {
         setSearch("");
+        if (props.allOptions) {
+            setSelectedElementTemp(props.allOptions);
+        }
         if (showDropDown && selectedElementTemp) {
             document.getElementById(selectedElementTemp)?.scrollIntoView({ behavior: "smooth", block: "nearest" });
         }

--- a/components/dashboard/src/components/SelectIDEComponent.tsx
+++ b/components/dashboard/src/components/SelectIDEComponent.tsx
@@ -71,6 +71,7 @@ export default function SelectIDEComponent(props: SelectIDEComponentProps) {
             getElements={getElements}
             onSelectionChange={internalOnSelectionChange}
             searchPlaceholder={"Select Editor"}
+            allOptions={ide}
         >
             <IdeOptionElementSelected option={ideOptions?.options[ide]} useLatest={!!props.useLatest} />
         </DropDown2>

--- a/components/dashboard/src/components/SelectWorkspaceClassComponent.tsx
+++ b/components/dashboard/src/components/SelectWorkspaceClassComponent.tsx
@@ -69,6 +69,7 @@ export default function SelectWorkspaceClassComponent(props: SelectWorkspaceClas
             onSelectionChange={internalOnSelectionChange}
             searchPlaceholder="Select class"
             disableSearch={true}
+            allOptions={selectedWsClass?.id}
         >
             <WorkspaceClassDropDownElementSelected wsClass={selectedWsClass} />
         </DropDown2>


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

[screen-capture (1).webm](https://user-images.githubusercontent.com/77020164/213983420-7dfbdc0a-7714-40fc-a563-07684a6e1186.webm)


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #15912

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[fix] :Preselect editor and class on the new workspace modal on first load
```


## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all-ci
- [ ] /werft no-test
      Run Leeway with `--dont-test`
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
