### PR TITLE
Run `make generateRenderTests`

### DIFF
--- a/install/installer/cmd/testdata/render/message-bus-password/output.golden
+++ b/install/installer/cmd/testdata/render/message-bus-password/output.golden
@@ -5410,7 +5410,6 @@ data:
       "stripeConfigFile": "",
       "enablePayment": false,
       "patSigningKeyFile": "",
-      "withoutWorkspaceComponents": false,
       "showSetupModal": true,
       "workspaceHeartbeat": {
         "intervalSeconds": 60,
@@ -10710,7 +10709,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: e32facbc4b3e033d097380f96946c743c51cb7f8ffad143acb1c62d9231a21dc
+        gitpod.io/checksum_config: be1a6e9b223875689a4e70b2e8dca5a0e576b2f78b2bdc08c633cfea5a241cc3
       creationTimestamp: null
       labels:
         app: gitpod
@@ -11453,11 +11452,11 @@ spec:
         - mountPath: /config
           name: config
           readOnly: true
-        - mountPath: /mnt/certificates
-          name: config-certificates
         - mountPath: /ws-manager-client-tls-certs
           name: ws-manager-client-tls-certs
           readOnly: true
+        - mountPath: /mnt/certificates
+          name: config-certificates
       - args:
         - --logtostderr
         - --insecure-listen-address=[$(IP)]:9500
@@ -11499,12 +11498,12 @@ spec:
       - configMap:
           name: ws-proxy
         name: config
-      - name: config-certificates
-        secret:
-          secretName: https-certificates
       - name: ws-manager-client-tls-certs
         secret:
           secretName: ws-manager-client-tls
+      - name: config-certificates
+        secret:
+          secretName: https-certificates
 status: {}
 ---
 # batch/v1/Job migrations


### PR DESCRIPTION
## Description

The golden files somehow ended up out-of-sync. 

This PR is the result of re-running `make generateRenderTests`.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all-ci
- [ ] /werft no-test
      Run Leeway with `--dont-test`
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
