### PR TITLE
Update Code Owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -95,26 +95,26 @@
 /dev/gpctl @gitpod-io/engineering-workspace
 /dev/gpctl/api/ @gitpod-io/engineering-webapp
 /dev/loadgen @gitpod-io/engineering-workspace
-/dev/preview @gitpod-io/engineering-devx
+/dev/preview @gitpod-io/engineering-delivery-operations-experience
 /operations/observability/mixins @gitpod-io/engineering-delivery-operations-experience
-/operations/observability/mixins/platform @gitpod-io/engineering-devx
+/operations/observability/mixins/platform @gitpod-io/engineering-delivery-operations-experience
 /operations/observability/mixins/IDE @gitpod-io/engineering-ide
 /operations/observability/mixins/meta @gitpod-io/engineering-webapp
 /operations/observability/mixins/workspace @gitpod-io/engineering-workspace
-/operations/observability/mixins/cross-teams @gitpod-io/engineering-workspace @gitpod-io/engineering-webapp @gitpod-io/engineering-ide @gitpod-io/engineering-devx @gitpod-io/engineering-delivery-operations-experience
+/operations/observability/mixins/cross-teams @gitpod-io/engineering-workspace @gitpod-io/engineering-webapp @gitpod-io/engineering-ide @gitpod-io/engineering-delivery-operations-experience
 
 /.werft/observability @gitpod-io/engineering-delivery-operations-experience
 
 /.werft/ide-* @gitpod-io/engineering-ide
-/.werft/platform-* @gitpod-io/engineering-devx
+/.werft/platform-* @gitpod-io/engineering-delivery-operations-experience
 /.werft/webapp-* @gitpod-io/engineering-webapp
 /.werft/workspace-* @gitpod-io/engineering-workspace
 /.werft/self-hosted-* @gitpod-io/engineering-delivery-operations-experience
 /.werft/*installer-tests* @gitpod-io/engineering-delivery-operations-experience
 /.werft/jobs/build/self-hosted-* @gitpod-io/engineering-delivery-operations-experience
 
-/dev/preview/infrastructure/harvester @gitpod-io/engineering-devx
-/dev/preview/workflow @gitpod-io/engineering-devx
+/dev/preview/infrastructure/harvester @gitpod-io/engineering-delivery-operations-experience
+/dev/preview/workflow @gitpod-io/engineering-delivery-operations-experience
 
 #
 # Automation


### PR DESCRIPTION
## Description
As announced in yesterday's all-hands, change owners from DevX to DOPE.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all-ci
- [ ] /werft no-test
      Run Leeway with `--dont-test`

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
