### PR TITLE
Download previewctl from Docker image

### DIFF
--- a/.github/actions/delete-preview/Dockerfile
+++ b/.github/actions/delete-preview/Dockerfile
@@ -1,3 +1,9 @@
 FROM eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-leeway-v0.7.3.4
+
+USER root
+ENV OCI_TOOL_VERSION="0.2.0"
+RUN curl -fsSL https://github.com/csweichel/oci-tool/releases/download/v${OCI_TOOL_VERSION}/oci-tool_${OCI_TOOL_VERSION}_linux_amd64.tar.gz | tar xz -C /usr/local/bin && chmod +x /usr/local/bin/oci-tool
+USER gitpod
+
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/delete-preview/entrypoint.sh
+++ b/.github/actions/delete-preview/entrypoint.sh
@@ -4,17 +4,16 @@ set -euo pipefail
 
 export HOME=/home/gitpod
 export PREVIEW_ENV_DEV_SA_KEY_PATH="$HOME/.config/gcloud/preview-environment-dev-sa.json"
+export PATH="$PATH:$HOME/bin"
+
+mkdir $HOME/bin
 
 echo "${INPUT_SA_KEY}" > "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
 gcloud auth activate-service-account --key-file "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
 
-# Hack alert: We're building previewctl here until we decide how to properly distribute internal tools
-# Also, LEEWAY_WORKSPACE_ROOT is set to /workspace/gitpod in our dev image, but that's not the path GH actions use
-# shellcheck disable=SC2155
-export LEEWAY_WORKSPACE_ROOT="$(pwd)"
-leeway run dev/preview/previewctl:install --dont-test
+leeway run dev/preview/previewctl:download
 
-/workspace/bin/previewctl get-credentials --gcp-service-account "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
+previewctl get-credentials --gcp-service-account "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
 
 export TF_INPUT=0
 export TF_IN_AUTOMATION=true

--- a/.github/actions/delete-preview/metadata.yml
+++ b/.github/actions/delete-preview/metadata.yml
@@ -7,6 +7,9 @@ inputs:
     name:
         description: "The name of the preview environment"
         required: true
+    previewctl_hash:
+        description: "The Leeway hash of the dev/preview/previewctl:docker package to be used when downloading previewclt"
+        required: false
 runs:
     using: "docker"
     image: "Dockerfile"

--- a/.github/actions/deploy-gitpod/entrypoint.sh
+++ b/.github/actions/deploy-gitpod/entrypoint.sh
@@ -4,11 +4,12 @@ set -euo pipefail
 
 export HOME=/home/gitpod
 export PREVIEW_ENV_DEV_SA_KEY_PATH="$HOME/.config/gcloud/preview-environment-dev-sa.json"
-
+# shellcheck disable=SC2155
+export LEEWAY_WORKSPACE_ROOT="$(pwd)"
 export VERSION="${INPUT_VERSION}"
+export PATH="$PATH:$HOME/bin"
 
 mkdir $HOME/bin
-export PATH="$PATH:$HOME/bin"
 
 echo "Downloading installer for ${VERSION}"
 oci-tool fetch file -o $HOME/bin/installer --platform=linux-amd64 "eu.gcr.io/gitpod-core-dev/build/installer:${VERSION}" app/installer
@@ -20,11 +21,7 @@ oci-tool fetch file -o /tmp/versions.yaml --platform=linux-amd64 "eu.gcr.io/gitp
 echo "${INPUT_SA_KEY}" > "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
 gcloud auth activate-service-account --key-file "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
 
-# Hack alert: We're building previewctl here until we decide how to properly distribute internal tools
-# Also, LEEWAY_WORKSPACE_ROOT is set to /workspace/gitpod in our dev image, but that's not the path GH actions use
-# shellcheck disable=SC2155
-export LEEWAY_WORKSPACE_ROOT="$(pwd)"
-leeway run dev/preview/previewctl:install --dont-test
+leeway run dev/preview/previewctl:download
 
 echo "Setting up access to core-dev and harvester"
 previewctl get-credentials --gcp-service-account "${PREVIEW_ENV_DEV_SA_KEY_PATH}"

--- a/.github/actions/deploy-gitpod/metadata.yml
+++ b/.github/actions/deploy-gitpod/metadata.yml
@@ -7,6 +7,9 @@ inputs:
     version:
         description: "The version of Gitpod to install"
         required: true
+    previewctl_hash:
+        description: "The Leeway hash of the dev/preview/previewctl:docker package to be used when downloading previewclt"
+        required: false
 runs:
     using: "docker"
     image: "Dockerfile"

