### PR TITLE
removing duplicated ReactQueryDevtools component

### DIFF
--- a/components/dashboard/src/index.tsx
+++ b/components/dashboard/src/index.tsx
@@ -22,7 +22,6 @@ import relativeTime from "dayjs/plugin/relativeTime";
 import utc from "dayjs/plugin/utc";
 import { getURLHash, isGitpodIo } from "./utils";
 import { isWebsiteSlug } from "./utils";
-import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 
 import "./index.css";
 import { setupQueryClientProvider } from "./data/setup";
@@ -69,7 +68,6 @@ const bootApp = () => {
                                                 <BrowserRouter>
                                                     <FeatureFlagContextProvider>
                                                         <App />
-                                                        <ReactQueryDevtools initialIsOpen={false} />
                                                     </FeatureFlagContextProvider>
                                                 </BrowserRouter>
                                             </StartWorkspaceModalContextProvider>


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PR fixes this for dev builds👇 
![image](https://user-images.githubusercontent.com/367275/214150184-2fe78444-8f54-46f6-956b-f4e008ca5991.png)

Removes a redundant rendering of `ReactQueryDevtools`. In #15908 rendering `ReactQueryDevtools` was shifted into a `GitpodQueryClientProvider` component, but I forgot to remove the entry in this file.

## How to test
<!-- Provide steps to test this PR -->
The devtools only show up in a dev build - but to test that, w/ a dev build loaded, ensure only 1 of the react-query devtools renders. You can resize the tool window and see if there's one rendered underneath it to verify.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all-ci
- [ ] /werft no-test
      Run Leeway with `--dont-test`
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
