### PR TITLE
[db] Enable spicedb in preview envs

### DIFF
--- a/dev/preview/workflow/preview/deploy-gitpod.sh
+++ b/dev/preview/workflow/preview/deploy-gitpod.sh
@@ -492,6 +492,11 @@ yq w -i "${INSTALLER_CONFIG_PATH}" "experimental.webapp.server.stripeSecret" "st
 yq w -i "${INSTALLER_CONFIG_PATH}" "experimental.webapp.server.stripeConfig" "stripe-config"
 
 #
+# Enable SpiceDB on all preview envs
+#
+yq w -i "${INSTALLER_CONFIG_PATH}" experimental.webapp.spicedb.enabled "true"
+
+#
 # Enable "Frontend Dev" on all preview envs
 #
 yq w -i "${INSTALLER_CONFIG_PATH}" experimental.webapp.proxy.frontendDevEnabled "true"

--- a/install/installer/cmd/testdata/render/agent-smith/output.golden
+++ b/install/installer/cmd/testdata/render/agent-smith/output.golden
@@ -1563,6 +1563,16 @@ data:
     @statementStr = CONCAT('CREATE DATABASE ', @gitpodDB, ' CHARSET utf8mb4');
     PREPARE statement FROM @statementStr;
     EXECUTE statement;
+    -- 03-create-authorization-db.sql
+
+    -- Copyright (c) 2020 Gitpod GmbH. All rights reserved.
+    -- Licensed under the GNU Affero General Public License (AGPL). See License.AGPL.txt in the project root for license information.
+
+    -- must be idempotent
+    CREATE DATABASE IF NOT EXISTS `authorization` CHARSET utf8mb4;
+
+    -- Grant privileges
+    GRANT ALL ON `authorization`.* TO "gitpod"@"%";
   tuneMysql.sql: SET GLOBAL innodb_lru_scan_depth=256;
 kind: ConfigMap
 metadata:

--- a/install/installer/cmd/testdata/render/aws-setup/output.golden
+++ b/install/installer/cmd/testdata/render/aws-setup/output.golden
@@ -1305,6 +1305,13 @@ data:
        `_lastModified` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
        PRIMARY KEY (`session_id`)
     );
+    -- 01-create-authorization-db.sql
+
+    -- Copyright (c) 2020 Gitpod GmbH. All rights reserved.
+    -- Licensed under the GNU Affero General Public License (AGPL). See License.AGPL.txt in the project root for license information.
+
+    -- must be idempotent
+    CREATE DATABASE IF NOT EXISTS `authorization` CHARSET utf8mb4;
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/install/installer/cmd/testdata/render/azure-setup/output.golden
+++ b/install/installer/cmd/testdata/render/azure-setup/output.golden
@@ -1336,6 +1336,13 @@ data:
        `_lastModified` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
        PRIMARY KEY (`session_id`)
     );
+    -- 01-create-authorization-db.sql
+
+    -- Copyright (c) 2020 Gitpod GmbH. All rights reserved.
+    -- Licensed under the GNU Affero General Public License (AGPL). See License.AGPL.txt in the project root for license information.
+
+    -- must be idempotent
+    CREATE DATABASE IF NOT EXISTS `authorization` CHARSET utf8mb4;
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
+++ b/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
@@ -1461,6 +1461,16 @@ data:
     @statementStr = CONCAT('CREATE DATABASE ', @gitpodDB, ' CHARSET utf8mb4');
     PREPARE statement FROM @statementStr;
     EXECUTE statement;
+    -- 03-create-authorization-db.sql
+
+    -- Copyright (c) 2020 Gitpod GmbH. All rights reserved.
+    -- Licensed under the GNU Affero General Public License (AGPL). See License.AGPL.txt in the project root for license information.
+
+    -- must be idempotent
+    CREATE DATABASE IF NOT EXISTS `authorization` CHARSET utf8mb4;
+
+    -- Grant privileges
+    GRANT ALL ON `authorization`.* TO "gitpod"@"%";
   tuneMysql.sql: SET GLOBAL innodb_lru_scan_depth=256;
 kind: ConfigMap
 metadata:

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -1595,6 +1595,16 @@ data:
     @statementStr = CONCAT('CREATE DATABASE ', @gitpodDB, ' CHARSET utf8mb4');
     PREPARE statement FROM @statementStr;
     EXECUTE statement;