--- a/.github/actions/deploy-monitoring-satellite/Dockerfile
+++ b/.github/actions/deploy-monitoring-satellite/Dockerfile
@@ -1,3 +1,9 @@
 FROM eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-leeway-v0.7.3.4
+
+USER root
+ENV OCI_TOOL_VERSION="0.2.0"
+RUN curl -fsSL https://github.com/csweichel/oci-tool/releases/download/v${OCI_TOOL_VERSION}/oci-tool_${OCI_TOOL_VERSION}_linux_amd64.tar.gz | tar xz -C /usr/local/bin && chmod +x /usr/local/bin/oci-tool
+USER gitpod
+
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/deploy-monitoring-satellite/entrypoint.sh
+++ b/.github/actions/deploy-monitoring-satellite/entrypoint.sh
@@ -4,15 +4,16 @@ set -euo pipefail
 
 export HOME=/home/gitpod
 export PREVIEW_ENV_DEV_SA_KEY_PATH="$HOME/.config/gcloud/preview-environment-dev-sa.json"
+# shellcheck disable=SC2155
+export LEEWAY_WORKSPACE_ROOT="$(pwd)"
+export PATH="$PATH:$HOME/bin"
+
+mkdir $HOME/bin
 
 echo "${INPUT_SA_KEY}" > "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
 gcloud auth activate-service-account --key-file "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
 
-# Hack alert: We're building previewctl here until we decide how to properly distribute internal tools
-# Also, LEEWAY_WORKSPACE_ROOT is set to /workspace/gitpod in our dev image, but that's not the path GH actions use
-# shellcheck disable=SC2155
-export LEEWAY_WORKSPACE_ROOT="$(pwd)"
-leeway run dev/preview/previewctl:install --dont-test
+leeway run dev/preview/previewctl:download
 
 echo "previewctl get-credentials"
 previewctl get-credentials --gcp-service-account "${PREVIEW_ENV_DEV_SA_KEY_PATH}"

--- a/.github/actions/deploy-monitoring-satellite/metadata.yml
+++ b/.github/actions/deploy-monitoring-satellite/metadata.yml
@@ -4,6 +4,9 @@ inputs:
     sa_key:
         description: "The service account key to use when authenticating with GCP"
         required: true
+    previewctl_hash:
+        description: "The Leeway hash of the dev/preview/previewctl:docker package to be used when downloading previewclt"
+        required: false
 runs:
     using: "docker"
     image: "Dockerfile"

--- a/.github/actions/preview-create/Dockerfile
+++ b/.github/actions/preview-create/Dockerfile
@@ -1,3 +1,9 @@
 FROM eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-leeway-v0.7.3.4
+
+USER root
+ENV OCI_TOOL_VERSION="0.2.0"
+RUN curl -fsSL https://github.com/csweichel/oci-tool/releases/download/v${OCI_TOOL_VERSION}/oci-tool_${OCI_TOOL_VERSION}_linux_amd64.tar.gz | tar xz -C /usr/local/bin && chmod +x /usr/local/bin/oci-tool
+USER gitpod
+
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/preview-create/entrypoint.sh
+++ b/.github/actions/preview-create/entrypoint.sh
@@ -4,20 +4,18 @@ set -euo pipefail
 
 export HOME=/home/gitpod
 export PREVIEW_ENV_DEV_SA_KEY_PATH="$HOME/.config/gcloud/preview-environment-dev-sa.json"
-
-# Don't prompt user before terraform apply
+# shellcheck disable=SC2155
+export LEEWAY_WORKSPACE_ROOT="$(pwd)"
 export TF_INPUT=0
 export TF_IN_AUTOMATION=true
+export PATH="$PATH:$HOME/bin"
+
+mkdir $HOME/bin
 
 echo "${INPUT_SA_KEY}" > "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
 gcloud auth activate-service-account --key-file "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
 
-# Hack alert: We're building previewctl here until we decide how to properly distribute internal tools
-# Also, LEEWAY_WORKSPACE_ROOT is set to /workspace/gitpod in our dev image, but that's not the path GH actions use
-# shellcheck disable=SC2155
-export LEEWAY_WORKSPACE_ROOT="$(pwd)"
-leeway run dev/preview/previewctl:install --dont-test
-
+leeway run dev/preview/previewctl:download
 previewctl get-credentials --gcp-service-account "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
 
 leeway run dev/preview:create-preview

--- a/.github/actions/preview-create/metadata.yml
+++ b/.github/actions/preview-create/metadata.yml
@@ -4,6 +4,9 @@ inputs:
     sa_key:
         description: "The service account key to use when authenticating with GCP"
         required: true
