### PR TITLE
[spicedb] Configure preshared key

### DIFF
--- a/install/installer/pkg/components/spicedb/constants.go
+++ b/install/installer/pkg/components/spicedb/constants.go
@@ -29,4 +29,6 @@ const (
 	ContainerName = "spicedb"
 
 	CloudSQLProxyPort = 3306
+
+	SecretPresharedKeyName = "presharedKey"
 )

--- a/install/installer/pkg/components/spicedb/objects.go
+++ b/install/installer/pkg/components/spicedb/objects.go
@@ -23,6 +23,7 @@ func Objects(ctx *common.RenderContext) ([]runtime.Object, error) {
 		common.DefaultServiceAccount(Component),
 		migrations,
 		networkpolicy,
+		secret,
 	)(ctx)
 }
 

--- a/install/installer/pkg/components/spicedb/secret.go
+++ b/install/installer/pkg/components/spicedb/secret.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package spicedb
+
+import (
+	"fmt"
+
+	"github.com/gitpod-io/gitpod/installer/pkg/common"
+	"github.com/gitpod-io/gitpod/installer/pkg/config/v1/experimental"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func secret(ctx *common.RenderContext) ([]runtime.Object, error) {
+	cfg := getExperimentalSpiceDBConfig(ctx)
+	if cfg == nil {
+		return nil, nil
+	}
+
+	// There's a secret-ref provided, we do not need to create a secret
+	if cfg.SecretRef != "" {
+		return nil, nil
+	}
+
+	generated, err := common.RandomString(20)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate spicedb preshared key: %w", err)
+	}
+
+	return []runtime.Object{
+		&corev1.Secret{
+			TypeMeta: common.TypeMetaSecret,
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretRef(cfg),
+				Namespace: ctx.Namespace,
+				Labels:    common.DefaultLabels(Component),
+			},
+			Data: map[string][]byte{
+				SecretPresharedKeyName: []byte(generated),
+			},
+		},
+	}, nil
+}
+
+func secretRef(cfg *experimental.SpiceDBConfig) string {
+	if cfg.SecretRef != "" {
+		return cfg.SecretRef
+	}
+
+	return fmt.Sprintf("%s-secret", Component)
+
+}

--- a/install/installer/pkg/config/v1/experimental/experimental.go
+++ b/install/installer/pkg/config/v1/experimental/experimental.go
@@ -198,6 +198,10 @@ type SpiceDBConfig struct {
 	Enabled bool `json:"enabled"`
 
 	DisableMigrations bool `json:"disableMigrations"`
+
+	// Reference to a k8s secret which contains a "presharedKey" for authentication with SpiceDB
+	// If not specified, a secret is generated.
+	SecretRef string `json:"secretRef"`
 }
 
 type WebAppConfig struct {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Configure, or create, a secret to be used as a pre-shared key for accessing spicedb

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