+    -- 03-create-authorization-db.sql
+
+    -- Copyright (c) 2020 Gitpod GmbH. All rights reserved.
+    -- Licensed under the GNU Affero General Public License (AGPL). See License.AGPL.txt in the project root for license information.
+
+    -- must be idempotent
+    CREATE DATABASE IF NOT EXISTS `authorization` CHARSET utf8mb4;
+
+    -- Grant privileges
+    GRANT ALL ON `authorization`.* TO "gitpod"@"%";
   tuneMysql.sql: SET GLOBAL innodb_lru_scan_depth=256;
 kind: ConfigMap
 metadata:

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -1390,6 +1390,16 @@ data:
     @statementStr = CONCAT('CREATE DATABASE ', @gitpodDB, ' CHARSET utf8mb4');
     PREPARE statement FROM @statementStr;
     EXECUTE statement;
+    -- 03-create-authorization-db.sql
+
+    -- Copyright (c) 2020 Gitpod GmbH. All rights reserved.
+    -- Licensed under the GNU Affero General Public License (AGPL). See License.AGPL.txt in the project root for license information.
+
+    -- must be idempotent
+    CREATE DATABASE IF NOT EXISTS `authorization` CHARSET utf8mb4;
+
+    -- Grant privileges
+    GRANT ALL ON `authorization`.* TO "gitpod"@"%";
   tuneMysql.sql: SET GLOBAL innodb_lru_scan_depth=256;
 kind: ConfigMap
 metadata:

--- a/install/installer/cmd/testdata/render/gcp-setup/output.golden
+++ b/install/installer/cmd/testdata/render/gcp-setup/output.golden
@@ -1324,6 +1324,13 @@ data:
        `_lastModified` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
        PRIMARY KEY (`session_id`)
     );
+    -- 01-create-authorization-db.sql
+
+    -- Copyright (c) 2020 Gitpod GmbH. All rights reserved.
+    -- Licensed under the GNU Affero General Public License (AGPL). See License.AGPL.txt in the project root for license information.
+
+    -- must be idempotent
+    CREATE DATABASE IF NOT EXISTS `authorization` CHARSET utf8mb4;
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/install/installer/cmd/testdata/render/http-proxy/output.golden
+++ b/install/installer/cmd/testdata/render/http-proxy/output.golden
@@ -1461,6 +1461,16 @@ data:
     @statementStr = CONCAT('CREATE DATABASE ', @gitpodDB, ' CHARSET utf8mb4');
     PREPARE statement FROM @statementStr;
     EXECUTE statement;
+    -- 03-create-authorization-db.sql
+
+    -- Copyright (c) 2020 Gitpod GmbH. All rights reserved.
+    -- Licensed under the GNU Affero General Public License (AGPL). See License.AGPL.txt in the project root for license information.
+
+    -- must be idempotent
+    CREATE DATABASE IF NOT EXISTS `authorization` CHARSET utf8mb4;
+
+    -- Grant privileges
+    GRANT ALL ON `authorization`.* TO "gitpod"@"%";
   tuneMysql.sql: SET GLOBAL innodb_lru_scan_depth=256;
 kind: ConfigMap
 metadata:

--- a/install/installer/cmd/testdata/render/kind-meta/output.golden
+++ b/install/installer/cmd/testdata/render/kind-meta/output.golden
@@ -1005,6 +1005,16 @@ data:
     @statementStr = CONCAT('CREATE DATABASE ', @gitpodDB, ' CHARSET utf8mb4');
     PREPARE statement FROM @statementStr;
     EXECUTE statement;
