### PR TITLE
[db] Use a valid UUID for the admin user

### DIFF
--- a/components/gitpod-db/src/user-db.ts
+++ b/components/gitpod-db/src/user-db.ts
@@ -155,7 +155,8 @@ export const BUILTIN_WORKSPACE_PROBE_USER_ID = "builtin-user-workspace-probe-000
 
 export const BUILTIN_WORKSPACE_USER_AGENT_SMITH = "builtin-user-agent-smith-0000000";
 
-export const BUILTIN_INSTLLATION_ADMIN_USER_ID = "builtin-installation-admin-user-0000";
+// We need a valid UUID for the builtin admin user so that it can authenticate in order to call endpoints for setting up SSO
+export const BUILTIN_INSTLLATION_ADMIN_USER_ID = "f071bb8e-b5d1-46cf-a436-da03ae63bcd2";
 
 export interface OwnerAndRepo {
     owner: string;


### PR DESCRIPTION
## Description

Use a valid UUID for the one-time admin user added by https://github.com/gitpod-io/gitpod/pull/15805.

A valid UUID is required for the admin user to able to interact with the public/server API to set up SSO.

See some [internal discussion](https://gitpod.slack.com/archives/C02EN94AEPL/p1674478515382859?thread_ts=1674466010.292799&cid=C02EN94AEPL).

## Related Issue(s)
Fixes #

## How to test

1. Start [workspace on this branch](https://gitpod-io/#https://github.com/gitpod-io/gitpod/pull/15805) and `kubectl port-forward deployment/server 9000:9000`
2. Obtain OTS key: `curl -X POST localhost:9000/admin-user/login-token/create`
3. Use the result to construct your login URL: `https://<preview-domain>/api/login/ots/admin-user/:yourOtsKey` and visit it.

It should now be possible to configure an OICD client (`Settings | OIDC`).

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all-ci
- [ ] /werft no-test
      Run Leeway with `--dont-test`
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