+    previewctl_hash:
+        description: "The Leeway hash of the dev/preview/previewctl:docker package to be used when downloading previewclt"
+        required: false
 runs:
     using: "docker"
     image: "Dockerfile"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -34,7 +34,7 @@ Does this PR require updates to the documentation at www.gitpod.io/docs?
 - [ ] /werft with-github-actions
       Experimental feature to run the build with GitHub Actions (and not in Werft).
 - [ ] leeway-no-cache
-      leeway-target=components:all-ci
+      leeway-target=components:all
 - [ ] /werft no-test
       Run Leeway with `--dont-test`
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,20 +4,55 @@ on:
     types: [opened, synchronize, edited]
 
 jobs:
-  # We are building "previewctl" outside of "build" because we want to start
-  # the infrastructure job as early as possible (before a full build is done)
-  # and that job requires previewctl
-  previewctl:
-    if: ${{ contains(github.event.pull_request.body, '[x] /werft with-github-actions') && contains(github.event.pull_request.body, '[x] /werft with-preview') }}
+
+  configuration:
+    name: Configure job parameters
+    runs-on: [self-hosted]
+    if: ${{ contains(github.event.pull_request.body, '[x] /werft with-github-actions') }}
     concurrency:
-      group: ${{ github.head_ref || github.ref }}-previewctl
+      group: ${{ github.head_ref || github.ref }}-configuration
+      cancel-in-progress: true
+    outputs:
+      version: ${{ steps.output.outputs.version }}
+      preview_enable: ${{ steps.output.outputs.preview_enable }}
+      preview_infra_provider: ${{ steps.output.outputs.preview_infra_provider }}
+      build_no_cache: ${{ steps.output.outputs.build_no_cache }}
+      build_no_test: ${{ steps.output.outputs.build_no_test }}
+      build_leeway_target: ${{ steps.output.outputs.build_leeway_target }}
+    steps:
+      - name: "Determine Branch"
+        id: branches
+        uses: transferwise/sanitize-branch-name@v1
+      - name: "Set outputs"
+        id: output
+        env:
+          PR_DESC: '${{ github.event.pull_request.body }}'
+        shell: bash
+        run: |
+          {
+            echo "version=${{ steps.branches.outputs.sanitized-branch-name }}.${{github.run_number}}"
+            echo "preview_enable=${{ contains(github.event.pull_request.body, '[x] /werft with-preview') }}"
+            echo "preview_infra_provider=${{ contains(github.event.pull_request.body, '[X] /werft with-gce-vm') && 'gce' || 'harvester' }}"
+            echo "build_no_cache=${{ contains(github.event.pull_request.body, '[x] leeway-no-cache') }}"
+            echo "build_no_test=${{ contains(github.event.pull_request.body, '[x] /werft no-test') }}"
+            echo "build_leeway_target=$(echo "$PR_DESC" | sed -n -e 's/^.*leeway-target=//p' | sed 's/\r$//')"
+          } >> $GITHUB_OUTPUT
+
+  build-previewctl:
+    name: Build previewctl
+    needs: [configuration]
+    concurrency:
+      group: ${{ github.head_ref || github.ref }}-build-previewctl
       cancel-in-progress: true
     runs-on: [self-hosted]
     container:
       image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-leeway-v0.7.3.4
+    outputs:
+      previewctl_hash: ${{ steps.build.outputs.previewctl_hash }}
     steps:
       - uses: actions/checkout@v3
-      - name: Build previewctl
+      - name: Build dev:all
+        id: build
         shell: bash
         env:
           HOME: /home/gitpod
@@ -29,31 +64,33 @@ jobs:
           gcloud auth activate-service-account --key-file "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
 
           export LEEWAY_WORKSPACE_ROOT="$(pwd)"
-          leeway build dev/preview/previewctl:cli
+          leeway build dev/preview/previewctl:docker -Dversion="${{needs.configuration.outputs.version}}"
+          echo "previewctl_hash=$(leeway describe dev/preview/previewctl:docker -t '{{ .Metadata.Version }}')" >> $GITHUB_OUTPUT
 
   infrastructure:
+    needs: [configuration, build-previewctl]
+    if: ${{ needs.configuration.outputs.preview_enable }}
     runs-on: [self-hosted]
-    needs: [previewctl]
     concurrency:
       group: ${{ github.head_ref || github.ref }}-infrastructure
     steps:
       - uses: actions/checkout@v3
       - name: Create preview environment infrastructure
         env:
-          TF_VAR_infra_provider: ${{ contains(github.event.pull_request.body, '[X] /werft with-gce-vm') && 'gce' || 'harvester' }}
+          TF_VAR_infra_provider: ${{ needs.configuration.outputs.preview_infra_provider }}
         id: create
         uses: ./.github/actions/preview-create
         with:
           sa_key: ${{ secrets.GCP_CREDENTIALS }}
+          previewctl_hash: ${{ needs.build-previewctl.outputs.previewctl_hash }}
 
-  build:
-    if: ${{ contains(github.event.pull_request.body, '[x] /werft with-github-actions') }}
+  build-gitpod:
+    name: Build Gitpod
+    needs: [configuration]
     runs-on: [self-hosted]
     concurrency:
-      group: ${{ github.head_ref || github.ref }}-build
+      group: ${{ github.head_ref || github.ref }}-build-gitpod
       cancel-in-progress: true
-    outputs:
-      version: ${{ steps.leeway.outputs.version }}
     services:
       mysql:
         image: mysql:5.7
@@ -85,9 +122,6 @@ jobs:
           registry: eu.gcr.io
           username: oauth2accesstoken
           password: "${{ steps.auth.outputs.access_token }}"
-      - name: "Determine Branch"
-        id: branches
-        uses: transferwise/sanitize-branch-name@v1
       - name: Leeway Vet
         shell: bash
         working-directory: /workspace/gitpod
@@ -119,32 +153,21 @@ jobs:
         with:
           secrets: |-
             segment-io-token:gitpod-core-dev/segment-io-token
-      - name: Parse PullRequest
-        shell: bash
-        working-directory: /workspace/gitpod
-        env:
-          PR_DESC: '${{ github.event.pull_request.body }}'
-        run: |
-          PR_NO_CACHE=${{ contains(github.event.pull_request.body, '[x] leeway-no-cache') }}
-          PR_NO_TEST=${{ contains(github.event.pull_request.body, '[x] /werft no-test') }}
-          PR_LEEWAY_TARGET=$(echo "$PR_DESC" | sed -n -e 's/^.*leeway-target=//p' | sed 's/\r$//')
-
-          echo "PR_NO_CACHE=$PR_NO_CACHE" >> $GITHUB_ENV
-          echo "PR_NO_TEST=$PR_NO_TEST"   >> $GITHUB_ENV
-          echo "PR_LEEWAY_TARGET=$PR_LEEWAY_TARGET" >> $GITHUB_ENV
       - name: Leeway Build
         id: leeway
         shell: bash
         working-directory: /workspace/gitpod
         env:
           JAVA_HOME: /home/gitpod/.sdkman/candidates/java/current
-          VERSION: "${{ steps.branches.outputs.sanitized-branch-name }}.${{github.run_number}}"
+          VERSION: ${{needs.configuration.outputs.version}}
           SEGMENT_IO_TOKEN: '${{ steps.secrets.outputs.segment-io-token }}'
+          PR_NO_CACHE: ${{needs.configuration.outputs.build_no_cache}}
+          PR_NO_TEST: ${{needs.configuration.outputs.build_no_test}}
+          PR_LEEWAY_TARGET: ${{needs.configuration.outputs.build_leeway_target}}
         run: |
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
           [[ "$PR_NO_CACHE" = "true" ]] && CACHE="none"       || CACHE="remote"
           [[ "$PR_NO_TEST"  = "true" ]] && TEST="--dont-test" || TEST=""
-          [[ -z "$PR_LEEWAY_TARGET" ]] && PR_LEEWAY_TARGET="components:all-ci"
+          [[ -z "$PR_LEEWAY_TARGET" ]] && PR_LEEWAY_TARGET="components:all"
 
           mkdir -p /__w/gitpod/gitpod/test-coverage-report
 
@@ -172,7 +195,7 @@ jobs:
 
   install:
     name: "Install Gitpod"
-    needs: [build, infrastructure]
+    needs: [configuration, build-previewctl, build-gitpod, infrastructure]
     runs-on: [self-hosted]
     concurrency:
       group: ${{ github.head_ref || github.ref }}-install
@@ -184,11 +207,12 @@ jobs:
         uses: ./.github/actions/deploy-gitpod
         with:
           sa_key: ${{ secrets.GCP_CREDENTIALS }}
-          version: ${{needs.build.outputs.version}}
+          version: ${{needs.configuration.outputs.version}}
+          previewctl_hash: ${{ needs.build-previewctl.outputs.previewctl_hash }}
 
   monitoring:
     name: "Install Monitoring Satellite"
