### PR TITLE
Define concurrency groups for the build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,9 @@ jobs:
   # and that job requires previewctl
   previewctl:
     if: ${{ contains(github.event.pull_request.body, '[x] /werft with-github-actions') && contains(github.event.pull_request.body, '[x] /werft with-preview') }}
+    concurrency:
+      group: ${{ github.head_ref || github.ref }}-previewctl
+      cancel-in-progress: true
     runs-on: [self-hosted]
     container:
       image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-leeway-v0.7.3.4
@@ -31,6 +34,8 @@ jobs:
   infrastructure:
     runs-on: [self-hosted]
     needs: [previewctl]
+    concurrency:
+      group: ${{ github.head_ref || github.ref }}-infrastructure
     steps:
       - uses: actions/checkout@v3
       - name: Create preview environment infrastructure
@@ -44,6 +49,9 @@ jobs:
   build:
     if: ${{ contains(github.event.pull_request.body, '[x] /werft with-github-actions') }}
     runs-on: [self-hosted]
+    concurrency:
+      group: ${{ github.head_ref || github.ref }}-build
+      cancel-in-progress: true
     outputs:
       version: ${{ steps.leeway.outputs.version }}
     services:
@@ -166,6 +174,9 @@ jobs:
     name: "Install Gitpod"
     needs: [build, infrastructure]
     runs-on: [self-hosted]
+    concurrency:
+      group: ${{ github.head_ref || github.ref }}-install
+      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v3
       - name: Deploy Gitpod to the preview environment
@@ -179,6 +190,9 @@ jobs:
     name: "Install Monitoring Satellite"
     needs: [infrastructure]
     runs-on: [self-hosted]
+    concurrency:
+      group: ${{ github.head_ref || github.ref }}-monitoring
+      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v3
       - name: Deploy monitoring satellite to the preview environment


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Define concurrency groups for the build jobs in order to limit concurrent jobs from running at the same time for the same branch/pr. Multiple triggers of the job will cancel the previous runs, essentially leaving only the last one active.

Only the `infrastructure` job will not cancel the previous ones, as we don't want to interrupt the terraform mid-run. It will wait it out until the last one is done and will get triggered after.

<img width="725" alt="image" src="https://user-images.githubusercontent.com/5501705/214104859-170c0e43-be1d-4938-8195-eb008d2c4394.png">


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [x] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all-ci
- [ ] /werft no-test
      Run Leeway with `--dont-test`
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
