### PR TITLE
[dashboard] Fix team creation view losing team name state

### DIFF
--- a/components/dashboard/src/teams/NewTeam.tsx
+++ b/components/dashboard/src/teams/NewTeam.tsx
@@ -12,11 +12,11 @@ import { ConnectError } from "@bufbuild/connect-web";
 
 export default function () {
     const { setTeams } = useContext(TeamsContext);
+    const [name, setName] = useState("");
 
     const history = useHistory();
 
     const [creationError, setCreationError] = useState<Error>();
-    let name = "";
     const createTeam = async (event: FormEvent) => {
         event.preventDefault();
 
@@ -64,7 +64,7 @@ export default function () {
                         autoFocus
                         className={`w-full${!!creationError ? " error" : ""}`}
                         type="text"
-                        onChange={(event) => (name = event.target.value)}
+                        onChange={(event) => setName(event.target.value)}
                     />
                     {!!creationError && (
                         <p className="text-gitpod-red">


### PR DESCRIPTION
## Description

Ensure that the team name is preserved between renders.

Using a simple variable to store the team name meant that the team name was forgotten every time the component re-rendered. By using local component state the value of the team name is preserved between renders (a render occurs when the error message state is set).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
* Try to create a new team using the same name as an existing team.
* Click the **Create Team** button repeatedly.
* Notice that the error message is the same after each click: `"A team with this name already exists"`.

Without these changes on each click after the first, the error would change to `"Name is a required argument when creating a team."` due to the state being wiped when an error message is set.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all-ci
- [ ] /werft no-test
      Run Leeway with `--dont-test`
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
