### PR TITLE
[ws-manager-mk2] Support backup of workspaces

### DIFF
--- a/components/ws-daemon/pkg/content/service.go
+++ b/components/ws-daemon/pkg/content/service.go
@@ -40,8 +40,8 @@ import (
 	"github.com/gitpod-io/gitpod/ws-daemon/pkg/quota"
 )
 
-// Metrics combine custom metrics exported by WorkspaceService
-type metrics struct {
+// Metrics combine custom Metrics exported by WorkspaceService
+type Metrics struct {
 	BackupWaitingTimeHist       prometheus.Histogram
 	BackupWaitingTimeoutCounter prometheus.Counter
 	InitializerHistogram        *prometheus.HistogramVec
@@ -56,7 +56,7 @@ type WorkspaceService struct {
 	stopService context.CancelFunc
 	runtime     container.Runtime
 
-	metrics *metrics
+	metrics *Metrics
 
 	// channel to limit the number of concurrent backups and uploads.
 	backupWorkspaceLimiter chan struct{}
@@ -96,17 +96,9 @@ func NewWorkspaceService(ctx context.Context, cfg Config, runtime container.Runt
 		return nil, xerrors.Errorf("cannot register Prometheus gauge for working area diskspace: %w", err)
 	}
 
-	waitingTimeHist, err := registerConcurrentBackupWaitingTime(reg)
+	waitingTimeHist, waitingTimeoutCounter, err := RegisterConcurrentBackupMetrics(reg, "")
 	if err != nil {
-		return nil, xerrors.Errorf("cannot register Prometheus histogram for backup waiting time: %w", err)
-	}
-	waitingTimeoutCounter := prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "concurrent_backup_waiting_timeout_total",
-		Help: "total count of backup rate limiting timeouts",
-	})
-	err = reg.Register(waitingTimeoutCounter)
-	if err != nil {
-		return nil, xerrors.Errorf("cannot register Prometheus counter for backup waiting timeouts: %w", err)
+		return nil, err
 	}
 
 	initializerHistogram := prometheus.NewHistogramVec(prometheus.HistogramOpts{
@@ -127,7 +119,7 @@ func NewWorkspaceService(ctx context.Context, cfg Config, runtime container.Runt
 		stopService: stopService,
 		runtime:     runtime,
 
-		metrics: &metrics{
+		metrics: &Metrics{
 			BackupWaitingTimeHist:       waitingTimeHist,
 			BackupWaitingTimeoutCounter: waitingTimeoutCounter,
 			InitializerHistogram:        initializerHistogram,
@@ -158,19 +150,28 @@ func registerWorkingAreaDiskspaceGauge(workingArea string, reg prometheus.Regist
 	}))
 }
 
-func registerConcurrentBackupWaitingTime(reg prometheus.Registerer) (prometheus.Histogram, error) {
+func RegisterConcurrentBackupMetrics(reg prometheus.Registerer, suffix string) (prometheus.Histogram, prometheus.Counter, error) {
 	backupWaitingTime := prometheus.NewHistogram(prometheus.HistogramOpts{
-		Name:    "concurrent_backup_waiting_seconds",
+		Name:    "concurrent_backup_waiting_seconds" + suffix,
 		Help:    "waiting time for concurrent backups to finish",
 		Buckets: []float64{5, 10, 30, 60, 120, 180, 300, 600, 1800},
 	})
 
 	err := reg.Register(backupWaitingTime)
 	if err != nil {
-		return nil, err
+		return nil, nil, xerrors.Errorf("cannot register Prometheus histogram for backup waiting time: %w", err)
 	}
 
-	return backupWaitingTime, nil
+	waitingTimeoutCounter := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "concurrent_backup_waiting_timeout_total" + suffix,
+		Help: "total count of backup rate limiting timeouts",
+	})
+	err = reg.Register(waitingTimeoutCounter)
+	if err != nil {
+		return nil, nil, xerrors.Errorf("cannot register Prometheus counter for backup waiting timeouts: %w", err)
+	}
+
+	return backupWaitingTime, waitingTimeoutCounter, nil
 }
 
 // Start starts this workspace service and returns when the service gets stopped.

--- a/components/ws-daemon/pkg/controller/controller.go
+++ b/components/ws-daemon/pkg/controller/controller.go
@@ -6,22 +6,13 @@ package controller
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"io/fs"
-	"os"
-	"path/filepath"
 	"time"
 
 	wsk8s "github.com/gitpod-io/gitpod/common-go/kubernetes"
 	glog "github.com/gitpod-io/gitpod/common-go/log"
 	"github.com/gitpod-io/gitpod/common-go/tracing"
 	csapi "github.com/gitpod-io/gitpod/content-service/api"
-	"github.com/gitpod-io/gitpod/content-service/pkg/archive"
-	"github.com/gitpod-io/gitpod/content-service/pkg/git"
-	wsinit "github.com/gitpod-io/gitpod/content-service/pkg/initializer"
-	"github.com/gitpod-io/gitpod/content-service/pkg/logs"
-	"github.com/gitpod-io/gitpod/content-service/pkg/storage"
 	"github.com/gitpod-io/gitpod/ws-daemon/pkg/container"
 	"github.com/gitpod-io/gitpod/ws-daemon/pkg/content"
 	"github.com/gitpod-io/gitpod/ws-daemon/pkg/internal/session"
@@ -30,28 +21,23 @@ import (
 	workspacev1 "github.com/gitpod-io/gitpod/ws-manager/api/crd/v1"
 	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/sirupsen/logrus"
 
-	"golang.org/x/xerrors"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-const (
-	// maxPendingChanges is the limit beyond which we no longer report pending changes.
-	// For example, if a workspace has then 150 untracked files, we'll report the first
-	// 100 followed by "... and 50 more".
-	//
-	// We do this to keep the load on our infrastructure light and because beyond this number
-	// the changes are irrelevant anyways.
-	maxPendingChanges = 100
-)
+// DefaultRetry is the recommended retry for a conflict where multiple clients
+// are making changes to the same resource.
+var retryParams = wait.Backoff{
+	Steps:    10,
+	Duration: 10 * time.Millisecond,
+	Factor:   2.0,
+	Jitter:   0.2,
+}
 
 type WorkspaceControllerOpts struct {
 	NodeName         string
@@ -64,14 +50,9 @@ type WorkspaceControllerOpts struct {
 
 type WorkspaceController struct {
 	client.Client
-
-	NodeName string
-
-	opts  *WorkspaceControllerOpts
-	store *session.Store
-	// channel to limit the number of concurrent backups and uploads.
-	backupWorkspaceLimiter chan struct{}
-	metrics                *content.Metrics
+	NodeName   string
+	opts       *WorkspaceControllerOpts
+	operations WorkspaceOperations
 }
 
 func NewWorkspaceController(c client.Client, opts WorkspaceControllerOpts) (*WorkspaceController, error) {
@@ -90,22 +71,16 @@ func NewWorkspaceController(c client.Client, opts WorkspaceControllerOpts) (*Wor
 		return nil, err
 	}
 
-	waitingTimeHist, waitingTimeoutCounter, err := content.RegisterConcurrentBackupMetrics(opts.MetricsRegistry, "_mk2")
+	ops, err := NewWorkspaceOperations(opts.ContentConfig, store, opts.MetricsRegistry)
 	if err != nil {
 		return nil, err
 	}
 
 	return &WorkspaceController{
-		Client:   c,
-		NodeName: opts.NodeName,
-		opts:     &opts,
-		store:    store,
-		metrics: &content.Metrics{
-			BackupWaitingTimeHist:       waitingTimeHist,
-			BackupWaitingTimeoutCounter: waitingTimeoutCounter,
-		},
-		// we permit five concurrent backups at any given time, hence the five in the channel
-		backupWorkspaceLimiter: make(chan struct{}, 5),
+		Client:     c,
+		NodeName:   opts.NodeName,
+		opts:       &opts,
+		operations: *ops,
 	}, nil
 }
 
@@ -116,8 +91,9 @@ func (wsc *WorkspaceController) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(wsc)
 }
 
-func (wsc *WorkspaceController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	log := log.FromContext(ctx)
+func (wsc *WorkspaceController) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, err error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "Reconcile")
+	defer tracing.FinishSpan(span, &err)
 
 	var workspace workspacev1.Workspace
 	if err := wsc.Get(ctx, req.NamespacedName, &workspace); err != nil {
@@ -132,82 +108,73 @@ func (wsc *WorkspaceController) Reconcile(ctx context.Context, req ctrl.Request)
 		return ctrl.Result{}, nil
 	}
 
-	log.WithValues("workspaceID", workspace.Name, "runtime", workspace.Status.Runtime, "phase", workspace.Status.Phase).Info("seen workspace we have to manage")
+	glog.WithField("workspaceID", workspace.Name).WithField("phase", workspace.Status.Phase).Debug("Reconcile workspace")
 
 	if workspace.Status.Phase == workspacev1.WorkspacePhaseCreating ||
 		workspace.Status.Phase == workspacev1.WorkspacePhaseInitializing ||
 		workspace.Status.Phase == workspacev1.WorkspacePhaseRunning {
 
-		if c := wsk8s.GetCondition(workspace.Status.Conditions, string(workspacev1.WorkspaceConditionContentReady)); c == nil {
-			failure, err := wsc.initWorkspaceContent(ctx, &workspace)
-			if err != nil {
-				return ctrl.Result{}, err
-			}
-
-			// we retry because re-init would cause OTS to fail during the CollectRemoteContent run.
-			// TODO(cw): make this reentrant
-			err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-				var workspace workspacev1.Workspace
-				err := wsc.Get(ctx, req.NamespacedName, &workspace)
-				if err != nil {
-					return err
-				}
-
-				if failure != "" {
-					workspace.Status.Conditions = wsk8s.AddUniqueCondition(workspace.Status.Conditions, metav1.Condition{
-						Type:               string(workspacev1.WorkspaceConditionContentReady),
-						Status:             metav1.ConditionFalse,
-						Message:            failure,
-						Reason:             "InitializationFailure",
-						LastTransitionTime: metav1.Now(),
-					})
-				} else {
-					workspace.Status.Conditions = wsk8s.AddUniqueCondition(workspace.Status.Conditions, metav1.Condition{
-						Type:               string(workspacev1.WorkspaceConditionContentReady),
-						Status:             metav1.ConditionTrue,
-						Message:            "content is ready",
-						LastTransitionTime: metav1.Now(),
-					})
-				}
-
-				return wsc.Status().Update(ctx, &workspace)
-			})
-			if err != nil {
-				return ctrl.Result{}, err
-			}
-		}
+		result, err = wsc.handleWorkspaceInit(ctx, &workspace, req)
+		return result, err
 	}
 
-	log.WithValues("workspaceID", workspace.Name, "runtime", workspace.Status.Runtime, "phase", workspace.Status.Phase).Info("CHECKING PHASE")
-
 	if workspace.Status.Phase == workspacev1.WorkspacePhaseStopping {
-		log.WithValues("workspaceID", workspace.Name, "runtime", workspace.Status.Runtime).Info("DISPOSING WORKSPACE")
-		alreadyDisposed, gitStatus, disposeErr := wsc.disposeWorkspace(ctx, &workspace)
-		if disposeErr != nil {
-			log.Error(disposeErr, "failed to dispose workspace", "workspace", workspace.Name)
+		result, err = wsc.handleWorkspaceStop(ctx, &workspace, req)
+		return result, err
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func (wsc *WorkspaceController) handleWorkspaceInit(ctx context.Context, ws *workspacev1.Workspace, req ctrl.Request) (result ctrl.Result, err error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "handleWorkspaceInit")
+	defer tracing.FinishSpan(span, &err)
+
+	if c := wsk8s.GetCondition(ws.Status.Conditions, string(workspacev1.WorkspaceConditionContentReady)); c == nil {
+		var init csapi.WorkspaceInitializer
+		err = proto.Unmarshal(ws.Spec.Initializer, &init)
+		if err != nil {
+			err = fmt.Errorf("cannot unmarshal initializer config: %w", err)
+			return ctrl.Result{}, err
 		}
 
-		glog.WithField("gitrepo", gitStatus).Info("got repo")
-		workspace.Status.GitStatus = toWorkspaceGitStatus(gitStatus)
-		glog.WithField("workspace", workspace).Info(" disposed workspace")
+		alreadyInit, failure, err := wsc.operations.InitWorkspaceContent(ctx, InitContentOptions{
+			Meta: WorkspaceMeta{
+				Owner:       ws.Spec.Ownership.Owner,
+				WorkspaceId: ws.Spec.Ownership.WorkspaceID,
+				InstanceId:  ws.Name,
+			},
+			Initializer: &init,
+			Headless:    ws.Status.Headless,
+		})
 
-		err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-			if alreadyDisposed {
-				return nil
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("could not initialize workspace %s: %w", ws.Name, err)
+		}
+
+		if alreadyInit {
+			return ctrl.Result{}, nil
+		}
+
+		err = retry.RetryOnConflict(retryParams, func() error {
+			var workspace workspacev1.Workspace
+			if err := wsc.Get(ctx, req.NamespacedName, &workspace); err != nil {
+				return err
 			}
 
-			if disposeErr != nil {
-				workspace.Status.Conditions = wsk8s.AddUniqueCondition(workspace.Status.Conditions, metav1.Condition{
-					Type:               string(workspacev1.WorkspaceConditionBackupFailure),
-					Status:             metav1.ConditionTrue,
-					Message:            disposeErr.Error(),
+			if failure != "" {
+				workspace.Status.Conditions = wsk8s.AddUniqueCondition(ws.Status.Conditions, metav1.Condition{
+					Type:               string(workspacev1.WorkspaceConditionContentReady),
+					Status:             metav1.ConditionFalse,
+					Message:            failure,
+					Reason:             "InitializationFailure",
 					LastTransitionTime: metav1.Now(),
 				})
 			} else {
-				workspace.Status.Conditions = wsk8s.AddUniqueCondition(workspace.Status.Conditions, metav1.Condition{
-					Type:               string(workspacev1.WorkspaceConditionBackupComplete),
+				workspace.Status.Conditions = wsk8s.AddUniqueCondition(ws.Status.Conditions, metav1.Condition{
+					Type:               string(workspacev1.WorkspaceConditionContentReady),
 					Status:             metav1.ConditionTrue,
-					Message:            "backup complete",
+					Reason:             "InitializationSuccess",
 					LastTransitionTime: metav1.Now(),
 				})
 			}
@@ -215,182 +182,68 @@ func (wsc *WorkspaceController) Reconcile(ctx context.Context, req ctrl.Request)
 			return wsc.Status().Update(ctx, &workspace)
 		})
 
-		if err != nil {
-			return ctrl.Result{}, err
-		}
+		return ctrl.Result{}, err
 	}
 
 	return ctrl.Result{}, nil
 }
 
-func (wsc *WorkspaceController) creator(ws *workspacev1.Workspace, init *csapi.WorkspaceInitializer) session.WorkspaceFactory {
-	var checkoutLocation string
-	allLocations := csapi.GetCheckoutLocationsFromInitializer(init)
-	if len(allLocations) > 0 {
-		checkoutLocation = allLocations[0]
-	}
-
-	serviceDirName := ws.Name + "-daemon"
-	return func(ctx context.Context, location string) (res *session.Workspace, err error) {
-		return &session.Workspace{
-			Location:              location,
-			CheckoutLocation:      checkoutLocation,
-			CreatedAt:             time.Now(),
-			Owner:                 ws.Spec.Ownership.Owner,
-			WorkspaceID:           ws.Spec.Ownership.WorkspaceID,
-			InstanceID:            ws.Name,
-			FullWorkspaceBackup:   false,
-			PersistentVolumeClaim: false,
-			RemoteStorageDisabled: ws.Status.Headless,
-			// StorageQuota:          int(req.StorageQuotaBytes),
-
-			ServiceLocDaemon: filepath.Join(wsc.opts.ContentConfig.WorkingArea, serviceDirName),
-			ServiceLocNode:   filepath.Join(wsc.opts.ContentConfig.WorkingAreaNode, serviceDirName),
-		}, nil
-	}
-}
-
-func (wsc *WorkspaceController) initWorkspaceContent(ctx context.Context, ws *workspacev1.Workspace) (failure string, err error) {
-	var initializer csapi.WorkspaceInitializer
-	err = proto.Unmarshal(ws.Spec.Initializer, &initializer)
-	if err != nil {
-		return "bug: cannot unmarshal initializer", xerrors.Errorf("cannot unmarshal init config: %w", err)
-	}
-
-	res, err := wsc.store.NewWorkspace(ctx, ws.Name, filepath.Join(wsc.store.Location, ws.Name), wsc.creator(ws, &initializer))
-	if errors.Is(err, storage.ErrNotFound) {
-		return "", nil
-	}
-
-	if err != nil {
-		return "bug: cannot add workspace to store", xerrors.Errorf("cannot add workspace to store: %w", err)
-	}
-
-	rs, ok := res.NonPersistentAttrs[session.AttrRemoteStorage].(storage.DirectAccess)
-	if rs == nil || !ok {
-		return "bug: workspace has no remote storage", xerrors.Errorf("workspace has no remote storage")
-	}
-	ps, err := storage.NewPresignedAccess(&wsc.opts.ContentConfig.Storage)
-	if err != nil {
-		return "bug: no presigned storage available", xerrors.Errorf("no presigned storage available: %w", err)
-	}
-
-	remoteContent, err := content.CollectRemoteContent(ctx, rs, ps, ws.Spec.Ownership.Owner, &initializer)
-	if err != nil {
-		return "remote content error", xerrors.Errorf("remote content error: %w", err)
-	}
-
-	// Initialize workspace.
-	// FWB workspaces initialize without the help of ws-daemon, but using their supervisor or the registry-facade.
-	opts := content.RunInitializerOpts{
-		Command: wsc.opts.ContentConfig.Initializer.Command,
-		Args:    wsc.opts.ContentConfig.Initializer.Args,
-		// This is a bit of a hack as it makes hard assumptions about the nature of the UID mapping.
-		// Also, we cannot do this in wsinit because we're dropping all the privileges that would be
-		// required for this operation.
-		//
-		// With FWB this bit becomes unneccesary.
-		UID: (wsinit.GitpodUID + 100000 - 1),
-		GID: (wsinit.GitpodGID + 100000 - 1),
-		IdMappings: []archive.IDMapping{
-			{ContainerID: 0, HostID: wsinit.GitpodUID, Size: 1},
-			{ContainerID: 1, HostID: 100000, Size: 65534},
-		},
-		OWI: content.OWI{
-			Owner:       ws.Spec.Ownership.Owner,
-			WorkspaceID: ws.Spec.Ownership.WorkspaceID,
-			InstanceID:  ws.Name,
-		},
-	}
-
-	err = content.RunInitializer(ctx, res.Location, &initializer, remoteContent, opts)
-	if err != nil {
-		return err.Error(), err
-	}
-
-	return "", nil
-}
-
-func (wsc *WorkspaceController) disposeWorkspace(ctx context.Context, ws *workspacev1.Workspace) (bool, *csapi.GitStatus, error) {
-	log := log.FromContext(ctx)
-
-	sess := wsc.store.Get(ws.Name)
-	if sess == nil {
-		return false, nil, status.Error(codes.NotFound, fmt.Sprintf("cannot find workspace %s during DisposeWorkspace", ws.Name))
-	}
-
-	log.Info("get condition")
+func (wsc *WorkspaceController) handleWorkspaceStop(ctx context.Context, ws *workspacev1.Workspace, req ctrl.Request) (result ctrl.Result, err error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "handleWorkspaceInit")
+	defer tracing.FinishSpan(span, &err)
 
 	if c := wsk8s.GetCondition(ws.Status.Conditions, string(workspacev1.WorkspaceConditionContentReady)); c == nil || c.Status == metav1.ConditionFalse {
-		return false, nil, xerrors.Errorf("workspace content was never ready")
+		return ctrl.Result{}, fmt.Errorf("workspace content was never ready")
 	}
 
-	log.Info("wait disposal")
+	alreadyDisposing, gitStatus, disposeErr := wsc.operations.DisposeWorkspace(ctx, DisposeOptions{
+		Meta: WorkspaceMeta{
+			Owner:       ws.Spec.Ownership.Owner,
+			WorkspaceId: ws.Spec.Ownership.WorkspaceID,
+			InstanceId:  ws.Name,
+		},
+		WorkspaceLocation: ws.Spec.WorkspaceLocation,
+		BackupLogs:        ws.Spec.Type == workspacev1.WorkspaceTypePrebuild,
+	})
 
-	// Maybe there's someone else already trying to dispose the workspace.
-	// In that case we'll simply wait for that to happen.
-	done, repo, err := sess.WaitOrMarkForDisposal(ctx)
-	if err != nil {
-		return false, nil, status.Error(codes.Internal, err.Error())
+	if disposeErr != nil {
+		err = fmt.Errorf("failed to dispose workspace %s: %w", ws.Name, disposeErr)
+		return ctrl.Result{}, err
 	}
 
-	if done {
-		log.Info("get git status", "repo", repo)
-		//ws.Status.GitStatus = toWorkspaceGitStatus(repo)
-		return true, repo, nil
+	if alreadyDisposing {
+		return ctrl.Result{}, nil
 	}
 
-	// todo(thomas) check when logs need to be backed up
-	if ws.Spec.Type == workspacev1.WorkspaceTypePrebuild {
-		err := wsc.uploadWorkspaceLogs(ctx, ws)
-		if err != nil {
-			// we do not fail the workspace yet because we still might succeed with its content!
-			glog.WithError(err).Error("log backup failed")
+	err = retry.RetryOnConflict(retryParams, func() error {
+		var workspace workspacev1.Workspace
+		if err := wsc.Get(ctx, req.NamespacedName, &workspace); err != nil {
+			return err
 		}
-	}
 
-	if sess.RemoteStorageDisabled {
-		return false, nil, xerrors.Errorf("workspace has no remote storage")
-	}
+		workspace.Status.GitStatus = toWorkspaceGitStatus(gitStatus)
 
-	log.Info("upload workspace content")
+		if disposeErr != nil {
+			workspace.Status.Conditions = wsk8s.AddUniqueCondition(ws.Status.Conditions, metav1.Condition{
+				Type:               string(workspacev1.WorkspaceConditionBackupFailure),
+				Status:             metav1.ConditionTrue,
+				Reason:             "BackupFailed",
+				Message:            disposeErr.Error(),
+				LastTransitionTime: metav1.Now(),
+			})
+		} else {
+			workspace.Status.Conditions = wsk8s.AddUniqueCondition(ws.Status.Conditions, metav1.Condition{
+				Type:               string(workspacev1.WorkspaceConditionBackupComplete),
+				Status:             metav1.ConditionTrue,
+				Reason:             "BackupComplete",
+				LastTransitionTime: metav1.Now(),
+			})
+		}
 
-	err = wsc.uploadWorkspaceContent(ctx, ws, sess)
-	if err != nil {
-		glog.WithError(err).Error("final backup failed")
-		return false, nil, xerrors.Errorf("final backup failed for workspace %s", ws.Name)
-	}
+		return wsc.Status().Update(ctx, &workspace)
+	})
 
-	log.Info("update git status")
-
-	// Update the git status prior to deleting the workspace
-	repo, err = sess.UpdateGitStatus(ctx, false)
-	if err != nil {
-		// do not fail workspace because we were unable to get git status
-		// which can happen for various reasons, including user corrupting his .git folder somehow
-		// instead we log the error and continue cleaning up workspace
-		// todo(pavel): it would be great if we can somehow bubble this up to user without failing workspace
-		glog.WithError(err).Warn("cannot get git status")
-	}
-
-	log.Info("updated git status", "repo", repo)
-
-	if repo != nil {
-		log.Info("updating repo status")
-		ws.Status.GitStatus = toWorkspaceGitStatus(repo)
-	}
-
-	if err = sess.Dispose(ctx); err != nil {
-		glog.WithError(err).Error("cannot dispose session")
-	}
-
-	// remove workspace daemon directory in the node
-	if err := os.RemoveAll(sess.ServiceLocDaemon); err != nil {
-		glog.WithError(err).Error("cannot delete workspace daemon directory")
-	}
-
-	log.Info("returning from dispose")
-	return false, repo, nil
+	return ctrl.Result{}, err
 }
 
 func toWorkspaceGitStatus(status *csapi.GitStatus) *workspacev1.GitStatus {
@@ -408,261 +261,4 @@ func toWorkspaceGitStatus(status *csapi.GitStatus) *workspacev1.GitStatus {
 		UnpushedCommits:      status.UnpushedCommits,
 		TotalUnpushedCommits: status.TotalUnpushedCommits,
 	}
-}
-
-func (wsc *WorkspaceController) uploadWorkspaceLogs(ctx context.Context, ws *workspacev1.Workspace) (err error) {
-	// currently we're only uploading prebuild log files
-	logFiles, err := logs.ListPrebuildLogFiles(ctx, ws.Spec.WorkspaceLocation)
-	if err != nil {
-		return err
-	}
-
-	rs, err := storage.NewDirectAccess(&wsc.opts.ContentConfig.Storage)
-	if err != nil {
-		return xerrors.Errorf("cannot use configured storage: %w", err)
-	}
-
-	err = rs.Init(ctx, ws.Spec.Ownership.Owner, ws.Spec.Ownership.WorkspaceID, ws.Name)
-	if err != nil {
-		return xerrors.Errorf("cannot use configured storage: %w", err)
-	}
-
-	err = rs.EnsureExists(ctx)
-	if err != nil {
-		return err
-	}
-
-	for _, absLogPath := range logFiles {
-		taskID, parseErr := logs.ParseTaskIDFromPrebuildLogFilePath(absLogPath)
-		if parseErr != nil {
-			glog.WithError(parseErr).Warn("cannot parse headless workspace log file name")
-			continue
-		}
-
-		err = retryIfErr(ctx, 5, glog.WithField("op", "upload log"), func(ctx context.Context) (err error) {
-			_, _, err = rs.UploadInstance(ctx, absLogPath, logs.UploadedHeadlessLogPath(taskID))
-			if err != nil {
-				return
-			}
-
-			return
-		})
-		if err != nil {
-			return xerrors.Errorf("cannot upload workspace logs: %w", err)
-		}
-	}
-	return err
-}
-
-func (wsc *WorkspaceController) uploadWorkspaceContent(ctx context.Context, ws *workspacev1.Workspace, sess *session.Workspace) (err error) {
-	var backupName = storage.DefaultBackup
-
-	// Avoid too many simultaneous backups in order to avoid excessive memory utilization.
-	waitStart := time.Now()
-	select {
-	case wsc.backupWorkspaceLimiter <- struct{}{}:
-	case <-time.After(15 * time.Minute):
-		// we timed out on the rate limit - let's upload anyways, because we don't want to actually block
-		// an upload. If we reach this point, chances are other things are broken. No upload should ever
-		// take this long.
-		wsc.metrics.BackupWaitingTimeoutCounter.Inc()
-	}
-
-	wsc.metrics.BackupWaitingTimeHist.Observe(time.Since(waitStart).Seconds())
-
-	defer func() {
-		<-wsc.backupWorkspaceLimiter
-	}()
-
-	var (
-		loc  = sess.Location
-		opts []storage.UploadOption
-	)
-
-	err = os.Remove(filepath.Join(sess.Location, wsinit.WorkspaceReadyFile))
-	if err != nil && !errors.Is(err, fs.ErrNotExist) {
-		// We'll still upload the backup, well aware that the UX during restart will be broken.
-		// But it's better to have a backup with all files (albeit one too many), than having no backup at all.
-		glog.WithError(err).WithFields(sess.OWI()).Warn("cannot remove workspace ready file")
-	}
-
-	rs, ok := sess.NonPersistentAttrs[session.AttrRemoteStorage].(storage.DirectAccess)
-	if rs == nil || !ok {
-		return xerrors.Errorf("no remote storage configured")
-	}
-
-	var (
-		tmpf     *os.File
-		tmpfSize int64
-	)
-
-	err = retryIfErr(ctx, wsc.opts.ContentConfig.Backup.Attempts, glog.WithFields(sess.OWI()).WithField("op", "create archive"), func(ctx context.Context) (err error) {
-		tmpf, err = os.CreateTemp(wsc.opts.ContentConfig.TmpDir, fmt.Sprintf("wsbkp-%s-*.tar", sess.InstanceID))
-		if err != nil {
-			return
-		}
-		defer tmpf.Close()
-
-		var opts []archive.TarOption
-		opts = append(opts)
-		if !sess.FullWorkspaceBackup {
-			mappings := []archive.IDMapping{
-				{ContainerID: 0, HostID: wsinit.GitpodUID, Size: 1},
-				{ContainerID: 1, HostID: 100000, Size: 65534},
-			}
-			opts = append(opts,
-				archive.WithUIDMapping(mappings),
-				archive.WithGIDMapping(mappings),
-			)
-		}
-
-		err = content.BuildTarbal(ctx, loc, tmpf.Name(), sess.FullWorkspaceBackup, opts...)
-		if err != nil {
-			return
-		}
-		err = tmpf.Sync()
-		if err != nil {
-			return
-		}
-		_, err = tmpf.Seek(0, 0)
-		if err != nil {
-			return
-		}
-
-		stat, err := tmpf.Stat()
-		if err != nil {
-			return
-		}
-		tmpfSize = stat.Size()
-		glog.WithField("size", tmpfSize).WithField("location", tmpf.Name()).WithFields(sess.OWI()).Debug("created temp file for workspace backup upload")
-
-		return
-	})
-	if err != nil {
-		return xerrors.Errorf("cannot create archive: %w", err)
-	}
-	defer func() {
-		if tmpf != nil {
-			// always remove the archive file to not fill up the node needlessly
-			os.Remove(tmpf.Name())
-		}
-	}()
-
-	err = retryIfErr(ctx, wsc.opts.ContentConfig.Backup.Attempts, glog.WithFields(sess.OWI()).WithField("op", "upload layer"), func(ctx context.Context) (err error) {
-		_, _, err = rs.Upload(ctx, tmpf.Name(), backupName, opts...)
-		if err != nil {
-			return
-		}
-
-		return
-	})
-	if err != nil {
-		return xerrors.Errorf("cannot upload workspace content: %w", err)
-	}
-
-	return nil
-}
-
-// UpdateGitStatus attempts to update the LastGitStatus from the workspace's local working copy.
-func (wsc *WorkspaceController) UpdateGitStatus(ctx context.Context, ws *workspacev1.Workspace, s *session.Workspace) (res *csapi.GitStatus, err error) {
-	var loc string
-	loc = s.Location
-	if loc == "" {
-		// FWB workspaces don't have `Location` set, but rather ServiceLocDaemon and ServiceLocNode.
-		// We'd can't easily produce the Git status, because in this context `mark` isn't mounted, and `upper`
-		// only contains the full git working copy if the content was just initialised.
-		// Something like
-		//   loc = filepath.Join(s.ServiceLocDaemon, "mark", "workspace")
-		// does not work.
-		//
-		// TODO(cw): figure out a way to get ahold of the Git status.
-		glog.WithField("loc", loc).WithFields(s.OWI()).Debug("not updating Git status of FWB workspace")
-		return
-	}
-
-	glog.Infof("GIT LOCATION IS %v", loc)
-	loc = filepath.Join(loc, s.CheckoutLocation)
-	if !git.IsWorkingCopy(loc) {
-		glog.WithField("loc", loc).WithField("checkout location", s.CheckoutLocation).WithFields(s.OWI()).Debug("did not find a Git working copy - not updating Git status")
-		return nil, nil
-	}
-
-	c := git.Client{Location: loc}
-
-	stat, err := c.Status(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	lastGitStatus := toGitStatus(stat)
-
-	err = s.Persist()
-	if err != nil {
-		glog.WithError(err).Warn("cannot persist latest Git status")
-		err = nil
-	}
-
-	return lastGitStatus, err
-}
-
-func toGitStatus(s *git.Status) *csapi.GitStatus {
-	limit := func(entries []string) []string {
-		if len(entries) > maxPendingChanges {
-			return append(entries[0:maxPendingChanges], fmt.Sprintf("... and %d more", len(entries)-maxPendingChanges))
-		}
-
-		return entries
-	}
-
-	return &csapi.GitStatus{
-		Branch:               s.BranchHead,
-		LatestCommit:         s.LatestCommit,
-		UncommitedFiles:      limit(s.UncommitedFiles),
-		TotalUncommitedFiles: int64(len(s.UncommitedFiles)),
-		UntrackedFiles:       limit(s.UntrackedFiles),
-		TotalUntrackedFiles:  int64(len(s.UntrackedFiles)),
-		UnpushedCommits:      limit(s.UnpushedCommits),
-		TotalUnpushedCommits: int64(len(s.UnpushedCommits)),
-	}
-}
-
-func retryIfErr(ctx context.Context, attempts int, log *logrus.Entry, op func(ctx context.Context) error) (err error) {
-	//nolint:ineffassign
-	span, ctx := opentracing.StartSpanFromContext(ctx, "retryIfErr")
-	defer tracing.FinishSpan(span, &err)
-	for k, v := range log.Data {
-		span.LogKV(k, v)
-	}
-
-	if attempts == 0 {
-		attempts = 1
-	}
-
-	backoff := 1 * time.Second
-	for i := 0; i < attempts; i++ {
-		span.LogKV("attempt", i)
-
-		if cerr := ctx.Err(); cerr != nil {
-			return cerr
-		}
-
-		bctx, cancel := context.WithCancel(ctx)
-		err = op(bctx)
-		cancel()
-		if err == nil {
-			break
-		}
-
-		log.WithError(err).Error("op failed")
-		span.LogKV("error", err.Error())
-		if i < attempts-1 {
-			log.WithField("backoff", backoff.String()).Debug("retrying op after backoff")
-			if cerr := ctx.Err(); cerr != nil {
-				return cerr
-			}
-			time.Sleep(backoff)
-			backoff = 2 * backoff
-		}
-	}
-	return
 }

--- a/components/ws-daemon/pkg/controller/controller.go
+++ b/components/ws-daemon/pkg/controller/controller.go
@@ -7,13 +7,20 @@ package controller
 import (
 	"context"
 	"errors"
+	"fmt"
+	"io/fs"
+	"os"
 	"path/filepath"
 	"time"
 
 	wsk8s "github.com/gitpod-io/gitpod/common-go/kubernetes"
+	glog "github.com/gitpod-io/gitpod/common-go/log"
+	"github.com/gitpod-io/gitpod/common-go/tracing"
 	csapi "github.com/gitpod-io/gitpod/content-service/api"
 	"github.com/gitpod-io/gitpod/content-service/pkg/archive"
+	"github.com/gitpod-io/gitpod/content-service/pkg/git"
 	wsinit "github.com/gitpod-io/gitpod/content-service/pkg/initializer"
+	"github.com/gitpod-io/gitpod/content-service/pkg/logs"
 	"github.com/gitpod-io/gitpod/content-service/pkg/storage"
 	"github.com/gitpod-io/gitpod/ws-daemon/pkg/container"
 	"github.com/gitpod-io/gitpod/ws-daemon/pkg/content"
@@ -21,8 +28,13 @@ import (
 	"github.com/gitpod-io/gitpod/ws-daemon/pkg/iws"
 	"github.com/gitpod-io/gitpod/ws-daemon/pkg/quota"
 	workspacev1 "github.com/gitpod-io/gitpod/ws-manager/api/crd/v1"
+	"github.com/opentracing/opentracing-go"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sirupsen/logrus"
 
 	"golang.org/x/xerrors"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
@@ -31,12 +43,23 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
+const (
+	// maxPendingChanges is the limit beyond which we no longer report pending changes.
+	// For example, if a workspace has then 150 untracked files, we'll report the first
+	// 100 followed by "... and 50 more".
+	//
+	// We do this to keep the load on our infrastructure light and because beyond this number
+	// the changes are irrelevant anyways.
+	maxPendingChanges = 100
+)
+
 type WorkspaceControllerOpts struct {
 	NodeName         string
 	ContentConfig    content.Config
 	UIDMapperConfig  iws.UidmapperConfig
 	ContainerRuntime container.Runtime
 	CGroupMountPoint string
+	MetricsRegistry  prometheus.Registerer
 }
 
 type WorkspaceController struct {
@@ -46,6 +69,9 @@ type WorkspaceController struct {
 
 	opts  *WorkspaceControllerOpts
 	store *session.Store
+	// channel to limit the number of concurrent backups and uploads.
+	backupWorkspaceLimiter chan struct{}
+	metrics                *content.Metrics
 }
 
 func NewWorkspaceController(c client.Client, opts WorkspaceControllerOpts) (*WorkspaceController, error) {
@@ -64,11 +90,22 @@ func NewWorkspaceController(c client.Client, opts WorkspaceControllerOpts) (*Wor
 		return nil, err
 	}
 
+	waitingTimeHist, waitingTimeoutCounter, err := content.RegisterConcurrentBackupMetrics(opts.MetricsRegistry, "_mk2")
+	if err != nil {
+		return nil, err
+	}
+
 	return &WorkspaceController{
 		Client:   c,
 		NodeName: opts.NodeName,
 		opts:     &opts,
 		store:    store,
+		metrics: &content.Metrics{
+			BackupWaitingTimeHist:       waitingTimeHist,
+			BackupWaitingTimeoutCounter: waitingTimeoutCounter,
+		},
+		// we permit five concurrent backups at any given time, hence the five in the channel
+		backupWorkspaceLimiter: make(chan struct{}, 5),
 	}, nil
 }
 
@@ -95,7 +132,7 @@ func (wsc *WorkspaceController) Reconcile(ctx context.Context, req ctrl.Request)
 		return ctrl.Result{}, nil
 	}
 
-	log.WithValues("workspaceID", workspace.Name, "runtime", workspace.Status.Runtime).Info("seen workspace we have to manage")
+	log.WithValues("workspaceID", workspace.Name, "runtime", workspace.Status.Runtime, "phase", workspace.Status.Phase).Info("seen workspace we have to manage")
 
 	if workspace.Status.Phase == workspacev1.WorkspacePhaseCreating ||
 		workspace.Status.Phase == workspacev1.WorkspacePhaseInitializing ||
@@ -121,7 +158,7 @@ func (wsc *WorkspaceController) Reconcile(ctx context.Context, req ctrl.Request)
 						Type:               string(workspacev1.WorkspaceConditionContentReady),
 						Status:             metav1.ConditionFalse,
 						Message:            failure,
-						Reason:             "failed to initialize",
+						Reason:             "InitializationFailure",
 						LastTransitionTime: metav1.Now(),
 					})
 				} else {
@@ -138,6 +175,48 @@ func (wsc *WorkspaceController) Reconcile(ctx context.Context, req ctrl.Request)
 			if err != nil {
 				return ctrl.Result{}, err
 			}
+		}
+	}
+
+	log.WithValues("workspaceID", workspace.Name, "runtime", workspace.Status.Runtime, "phase", workspace.Status.Phase).Info("CHECKING PHASE")
+
+	if workspace.Status.Phase == workspacev1.WorkspacePhaseStopping {
+		log.WithValues("workspaceID", workspace.Name, "runtime", workspace.Status.Runtime).Info("DISPOSING WORKSPACE")
+		alreadyDisposed, gitStatus, disposeErr := wsc.disposeWorkspace(ctx, &workspace)
+		if disposeErr != nil {
+			log.Error(disposeErr, "failed to dispose workspace", "workspace", workspace.Name)
+		}
+
+		glog.WithField("gitrepo", gitStatus).Info("got repo")
+		workspace.Status.GitStatus = toWorkspaceGitStatus(gitStatus)
+		glog.WithField("workspace", workspace).Info(" disposed workspace")
+
+		err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			if alreadyDisposed {
+				return nil
+			}
+
+			if disposeErr != nil {
+				workspace.Status.Conditions = wsk8s.AddUniqueCondition(workspace.Status.Conditions, metav1.Condition{
+					Type:               string(workspacev1.WorkspaceConditionBackupFailure),
+					Status:             metav1.ConditionTrue,
+					Message:            disposeErr.Error(),
+					LastTransitionTime: metav1.Now(),
+				})
+			} else {
+				workspace.Status.Conditions = wsk8s.AddUniqueCondition(workspace.Status.Conditions, metav1.Condition{
+					Type:               string(workspacev1.WorkspaceConditionBackupComplete),
+					Status:             metav1.ConditionTrue,
+					Message:            "backup complete",
+					LastTransitionTime: metav1.Now(),
+				})
+			}
+
+			return wsc.Status().Update(ctx, &workspace)
+		})
+
+		if err != nil {
+			return ctrl.Result{}, err
 		}
 	}
 
@@ -230,4 +309,360 @@ func (wsc *WorkspaceController) initWorkspaceContent(ctx context.Context, ws *wo
 	}
 
 	return "", nil
+}
+
+func (wsc *WorkspaceController) disposeWorkspace(ctx context.Context, ws *workspacev1.Workspace) (bool, *csapi.GitStatus, error) {
+	log := log.FromContext(ctx)
+
+	sess := wsc.store.Get(ws.Name)
+	if sess == nil {
+		return false, nil, status.Error(codes.NotFound, fmt.Sprintf("cannot find workspace %s during DisposeWorkspace", ws.Name))
+	}
+
+	log.Info("get condition")
+
+	if c := wsk8s.GetCondition(ws.Status.Conditions, string(workspacev1.WorkspaceConditionContentReady)); c == nil || c.Status == metav1.ConditionFalse {
+		return false, nil, xerrors.Errorf("workspace content was never ready")
+	}
+
+	log.Info("wait disposal")
+
+	// Maybe there's someone else already trying to dispose the workspace.
+	// In that case we'll simply wait for that to happen.
+	done, repo, err := sess.WaitOrMarkForDisposal(ctx)
+	if err != nil {
+		return false, nil, status.Error(codes.Internal, err.Error())
+	}
+
+	if done {
+		log.Info("get git status", "repo", repo)
+		//ws.Status.GitStatus = toWorkspaceGitStatus(repo)
+		return true, repo, nil
+	}
+
+	// todo(thomas) check when logs need to be backed up
+	if ws.Spec.Type == workspacev1.WorkspaceTypePrebuild {
+		err := wsc.uploadWorkspaceLogs(ctx, ws)
+		if err != nil {
+			// we do not fail the workspace yet because we still might succeed with its content!
+			glog.WithError(err).Error("log backup failed")
+		}
+	}
+
+	if sess.RemoteStorageDisabled {
+		return false, nil, xerrors.Errorf("workspace has no remote storage")
+	}
+
+	log.Info("upload workspace content")
+
+	err = wsc.uploadWorkspaceContent(ctx, ws, sess)
+	if err != nil {
+		glog.WithError(err).Error("final backup failed")
+		return false, nil, xerrors.Errorf("final backup failed for workspace %s", ws.Name)
+	}
+
+	log.Info("update git status")
+
+	// Update the git status prior to deleting the workspace
+	repo, err = sess.UpdateGitStatus(ctx, false)
+	if err != nil {
+		// do not fail workspace because we were unable to get git status
+		// which can happen for various reasons, including user corrupting his .git folder somehow
+		// instead we log the error and continue cleaning up workspace
+		// todo(pavel): it would be great if we can somehow bubble this up to user without failing workspace
+		glog.WithError(err).Warn("cannot get git status")
+	}
+
+	log.Info("updated git status", "repo", repo)
+
+	if repo != nil {
+		log.Info("updating repo status")
+		ws.Status.GitStatus = toWorkspaceGitStatus(repo)
+	}
+
+	if err = sess.Dispose(ctx); err != nil {
+		glog.WithError(err).Error("cannot dispose session")
+	}
+
+	// remove workspace daemon directory in the node
+	if err := os.RemoveAll(sess.ServiceLocDaemon); err != nil {
+		glog.WithError(err).Error("cannot delete workspace daemon directory")
+	}
+
+	log.Info("returning from dispose")
+	return false, repo, nil
+}
+
+func toWorkspaceGitStatus(status *csapi.GitStatus) *workspacev1.GitStatus {
+	if status == nil {
+		return nil
+	}
+
+	return &workspacev1.GitStatus{
+		Branch:               status.Branch,
+		LatestCommit:         status.LatestCommit,
+		UncommitedFiles:      status.UncommitedFiles,
+		TotalUncommitedFiles: status.TotalUncommitedFiles,
+		UntrackedFiles:       status.UntrackedFiles,
+		TotalUntrackedFiles:  status.TotalUntrackedFiles,
+		UnpushedCommits:      status.UnpushedCommits,
+		TotalUnpushedCommits: status.TotalUnpushedCommits,
+	}
+}
+
+func (wsc *WorkspaceController) uploadWorkspaceLogs(ctx context.Context, ws *workspacev1.Workspace) (err error) {
+	// currently we're only uploading prebuild log files
+	logFiles, err := logs.ListPrebuildLogFiles(ctx, ws.Spec.WorkspaceLocation)
+	if err != nil {
+		return err
+	}
+
+	rs, err := storage.NewDirectAccess(&wsc.opts.ContentConfig.Storage)
+	if err != nil {
+		return xerrors.Errorf("cannot use configured storage: %w", err)
+	}
+
+	err = rs.Init(ctx, ws.Spec.Ownership.Owner, ws.Spec.Ownership.WorkspaceID, ws.Name)
+	if err != nil {
+		return xerrors.Errorf("cannot use configured storage: %w", err)
+	}
+
+	err = rs.EnsureExists(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, absLogPath := range logFiles {
+		taskID, parseErr := logs.ParseTaskIDFromPrebuildLogFilePath(absLogPath)
+		if parseErr != nil {
+			glog.WithError(parseErr).Warn("cannot parse headless workspace log file name")
+			continue
+		}
+
+		err = retryIfErr(ctx, 5, glog.WithField("op", "upload log"), func(ctx context.Context) (err error) {
+			_, _, err = rs.UploadInstance(ctx, absLogPath, logs.UploadedHeadlessLogPath(taskID))
+			if err != nil {
+				return
+			}
+
+			return
+		})
+		if err != nil {
+			return xerrors.Errorf("cannot upload workspace logs: %w", err)
+		}
+	}
+	return err
+}
+
+func (wsc *WorkspaceController) uploadWorkspaceContent(ctx context.Context, ws *workspacev1.Workspace, sess *session.Workspace) (err error) {
+	var backupName = storage.DefaultBackup
+
+	// Avoid too many simultaneous backups in order to avoid excessive memory utilization.
+	waitStart := time.Now()
+	select {
+	case wsc.backupWorkspaceLimiter <- struct{}{}:
+	case <-time.After(15 * time.Minute):
+		// we timed out on the rate limit - let's upload anyways, because we don't want to actually block
+		// an upload. If we reach this point, chances are other things are broken. No upload should ever
+		// take this long.
+		wsc.metrics.BackupWaitingTimeoutCounter.Inc()
+	}
+
+	wsc.metrics.BackupWaitingTimeHist.Observe(time.Since(waitStart).Seconds())
+
+	defer func() {
+		<-wsc.backupWorkspaceLimiter
+	}()
+
+	var (
+		loc  = sess.Location
+		opts []storage.UploadOption
+	)
+
+	err = os.Remove(filepath.Join(sess.Location, wsinit.WorkspaceReadyFile))
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		// We'll still upload the backup, well aware that the UX during restart will be broken.
+		// But it's better to have a backup with all files (albeit one too many), than having no backup at all.
+		glog.WithError(err).WithFields(sess.OWI()).Warn("cannot remove workspace ready file")
+	}
+
+	rs, ok := sess.NonPersistentAttrs[session.AttrRemoteStorage].(storage.DirectAccess)
+	if rs == nil || !ok {
+		return xerrors.Errorf("no remote storage configured")
+	}
+
+	var (
+		tmpf     *os.File
+		tmpfSize int64
+	)
+
+	err = retryIfErr(ctx, wsc.opts.ContentConfig.Backup.Attempts, glog.WithFields(sess.OWI()).WithField("op", "create archive"), func(ctx context.Context) (err error) {
+		tmpf, err = os.CreateTemp(wsc.opts.ContentConfig.TmpDir, fmt.Sprintf("wsbkp-%s-*.tar", sess.InstanceID))
+		if err != nil {
+			return
+		}
+		defer tmpf.Close()
+
+		var opts []archive.TarOption
+		opts = append(opts)
+		if !sess.FullWorkspaceBackup {
+			mappings := []archive.IDMapping{
+				{ContainerID: 0, HostID: wsinit.GitpodUID, Size: 1},
+				{ContainerID: 1, HostID: 100000, Size: 65534},
+			}
+			opts = append(opts,
+				archive.WithUIDMapping(mappings),
+				archive.WithGIDMapping(mappings),
+			)
+		}
+
+		err = content.BuildTarbal(ctx, loc, tmpf.Name(), sess.FullWorkspaceBackup, opts...)
+		if err != nil {
+			return
+		}
+		err = tmpf.Sync()
+		if err != nil {
+			return
+		}
+		_, err = tmpf.Seek(0, 0)
+		if err != nil {
+			return
+		}
+
+		stat, err := tmpf.Stat()
+		if err != nil {
+			return
+		}
+		tmpfSize = stat.Size()
+		glog.WithField("size", tmpfSize).WithField("location", tmpf.Name()).WithFields(sess.OWI()).Debug("created temp file for workspace backup upload")
+
+		return
+	})
+	if err != nil {
+		return xerrors.Errorf("cannot create archive: %w", err)
+	}
+	defer func() {
+		if tmpf != nil {
+			// always remove the archive file to not fill up the node needlessly
+			os.Remove(tmpf.Name())
+		}
+	}()
+
+	err = retryIfErr(ctx, wsc.opts.ContentConfig.Backup.Attempts, glog.WithFields(sess.OWI()).WithField("op", "upload layer"), func(ctx context.Context) (err error) {
+		_, _, err = rs.Upload(ctx, tmpf.Name(), backupName, opts...)
+		if err != nil {
+			return
+		}
+
+		return
+	})
+	if err != nil {
+		return xerrors.Errorf("cannot upload workspace content: %w", err)
+	}
+
+	return nil
+}
+
+// UpdateGitStatus attempts to update the LastGitStatus from the workspace's local working copy.
+func (wsc *WorkspaceController) UpdateGitStatus(ctx context.Context, ws *workspacev1.Workspace, s *session.Workspace) (res *csapi.GitStatus, err error) {
+	var loc string
+	loc = s.Location
+	if loc == "" {
+		// FWB workspaces don't have `Location` set, but rather ServiceLocDaemon and ServiceLocNode.
+		// We'd can't easily produce the Git status, because in this context `mark` isn't mounted, and `upper`
+		// only contains the full git working copy if the content was just initialised.
+		// Something like
+		//   loc = filepath.Join(s.ServiceLocDaemon, "mark", "workspace")
+		// does not work.
+		//
+		// TODO(cw): figure out a way to get ahold of the Git status.
+		glog.WithField("loc", loc).WithFields(s.OWI()).Debug("not updating Git status of FWB workspace")
+		return
+	}
+
+	glog.Infof("GIT LOCATION IS %v", loc)
+	loc = filepath.Join(loc, s.CheckoutLocation)
+	if !git.IsWorkingCopy(loc) {
+		glog.WithField("loc", loc).WithField("checkout location", s.CheckoutLocation).WithFields(s.OWI()).Debug("did not find a Git working copy - not updating Git status")
+		return nil, nil
+	}
+
+	c := git.Client{Location: loc}
+
+	stat, err := c.Status(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	lastGitStatus := toGitStatus(stat)
+
+	err = s.Persist()
+	if err != nil {
+		glog.WithError(err).Warn("cannot persist latest Git status")
+		err = nil
+	}
+
+	return lastGitStatus, err
+}
+
+func toGitStatus(s *git.Status) *csapi.GitStatus {
+	limit := func(entries []string) []string {
+		if len(entries) > maxPendingChanges {
+			return append(entries[0:maxPendingChanges], fmt.Sprintf("... and %d more", len(entries)-maxPendingChanges))
+		}
+
+		return entries
+	}
+
+	return &csapi.GitStatus{
+		Branch:               s.BranchHead,
+		LatestCommit:         s.LatestCommit,
+		UncommitedFiles:      limit(s.UncommitedFiles),
+		TotalUncommitedFiles: int64(len(s.UncommitedFiles)),
+		UntrackedFiles:       limit(s.UntrackedFiles),
+		TotalUntrackedFiles:  int64(len(s.UntrackedFiles)),
+		UnpushedCommits:      limit(s.UnpushedCommits),
+		TotalUnpushedCommits: int64(len(s.UnpushedCommits)),
+	}
+}
+
+func retryIfErr(ctx context.Context, attempts int, log *logrus.Entry, op func(ctx context.Context) error) (err error) {
+	//nolint:ineffassign
+	span, ctx := opentracing.StartSpanFromContext(ctx, "retryIfErr")
+	defer tracing.FinishSpan(span, &err)
+	for k, v := range log.Data {
+		span.LogKV(k, v)
+	}
+
+	if attempts == 0 {
+		attempts = 1
+	}
+
+	backoff := 1 * time.Second
+	for i := 0; i < attempts; i++ {
+		span.LogKV("attempt", i)
+
+		if cerr := ctx.Err(); cerr != nil {
+			return cerr
+		}
+
+		bctx, cancel := context.WithCancel(ctx)
+		err = op(bctx)
+		cancel()
+		if err == nil {
+			break
+		}
+
+		log.WithError(err).Error("op failed")
+		span.LogKV("error", err.Error())
+		if i < attempts-1 {
+			log.WithField("backoff", backoff.String()).Debug("retrying op after backoff")
+			if cerr := ctx.Err(); cerr != nil {
+				return cerr
+			}
+			time.Sleep(backoff)
+			backoff = 2 * backoff
+		}
+	}
+	return
 }

--- a/components/ws-daemon/pkg/controller/workspace_operations.go
+++ b/components/ws-daemon/pkg/controller/workspace_operations.go
@@ -1,0 +1,484 @@
+// Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package controller
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"time"
+
+	glog "github.com/gitpod-io/gitpod/common-go/log"
+	"github.com/gitpod-io/gitpod/common-go/tracing"
+	csapi "github.com/gitpod-io/gitpod/content-service/api"
+	"github.com/gitpod-io/gitpod/content-service/pkg/archive"
+	"github.com/gitpod-io/gitpod/content-service/pkg/git"
+	wsinit "github.com/gitpod-io/gitpod/content-service/pkg/initializer"
+	"github.com/gitpod-io/gitpod/content-service/pkg/logs"
+	"github.com/gitpod-io/gitpod/content-service/pkg/storage"
+	"github.com/gitpod-io/gitpod/ws-daemon/pkg/content"
+	"github.com/gitpod-io/gitpod/ws-daemon/pkg/internal/session"
+	workspacev1 "github.com/gitpod-io/gitpod/ws-manager/api/crd/v1"
+	"github.com/opentracing/opentracing-go"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/xerrors"
+)
+
+const (
+	// maxPendingChanges is the limit beyond which we no longer report pending changes.
+	// For example, if a workspace has then 150 untracked files, we'll report the first
+	// 100 followed by "... and 50 more".
+	//
+	// We do this to keep the load on our infrastructure light and because beyond this number
+	// the changes are irrelevant anyways.
+	maxPendingChanges = 100
+)
+
+type WorkspaceOperations struct {
+	config                 content.Config
+	store                  *session.Store
+	backupWorkspaceLimiter chan struct{}
+	metrics                *content.Metrics
+}
+
+type WorkspaceMeta struct {
+	Owner       string
+	WorkspaceId string
+	InstanceId  string
+}
+
+type InitContentOptions struct {
+	Meta        WorkspaceMeta
+	Initializer *csapi.WorkspaceInitializer
+	Headless    bool
+}
+
+type DisposeOptions struct {
+	Meta              WorkspaceMeta
+	WorkspaceLocation string
+	BackupLogs        bool
+}
+
+func NewWorkspaceOperations(config content.Config, store *session.Store, reg prometheus.Registerer) (*WorkspaceOperations, error) {
+	waitingTimeHist, waitingTimeoutCounter, err := content.RegisterConcurrentBackupMetrics(reg, "mk2")
+	if err != nil {
+		return nil, err
+	}
+
+	return &WorkspaceOperations{
+		config: config,
+		store:  store,
+		metrics: &content.Metrics{
+			BackupWaitingTimeHist:       waitingTimeHist,
+			BackupWaitingTimeoutCounter: waitingTimeoutCounter,
+		},
+		// we permit five concurrent backups at any given time, hence the five in the channel
+		backupWorkspaceLimiter: make(chan struct{}, 5),
+	}, nil
+}
+
+func (wso *WorkspaceOperations) InitWorkspaceContent(ctx context.Context, options InitContentOptions) (bool, string, error) {
+	res, err := wso.store.NewWorkspace(
+		ctx, options.Meta.InstanceId, filepath.Join(wso.store.Location, options.Meta.InstanceId),
+		wso.creator(options.Meta.Owner, options.Meta.WorkspaceId, options.Meta.InstanceId, options.Initializer, options.Headless))
+	if errors.Is(err, storage.ErrNotFound) {
+		return false, "", nil
+	}
+
+	if errors.Is(err, session.ErrAlreadyExists) {
+		return true, "", nil
+	}
+
+	if err != nil {
+		return false, "bug: cannot add workspace to store", xerrors.Errorf("cannot add workspace to store: %w", err)
+	}
+
+	rs, ok := res.NonPersistentAttrs[session.AttrRemoteStorage].(storage.DirectAccess)
+	if rs == nil || !ok {
+		return false, "bug: workspace has no remote storage", xerrors.Errorf("workspace has no remote storage")
+	}
+	ps, err := storage.NewPresignedAccess(&wso.config.Storage)
+	if err != nil {
+		return false, "bug: no presigned storage available", xerrors.Errorf("no presigned storage available: %w", err)
+	}
+
+	remoteContent, err := content.CollectRemoteContent(ctx, rs, ps, options.Meta.Owner, options.Initializer)
+	if err != nil {
+		return false, "remote content error", xerrors.Errorf("remote content error: %w", err)
+	}
+
+	// Initialize workspace.
+	// FWB workspaces initialize without the help of ws-daemon, but using their supervisor or the registry-facade.
+	opts := content.RunInitializerOpts{
+		Command: wso.config.Initializer.Command,
+		Args:    wso.config.Initializer.Args,
+		// This is a bit of a hack as it makes hard assumptions about the nature of the UID mapping.
+		// Also, we cannot do this in wsinit because we're dropping all the privileges that would be
+		// required for this operation.
+		//
+		// With FWB this bit becomes unneccesary.
+		UID: (wsinit.GitpodUID + 100000 - 1),
+		GID: (wsinit.GitpodGID + 100000 - 1),
+		IdMappings: []archive.IDMapping{
+			{ContainerID: 0, HostID: wsinit.GitpodUID, Size: 1},
+			{ContainerID: 1, HostID: 100000, Size: 65534},
+		},
+		OWI: content.OWI{
+			Owner:       options.Meta.Owner,
+			WorkspaceID: options.Meta.WorkspaceId,
+			InstanceID:  options.Meta.InstanceId,
+		},
+	}
+
+	err = content.RunInitializer(ctx, res.Location, options.Initializer, remoteContent, opts)
+	if err != nil {
+		glog.Infof("error running initializer %v", err)
+		return false, err.Error(), err
+	}
+
+	return false, "", nil
+}
+
+func (wso *WorkspaceOperations) creator(owner, workspaceId, instanceId string, init *csapi.WorkspaceInitializer, storageDisabled bool) session.WorkspaceFactory {
+	var checkoutLocation string
+	allLocations := csapi.GetCheckoutLocationsFromInitializer(init)
+	if len(allLocations) > 0 {
+		checkoutLocation = allLocations[0]
+	}
+
+	serviceDirName := instanceId + "-daemon"
+	return func(ctx context.Context, location string) (res *session.Workspace, err error) {
+		return &session.Workspace{
+			Location:              location,
+			CheckoutLocation:      checkoutLocation,
+			CreatedAt:             time.Now(),
+			Owner:                 owner,
+			WorkspaceID:           workspaceId,
+			InstanceID:            instanceId,
+			FullWorkspaceBackup:   false,
+			PersistentVolumeClaim: false,
+			RemoteStorageDisabled: storageDisabled,
+
+			ServiceLocDaemon: filepath.Join(wso.config.WorkingArea, serviceDirName),
+			ServiceLocNode:   filepath.Join(wso.config.WorkingAreaNode, serviceDirName),
+		}, nil
+	}
+}
+
+func (wso *WorkspaceOperations) DisposeWorkspace(ctx context.Context, opts DisposeOptions) (bool, *csapi.GitStatus, error) {
+	sess := wso.store.Get(opts.Meta.InstanceId)
+	if sess == nil {
+		return false, nil, fmt.Errorf("cannot find workspace %s during DisposeWorkspace", opts.Meta.InstanceId)
+	}
+
+	// Maybe there's someone else already trying to dispose the workspace.
+	// In that case we'll simply wait for that to happen.
+	done, repo, err := sess.WaitOrMarkForDisposal(ctx)
+	if err != nil {
+		return false, nil, fmt.Errorf("failed to wait for workspace disposal of %s", opts.Meta.InstanceId)
+	}
+
+	if done {
+		return true, repo, nil
+	}
+
+	if sess.RemoteStorageDisabled {
+		return false, nil, xerrors.Errorf("workspace has no remote storage")
+	}
+
+	if opts.BackupLogs {
+		err := wso.uploadWorkspaceLogs(ctx, opts)
+		if err != nil {
+			// we do not fail the workspace yet because we still might succeed with its content!
+			glog.WithError(err).Error("log backup failed")
+		}
+	}
+
+	err = wso.uploadWorkspaceContent(ctx, sess)
+	if err != nil {
+		return false, nil, xerrors.Errorf("final backup failed for workspace %s", opts.Meta.InstanceId)
+	}
+
+	// Update the git status prior to deleting the workspace
+	repo, err = sess.UpdateGitStatus(ctx, false)
+	if err != nil {
+		// do not fail workspace because we were unable to get git status
+		// which can happen for various reasons, including user corrupting his .git folder somehow
+		// instead we log the error and continue cleaning up workspace
+		// todo(pavel): it would be great if we can somehow bubble this up to user without failing workspace
+		glog.WithError(err).Warn("cannot get git status")
+	}
+
+	if err = sess.Dispose(ctx); err != nil {
+		glog.WithError(err).Error("cannot dispose session")
+	}
+
+	// remove workspace daemon directory in the node
+	if err := os.RemoveAll(sess.ServiceLocDaemon); err != nil {
+		glog.WithError(err).Error("cannot delete workspace daemon directory")
+	}
+
+	return false, repo, nil
+}
+
+func (wso *WorkspaceOperations) uploadWorkspaceLogs(ctx context.Context, opts DisposeOptions) (err error) {
+	// currently we're only uploading prebuild log files
+	logFiles, err := logs.ListPrebuildLogFiles(ctx, opts.WorkspaceLocation)
+	if err != nil {
+		return err
+	}
+
+	rs, err := storage.NewDirectAccess(&wso.config.Storage)
+	if err != nil {
+		return xerrors.Errorf("cannot use configured storage: %w", err)
+	}
+
+	err = rs.Init(ctx, opts.Meta.Owner, opts.Meta.WorkspaceId, opts.Meta.InstanceId)
+	if err != nil {
+		return xerrors.Errorf("cannot use configured storage: %w", err)
+	}
+
+	err = rs.EnsureExists(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, absLogPath := range logFiles {
+		taskID, parseErr := logs.ParseTaskIDFromPrebuildLogFilePath(absLogPath)
+		if parseErr != nil {
+			glog.WithError(parseErr).Warn("cannot parse headless workspace log file name")
+			continue
+		}
+
+		err = retryIfErr(ctx, 5, glog.WithField("op", "upload log"), func(ctx context.Context) (err error) {
+			_, _, err = rs.UploadInstance(ctx, absLogPath, logs.UploadedHeadlessLogPath(taskID))
+			if err != nil {
+				return
+			}
+
+			return
+		})
+		if err != nil {
+			return xerrors.Errorf("cannot upload workspace logs: %w", err)
+		}
+	}
+	return err
+}
+
+func (wso *WorkspaceOperations) uploadWorkspaceContent(ctx context.Context, sess *session.Workspace) error {
+	var backupName = storage.DefaultBackup
+	// Avoid too many simultaneous backups in order to avoid excessive memory utilization.
+	waitStart := time.Now()
+	select {
+	case wso.backupWorkspaceLimiter <- struct{}{}:
+	case <-time.After(15 * time.Minute):
+		// we timed out on the rate limit - let's upload anyways, because we don't want to actually block
+		// an upload. If we reach this point, chances are other things are broken. No upload should ever
+		// take this long.
+		wso.metrics.BackupWaitingTimeoutCounter.Inc()
+	}
+
+	wso.metrics.BackupWaitingTimeHist.Observe(time.Since(waitStart).Seconds())
+
+	defer func() {
+		<-wso.backupWorkspaceLimiter
+	}()
+
+	var (
+		loc  = sess.Location
+		opts []storage.UploadOption
+	)
+
+	err := os.Remove(filepath.Join(sess.Location, wsinit.WorkspaceReadyFile))
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		// We'll still upload the backup, well aware that the UX during restart will be broken.
+		// But it's better to have a backup with all files (albeit one too many), than having no backup at all.
+		glog.WithError(err).WithFields(sess.OWI()).Warn("cannot remove workspace ready file")
+	}
+
+	rs, ok := sess.NonPersistentAttrs[session.AttrRemoteStorage].(storage.DirectAccess)
+	if rs == nil || !ok {
+		return xerrors.Errorf("no remote storage configured")
+	}
+
+	var (
+		tmpf     *os.File
+		tmpfSize int64
+	)
+
+	err = retryIfErr(ctx, wso.config.Backup.Attempts, glog.WithFields(sess.OWI()).WithField("op", "create archive"), func(ctx context.Context) (err error) {
+		tmpf, err = os.CreateTemp(wso.config.TmpDir, fmt.Sprintf("wsbkp-%s-*.tar", sess.InstanceID))
+		if err != nil {
+			return
+		}
+		defer tmpf.Close()
+
+		var opts []archive.TarOption
+		opts = append(opts)
+		if !sess.FullWorkspaceBackup {
+			mappings := []archive.IDMapping{
+				{ContainerID: 0, HostID: wsinit.GitpodUID, Size: 1},
+				{ContainerID: 1, HostID: 100000, Size: 65534},
+			}
+			opts = append(opts,
+				archive.WithUIDMapping(mappings),
+				archive.WithGIDMapping(mappings),
+			)
+		}
+
+		err = content.BuildTarbal(ctx, loc, tmpf.Name(), sess.FullWorkspaceBackup, opts...)
+		if err != nil {
+			return
+		}
+		err = tmpf.Sync()
+		if err != nil {
+			return
+		}
+		_, err = tmpf.Seek(0, 0)
+		if err != nil {
+			return
+		}
+
+		stat, err := tmpf.Stat()
+		if err != nil {
+			return
+		}
+		tmpfSize = stat.Size()
+		glog.WithField("size", tmpfSize).WithField("location", tmpf.Name()).WithFields(sess.OWI()).Debug("created temp file for workspace backup upload")
+
+		return
+	})
+	if err != nil {
+		return xerrors.Errorf("cannot create archive: %w", err)
+	}
+	defer func() {
+		if tmpf != nil {
+			// always remove the archive file to not fill up the node needlessly
+			os.Remove(tmpf.Name())
+		}
+	}()
+
+	err = retryIfErr(ctx, wso.config.Backup.Attempts, glog.WithFields(sess.OWI()).WithField("op", "upload layer"), func(ctx context.Context) (err error) {
+		_, _, err = rs.Upload(ctx, tmpf.Name(), backupName, opts...)
+		if err != nil {
+			return
+		}
+
+		return
+	})
+	if err != nil {
+		return xerrors.Errorf("cannot upload workspace content: %w", err)
+	}
+
+	return nil
+}
+
+// UpdateGitStatus attempts to update the LastGitStatus from the workspace's local working copy.
+func (wsc *WorkspaceController) UpdateGitStatus(ctx context.Context, ws *workspacev1.Workspace, s *session.Workspace) (res *csapi.GitStatus, err error) {
+	var loc string
+	loc = s.Location
+	if loc == "" {
+		// FWB workspaces don't have `Location` set, but rather ServiceLocDaemon and ServiceLocNode.
+		// We'd can't easily produce the Git status, because in this context `mark` isn't mounted, and `upper`
+		// only contains the full git working copy if the content was just initialised.
+		// Something like
+		//   loc = filepath.Join(s.ServiceLocDaemon, "mark", "workspace")
+		// does not work.
+		//
+		// TODO(cw): figure out a way to get ahold of the Git status.
+		glog.WithField("loc", loc).WithFields(s.OWI()).Debug("not updating Git status of FWB workspace")
+		return
+	}
+
+	glog.Infof("GIT LOCATION IS %v", loc)
+	loc = filepath.Join(loc, s.CheckoutLocation)
+	if !git.IsWorkingCopy(loc) {
+		glog.WithField("loc", loc).WithField("checkout location", s.CheckoutLocation).WithFields(s.OWI()).Debug("did not find a Git working copy - not updating Git status")
+		return nil, nil
+	}
+
+	c := git.Client{Location: loc}
+
+	stat, err := c.Status(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	lastGitStatus := toGitStatus(stat)
+
+	err = s.Persist()
+	if err != nil {
+		glog.WithError(err).Warn("cannot persist latest Git status")
+		err = nil
+	}
+
+	return lastGitStatus, err
+}
+
+func toGitStatus(s *git.Status) *csapi.GitStatus {
+	limit := func(entries []string) []string {
+		if len(entries) > maxPendingChanges {
+			return append(entries[0:maxPendingChanges], fmt.Sprintf("... and %d more", len(entries)-maxPendingChanges))
+		}
+
+		return entries
+	}
+
+	return &csapi.GitStatus{
+		Branch:               s.BranchHead,
+		LatestCommit:         s.LatestCommit,
+		UncommitedFiles:      limit(s.UncommitedFiles),
+		TotalUncommitedFiles: int64(len(s.UncommitedFiles)),
+		UntrackedFiles:       limit(s.UntrackedFiles),
+		TotalUntrackedFiles:  int64(len(s.UntrackedFiles)),
+		UnpushedCommits:      limit(s.UnpushedCommits),
+		TotalUnpushedCommits: int64(len(s.UnpushedCommits)),
+	}
+}
+
+func retryIfErr(ctx context.Context, attempts int, log *logrus.Entry, op func(ctx context.Context) error) (err error) {
+	//nolint:ineffassign
+	span, ctx := opentracing.StartSpanFromContext(ctx, "retryIfErr")
+	defer tracing.FinishSpan(span, &err)
+	for k, v := range log.Data {
+		span.LogKV(k, v)
+	}
+
+	if attempts == 0 {
+		attempts = 1
+	}
+
+	backoff := 1 * time.Second
+	for i := 0; i < attempts; i++ {
+		span.LogKV("attempt", i)
+
+		if cerr := ctx.Err(); cerr != nil {
+			return cerr
+		}
+
+		bctx, cancel := context.WithCancel(ctx)
+		err = op(bctx)
+		cancel()
+		if err == nil {
+			break
+		}
+
+		log.WithError(err).Error("op failed")
+		span.LogKV("error", err.Error())
+		if i < attempts-1 {
+			log.WithField("backoff", backoff.String()).Debug("retrying op after backoff")
+			if cerr := ctx.Err(); cerr != nil {
+				return cerr
+			}
+			time.Sleep(backoff)
+			backoff = 2 * backoff
+		}
+	}
+	return
+}

--- a/components/ws-manager-api/go/crd/v1/workspace_types.go
+++ b/components/ws-manager-api/go/crd/v1/workspace_types.go
@@ -5,6 +5,7 @@
 package v1
 
 import (
+	"github.com/gitpod-io/gitpod/common-go/log"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -265,4 +266,12 @@ type WorkspaceList struct {
 
 func init() {
 	SchemeBuilder.Register(&Workspace{}, &WorkspaceList{})
+}
+
+func (ws *Workspace) OWI() log.Fields {
+	return log.Fields{
+		OwnerField:     ws.Spec.Ownership.Owner,
+		WorkspaceField: ws.Spec.Ownership.WorkspaceID,
+		InstanceField:  ws.ObjectMeta.Name,
+	}
 }

--- a/components/ws-manager-api/go/crd/v1/workspace_types.go
+++ b/components/ws-manager-api/go/crd/v1/workspace_types.go
@@ -5,7 +5,6 @@
 package v1
 
 import (
-	"github.com/gitpod-io/gitpod/common-go/log"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -266,12 +265,4 @@ type WorkspaceList struct {
 
 func init() {
 	SchemeBuilder.Register(&Workspace{}, &WorkspaceList{})
-}
-
-func (ws *Workspace) OWI() log.Fields {
-	return log.Fields{
-		OwnerField:     ws.Spec.Ownership.Owner,
-		WorkspaceField: ws.Spec.Ownership.WorkspaceID,
-		InstanceField:  ws.ObjectMeta.Name,
-	}
 }

--- a/components/ws-manager-mk2/controllers/status.go
+++ b/components/ws-manager-mk2/controllers/status.go
@@ -40,7 +40,7 @@ func updateWorkspaceStatus(ctx context.Context, workspace *workspacev1.Workspace
 		// continue below
 	default:
 		// This is exceptional - not sure what to do here. Probably fail the pod
-		workspace.Status.Conditions = addUniqueCondition(workspace.Status.Conditions, metav1.Condition{
+		workspace.Status.Conditions = AddUniqueCondition(workspace.Status.Conditions, metav1.Condition{
 			Type:               string(workspacev1.WorkspaceConditionFailed),
 			Status:             metav1.ConditionTrue,
 			LastTransitionTime: metav1.Now(),
@@ -50,7 +50,7 @@ func updateWorkspaceStatus(ctx context.Context, workspace *workspacev1.Workspace
 		return nil
 	}
 
-	workspace.Status.Conditions = addUniqueCondition(workspace.Status.Conditions, metav1.Condition{
+	workspace.Status.Conditions = AddUniqueCondition(workspace.Status.Conditions, metav1.Condition{
 		Type:               string(workspacev1.WorkspaceConditionDeployed),
 		Status:             metav1.ConditionTrue,
 		LastTransitionTime: metav1.Now(),
@@ -81,7 +81,7 @@ func updateWorkspaceStatus(ctx context.Context, workspace *workspacev1.Workspace
 
 	if failure != "" && !conditionPresentAndTrue(workspace.Status.Conditions, string(workspacev1.WorkspaceConditionFailed)) {
 		// workspaces can fail only once - once there is a failed condition set, stick with it
-		workspace.Status.Conditions = addUniqueCondition(workspace.Status.Conditions, metav1.Condition{
+		workspace.Status.Conditions = AddUniqueCondition(workspace.Status.Conditions, metav1.Condition{
 			Type:               string(workspacev1.WorkspaceConditionFailed),
 			Status:             metav1.ConditionTrue,
 			LastTransitionTime: metav1.Now(),
@@ -91,6 +91,7 @@ func updateWorkspaceStatus(ctx context.Context, workspace *workspacev1.Workspace
 
 	switch {
 	case isPodBeingDeleted(pod):
+		log.Info("setting phase for workspace to stopping", "workspace", workspace.Name)
 		workspace.Status.Phase = workspacev1.WorkspacePhaseStopping
 
 		var hasFinalizer bool
@@ -102,9 +103,11 @@ func updateWorkspaceStatus(ctx context.Context, workspace *workspacev1.Workspace
 		}
 		if hasFinalizer {
 			// TODO(cw): if the condition isn't present or not true, we should re-trigger the reconiliation
-			if conditionPresentAndTrue(workspace.Status.Conditions, string(workspacev1.WorkspaceConditionBackupComplete)) {
+			if conditionPresentAndTrue(workspace.Status.Conditions, string(workspacev1.WorkspaceConditionBackupComplete)) ||
+				conditionPresentAndTrue(workspace.Status.Conditions, string(workspacev1.WorkspaceConditionBackupFailure)) {
 				workspace.Status.Phase = workspacev1.WorkspacePhaseStopped
 			}
+
 		} else {
 			// We do this independently of the dispostal status because pods only get their finalizer
 			// once they're running. If they fail before they reach the running phase we'll never see
@@ -134,7 +137,6 @@ func updateWorkspaceStatus(ctx context.Context, workspace *workspacev1.Workspace
 		}
 
 	case pod.Status.Phase == corev1.PodRunning:
-		// TODO(cw): port interrupted handling - after making sure this is even still relevant
 		var ready bool
 		for _, cs := range pod.Status.ContainerStatuses {
 			if cs.Ready {

--- a/components/ws-manager-mk2/controllers/workspace_controller.go
+++ b/components/ws-manager-mk2/controllers/workspace_controller.go
@@ -187,10 +187,10 @@ func (r *WorkspaceReconciler) actOnStatus(ctx context.Context, workspace *worksp
 			return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 		}
 
-		err = r.Client.Delete(ctx, workspace)
-		if err != nil {
-			return ctrl.Result{Requeue: true}, err
-		}
+		// err = r.Client.Delete(ctx, workspace)
+		// if err != nil {
+		// 	return ctrl.Result{Requeue: true}, err
+		// }
 	}
 
 	return ctrl.Result{}, nil
@@ -238,7 +238,7 @@ func (r *WorkspaceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-func addUniqueCondition(conds []metav1.Condition, cond metav1.Condition) []metav1.Condition {
+func AddUniqueCondition(conds []metav1.Condition, cond metav1.Condition) []metav1.Condition {
 	if cond.Reason == "" {
 		cond.Reason = "Foo"
 	}

--- a/components/ws-manager-mk2/controllers/workspace_controller.go
+++ b/components/ws-manager-mk2/controllers/workspace_controller.go
@@ -187,10 +187,10 @@ func (r *WorkspaceReconciler) actOnStatus(ctx context.Context, workspace *worksp
 			return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 		}
 
-		// err = r.Client.Delete(ctx, workspace)
-		// if err != nil {
-		// 	return ctrl.Result{Requeue: true}, err
-		// }
+		err = r.Client.Delete(ctx, workspace)
+		if err != nil {
+			return ctrl.Result{Requeue: true}, err
+		}
 	}
 
 	return ctrl.Result{}, nil

--- a/components/ws-manager-mk2/debug.sh
+++ b/components/ws-manager-mk2/debug.sh
@@ -5,4 +5,4 @@
 
 set -Eeuo pipefail
 
-source /workspace/gitpod/scripts/ws-deploy.sh deployment ws-manager
+source /workspace/gitpod/scripts/ws-deploy.sh deployment ws-manager-mk2

--- a/components/ws-manager-mk2/service/manager.go
+++ b/components/ws-manager-mk2/service/manager.go
@@ -228,6 +228,7 @@ func (wsm *WorkspaceManagerServer) StopWorkspace(ctx context.Context, req *wsman
 			Type:               string(workspacev1.WorkspaceConditionStoppedByRequest),
 			Status:             metav1.ConditionTrue,
 			LastTransitionTime: metav1.Now(),
+			Reason:             "unknown",
 		})
 		return nil
 	})


### PR DESCRIPTION
## Description
Workspaces that have been started by ws-manager-mk2 can now be stopped and successfully backed up.

## Related Issue(s)
n.a.

## How to test
- Open workspace in [preview environment](https://fo-mk2-dispose-ws.preview.gitpod-dev.com/workspaces)
- Stop workspace

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all-ci
- [ ] /werft no-test
      Run Leeway with `--dont-test`

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
