### PR TITLE
git auth under team settings

### DIFF
--- a/components/dashboard/src/app/AppRoutes.tsx
+++ b/components/dashboard/src/app/AppRoutes.tsx
@@ -69,6 +69,7 @@ const Members = React.lazy(() => import(/* webpackPrefetch: true */ "../teams/Me
 const TeamSettings = React.lazy(() => import(/* webpackPrefetch: true */ "../teams/TeamSettings"));
 const TeamBilling = React.lazy(() => import(/* webpackPrefetch: true */ "../teams/TeamBilling"));
 const SSO = React.lazy(() => import(/* webpackPrefetch: true */ "../teams/SSO"));
+const TeamGitIntegrations = React.lazy(() => import(/* webpackPrefetch: true */ "../teams/GitIntegrationsPage"));
 const NewProject = React.lazy(() => import(/* webpackPrefetch: true */ "../projects/NewProject"));
 const Projects = React.lazy(() => import(/* webpackPrefetch: true */ "../projects/Projects"));
 const Project = React.lazy(() => import(/* webpackPrefetch: true */ "../projects/Project"));
@@ -232,6 +233,8 @@ export const AppRoutes: FunctionComponent<AppRoutesProps> = ({ user, teams }) =>
                     <Route exact path="/members" component={Members} />
                     <Route exact path="/projects" component={Projects} />
                     <Route exact path="/settings" component={TeamSettings} />
+                    <Route exact path="/settings/git" component={TeamGitIntegrations} />
+                    {/* TODO: migrate other org settings pages underneath /settings prefix */}
                     <Route exact path="/billing" component={TeamBilling} />
                     <Route exact path="/sso" component={SSO} />
                     <Route exact path={`/projects/:projectSlug`} component={Project} />

--- a/components/dashboard/src/components/ConfirmationModal.tsx
+++ b/components/dashboard/src/components/ConfirmationModal.tsx
@@ -20,39 +20,6 @@ export default function ConfirmationModal(props: {
     onClose: () => void;
     onConfirm: () => void;
 }) {
-    const children: React.ReactChild[] = [
-        <p key="areYouSure" className="mb-3 text-base text-gray-500">
-            {props.areYouSureText}
-        </p>,
-    ];
-
-    if (props.warningText) {
-        children.unshift(
-            <Alert type="warning" className="mb-4">
-                <strong>{props.warningHead}</strong>
-                {props.warningHead ? ": " : ""}
-                {props.warningText}
-            </Alert>,
-        );
-    }
-
-    const isEntity = (x: any): x is Entity => typeof x === "object" && "name" in x;
-    if (props.children) {
-        if (isEntity(props.children)) {
-            children.push(
-                <div key="entity" className="w-full p-4 mb-2 bg-gray-100 dark:bg-gray-700 rounded-xl group">
-                    <p className="text-base text-gray-800 dark:text-gray-100 font-semibold">{props.children.name}</p>
-                    {props.children.description && (
-                        <p className="text-gray-500 truncate">{props.children.description}</p>
-                    )}
-                </div>,
-            );
-        } else if (Array.isArray(props.children)) {
-            children.push(...props.children);
-        } else {
-            children.push(props.children);
-        }
-    }
     const cancelButtonRef = useRef<HTMLButtonElement>(null);
 
     const buttons = [
@@ -87,7 +54,24 @@ export default function ConfirmationModal(props: {
                 return true;
             }}
         >
-            {children}
+            <p className="mb-3 text-base text-gray-500">{props.areYouSureText}</p>
+            {props.warningText && (
+                <Alert type="warning" className="mb-4">
+                    <strong>{props.warningHead}</strong>
+                    {props.warningHead ? ": " : ""}
+                    {props.warningText}
+                </Alert>
+            )}
+            {isEntity(props.children) ? (
+                <div className="w-full p-4 mb-2 bg-gray-100 dark:bg-gray-700 rounded-xl group">
+                    <p className="text-base text-gray-800 dark:text-gray-100 font-semibold">{props.children.name}</p>
+                    {props.children.description && (
+                        <p className="text-gray-500 truncate">{props.children.description}</p>
+                    )}
+                </div>
+            ) : (
+                props.children
+            )}
         </Modal>
     );
 }
@@ -96,3 +80,5 @@ export interface Entity {
     name: string;
     description?: string;
 }
+
+const isEntity = (x: any): x is Entity => typeof x === "object" && "name" in x;

--- a/components/dashboard/src/components/Modal.tsx
+++ b/components/dashboard/src/components/Modal.tsx
@@ -118,13 +118,15 @@ export const ModalHeader = ({ children }: ModalHeaderProps) => {
 type ModalBodyProps = {
     children: ReactNode;
     hideDivider?: boolean;
+    noScroll?: boolean;
 };
 
-export const ModalBody = ({ children, hideDivider = false }: ModalBodyProps) => {
+export const ModalBody = ({ children, hideDivider = false, noScroll = false }: ModalBodyProps) => {
     return (
         <div
             className={cn("border-gray-200 dark:border-gray-800 -mx-6 px-6 ", {
                 "border-t border-b mt-2 py-4": !hideDivider,
+                "overflow-y-auto": !noScroll,
             })}
         >
             {children}

--- a/components/dashboard/src/components/PageWithSubMenu.tsx
+++ b/components/dashboard/src/components/PageWithSubMenu.tsx
@@ -42,7 +42,7 @@ export function PageWithSubMenu(p: PageWithSubMenuProps) {
                         })}
                     </ul>
                 </div>
-                <div className="ml-32 w-full pt-1 mb-40">{p.children}</div>
+                <div className="ml-16 lg:ml-32 w-full pt-1 mb-40">{p.children}</div>
             </div>
         </div>
     );

--- a/components/dashboard/src/components/forms/InputField.tsx
+++ b/components/dashboard/src/components/forms/InputField.tsx
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import classNames from "classnames";
+import { FunctionComponent, memo, ReactNode } from "react";
+
+type Props = {
+    label: ReactNode;
+    id?: string;
+    hint?: ReactNode;
+    error?: ReactNode;
+};
+
+export const InputField: FunctionComponent<Props> = memo(({ label, id, hint, error, children }) => {
+    return (
+        <div className="mt-4 flex flex-col space-y-2">
+            <label
+                className={classNames(
+                    "text-sm font-semibold dark:text-gray-400",
+                    error ? "text-red-600" : "text-gray-600",
+                )}
+                htmlFor={id}
+            >
+                {label}
+            </label>
+            {children}
+            {error && <span className="text-red-500 text-sm">{error}</span>}
+            {hint && <span className="text-gray-500 text-sm">{hint}</span>}
+        </div>
+    );
+});

--- a/components/dashboard/src/components/forms/SelectInputField.tsx
+++ b/components/dashboard/src/components/forms/SelectInputField.tsx
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import classNames from "classnames";
+import { FunctionComponent, memo, ReactNode, useCallback } from "react";
+import { useId } from "../../hooks/useId";
+import { InputField } from "./InputField";
+
+type Props = {
+    label: ReactNode;
+    value: string;
+    id?: string;
+    hint?: ReactNode;
+    error?: ReactNode;
+    disabled?: boolean;
+    required?: boolean;
+    onChange: (newValue: string) => void;
+    onBlur?: () => void;
+};
+
+export const SelectInputField: FunctionComponent<Props> = memo(
+    ({ label, value, id, hint, error, disabled = false, required = false, children, onChange, onBlur }) => {
+        const maybeId = useId();
+        const elementId = id || maybeId;
+
+        return (
+            <InputField id={elementId} label={label} hint={hint} error={error}>
+                <SelectInput
+                    id={elementId}
+                    value={value}
+                    onChange={onChange}
+                    disabled={disabled}
+                    required={required}
+                    onBlur={onBlur}
+                >
+                    {children}
+                </SelectInput>
+            </InputField>
+        );
+    },
+);
+
+type SelectInputProps = {
+    value: string;
+    className?: string;
+    id?: string;
+    disabled?: boolean;
+    required?: boolean;
+    onChange?: (newValue: string) => void;
+    onBlur?: () => void;
+};
+
+export const SelectInput: FunctionComponent<SelectInputProps> = memo(
+    ({ value, className, id, disabled = false, required = false, children, onChange, onBlur }) => {
+        const handleChange = useCallback(
+            (e) => {
+                onChange && onChange(e.target.value);
+            },
+            [onChange],
+        );
+
+        const handleBlur = useCallback(() => onBlur && onBlur(), [onBlur]);
+
+        return (
+            <select
+                id={id}
+                className={classNames("w-full max-w-lg", className)}
+                value={value}
+                disabled={disabled}
+                required={required}
+                onChange={handleChange}
+                onBlur={handleBlur}
+            >
+                {children}
+            </select>
+        );
+    },
+);

--- a/components/dashboard/src/components/forms/TextInputField.tsx
+++ b/components/dashboard/src/components/forms/TextInputField.tsx
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import classNames from "classnames";
+import { FunctionComponent, memo, ReactNode, useCallback } from "react";
+import { useId } from "../../hooks/useId";
+import { InputField } from "./InputField";
+
+type Props = {
+    type?: "text" | "password";
+    label: ReactNode;
+    value: string;
+    id?: string;
+    hint?: ReactNode;
+    error?: ReactNode;
+    placeholder?: string;
+    disabled?: boolean;
+    required?: boolean;
+    onChange: (newValue: string) => void;
+    onBlur?: () => void;
+};
+
+export const TextInputField: FunctionComponent<Props> = memo(
+    ({
+        type = "text",
+        label,
+        value,
+        id,
+        placeholder,
+        hint,
+        error,
+        disabled = false,
+        required = false,
+        onChange,
+        onBlur,
+    }) => {
+        const maybeId = useId();
+        const elementId = id || maybeId;
+
+        return (
+            <InputField id={elementId} label={label} hint={hint} error={error}>
+                <TextInput
+                    id={elementId}
+                    value={value}
+                    type={type}
+                    placeholder={placeholder}
+                    disabled={disabled}
+                    required={required}
+                    className={error ? "border-red-500" : ""}
+                    onChange={onChange}
+                    onBlur={onBlur}
+                />
+            </InputField>
+        );
+    },
+);
+
+type TextInputProps = {
+    type?: "text" | "password";
+    value: string;
+    className?: string;
+    id?: string;
+    placeholder?: string;
+    disabled?: boolean;
+    required?: boolean;
+    onChange: (newValue: string) => void;
+    onBlur?: () => void;
+};
+
+export const TextInput: FunctionComponent<TextInputProps> = memo(
+    ({ type = "text", value, className, id, placeholder, disabled = false, required = false, onChange, onBlur }) => {
+        const handleChange = useCallback(
+            (e) => {
+                onChange(e.target.value);
+            },
+            [onChange],
+        );
+
+        const handleBlur = useCallback(() => onBlur && onBlur(), [onBlur]);
+
+        return (
+            <input
+                id={id}
+                className={classNames("w-full max-w-lg", className)}
+                value={value}
+                type={type}
+                placeholder={placeholder}
+                disabled={disabled}
+                required={required}
+                onChange={handleChange}
+                onBlur={handleBlur}
+            />
+        );
+    },
+);

--- a/components/dashboard/src/contexts/FeatureFlagContext.tsx
+++ b/components/dashboard/src/contexts/FeatureFlagContext.tsx
@@ -21,6 +21,7 @@ const FeatureFlagContext = createContext<{
     usePublicApiWorkspacesService: boolean;
     enablePersonalAccessTokens: boolean;
     oidcServiceEnabled: boolean;
+    orgGitAuthProviders: boolean;
 }>({
     showUsageView: false,
     isUsageBasedBillingEnabled: false,
@@ -28,6 +29,7 @@ const FeatureFlagContext = createContext<{
     usePublicApiWorkspacesService: false,
     enablePersonalAccessTokens: false,
     oidcServiceEnabled: false,
+    orgGitAuthProviders: false,
 });
 
 const FeatureFlagContextProvider: React.FC = ({ children }) => {
@@ -41,6 +43,7 @@ const FeatureFlagContextProvider: React.FC = ({ children }) => {
     const [enablePersonalAccessTokens, setPersonalAccessTokensEnabled] = useState<boolean>(false);
     const [usePublicApiWorkspacesService, setUsePublicApiWorkspacesService] = useState<boolean>(false);
     const [oidcServiceEnabled, setOidcServiceEnabled] = useState<boolean>(false);
+    const [orgGitAuthProviders, setOrgGitAuthProviders] = useState<boolean>(false);
 
     useEffect(() => {
         if (!user) return;
@@ -55,6 +58,7 @@ const FeatureFlagContextProvider: React.FC = ({ children }) => {
                     setter: setUsePublicApiWorkspacesService,
                 },
                 oidcServiceEnabled: { defaultValue: false, setter: setOidcServiceEnabled },
+                orgGitAuthProviders: { defaultValue: false, setter: setOrgGitAuthProviders },
             };
 
             for (const [flagName, config] of Object.entries(featureFlags)) {
@@ -100,6 +104,7 @@ const FeatureFlagContextProvider: React.FC = ({ children }) => {
                 enablePersonalAccessTokens,
                 usePublicApiWorkspacesService,
                 oidcServiceEnabled,
+                orgGitAuthProviders,
             }}
         >
             {children}

--- a/components/dashboard/src/data/auth-providers/delete-org-auth-provider-mutation.ts
+++ b/components/dashboard/src/data/auth-providers/delete-org-auth-provider-mutation.ts
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { getGitpodService } from "../../service/service";
+import { useCurrentTeam } from "../../teams/teams-context";
+import { getOrgAuthProvidersQueryKey, OrgAuthProvidersQueryResult } from "./org-auth-providers-query";
+
+type DeleteAuthProviderArgs = {
+    providerId: string;
+};
+export const useDeleteOrgAuthProviderMutation = () => {
+    const queryClient = useQueryClient();
+    const organization = useCurrentTeam();
+
+    return useMutation({
+        mutationFn: async ({ providerId }: DeleteAuthProviderArgs) => {
+            if (!organization) {
+                throw new Error("No current organization selected");
+            }
+
+            return await getGitpodService().server.deleteOrgAuthProvider({
+                id: providerId,
+                organizationId: organization.id,
+            });
+        },
+        onSuccess: (_, { providerId }) => {
+            if (!organization) {
+                throw new Error("No current organization selected");
+            }
+
+            const queryKey = getOrgAuthProvidersQueryKey(organization.id);
+            queryClient.setQueryData<OrgAuthProvidersQueryResult>(queryKey, (providers) => {
+                return providers?.filter((p) => p.id !== providerId);
+            });
+
+            queryClient.invalidateQueries({ queryKey });
+        },
+    });
+};

--- a/components/dashboard/src/data/auth-providers/org-auth-providers-query.ts
+++ b/components/dashboard/src/data/auth-providers/org-auth-providers-query.ts
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { AuthProviderEntry } from "@gitpod/gitpod-protocol";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useCallback } from "react";
+import { getGitpodService } from "../../service/service";
+import { useCurrentTeam } from "../../teams/teams-context";
+
+export type OrgAuthProvidersQueryResult = AuthProviderEntry[];
+export const useOrgAuthProvidersQuery = () => {
+    const organization = useCurrentTeam();
+
+    return useQuery<OrgAuthProvidersQueryResult>({
+        queryKey: getOrgAuthProvidersQueryKey(organization?.id ?? ""),
+        queryFn: async () => {
+            if (!organization) {
+                throw new Error("No current organization selected");
+            }
+
+            return await getGitpodService().server.getOrgAuthProviders({ organizationId: organization.id });
+        },
+    });
+};
+
+export const useInvalidateOrgAuthProvidersQuery = (organizationId: string) => {
+    const queryClient = useQueryClient();
+
+    return useCallback(() => {
+        queryClient.invalidateQueries({ queryKey: getOrgAuthProvidersQueryKey(organizationId) });
+    }, [organizationId, queryClient]);
+};
+
+export const getOrgAuthProvidersQueryKey = (organizationId: string) => ["auth-providers", { organizationId }];

--- a/components/dashboard/src/data/auth-providers/upsert-org-auth-provider-mutation.ts
+++ b/components/dashboard/src/data/auth-providers/upsert-org-auth-provider-mutation.ts
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { GitpodServer } from "@gitpod/gitpod-protocol";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { getGitpodService } from "../../service/service";
+import { getOrgAuthProvidersQueryKey } from "./org-auth-providers-query";
+
+type UpsertAuthProviderArgs = {
+    provider: GitpodServer.CreateOrgAuthProviderParams["entry"] | GitpodServer.UpdateOrgAuthProviderParams["entry"];
+};
+export const useUpsertOrgAuthProviderMutation = () => {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: async ({ provider }: UpsertAuthProviderArgs) => {
+            if ("id" in provider) {
+                return await getGitpodService().server.updateOrgAuthProvider({ entry: provider });
+            } else {
+                return await getGitpodService().server.createOrgAuthProvider({ entry: provider });
+            }
+        },
+        onSuccess(provider) {
+            if (!provider || !provider.organizationId) {
+                return;
+            }
+
+            queryClient.invalidateQueries({ queryKey: getOrgAuthProvidersQueryKey(provider.organizationId) });
+        },
+    });
+};

--- a/components/dashboard/src/data/billing-mode/org-billing-mode-query.ts
+++ b/components/dashboard/src/data/billing-mode/org-billing-mode-query.ts
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { BillingMode } from "@gitpod/gitpod-protocol/lib/billing-mode";
+import { useQuery } from "@tanstack/react-query";
+import { getGitpodService } from "../../service/service";
+import { useCurrentTeam } from "../../teams/teams-context";
+
+type OrgBillingModeQueryResult = BillingMode;
+
+export const useOrgBillingMode = () => {
+    const team = useCurrentTeam();
+
+    return useQuery<OrgBillingModeQueryResult>({
+        queryKey: getOrgBillingModeQueryKey(team?.id ?? ""),
+        queryFn: async () => {
+            if (!team) {
+                throw new Error("No current organization selected");
+            }
+            return await getGitpodService().server.getBillingModeForTeam(team.id);
+        },
+        enabled: !!team,
+    });
+};
+
+export const getOrgBillingModeQueryKey = (organizationId: string) => ["billing-mode", { organizationId }];

--- a/components/dashboard/src/data/organizations/org-members-query.ts
+++ b/components/dashboard/src/data/organizations/org-members-query.ts
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { TeamMemberInfo } from "@gitpod/gitpod-protocol";
+import { useQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
+import { publicApiTeamMembersToProtocol, teamsService } from "../../service/public-api";
+import { useCurrentTeam } from "../../teams/teams-context";
+import { useCurrentUser } from "../../user-context";
+
+export type OrgMembersQueryResult = TeamMemberInfo[];
+
+export const useOrgMembers = () => {
+    const organization = useCurrentTeam();
+
+    return useQuery<OrgMembersQueryResult>({
+        queryKey: getOrgMembersQueryKey(organization?.id ?? ""),
+        queryFn: async () => {
+            if (!organization) {
+                throw new Error("No current organization");
+            }
+            const resp = await teamsService.getTeam({ teamId: organization.id });
+
+            return publicApiTeamMembersToProtocol(resp.team?.members || []);
+        },
+    });
+};
+
+// Wrapper around useOrgMembers to get the current user's, current orgs member info record
+export const useCurrentOrgMember = () => {
+    const user = useCurrentUser();
+
+    const { data: members, isLoading } = useOrgMembers();
+
+    return useMemo(() => {
+        let member: TeamMemberInfo | undefined;
+
+        if (!isLoading && members && user) {
+            member = members.find((m) => m.userId === user.id);
+        }
+
+        return { isLoading, member };
+    }, [isLoading, members, user]);
+};
+
+export const getOrgMembersQueryKey = (organizationId: string) => ["organizations", { organizationId }, "members"];

--- a/components/dashboard/src/hooks/use-onblur-error.ts
+++ b/components/dashboard/src/hooks/use-onblur-error.ts
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { useCallback, useState } from "react";
+
+// Provided an error message and boolean indicating if related property is valid
+// returns an error message if field has been blurred and it's invalid.
+// An `onBlur` handler is meant to be applied to the relevant input field
+export const useOnBlurError = (message: string, isValid: boolean) => {
+    const [hasBlurred, setHasBlurred] = useState(false);
+
+    const onBlur = useCallback(() => {
+        setHasBlurred(true);
+    }, []);
+
+    return { message: !isValid && hasBlurred ? message : "", isValid, onBlur };
+};

--- a/components/dashboard/src/hooks/useId.ts
+++ b/components/dashboard/src/hooks/useId.ts
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { useState } from "react";
+
+let currentId = 0;
+const getId = () => currentId++;
+
+//TODO: Replace this with React.useId once we upgrade to v18
+export function useId({ prefix = "el" } = {}) {
+    const [id] = useState(getId);
+
+    return `${prefix}_${id}`;
+}

--- a/components/dashboard/src/menu/Menu.tsx
+++ b/components/dashboard/src/menu/Menu.tsx
@@ -13,7 +13,7 @@ import { countries } from "countries-list";
 import gitpodIcon from "../icons/gitpod.svg";
 import { getGitpodService, gitpodHostUrl } from "../service/service";
 import { useCurrentUser } from "../user-context";
-import { useBillingModeForCurrentTeam, useCurrentTeam, useTeamMemberInfos } from "../teams/teams-context";
+import { useCurrentTeam, useTeamMemberInfos } from "../teams/teams-context";
 import ContextMenu from "../components/ContextMenu";
 import Separator from "../components/Separator";
 import PillMenuItem from "../components/PillMenuItem";
@@ -22,8 +22,9 @@ import { PaymentContext } from "../payment-context";
 import FeedbackFormModal from "../feedback-form/FeedbackModal";
 import { inResource, isGitpodIo } from "../utils";
 import { BillingMode } from "@gitpod/gitpod-protocol/lib/billing-mode";
-import { FeatureFlagContext } from "../contexts/FeatureFlagContext";
+import { useFeatureFlags } from "../contexts/FeatureFlagContext";
 import OrganizationSelector from "./OrganizationSelector";
+import { useOrgBillingMode } from "../data/billing-mode/org-billing-mode-query";
 
 interface Entry {
     title: string;
@@ -35,8 +36,8 @@ export default function Menu() {
     const user = useCurrentUser();
     const team = useCurrentTeam();
     const location = useLocation();
-    const teamBillingMode = useBillingModeForCurrentTeam();
-    const { showUsageView, oidcServiceEnabled } = useContext(FeatureFlagContext);
+    const { data: teamBillingMode } = useOrgBillingMode();
+    const { showUsageView, oidcServiceEnabled, orgGitAuthProviders } = useFeatureFlags();
     const { setCurrency, setIsStudent, setIsChargebeeCustomer } = useContext(PaymentContext);
     const [userBillingMode, setUserBillingMode] = useState<BillingMode | undefined>(undefined);
     const [isFeedbackFormVisible, setFeedbackFormVisible] = useState<boolean>(false);
@@ -114,12 +115,23 @@ export default function Menu() {
                         team,
                         billingMode: teamBillingMode,
                         ssoEnabled: oidcServiceEnabled,
+                        orgGitAuthProviders,
                     }).flatMap((e) => e.link),
                 });
             }
         }
         return leftMenu;
-    }, [oidcServiceEnabled, showUsageView, team, teamBillingMode, teamMembers, user, userBillingMode]);
+    }, [
+        oidcServiceEnabled,
+        orgGitAuthProviders,
+        showUsageView,
+        team,
+        teamBillingMode,
+        teamMembers,
+        user?.additionalData?.isMigratedToTeamOnlyAttribution,
+        user?.id,
+        userBillingMode,
+    ]);
 
     const handleFeedbackFormClick = () => {
         setFeedbackFormVisible(true);

--- a/components/dashboard/src/teams/GitIntegrationsPage.tsx
+++ b/components/dashboard/src/teams/GitIntegrationsPage.tsx
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { FunctionComponent, useMemo } from "react";
+import { Redirect } from "react-router";
+import Header from "../components/Header";
+import { SpinnerLoader } from "../components/Loader";
+import { useOrgBillingMode } from "../data/billing-mode/org-billing-mode-query";
+import { useCurrentOrgMember } from "../data/organizations/org-members-query";
+import { GitIntegrations } from "./git-integrations/GitIntegrations";
+import { OrgSettingsPage } from "./OrgSettingsPage";
+
+export default function GitAuth() {
+    return (
+        <OrgSettingsPageWrapper>
+            <GitIntegrations />
+        </OrgSettingsPageWrapper>
+    );
+}
+
+// TODO: Refactor this into OrgSettingsPage so each page doesn't have to do this
+export const OrgSettingsPageWrapper: FunctionComponent = ({ children }) => {
+    const { isLoading: isBillingModeLoading } = useOrgBillingMode();
+    const { member, isLoading: isMemberInfoLoading } = useCurrentOrgMember();
+
+    const isLoading = useMemo(
+        () => isBillingModeLoading || isMemberInfoLoading,
+        [isBillingModeLoading, isMemberInfoLoading],
+    );
+
+    const isOwner = useMemo(() => {
+        return member?.role === "owner";
+    }, [member?.role]);
+
+    // Render as much of the page as we can in a loading state to avoid content shift
+    if (isLoading) {
+        return (
+            <div className="w-full">
+                <Header title="Organization Settings" subtitle="Manage your organization's settings." />
+                <div className="w-full">
+                    <SpinnerLoader />
+                </div>
+            </div>
+        );
+    }
+
+    if (!isOwner) {
+        return <Redirect to={"/"} />;
+    }
+
+    return <OrgSettingsPage>{children}</OrgSettingsPage>;
+};

--- a/components/dashboard/src/teams/OrgSettingsPage.tsx
+++ b/components/dashboard/src/teams/OrgSettingsPage.tsx
@@ -7,7 +7,8 @@
 import { useContext } from "react";
 import { PageWithSubMenu } from "../components/PageWithSubMenu";
 import { FeatureFlagContext } from "../contexts/FeatureFlagContext";
-import { useCurrentTeam, useBillingModeForCurrentTeam } from "./teams-context";
+import { useOrgBillingMode } from "../data/billing-mode/org-billing-mode-query";
+import { useCurrentTeam } from "./teams-context";
 import { getTeamSettingsMenu } from "./TeamSettings";
 
 export interface OrgSettingsPageProps {
@@ -16,9 +17,14 @@ export interface OrgSettingsPageProps {
 
 export function OrgSettingsPage({ children }: OrgSettingsPageProps) {
     const team = useCurrentTeam();
-    const teamBillingMode = useBillingModeForCurrentTeam();
-    const { oidcServiceEnabled } = useContext(FeatureFlagContext);
-    const menu = getTeamSettingsMenu({ team, billingMode: teamBillingMode, ssoEnabled: oidcServiceEnabled });
+    const { data: teamBillingMode } = useOrgBillingMode();
+    const { oidcServiceEnabled, orgGitAuthProviders } = useContext(FeatureFlagContext);
+    const menu = getTeamSettingsMenu({
+        team,
+        billingMode: teamBillingMode,
+        ssoEnabled: oidcServiceEnabled,
+        orgGitAuthProviders,
+    });
 
     return (
         <PageWithSubMenu subMenu={menu} title="Organization Settings" subtitle="Manage your organization's settings.">

--- a/components/dashboard/src/teams/TeamBilling.tsx
+++ b/components/dashboard/src/teams/TeamBilling.tsx
@@ -15,6 +15,7 @@ import Card from "../components/Card";
 import DropDown from "../components/DropDown";
 import PillLabel from "../components/PillLabel";
 import SolidCard from "../components/SolidCard";
+import { useOrgBillingMode } from "../data/billing-mode/org-billing-mode-query";
 import { getExperimentsClient } from "../experiments/client";
 import { ReactComponent as Spinner } from "../icons/Spinner.svg";
 import { ReactComponent as CheckSvg } from "../images/check.svg";
@@ -22,12 +23,7 @@ import { PaymentContext } from "../payment-context";
 import { getGitpodService } from "../service/service";
 import { useCurrentUser } from "../user-context";
 import { OrgSettingsPage } from "./OrgSettingsPage";
-import {
-    useBillingModeForCurrentTeam,
-    useCurrentTeam,
-    useIsOwnerOfCurrentTeam,
-    useTeamMemberInfos,
-} from "./teams-context";
+import { useCurrentTeam, useIsOwnerOfCurrentTeam, useTeamMemberInfos } from "./teams-context";
 import TeamUsageBasedBilling from "./TeamUsageBasedBilling";
 
 type PendingPlan = Plan & { pendingSince: number };
@@ -37,7 +33,7 @@ export default function TeamBilling() {
     const team = useCurrentTeam();
     const members = useTeamMemberInfos();
     const isUserOwner = useIsOwnerOfCurrentTeam();
-    const teamBillingMode = useBillingModeForCurrentTeam();
+    const { data: teamBillingMode } = useOrgBillingMode();
     const [teamSubscription, setTeamSubscription] = useState<TeamSubscription2 | undefined>();
     const { currency, setCurrency } = useContext(PaymentContext);
     const [isUsageBasedBillingEnabled, setIsUsageBasedBillingEnabled] = useState<boolean>(false);

--- a/components/dashboard/src/teams/TeamSettings.tsx
+++ b/components/dashboard/src/teams/TeamSettings.tsx
@@ -16,8 +16,13 @@ import { useCurrentUser } from "../user-context";
 import { OrgSettingsPage } from "./OrgSettingsPage";
 import { TeamsContext, useCurrentTeam, useIsOwnerOfCurrentTeam } from "./teams-context";
 
-export function getTeamSettingsMenu(params: { team?: Team; billingMode?: BillingMode; ssoEnabled?: boolean }) {
-    const { billingMode, ssoEnabled } = params;
+export function getTeamSettingsMenu(params: {
+    team?: Team;
+    billingMode?: BillingMode;
+    ssoEnabled?: boolean;
+    orgGitAuthProviders: boolean;
+}) {
+    const { billingMode, ssoEnabled, orgGitAuthProviders } = params;
     const result = [
         {
             title: "General",
@@ -28,6 +33,12 @@ export function getTeamSettingsMenu(params: { team?: Team; billingMode?: Billing
         result.push({
             title: "SSO",
             link: [`/sso`],
+        });
+    }
+    if (orgGitAuthProviders) {
+        result.push({
+            title: "Git Integrations",
+            link: [`/settings/git`],
         });
     }
     if (billingMode?.mode !== "none") {

--- a/components/dashboard/src/teams/git-integrations/GitIntegrationListItem.tsx
+++ b/components/dashboard/src/teams/git-integrations/GitIntegrationListItem.tsx
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { AuthProviderEntry } from "@gitpod/gitpod-protocol";
+import { FunctionComponent, useCallback, useMemo, useState } from "react";
+import ConfirmationModal from "../../components/ConfirmationModal";
+import { ContextMenuEntry } from "../../components/ContextMenu";
+import { Item, ItemField, ItemFieldContextMenu, ItemFieldIcon } from "../../components/ItemsList";
+import { useDeleteOrgAuthProviderMutation } from "../../data/auth-providers/delete-org-auth-provider-mutation";
+import { GitIntegrationModal } from "./GitIntegrationModal";
+
+type Props = {
+    provider: AuthProviderEntry;
+};
+export const GitIntegrationListItem: FunctionComponent<Props> = ({ provider }) => {
+    const [showEditModal, setShowEditModal] = useState(false);
+    const [showDeleteConfirmation, setShowDeleteConfirmation] = useState(false);
+    const deleteAuthProvider = useDeleteOrgAuthProviderMutation();
+
+    const menuEntries = useMemo(() => {
+        const result: ContextMenuEntry[] = [];
+        result.push({
+            title: provider.status === "verified" ? "Edit Configuration" : "Activate Integration",
+            onClick: () => setShowEditModal(true),
+            separator: true,
+        });
+        result.push({
+            title: "Remove",
+            customFontStyle: "text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-300",
+            onClick: () => setShowDeleteConfirmation(true),
+        });
+        return result;
+    }, [provider.status]);
+
+    const deleteProvider = useCallback(async () => {
+        try {
+            await deleteAuthProvider.mutateAsync({ providerId: provider.id });
+            setShowDeleteConfirmation(false);
+        } catch (error) {
+            console.log(error);
+        }
+    }, [deleteAuthProvider, provider.id]);
+
+    return (
+        <>
+            <Item className="h-16">
+                <ItemFieldIcon>
+                    <div
+                        className={
+                            "rounded-full w-3 h-3 text-sm align-middle m-auto " +
+                            (provider.status === "verified" ? "bg-green-500" : "bg-gray-400")
+                        }
+                    >
+                        &nbsp;
+                    </div>
+                </ItemFieldIcon>
+                <ItemField className="w-3/12 flex flex-col my-auto">
+                    <span className="font-medium truncate overflow-ellipsis">{provider.type}</span>
+                </ItemField>
+                <ItemField className="w-7/12 flex flex-col my-auto">
+                    <span className="my-auto truncate text-gray-500 overflow-ellipsis">{provider.host}</span>
+                </ItemField>
+                <ItemFieldContextMenu menuEntries={menuEntries} />
+            </Item>
+            {showDeleteConfirmation && (
+                <ConfirmationModal
+                    title="Remove Integration"
+                    areYouSureText="Are you sure you want to remove the following Git integration?"
+                    children={{
+                        name: provider.type,
+                        description: provider.host,
+                    }}
+                    buttonText="Remove Integration"
+                    buttonDisabled={deleteAuthProvider.isLoading}
+                    warningText={deleteAuthProvider.isError ? "There was a problem deleting the provider" : undefined}
+                    onClose={() => setShowDeleteConfirmation(false)}
+                    onConfirm={deleteProvider}
+                />
+            )}
+            {showEditModal && <GitIntegrationModal provider={provider} onClose={() => setShowEditModal(false)} />}
+        </>
+    );
+};

--- a/components/dashboard/src/teams/git-integrations/GitIntegrationModal.tsx
+++ b/components/dashboard/src/teams/git-integrations/GitIntegrationModal.tsx
@@ -1,0 +1,328 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { AuthProviderEntry } from "@gitpod/gitpod-protocol";
+import { FunctionComponent, useCallback, useMemo, useState } from "react";
+import Alert from "../../components/Alert";
+import { InputWithCopy } from "../../components/InputWithCopy";
+import Modal, { ModalBody, ModalFooter, ModalHeader } from "../../components/Modal";
+import { openAuthorizeWindow } from "../../provider-utils";
+import { getGitpodService, gitpodHostUrl } from "../../service/service";
+import exclamation from "../../images/exclamation.svg";
+import { TextInputField } from "../../components/forms/TextInputField";
+import { InputField } from "../../components/forms/InputField";
+import { SelectInputField } from "../../components/forms/SelectInputField";
+import { useUpsertOrgAuthProviderMutation } from "../../data/auth-providers/upsert-org-auth-provider-mutation";
+import { useInvalidateOrgAuthProvidersQuery } from "../../data/auth-providers/org-auth-providers-query";
+import { useCurrentTeam } from "../teams-context";
+import { useOnBlurError } from "../../hooks/use-onblur-error";
+
+type Props = {
+    provider?: AuthProviderEntry;
+    onClose: () => void;
+};
+
+export const GitIntegrationModal: FunctionComponent<Props> = (props) => {
+    const team = useCurrentTeam();
+    const [type, setType] = useState<string>(props.provider?.type ?? "GitLab");
+    const [host, setHost] = useState<string>(props.provider?.host ?? "");
+    const [clientId, setClientId] = useState<string>(props.provider?.oauth.clientId ?? "");
+    const [clientSecret, setClientSecret] = useState<string>(props.provider?.oauth.clientSecret ?? "");
+
+    const [savedProvider, setSavedProvider] = useState(props.provider);
+    const isNew = !savedProvider;
+
+    // This is a readonly value to copy and plug into external oauth config
+    const redirectURL = useMemo(() => {
+        // Default to an example
+        let url = callbackUrl("gitlab.example.com");
+
+        // Once it's saved, use what's stored
+        if (!isNew) {
+            url = savedProvider?.oauth.callBackUrl ?? url;
+        } else {
+            // Otherwise construct it w/ their provided host value
+            url = callbackUrl(host);
+        }
+
+        return url;
+    }, [host, isNew, savedProvider?.oauth.callBackUrl]);
+
+    const [savingProvider, setSavingProvider] = useState(false);
+    const [errorMessage, setErrorMessage] = useState<string | undefined>();
+
+    const upsertProvider = useUpsertOrgAuthProviderMutation();
+    const invalidateOrgAuthProviders = useInvalidateOrgAuthProvidersQuery(team?.id ?? "");
+
+    const {
+        message: hostError,
+        onBlur: hostOnBlurErrorTracking,
+        isValid: hostValid,
+    } = useOnBlurError(`Provider Host Name is missing.`, host.trim().length > 0);
+
+    const {
+        message: clientIdError,
+        onBlur: clientIdOnBlur,
+        isValid: clientIdValid,
+    } = useOnBlurError(`${type === "GitLab" ? "Application ID" : "Client ID"} is missing.`, clientId.trim().length > 0);
+
+    const {
+        message: clientSecretError,
+        onBlur: clientSecretOnBlur,
+        isValid: clientSecretValid,
+    } = useOnBlurError(`${type === "GitLab" ? "Secret" : "Client Secret"} is missing.`, clientSecret.trim().length > 0);
+
+    // Call our error onBlur handler, and remove prefixed "https://"
+    const hostOnBlur = useCallback(() => {
+        hostOnBlurErrorTracking();
+
+        if (host.startsWith("https://")) {
+            setHost(host.replace("https://", ""));
+        }
+    }, [host, hostOnBlurErrorTracking]);
+
+    // TODO: We could remove this extra state management if we convert the modal into a detail flow w/ it's own route
+    // Used to grab latest provider record after activation flow
+    const reloadSavedProvider = useCallback(async () => {
+        if (!savedProvider || !team) {
+            return;
+        }
+
+        const provider = (await getGitpodService().server.getOrgAuthProviders({ organizationId: team.id })).find(
+            (ap) => ap.id === savedProvider.id,
+        );
+        if (provider) {
+            setSavedProvider(provider);
+        }
+    }, [savedProvider, team]);
+
+    const activate = useCallback(async () => {
+        if (!team) {
+            console.error("no current team selected");
+            return;
+        }
+        // Set a saving state and clear any error message
+        setSavingProvider(true);
+        setErrorMessage(undefined);
+
+        const trimmedId = clientId.trim();
+        const trimmedSecret = clientSecret.trim();
+
+        try {
+            const newProvider = await upsertProvider.mutateAsync({
+                provider: isNew
+                    ? {
+                          host: host.replace("https://", ""),
+                          type,
+                          clientId: trimmedId,
+                          clientSecret: trimmedSecret,
+                          organizationId: team.id,
+                      }
+                    : {
+                          id: savedProvider.id,
+                          clientId: trimmedId,
+                          clientSecret: clientSecret === "redacted" ? "" : trimmedSecret,
+                          organizationId: team.id,
+                      },
+            });
+
+            // switch mode to stay and edit this integration.
+            setSavedProvider(newProvider);
+
+            // the server is checking periodically for updates of dynamic providers, thus we need to
+            // wait at least 2 seconds for the changes to be propagated before we try to use this provider.
+            await new Promise((resolve) => setTimeout(resolve, 2000));
+
+            // just open the authorization window and do *not* await
+            openAuthorizeWindow({
+                login: false,
+                host: newProvider.host,
+                onSuccess: (payload) => {
+                    invalidateOrgAuthProviders();
+
+                    props.onClose();
+                },
+                onError: (payload) => {
+                    reloadSavedProvider();
+
+                    let errorMessage: string;
+                    if (typeof payload === "string") {
+                        errorMessage = payload;
+                    } else {
+                        errorMessage = payload.description ? payload.description : `Error: ${payload.error}`;
+                    }
+                    setErrorMessage(errorMessage);
+                },
+            });
+        } catch (error) {
+            console.log(error);
+            setErrorMessage("message" in error ? error.message : "Failed to update Git provider");
+        }
+
+        setSavingProvider(false);
+    }, [
+        clientId,
+        clientSecret,
+        host,
+        invalidateOrgAuthProviders,
+        isNew,
+        props,
+        reloadSavedProvider,
+        savedProvider?.id,
+        team,
+        type,
+        upsertProvider,
+    ]);
+
+    const isValid = useMemo(
+        () => clientIdValid && clientSecretValid && hostValid,
+        [clientIdValid, clientSecretValid, hostValid],
+    );
+
+    return (
+        <Modal
+            visible
+            onClose={props.onClose}
+            onEnter={() => {
+                activate();
+                return false;
+            }}
+        >
+            <ModalHeader>{isNew ? "New Git Integration" : "Git Integration"}</ModalHeader>
+            <ModalBody>
+                {!isNew && savedProvider?.status !== "verified" && (
+                    <Alert type="warning">You need to activate this integration.</Alert>
+                )}
+                <div className="flex flex-col text-gray-500">
+                    Configure an integration with a self-managed instance of GitLab, GitHub, or Bitbucket.
+                </div>
+
+                <div>
+                    {isNew && (
+                        <SelectInputField label="Provider Type" value={type} onChange={setType}>
+                            <option value="GitHub">GitHub</option>
+                            <option value="GitLab">GitLab</option>
+                            <option value="BitbucketServer">Bitbucket Server</option>
+                        </SelectInputField>
+                    )}
+                    <TextInputField
+                        label="Provider Host Name"
+                        value={host}
+                        disabled={!isNew}
+                        placeholder={getPlaceholderForIntegrationType(type)}
+                        error={hostError}
+                        onChange={setHost}
+                        onBlur={hostOnBlur}
+                    />
+
+                    <InputField label="Redirect URL" hint={<RedirectUrlDescription type={type} host={host} />}>
+                        <InputWithCopy value={redirectURL} tip="Copy the Redirect URL to clipboard" />
+                    </InputField>
+
+                    <TextInputField
+                        label={type === "GitLab" ? "Application ID" : "Client ID"}
+                        value={clientId}
+                        error={clientIdError}
+                        onBlur={clientIdOnBlur}
+                        onChange={setClientId}
+                    />
+
+                    <TextInputField
+                        label={type === "GitLab" ? "Secret" : "Client Secret"}
+                        type="password"
+                        value={clientSecret}
+                        error={clientSecretError}
+                        onChange={setClientSecret}
+                        onBlur={clientSecretOnBlur}
+                    />
+                </div>
+
+                {errorMessage && (
+                    <div className="flex rounded-md bg-red-600 p-3">
+                        <img
+                            className="w-4 h-4 mx-2 my-auto filter-brightness-10"
+                            src={exclamation}
+                            alt="exclamation mark"
+                        />
+                        <span className="text-white">{errorMessage}</span>
+                    </div>
+                )}
+            </ModalBody>
+            <ModalFooter>
+                <button onClick={activate} disabled={!isValid || savingProvider}>
+                    Activate Integration
+                </button>
+            </ModalFooter>
+        </Modal>
+    );
+};
+
+const callbackUrl = (host: string) => {
+    // Negative Lookahead (?!\/)
+    // `\/` matches the character `/`
+    // "https://foobar:80".replace(/:(?!\/)/, "_")
+    // => 'https://foobar_80'
+    host = host.replace(/:(?!\/)/, "_");
+    const pathname = `/auth/${host}/callback`;
+    return gitpodHostUrl.with({ pathname }).toString();
+};
+
+const getPlaceholderForIntegrationType = (type: string) => {
+    switch (type) {
+        case "GitHub":
+            return "github.example.com";
+        case "GitLab":
+            return "gitlab.example.com";
+        case "BitbucketServer":
+            return "bitbucket.example.com";
+        default:
+            return "";
+    }
+};
+
+type RedirectUrlDescriptionProps = {
+    type: string;
+    host: string;
+};
+const RedirectUrlDescription: FunctionComponent<RedirectUrlDescriptionProps> = ({ type, host }) => {
+    let settingsUrl = ``;
+    switch (type) {
+        case "GitHub":
+            settingsUrl = `${host}/settings/developers`;
+            break;
+        case "GitLab":
+            settingsUrl = `${host}/-/profile/applications`;
+            break;
+        default:
+            return null;
+    }
+
+    let docsUrl = ``;
+    switch (type) {
+        case "GitHub":
+            docsUrl = `https://www.gitpod.io/docs/github-integration/#oauth-application`;
+            break;
+        case "GitLab":
+            docsUrl = `https://www.gitpod.io/docs/gitlab-integration/#oauth-application`;
+            break;
+        default:
+            return null;
+    }
+
+    return (
+        <span>
+            Use this redirect URL to update the OAuth application. Go to{" "}
+            <a href={`https://${settingsUrl}`} target="_blank" rel="noreferrer noopener" className="gp-link">
+                developer settings
+            </a>{" "}
+            and setup the OAuth application.&nbsp;
+            <a href={docsUrl} target="_blank" rel="noreferrer noopener" className="gp-link">
+                Learn more
+            </a>
+            .
+        </span>
+    );
+};

--- a/components/dashboard/src/teams/git-integrations/GitIntegrations.tsx
+++ b/components/dashboard/src/teams/git-integrations/GitIntegrations.tsx
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { FunctionComponent } from "react";
+import { SpinnerLoader } from "../../components/Loader";
+import { useOrgAuthProvidersQuery } from "../../data/auth-providers/org-auth-providers-query";
+import { GitIntegrationsList } from "./GitIntegrationsList";
+
+export const GitIntegrations: FunctionComponent = () => {
+    const { data, isLoading } = useOrgAuthProvidersQuery();
+
+    return (
+        <div>
+            <div className="flex items-start sm:justify-between mb-2">
+                <div>
+                    <h3>Git Integrations</h3>
+                    <h2>Manage Git integrations for self-managed instances of GitLab, GitHub, or Bitbucket.</h2>
+                </div>
+            </div>
+
+            {isLoading ? <SpinnerLoader /> : <GitIntegrationsList providers={data || []} />}
+        </div>
+    );
+};

--- a/components/dashboard/src/teams/git-integrations/GitIntegrationsList.tsx
+++ b/components/dashboard/src/teams/git-integrations/GitIntegrationsList.tsx
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { AuthProviderEntry } from "@gitpod/gitpod-protocol";
+import { FunctionComponent, useCallback, useState } from "react";
+import { ItemsList } from "../../components/ItemsList";
+import { GitIntegrationListItem } from "./GitIntegrationListItem";
+import { GitIntegrationModal } from "./GitIntegrationModal";
+
+type Props = {
+    providers: AuthProviderEntry[];
+};
+export const GitIntegrationsList: FunctionComponent<Props> = ({ providers }) => {
+    const [showCreateModal, setShowCreateModal] = useState(false);
+
+    const onCreate = useCallback(() => setShowCreateModal(true), []);
+    const hideModal = useCallback(() => setShowCreateModal(false), []);
+
+    return (
+        <>
+            {providers.length === 0 ? (
+                <div className="w-full flex h-80 mt-2 rounded-xl bg-gray-100 dark:bg-gray-900">
+                    <div className="m-auto text-center px-8">
+                        <h3 className="self-center text-gray-500 dark:text-gray-400 mb-4">No Git Integrations</h3>
+                        <div className="text-gray-500 mb-6 max-w-md">
+                            In addition to the default Git Providers you can authorize with a self-hosted instance of a
+                            provider.
+                        </div>
+                        <button className="self-center" onClick={onCreate}>
+                            New Integration
+                        </button>
+                    </div>
+                </div>
+            ) : (
+                <>
+                    <div className="mt-3">
+                        <button onClick={onCreate}>New Integration</button>
+                    </div>
+
+                    <ItemsList className="pt-6">
+                        {providers.map((p) => (
+                            <GitIntegrationListItem key={p.id} provider={p} />
+                        ))}
+                    </ItemsList>
+                </>
+            )}
+            {showCreateModal && <GitIntegrationModal onClose={hideModal} />}
+        </>
+    );
+};

--- a/components/dashboard/src/teams/teams-context.tsx
+++ b/components/dashboard/src/teams/teams-context.tsx
@@ -5,11 +5,9 @@
  */
 
 import { Team, TeamMemberInfo } from "@gitpod/gitpod-protocol";
-import { BillingMode } from "@gitpod/gitpod-protocol/lib/billing-mode";
 import React, { createContext, useContext, useEffect, useState } from "react";
 import { useLocation } from "react-router";
 import { publicApiTeamMembersToProtocol, teamsService } from "../service/public-api";
-import { getGitpodService } from "../service/service";
 import { useCurrentUser } from "../user-context";
 
 export const TeamsContext = createContext<{
@@ -54,17 +52,6 @@ export function useCurrentTeam(): Team | undefined {
 export function useTeams(): Team[] | undefined {
     const { teams } = useContext(TeamsContext);
     return teams;
-}
-
-export function useBillingModeForCurrentTeam(): BillingMode | undefined {
-    const team = useCurrentTeam();
-    const [billingMode, setBillingMode] = useState<BillingMode | undefined>();
-    useEffect(() => {
-        if (!!team) {
-            getGitpodService().server.getBillingModeForTeam(team.id).then(setBillingMode);
-        }
-    }, [team]);
-    return billingMode;
 }
 
 export function useTeamMemberInfos(): Record<string, TeamMemberInfo[]> {

--- a/components/dashboard/src/workspaces/StartWorkspaceModal.tsx
+++ b/components/dashboard/src/workspaces/StartWorkspaceModal.tsx
@@ -4,8 +4,8 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { useCallback, useContext, useMemo, useState } from "react";
-import Modal from "../components/Modal";
+import { useCallback, useContext, useState } from "react";
+import Modal, { ModalBody, ModalFooter, ModalHeader } from "../components/Modal";
 import RepositoryFinder from "../components/RepositoryFinder";
 import SelectIDEComponent from "../components/SelectIDEComponent";
 import SelectWorkspaceClassComponent from "../components/SelectWorkspaceClassComponent";
@@ -58,61 +58,57 @@ export function StartWorkspaceModal(props: StartWorkspaceModalProps) {
         return true;
     }, [repo, selectedIde, selectedWsClass, useLatestIde, errorIde, errorWsClass]);
 
-    const buttons = useMemo(() => {
-        const result = [
-            <button key="cancel" className="secondary" onClick={props.onClose}>
-                Cancel
-            </button>,
-            <button
-                key="start"
-                className=""
-                onClick={startWorkspace}
-                disabled={!repo || repo.length === 0 || !!errorIde || !!errorWsClass}
-            >
-                New Workspace
-            </button>,
-        ];
-        if (!props.onClose) {
-            return result.slice(1, 2);
-        }
-        return result;
-    }, [props.onClose, startWorkspace, repo, errorIde, errorWsClass]);
-
     return (
         <Modal
             onClose={props.onClose || (() => {})}
             closeable={!!props.onClose}
             onEnter={startWorkspace}
             visible={true}
-            title="Open in Gitpod"
-            buttons={buttons}
         >
-            <div className="-mx-6 px-6">
-                <div className="text-xs text-gray-500">Start a new workspace with the following options.</div>
-                <div className="pt-3">
-                    <RepositoryFinder
-                        setSelection={props.contextUrl && !props.allowContextUrlChange ? undefined : setRepo}
-                        initialValue={repo}
-                    />
+            <ModalHeader>Open in Gitpod</ModalHeader>
+            <ModalBody noScroll>
+                <div className="-mx-6 px-6">
+                    <div className="text-xs text-gray-500">Start a new workspace with the following options.</div>
+                    <div className="pt-3">
+                        <RepositoryFinder
+                            setSelection={props.contextUrl && !props.allowContextUrlChange ? undefined : setRepo}
+                            initialValue={repo}
+                        />
+                    </div>
+                    <div className="pt-3">
+                        {errorIde && <div className="text-red-500 text-sm">{errorIde}</div>}
+                        <SelectIDEComponent
+                            onSelectionChange={onSelectEditorChange}
+                            setError={setErrorIde}
+                            selectedIdeOption={selectedIde}
+                            useLatest={useLatestIde}
+                        />
+                    </div>
+                    <div className="pt-3">
+                        {errorWsClass && <div className="text-red-500 text-sm">{errorWsClass}</div>}
+                        <SelectWorkspaceClassComponent
+                            onSelectionChange={setSelectedWsClass}
+                            setError={setErrorWsClass}
+                            selectedWorkspaceClass={selectedWsClass}
+                        />
+                    </div>
                 </div>
-                <div className="pt-3">
-                    {errorIde && <div className="text-red-500 text-sm">{errorIde}</div>}
-                    <SelectIDEComponent
-                        onSelectionChange={onSelectEditorChange}
-                        setError={setErrorIde}
-                        selectedIdeOption={selectedIde}
-                        useLatest={useLatestIde}
-                    />
-                </div>
-                <div className="pt-3">
-                    {errorWsClass && <div className="text-red-500 text-sm">{errorWsClass}</div>}
-                    <SelectWorkspaceClassComponent
-                        onSelectionChange={setSelectedWsClass}
-                        setError={setErrorWsClass}
-                        selectedWorkspaceClass={selectedWsClass}
-                    />
-                </div>
-            </div>
+            </ModalBody>
+            <ModalFooter>
+                {props.onClose && (
+                    <button key="cancel" className="secondary" onClick={props.onClose}>
+                        Cancel
+                    </button>
+                )}
+                <button
+                    key="start"
+                    className=""
+                    onClick={startWorkspace}
+                    disabled={!repo || repo.length === 0 || !!errorIde || !!errorWsClass}
+                >
+                    New Workspace
+                </button>
+            </ModalFooter>
         </Modal>
     );
 }

--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -467,7 +467,8 @@ export namespace GitpodServer {
         readonly id: string;
     }
     export interface CreateOrgAuthProviderParams {
-        readonly entry: AuthProviderEntry.NewOrgEntry;
+        // ownerId is automatically set to the authenticated user
+        readonly entry: Omit<AuthProviderEntry.NewOrgEntry, "ownerId">;
     }
     export interface UpdateOrgAuthProviderParams {
         readonly entry: AuthProviderEntry.UpdateOrgEntry;


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This PR adds a new **Git Integrations** page to the Organization Settings area that is behind the `orgGitAuthProviders` feature flag, which is off in prod, but on otherwise. It's largely like the Integrations found under Personal Settings, but refactored to plug in react-query, and be a bit more idiomatic React. This helped simplify some of the state management that was happening. It's still quite a bit of code though for these new views. While refactoring, I tried to pave some ground for simplifying a few things going forward:

|   |  |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/367275/216502699-ddb4ac08-1dd9-4e2b-8e80-cc094d797c07.png)  | ![image](https://user-images.githubusercontent.com/367275/216502732-382aa3f1-6acc-4d41-98d2-cbb55e186030.png)  |


### Forms
I started a [set of form components](https://github.com/gitpod-io/gitpod/tree/1125999e9cc3337f7cbf19202c34e6a46976b778/components/dashboard/src/components/forms), namely `TextInputField` and `SelectInputField` to consolidate how we render/handle form fields. I also added some input validation and contextual error messages for them that tracks if the user "touched" a field before we show an error message for it. There's a bit more I'd like to do to deal with spacing when a field has an error, but figured this was enough already, and can iterate later.

![image](https://user-images.githubusercontent.com/367275/216502780-d77a5e2b-77b7-492f-a3d4-fd3f4d14855a.png)

### `<TeamSettingsPage/>`
Each of the pages under the Org Settings has a bunch of shared complexity around loading some data, and determining if a user has access to that page before it renders. To consolidate that, and migrate more to react-query, I created a `<TeamSettingsPage/>` component that the new Git Integrations page uses, with a plan to update the other pages to use it in a followup PR. This should also help this area avoid some menu items flashing in and out during rendering as it loads data to determine access.

## Future Work
* Update the rest of the Org Settings pages to use `<TeamSettingsPage/>`
* Improving how modals render static error messages, such as an api error on submit. Currently it renders at the bottom of the ModalBody, but I'd like to have it pinned to the bottom, and slide up when there's an error.
![image](https://user-images.githubusercontent.com/367275/216504789-502733eb-6a4b-4d49-b422-2ee682863c12.png)
* There's some nice improvements we could make by adjusting the routing a bit for these sort of list=>detail views, even if we keep them in modals, but could also be worth considering a full nested nav detail page pattern (kinda like person access tokens).


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #15964

## How to test
<!-- Provide steps to test this PR -->
* Using the preview environment, create an organization, and visit the Settings area.
* Go to the Git Integrations page. Create a new Integration. I've used fake values for the create, but obviously those won't result in a provider you can activate. I wasn't able to determine a good way to test it all the way through, but the code that handles that part shouldn't have changed in this PR.
* Test updating an integration
* Test deleting an integration

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all-ci
- [ ] /werft no-test
      Run Leeway with `--dont-test`

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
