### PR TITLE
[ws-rollout] Fix Build Versioning

### DIFF
--- a/components/workspace-rollout-job/cmd/root.go
+++ b/components/workspace-rollout-job/cmd/root.go
@@ -20,8 +20,9 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-const (
-	version string = "0.0.0"
+var (
+	Version string
+	conf    config
 )
 
 type config struct {
@@ -34,10 +35,6 @@ type config struct {
 	okayScoreUntilNoData     int32
 	targetPositivePercentage int
 }
-
-var (
-	conf config
-)
 
 var rootCmd = &cobra.Command{
 	Short: "Rollout from old to a new cluster while monitoring metrics",
@@ -58,7 +55,7 @@ var rootCmd = &cobra.Command{
 		}
 
 		serverOpts := []baseserver.Option{
-			baseserver.WithVersion(version),
+			baseserver.WithVersion(Version),
 		}
 
 		srv, err := baseserver.New("workspace-rollout-job", serverOpts...)
@@ -134,10 +131,12 @@ func Execute() {
 	rootCmd.Flags().Int32Var(&conf.rolloutStepScore, "rollout-step-score", 10, "Score to be added to the new cluster, and decreased from the old cluster")
 	rootCmd.Flags().Int32Var(&conf.okayScoreUntilNoData, "okay-score-until-no-data", 60, "If the score is below this value, and there is no data, the rollout score will be considered okay")
 	rootCmd.Flags().IntVar(&conf.targetPositivePercentage, "target-positive-percentage", 95, "Target percentage of positive metrics")
-
 	rootCmd.MarkFlagRequired("old-cluster")
 	rootCmd.MarkFlagRequired("new-cluster")
 	rootCmd.MarkFlagRequired("prometheus-url")
+
+	rootCmd.Version = Version
+
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(1)


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This PR updates the Version field in root to
be set correctly and also use the same with
the cobra CLI.

Signed-off-by: Tarun Pothulapati <tarun@gitpod.io>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

## How to test
<!-- Provide steps to test this PR -->

`-v` flag should give the relevant build commit output

```bash
gitpod /workspace/gitpod/components/workspace-rollout-job (tar/ws-rollout-version) $ docker run eu.gcr.io/gitpod-core-dev/build/workspace-rollout-job:commit-3db17158fe4b68b642d634932b26c4d1c5b5eb84 -v
version commit-3db17158fe4b68b642d634932b26c4d1c5b5eb84
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[ws-rollout] Fix Build Versioning
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all-ci
- [ ] /werft no-test
      Run Leeway with `--dont-test`
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
