### PR TITLE
[ws-rollout] Add prometheus init check

### DIFF
--- a/components/workspace-rollout-job/cmd/root.go
+++ b/components/workspace-rollout-job/cmd/root.go
@@ -99,6 +99,13 @@ var rootCmd = &cobra.Command{
 			return err
 		}
 
+		// Check if prometheus is reachable
+		err = analysis.CheckPrometheusReachable(ctx, conf.prometheusURL)
+		if err != nil {
+			log.WithError(err).Fatal("init: prometheus is not reachable")
+			return err
+		}
+
 		prometheusAnalyzer, err := analysis.NewWorkspaceKeyMetricsAnalyzer(ctx, config, conf.prometheusURL, conf.targetPositivePercentage, 30305)
 		if err != nil {
 			log.WithError(err).Fatal("failed to create a prometheus client")


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

When given a non-usable `--prometheus-url`, We start the rollout without verifying if the prometheus is reachable or not. This is a problem as we will be unable to get the metrics from prometheus and hence the rollout will be reverted later causing unnecessary time waste.

This can be prevented by performing a simple check to see if the prometheus is reachable or not. `up` query is used instead of key metrics as we can't be sure of their existence.

Signed-off-by: Tarun Pothulapati <tarun@gitpod.io>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

Testing by passing a unreachable prometheus URL

```bash
gitpod /workspace/gitpod/components/workspace-rollout-job (tar/ws-rollout-prom-init) $ go run . --new-cluster g2c4ec3d5cb --old-cluster gfd9876cfe2 --prometheus-url http://localhos:9090
INFO[0000] Starting workspace-rollout-job               
FATA[0001] init: prometheus is not reachable             error="Post \"http://localhos:9090/api/v1/query\": dial tcp: lookup localhos on 1.1.1.1:53: no such host"
exit status 1
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[ws-rollout] Add prometheus init check
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all-ci
- [ ] /werft no-test
      Run Leeway with `--dont-test`
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
