### PR TITLE
[gitpod-cli] add command analytics

### DIFF
--- a/components/gitpod-cli/cmd/completion.go
+++ b/components/gitpod-cli/cmd/completion.go
@@ -7,6 +7,7 @@ package cmd
 import (
 	"os"
 
+	"github.com/gitpod-io/gitpod/gitpod-cli/pkg/utils"
 	"github.com/spf13/cobra"
 )
 
@@ -24,8 +25,12 @@ To configure your bash shell to load completions for each session add to your ba
 # ~/.bashrc or ~/.profile
 . <(gp completion)
 `,
-	Run: func(cmd *cobra.Command, args []string) {
-		rootCmd.GenBashCompletion(os.Stdout)
+	RunE: func(cmd *cobra.Command, args []string) error {
+		// ignore trace
+		utils.TrackCommandUsageEvent.Command = nil
+
+		_ = rootCmd.GenBashCompletion(os.Stdout)
+		return nil
 	},
 }
 

--- a/components/gitpod-cli/cmd/credential-helper.go
+++ b/components/gitpod-cli/cmd/credential-helper.go
@@ -18,10 +18,12 @@ import (
 	"github.com/prometheus/procfs"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"golang.org/x/xerrors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/gitpod-io/gitpod/common-go/util"
+	"github.com/gitpod-io/gitpod/gitpod-cli/pkg/utils"
 	supervisor "github.com/gitpod-io/gitpod/supervisor/api"
 )
 
@@ -31,7 +33,11 @@ var credentialHelper = &cobra.Command{
 	Long:   "Supports reading of credentials per host.",
 	Args:   cobra.MinimumNArgs(1),
 	Hidden: true,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
+		// ignore trace
+		utils.TrackCommandUsageEvent.Command = nil
+
+		exitCode := 0
 		action := args[0]
 		log.SetOutput(io.Discard)
 		f, err := os.OpenFile(os.TempDir()+"/gitpod-git-credential-helper.log", os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0644)
@@ -40,14 +46,14 @@ var credentialHelper = &cobra.Command{
 			log.SetOutput(f)
 		}
 		if action != "get" {
-			return
+			return nil
 		}
 
 		result, err := parseFromStdin()
 		host := result["host"]
 		if err != nil || host == "" {
 			log.WithError(err).Print("error parsing 'host' from stdin")
-			return
+			return GpError{OutCome: utils.Outcome_UserErr, Silence: true, ExitCode: &exitCode}
 		}
 
 		var user, token string
@@ -66,13 +72,13 @@ var credentialHelper = &cobra.Command{
 			}
 		}()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+		ctx, cancel := context.WithTimeout(cmd.Context(), 1*time.Minute)
 		defer cancel()
 
 		supervisorConn, err := grpc.Dial(util.GetSupervisorAddress(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 		if err != nil {
 			log.WithError(err).Print("error connecting to supervisor")
-			return
+			return GpError{Err: xerrors.Errorf("error connecting to supervisor: %w", err), Silence: true, ExitCode: &exitCode}
 		}
 
 		resp, err := supervisor.NewTokenServiceClient(supervisorConn).GetToken(ctx, &supervisor.GetTokenRequest{
@@ -81,7 +87,7 @@ var credentialHelper = &cobra.Command{
 		})
 		if err != nil {
 			log.WithError(err).Print("error getting token from supervisior")
-			return
+			return GpError{Err: xerrors.Errorf("error getting token from supervisior: %w", err), Silence: true, ExitCode: &exitCode}
 		}
 
 		user = resp.User
@@ -102,12 +108,11 @@ var credentialHelper = &cobra.Command{
 			return gitCmdInfo.Ok()
 		})
 		if err != nil {
-			log.WithError(err).Print("error walking process tree")
-			return
+			return GpError{Err: xerrors.Errorf("error walking process tree: %w", err), Silence: true, ExitCode: &exitCode}
 		}
 		if !gitCmdInfo.Ok() {
 			log.Warn(`Could not detect "RepoUrl" and or "GitCommand", token validation will not be performed`)
-			return
+			return nil
 		}
 
 		// Starts another process which tracks the executed git event
@@ -134,14 +139,14 @@ var credentialHelper = &cobra.Command{
 		)
 		err = validator.Start()
 		if err != nil {
-			log.WithError(err).Print("error spawning validator")
-			return
+			return GpError{Err: xerrors.Errorf("error spawning validator: %w", err), Silence: true, ExitCode: &exitCode}
 		}
 		err = validator.Process.Release()
 		if err != nil {
 			log.WithError(err).Print("error releasing validator")
-			return
+			return GpError{Err: xerrors.Errorf("error releasing validator: %w", err), Silence: true, ExitCode: &exitCode}
 		}
+		return nil
 	},
 }
 

--- a/components/gitpod-cli/cmd/docs.go
+++ b/components/gitpod-cli/cmd/docs.go
@@ -14,8 +14,8 @@ const DocsUrl = "https://www.gitpod.io/docs"
 var docsCmd = &cobra.Command{
 	Use:   "docs",
 	Short: "Open Gitpod Documentation in default browser",
-	Run: func(cmd *cobra.Command, args []string) {
-		openPreview("GP_EXTERNAL_BROWSER", DocsUrl)
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return openPreview("GP_EXTERNAL_BROWSER", DocsUrl)
 	},
 }
 

--- a/components/gitpod-cli/cmd/gitpodRun.go
+++ b/components/gitpod-cli/cmd/gitpodRun.go
@@ -7,10 +7,10 @@ package cmd
 import (
 	"encoding/base64"
 	"io"
-	"log"
 	"os"
 	"syscall"
 
+	"github.com/gitpod-io/gitpod/gitpod-cli/pkg/utils"
 	"github.com/spf13/cobra"
 )
 
@@ -26,7 +26,10 @@ var gitpodRunCmd = &cobra.Command{
 	Short:  "Used by Gitpod to ensure smooth operation",
 	Hidden: true,
 	Args:   cobra.MaximumNArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
+		// ignore trace
+		utils.TrackCommandUsageEvent.Command = nil
+
 		var tmpfile *os.File
 		var err error
 		if len(args) == 1 {
@@ -36,27 +39,28 @@ var gitpodRunCmd = &cobra.Command{
 		}
 		if err != nil {
 			_ = os.Remove(tmpfile.Name())
-			log.Fatal(err)
+			return err
 		}
 
 		decoder := base64.NewDecoder(base64.RawStdEncoding, &delimitingReader{os.Stdin, false})
 		_, err = io.Copy(tmpfile, decoder)
 		if err != nil {
 			_ = os.Remove(tmpfile.Name())
-			log.Fatal(err)
+			return err
 		}
 		tmpfile.Close()
 
 		err = os.Chmod(tmpfile.Name(), 0700)
 		if err != nil {
 			_ = os.Remove(tmpfile.Name())
-			log.Fatal(err)
+			return err
 		}
 		err = syscall.Exec(tmpfile.Name(), []string{"gpr", "serve"}, []string{})
 		if err != nil {
 			_ = os.Remove(tmpfile.Name())
-			log.Fatal(err)
+			return err
 		}
+		return nil
 	},
 }
 

--- a/components/gitpod-cli/cmd/info.go
+++ b/components/gitpod-cli/cmd/info.go
@@ -11,8 +11,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/gitpod-io/gitpod/common-go/log"
-	"github.com/gitpod-io/gitpod/gitpod-cli/pkg/supervisor"
+	"github.com/gitpod-io/gitpod/gitpod-cli/pkg/gitpod"
 	"github.com/gitpod-io/gitpod/supervisor/api"
 	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
@@ -27,17 +26,14 @@ var infoCmdOpts struct {
 var infoCmd = &cobra.Command{
 	Use:   "info",
 	Short: "Display workspace info, such as its ID, class, etc.",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx, cancel := context.WithTimeout(cmd.Context(), 5*time.Second)
 		defer cancel()
 
-		client, err := supervisor.New(ctx)
+		wsInfo, err := gitpod.GetWSInfo(ctx)
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
-		defer client.Close()
-
-		wsInfo, err := client.Info.WorkspaceInfo(ctx, &api.WorkspaceInfoRequest{})
 
 		data := &infoData{
 			WorkspaceId:         wsInfo.WorkspaceId,
@@ -48,17 +44,13 @@ var infoCmd = &cobra.Command{
 			ClusterHost:         wsInfo.WorkspaceClusterHost,
 		}
 
-		if err != nil {
-			log.Fatal(err)
-		}
-
 		if infoCmdOpts.Json {
 			content, _ := json.Marshal(data)
 			fmt.Println(string(content))
-			return
+			return nil
 		}
-
 		outputInfo(data)
+		return nil
 	},
 }
 

--- a/components/gitpod-cli/cmd/open.go
+++ b/components/gitpod-cli/cmd/open.go
@@ -5,16 +5,17 @@
 package cmd
 
 import (
-	"context"
-	"log"
 	"os"
 	"os/exec"
+	"time"
 
 	"github.com/gitpod-io/gitpod/gitpod-cli/pkg/supervisor"
 
+	"context"
+
 	"github.com/google/shlex"
 	"github.com/spf13/cobra"
-	"golang.org/x/sys/unix"
+	"golang.org/x/xerrors"
 )
 
 // initCmd represents the init command
@@ -22,14 +23,15 @@ var openCmd = &cobra.Command{
 	Use:   "open <filename>",
 	Short: "Opens a file in Gitpod",
 	Args:  cobra.MinimumNArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		// TODO(ak) use NotificationService.NotifyActive supervisor API instead
 
-		ctx := context.Background()
+		ctx, cancel := context.WithTimeout(cmd.Context(), 5*time.Second)
+		defer cancel()
 
 		client, err := supervisor.New(ctx)
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 		defer client.Close()
 
@@ -39,30 +41,28 @@ var openCmd = &cobra.Command{
 
 		pcmd := os.Getenv("GP_OPEN_EDITOR")
 		if pcmd == "" {
-			log.Fatal("GP_OPEN_EDITOR is not set")
-			return
+			return xerrors.Errorf("GP_OPEN_EDITOR is not set")
 		}
 		pargs, err := shlex.Split(pcmd)
 		if err != nil {
-			log.Fatalf("cannot parse GP_OPEN_EDITOR: %v", err)
-			return
+			return xerrors.Errorf("cannot parse GP_OPEN_EDITOR: %w", err)
 		}
 		if len(pargs) > 1 {
 			pcmd = pargs[0]
 		}
 		pcmd, err = exec.LookPath(pcmd)
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 
 		if wait {
 			pargs = append(pargs, "--wait")
 		}
-
-		err = unix.Exec(pcmd, append(pargs, args...), os.Environ())
-		if err != nil {
-			log.Fatal(err)
-		}
+		c := exec.Command(pcmd, append(pargs, args...)...)
+		c.Stdin = os.Stdin
+		c.Stdout = os.Stdout
+		c.Stderr = os.Stderr
+		return c.Run()
 	},
 }
 

--- a/components/gitpod-cli/cmd/ports-list.go
+++ b/components/gitpod-cli/cmd/ports-list.go
@@ -21,27 +21,24 @@ import (
 var listPortsCmd = &cobra.Command{
 	Use:   "list",
 	Short: "Lists the workspace ports and their states.",
-	Run: func(*cobra.Command, []string) {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx, cancel := context.WithTimeout(cmd.Context(), 5*time.Second)
 		defer cancel()
 
-		client, portsListError := supervisor.New(ctx)
-		if portsListError != nil {
-			utils.LogError(ctx, portsListError, "Could not get the ports list.", client)
-			return
+		client, err := supervisor.New(ctx)
+		if err != nil {
+			return err
 		}
 		defer client.Close()
 
-		ports, portsListError := client.GetPortsList(ctx)
-
-		if portsListError != nil {
-			utils.LogError(ctx, portsListError, "Could not get the ports list.", client)
-			return
+		ports, err := client.GetPortsList(ctx)
+		if err != nil {
+			return err
 		}
 
 		if len(ports) == 0 {
 			fmt.Println("No ports detected.")
-			return
+			return nil
 		}
 
 		table := tablewriter.NewWriter(os.Stdout)
@@ -110,6 +107,7 @@ var listPortsCmd = &cobra.Command{
 		}
 
 		table.Render()
+		return nil
 	},
 }
 

--- a/components/gitpod-cli/cmd/ports-visibility.go
+++ b/components/gitpod-cli/cmd/ports-visibility.go
@@ -7,14 +7,15 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"log"
 	"strconv"
 	"strings"
 	"time"
 
-	gitpod "github.com/gitpod-io/gitpod/gitpod-cli/pkg/gitpod"
+	"github.com/gitpod-io/gitpod/gitpod-cli/pkg/gitpod"
+	"github.com/gitpod-io/gitpod/gitpod-cli/pkg/utils"
 	serverapi "github.com/gitpod-io/gitpod/gitpod-protocol"
 	"github.com/spf13/cobra"
+	"golang.org/x/xerrors"
 )
 
 // portsVisibilityCmd change visibility of port
@@ -22,41 +23,44 @@ var portsVisibilityCmd = &cobra.Command{
 	Use:   "visibility <port:{private|public}>",
 	Short: "Make a port public or private",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
+		// TODO: we can add visibility for analysis later.
 		portVisibility := args[0]
 		s := strings.Split(portVisibility, ":")
 		if len(s) != 2 {
-			log.Fatal("cannot parse args, should be something like `3000:public` or `3000:private`")
+			return GpError{Err: xerrors.Errorf("cannot parse args, should be something like `3000:public` or `3000:private`"), OutCome: utils.Outcome_UserErr, ErrorCode: utils.UserErrorCode_InvalidArguments}
 		}
 		port, err := strconv.Atoi(s[0])
 		if err != nil {
-			log.Fatal("port should be integer")
+			return GpError{Err: xerrors.Errorf("port should be integer"), OutCome: utils.Outcome_UserErr, ErrorCode: utils.UserErrorCode_InvalidArguments}
 		}
 		visibility := s[1]
 		if visibility != serverapi.PortVisibilityPublic && visibility != serverapi.PortVisibilityPrivate {
-			log.Fatalf("visibility should be `%s` or `%s`", serverapi.PortVisibilityPublic, serverapi.PortVisibilityPrivate)
+			return GpError{Err: xerrors.Errorf("visibility should be `%s` or `%s`", serverapi.PortVisibilityPublic, serverapi.PortVisibilityPrivate), OutCome: utils.Outcome_UserErr, ErrorCode: utils.UserErrorCode_InvalidArguments}
 		}
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(cmd.Context(), 5*time.Second)
 		defer cancel()
 
 		wsInfo, err := gitpod.GetWSInfo(ctx)
 		if err != nil {
-			log.Fatalf("cannot get workspace info, %s", err.Error())
+			return xerrors.Errorf("cannot get workspace info, %w", err)
 		}
 		client, err := gitpod.ConnectToServer(ctx, wsInfo, []string{
 			"function:openPort",
 			"resource:workspace::" + wsInfo.WorkspaceId + "::get/update",
 		})
 		if err != nil {
-			log.Fatalf("cannot connect to server, %s", err.Error())
+			return xerrors.Errorf("cannot connect to server, %w", err)
 		}
+		defer client.Close()
 		if _, err := client.OpenPort(ctx, wsInfo.WorkspaceId, &serverapi.WorkspaceInstancePort{
 			Port:       float64(port),
 			Visibility: visibility,
 		}); err != nil {
-			log.Fatalf("failed to change port visibility: %s", err.Error())
+			return xerrors.Errorf("failed to change port visibility: %w", err)
 		}
 		fmt.Printf("port %v is now %s\n", port, visibility)
+		return nil
 	},
 }
 

--- a/components/gitpod-cli/cmd/ports.go
+++ b/components/gitpod-cli/cmd/ports.go
@@ -11,12 +11,6 @@ import (
 var portsCmd = &cobra.Command{
 	Use:   "ports",
 	Short: "Interact with workspace ports.",
-	Args:  cobra.NoArgs,
-	Run: func(cmd *cobra.Command, args []string) {
-		if len(args) == 0 {
-			_ = cmd.Help()
-		}
-	},
 }
 
 func init() {

--- a/components/gitpod-cli/cmd/preview.go
+++ b/components/gitpod-cli/cmd/preview.go
@@ -6,17 +6,17 @@ package cmd
 
 import (
 	"context"
-	"log"
 	"os"
 	"os/exec"
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/gitpod-io/gitpod/gitpod-cli/pkg/supervisor"
 	"github.com/google/shlex"
 	"github.com/spf13/cobra"
-	"golang.org/x/sys/unix"
+	"golang.org/x/xerrors"
 )
 
 var regexLocalhost = regexp.MustCompile(`((^(localhost|127\.0\.0\.1))|(https?://(localhost|127\.0\.0\.1)))(:[0-9]+)?`)
@@ -30,53 +30,63 @@ var previewCmd = &cobra.Command{
 	Use:   "preview <url>",
 	Short: "Opens a URL in the IDE's preview",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		// TODO(ak) use NotificationService.NotifyActive supervisor API instead
 
-		ctx := context.Background()
-
+		ctx, cancel := context.WithTimeout(cmd.Context(), 5*time.Second)
+		defer cancel()
 		client, err := supervisor.New(ctx)
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 		defer client.Close()
+
 		client.WaitForIDEReady(ctx)
+
+		gpBrowserEnvVar := "GP_PREVIEW_BROWSER"
 
 		url := replaceLocalhostInURL(args[0])
 		if previewCmdOpts.External {
 			if !strings.HasPrefix(url, "http://") && !strings.HasPrefix(url, "https://") {
 				url = "https://" + url
 			}
-			openPreview("GP_EXTERNAL_BROWSER", url)
-			return
+			gpBrowserEnvVar = "GP_EXTERNAL_BROWSER"
 		}
-		openPreview("GP_PREVIEW_BROWSER", url)
+
+		return openPreview(gpBrowserEnvVar, url)
 	},
 }
 
-func openPreview(gpBrowserEnvVar string, url string) {
+func openPreview(gpBrowserEnvVar string, url string) error {
 	pcmd := os.Getenv(gpBrowserEnvVar)
 	if pcmd == "" {
-		log.Fatalf("%s is not set", gpBrowserEnvVar)
-		return
+		return xerrors.Errorf("%s is not set", gpBrowserEnvVar)
 	}
 	pargs, err := shlex.Split(pcmd)
 	if err != nil {
-		log.Fatalf("cannot parse %s: %v", gpBrowserEnvVar, err)
-		return
+		return xerrors.Errorf("cannot parse %s: %w", gpBrowserEnvVar, err)
 	}
 	if len(pargs) > 1 {
 		pcmd = pargs[0]
 	}
 	pcmd, err = exec.LookPath(pcmd)
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 
-	err = unix.Exec(pcmd, append(pargs, url), os.Environ())
-	if err != nil {
-		log.Fatal(err)
+	var args []string
+	if len(pargs) > 1 && pargs[1] != "" {
+		args = append(args, pargs[1])
 	}
+	args = append(args, url)
+
+	previewCmd := exec.Command(pcmd, args...)
+	err = previewCmd.Run()
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func replaceLocalhostInURL(url string) string {

--- a/components/gitpod-cli/cmd/root.go
+++ b/components/gitpod-cli/cmd/root.go
@@ -5,17 +5,87 @@
 package cmd
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"os"
+	"os/exec"
+	"os/signal"
 	"path/filepath"
 	"strings"
+	"syscall"
+	"time"
 
+	"github.com/go-errors/errors"
+
+	"github.com/gitpod-io/gitpod/gitpod-cli/pkg/gitpod"
+	"github.com/gitpod-io/gitpod/gitpod-cli/pkg/utils"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	ide_metrics "github.com/gitpod-io/gitpod/ide-metrics-api"
 )
 
+const (
+	rootCmdName = "gp"
+)
+
+type GpError struct {
+	Err       error
+	Message   string
+	OutCome   string
+	ErrorCode string
+	ExitCode  *int
+	Silence   bool
+}
+
+func (e GpError) Error() string {
+	if e.Silence {
+		return ""
+	}
+	ret := e.Message
+	if ret != "" && e.Err != nil {
+		ret += ": "
+	}
+	if e.Err != nil {
+		ret += e.Err.Error()
+	}
+	return ret
+}
+
+func GetCommandName(path string) []string {
+	return strings.Fields(strings.TrimSpace(strings.TrimPrefix(path, rootCmdName)))
+}
+
 var rootCmd = &cobra.Command{
-	Use:   "gp",
-	Short: "Command line interface for Gitpod",
+	Use:           rootCmdName,
+	SilenceErrors: true,
+	Short:         "Command line interface for Gitpod",
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		cmd.SilenceUsage = true
+		cmdName := GetCommandName(cmd.CommandPath())
+		usedFlags := []string{}
+		flags := cmd.Flags()
+		flags.VisitAll(func(flag *pflag.Flag) {
+			if flag.Changed {
+				usedFlags = append(usedFlags, flag.Name)
+			}
+		})
+		utils.TrackCommandUsageEvent.Args = int64(len(args))
+		utils.TrackCommandUsageEvent.Command = cmdName
+		utils.TrackCommandUsageEvent.Flags = usedFlags
+		ctx, cancel := context.WithCancel(cmd.Context())
+		cmd.SetContext(ctx)
+
+		go func() {
+			signals := make(chan os.Signal, 1)
+			signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
+			<-signals
+			cancel()
+		}()
+	},
 }
 
 var noColor bool
@@ -32,8 +102,120 @@ func Execute() {
 		}
 	}
 
-	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+	err := rootCmd.Execute()
+
+	file, ferr := os.OpenFile(os.TempDir()+"/gitpod-cli-errors.log", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
+	if ferr == nil {
+		log.SetOutput(file)
+		defer file.Close()
+	} else {
+		log.SetLevel(log.FatalLevel)
+	}
+
+	exitCode := 0
+	utils.TrackCommandUsageEvent.Outcome = utils.Outcome_Success
+	utils.TrackCommandUsageEvent.Duration = time.Since(time.UnixMilli(utils.TrackCommandUsageEvent.Timestamp)).Milliseconds()
+
+	if err != nil {
+		utils.TrackCommandUsageEvent.Outcome = utils.Outcome_SystemErr
+		exitCode = 1
+		if gpErr, ok := err.(GpError); ok {
+			if gpErr.OutCome != "" {
+				utils.TrackCommandUsageEvent.Outcome = gpErr.OutCome
+			}
+			if gpErr.ErrorCode != "" {
+				utils.TrackCommandUsageEvent.ErrorCode = gpErr.ErrorCode
+			}
+			if gpErr.ExitCode != nil {
+				exitCode = *gpErr.ExitCode
+			}
+		}
+		if utils.TrackCommandUsageEvent.ErrorCode == "" {
+			switch utils.TrackCommandUsageEvent.Outcome {
+			case utils.Outcome_UserErr:
+				utils.TrackCommandUsageEvent.ErrorCode = utils.UserErrorCode
+			case utils.Outcome_SystemErr:
+				utils.TrackCommandUsageEvent.ErrorCode = utils.SystemErrorCode
+			}
+		}
+		if utils.TrackCommandUsageEvent.Outcome == utils.Outcome_SystemErr {
+			errorReport(err)
+		}
+	}
+
+	sendAnalytics()
+
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(exitCode)
+	}
+}
+
+func sendAnalytics() {
+	if len(utils.TrackCommandUsageEvent.Command) == 0 {
+		return
+	}
+	data, err := utils.TrackCommandUsageEvent.ExportToJson()
+	if err != nil {
+		return
+	}
+	cmd := exec.Command(
+		"/.supervisor/supervisor",
+		"send-analytics",
+		"--event",
+		"gp_command",
+		"--data",
+		data,
+	)
+	cmd.Stdout = ioutil.Discard
+	cmd.Stderr = ioutil.Discard
+
+	// fire and release
+	err = cmd.Start()
+	if err != nil {
+		log.WithError(err).Error("cannot start send-analytics process")
+		return
+	}
+	if cmd.Process != nil {
+		_ = cmd.Process.Release()
+	}
+}
+
+func errorReport(err error) {
+	if err == nil {
+		return
+	}
+	reportErrorRequest := &ide_metrics.ReportErrorRequest{
+		ErrorStack: errors.New(err).ErrorStack(),
+		Component:  "gitpod-cli",
+		Version:    gitpod.Version,
+	}
+
+	payload, err := json.Marshal(reportErrorRequest)
+	if err != nil {
+		log.WithError(err).Error("failed to marshal json while attempting to report error")
+		return
+	}
+
+	if err != nil {
+		return
+	}
+	cmd := exec.Command(
+		"/.supervisor/supervisor",
+		"error-report",
+		"--data",
+		string(payload),
+	)
+	cmd.Stdout = ioutil.Discard
+	cmd.Stderr = ioutil.Discard
+
+	// fire and release
+	err = cmd.Start()
+	if err != nil {
+		log.WithError(err).Error("cannot start error-report process")
+		return
+	}
+	if cmd.Process != nil {
+		_ = cmd.Process.Release()
 	}
 }

--- a/components/gitpod-cli/cmd/root_test.go
+++ b/components/gitpod-cli/cmd/root_test.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestGetCommandName(t *testing.T) {
+	tests := []struct {
+		Input       string
+		Expectation []string
+	}{
+		{"gp", []string{}},
+		{"gp top", []string{"top"}},
+		{"gp tasks list", []string{"tasks", "list"}},
+		{"gp very nested command", []string{"very", "nested", "command"}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Input, func(t *testing.T) {
+			cmdName := GetCommandName(test.Input)
+
+			if diff := cmp.Diff(test.Expectation, cmdName); diff != "" {
+				t.Errorf("GetCommandName() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/components/gitpod-cli/cmd/snapshot.go
+++ b/components/gitpod-cli/cmd/snapshot.go
@@ -8,12 +8,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
-	"os/signal"
-	"syscall"
 	"time"
 
-	gitpod "github.com/gitpod-io/gitpod/gitpod-cli/pkg/gitpod"
+	"github.com/gitpod-io/gitpod/gitpod-cli/pkg/gitpod"
 	protocol "github.com/gitpod-io/gitpod/gitpod-protocol"
 	"github.com/sourcegraph/jsonrpc2"
 	"github.com/spf13/cobra"
@@ -29,17 +26,13 @@ var snapshotCmd = &cobra.Command{
 	Use:   "snapshot",
 	Short: "Take a snapshot of the current workspace",
 	Args:  cobra.ArbitraryArgs,
-	Run: func(cmd *cobra.Command, args []string) {
-		ctx, cancel := context.WithCancel(context.Background())
-		sigChan := make(chan os.Signal, 1)
-		signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
-		go func() {
-			<-sigChan
-			cancel()
-		}()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx, cancel := context.WithCancel(cmd.Context())
+		defer cancel()
+
 		wsInfo, err := gitpod.GetWSInfo(ctx)
 		if err != nil {
-			fail(err.Error())
+			return err
 		}
 		client, err := gitpod.ConnectToServer(ctx, wsInfo, []string{
 			"function:takeSnapshot",
@@ -47,21 +40,22 @@ var snapshotCmd = &cobra.Command{
 			"resource:workspace::" + wsInfo.WorkspaceId + "::get/update",
 		})
 		if err != nil {
-			fail(err.Error())
+			return err
 		}
+		defer client.Close()
 		snapshotId, err := client.TakeSnapshot(ctx, &protocol.TakeSnapshotOptions{
 			WorkspaceID: wsInfo.WorkspaceId,
 			DontWait:    true,
 		})
 		if err != nil {
-			fail(err.Error())
+			return err
 		}
 		for ctx.Err() == nil {
-			err := client.WaitForSnapshot(ctx, snapshotId)
+			err = client.WaitForSnapshot(ctx, snapshotId)
 			if err != nil {
 				var responseErr *jsonrpc2.Error
 				if errors.As(err, &responseErr) && (responseErr.Code == ErrorCodeSnapshotNotFound || responseErr.Code == ErrorCodeSnapshotError) {
-					panic(err)
+					return err
 				}
 				time.Sleep(time.Second * 3)
 			} else {
@@ -70,6 +64,7 @@ var snapshotCmd = &cobra.Command{
 		}
 		url := fmt.Sprintf("%s/#snapshot/%s", wsInfo.GitpodHost, snapshotId)
 		fmt.Println(url)
+		return nil
 	},
 }
 

--- a/components/gitpod-cli/cmd/stop-workspace.go
+++ b/components/gitpod-cli/cmd/stop-workspace.go
@@ -8,7 +8,8 @@ import (
 	"context"
 	"time"
 
-	gitpod "github.com/gitpod-io/gitpod/gitpod-cli/pkg/gitpod"
+	"github.com/gitpod-io/gitpod/gitpod-cli/pkg/gitpod"
+	"github.com/gitpod-io/gitpod/gitpod-cli/pkg/utils"
 	"github.com/spf13/cobra"
 )
 
@@ -17,24 +18,25 @@ var stopWorkspaceCmd = &cobra.Command{
 	Use:   "stop",
 	Short: "Stop current workspace",
 	Args:  cobra.ArbitraryArgs,
-	Run: func(cmd *cobra.Command, args []string) {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	RunE: func(cmd *cobra.Command, args []string) error {
+		// TOOD: currently, we skip sending analysis because we cannot send it while the workspace stopping.
+		utils.TrackCommandUsageEvent.Command = nil
+
+		ctx, cancel := context.WithTimeout(cmd.Context(), 5*time.Second)
 		defer cancel()
 		wsInfo, err := gitpod.GetWSInfo(ctx)
 		if err != nil {
-			fail(err.Error())
+			return err
 		}
 		client, err := gitpod.ConnectToServer(ctx, wsInfo, []string{
 			"function:stopWorkspace",
 			"resource:workspace::" + wsInfo.WorkspaceId + "::get/update",
 		})
 		if err != nil {
-			fail(err.Error())
+			return err
 		}
-		err = client.StopWorkspace(ctx, wsInfo.WorkspaceId)
-		if err != nil {
-			fail(err.Error())
-		}
+		defer client.Close()
+		return client.StopWorkspace(ctx, wsInfo.WorkspaceId)
 	},
 }
 

--- a/components/gitpod-cli/cmd/sync-await.go
+++ b/components/gitpod-cli/cmd/sync-await.go
@@ -19,7 +19,7 @@ var awaitSyncCmd = &cobra.Command{
 	Use:   "sync-await <name>",
 	Short: "Awaits an event triggered using gp sync-done",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		h := sha1.New()
 		h.Write([]byte(args[0]))
 		id := hex.EncodeToString(h.Sum(nil))
@@ -42,6 +42,7 @@ var awaitSyncCmd = &cobra.Command{
 
 		<-done
 		fmt.Printf("%s done\n", args[0])
+		return nil
 	},
 }
 

--- a/components/gitpod-cli/cmd/sync-done.go
+++ b/components/gitpod-cli/cmd/sync-done.go
@@ -8,10 +8,10 @@ import (
 	"crypto/sha1"
 	"encoding/hex"
 	"fmt"
-	"log"
 	"os"
 
 	"github.com/spf13/cobra"
+	"golang.org/x/xerrors"
 )
 
 // doneCmd represents the done command
@@ -19,7 +19,7 @@ var syncDoneCmd = &cobra.Command{
 	Use:   "sync-done <name>",
 	Short: "Notifies the corresponding gp sync-await calls that this event has happened",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		h := sha1.New()
 		h.Write([]byte(args[0]))
 		id := hex.EncodeToString(h.Sum(nil))
@@ -27,13 +27,14 @@ var syncDoneCmd = &cobra.Command{
 
 		if _, err := os.Stat(lockFile); !os.IsNotExist(err) {
 			// file already exists - we're done
-			return
+			return nil
 		}
 
 		err := os.WriteFile(lockFile, []byte("done"), 0600)
 		if err != nil {
-			log.Fatalf("cannot write lock file: %v", err)
+			return xerrors.Errorf("cannot write lock file: %w", err)
 		}
+		return nil
 	},
 }
 

--- a/components/gitpod-cli/cmd/tasks-attach.go
+++ b/components/gitpod-cli/cmd/tasks-attach.go
@@ -5,16 +5,15 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
-	"log"
 	"os"
-	"time"
 
 	"github.com/gitpod-io/gitpod/gitpod-cli/pkg/supervisor"
+	"github.com/gitpod-io/gitpod/gitpod-cli/pkg/utils"
 	"github.com/gitpod-io/gitpod/supervisor/api"
 	"github.com/manifoldco/promptui"
 	"github.com/spf13/cobra"
+	"golang.org/x/xerrors"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -29,10 +28,10 @@ var attachTaskCmd = &cobra.Command{
 	Use:   "attach <id>",
 	Short: "Attach to a workspace task",
 	Args:  cobra.MaximumNArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
-		client, err := supervisor.New(context.Background())
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := supervisor.New(cmd.Context())
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 		defer client.Close()
 
@@ -41,16 +40,14 @@ var attachTaskCmd = &cobra.Command{
 		if len(args) > 0 {
 			terminalAlias = args[0]
 		} else {
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-			defer cancel()
-			tasks, err := client.GetTasksListByState(ctx, api.TaskState_running)
+			tasks, err := client.GetTasksListByState(cmd.Context(), api.TaskState_running)
 			if err != nil {
-				log.Fatalf("cannot get task list: %s", err)
+				return xerrors.Errorf("cannot get task list: %w", err)
 			}
 
 			if len(tasks) == 0 {
 				fmt.Println("There are no running tasks")
-				return
+				return nil
 			}
 
 			var taskNames []string
@@ -75,11 +72,11 @@ var attachTaskCmd = &cobra.Command{
 				selectedIndex, selectedValue, err := prompt.Run()
 
 				if selectedValue == "" {
-					return
+					return nil
 				}
 
 				if err != nil {
-					panic(err)
+					return err
 				}
 
 				taskIndex = selectedIndex
@@ -88,7 +85,7 @@ var attachTaskCmd = &cobra.Command{
 			terminalAlias = tasks[taskIndex].Terminal
 		}
 
-		terminal, err := client.Terminal.Get(context.Background(), &api.GetTerminalRequest{Alias: terminalAlias})
+		terminal, err := client.Terminal.Get(cmd.Context(), &api.GetTerminalRequest{Alias: terminalAlias})
 		if err != nil {
 			if e, ok := status.FromError(err); ok {
 				switch e.Code() {
@@ -97,25 +94,29 @@ var attachTaskCmd = &cobra.Command{
 				default:
 					fmt.Println(e.Code(), e.Message())
 				}
-				return
+				return nil
 			} else {
-				panic(err)
+				return err
 			}
 		}
 		ppid := int64(os.Getppid())
 
 		if ppid == terminal.Pid {
 			fmt.Println("You are already in terminal:", terminalAlias)
-			return
+			return GpError{OutCome: utils.UserErrorCode, ErrorCode: utils.UserErrorCode_AlreadyAttached}
 		}
 
 		interactive, _ := cmd.Flags().GetBool("interactive")
 		forceResize, _ := cmd.Flags().GetBool("force-resize")
 
-		client.AttachToTerminal(context.Background(), terminalAlias, supervisor.AttachToTerminalOpts{
+		exitCode, err := client.AttachToTerminal(cmd.Context(), terminalAlias, supervisor.AttachToTerminalOpts{
 			ForceResize: forceResize,
 			Interactive: interactive,
 		})
+		if err != nil {
+			return err
+		}
+		return GpError{ExitCode: &exitCode, OutCome: utils.Outcome_Success, Silence: true}
 	},
 }
 

--- a/components/gitpod-cli/cmd/tasks.go
+++ b/components/gitpod-cli/cmd/tasks.go
@@ -13,10 +13,11 @@ var tasksCmd = &cobra.Command{
 	Use:   "tasks",
 	Short: "Interact with workspace tasks",
 	Args:  cobra.NoArgs,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) == 0 {
 			_ = cmd.Help()
 		}
+		return nil
 	},
 }
 

--- a/components/gitpod-cli/cmd/top.go
+++ b/components/gitpod-cli/cmd/top.go
@@ -8,13 +8,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"os"
-	"sync"
 	"time"
 
 	"github.com/gitpod-io/gitpod/gitpod-cli/pkg/supervisor"
 	"github.com/gitpod-io/gitpod/supervisor/api"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/gitpod-io/gitpod/gitpod-cli/pkg/utils"
 
@@ -35,45 +34,49 @@ type topData struct {
 var topCmd = &cobra.Command{
 	Use:   "top",
 	Short: "Display usage of workspace resources (CPU and memory)",
-	Run: func(cmd *cobra.Command, args []string) {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx, cancel := context.WithTimeout(cmd.Context(), 5*time.Second)
 		defer cancel()
 
 		client, err := supervisor.New(ctx)
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 		defer client.Close()
 
 		data := &topData{}
 
-		var wg sync.WaitGroup
-		wg.Add(2)
-
-		go func() {
+		g, ctx := errgroup.WithContext(ctx)
+		g.Go(func() error {
 			workspaceResources, err := client.Status.ResourcesStatus(ctx, &api.ResourcesStatuRequest{})
 			if err != nil {
-				log.Fatalf("cannot get workspace resources: %s", err)
+				return err
 			}
 			data.Resources = workspaceResources
-			wg.Done()
-		}()
+			return nil
+		})
 
-		go func() {
-			if wsInfo, err := client.Info.WorkspaceInfo(ctx, &api.WorkspaceInfoRequest{}); err == nil {
-				data.WorkspaceClass = wsInfo.WorkspaceClass
+		g.Go(func() error {
+			wsInfo, err := client.Info.WorkspaceInfo(ctx, &api.WorkspaceInfoRequest{})
+			if err != nil {
+				return err
 			}
-			wg.Done()
-		}()
+			data.WorkspaceClass = wsInfo.WorkspaceClass
+			return nil
+		})
 
-		wg.Wait()
+		err = g.Wait()
+		if err != nil {
+			return err
+		}
 
 		if topCmdOpts.Json {
 			content, _ := json.Marshal(data)
 			fmt.Println(string(content))
-			return
+			return nil
 		}
 		outputTable(data.Resources, data.WorkspaceClass)
+		return nil
 	},
 }
 

--- a/components/gitpod-cli/cmd/url.go
+++ b/components/gitpod-cli/cmd/url.go
@@ -10,7 +10,9 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/gitpod-io/gitpod/gitpod-cli/pkg/utils"
 	"github.com/spf13/cobra"
+	"golang.org/x/xerrors"
 )
 
 // urlCmd represents the url command
@@ -23,19 +25,19 @@ particular port. For example:
     gp url 8080
 will print the URL of a service/server exposed on port 8080.`,
 	Args: cobra.MaximumNArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) == 0 {
 			fmt.Println(os.Getenv("GITPOD_WORKSPACE_URL"))
-			return
+			return nil
 		}
 
 		port, err := strconv.ParseUint(args[0], 10, 16)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "port \"%s\" is not a valid number\n", args[0])
-			return
+			return GpError{Err: xerrors.Errorf("port \"%s\" is not a valid number", args[0]), OutCome: utils.Outcome_UserErr, ErrorCode: utils.UserErrorCode_InvalidArguments}
 		}
 
 		fmt.Println(GetWorkspaceURL(int(port)))
+		return nil
 	},
 }
 

--- a/components/gitpod-cli/cmd/version.go
+++ b/components/gitpod-cli/cmd/version.go
@@ -8,7 +8,7 @@ import (
 	_ "embed"
 	"fmt"
 
-	gitpod "github.com/gitpod-io/gitpod/gitpod-cli/pkg/gitpod"
+	"github.com/gitpod-io/gitpod/gitpod-cli/pkg/gitpod"
 
 	"github.com/spf13/cobra"
 )
@@ -19,8 +19,9 @@ var versionCmd = &cobra.Command{
 	Hidden: false,
 	Short:  "Prints the version of the CLI",
 	Args:   cobra.MaximumNArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		fmt.Println(gitpod.Version)
+		return nil
 	},
 }
 

--- a/components/gitpod-cli/go.mod
+++ b/components/gitpod-cli/go.mod
@@ -19,7 +19,8 @@ require (
 	github.com/prometheus/procfs v0.8.0
 	github.com/sirupsen/logrus v1.8.1
 	github.com/sourcegraph/jsonrpc2 v0.0.0-20200429184054-15c2290dcb37
-	github.com/spf13/cobra v1.1.3
+	github.com/spf13/cobra v1.6.1
+	golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f
 	golang.org/x/sys v0.3.0
 	golang.org/x/term v0.3.0
 	golang.org/x/xerrors v0.0.0-20220609144429-65e65417b02f
@@ -44,13 +45,12 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.11.3 // indirect
-	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/inconshreveable/mousetrap v1.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.9 // indirect
 	github.com/segmentio/backo-go v0.0.0-20200129164019-23eae7c10bd3 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/xtgo/uuid v0.0.0-20140804021211-a0b114877d4c // indirect
-	google.golang.org/genproto v0.0.0-20220822174746-9e6da59bd2fc // indirect
+	github.com/spf13/pflag v1.0.5
 	github.com/x-cray/logrus-prefixed-formatter v0.5.2
+	github.com/xtgo/uuid v0.0.0-20140804021211-a0b114877d4c // indirect
 	golang.org/x/net v0.4.0 // indirect
 	golang.org/x/text v0.5.0 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect

--- a/components/gitpod-cli/go.sum
+++ b/components/gitpod-cli/go.sum
@@ -40,6 +40,7 @@ github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3Ee
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
+github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.17 h1:QeVUsEDNrLBW4tMgZHvxy18sKtr6VI492kBhUfhDJNI=
 github.com/creack/pty v1.1.17/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -138,6 +139,8 @@ github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/J
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/inconshreveable/mousetrap v1.0.1 h1:U3uMjPSQEBMNp1lFxmllqCPM6P5u/Xq7Pgzkat/bFNc=
+github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
@@ -211,6 +214,7 @@ github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40T
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/segmentio/backo-go v0.0.0-20200129164019-23eae7c10bd3 h1:ZuhckGJ10ulaKkdvJtiAqsLTiPrLaXSdnVgXJKJkTxE=
@@ -229,6 +233,8 @@ github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v1.1.3 h1:xghbfqPkxzxP3C/f3n5DdpAbdKLj4ZE4BWQI362l53M=
 github.com/spf13/cobra v1.1.3/go.mod h1:pGADOWyqRD/YMrPZigI/zbliZ2wVD/23d+is3pSWzOo=
+github.com/spf13/cobra v1.6.1 h1:o94oiPyS4KD1mPy2fmcYYHHfCxLqYjJOhGsCHFZtEzA=
+github.com/spf13/cobra v1.6.1/go.mod h1:IOw/AERYS7UzyrGinqmz6HLUo219MORXGxhbaJUqzrY=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
@@ -313,6 +319,8 @@ golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f h1:Ax0t5p6N38Ga0dThY21weqDEyz2oklo4IvDkpigvkD8=
+golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -432,6 +440,7 @@ gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/components/gitpod-cli/pkg/gitpod/server.go
+++ b/components/gitpod-cli/pkg/gitpod/server.go
@@ -2,7 +2,7 @@
 // Licensed under the GNU Affero General Public License (AGPL).
 // See License.AGPL.txt in the project root for license information.
 
-package server
+package gitpod
 
 import (
 	"context"

--- a/components/gitpod-cli/pkg/utils/global.go
+++ b/components/gitpod-cli/pkg/utils/global.go
@@ -1,0 +1,13 @@
+// Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package utils
+
+import (
+	"time"
+)
+
+var TrackCommandUsageEvent = &TrackCommandUsageParams{
+	Timestamp: time.Now().UnixMilli(),
+}

--- a/components/gitpod-cli/pkg/utils/logError.go
+++ b/components/gitpod-cli/pkg/utils/logError.go
@@ -6,22 +6,20 @@ package utils
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
 	"os"
 
-	gitpod "github.com/gitpod-io/gitpod/gitpod-cli/pkg/gitpod"
-	"github.com/gitpod-io/gitpod/gitpod-cli/pkg/supervisor"
+	"github.com/gitpod-io/gitpod/gitpod-cli/pkg/gitpod"
 	ide_metrics "github.com/gitpod-io/gitpod/ide-metrics-api"
 	"github.com/gitpod-io/gitpod/supervisor/api"
 	"github.com/go-errors/errors"
 	log "github.com/sirupsen/logrus"
 )
 
-func LogError(ctx context.Context, errToReport error, errorMessage string, supervisorClient *supervisor.SupervisorClient) {
+func LogError(errToReport error, errorMessage string, wsInfo *api.WorkspaceInfoResponse) {
 	log.WithError(errToReport).Error(errorMessage)
 
 	file, err := os.OpenFile(os.TempDir()+"/gitpod-cli-errors.log", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
@@ -31,12 +29,7 @@ func LogError(ctx context.Context, errToReport error, errorMessage string, super
 		log.SetLevel(log.FatalLevel)
 	}
 
-	if supervisorClient == nil {
-		return
-	}
-
-	wsInfo, err := supervisorClient.Info.WorkspaceInfo(ctx, &api.WorkspaceInfoRequest{})
-	if err != nil {
+	if wsInfo == nil {
 		log.WithError(err).Error("failed to retrieve workspace info")
 		return
 	}

--- a/components/supervisor/cmd/error-report.go
+++ b/components/supervisor/cmd/error-report.go
@@ -1,0 +1,97 @@
+// Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"time"
+
+	"github.com/gitpod-io/gitpod/supervisor/api"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	ide_metrics "github.com/gitpod-io/gitpod/ide-metrics-api"
+)
+
+var errorReportCmdOpts struct {
+	data string
+}
+
+// errorReportCmd represents the errorReportCmd command
+var errorReportCmd = &cobra.Command{
+	Use:    "error-report",
+	Long:   "Sending error report to ide-metrics",
+	Hidden: true,
+	Args:   cobra.ExactArgs(0),
+	Run: func(cmd *cobra.Command, args []string) {
+		file, err := os.OpenFile(os.TempDir()+"/supervisor-errors.log", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
+		if err == nil {
+			log.SetOutput(file)
+			defer file.Close()
+		} else {
+			log.SetLevel(log.FatalLevel)
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		var data ide_metrics.ReportErrorRequest
+		err = json.Unmarshal([]byte(errorReportCmdOpts.data), &data)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		conn := dialSupervisor()
+		defer conn.Close()
+		wsInfo, err := api.NewInfoServiceClient(conn).WorkspaceInfo(ctx, &api.WorkspaceInfoRequest{})
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		data.WorkspaceId = wsInfo.WorkspaceId
+		data.InstanceId = wsInfo.InstanceId
+		data.UserId = wsInfo.OwnerId
+
+		parsedUrl, err := url.Parse(wsInfo.GitpodHost)
+		if err != nil {
+			log.Fatal("cannot parse GitpodHost")
+			return
+		}
+
+		ideMetricsUrl := fmt.Sprintf("https://ide.%s/metrics-api/reportError", parsedUrl.Host)
+
+		payload, err := json.Marshal(data)
+		if err != nil {
+			log.WithError(err).Error("failed to marshal json while attempting to report error")
+			return
+		}
+
+		req, err := http.NewRequest("POST", ideMetricsUrl, bytes.NewBuffer(payload))
+		if err != nil {
+			log.WithError(err).Error("failed to init request for ide-metrics-api")
+			return
+		}
+
+		client := &http.Client{}
+		_, err = client.Do(req)
+		if err != nil {
+			log.WithError(err).Error("cannot report error to ide-metrics-api")
+			return
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(errorReportCmd)
+	errorReportCmd.Flags().StringVarP(&errorReportCmdOpts.data, "data", "", "", "json data")
+
+	_ = errorReportCmd.MarkFlagRequired("data")
+}

--- a/components/supervisor/cmd/send-analytics.go
+++ b/components/supervisor/cmd/send-analytics.go
@@ -1,0 +1,76 @@
+// Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"time"
+
+	"github.com/gitpod-io/gitpod/common-go/analytics"
+	"github.com/gitpod-io/gitpod/supervisor/api"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var sendAnalyticsCmdOpts struct {
+	data  string
+	event string
+}
+
+// sendAnalyticsCmd represents the send-analytics command
+var sendAnalyticsCmd = &cobra.Command{
+	Use:    "send-analytics",
+	Long:   "Sending anonymous statistics",
+	Hidden: true,
+	Args:   cobra.ExactArgs(0),
+	Run: func(cmd *cobra.Command, args []string) {
+		file, err := os.OpenFile(os.TempDir()+"/supervisor-errors.log", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
+		if err == nil {
+			log.SetOutput(file)
+			defer file.Close()
+		} else {
+			log.SetLevel(log.FatalLevel)
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		data := make(map[string]interface{})
+		err = json.Unmarshal([]byte(sendAnalyticsCmdOpts.data), &data)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		conn := dialSupervisor()
+		defer conn.Close()
+		wsInfo, err := api.NewInfoServiceClient(conn).WorkspaceInfo(ctx, &api.WorkspaceInfoRequest{})
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		data["instanceId"] = wsInfo.InstanceId
+		data["workspaceId"] = wsInfo.WorkspaceId
+
+		w := analytics.NewFromEnvironment()
+		w.Track(analytics.TrackMessage{
+			Identity:   analytics.Identity{UserID: wsInfo.OwnerId},
+			Event:      sendAnalyticsCmdOpts.event,
+			Properties: data,
+		})
+		w.Close()
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(sendAnalyticsCmd)
+
+	sendAnalyticsCmd.Flags().StringVarP(&sendAnalyticsCmdOpts.event, "event", "", "", "event name")
+	sendAnalyticsCmd.Flags().StringVarP(&sendAnalyticsCmdOpts.data, "data", "", "", "json data")
+
+	_ = sendAnalyticsCmd.MarkFlagRequired("event")
+	_ = sendAnalyticsCmd.MarkFlagRequired("data")
+}


### PR DESCRIPTION
## Description
This PR adds analytics to the `gp` CLI. This will help us understand which commands are most and least useful.

All commands updated

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/10349

## How to test
<!-- Provide steps to test this PR -->
1. start a workspace in this preview environment
2. use [segment](https://app.segment.com/gitpod/sources/staging_trusted/debugger) to check event.
3. all commands should send track event, except `send-analytics` itself, if the command success, `outcome` should be `success`, if the command failed, the `outcome` should be `system_error` or `user_error` depending on the error.
4. we might not able to trace `gp stop` command, because at that time, the workspace is going to stop.

- [ ] ~~credential-helper~~
- [x] docs
- [x] env
- [ ] ~~git-token-validator~~
- [ ] ~~git-track-command~~
- [x] info
- [x] init
- [x] open
- [x] ports await
- [x] ports expose - skip
- [x] ports list
- [x] ports visibility
- [x] preview
- [x] rebuild
- [x] snapshot
- [x] stop
- [x] sync await
- [x] sync done
- [x] tasks attach
- [x] tasks list
- [x] tasks stop
- [x] timeout extend
- [x] timeout set
- [x] timeout show
- [x] top
- [x] url
- [x] version

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Werft options:

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
- [ ] /werft analytics=segment