### PR TITLE
[db] Make 'leeway run components/gitpod-db:init-testdb' the new defau…

### DIFF
--- a/components/gitpod-db/BUILD.yaml
+++ b/components/gitpod-db/BUILD.yaml
@@ -94,6 +94,12 @@ packages:
         - ${imageRepoBase}/db-migrations:${version}
         - ${imageRepoBase}/db-migrations:commit-${__git_commit}
 scripts:
+- name: init-testdb
+  description: "Starts a properly initialized MySQL instance to run tests against. Usage: '. $(leeway run components/gitpod-db:db-test-env)'"
+  deps: []
+  script: |
+    export DB_HOST=127.0.0.1
+    leeway build components/gitpod-db/go:init-testdb
 - name: db-test-env
   description: "Creates a file with env vars necessary for running DB tests. The file delets itself after being sourced. Usage: '. $(leeway run components/gitpod-db:db-test-env)'"
   deps: []

--- a/components/gitpod-db/go/dbtest/conn.go
+++ b/components/gitpod-db/go/dbtest/conn.go
@@ -39,7 +39,7 @@ func ConnectForTests(t *testing.T) *gorm.DB {
 		Host:     net.JoinHostPort(os.Getenv("DB_HOST"), "23306"),
 		Database: "gitpod",
 	})
-	require.NoError(t, err, "Failed to establish connection to  In a workspace, run `leeway build components/gitpod-db/go:init-testdb` once to bootstrap the db")
+	require.NoError(t, err, "Failed to establish connection to  In a workspace, run `leeway run components/gitpod-db:init-testdb` once to bootstrap the db")
 
 	return conn
 }


### PR DESCRIPTION
…lt for starting test dbs

## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
Related:
 - https://github.com/gitpod-io/gitpod/pull/15824#issuecomment-1400433446

## How to test

- open a workspace
- run `leeway run components/gitpod-db:init-testdb` and wait until the script returns :heavy_check_mark: 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all-ci
- [ ] /werft no-test
      Run Leeway with `--dont-test`
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
