### PR TITLE
[ws-manager-mk2] Add print columns and shortname

### DIFF
--- a/components/ws-manager-api/go/crd/v1/workspace_types.go
+++ b/components/ws-manager-api/go/crd/v1/workspace_types.go
@@ -232,6 +232,18 @@ type WorkspaceRuntimeStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:resource:shortName=ws
+// Custom print columns on the Custom Resource Definition. These are the columns
+// showing up when doing e.g. `kubectl get workspaces`.
+// Columns with priority > 0 will only show up with `-o wide`.
+//+kubebuilder:printcolumn:name="Workspace",type="string",JSONPath=".spec.ownership.workspaceID",priority=10
+//+kubebuilder:printcolumn:name="Class",type="string",JSONPath=".spec.class"
+//+kubebuilder:printcolumn:name="Type",type="string",JSONPath=".spec.type",priority=10
+//+kubebuilder:printcolumn:name="Node",type="string",JSONPath=".status.runtime.nodeName"
+//+kubebuilder:printcolumn:name="Owner",type="string",JSONPath=".spec.ownership.owner"
+//+kubebuilder:printcolumn:name="Team",type="string",JSONPath=".spec.ownership.team"
+//+kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase"
+//+kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
 // Workspace is the Schema for the workspaces API
 type Workspace struct {

--- a/components/ws-manager-mk2/config/crd/bases/workspace.gitpod.io_workspaces.yaml
+++ b/components/ws-manager-mk2/config/crd/bases/workspace.gitpod.io_workspaces.yaml
@@ -16,10 +16,39 @@ spec:
     kind: Workspace
     listKind: WorkspaceList
     plural: workspaces
+    shortNames:
+    - ws
     singular: workspace
   scope: Namespaced
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.ownership.workspaceID
+      name: Workspace
+      priority: 10
+      type: string
+    - jsonPath: .spec.class
+      name: Class
+      type: string
+    - jsonPath: .spec.type
+      name: Type
+      priority: 10
+      type: string
+    - jsonPath: .status.runtime.nodeName
+      name: Node
+      type: string
+    - jsonPath: .spec.ownership.owner
+      name: Owner
+      type: string
+    - jsonPath: .spec.ownership.team
+      name: Team
+      type: string
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
     schema:
       openAPIV3Schema:
         description: Workspace is the Schema for the workspaces API


### PR DESCRIPTION
## Description
- Add `ws` shortname to the CRD, lets you do `kubectl get ws`.
- Add print columns:
  ```
  $ k get ws
  NAME               CLASS   NODE   OWNER                 TEAM                             PHASE   AGE
  workspace-sample   Large   node   111-222-333-444-555   team-abacdvjklasd-fasdfajskdfl   Running 27m
  ```
  - `-o wide` also shows the workspace ID and type

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

## How to test
<!-- Provide steps to test this PR -->

* Create a preview env
* Run `make install` inside `components/ws-manager-mk2` (kubectx pointing to preview env)
* Create a sample `Workspace` resource, e.g. `kubectl apply -f config/samples/workspace_v1_workspace.yaml`
* Run `kubectl get ws`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all-ci
- [ ] /werft no-test
      Run Leeway with `--dont-test`
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