-    needs: [infrastructure]
+    needs: [infrastructure, build-previewctl]
     runs-on: [self-hosted]
     concurrency:
       group: ${{ github.head_ref || github.ref }}-monitoring
@@ -200,3 +224,4 @@ jobs:
         uses: ./.github/actions/deploy-monitoring-satellite
         with:
           sa_key: ${{ secrets.GCP_CREDENTIALS }}
+          previewctl_hash: ${{ needs.build-previewctl.outputs.previewctl_hash }}

--- a/components/BUILD.yaml
+++ b/components/BUILD.yaml
@@ -15,19 +15,6 @@ packages:
       - install/installer:docker
       - install/kots:lint
       - components/gitpod-protocol:all
-
-  - name: all-ci
-  # like components:all + dev:all + exports files for .github/workflows/build.yml
-    type: generic
-    deps:
-      - :all
-      - dev:all
-      - :all-docker
-      - install/installer:raw-app
-    config:
-      commands:
-        - [ "sh", "-c", "mv install-installer--raw-app/installer /tmp/installer" ]
-        - [ "sh", "-c", "cat components--all-docker/versions.yaml > /tmp/versions.yaml" ]
   - name: docker-versions
     type: docker
     config:

--- a/dev/BUILD.yaml
+++ b/dev/BUILD.yaml
@@ -11,14 +11,12 @@ packages:
       - dev/gpctl:app
       - dev/loadgen:app
       - dev/gp-gcloud:app
-      - dev/preview/previewctl:cli
   - name: dev-utils
     type: docker
     deps:
       - dev/gpctl:app
       - dev/kubecdl:app
       - dev/gp-gcloud:app
-      - dev/preview/previewctl:cli
     argdeps:
       - imageRepoBase
     config:

--- a/dev/preview/previewctl/BUILD.yaml
+++ b/dev/preview/previewctl/BUILD.yaml
@@ -11,6 +11,17 @@ packages:
       - components/common-go:lib
     config:
       packaging: app
+  - name: docker
+    type: docker
+    deps:
+      - :cli
+    argdeps:
+      - imageRepoBase
+    config:
+      dockerfile: leeway.Dockerfile
+      image:
+        - ${imageRepoBase}/previewctl:${version}
+        - ${imageRepoBase}/previewctl:hash-${__pkg_version}
   - name: "install"
     type: "generic"
     argdeps:
@@ -28,3 +39,23 @@ scripts:
     description: Build and install previewctl into the current environment
     script:
       leeway build dev/preview/previewctl:install -Dno-cache=$RANDOM --dont-test --cache=remote-pull
+  - name: download
+    description:
+    script: |
+      if [[ -z "$INPUT_PREVIEWCTL_HASH" ]]; then
+        # If a specific hash isn't provided we'll use the latest image off main
+        PREVIEWCTL_VERSION=$(\
+            gcloud container images list-tags eu.gcr.io/gitpod-core-dev/build/previewctl \
+                --filter="tags:main.*" \
+                --limit=1 \
+                --format=json \
+            | jq --raw-output '.[0].tags[0]' \
+        )
+        PREVIEWCTL_IMAGE="eu.gcr.io/gitpod-core-dev/build/previewctl:$PREVIEWCTL_VERSION"
+      else
+        PREVIEWCTL_IMAGE="eu.gcr.io/gitpod-core-dev/build/previewctl:hash-$INPUT_PREVIEWCTL_HASH"
+      fi
+
+      echo "Downloading previewctil for $PREVIEWCTL_IMAGE"
+      oci-tool fetch file -o $HOME/bin/previewctl --platform=linux-amd64 "$PREVIEWCTL_IMAGE" app/previewctl
+      chmod +x $HOME/bin/previewctl

--- a/dev/preview/previewctl/leeway.Dockerfile
+++ b/dev/preview/previewctl/leeway.Dockerfile
@@ -1,0 +1,7 @@
+# Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+# Licensed under the GNU Affero General Public License (AGPL).
+# See License.AGPL.txt in the project root for license information.
+
+FROM scratch
+
+COPY dev-preview-previewctl--cli/previewctl /app/


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

With this PR our custom GitHub Actions for managing preview environments will now download previewctl from a Docker image instead of using Leeway to build it. This is a step towards eventually being able to use smaller base images for these actions as they then won't need to have all the build tools available.

I also used this as an opportunity to change the structure of the jobs a little bit.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/15970

## How to test
<!-- Provide steps to test this PR -->

See the GH actions run

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [x] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
