### PR TITLE
Handle context installation when switching underlying infra

### DIFF
--- a/dev/preview/previewctl/pkg/k8s/vm.go
+++ b/dev/preview/previewctl/pkg/k8s/vm.go
@@ -6,7 +6,7 @@ package k8s
 
 import (
 	"context"
-	"github.com/cockroachdb/errors"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -17,18 +17,10 @@ var (
 		Version:  "v1",
 		Resource: "virtualmachines",
 	}
-
-	vmInstanceResource = schema.GroupVersionResource{
-		Group:    "kubevirt.io",
-		Version:  "v1",
-		Resource: "virtualmachineinstances",
-	}
-
-	ErrVmNotReady = errors.New("vm not ready")
 )
 
 func (c *Config) GetSVCCreationTimestamp(ctx context.Context, name, namespace string) (*metav1.Time, error) {
-	svc, err := c.CoreClient.CoreV1().Services(namespace).Get(ctx, name, metav1.GetOptions{})
+	svc, err := c.CoreClient.CoreV1().Services(namespace).Get(ctx, "proxy", metav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Fixing a small issue from: https://github.com/gitpod-io/gitpod/pull/16007

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all-ci
- [ ] /werft no-test
      Run Leeway with `--dont-test`

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
