### PR TITLE
[previewctl] Add create command as alias to leeway run preview:dev

### DIFF
--- a/dev/preview/previewctl/cmd/create.go
+++ b/dev/preview/previewctl/cmd/create.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+func newCreateCmd(logger *logrus.Logger) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "create",
+		Aliases: []string{"start"},
+		Short:   "Create a new preview environment. Alias to `leeway run dev:preview`",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := create(); err != nil {
+				logger.WithError(err).Fatal("Failed to create preview.")
+			}
+
+			return nil
+		},
+	}
+
+	return cmd
+}
+
+func create() error {
+	cmd := exec.Command("leeway", "run", "dev:preview")
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Env = os.Environ()
+
+	err := cmd.Run()
+	if err != nil {
+		return fmt.Errorf("failed to run command: %s", cmd.String())
+	}
+
+	return nil
+}

--- a/dev/preview/previewctl/cmd/root.go
+++ b/dev/preview/previewctl/cmd/root.go
@@ -46,6 +46,7 @@ func NewRootCmd(logger *logrus.Logger) *cobra.Command {
 		newGetCmd(logger),
 		newHasAccessCmd(logger),
 		newReportNameCmd(),
+		newCreateCmd(logger),
 	)
 
 	return cmd


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Aliases `leeway run dev:preview` into `previewctl create`. 

I can never remember the leeway command, and `previewctl` has help text support so I can easily discover what to run.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
1. `go run main.go create` on a branch, observe 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all-ci
- [ ] /werft no-test
      Run Leeway with `--dont-test`

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
