### PR TITLE
[ws-manager-mk2] Create code owners entries

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -64,6 +64,7 @@
 /install/installer/pkg/components/workspace/ide @gitpod-io/engineering-ide
 /install/installer/pkg/components/ws-daemon @gitpod-io/engineering-workspace
 /install/installer/pkg/components/ws-manager @gitpod-io/engineering-workspace
+/install/installer/pkg/components/ws-manager-mk2 @gitpod-io/engineering-workspace
 /install/installer/pkg/components/ws-manager-bridge @gitpod-io/engineering-webapp
 /install/installer/pkg/components/ws-proxy @gitpod-io/engineering-workspace
 /install/installer/pkg/config/versions @gitpod-io/engineering-ide
@@ -92,6 +93,7 @@
 /components/ws-manager-bridge-api @gitpod-io/engineering-webapp
 /components/ws-manager-bridge @gitpod-io/engineering-webapp
 /components/ws-manager @gitpod-io/engineering-workspace
+/components/ws-manager-mk2 @gitpod-io/engineering-workspace
 /components/ws-proxy @gitpod-io/engineering-workspace
 /dev/gpctl @gitpod-io/engineering-workspace
 /dev/gpctl/api/ @gitpod-io/engineering-webapp


### PR DESCRIPTION
## Description
Create codeowner entries for ws-manager-mk2

## Related Issue(s)
n.a.

## How to test
n.a.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all-ci
- [ ] /werft no-test
      Run Leeway with `--dont-test`
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
