### PR TITLE
[installer] Global cloud-sql-proxy

### DIFF
--- a/install/installer/cmd/testdata/render/gcp-setup/config.yaml
+++ b/install/installer/cmd/testdata/render/gcp-setup/config.yaml
@@ -18,6 +18,11 @@ database:
     serviceAccount:
       kind: secret
       name: gcp-database
+  cloudSQLGlobal:
+    instance: gcp-global-db-instance
+    serviceAccount:
+      kind: secret
+      name: gcp-global-database
 metadata:
   region: europe-west2
 objectStorage:

--- a/install/installer/cmd/testdata/render/gcp-setup/output.golden
+++ b/install/installer/cmd/testdata/render/gcp-setup/output.golden
@@ -785,6 +785,18 @@ metadata:
   name: cloudsqlproxy
   namespace: default
 ---
+# v1/ServiceAccount cloudsqlproxy-global
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: cloudsqlproxy-global
+  name: cloudsqlproxy-global
+  namespace: default
+---
 # v1/ServiceAccount content-service
 apiVersion: v1
 automountServiceAccountToken: true
@@ -1347,6 +1359,11 @@ data:
         serviceAccount:
           kind: secret
           name: gcp-database
+      cloudSQLGlobal:
+        instance: gcp-global-db-instance
+        serviceAccount:
+          kind: secret
+          name: gcp-global-database
       inCluster: false
     disableDefinitelyGp: true
     domain: gitpod.example.com
@@ -2234,6 +2251,47 @@ data:
         component: cloudsqlproxy
         kind: service
       name: cloudsqlproxy
+      namespace: default
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: cloudsqlproxy-global
+      name: cloudsqlproxy-global-cloud-sql-proxy
+      namespace: default
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: cloudsqlproxy-global
+      name: cloudsqlproxy-global
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: cloudsqlproxy-global
+      name: cloudsqlproxy-global
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: cloudsqlproxy-global
+        kind: service
+      name: cloudsqlproxy-global
       namespace: default
     ---
     apiVersion: rbac.authorization.k8s.io/v1
@@ -6228,6 +6286,24 @@ subjects:
 - kind: ServiceAccount
   name: cloudsqlproxy
 ---
+# rbac.authorization.k8s.io/v1/RoleBinding cloudsqlproxy-global
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: cloudsqlproxy-global
+  name: cloudsqlproxy-global
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-ns-psp:restricted-root-user
+subjects:
+- kind: ServiceAccount
+  name: cloudsqlproxy-global
+---
 # rbac.authorization.k8s.io/v1/RoleBinding content-service
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -6704,6 +6780,30 @@ spec:
   selector:
     app: gitpod
     component: cloudsqlproxy
+  type: ClusterIP
+status:
+  loadBalancer: {}
+---
+# v1/Service cloudsqlproxy-global
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: cloudsqlproxy-global
+    kind: service
+  name: cloudsqlproxy-global
+  namespace: default
+spec:
+  ports:
+  - name: cloudsqlproxy-global
+    port: 3306
+    protocol: TCP
+    targetPort: 3306
+  selector:
+    app: gitpod
+    component: cloudsqlproxy-global
   type: ClusterIP
 status:
   loadBalancer: {}
@@ -8358,6 +8458,76 @@ spec:
       - name: gcloud-sql-token
         secret:
           secretName: gcp-database
+status: {}
+---
+# apps/v1/Deployment cloudsqlproxy-global-cloud-sql-proxy
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: cloudsqlproxy-global
+  name: cloudsqlproxy-global-cloud-sql-proxy
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gitpod
+      component: cloudsqlproxy-global
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: cloudsqlproxy-global
+      name: cloudsqlproxy-global
+      namespace: default
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: gitpod.io/workload_meta
+                operator: Exists
+      containers:
+      - command:
+        - /cloud_sql_proxy
+        - -dir=/cloudsql
+        - -instances=gcp-global-db-instance=tcp:0.0.0.0:3306
+        - -credential_file=/credentials/credentials.json
+        image: b.gcr.io/cloudsql-docker/gce-proxy:1.11
+        name: cloud-sql-proxy
+        ports:
+        - containerPort: 3306
+        resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
+          privileged: false
+          runAsNonRoot: false
+        volumeMounts:
+        - mountPath: /cloudsql
+          name: cloudsql
+        - mountPath: /credentials
+          name: gcloud-sql-token
+      dnsPolicy: ClusterFirst
+      enableServiceLinks: false
+      restartPolicy: Always
+      serviceAccountName: cloudsqlproxy-global
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - emptyDir: {}
+        name: cloudsql
+      - name: gcloud-sql-token
+        secret:
+          secretName: gcp-global-database
 status: {}
 ---
 # apps/v1/Deployment content-service