+    -- 03-create-authorization-db.sql
+
+    -- Copyright (c) 2020 Gitpod GmbH. All rights reserved.
+    -- Licensed under the GNU Affero General Public License (AGPL). See License.AGPL.txt in the project root for license information.
+
+    -- must be idempotent
+    CREATE DATABASE IF NOT EXISTS `authorization` CHARSET utf8mb4;
+
+    -- Grant privileges
+    GRANT ALL ON `authorization`.* TO "gitpod"@"%";
   tuneMysql.sql: SET GLOBAL innodb_lru_scan_depth=256;
 kind: ConfigMap
 metadata:

--- a/install/installer/cmd/testdata/render/kind-webapp/output.golden
+++ b/install/installer/cmd/testdata/render/kind-webapp/output.golden
@@ -739,6 +739,16 @@ data:
     @statementStr = CONCAT('CREATE DATABASE ', @gitpodDB, ' CHARSET utf8mb4');
     PREPARE statement FROM @statementStr;
     EXECUTE statement;
+    -- 03-create-authorization-db.sql
+
+    -- Copyright (c) 2020 Gitpod GmbH. All rights reserved.
+    -- Licensed under the GNU Affero General Public License (AGPL). See License.AGPL.txt in the project root for license information.
+
+    -- must be idempotent
+    CREATE DATABASE IF NOT EXISTS `authorization` CHARSET utf8mb4;
+
+    -- Grant privileges
+    GRANT ALL ON `authorization`.* TO "gitpod"@"%";
   tuneMysql.sql: SET GLOBAL innodb_lru_scan_depth=256;
 kind: ConfigMap
 metadata:

--- a/install/installer/cmd/testdata/render/message-bus-password/output.golden
+++ b/install/installer/cmd/testdata/render/message-bus-password/output.golden
@@ -1460,6 +1460,16 @@ data:
     @statementStr = CONCAT('CREATE DATABASE ', @gitpodDB, ' CHARSET utf8mb4');
     PREPARE statement FROM @statementStr;
     EXECUTE statement;
+    -- 03-create-authorization-db.sql
+
+    -- Copyright (c) 2020 Gitpod GmbH. All rights reserved.
+    -- Licensed under the GNU Affero General Public License (AGPL). See License.AGPL.txt in the project root for license information.
+
+    -- must be idempotent
+    CREATE DATABASE IF NOT EXISTS `authorization` CHARSET utf8mb4;
+
+    -- Grant privileges
+    GRANT ALL ON `authorization`.* TO "gitpod"@"%";
   tuneMysql.sql: SET GLOBAL innodb_lru_scan_depth=256;
 kind: ConfigMap
 metadata:

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -1461,6 +1461,16 @@ data:
     @statementStr = CONCAT('CREATE DATABASE ', @gitpodDB, ' CHARSET utf8mb4');
     PREPARE statement FROM @statementStr;
     EXECUTE statement;
+    -- 03-create-authorization-db.sql
+
+    -- Copyright (c) 2020 Gitpod GmbH. All rights reserved.
+    -- Licensed under the GNU Affero General Public License (AGPL). See License.AGPL.txt in the project root for license information.
+
+    -- must be idempotent
+    CREATE DATABASE IF NOT EXISTS `authorization` CHARSET utf8mb4;
+
+    -- Grant privileges
+    GRANT ALL ON `authorization`.* TO "gitpod"@"%";
   tuneMysql.sql: SET GLOBAL innodb_lru_scan_depth=256;
 kind: ConfigMap
 metadata:

--- a/install/installer/cmd/testdata/render/overrides-inline/output.golden
+++ b/install/installer/cmd/testdata/render/overrides-inline/output.golden
@@ -1459,6 +1459,16 @@ data:
     @statementStr = CONCAT('CREATE DATABASE ', @gitpodDB, ' CHARSET utf8mb4');
     PREPARE statement FROM @statementStr;
     EXECUTE statement;
+    -- 03-create-authorization-db.sql
+
+    -- Copyright (c) 2020 Gitpod GmbH. All rights reserved.
+    -- Licensed under the GNU Affero General Public License (AGPL). See License.AGPL.txt in the project root for license information.
+
+    -- must be idempotent
+    CREATE DATABASE IF NOT EXISTS `authorization` CHARSET utf8mb4;
+
+    -- Grant privileges
+    GRANT ALL ON `authorization`.* TO "gitpod"@"%";
   tuneMysql.sql: SET GLOBAL innodb_lru_scan_depth=256;
 kind: ConfigMap
 metadata:

--- a/install/installer/cmd/testdata/render/pod-config/output.golden
+++ b/install/installer/cmd/testdata/render/pod-config/output.golden
@@ -1461,6 +1461,16 @@ data:
     @statementStr = CONCAT('CREATE DATABASE ', @gitpodDB, ' CHARSET utf8mb4');
     PREPARE statement FROM @statementStr;
     EXECUTE statement;
+    -- 03-create-authorization-db.sql
+
+    -- Copyright (c) 2020 Gitpod GmbH. All rights reserved.
+    -- Licensed under the GNU Affero General Public License (AGPL). See License.AGPL.txt in the project root for license information.
+
+    -- must be idempotent
+    CREATE DATABASE IF NOT EXISTS `authorization` CHARSET utf8mb4;
+
+    -- Grant privileges
+    GRANT ALL ON `authorization`.* TO "gitpod"@"%";
   tuneMysql.sql: SET GLOBAL innodb_lru_scan_depth=256;
 kind: ConfigMap
 metadata:

--- a/install/installer/cmd/testdata/render/shortname/output.golden
+++ b/install/installer/cmd/testdata/render/shortname/output.golden
@@ -1461,6 +1461,16 @@ data:
     @statementStr = CONCAT('CREATE DATABASE ', @gitpodDB, ' CHARSET utf8mb4');
     PREPARE statement FROM @statementStr;
     EXECUTE statement;
+    -- 03-create-authorization-db.sql
+
+    -- Copyright (c) 2020 Gitpod GmbH. All rights reserved.
+    -- Licensed under the GNU Affero General Public License (AGPL). See License.AGPL.txt in the project root for license information.
+
+    -- must be idempotent
+    CREATE DATABASE IF NOT EXISTS `authorization` CHARSET utf8mb4;
+
+    -- Grant privileges
+    GRANT ALL ON `authorization`.* TO "gitpod"@"%";
   tuneMysql.sql: SET GLOBAL innodb_lru_scan_depth=256;
 kind: ConfigMap
 metadata:

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -1461,6 +1461,16 @@ data:
     @statementStr = CONCAT('CREATE DATABASE ', @gitpodDB, ' CHARSET utf8mb4');
     PREPARE statement FROM @statementStr;
     EXECUTE statement;
+    -- 03-create-authorization-db.sql
+
+    -- Copyright (c) 2020 Gitpod GmbH. All rights reserved.
+    -- Licensed under the GNU Affero General Public License (AGPL). See License.AGPL.txt in the project root for license information.
+
+    -- must be idempotent
+    CREATE DATABASE IF NOT EXISTS `authorization` CHARSET utf8mb4;
+
+    -- Grant privileges
+    GRANT ALL ON `authorization`.* TO "gitpod"@"%";
   tuneMysql.sql: SET GLOBAL innodb_lru_scan_depth=256;
 kind: ConfigMap
 metadata:

--- a/install/installer/cmd/testdata/render/telemetry/output.golden
+++ b/install/installer/cmd/testdata/render/telemetry/output.golden
@@ -1461,6 +1461,16 @@ data:
     @statementStr = CONCAT('CREATE DATABASE ', @gitpodDB, ' CHARSET utf8mb4');
     PREPARE statement FROM @statementStr;
     EXECUTE statement;
+    -- 03-create-authorization-db.sql
+
+    -- Copyright (c) 2020 Gitpod GmbH. All rights reserved.
+    -- Licensed under the GNU Affero General Public License (AGPL). See License.AGPL.txt in the project root for license information.
+
+    -- must be idempotent
+    CREATE DATABASE IF NOT EXISTS `authorization` CHARSET utf8mb4;
+
+    -- Grant privileges
+    GRANT ALL ON `authorization`.* TO "gitpod"@"%";
   tuneMysql.sql: SET GLOBAL innodb_lru_scan_depth=256;
 kind: ConfigMap
 metadata:

