### PR TITLE
Replace for gce vm

### DIFF
--- a/.werft/jobs/build/prepare.ts
+++ b/.werft/jobs/build/prepare.ts
@@ -43,6 +43,7 @@ async function createVM(werft: Werft, config: JobConfig) {
     const cpu = config.withLargeVM ? 12 : 6;
     const memory = config.withLargeVM ? 24 : 12;
     const infra = config.withGceVm ? "gce" : "harvester"
+    const replace = config.withGceVm ? "module.preview_gce[0].google_compute_instance.default" : "module.preview_harvester[0].harvester_virtualmachine.harvester"
 
     const environment = {
         // We pass the GCP credentials explicitly, otherwise for some reason TF doesn't pick them up
@@ -59,6 +60,7 @@ async function createVM(werft: Werft, config: JobConfig) {
         environment["TF_VAR_vm_storage_class"] = config.storageClass
     }
 
+
     const variables = Object
         .entries(environment)
         .filter(([_, value]) => value.length > 0)
@@ -73,7 +75,7 @@ async function createVM(werft: Werft, config: JobConfig) {
         werft.log(prepareSlices.BOOT_VM, "Cleaning previously created VM");
         // -replace=... forces recreation of the resource
         await execStream(`${variables} \
-                                   TF_CLI_ARGS_plan=-replace=module.preview_harvester[0].harvester_virtualmachine.harvester \
+                                   TF_CLI_ARGS_plan=-replace=${replace} \
                                    leeway run dev/preview:create-preview`, {slice: prepareSlices.BOOT_VM});
     }
 

--- a/.werft/vm/vm.ts
+++ b/.werft/vm/vm.ts
@@ -29,7 +29,7 @@ export async function destroyPreview(options: { name: string }) {
  */
 export function vmExists(options: { name: string }) {
     const namespace = `preview-${options.name}`;
-    const status = exec(`kubectl --kubeconfig ${HARVESTER_KUBECONFIG_PATH} -n ${namespace} get vmi ${options.name}`, {
+    const status = exec(`kubectl --kubeconfig ${HARVESTER_KUBECONFIG_PATH} -n ${namespace} get svc proxy`, {
         dontCheckRc: true,
         silent: true,
     });


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all-ci
- [ ] /werft no-test
      Run Leeway with `--dont-test`

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