--- a/install/installer/pkg/components/database/cloudsql/constants.go
+++ b/install/installer/pkg/components/database/cloudsql/constants.go
@@ -10,4 +10,6 @@ const (
 	ImageName    = "gce-proxy"
 	ImageVersion = "1.11"
 	Port         = 3306
+
+	ComponentGlobal = "cloudsqlproxy-global"
 )

--- a/install/installer/pkg/components/database/cloudsql/global.go
+++ b/install/installer/pkg/components/database/cloudsql/global.go
@@ -1,0 +1,141 @@
+// Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package cloudsql
+
+import (
+	"fmt"
+
+	"github.com/gitpod-io/gitpod/installer/pkg/cluster"
+	"github.com/gitpod-io/gitpod/installer/pkg/common"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/pointer"
+)
+
+// Global CloudSQL is a cloud-sql-proxy which uses only one underlying database across multiple regions
+func CloudSQLGlobalObjects(ctx *common.RenderContext) ([]runtime.Object, error) {
+	if ctx.Config.Database.CloudSQLGlobal == nil {
+		return nil, nil
+	}
+
+	return common.CompositeRenderFunc(
+		cloudSQLGlobalDeployment,
+		globalCloudSQLRoleBinding,
+		common.DefaultServiceAccount(ComponentGlobal),
+		common.GenerateService(ComponentGlobal, []common.ServicePort{
+			{
+				Name:          ComponentGlobal,
+				ContainerPort: Port,
+				ServicePort:   Port,
+			},
+		}),
+	)(ctx)
+}
+
+func cloudSQLGlobalDeployment(ctx *common.RenderContext) ([]runtime.Object, error) {
+	labels := common.CustomizeLabel(ctx, ComponentGlobal, common.TypeMetaDeployment)
+
+	cfg := ctx.Config.Database.CloudSQLGlobal
+
+	return []runtime.Object{
+		&appsv1.Deployment{
+			TypeMeta: common.TypeMetaDeployment,
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        fmt.Sprintf("%s-cloud-sql-proxy", ComponentGlobal),
+				Namespace:   ctx.Namespace,
+				Labels:      labels,
+				Annotations: common.CustomizeAnnotation(ctx, ComponentGlobal, common.TypeMetaDeployment),
+			},
+			Spec: appsv1.DeploymentSpec{
+				Strategy: appsv1.DeploymentStrategy{
+					Type: appsv1.RollingUpdateDeploymentStrategyType,
+					RollingUpdate: &appsv1.RollingUpdateDeployment{
+						MaxUnavailable: &intstr.IntOrString{IntVal: 0},
+						MaxSurge:       &intstr.IntOrString{IntVal: 1},
+					},
+				},
+				Selector: &metav1.LabelSelector{MatchLabels: common.DefaultLabels(ComponentGlobal)},
+				Replicas: common.Replicas(ctx, ComponentGlobal),
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        ComponentGlobal,
+						Namespace:   ctx.Namespace,
+						Labels:      labels,
+						Annotations: common.CustomizeAnnotation(ctx, ComponentGlobal, common.TypeMetaDeployment),
+					},
+					Spec: corev1.PodSpec{
+						Affinity: &corev1.Affinity{
+							NodeAffinity: common.NodeAffinity(cluster.AffinityLabelMeta).NodeAffinity,
+						},
+						ServiceAccountName:            ComponentGlobal,
+						EnableServiceLinks:            pointer.Bool(false),
+						DNSPolicy:                     "ClusterFirst",
+						RestartPolicy:                 "Always",
+						TerminationGracePeriodSeconds: pointer.Int64(30),
+						Volumes: []corev1.Volume{{
+							Name:         "cloudsql",
+							VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+						}, {
+							Name: "gcloud-sql-token",
+							VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{
+								SecretName: cfg.ServiceAccount.Name,
+							}},
+						}},
+						Containers: []corev1.Container{{
+							Name: "cloud-sql-proxy",
+							SecurityContext: &corev1.SecurityContext{
+								Privileged:               pointer.Bool(false),
+								RunAsNonRoot:             pointer.Bool(false),
+								AllowPrivilegeEscalation: pointer.Bool(false),
+							},
+							Image: ctx.ImageName(ImageRepo, ImageName, ImageVersion),
+							Command: []string{
+								"/cloud_sql_proxy",
+								"-dir=/cloudsql",
+								fmt.Sprintf("-instances=%s=tcp:0.0.0.0:%d", cfg.Instance, Port),
+								"-credential_file=/credentials/credentials.json",
+							},
+							Ports: []corev1.ContainerPort{{
+								ContainerPort: Port,
+							}},
+							VolumeMounts: []corev1.VolumeMount{{
+								MountPath: "/cloudsql",
+								Name:      "cloudsql",
+							}, {
+								MountPath: "/credentials",
+								Name:      "gcloud-sql-token",
+							}},
+							Env: common.CustomizeEnvvar(ctx, ComponentGlobal, []corev1.EnvVar{}),
+						}},
+					},
+				},
+			},
+		},
+	}, nil
+}
+
+func globalCloudSQLRoleBinding(ctx *common.RenderContext) ([]runtime.Object, error) {
+	return []runtime.Object{&rbacv1.RoleBinding{
+		TypeMeta: common.TypeMetaRoleBinding,
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ComponentGlobal,
+			Namespace: ctx.Namespace,
+			Labels:    common.DefaultLabels(ComponentGlobal),
+		},
+		RoleRef: rbacv1.RoleRef{
+			Kind:     "ClusterRole",
+			Name:     fmt.Sprintf("%s-ns-psp:restricted-root-user", ctx.Namespace),
+			APIGroup: "rbac.authorization.k8s.io",
+		},
+		Subjects: []rbacv1.Subject{{
+			Kind: "ServiceAccount",
+			Name: ComponentGlobal,
+		}},
+	}}, nil
+}

