### PR TITLE
[spicedb] Remove cloud-sql-proxy sidecar

### DIFF
--- a/install/installer/pkg/components/spicedb/deployment.go
+++ b/install/installer/pkg/components/spicedb/deployment.go
@@ -5,8 +5,6 @@
 package spicedb
 
 import (
-	"fmt"
-
 	"github.com/gitpod-io/gitpod/installer/pkg/cluster"
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 	"github.com/gitpod-io/gitpod/installer/pkg/components/database/cloudsql"
@@ -28,150 +26,20 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 		return nil, nil
 	}
 
-	var containers []corev1.Container
-
 	var volumes []corev1.Volume
-	var containerEnvVars []corev1.EnvVar
+	containerEnvVars := common.DatabaseEnv(&ctx.Config)
 
-	if cfg.CloudSQL != nil {
-		containers = append(containers, corev1.Container{
-			Name: "cloud-sql-proxy",
-			SecurityContext: &corev1.SecurityContext{
-				Privileged:               pointer.Bool(false),
-				RunAsNonRoot:             pointer.Bool(false),
-				AllowPrivilegeEscalation: pointer.Bool(false),
-			},
-			Image: ctx.ImageName(cloudsql.ImageRepo, cloudsql.ImageName, cloudsql.ImageVersion),
-			Command: []string{
-				"/cloud_sql_proxy",
-				"-dir=/cloudsql",
-				fmt.Sprintf("-instances=%s=tcp:0.0.0.0:%d", cfg.CloudSQL.Instance, CloudSQLProxyPort),
-				"-credential_file=/credentials/credentials.json",
-			},
-			Ports: []corev1.ContainerPort{{
-				ContainerPort: CloudSQLProxyPort,
-			}},
-			VolumeMounts: []corev1.VolumeMount{{
-				MountPath: "/cloudsql",
-				Name:      "cloudsql",
-			}, {
-				MountPath: "/credentials",
-				Name:      "gcloud-sql-token",
-			}},
-			Env: common.CustomizeEnvvar(ctx, Component, []corev1.EnvVar{}),
-		})
-
-		volumes = append(volumes, []corev1.Volume{
-			{
-				Name:         "cloudsql",
-				VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
-			}, {
-				Name: "gcloud-sql-token",
-				VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{
-					SecretName: cfg.CloudSQL.ProxySecretRef,
-				}},
-			},
-		}...)
-
-		// We use our cloud-sql-proxy sidecar to target the DB.
-		dbHost := "localhost"
-		containerEnvVars = append(containerEnvVars, []corev1.EnvVar{
-			{
-				Name: "DB_PASSWORD",
-				ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: cfg.CloudSQL.DatabaseSecretRef,
-					},
-					Key: "password",
-				}},
-			},
-			{
-				Name: "DB_USERNAME",
-				ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: cfg.CloudSQL.DatabaseSecretRef,
-					},
-					Key: "user",
-				}},
-			},
-			{
-				Name:  "SPICEDB_DATASTORE_CONN_URI",
-				Value: fmt.Sprintf("$(DB_USERNAME):$(DB_PASSWORD)@tcp(%s:%d)/%s?parseTime=true", dbHost, CloudSQLProxyPort, cfg.CloudSQL.Database),
-			},
-			{
-				Name:  "SPICEDB_GRPC_PRESHARED_KEY",
-				Value: "static-for-now",
-			},
-		}...)
-	}
-
-	container := corev1.Container{
-		Name:            ContainerName,
-		Image:           ctx.ImageName(common.ThirdPartyContainerRepo(ctx.Config.Repository, RegistryRepo), RegistryImage, ImageTag),
-		ImagePullPolicy: corev1.PullIfNotPresent,
-		Args: []string{
-			"serve",
-			"--log-format=json",
-			"--log-level=debug",
-			"--datastore-engine=mysql",
-			"--datastore-conn-max-open=100",
-		},
-		Env: common.CustomizeEnvvar(ctx, Component, common.MergeEnv(
-			common.DefaultEnv(&ctx.Config),
-			containerEnvVars,
-		)),
-		Ports: []corev1.ContainerPort{
-			{
-				ContainerPort: ContainerGRPCPort,
-				Name:          ContainerGRPCName,
-				Protocol:      *common.TCPProtocol,
-			},
-			{
-				ContainerPort: ContainerHTTPPort,
-				Name:          ContainerHTTPName,
-				Protocol:      *common.TCPProtocol,
-			},
-			{
-				ContainerPort: ContainerDashboardPort,
-				Name:          ContainerDashboardName,
-				Protocol:      *common.TCPProtocol,
-			},
-			{
-				ContainerPort: ContainerDispatchPort,
-				Name:          ContainerDispatchName,
-				Protocol:      *common.TCPProtocol,
-			},
-			{
-				ContainerPort: ContainerPrometheusPort,
-				Name:          ContainterPrometheusName,
-				Protocol:      *common.TCPProtocol,
-			},
-		},
-		Resources: common.ResourceRequirements(ctx, Component, ContainerName, corev1.ResourceRequirements{
-			Requests: corev1.ResourceList{
-				"cpu":    resource.MustParse("1"),
-				"memory": resource.MustParse("1Gi"),
-			},
-		}),
-		SecurityContext: &corev1.SecurityContext{
-			RunAsGroup:   pointer.Int64(65532),
-			RunAsNonRoot: pointer.Bool(true),
-			RunAsUser:    pointer.Int64(65532),
-		},
-		ReadinessProbe: &corev1.Probe{
-			ProbeHandler: corev1.ProbeHandler{
-				Exec: &v1.ExecAction{
-					Command: []string{"grpc_health_probe", "-v", "-addr=localhost:50051"},
+	if ctx.Config.Database.CloudSQLGlobal != nil {
+		containerEnvVars = append(containerEnvVars, common.MergeEnv(
+			// Override the DB host to point to global cloudsql
+			[]corev1.EnvVar{
+				{
+					Name:  "DB_HOST",
+					Value: cloudsql.ComponentGlobal,
 				},
 			},
-			FailureThreshold: 5,
-			PeriodSeconds:    10,
-			SuccessThreshold: 1,
-			TimeoutSeconds:   5,
-		},
+		)...)
 	}
-
-	containers = append(containers, container)
 
 	return []runtime.Object{
 		&appsv1.Deployment{
@@ -204,8 +72,84 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 						SecurityContext: &corev1.PodSecurityContext{
 							RunAsNonRoot: pointer.Bool(false),
 						},
-						Containers: containers,
-						Volumes:    volumes,
+						Containers: []corev1.Container{
+							{
+								Name:            ContainerName,
+								Image:           ctx.ImageName(common.ThirdPartyContainerRepo(ctx.Config.Repository, RegistryRepo), RegistryImage, ImageTag),
+								ImagePullPolicy: corev1.PullIfNotPresent,
+								Args: []string{
+									"serve",
+									"--log-format=json",
+									"--log-level=debug",
+									"--datastore-engine=mysql",
+									"--datastore-conn-max-open=100",
+								},
+								Env: common.CustomizeEnvvar(ctx, Component, common.MergeEnv(
+									common.DefaultEnv(&ctx.Config),
+									containerEnvVars,
+									[]corev1.EnvVar{
+										{
+											Name:  "SPICEDB_DATASTORE_CONN_URI",
+											Value: "$(DB_USERNAME):$(DB_PASSWORD)@tcp($(DB_HOST):$(DB_PORT))/authorization?parseTime=true",
+										},
+										{
+											Name:  "SPICEDB_GRPC_PRESHARED_KEY",
+											Value: "static-for-now",
+										},
+									},
+								)),
+								Ports: []corev1.ContainerPort{
+									{
+										ContainerPort: ContainerGRPCPort,
+										Name:          ContainerGRPCName,
+										Protocol:      *common.TCPProtocol,
+									},
+									{
+										ContainerPort: ContainerHTTPPort,
+										Name:          ContainerHTTPName,
+										Protocol:      *common.TCPProtocol,
+									},
+									{
+										ContainerPort: ContainerDashboardPort,
+										Name:          ContainerDashboardName,
+										Protocol:      *common.TCPProtocol,
+									},
+									{
+										ContainerPort: ContainerDispatchPort,
+										Name:          ContainerDispatchName,
+										Protocol:      *common.TCPProtocol,
+									},
+									{
+										ContainerPort: ContainerPrometheusPort,
+										Name:          ContainterPrometheusName,
+										Protocol:      *common.TCPProtocol,
+									},
+								},
+								Resources: common.ResourceRequirements(ctx, Component, ContainerName, corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										"cpu":    resource.MustParse("1"),
+										"memory": resource.MustParse("1Gi"),
+									},
+								}),
+								SecurityContext: &corev1.SecurityContext{
+									RunAsGroup:   pointer.Int64(65532),
+									RunAsNonRoot: pointer.Bool(true),
+									RunAsUser:    pointer.Int64(65532),
+								},
+								ReadinessProbe: &corev1.Probe{
+									ProbeHandler: corev1.ProbeHandler{
+										Exec: &v1.ExecAction{
+											Command: []string{"grpc_health_probe", "-v", "-addr=localhost:50051"},
+										},
+									},
+									FailureThreshold: 5,
+									PeriodSeconds:    10,
+									SuccessThreshold: 1,
+									TimeoutSeconds:   5,
+								},
+							},
+						},
+						Volumes: volumes,
 					},
 				},
 			},


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

We use a `cloudsql-global` instead of the side-car.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all-ci
- [ ] /werft no-test
      Run Leeway with `--dont-test`

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
