### PR TITLE
[server] synchronize migration and only migrate users without chargebee plan

### DIFF
--- a/components/gitpod-db/src/container-module.ts
+++ b/components/gitpod-db/src/container-module.ts
@@ -69,6 +69,7 @@ import { WebhookEventDB } from "./webhook-event-db";
 import { WebhookEventDBImpl } from "./typeorm/webhook-event-db-impl";
 import { PersonalAccessTokenDBImpl } from "./typeorm/personal-access-token-db-impl";
 import { UserToTeamMigrationService } from "./user-to-team-migration-service";
+import { Synchronizer } from "./typeorm/synchronizer";
 
 // THE DB container module that contains all DB implementations
 export const dbContainerModule = new ContainerModule((bind, unbind, isBound, rebind) => {
@@ -163,4 +164,5 @@ export const dbContainerModule = new ContainerModule((bind, unbind, isBound, reb
     bind(LicenseDB).to(LicenseDBImpl).inSingletonScope();
     bind(OssAllowListDB).to(OssAllowListDBImpl).inSingletonScope();
     bind(UserToTeamMigrationService).toSelf().inSingletonScope();
+    bind(Synchronizer).toSelf().inSingletonScope();
 });

--- a/components/gitpod-db/src/typeorm/synchronizer.spec.db.ts
+++ b/components/gitpod-db/src/typeorm/synchronizer.spec.db.ts
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { suite, test, timeout } from "mocha-typescript";
+import { testContainer } from "../test-container";
+import { UserDB } from "../user-db";
+import { TypeORM } from "./typeorm";
+import { DBUser } from "./entity/db-user";
+import * as chai from "chai";
+import { Synchronizer } from "./synchronizer";
+import { User } from "@gitpod/gitpod-protocol";
+const expect = chai.expect;
+
+@suite(timeout(10000))
+export class SynchronizerSpec {
+    private readonly synchronizer = testContainer.get<Synchronizer>(Synchronizer);
+    private readonly userDB = testContainer.get<UserDB>(UserDB);
+
+    async before() {
+        await this.wipeRepo();
+    }
+
+    async after() {
+        await this.wipeRepo();
+    }
+
+    async wipeRepo() {
+        const typeorm = testContainer.get<TypeORM>(TypeORM);
+        const manager = await typeorm.getConnection();
+        await manager.getRepository(DBUser).delete({});
+    }
+
+    @test()
+    async testSynchronize(): Promise<void> {
+        const user = await this.userDB.newUser();
+        const all: Promise<void>[] = [];
+        for (let i = 0; i < 20; i++) {
+            all.push(
+                this.synchronizer.synchronized(user.id, "testSynchronize", async () => {
+                    try {
+                        const loadedUser = (await this.userDB.findUserById(user.id)) as User;
+                        if (!loadedUser?.name) {
+                            loadedUser!.name = "1";
+                        } else {
+                            loadedUser!.name = String(Number(loadedUser!.name) + 1);
+                        }
+                        await this.userDB.storeUser(loadedUser);
+                    } catch (error) {
+                        console.error(error);
+                    }
+                }),
+            );
+        }
+        await Promise.all(all);
+        const afterSyncUser = await this.userDB.findUserById(user.id);
+        expect(afterSyncUser!.name).to.be.eq("20");
+    }
+}

--- a/components/gitpod-db/src/typeorm/synchronizer.ts
+++ b/components/gitpod-db/src/typeorm/synchronizer.ts
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { Deferred } from "@gitpod/gitpod-protocol/lib/util/deferred";
+import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
+import { inject, injectable } from "inversify";
+import { TypeORM } from "./typeorm";
+
+@injectable()
+export class Synchronizer {
+    @inject(TypeORM) protected typeORM: TypeORM;
+
+    private semaphore = new Semaphore(5);
+
+    /**
+     * runs the given function with a distributed lock based on mysql's GET_LOCK
+     */
+    async synchronized<T>(lockKey: string, component: string, fn: () => Promise<T>): Promise<T> {
+        // we use a query runner because that will use the same connection exclusively.
+        // GET_LOCK is per connection, so we need to make sure we're using the same connection
+        // note that calling this method will block the connection for the duration of the function, so if we exceed the pool with lots of concurrent calls, we'll run into trouble
+        const before = new Date().getTime();
+        await this.semaphore.acquire();
+        const conn = (await this.typeORM.getConnection()).createQueryRunner();
+        try {
+            // this obtains and holds a dedicated db connection
+            await conn.connect();
+            const [lockResult] = await conn.query("SELECT get_lock(?,10) as lock_status", [lockKey]);
+            if (lockResult.lock_status !== "1") {
+                throw new Error(
+                    "Failed to acquire lock - lock status: " +
+                        lockResult.lock_status +
+                        " - lock key: " +
+                        lockKey +
+                        " - component: " +
+                        component +
+                        " - time: " +
+                        (new Date().getTime() - before) +
+                        "ms",
+                );
+            }
+            const result = await fn();
+            return result;
+        } finally {
+            const [result] = await conn.query("SELECT RELEASE_LOCK(?) as lock_status", [lockKey]);
+            if (result.lock_status !== "1") {
+                log.error("failed to release lock", result);
+            }
+            try {
+                await conn.release();
+            } catch (error) {
+                log.error("failed to release db connection", error);
+            }
+            this.semaphore.release();
+        }
+    }
+}
+
+class Semaphore {
+    private semaphore: number;
+    private queue: Array<Deferred<void>>;
+
+    constructor(semaphore: number) {
+        this.semaphore = semaphore;
+        this.queue = [];
+    }
+
+    async acquire(): Promise<void> {
+        if (this.semaphore > 0) {
+            this.semaphore--;
+            return;
+        }
+
+        const queueItem = new Deferred<void>();
+        this.queue.push(queueItem);
+        return queueItem.promise;
+    }
+
+    release(): void {
+        if (this.queue.length > 0) {
+            this.queue.shift()?.resolve();
+        } else {
+            this.semaphore++;
+        }
+    }
+}

--- a/components/gitpod-db/src/typeorm/typeorm.ts
+++ b/components/gitpod-db/src/typeorm/typeorm.ts
@@ -44,6 +44,10 @@ export class TypeORM {
                 subscribersDir: "src/typeorm/subscriber",
             },
             namingStrategy: new DefaultNamingStrategy(),
+            extra: {
+                // default is 10 (see https://github.com/mysqljs/mysql#pool-options), which is too low for our use case
+                connectionLimit: 20,
+            },
         };
     }
 

--- a/components/gitpod-db/src/user-to-team-migration-service.spec.db.ts
+++ b/components/gitpod-db/src/user-to-team-migration-service.spec.db.ts
@@ -132,4 +132,18 @@ describe("Migration Service", () => {
                 .length,
         ).be.eq(1);
     });
+
+    it("should not migrate the same user multiple times", async () => {
+        await wipeRepo();
+        const user = await userDB.newUser();
+
+        // run multiple migration
+        await Promise.all([
+            migrationService.migrateUser(user),
+            migrationService.migrateUser(user),
+            migrationService.migrateUser(user),
+        ]);
+        let teams = await teamDB.findTeamsByUser(user.id);
+        expect(teams.length).to.be.eq(1);
+    });
 });


### PR DESCRIPTION
## Description
1) We only want to migrate users to team-only attribution if they are not on a chargebee plan, because chargebee plans are always personal and cannot be migrated to a team.
2) We only want to migrate users once, so the operation needs to be synchronized

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

## How to test
<!-- Provide steps to test this PR -->


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all-ci
- [ ] /werft no-test
      Run Leeway with `--dont-test`
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-payment
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