--- a/install/installer/pkg/components/database/cloudsql/objects.go
+++ b/install/installer/pkg/components/database/cloudsql/objects.go
@@ -21,4 +21,5 @@ var Objects = common.CompositeRenderFunc(
 			ServicePort:   Port,
 		},
 	}),
+	CloudSQLGlobalObjects,
 )

--- a/install/installer/pkg/config/v1/config.go
+++ b/install/installer/pkg/config/v1/config.go
@@ -202,6 +202,9 @@ type Database struct {
 	External  *DatabaseExternal `json:"external,omitempty"`
 	CloudSQL  *DatabaseCloudSQL `json:"cloudSQL,omitempty"`
 	SSL       *SSLOptions       `json:"ssl,omitempty"`
+
+	// Experimental. CloudSQLGlobal is configuration for a single CloudSQL DB across multiple regions.
+	CloudSQLGlobal *DatabaseCloudSQL `json:"cloudSQLGlobal,omitempty"`
 }
 
 type DatabaseExternal struct {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

We need support for a second cloud-sql-proxy which can point to a global DB instance. This is temporary while we progress the removal of db-sync, and also progress rollout of fine grained permissions.

* Add `cloudSQLGlobal` config to `database` config
* If `cloudSQL` is configured, and `cloudSQLGlobal` is also configured, we render the following:
	* cloudsql-global deployment
	* cloudsql-global service
	* cloudsql-global rolebinding
	* cloudsql-global service-account	

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
See unit tests (and generated files)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all-ci
- [ ] /werft no-test
      Run Leeway with `--dont-test`

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
