### PR TITLE
[alerts] Reduce trigger duration for Stripe Webhook Failure alert

### DIFF
--- a/operations/observability/mixins/meta/rules/public-api.yaml
+++ b/operations/observability/mixins/meta/rules/public-api.yaml
@@ -30,3 +30,14 @@ spec:
         runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/PublicAPI_ServiceReturningServerErrors.md
         summary: PublicAPI serves multiple different Services and RPC. There have been failing requests due to server errors. Investigation required.
         description: Service {{ $labels.package }}.{{ $labels.call }} has returned {{ printf "%.2f" $value }} server errors in the last 10 minutes.
+
+    - alert: GitpodStripeWebhookFailures
+      expr: sum(increase(gitpod_http_request_duration_seconds_count{handler="/stripe/invoices/webhook", code=~"5.*"}[30m])) > 0
+      for: 10m
+      labels:
+        severity: warning
+        team: webapp
+      annotations:
+        runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodUsageStripeWebhookFailures.md
+        summary: Detected {{ printf "%.2f" $value }} errors handling Stripe webhook.
+        description: Stripe is sending us webhooks but we are failing to handle them. Inconsistent usage data very likely.

--- a/operations/observability/mixins/meta/rules/usage.yaml
+++ b/operations/observability/mixins/meta/rules/usage.yaml
@@ -57,17 +57,6 @@ spec:
         summary: Usage reconciliation has not run successfully for {{ printf "%.2f" $value }} seconds. Usage data is stale.
         description: We have not executed scheduled usage reconciliation for {{ printf "%.2f" $value }} seconds. We expect the data to update every 15 minutes to avoid stale usage records and stale invoices.
 
-    - alert: GitpodUsageStripeWebhookFailures
-      expr: sum(increase(gitpod_http_request_duration_seconds_count{handler="/stripe/invoices/webhook", code=~"5.*"}[30m])) > 0
-      for: 30m
-      labels:
-        severity: warning
-        team: webapp
-      annotations:
-        runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodUsageStripeWebhookFailures.md
-        summary: Detected {{ printf "%.2f" $value }} errors handling Stripe webhook.
-        description: Stripe is sending us webhooks but we are failing to handle them. Inconsistent usage data very likely.
-
     - alert: UsageHighCPUUsage
       # Reasoning: high rates of CPU consumption should only be temporary.
       expr: avg(rate(container_cpu_usage_seconds_total{container!="POD", pod=~"usage-.*"}[5m])) by (cluster) > 0.2


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/15202

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all-ci
- [ ] /werft no-test
      Run Leeway with `--dont-test`
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