--- a/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
+++ b/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
@@ -1683,6 +1683,16 @@ data:
     @statementStr = CONCAT('CREATE DATABASE ', @gitpodDB, ' CHARSET utf8mb4');
     PREPARE statement FROM @statementStr;
     EXECUTE statement;
+    -- 03-create-authorization-db.sql
+
+    -- Copyright (c) 2020 Gitpod GmbH. All rights reserved.
+    -- Licensed under the GNU Affero General Public License (AGPL). See License.AGPL.txt in the project root for license information.
+
+    -- must be idempotent
+    CREATE DATABASE IF NOT EXISTS `authorization` CHARSET utf8mb4;
+
+    -- Grant privileges
+    GRANT ALL ON `authorization`.* TO "gitpod"@"%";
   tuneMysql.sql: SET GLOBAL innodb_lru_scan_depth=256;
 kind: ConfigMap
 metadata:

--- a/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
+++ b/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
@@ -1461,6 +1461,16 @@ data:
     @statementStr = CONCAT('CREATE DATABASE ', @gitpodDB, ' CHARSET utf8mb4');
     PREPARE statement FROM @statementStr;
     EXECUTE statement;
+    -- 03-create-authorization-db.sql
+
+    -- Copyright (c) 2020 Gitpod GmbH. All rights reserved.
+    -- Licensed under the GNU Affero General Public License (AGPL). See License.AGPL.txt in the project root for license information.
+
+    -- must be idempotent
+    CREATE DATABASE IF NOT EXISTS `authorization` CHARSET utf8mb4;
+
+    -- Grant privileges
+    GRANT ALL ON `authorization`.* TO "gitpod"@"%";
   tuneMysql.sql: SET GLOBAL innodb_lru_scan_depth=256;
 kind: ConfigMap
 metadata:

--- a/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
+++ b/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
@@ -1461,6 +1461,16 @@ data:
     @statementStr = CONCAT('CREATE DATABASE ', @gitpodDB, ' CHARSET utf8mb4');
     PREPARE statement FROM @statementStr;
     EXECUTE statement;
+    -- 03-create-authorization-db.sql
+
+    -- Copyright (c) 2020 Gitpod GmbH. All rights reserved.
+    -- Licensed under the GNU Affero General Public License (AGPL). See License.AGPL.txt in the project root for license information.
+
+    -- must be idempotent
+    CREATE DATABASE IF NOT EXISTS `authorization` CHARSET utf8mb4;
+
+    -- Grant privileges
+    GRANT ALL ON `authorization`.* TO "gitpod"@"%";
   tuneMysql.sql: SET GLOBAL innodb_lru_scan_depth=256;
 kind: ConfigMap
 metadata:

--- a/install/installer/pkg/components/database/incluster/init/03-create-authorization-db.sql
+++ b/install/installer/pkg/components/database/incluster/init/03-create-authorization-db.sql
@@ -1,0 +1,8 @@
+-- Copyright (c) 2020 Gitpod GmbH. All rights reserved.
+-- Licensed under the GNU Affero General Public License (AGPL). See License.AGPL.txt in the project root for license information.
+
+-- must be idempotent
+CREATE DATABASE IF NOT EXISTS `authorization` CHARSET utf8mb4;
+
+-- Grant privileges
+GRANT ALL ON `authorization`.* TO "__GITPOD_USERNAME__"@"%";

--- a/install/installer/pkg/components/database/init/files/01-create-authorization-db.sql
+++ b/install/installer/pkg/components/database/init/files/01-create-authorization-db.sql
@@ -1,0 +1,5 @@
+-- Copyright (c) 2020 Gitpod GmbH. All rights reserved.
+-- Licensed under the GNU Affero General Public License (AGPL). See License.AGPL.txt in the project root for license information.
+
+-- must be idempotent
+CREATE DATABASE IF NOT EXISTS `authorization` CHARSET utf8mb4;

