### PR TITLE
[server, dashboard] Remove isUsageBasedBillingEnabled feature flag

### DIFF
--- a/components/dashboard/src/contexts/FeatureFlagContext.tsx
+++ b/components/dashboard/src/contexts/FeatureFlagContext.tsx
@@ -17,14 +17,12 @@ interface FeatureFlagConfig {
 
 const FeatureFlagContext = createContext<{
     showUsageView: boolean;
-    isUsageBasedBillingEnabled: boolean;
     showUseLastSuccessfulPrebuild: boolean;
     usePublicApiWorkspacesService: boolean;
     enablePersonalAccessTokens: boolean;
     oidcServiceEnabled: boolean;
 }>({
     showUsageView: false,
-    isUsageBasedBillingEnabled: false,
     showUseLastSuccessfulPrebuild: false,
     usePublicApiWorkspacesService: false,
     enablePersonalAccessTokens: false,
@@ -38,7 +36,6 @@ const FeatureFlagContextProvider: React.FC = ({ children }) => {
     const location = useLocation();
     const team = getCurrentTeam(location, teams);
     const [showUsageView, setShowUsageView] = useState<boolean>(false);
-    const [isUsageBasedBillingEnabled, setIsUsageBasedBillingEnabled] = useState<boolean>(false);
     const [showUseLastSuccessfulPrebuild, setShowUseLastSuccessfulPrebuild] = useState<boolean>(false);
     const [enablePersonalAccessTokens, setPersonalAccessTokensEnabled] = useState<boolean>(false);
     const [usePublicApiWorkspacesService, setUsePublicApiWorkspacesService] = useState<boolean>(false);
@@ -49,7 +46,6 @@ const FeatureFlagContextProvider: React.FC = ({ children }) => {
         (async () => {
             const featureFlags: FeatureFlagConfig = {
                 usage_view: { defaultValue: false, setter: setShowUsageView },
-                isUsageBasedBillingEnabled: { defaultValue: false, setter: setIsUsageBasedBillingEnabled },
                 showUseLastSuccessfulPrebuild: { defaultValue: false, setter: setShowUseLastSuccessfulPrebuild },
                 personalAccessTokensEnabled: { defaultValue: false, setter: setPersonalAccessTokensEnabled },
                 publicApiExperimentalWorkspaceService: {
@@ -97,7 +93,6 @@ const FeatureFlagContextProvider: React.FC = ({ children }) => {
         <FeatureFlagContext.Provider
             value={{
                 showUsageView,
-                isUsageBasedBillingEnabled,
                 showUseLastSuccessfulPrebuild,
                 enablePersonalAccessTokens,
                 usePublicApiWorkspacesService,

--- a/components/dashboard/src/settings/Plans.tsx
+++ b/components/dashboard/src/settings/Plans.tsx
@@ -25,7 +25,6 @@ import { UserContext } from "../user-context";
 import Tooltip from "../components/Tooltip";
 import { PaymentContext } from "../payment-context";
 import { PageWithSettingsSubMenu } from "./PageWithSettingsSubMenu";
-import { FeatureFlagContext } from "../contexts/FeatureFlagContext";
 
 type PlanWithOriginalPrice = Plan & { originalPrice?: number };
 type Pending = { pendingSince: number };
@@ -46,7 +45,7 @@ type TeamClaimModal =
 export default function () {
     const { user, userBillingMode } = useContext(UserContext);
     const { currency, setCurrency, isStudent, isChargebeeCustomer } = useContext(PaymentContext);
-    const { isUsageBasedBillingEnabled } = useContext(FeatureFlagContext);
+    const isUsageBasedBillingEnabled = true; // TODO(gpl) No need to clean up all the code below as we're going to remove all Chargebee related code anyway.
     const [accountStatement, setAccountStatement] = useState<AccountStatement>();
     const [availableCoupons, setAvailableCoupons] = useState<PlanCoupon[]>();
     const [appliedCoupons, setAppliedCoupons] = useState<PlanCoupon[]>();

--- a/components/dashboard/src/settings/Teams.tsx
+++ b/components/dashboard/src/settings/Teams.tsx
@@ -23,7 +23,6 @@ import { poll, PollOptions } from "../utils";
 import { Disposable } from "@gitpod/gitpod-protocol";
 import { PaymentContext } from "../payment-context";
 import { PageWithSettingsSubMenu } from "./PageWithSettingsSubMenu";
-import { FeatureFlagContext } from "../contexts/FeatureFlagContext";
 
 export default function Teams() {
     return (
@@ -44,7 +43,6 @@ interface Slot extends TeamSubscriptionSlotResolved {
 }
 
 function AllTeams() {
-    const { isUsageBasedBillingEnabled } = useContext(FeatureFlagContext);
     const { currency, isStudent, isChargebeeCustomer, setIsChargebeeCustomer } = useContext(PaymentContext);
 
     const [slots, setSlots] = useState<Slot[]>([]);
@@ -454,7 +452,7 @@ function AllTeams() {
 
     return (
         <div>
-            {isUsageBasedBillingEnabled && (
+            {
                 <Alert type="message" className="mb-4">
                     To access{" "}
                     <a className="gp-link" href="https://www.gitpod.io/docs/configure/workspaces/workspace-classes">
@@ -466,7 +464,7 @@ function AllTeams() {
                     </a>
                     , first cancel your existing plan. Existing plans will keep working until the end of March, 2023.
                 </Alert>
-            )}
+            }
             <div className="flex flex-row">
                 <div className="flex-grow ">
                     <h3 className="self-center">All Team Plans</h3>
@@ -482,9 +480,10 @@ function AllTeams() {
                         <button
                             className="self-end my-auto"
                             disabled={
-                                !!isUsageBasedBillingEnabled ||
+                                true
+                                /** !!isUsageBasedBillingEnabled ||
                                 !!pendingPlanPurchase ||
-                                getAvailableSubTypes().length === 0
+                                getAvailableSubTypes().length === 0 **/
                             }
                             onClick={() => showCreateTeamModal()}
                         >
@@ -515,29 +514,6 @@ function AllTeams() {
 
             {addMembersModal && (
                 <AddMembersModal onClose={() => setAddMembersModal(undefined)} onBuy={onBuy} {...addMembersModal} />
-            )}
-
-            {getActiveSubs().length === 0 && !pendingPlanPurchase && !isUsageBasedBillingEnabled && (
-                <div className="w-full flex h-80 mt-2 rounded-xl bg-gray-100 dark:bg-gray-900">
-                    <div className="m-auto text-center">
-                        <h3 className="self-center text-gray-500 dark:text-gray-400 mb-4">No Active Team Plans</h3>
-                        <div className="text-gray-500 mb-6">
-                            Get started by creating a team plan
-                            <br /> and adding team members.{" "}
-                            <a
-                                href="https://www.gitpod.io/docs/teams/"
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                className="gp-link"
-                            >
-                                Learn more
-                            </a>
-                        </div>
-                        <button className="self-center" onClick={() => showCreateTeamModal()}>
-                            Create Team Plan
-                        </button>
-                    </div>
-                </div>
             )}
 
             {(getActiveSubs().length > 0 || !!pendingPlanPurchase) && (

--- a/components/server/ee/src/billing/billing-mode.spec.db.ts
+++ b/components/server/ee/src/billing/billing-mode.spec.db.ts
@@ -149,7 +149,6 @@ class BillingModeSpec {
             subject: User | Pick<Team, "name">;
             config: {
                 enablePayment: boolean;
-                usageBasedPricingEnabled: boolean;
                 subscriptions?: TestSubscription[];
                 stripeSubscription?: StripeSubscription & { isTeam?: boolean };
             };
@@ -163,69 +162,9 @@ class BillingModeSpec {
                 subject: user(),
                 config: {
                     enablePayment: false,
-                    usageBasedPricingEnabled: true,
                 },
                 expectation: {
                     mode: "none",
-                },
-            },
-            {
-                name: "payment disabled (ubb: false)",
-                subject: user(),
-                config: {
-                    enablePayment: false,
-                    usageBasedPricingEnabled: false,
-                },
-                expectation: {
-                    mode: "none",
-                },
-            },
-            {
-                name: "payment enabled (ubb: false)",
-                subject: user(),
-                config: {
-                    enablePayment: true,
-                    usageBasedPricingEnabled: false,
-                },
-                expectation: {
-                    mode: "chargebee",
-                },
-            },
-            // user: chargebee
-            {
-                name: "user: chargebee paid personal",
-                subject: user(),
-                config: {
-                    enablePayment: true,
-                    usageBasedPricingEnabled: false,
-                    subscriptions: [subscription(Plans.PERSONAL_EUR)],
-                },
-                expectation: {
-                    mode: "chargebee",
-                },
-            },
-            {
-                name: "user: chargebee paid team seat",
-                subject: user(),
-                config: {
-                    enablePayment: true,
-                    usageBasedPricingEnabled: false,
-                    subscriptions: [teamSubscription(Plans.TEAM_PROFESSIONAL_EUR)],
-                },
-                expectation: {
-                    mode: "chargebee",
-                },
-            },
-            {
-                name: "user: chargebee paid personal + team seat",
-                subject: user(),
-                config: {
-                    enablePayment: true,
-                    usageBasedPricingEnabled: false,
-                    subscriptions: [subscription(Plans.PERSONAL_EUR), teamSubscription(Plans.TEAM_PROFESSIONAL_EUR)],
-                },
-                expectation: {
-                    mode: "chargebee",
                 },
             },
             // user: transition chargebee -> UBB
@@ -234,7 +173,6 @@ class BillingModeSpec {
                 subject: user(),
                 config: {
                     enablePayment: true,
-                    usageBasedPricingEnabled: true,
                     subscriptions: [
                         subscription(Plans.PERSONAL_EUR, cancellationDate, endDate),
                         teamSubscription(Plans.TEAM_PROFESSIONAL_EUR),
@@ -251,7 +189,6 @@ class BillingModeSpec {
                 subject: user(),
                 config: {
                     enablePayment: true,
-                    usageBasedPricingEnabled: true,
                     subscriptions: [
                         subscription(Plans.PERSONAL_EUR, cancellationDate, endDate),
                         teamSubscription(Plans.TEAM_PROFESSIONAL_EUR, cancellationDate, endDate),
@@ -268,7 +205,6 @@ class BillingModeSpec {
                 subject: user(),
                 config: {
                     enablePayment: true,
-                    usageBasedPricingEnabled: true,
                     subscriptions: [
                         subscription(Plans.PERSONAL_EUR, cancellationDate, endDate),
                         teamSubscription(Plans.TEAM_PROFESSIONAL_EUR),
@@ -286,7 +222,6 @@ class BillingModeSpec {
                 subject: user(),
                 config: {
                     enablePayment: true,
-                    usageBasedPricingEnabled: true,
                     subscriptions: [
                         subscription(Plans.PERSONAL_EUR, cancellationDate, cancellationDate),
                         teamSubscription(Plans.TEAM_PROFESSIONAL_EUR, cancellationDate, cancellationDate),
@@ -301,7 +236,6 @@ class BillingModeSpec {
                 subject: user(),
                 config: {
                     enablePayment: true,
-                    usageBasedPricingEnabled: true,
                     subscriptions: [subscription(Plans.PERSONAL_EUR, cancellationDate, cancellationDate)],
                 },
                 expectation: {
@@ -313,7 +247,6 @@ class BillingModeSpec {
                 subject: user(),
                 config: {
                     enablePayment: true,
-                    usageBasedPricingEnabled: true,
                     subscriptions: [
                         subscription(Plans.PERSONAL_EUR, cancellationDate, cancellationDate),
                         teamSubscription(Plans.TEAM_PROFESSIONAL_EUR, cancellationDate, cancellationDate),
@@ -329,7 +262,6 @@ class BillingModeSpec {
                 subject: user(),
                 config: {
                     enablePayment: true,
-                    usageBasedPricingEnabled: true,
                     stripeSubscription: stripeSubscription(),
                 },
                 expectation: {
@@ -341,7 +273,6 @@ class BillingModeSpec {
                 subject: user(),
                 config: {
                     enablePayment: true,
-                    usageBasedPricingEnabled: true,
                 },
                 expectation: {
                     mode: "usage-based",
@@ -353,55 +284,17 @@ class BillingModeSpec {
                 subject: team(),
                 config: {
                     enablePayment: false,
-                    usageBasedPricingEnabled: true,
                 },
                 expectation: {
                     mode: "none",
-                },
-            },
-            {
-                name: "payment disabled (ubb: false)",
-                subject: team(),
-                config: {
-                    enablePayment: false,
-                    usageBasedPricingEnabled: false,
-                },
-                expectation: {
-                    mode: "none",
-                },
-            },
-            {
-                name: "payment enabled (ubb: false)",
-                subject: team(),
-                config: {
-                    enablePayment: true,
-                    usageBasedPricingEnabled: false,
-                },
-                expectation: {
-                    mode: "chargebee",
                 },
             },
             // team: chargebee
-            {
-                name: "team: chargebee paid",
-                subject: team(),
-                config: {
-                    enablePayment: true,
-                    usageBasedPricingEnabled: false,
-                    subscriptions: [teamSubscription2(Plans.TEAM_PROFESSIONAL_EUR)],
-                },
-                expectation: {
-                    mode: "chargebee",
-                    paid: true,
-                    teamNames: ["team-123"],
-                },
-            },
             {
                 name: "team: chargebee paid (UBB)",
                 subject: team(),
                 config: {
                     enablePayment: true,
-                    usageBasedPricingEnabled: true,
                     subscriptions: [teamSubscription2(Plans.TEAM_PROFESSIONAL_EUR)],
                 },
                 expectation: {
@@ -416,7 +309,6 @@ class BillingModeSpec {
                 subject: team(),
                 config: {
                     enablePayment: true,
-                    usageBasedPricingEnabled: true,
                     subscriptions: [teamSubscription2(Plans.TEAM_PROFESSIONAL_EUR, cancellationDate, endDate)],
                 },
                 expectation: {
@@ -429,7 +321,6 @@ class BillingModeSpec {
                 subject: team(),
                 config: {
                     enablePayment: true,
-                    usageBasedPricingEnabled: true,
                     subscriptions: [teamSubscription(Plans.TEAM_PROFESSIONAL_EUR, cancellationDate, endDate)],
                 },
                 expectation: {
@@ -442,7 +333,6 @@ class BillingModeSpec {
                 subject: team(),
                 config: {
                     enablePayment: true,
-                    usageBasedPricingEnabled: true,
                 },
                 expectation: {
                     mode: "usage-based",
@@ -453,7 +343,6 @@ class BillingModeSpec {
                 subject: team(),
                 config: {
                     enablePayment: true,
-                    usageBasedPricingEnabled: true,
                     subscriptions: [teamSubscription2(Plans.TEAM_PROFESSIONAL_EUR, cancellationDate, cancellationDate)],
                 },
                 expectation: {
@@ -465,7 +354,6 @@ class BillingModeSpec {
                 subject: team(),
                 config: {
                     enablePayment: true,
-                    usageBasedPricingEnabled: true,
                     subscriptions: [teamSubscription2(Plans.TEAM_PROFESSIONAL_EUR, cancellationDate, cancellationDate)],
                     stripeSubscription: stripeSubscription(),
                 },
@@ -479,38 +367,11 @@ class BillingModeSpec {
                 subject: team(),
                 config: {
                     enablePayment: true,
-                    usageBasedPricingEnabled: true,
                     stripeSubscription: stripeSubscription(),
                 },
                 expectation: {
                     mode: "usage-based",
                     paid: true,
-                },
-            },
-            // rollback: make sure users/teams with Stripe subscription stay UBP
-            {
-                name: "team: stripe paid, w/o UBP",
-                subject: team(),
-                config: {
-                    enablePayment: true,
-                    usageBasedPricingEnabled: false,
-                    stripeSubscription: stripeSubscription(),
-                },
-                expectation: {
-                    mode: "usage-based",
-                    paid: true,
-                },
-            },
-            {
-                name: "user: stripe paid, w/o UBP",
-                subject: user(),
-                config: {
-                    enablePayment: true,
-                    usageBasedPricingEnabled: false,
-                    stripeSubscription: stripeSubscription(),
-                },
-                expectation: {
-                    mode: "usage-based",
                 },
             },
         ];
@@ -527,12 +388,7 @@ class BillingModeSpec {
                     bind(BillingModes).to(BillingModesImpl).inSingletonScope();
 
                     bind(UsageService).toConstantValue(new UsageServiceMock(test.config.stripeSubscription));
-                    bind(ConfigCatClientFactory).toConstantValue(
-                        () =>
-                            new ConfigCatClientMock({
-                                isUsageBasedBillingEnabled: test.config.usageBasedPricingEnabled,
-                            }),
-                    );
+                    bind(ConfigCatClientFactory).toConstantValue(() => new ConfigCatClientMock({}));
                 }),
             );
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
 - `leeway run components/gitpod-db:init-testdb`
 - `(cd components/server && yarn db-test)`
 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all-ci
- [ ] /werft no-test
      Run Leeway with `--dont-test`

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
