### PR TITLE
preview env `with-gce-vm` option

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -37,9 +37,13 @@ Does this PR require updates to the documentation at www.gitpod.io/docs?
       leeway-target=components:all-ci
 - [ ] /werft no-test
       Run Leeway with `--dont-test`
+
+#### Preview Environment Options:
 - [ ] /werft with-local-preview
       If enabled this will build `install/preview`
 - [ ] /werft with-preview
 - [ ] /werft with-large-vm
+- [ ] /werft with-gce-vm
+      If enabled this will create the environment on GCE infra
 - [ ] /werft with-integration-tests=all
       Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Create preview environment infrastructure
+        env:
+          TF_VAR_infra_provider: ${{ contains(github.event.pull_request.body, '[X] /werft with-gce-vm') && 'gce' || 'harvester' }}
         id: create
         uses: ./.github/actions/preview-create
         with:

--- a/.werft/jobs/build/job-config.ts
+++ b/.werft/jobs/build/job-config.ts
@@ -46,6 +46,7 @@ export interface JobConfig {
     recreateVm: boolean;
     withGitHubActions: boolean;
     useWsManagerMk2: boolean;
+    withGceVm: boolean;
 }
 
 export interface PreviewEnvironmentConfig {
@@ -116,6 +117,7 @@ export function jobConfig(werft: Werft, context: any): JobConfig {
     const withIntegrationTests = parseWithIntegrationTests(werft, sliceId, buildConfig["with-integration-tests"]);
     const withPreview = decideWithPreview({werft, sliceID: sliceId, buildConfig, mainBuild, withIntegrationTests})
     const withGitHubActions = "with-github-actions" in buildConfig;
+    const withGceVm = "with-gce-vm" in buildConfig;
 
     switch (buildConfig["cert-issuer"]) {
         case "zerossl":
@@ -189,6 +191,7 @@ export function jobConfig(werft: Werft, context: any): JobConfig {
         withGitHubActions,
         withDedicatedEmulation,
         useWsManagerMk2,
+        withGceVm,
     };
 
     werft.logOutput(sliceId, JSON.stringify(jobConfig, null, 2));

--- a/.werft/jobs/build/prepare.ts
+++ b/.werft/jobs/build/prepare.ts
@@ -42,6 +42,7 @@ async function decideHarvesterVMCreation(werft: Werft, config: JobConfig) {
 async function createVM(werft: Werft, config: JobConfig) {
     const cpu = config.withLargeVM ? 12 : 6;
     const memory = config.withLargeVM ? 24 : 12;
+    const infra = config.withGceVm ? "gce" : "harvester"
 
     const environment = {
         // We pass the GCP credentials explicitly, otherwise for some reason TF doesn't pick them up
@@ -51,6 +52,7 @@ async function createVM(werft: Werft, config: JobConfig) {
         "TF_VAR_preview_name": config.previewEnvironment.destname,
         "TF_VAR_vm_cpu": `${cpu}`,
         "TF_VAR_vm_memory": `${memory}Gi`,
+        "TF_VAR_infra_provider": `${infra}`,
     }
 
     if (config.storageClass.length > 0) {

--- a/dev/preview/previewctl/pkg/preview/util.go
+++ b/dev/preview/previewctl/pkg/preview/util.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
+	"os"
 	"os/exec"
 	"regexp"
 	"strings"
@@ -20,6 +21,11 @@ import (
 
 func GetName(branch string) (string, error) {
 	var err error
+
+	if v := os.Getenv("GITHUB_ACTIONS"); v != "" && branch == "" {
+		branch = os.Getenv("GITHUB_HEAD_REF")
+	}
+
 	if branch == "" {
 		branch, err = util.BranchFromGit(branch)
 		if err != nil {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Adds the `with-gce-vm` option for both GHA and werft

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/ops/issues/7803

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [X] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all-ci
- [ ] /werft no-test
      Run Leeway with `--dont-test`

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [X] /werft with-preview
- [X] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