--- a/install/installer/pkg/components/spicedb/constants.go
+++ b/install/installer/pkg/components/spicedb/constants.go
@@ -24,7 +24,7 @@ const (
 
 	RegistryRepo  = "registry.hub.docker.com"
 	RegistryImage = "authzed/spicedb"
-	ImageTag      = "v1.16.0"
+	ImageTag      = "v1.16.1"
 
 	ContainerName = "spicedb"
 

--- a/install/installer/pkg/components/spicedb/migrations.go
+++ b/install/installer/pkg/components/spicedb/migrations.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package spicedb
+
+import (
+	"fmt"
+
+	"github.com/gitpod-io/gitpod/installer/pkg/cluster"
+	"github.com/gitpod-io/gitpod/installer/pkg/common"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/pointer"
+)
+
+func migrations(ctx *common.RenderContext) ([]runtime.Object, error) {
+
+	cfg := getExperimentalSpiceDBConfig(ctx)
+	if cfg == nil {
+		return nil, nil
+	}
+
+	if cfg.DisableMigrations {
+		return nil, nil
+	}
+
+	objectMeta := metav1.ObjectMeta{
+		Name:        Component,
+		Namespace:   ctx.Namespace,
+		Labels:      common.CustomizeLabel(ctx, Component, common.TypeMetaBatchJob),
+		Annotations: common.CustomizeAnnotation(ctx, Component, common.TypeMetaBatchJob),
+	}
+
+	return []runtime.Object{
+		&batchv1.Job{
+			TypeMeta:   common.TypeMetaBatchJob,
+			ObjectMeta: objectMeta,
+			Spec: batchv1.JobSpec{
+				TTLSecondsAfterFinished: pointer.Int32(120),
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: objectMeta,
+					Spec: corev1.PodSpec{
+						Affinity:           common.NodeAffinity(cluster.AffinityLabelMeta),
+						RestartPolicy:      corev1.RestartPolicyNever,
+						ServiceAccountName: Component,
+						EnableServiceLinks: pointer.Bool(false),
+						InitContainers: []corev1.Container{
+							dbWaiter(ctx),
+						},
+						Containers: []corev1.Container{{
+							Name:            fmt.Sprintf("%s-migrations", Component),
+							Image:           ctx.ImageName(common.ThirdPartyContainerRepo(ctx.Config.Repository, RegistryRepo), RegistryImage, ImageTag),
+							ImagePullPolicy: corev1.PullIfNotPresent,
+							Env: common.CustomizeEnvvar(ctx, Component, common.MergeEnv(
+								common.DefaultEnv(&ctx.Config),
+								spicedbEnvVars(ctx),
+							)),
+							SecurityContext: &corev1.SecurityContext{
+								AllowPrivilegeEscalation: pointer.Bool(false),
+							},
+							Args: []string{
+								"migrate",
+								"head",
+								"--log-format=json",
+								"--log-level=debug",
+								"--datastore-engine=mysql",
+							},
+						}},
+					},
+				},
+			},
+		},
+	}, nil
+}

--- a/install/installer/pkg/components/spicedb/objects.go
+++ b/install/installer/pkg/components/spicedb/objects.go
@@ -21,6 +21,7 @@ func Objects(ctx *common.RenderContext) ([]runtime.Object, error) {
 		deployment,
 		service,
 		common.DefaultServiceAccount(Component),
+		migrations,
 	)(ctx)
 }
 

--- a/install/installer/pkg/config/v1/experimental/experimental.go
+++ b/install/installer/pkg/config/v1/experimental/experimental.go
@@ -197,6 +197,8 @@ type IAMConfig struct {
 type SpiceDBConfig struct {
 	Enabled bool `json:"enabled"`
 
+	DisableMigrations bool `json:"disableMigrations"`
+
 	CloudSQL *struct {
 		Instance string `json:"instance"`
 		Database string `json:"database"`


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Configures and deploys spice db in preview envs

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/15951

## How to test
<!-- Provide steps to test this PR -->

1. Preview
2. 
```
kubectl get po 

...
spicedb-5569847b47-bccnh             1/1     Running     1 (14m ago)   15m
...
```
## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all-ci
- [ ] /werft no-test
      Run Leeway with `--dont-test`

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
