### PR TITLE
Remove the unused publishToKots function

### DIFF
--- a/.werft/cleanup-installer-tests.yaml
+++ b/.werft/cleanup-installer-tests.yaml
@@ -137,5 +137,3 @@ pod:
         TESTCONFIG="CLEANUP_OLD_TESTS"
 
         npx ts-node .werft/installer-tests.ts ${TESTCONFIG}
-plugins:
-  cron: "0 */12 * * *"

--- a/.werft/jobs/build/build-and-publish.ts
+++ b/.werft/jobs/build/build-and-publish.ts
@@ -4,14 +4,6 @@ import { Werft } from "../../util/werft";
 import { GCLOUD_SERVICE_ACCOUNT_PATH } from "./const";
 import { JobConfig } from "./job-config";
 
-const phases = {
-    PUBLISH_KOTS: "publish kots",
-};
-
-const REPLICATED_DIR = "./install/kots";
-const REPLICATED_YAML_DIR = `${REPLICATED_DIR}/manifests`;
-const INSTALLER_JOB_IMAGE = "spec.template.spec.containers[0].image";
-
 export async function buildAndPublish(werft: Werft, jobConfig: JobConfig) {
     const {
         publishRelease,


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This removes a regression introduced in #16008 . This PR removed the unused function `publishToKots`

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all-ci
- [ ] /werft no-test
      Run Leeway with `--dont-test`

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
