### PR TITLE
Handle context installation when switching underlying infra

### DIFF
--- a/dev/preview/previewctl/cmd/install_context.go
+++ b/dev/preview/previewctl/cmd/install_context.go
@@ -57,7 +57,6 @@ func newInstallContextCmd(logger *logrus.Logger) *cobra.Command {
 		}
 
 		p, err := preview.New(branch, logger)
-
 		if err != nil {
 			return err
 		}

--- a/dev/preview/previewctl/pkg/k8s/context.go
+++ b/dev/preview/previewctl/pkg/k8s/context.go
@@ -99,3 +99,13 @@ func OutputContext(kubeConfigSavePath string, config *api.Config) error {
 
 	return err
 }
+
+func DeleteContext(config *api.Config, name string) {
+	_, exists := config.Contexts[name]
+	if !exists {
+		return
+	}
+
+	delete(config.Contexts, name)
+	delete(config.Clusters, name)
+}

--- a/dev/preview/previewctl/pkg/k8s/vm.go
+++ b/dev/preview/previewctl/pkg/k8s/vm.go
@@ -7,11 +7,8 @@ package k8s
 import (
 	"context"
 	"github.com/cockroachdb/errors"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	virtv1 "kubevirt.io/api/core/v1"
 )
 
 var (
@@ -30,14 +27,13 @@ var (
 	ErrVmNotReady = errors.New("vm not ready")
 )
 
-func (c *Config) GetVMICreationTimestamp(ctx context.Context, name, namespace string) (*metav1.Time, error) {
-	vmi, err := c.getVMI(ctx, name, namespace)
-
+func (c *Config) GetSVCCreationTimestamp(ctx context.Context, name, namespace string) (*metav1.Time, error) {
+	svc, err := c.CoreClient.CoreV1().Services(namespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}
 
-	return &vmi.ObjectMeta.CreationTimestamp, nil
+	return &svc.ObjectMeta.CreationTimestamp, nil
 }
 
 func (c *Config) GetVMs(ctx context.Context) ([]string, error) {
@@ -53,30 +49,4 @@ func (c *Config) GetVMs(ctx context.Context) ([]string, error) {
 	}
 
 	return vms, nil
-}
-
-func (c *Config) getVMI(ctx context.Context, name, namespace string) (*virtv1.VirtualMachineInstance, error) {
-	_, err := c.CoreClient.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
-	if err != nil && !kerrors.IsNotFound(err) {
-		return nil, errors.Wrap(ErrVmNotReady, err.Error())
-	}
-
-	if kerrors.IsNotFound(err) {
-		c.logger.Infof("namespace [%s] not found", namespace)
-		return nil, errors.Wrap(ErrVmNotReady, err.Error())
-	}
-
-	vmClient := c.DynamicClient.Resource(vmInstanceResource).Namespace(namespace)
-	res, err := vmClient.Get(ctx, name, metav1.GetOptions{})
-	if err != nil {
-		return nil, errors.Wrap(ErrVmNotReady, err.Error())
-	}
-
-	var vmi virtv1.VirtualMachineInstance
-	err = runtime.DefaultUnstructuredConverter.FromUnstructured(res.UnstructuredContent(), &vmi)
-	if err != nil {
-		return nil, errors.Wrap(ErrVmNotReady, err.Error())
-	}
-
-	return &vmi, nil
 }

--- a/dev/preview/previewctl/pkg/preview/status.go
+++ b/dev/preview/previewctl/pkg/preview/status.go
@@ -40,14 +40,14 @@ func (c *Config) GetStatus(ctx context.Context) (Status, error) {
 
 	// If the VM got created in the last 120 mins, always assume it's active
 	// clock skew can go to hell
-	c.ensureVMICreationTime()
-	if c.vmiCreationTime.After(time.Now().Add(-120 * time.Minute)) {
+	c.ensureCreationTime()
+	if c.creationTime != nil && c.creationTime.After(time.Now().Add(-120*time.Minute)) {
 		logEntry.WithFields(log.Fields{
-			"created": c.vmiCreationTime,
+			"created": c.creationTime,
 		}).Debug("VM created in the past 120 mins, assuming active")
 
 		c.status.Active = true
-		c.status.Reason = fmt.Sprintf("VM created in the past 120 mins, assuming active: [%v]", c.vmiCreationTime.Time)
+		c.status.Reason = fmt.Sprintf("VM created in the past 120 mins, assuming active: [%v]", c.creationTime.Time)
 		return c.status, nil
 	}
 
@@ -144,7 +144,7 @@ func (c *Config) dbStatus(ctx context.Context, password, port string) (Status, e
 		if r.RowsAffected > 0 {
 			c.logger.WithFields(log.Fields{
 				"preview":  c.name,
-				"created":  c.vmiCreationTime,
+				"created":  c.creationTime,
 				"query":    q,
 				"activity": fmt.Sprintf("%v hours ago", res["timediff"]),
 			}).Debug("db has activity")


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Handle context installation when switching infra.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all-ci
- [ ] /werft no-test
      Run Leeway with `--dont-test`

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
