### PR TITLE
[ws-manager-mk2] Rename TLS secrets

### DIFF
--- a/install/installer/cmd/testdata/render/agent-smith/output.golden
+++ b/install/installer/cmd/testdata/render/agent-smith/output.golden
@@ -162,6 +162,9 @@ spec:
         - podSelector:
             matchLabels:
               component: ws-manager
+        - podSelector:
+            matchLabels:
+              component: ws-manager-mk2
   podSelector:
     matchLabels:
       app: gitpod

--- a/install/installer/cmd/testdata/render/aws-setup/output.golden
+++ b/install/installer/cmd/testdata/render/aws-setup/output.golden
@@ -162,6 +162,9 @@ spec:
         - podSelector:
             matchLabels:
               component: ws-manager
+        - podSelector:
+            matchLabels:
+              component: ws-manager-mk2
   podSelector:
     matchLabels:
       app: gitpod

--- a/install/installer/cmd/testdata/render/azure-setup/output.golden
+++ b/install/installer/cmd/testdata/render/azure-setup/output.golden
@@ -162,6 +162,9 @@ spec:
         - podSelector:
             matchLabels:
               component: ws-manager
+        - podSelector:
+            matchLabels:
+              component: ws-manager-mk2
   podSelector:
     matchLabels:
       app: gitpod

--- a/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
+++ b/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
@@ -162,6 +162,9 @@ spec:
         - podSelector:
             matchLabels:
               component: ws-manager
+        - podSelector:
+            matchLabels:
+              component: ws-manager-mk2
   podSelector:
     matchLabels:
       app: gitpod

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -162,6 +162,9 @@ spec:
         - podSelector:
             matchLabels:
               component: ws-manager
+        - podSelector:
+            matchLabels:
+              component: ws-manager-mk2
   podSelector:
     matchLabels:
       app: gitpod

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -162,6 +162,9 @@ spec:
         - podSelector:
             matchLabels:
               component: ws-manager
+        - podSelector:
+            matchLabels:
+              component: ws-manager-mk2
   podSelector:
     matchLabels:
       app: gitpod

--- a/install/installer/cmd/testdata/render/gcp-setup/output.golden
+++ b/install/installer/cmd/testdata/render/gcp-setup/output.golden
@@ -162,6 +162,9 @@ spec:
         - podSelector:
             matchLabels:
               component: ws-manager
+        - podSelector:
+            matchLabels:
+              component: ws-manager-mk2
   podSelector:
     matchLabels:
       app: gitpod

--- a/install/installer/cmd/testdata/render/http-proxy/output.golden
+++ b/install/installer/cmd/testdata/render/http-proxy/output.golden
@@ -162,6 +162,9 @@ spec:
         - podSelector:
             matchLabels:
               component: ws-manager
+        - podSelector:
+            matchLabels:
+              component: ws-manager-mk2
   podSelector:
     matchLabels:
       app: gitpod

--- a/install/installer/cmd/testdata/render/message-bus-password/output.golden
+++ b/install/installer/cmd/testdata/render/message-bus-password/output.golden
@@ -162,6 +162,9 @@ spec:
         - podSelector:
             matchLabels:
               component: ws-manager
+        - podSelector:
+            matchLabels:
+              component: ws-manager-mk2
   podSelector:
     matchLabels:
       app: gitpod

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -162,6 +162,9 @@ spec:
         - podSelector:
             matchLabels:
               component: ws-manager
+        - podSelector:
+            matchLabels:
+              component: ws-manager-mk2
   podSelector:
     matchLabels:
       app: gitpod

--- a/install/installer/cmd/testdata/render/overrides-inline/output.golden
+++ b/install/installer/cmd/testdata/render/overrides-inline/output.golden
@@ -162,6 +162,9 @@ spec:
         - podSelector:
             matchLabels:
               component: ws-manager
