### PR TITLE
[supervisor] Do not log error when it has Canceled code

### DIFF
--- a/components/supervisor/pkg/serverapi/publicapi.go
+++ b/components/supervisor/pkg/serverapi/publicapi.go
@@ -339,10 +339,11 @@ func (s *Service) publicAPIInstanceUpdate(ctx context.Context, errChan chan erro
 	for {
 		resp, err := resp.Recv()
 		if err != nil {
-			if err != io.EOF && status.Code(err) != codes.Unavailable {
+			code := status.Code(err)
+			if err != io.EOF && code != codes.Unavailable && code != codes.Canceled {
 				log.WithField("method", "StreamWorkspaceStatus").WithError(err).Error("failed to receive status update")
 			}
-			if ctx.Err() != nil {
+			if ctx.Err() != nil || code == codes.Canceled {
 				return
 			}
 			errChan <- err


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Do not log error when it has `Canceled` code

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all-ci
- [ ] /werft no-test
      Run Leeway with `--dont-test`
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
