### PR TITLE
[ws-manager-mk2] Configure leader election

### DIFF
--- a/components/ws-manager-mk2/main.go
+++ b/components/ws-manager-mk2/main.go
@@ -89,7 +89,7 @@ func main() {
 		Port:                   9443,
 		HealthProbeBindAddress: cfg.Health.Addr,
 		LeaderElection:         enableLeaderElection,
-		LeaderElectionID:       "0616d21e.gitpod.io",
+		LeaderElectionID:       "ws-manager-mk2.gitpod.io",
 		Namespace:              cfg.Manager.Namespace,
 	})
 	if err != nil {

--- a/install/installer/pkg/components/ws-manager-mk2/deployment.go
+++ b/install/installer/pkg/components/ws-manager-mk2/deployment.go
@@ -54,8 +54,11 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 			RunAsUser: pointer.Int64(31002),
 		},
 		Containers: []corev1.Container{{
-			Name:            Component,
-			Args:            []string{"--config", "/config/config.json"},
+			Name: Component,
+			Args: []string{
+				"--config", "/config/config.json",
+				"--leader-elect",
+			},
 			Image:           ctx.ImageName(ctx.Config.Repository, Component, ctx.VersionManifest.Components.WSManagerMk2.Version),
 			ImagePullPolicy: corev1.PullIfNotPresent,
 			Resources: common.ResourceRequirements(ctx, Component, Component, corev1.ResourceRequirements{

--- a/install/installer/pkg/components/ws-manager-mk2/role.go
+++ b/install/installer/pkg/components/ws-manager-mk2/role.go
@@ -69,6 +69,41 @@ func role(ctx *common.RenderContext) ([]runtime.Object, error) {
 						"update",
 					},
 				},
+				// ConfigMap, Leases, and Events access is required for leader-election.
+				{
+					APIGroups: []string{""},
+					Resources: []string{"configmaps"},
+					Verbs: []string{
+						"create",
+						"delete",
+						"get",
+						"list",
+						"patch",
+						"update",
+						"watch",
+					},
+				},
+				{
+					APIGroups: []string{"coordination.k8s.io"},
+					Resources: []string{"leases"},
+					Verbs: []string{
+						"create",
+						"delete",
+						"get",
+						"list",
+						"patch",
+						"update",
+						"watch",
+					},
+				},
+				{
+					APIGroups: []string{""},
+					Resources: []string{"events"},
+					Verbs: []string{
+						"create",
+						"patch",
+					},
+				},
 			},
 		},
 	}, nil


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Configure leader election on the ws-manager-mk2 controller manager. Requires additional role policy rules to manage leases, these rules are taken from the generated [`leader_election_role.yaml`](https://github.com/gitpod-io/gitpod/blob/main/components/ws-manager-mk2/config/rbac/leader_election_role.yaml) by kubebuilder

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Relates to #11416 

## How to test
<!-- Provide steps to test this PR -->

Open preview env, check logs of `ws-manager-mk2` to confirm a leader-election lease has been successfully acquired

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all-ci
- [ ] /werft no-test
      Run Leeway with `--dont-test`

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft with-wsman-mk2
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