+        - podSelector:
+            matchLabels:
+              component: ws-manager-mk2
   podSelector:
     matchLabels:
       app: gitpod

--- a/install/installer/cmd/testdata/render/pod-config/output.golden
+++ b/install/installer/cmd/testdata/render/pod-config/output.golden
@@ -162,6 +162,9 @@ spec:
         - podSelector:
             matchLabels:
               component: ws-manager
+        - podSelector:
+            matchLabels:
+              component: ws-manager-mk2
   podSelector:
     matchLabels:
       app: gitpod

--- a/install/installer/cmd/testdata/render/shortname/output.golden
+++ b/install/installer/cmd/testdata/render/shortname/output.golden
@@ -162,6 +162,9 @@ spec:
         - podSelector:
             matchLabels:
               component: ws-manager
+        - podSelector:
+            matchLabels:
+              component: ws-manager-mk2
   podSelector:
     matchLabels:
       app: gitpod

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -162,6 +162,9 @@ spec:
         - podSelector:
             matchLabels:
               component: ws-manager
+        - podSelector:
+            matchLabels:
+              component: ws-manager-mk2
   podSelector:
     matchLabels:
       app: gitpod

--- a/install/installer/cmd/testdata/render/telemetry/output.golden
+++ b/install/installer/cmd/testdata/render/telemetry/output.golden
@@ -162,6 +162,9 @@ spec:
         - podSelector:
             matchLabels:
               component: ws-manager
+        - podSelector:
+            matchLabels:
+              component: ws-manager-mk2
   podSelector:
     matchLabels:
       app: gitpod

--- a/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
+++ b/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
@@ -162,6 +162,9 @@ spec:
         - podSelector:
             matchLabels:
               component: ws-manager
+        - podSelector:
+            matchLabels:
+              component: ws-manager-mk2
   podSelector:
     matchLabels:
       app: gitpod

--- a/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
+++ b/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
@@ -162,6 +162,9 @@ spec:
         - podSelector:
             matchLabels:
               component: ws-manager
+        - podSelector:
+            matchLabels:
+              component: ws-manager-mk2
   podSelector:
     matchLabels:
       app: gitpod

--- a/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
+++ b/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
@@ -162,6 +162,9 @@ spec:
         - podSelector:
             matchLabels:
               component: ws-manager
+        - podSelector:
+            matchLabels:
+              component: ws-manager-mk2
   podSelector:
     matchLabels:
       app: gitpod

--- a/install/installer/pkg/components/image-builder-mk3/networkpolicy.go
+++ b/install/installer/pkg/components/image-builder-mk3/networkpolicy.go
@@ -42,6 +42,13 @@ func networkpolicy(ctx *common.RenderContext) ([]runtime.Object, error) {
 					},
 				},
 			},
+			{
+				PodSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"component": common.WSManagerMk2Component,
+					},
+				},
+			},
 		}
 	}
 

--- a/install/installer/pkg/components/ws-manager-mk2/constants.go
+++ b/install/installer/pkg/components/ws-manager-mk2/constants.go
@@ -10,8 +10,8 @@ const (
 	Component                  = common.WSManagerMk2Component
 	RPCPort                    = 8080
 	RPCPortName                = "rpc"
-	TLSSecretNameSecret        = "ws-manager-tls"
-	TLSSecretNameClient        = "ws-manager-client-tls"
+	TLSSecretNameSecret        = "ws-manager-mk2-tls"
+	TLSSecretNameClient        = "ws-manager-mk2-client-tls"
 	VolumeConfig               = "config"
 	VolumeTLSCerts             = "tls-certs"
 	VolumeWorkspaceTemplate    = "workspace-template"


### PR DESCRIPTION
## Description
Rename mk2's TLS secrets to be unique from mk1's. Otherwise one will overwrite the other

Also add ws-manager-mk2 to image builder network policy.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all-ci
- [ ] /werft no-test
      Run Leeway with `--dont-test`
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
