### PR TITLE
Introduce action and workflow to delete preview

### DIFF
--- a/.github/actions/delete-preview/Dockerfile
+++ b/.github/actions/delete-preview/Dockerfile
@@ -1,0 +1,3 @@
+FROM eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-leeway-v0.7.3.4
+COPY entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/delete-preview/entrypoint.sh
+++ b/.github/actions/delete-preview/entrypoint.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+export HOME=/home/gitpod
+export PREVIEW_ENV_DEV_SA_KEY_PATH="$HOME/.config/gcloud/preview-environment-dev-sa.json"
+
+echo "${INPUT_SA_KEY}" > "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
+gcloud auth activate-service-account --key-file "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
+
+# Hack alert: We're building previewctl here until we decide how to properly distribute internal tools
+# Also, LEEWAY_WORKSPACE_ROOT is set to /workspace/gitpod in our dev image, but that's not the path GH actions use
+# shellcheck disable=SC2155
+export LEEWAY_WORKSPACE_ROOT="$(pwd)"
+leeway run dev/preview/previewctl:install --dont-test
+
+/workspace/bin/previewctl get-credentials --gcp-service-account "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
+
+export TF_INPUT=0
+export TF_IN_AUTOMATION=true
+export TF_VAR_preview_name="${INPUT_NAME}"
+leeway run dev/preview:delete-preview

--- a/.github/actions/delete-preview/metadata.yml
+++ b/.github/actions/delete-preview/metadata.yml
@@ -1,0 +1,12 @@
+name: "Delete preview environment"
+description: "Deletes a preview environment"
+inputs:
+    sa_key:
+        description: "The service account key to use when authenticating with GCP"
+        required: true
+    name:
+        description: "The name of the preview environment"
+        required: true
+runs:
+    using: "docker"
+    image: "Dockerfile"

--- a/.github/workflows/preview-env-delete.yml
+++ b/.github/workflows/preview-env-delete.yml
@@ -1,0 +1,17 @@
+name: "Delete preview environment"
+on:
+    workflow_dispatch:
+        inputs:
+            name:
+                required: true
+                description: "The name of the preview environment to delete"
+jobs:
+    delete:
+        runs-on: [self-hosted]
+        steps:
+            - uses: actions/checkout@v3
+            - name: Delete preview environment
+              uses: ./.github/actions/delete-preview
+              with:
+                  name: ${{ github.event.inputs.name }}
+                  sa_key: ${{ secrets.GCP_CREDENTIALS }}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This PR introduces

1. A new custom action to delete preview environments
2. A new workflow (triggered manually) which uses the action to delete a preview environment

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of https://github.com/gitpod-io/gitpod/issues/15866

## How to test
<!-- Provide steps to test this PR -->

You can only test newly introduced workflow_dispatch workflows once they're on main. So this is a best effort implementation and I I'll verify if it works on main after the PR is merged.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all-ci
- [ ] /werft no-test
      Run Leeway with `--dont-test`
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
