### PR TITLE
[dashboard] user visible rename team->organization

### DIFF
--- a/components/dashboard/src/Menu.tsx
+++ b/components/dashboard/src/Menu.tsx
@@ -82,6 +82,7 @@ export default function Menu() {
                 "users",
                 "workspaces",
                 "teams",
+                "orgs",
             ].includes(resource)
         ) {
             return resource;
@@ -118,6 +119,7 @@ export default function Menu() {
         "usage",
         "plans",
         "teams",
+        "orgs",
         "variables",
         "keys",
         "integrations",
@@ -282,8 +284,8 @@ export default function Menu() {
                 <div className="p-1 text-base text-gray-500 dark:text-gray-400 border-gray-800">
                     <PillMenuItem
                         additionalClasses="border-2 border-gray-200 dark:border-gray-700 border-dashed"
-                        name="New Team →"
-                        link="/teams/new"
+                        name="New Organization →"
+                        link="/orgs/new"
                     />
                 </div>
             );
@@ -330,10 +332,10 @@ export default function Menu() {
                 .sort((a, b) => (a.title.toLowerCase() > b.title.toLowerCase() ? 1 : -1)),
             {
                 slug: "new",
-                title: "Create a new team",
+                title: "Create a new organization",
                 customContent: (
                     <div className="w-full text-gray-400 flex items-center">
-                        <span className="flex-1 font-semibold">New Team</span>
+                        <span className="flex-1 font-semibold">New Organization</span>
                         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 14 14" className="w-3.5">
                             <path
                                 fill="currentColor"
@@ -344,7 +346,7 @@ export default function Menu() {
                         </svg>
                     </div>
                 ),
-                link: "/teams/new",
+                link: "/orgs/new",
             },
         ];
         const classes =
@@ -370,7 +372,7 @@ export default function Menu() {
                                     d="M5.293 7.293a1 1 0 0 1 1.414 0L10 10.586l3.293-3.293a1 1 0 1 1 1.414 1.414l-4 4a1 1 0 0 1-1.414 0l-4-4a1 1 0 0 1 0-1.414Z"
                                     fill="#78716C"
                                 />
-                                <title>Toggle team selection menu</title>
+                                <title>Toggle organization selection menu</title>
                             </svg>
                         </div>
                     </ContextMenu>

--- a/components/dashboard/src/admin/TeamsSearch.tsx
+++ b/components/dashboard/src/admin/TeamsSearch.tsx
@@ -18,7 +18,7 @@ import Pagination from "../Pagination/Pagination";
 
 export default function TeamsSearchPage() {
     return (
-        <PageWithAdminSubMenu title="Teams" subtitle="Search and manage teams.">
+        <PageWithAdminSubMenu title="Organizations" subtitle="Search and manage organizations.">
             <TeamsSearch />
         </PageWithAdminSubMenu>
     );
@@ -104,7 +104,7 @@ export function TeamsSearch() {
                         </div>
                         <input
                             type="search"
-                            placeholder="Search Teams"
+                            placeholder="Search Organizations"
                             onKeyDown={(k) => k.key === "Enter" && search()}
                             onChange={(v) => {
                                 setSearchTerm(v.target.value.trim());
@@ -147,7 +147,7 @@ export function TeamsSearch() {
         return (
             <Link
                 key={"pr-" + props.team.name}
-                to={"/admin/teams/" + props.team.id}
+                to={"/admin/orgs/" + props.team.id}
                 data-analytics='{"button_type":"sidebar_menu"}'
             >
                 <div className="rounded-xl whitespace-nowrap flex py-6 px-6 w-full justify-between hover:bg-gray-100 dark:hover:bg-gray-800 focus:bg-gitpod-kumquat-light group">

--- a/components/dashboard/src/admin/admin-menu.ts
+++ b/components/dashboard/src/admin/admin-menu.ts
@@ -19,8 +19,8 @@ export function getAdminMenu() {
             link: ["/admin/projects"],
         },
         {
-            title: "Teams",
-            link: ["/admin/teams"],
+            title: "Organizationss",
+            link: ["/admin/orgs"],
         },
         {
             title: "Blocked Repositories",

--- a/components/dashboard/src/app/AppRoutes.tsx
+++ b/components/dashboard/src/app/AppRoutes.tsx
@@ -26,7 +26,9 @@ import {
     settingsPathPreferences,
     settingsPathTeams,
     settingsPathTeamsJoin,
-    settingsPathTeamsNew,
+    settingsPathOrgs,
+    settingsPathOrgsJoin,
+    settingsPathOrgsNew,
     settingsPathVariables,
     settingsPathSSHKeys,
     usagePathMain,
@@ -198,7 +200,7 @@ export const AppRoutes: FunctionComponent<AppRoutesProps> = ({ user, teams }) =>
                     <Route path="/from-referrer" exact component={FromReferrer} />
 
                     <AdminRoute path="/admin/users" component={UserSearch} />
-                    <AdminRoute path="/admin/teams" component={TeamsSearch} />
+                    <AdminRoute path="/admin/orgs" component={TeamsSearch} />
                     <AdminRoute path="/admin/workspaces" component={WorkspacesSearch} />
                     <AdminRoute path="/admin/projects" component={ProjectsSearch} />
                     <AdminRoute path="/admin/blocked-repositories" component={BlockedRepositories} />
@@ -248,10 +250,14 @@ export const AppRoutes: FunctionComponent<AppRoutesProps> = ({ user, teams }) =>
                             }}
                         />
                     </Route>
+                    {/* TODO remove these navigation after a few weeks */}
                     <Route path={settingsPathTeams}>
-                        <Route exact path={settingsPathTeams} component={Teams} />
-                        <Route exact path={settingsPathTeamsNew} component={NewTeam} />
                         <Route exact path={settingsPathTeamsJoin} component={JoinTeam} />
+                    </Route>
+                    <Route path={settingsPathOrgs}>
+                        <Route exact path={settingsPathOrgs} component={Teams} />
+                        <Route exact path={settingsPathOrgsNew} component={NewTeam} />
+                        <Route exact path={settingsPathOrgsJoin} component={JoinTeam} />
                     </Route>
                     {(teams || []).map((team) => (
                         <Route path={`/t/${team.slug}`} key={team.slug}>

--- a/components/dashboard/src/components/BillingAccountSelector.tsx
+++ b/components/dashboard/src/components/BillingAccountSelector.tsx
@@ -28,7 +28,7 @@ export function BillingAccountSelector(props: { onSelected?: () => void }) {
             return;
         }
 
-        // Fetch the list of teams we can actually attribute to
+        // Fetch the list of orgs we can actually attribute to
         getGitpodService()
             .server.listAvailableUsageAttributionIds()
             .then((attrIds) => {
@@ -59,7 +59,7 @@ export function BillingAccountSelector(props: { onSelected?: () => void }) {
                         (await teamsService.getTeam({ teamId: team!.id })).team?.members || [],
                     );
                 } catch (error) {
-                    console.warn("Could not get members of team", team, error);
+                    console.warn("Could not get members of org", team, error);
                 }
             }),
         ).then(() => setMembersByTeam(members));

--- a/components/dashboard/src/components/UsageBasedBillingConfig.tsx
+++ b/components/dashboard/src/components/UsageBasedBillingConfig.tsx
@@ -170,7 +170,7 @@ export default function UsageBasedBillingConfig({ attributionId }: Props) {
             <h2 className="text-gray-500">
                 {attributionId && AttributionId.parse(attributionId)?.kind === "user"
                     ? "Manage billing for your personal account."
-                    : "Manage billing for your team."}
+                    : "Manage billing for your organization."}
             </h2>
             <div className="max-w-xl flex flex-col">
                 {errorMessage && (

--- a/components/dashboard/src/components/UsageLimitReachedModal.tsx
+++ b/components/dashboard/src/components/UsageLimitReachedModal.tsx
@@ -39,7 +39,7 @@ export function UsageLimitReachedModal(p: { hints: any }) {
                     You have reached the <strong>usage limit</strong> of your billing account.
                 </Alert>
                 <p className="mt-3 text-base text-gray-600 dark:text-gray-300">
-                    {"Contact a team owner "}
+                    {"Contact an organization owner "}
                     {attributedTeamName && (
                         <>
                             of <strong>{attributedTeamName} </strong>

--- a/components/dashboard/src/components/UsageView.tsx
+++ b/components/dashboard/src/components/UsageView.tsx
@@ -174,9 +174,6 @@ function UsageView({ attributionId }: UsageViewProps) {
     };
 
     const currentPaginatedResults = usagePage?.usageEntriesList.filter((u) => u.kind === "workspaceinstance") ?? [];
-
-    const headerTitle = attributionId.kind === "team" ? "Team Usage" : "Personal Usage";
-
     const DateDisplay = forwardRef((arg: any, ref: any) => (
         <div
             className="px-2 py-0.5 text-gray-500 bg-gray-50 dark:text-gray-400 dark:bg-gray-800 rounded-md cursor-pointer flex items-center hover:bg-gray-100 dark:hover:bg-gray-700"
@@ -209,7 +206,7 @@ function UsageView({ attributionId }: UsageViewProps) {
             <Header
                 title={
                     <div className="flex items-baseline">
-                        <h1 className="tracking-tight">{headerTitle}</h1>
+                        <h1 className="tracking-tight">Usage</h1>
                         <h2 className="ml-3">(updated every 15 minutes).</h2>
                     </div>
                 }
@@ -281,7 +278,7 @@ function UsageView({ attributionId }: UsageViewProps) {
                                             {" "}
                                             workspaces
                                         </a>{" "}
-                                        in {startDate.format("MMMM YYYY")} or checked your other teams?
+                                        in {startDate.format("MMMM YYYY")} or checked your other organizations?
                                     </p>
                                 </div>
                             )}

--- a/components/dashboard/src/contexts/FeatureFlagContext.tsx
+++ b/components/dashboard/src/contexts/FeatureFlagContext.tsx
@@ -61,7 +61,7 @@ const FeatureFlagContextProvider: React.FC = ({ children }) => {
 
             for (const [flagName, config] of Object.entries(featureFlags)) {
                 const value = async () => {
-                    // First check if the flag is non-default for any of the teams
+                    // First check if the flag is non-default for any of the orgs
                     for (const team of teams || []) {
                         const flagValue = await getExperimentsClient().getValueAsync(flagName, config.defaultValue, {
                             user,

--- a/components/dashboard/src/hooks/use-user-and-teams-loader.ts
+++ b/components/dashboard/src/hooks/use-user-and-teams-loader.ts
@@ -47,7 +47,7 @@ export const useUserAndTeamsLoader = () => {
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
-    // TODO: Can this check happen when we load the teams rather than a separate effect?
+    // TODO: Can this check happen when we load the orgs rather than a separate effect?
     useEffect(() => {
         if (!teams) {
             return;

--- a/components/dashboard/src/projects/NewProject.tsx
+++ b/components/dashboard/src/projects/NewProject.tsx
@@ -333,7 +333,7 @@ export default function NewProject() {
                 <p className="text-gray-500 text-center text-base">
                     Projects allow you to manage prebuilds and workspaces for your repository.{" "}
                     <a
-                        href="https://www.gitpod.io/docs/teams-and-projects"
+                        href="https://www.gitpod.io/docs/orgs-and-projects"
                         target="_blank"
                         rel="noreferrer"
                         className="gp-link"
@@ -527,23 +527,11 @@ export default function NewProject() {
     };
 
     const renderSelectTeam = () => {
-        const userFullName = user?.fullName || user?.name || "...";
         const teamsToRender = teams || [];
         return (
             <>
-                <p className="mt-2 text-gray-500 text-center text-base">Select team or personal account</p>
+                <p className="mt-2 text-gray-500 text-center text-base">Select organization</p>
                 <div className="mt-14 flex flex-col space-y-2">
-                    <label
-                        key={`user-${userFullName}`}
-                        className={`w-80 px-4 py-3 flex space-x-3 items-center cursor-pointer rounded-xl hover:bg-gray-100 dark:hover:bg-gray-800`}
-                        onClick={() => setSelectedTeamOrUser(user)}
-                    >
-                        <input type="radio" />
-                        <div className="flex-grow overflow-ellipsis truncate flex flex-col">
-                            <span className="font-semibold">{userFullName}</span>
-                            <span className="text-sm text-gray-400">Personal account</span>
-                        </div>
-                    </label>
                     {teamsToRender.map((t) => (
                         <label
                             key={`team-${t.name}`}
@@ -558,7 +546,7 @@ export default function NewProject() {
                                         ? `${teamMembers[t.id].length} member${
                                               teamMembers[t.id].length === 1 ? "" : "s"
                                           }`
-                                        : "Team"}
+                                        : "Organization"}
                                 </span>
                             </div>
                         </label>
@@ -567,7 +555,7 @@ export default function NewProject() {
                         <div className="flex space-x-3 items-center relative">
                             <input type="radio" onChange={() => setShowNewTeam(!showNewTeam)} />
                             <div className="flex-grow overflow-ellipsis truncate flex flex-col">
-                                <span className="font-semibold">Create new team</span>
+                                <span className="font-semibold">Create new organization</span>
                                 <span className="text-sm text-gray-400">Collaborate with others</span>
                             </div>
                             {teamsToRender.length > 0 && (
@@ -624,7 +612,7 @@ export default function NewProject() {
         ) : (
             <>
                 {" "}
-                in team{" "}
+                in organization{" "}
                 <a className="gp-link" href={`/t/${selectedTeamOrUser?.slug}/projects`}>
                     {selectedTeamOrUser?.name}
                 </a>

--- a/components/dashboard/src/projects/ProjectSettings.tsx
+++ b/components/dashboard/src/projects/ProjectSettings.tsx
@@ -141,7 +141,7 @@ export default function () {
                             , first cancel your existing plan.
                         </span>
                         <Link className="mt-2" to={project.teamId ? "../billing" : "/plans"}>
-                            <button>Go to {project.teamId ? "Team" : "Personal"} Billing</button>
+                            <button>Go to {project.teamId ? "Organization" : "Personal"} Billing</button>
                         </Link>
                     </div>
                 </Alert>
@@ -254,7 +254,7 @@ export default function () {
                                 , first cancel your existing plan.
                             </span>
                             <Link className="mt-2" to={project.teamId ? "../billing" : "/plans"}>
-                                <button>Go to {project.teamId ? "Team" : "Personal"} Billing</button>
+                                <button>Go to {project.teamId ? "Organization" : "Personal"} Billing</button>
                             </Link>
                         </div>
                     </Alert>

--- a/components/dashboard/src/projects/RemoveProjectModal.tsx
+++ b/components/dashboard/src/projects/RemoveProjectModal.tsx
@@ -28,7 +28,7 @@ export const RemoveProjectModal: FunctionComponent<RemoveProjectModalProps> = ({
     return (
         <ConfirmationModal
             title="Remove Project"
-            areYouSureText="Are you sure you want to remove this project from this team? Team members will also lose access to this project."
+            areYouSureText="Are you sure you want to remove this project from this organization? Organization members will also lose access to this project."
             children={{
                 name: project?.name ?? "",
                 description: project?.cloneUrl ?? "",

--- a/components/dashboard/src/settings/Plans.tsx
+++ b/components/dashboard/src/settings/Plans.tsx
@@ -109,14 +109,14 @@ export default function () {
                 if (!freeSlot) {
                     setTeamClaimModal({
                         mode: "error",
-                        errorText: "This invitation is no longer valid. Please contact the team owner.",
+                        errorText: "This invitation is no longer valid. Please contact the organization owner.",
                     });
                 } else {
                     setTeamClaimModal({
                         mode: "confirmation",
                         teamId: claimedTeamSubscriptionId,
                         slotId: freeSlot.id,
-                        text: "You are about to claim a seat in a team.",
+                        text: "You are about to claim a seat in an organization.",
                     });
                 }
             });
@@ -722,7 +722,7 @@ export default function () {
                 <div className="mt-4 flex justify-center space-x-3 2xl:space-x-7">{planCards}</div>
                 {assignedTs && userBillingMode?.mode === "chargebee" && !!userBillingMode.teamNames && (
                     <Alert type="info" className="mt-10 mx-auto">
-                        <p>Assigned Team Seats</p>
+                        <p>Assigned Organization Seats</p>
                         <ul>{userBillingMode.teamNames.join(", ")}</ul>
                     </Alert>
                 )}
@@ -805,7 +805,7 @@ export default function () {
                 {!!teamClaimModal && (
                     // TODO: Use title and buttons props
                     <Modal visible={true} onClose={() => setTeamClaimModal(undefined)}>
-                        <h3 className="pb-2">Team Invitation</h3>
+                        <h3 className="pb-2">Organization Invitation</h3>
                         <div className="border-t border-b border-gray-200 dark:border-gray-800 mt-2 -mx-6 px-6 py-4">
                             <p className="pb-4 text-gray-500 text-base">
                                 {teamClaimModal.mode === "error" ? teamClaimModal.errorText : teamClaimModal.text}
@@ -925,7 +925,7 @@ function PlanCard(p: PlanCardProps) {
             <div className="relative w-full">
                 {p.isTsAssigned && (
                     <div className="absolute w-full mt-5 text-center font-semibold cursor-default">
-                        Team seat assigned
+                        Organization seat assigned
                     </div>
                 )}
                 <div className="absolute w-full mt-5 text-center font-semibold cursor-default">{p.bottomLabel}</div>

--- a/components/dashboard/src/settings/Teams.tsx
+++ b/components/dashboard/src/settings/Teams.tsx
@@ -29,8 +29,8 @@ export default function Teams() {
     return (
         <div>
             <PageWithSettingsSubMenu
-                title="Team Plans"
-                subtitle="View and manage subscriptions for your team with one centralized billing."
+                title="Organization Plans"
+                subtitle="View and manage subscriptions for your organization with one centralized billing."
             >
                 <AllTeams />
             </PageWithSettingsSubMenu>
@@ -469,8 +469,8 @@ function AllTeams() {
             )}
             <div className="flex flex-row">
                 <div className="flex-grow ">
-                    <h3 className="self-center">All Team Plans</h3>
-                    <h2>Manage team plans and team members.</h2>
+                    <h3 className="self-center">All Organization Plans</h3>
+                    <h2>Manage organization plans and organization members.</h2>
                 </div>
                 <div className="flex flex-end space-x-3">
                     {isChargebeeCustomer && (
@@ -488,7 +488,7 @@ function AllTeams() {
                             }
                             onClick={() => showCreateTeamModal()}
                         >
-                            Create Team Plan
+                            Create Organization Plan
                         </button>
                     )}
                 </div>
@@ -520,12 +520,14 @@ function AllTeams() {
             {getActiveSubs().length === 0 && !pendingPlanPurchase && !isUsageBasedBillingEnabled && (
                 <div className="w-full flex h-80 mt-2 rounded-xl bg-gray-100 dark:bg-gray-900">
                     <div className="m-auto text-center">
-                        <h3 className="self-center text-gray-500 dark:text-gray-400 mb-4">No Active Team Plans</h3>
+                        <h3 className="self-center text-gray-500 dark:text-gray-400 mb-4">
+                            No Active Organization Plans
+                        </h3>
                         <div className="text-gray-500 mb-6">
-                            Get started by creating a team plan
-                            <br /> and adding team members.{" "}
+                            Get started by creating an organization plan
+                            <br /> and adding members.{" "}
                             <a
-                                href="https://www.gitpod.io/docs/teams/"
+                                href="https://www.gitpod.io/docs/orgs/"
                                 target="_blank"
                                 rel="noopener noreferrer"
                                 className="gp-link"
@@ -534,7 +536,7 @@ function AllTeams() {
                             </a>
                         </div>
                         <button className="self-center" onClick={() => showCreateTeamModal()}>
-                            Create Team Plan
+                            Create Organization Plan
                         </button>
                     </div>
                 </div>
@@ -651,7 +653,7 @@ function InviteMembersModal(props: { sub: TeamSubscription; onClose: () => void 
         <Modal visible={true} onClose={props.onClose}>
             <h3 className="pb-2">Invite Members</h3>
             <div className="border-t border-b border-gray-200 dark:border-gray-800 mt-2 -mx-6 px-6 py-4 space-y-2">
-                <p className="pb-2 text-gray-500 text-base">Invite members to the team plan using the URL below.</p>
+                <p className="pb-2 text-gray-500 text-base">Invite members to the plan using the URL below.</p>
 
                 <div className="flex flex-col space-y-2">
                     <label htmlFor="inviteUrl" className="font-medium">
@@ -671,7 +673,7 @@ function InviteMembersModal(props: { sub: TeamSubscription; onClose: () => void 
                         </div>
                     </div>
                     <p className="pb-4 text-gray-500 text-sm">
-                        {copied ? "Copied to clipboard!" : "Use this URL to join this team plan."}
+                        {copied ? "Copied to clipboard!" : "Use this URL to join this plan."}
                     </p>
                 </div>
             </div>
@@ -710,7 +712,7 @@ function AddMembersModal(props: {
         <Modal visible={true} onClose={props.onClose}>
             <h3 className="pb-2">Add Members</h3>
             <div className="border-t border-b border-gray-200 dark:border-gray-800 mt-2 -mx-6 px-6 py-4">
-                <p className="pb-4 text-gray-500 text-base">Select the number of members to add to the team plan.</p>
+                <p className="pb-4 text-gray-500 text-base">Select the number of members to add to the plan.</p>
 
                 <div className="flex flex-col space-y-2 pb-4">
                     <label htmlFor="quantity" className="font-medium">
@@ -774,13 +776,13 @@ function NewTeamModal(props: {
     return (
         // TODO: Use title and buttons props
         <Modal visible={true} onClose={props.onClose}>
-            <h3 className="pb-2">New Team Plan</h3>
+            <h3 className="pb-2">New Organization Plan</h3>
             <div className="border-t border-b border-gray-200 dark:border-gray-800 mt-2 -mx-6 px-6 py-4 space-y-2">
-                <p className="pb-4 text-gray-500 text-base">Create a team plan and add team members.</p>
+                <p className="pb-4 text-gray-500 text-base">Create a plan and add members.</p>
 
                 <div className="flex flex-col space-y-2">
                     <label htmlFor="type" className="font-medium">
-                        Team
+                        Plan
                     </label>
                     <select
                         name="type"
@@ -856,7 +858,7 @@ function ManageTeamModal(props: { slots: Slot[]; slotInputHandler: SlotInputHand
     return (
         // TODO: Use title and buttons props
         <Modal visible={true} onClose={props.onClose}>
-            <h3 className="pb-2">Manage Team</h3>
+            <h3 className="pb-2">Manage Plan</h3>
             <div className="border-t border-b border-gray-200 dark:border-gray-800 mt-2 -mx-6 px-6 py-4 space-y-2">
                 <p className="pb-4 text-gray-500 text-base">
                     Add members using their username prefixed by the Git Provider's host.

--- a/components/dashboard/src/settings/settings-menu.ts
+++ b/components/dashboard/src/settings/settings-menu.ts
@@ -13,7 +13,7 @@ import {
     settingsPathNotifications,
     settingsPathPlans,
     settingsPathPreferences,
-    settingsPathTeams,
+    settingsPathOrgs,
     settingsPathVariables,
     settingsPathSSHKeys,
     settingsPathPersonalAccessTokens,
@@ -80,8 +80,8 @@ function renderBillingMenuEntries(billingMode?: BillingMode) {
                     link: [settingsPathPlans],
                 },
                 {
-                    title: "Team Plans",
-                    link: [settingsPathTeams],
+                    title: "Organization Plans",
+                    link: [settingsPathOrgs],
                 },
                 ...(BillingMode.showUsageBasedBilling(billingMode)
                     ? [
@@ -98,12 +98,12 @@ function renderBillingMenuEntries(billingMode?: BillingMode) {
                     title: "Billing",
                     link: [settingsPathBilling],
                 },
-                // We need to allow access to "Team Plans" here, at least for owners.
+                // We need to allow access to "Organization Plans" here, at least for owners.
                 ...(BillingMode.showTeamSubscriptionUI(billingMode)
                     ? [
                           {
-                              title: "Team Plans",
-                              link: [settingsPathTeams],
+                              title: "Organization Plans",
+                              link: [settingsPathOrgs],
                           },
                       ]
                     : []),

--- a/components/dashboard/src/settings/settings.routes.ts
+++ b/components/dashboard/src/settings/settings.routes.ts
@@ -14,9 +14,17 @@ export const settingsPathBilling = "/billing";
 export const settingsPathPlans = "/plans";
 export const settingsPathPreferences = "/preferences";
 
+/**
+ * @deprecated use settingsPathOrgs instead
+ * we keep this for some time to not break links
+ */
 export const settingsPathTeams = "/teams";
 export const settingsPathTeamsJoin = [settingsPathTeams, "join"].join("/");
 export const settingsPathTeamsNew = [settingsPathTeams, "new"].join("/");
+
+export const settingsPathOrgs = "/orgs";
+export const settingsPathOrgsJoin = [settingsPathOrgs, "join"].join("/");
+export const settingsPathOrgsNew = [settingsPathOrgs, "new"].join("/");
 
 export const settingsPathVariables = "/variables";
 export const settingsPathPersonalAccessTokens = "/tokens";

--- a/components/dashboard/src/start/CreateWorkspace.tsx
+++ b/components/dashboard/src/start/CreateWorkspace.tsx
@@ -330,7 +330,7 @@ export default class CreateWorkspace extends React.Component<CreateWorkspaceProp
 function SelectCostCenterModal(props: { onSelected?: () => void }) {
     return (
         <Modal visible={true} closeable={false} onClose={() => {}}>
-            <h3>Choose Billing Team</h3>
+            <h3>Choose Billing Organization</h3>
             <BillingAccountSelector onSelected={props.onSelected} />
         </Modal>
     );

--- a/components/dashboard/src/teams/JoinTeam.tsx
+++ b/components/dashboard/src/teams/JoinTeam.tsx
@@ -37,7 +37,7 @@ export default function () {
     }, []);
 
     useEffect(() => {
-        document.title = "Joining Team — Gitpod";
+        document.title = "Joining Organization — Gitpod";
     }, []);
 
     return joinError ? <div className="mt-16 text-center text-gitpod-red">{String(joinError)}</div> : <></>;

--- a/components/dashboard/src/teams/Members.tsx
+++ b/components/dashboard/src/teams/Members.tsx
@@ -58,7 +58,7 @@ export default function () {
 
     const getInviteURL = (inviteId: string) => {
         const link = new URL(window.location.href);
-        link.pathname = "/teams/join";
+        link.pathname = "/orgs/join";
         link.search = "?inviteId=" + inviteId;
         return link.href;
     };
@@ -131,7 +131,7 @@ export default function () {
 
     return (
         <>
-            <Header title="Members" subtitle="Manage team members." />
+            <Header title="Members" subtitle="Manage organization members." />
             <div className="app-container">
                 <div className="flex mt-8">
                     <div className="flex">
@@ -264,7 +264,9 @@ export default function () {
                                             m.userId === user?.id
                                                 ? [
                                                       {
-                                                          title: leaveTeamEnabled ? "Leave Team" : "Remaining owner",
+                                                          title: leaveTeamEnabled
+                                                              ? "Leave Organization"
+                                                              : "Remaining owner",
                                                           customFontStyle: leaveTeamEnabled
                                                               ? "text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-300"
                                                               : "text-gray-400 dark:text-gray-200",
@@ -317,7 +319,9 @@ export default function () {
                                 </div>
                             </div>
                         </div>
-                        <p className="mt-1 text-gray-500 text-sm">Use this URL to join this team as a Member.</p>
+                        <p className="mt-1 text-gray-500 text-sm">
+                            Use this URL to join this organization as a member.
+                        </p>
                     </div>
                     <div className="flex justify-end mt-6 space-x-2">
                         <button className="secondary" onClick={() => resetInviteLink()}>

--- a/components/dashboard/src/teams/NewTeam.tsx
+++ b/components/dashboard/src/teams/NewTeam.tsx
@@ -38,15 +38,15 @@ export default function () {
     };
 
     useEffect(() => {
-        document.title = "New Team — Gitpod";
+        document.title = "New Organization — Gitpod";
     }, []);
 
     return (
         <div className="flex flex-col w-96 mt-24 mx-auto items-center">
-            <h1>New Team</h1>
+            <h1>New&nbsp;Organization</h1>
             <p className="text-gray-500 text-center text-base">
                 <a href="https://www.gitpod.io/docs/configure/teams" className="gp-link">
-                    Teams
+                    Organizations
                 </a>{" "}
                 allow you to manage related{" "}
                 <a href="https://www.gitpod.io/docs/configure/projects" className="gp-link">
@@ -54,12 +54,12 @@ export default function () {
                 </a>{" "}
                 and collaborate with other members.
             </p>
-            <form className="mt-16 w-full" onSubmit={createTeam}>
+            <form className="mt-16" onSubmit={createTeam}>
                 <div className="rounded-xl p-6 bg-gray-50 dark:bg-gray-800">
-                    <h3 className="text-left text-lg">You're creating a new team</h3>
-                    <p className="text-gray-500">After creating a team, you can invite others to join.</p>
+                    <h3 className="text-left text-lg">You're creating a new organization</h3>
+                    <p className="text-gray-500">After creating an organization, you can invite others to join.</p>
                     <br />
-                    <h4>Team Name</h4>
+                    <h4>Organization Name</h4>
                     <input
                         autoFocus
                         className={`w-full${!!creationError ? " error" : ""}`}
@@ -73,7 +73,7 @@ export default function () {
                     )}
                 </div>
                 <div className="flex flex-row-reverse space-x-2 space-x-reverse mt-2">
-                    <button type="submit">Create Team</button>
+                    <button type="submit">Create Organization</button>
                     <button className="secondary" onClick={() => history.push("/")}>
                         Cancel
                     </button>

--- a/components/dashboard/src/teams/TeamBilling.tsx
+++ b/components/dashboard/src/teams/TeamBilling.tsx
@@ -190,7 +190,7 @@ export default function TeamBilling() {
                         2023.
                     </Alert>
                 )}
-                <h3>{!teamPlan ? "Select Team Plan" : "Team Plan"}</h3>
+                <h3>{!teamPlan ? "Select Plan" : "Current Plan"}</h3>
                 <h2 className="text-gray-500">
                     {!teamPlan ? (
                         <div className="flex space-x-1">
@@ -213,7 +213,7 @@ export default function TeamBilling() {
                         </div>
                     ) : (
                         <span>
-                            This team is currently on the <strong>{teamPlan.name}</strong> plan.
+                            This organization is currently on the <strong>{teamPlan.name}</strong> plan.
                         </span>
                     )}
                 </h2>
@@ -335,7 +335,7 @@ export default function TeamBilling() {
                     )}
                 </div>
                 <div className="mt-4 text-gray-500">
-                    Team Billing automatically adds all members to the plan.{" "}
+                    Gitpod automatically adds all members of this organization to the plan.{" "}
                     <a href="https://www.gitpod.io/docs/team-billing" rel="noopener" className="gp-link">
                         Learn more
                     </a>
@@ -349,7 +349,7 @@ export default function TeamBilling() {
         <PageWithSubMenu
             subMenu={getTeamSettingsMenu({ team, billingMode: teamBillingMode, ssoEnabled: oidcServiceEnabled })}
             title="Billing"
-            subtitle="Configure and manage billing for your team."
+            subtitle="Configure and manage billing for your organization."
         >
             {teamBillingMode === undefined ? (
                 <div className="p-20">

--- a/components/dashboard/src/teams/TeamSettings.tsx
+++ b/components/dashboard/src/teams/TeamSettings.tsx
@@ -84,7 +84,7 @@ export default function TeamSettings() {
             setUpdated(true);
             setTimeout(() => setUpdated(false), 3000);
         } catch (error) {
-            setErrorMessage(`Failed to update team information: ${error.message}`);
+            setErrorMessage(`Failed to update organization information: ${error.message}`);
         }
     }, [team, errorMessage, teams, teamName, setTeams]);
 
@@ -96,10 +96,10 @@ export default function TeamSettings() {
             const newName = event.target.value || "";
             setTeamName(newName);
             if (newName.trim().length === 0) {
-                setErrorMessage("Team name can not be blank.");
+                setErrorMessage("Organization name can not be blank.");
                 return;
             } else if (newName.trim().length > 32) {
-                setErrorMessage("Team name must not be longer than 32 characters.");
+                setErrorMessage("Organization name must not be longer than 32 characters.");
                 return;
             } else {
                 setErrorMessage(undefined);
@@ -127,11 +127,11 @@ export default function TeamSettings() {
             <PageWithSubMenu
                 subMenu={getTeamSettingsMenu({ team, billingMode, ssoEnabled: oidcServiceEnabled })}
                 title="Settings"
-                subtitle="Manage general team settings."
+                subtitle="Manage general organization settings."
             >
-                <h3>Team Name</h3>
+                <h3>Organization Name</h3>
                 <p className="text-base text-gray-500 max-w-2xl">
-                    This is your team's visible name within Gitpod. For example, the name of your company.
+                    This is your organization's visible name within Gitpod. For example, the name of your company.
                 </p>
                 {errorMessage && (
                     <Alert type="error" closable={true} className="mb-2 max-w-xl rounded-md">
@@ -140,7 +140,7 @@ export default function TeamSettings() {
                 )}
                 {updated && (
                     <Alert type="message" closable={true} className="mb-2 max-w-xl rounded-md">
-                        Team name has been updated.
+                        Organization name has been updated.
                     </Alert>
                 )}
                 <div className="flex flex-col lg:flex-row">
@@ -157,17 +157,17 @@ export default function TeamSettings() {
                         disabled={team?.name === teamName || !!errorMessage}
                         onClick={updateTeamInformation}
                     >
-                        Update Team Name
+                        Update Organization Name
                     </button>
                 </div>
 
-                <h3 className="pt-12">Delete Team</h3>
+                <h3 className="pt-12">Delete Organization</h3>
                 <p className="text-base text-gray-500 pb-4 max-w-2xl">
-                    Deleting this team will also remove all associated data with this team, including projects and
-                    workspaces. Deleted teams cannot be restored!
+                    Deleting this organization will also remove all associated data, including projects and workspaces.
+                    Deleted organizations cannot be restored!
                 </p>
                 <button className="danger secondary" onClick={() => setModal(true)}>
-                    Delete Team
+                    Delete Organization
                 </button>
             </PageWithSubMenu>
 
@@ -182,16 +182,16 @@ export default function TeamSettings() {
                 onConfirm={deleteTeam}
             >
                 <p className="text-base text-gray-500">
-                    You are about to permanently delete <b>{team?.slug}</b> including all associated data with this
-                    team.
+                    You are about to permanently delete <b>{team?.slug}</b> including all associated data.
                 </p>
                 <ol className="text-gray-500 text-m list-outside list-decimal">
                     <li className="ml-5">
-                        All <b>projects</b> added in this team will be deleted and cannot be restored afterwards.
+                        All <b>projects</b> added in this organization will be deleted and cannot be restored
+                        afterwards.
                     </li>
                     <li className="ml-5">
-                        All <b>members</b> of this team will lose access to this team, associated projects and
-                        workspaces.
+                        All <b>members</b> of this organization will lose access to this organization, associated
+                        projects and workspaces.
                     </li>
                 </ol>
                 <p className="pt-4 pb-2 text-gray-600 dark:text-gray-400 text-base font-semibold">

--- a/components/dashboard/src/teams/TeamUsageBasedBilling.tsx
+++ b/components/dashboard/src/teams/TeamUsageBasedBilling.tsx
@@ -33,7 +33,7 @@ export default function TeamUsageBasedBilling() {
 
     return (
         <>
-            <h3>Team Billing</h3>
+            <h3>Organization Billing</h3>
             <UsageBasedBillingConfig attributionId={team && AttributionId.render({ kind: "team", teamId: team.id })} />
         </>
     );

--- a/components/gitpod-db/src/typeorm/team-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/team-db-impl.ts
@@ -126,11 +126,11 @@ export class TeamDBImpl implements TeamDB {
         const teamRepo = await this.getTeamRepo();
         const existingTeam = await teamRepo.findOne({ id: teamId, deleted: false, markedDeleted: false });
         if (!existingTeam) {
-            throw new ResponseError(ErrorCodes.NOT_FOUND, "Team not found");
+            throw new ResponseError(ErrorCodes.NOT_FOUND, "Organization not found");
         }
         const name = team.name && team.name.trim();
         if (!name || name.length === 0 || name.length > 32) {
-            throw new ResponseError(ErrorCodes.INVALID_VALUE, "A team's name must be between 1 and 32 characters long");
+            throw new ResponseError(ErrorCodes.INVALID_VALUE, "The name must be between 1 and 32 characters long");
         }
         existingTeam.name = name;
         return teamRepo.save(existingTeam);
@@ -138,22 +138,22 @@ export class TeamDBImpl implements TeamDB {
 
     public async createTeam(userId: string, name: string): Promise<Team> {
         if (!name) {
-            throw new ResponseError(ErrorCodes.BAD_REQUEST, "Team name cannot be empty");
+            throw new ResponseError(ErrorCodes.BAD_REQUEST, "Name cannot be empty");
         }
         if (!/^[A-Za-z0-9 '_-]+$/.test(name)) {
             throw new ResponseError(
                 ErrorCodes.BAD_REQUEST,
-                "Please choose a team name containing only letters, numbers, -, _, ', or spaces.",
+                "Please choose a name containing only letters, numbers, -, _, ', or spaces.",
             );
         }
         const slug = name.toLocaleLowerCase().replace(/[ ']/g, "-");
         if (blocklist.indexOf(slug) !== -1) {
-            throw new ResponseError(ErrorCodes.BAD_REQUEST, "Creating a team with this name is not allowed");
+            throw new ResponseError(ErrorCodes.BAD_REQUEST, "Creating an organization with this name is not allowed");
         }
         const teamRepo = await this.getTeamRepo();
         const existingTeam = await teamRepo.findOne({ slug, deleted: false, markedDeleted: false });
         if (!!existingTeam) {
-            throw new ResponseError(ErrorCodes.CONFLICT, "A team with this name already exists");
+            throw new ResponseError(ErrorCodes.CONFLICT, "An organization with this name already exists");
         }
         const team: Team = {
             id: uuidv4(),
@@ -186,7 +186,7 @@ export class TeamDBImpl implements TeamDB {
         const teamRepo = await this.getTeamRepo();
         const team = await teamRepo.findOne(teamId);
         if (!team || !!team.deleted) {
-            throw new ResponseError(ErrorCodes.NOT_FOUND, "A team with this ID could not be found");
+            throw new ResponseError(ErrorCodes.NOT_FOUND, "An organization with this ID could not be found");
         }
         const membershipRepo = await this.getMembershipRepo();
         const membership = await membershipRepo.findOne({ teamId, userId, deleted: false });
@@ -208,7 +208,7 @@ export class TeamDBImpl implements TeamDB {
         const teamRepo = await this.getTeamRepo();
         const team = await teamRepo.findOne(teamId);
         if (!team || !!team.deleted) {
-            throw new ResponseError(ErrorCodes.NOT_FOUND, "A team with this ID could not be found");
+            throw new ResponseError(ErrorCodes.NOT_FOUND, "An organization with this ID could not be found");
         }
         const membershipRepo = await this.getMembershipRepo();
 
@@ -219,13 +219,13 @@ export class TeamDBImpl implements TeamDB {
                 deleted: false,
             });
             if (ownerCount <= 1) {
-                throw new ResponseError(ErrorCodes.CONFLICT, "Team must retain at least one owner");
+                throw new ResponseError(ErrorCodes.CONFLICT, "An organization must retain at least one owner");
             }
         }
 
         const membership = await membershipRepo.findOne({ teamId, userId, deleted: false });
         if (!membership) {
-            throw new ResponseError(ErrorCodes.NOT_FOUND, "The user is not currently a member of this team");
+            throw new ResponseError(ErrorCodes.NOT_FOUND, "The user is not currently a member of this organization");
         }
         membership.role = role;
         await membershipRepo.save(membership);
@@ -235,12 +235,12 @@ export class TeamDBImpl implements TeamDB {
         const teamRepo = await this.getTeamRepo();
         const team = await teamRepo.findOne(teamId);
         if (!team || !!team.deleted) {
-            throw new ResponseError(ErrorCodes.NOT_FOUND, "A team with this ID could not be found");
+            throw new ResponseError(ErrorCodes.NOT_FOUND, "An organization with this ID could not be found");
         }
         const membershipRepo = await this.getMembershipRepo();
         const membership = await membershipRepo.findOne({ teamId, userId, deleted: false });
         if (!membership) {
-            throw new ResponseError(ErrorCodes.NOT_FOUND, "The user is not currently a member of this team");
+            throw new ResponseError(ErrorCodes.NOT_FOUND, "The user is not currently a member of this organization");
         }
         membership.subscriptionId = subscriptionId;
         await membershipRepo.save(membership);
@@ -250,12 +250,15 @@ export class TeamDBImpl implements TeamDB {
         const teamRepo = await this.getTeamRepo();
         const team = await teamRepo.findOne(teamId);
         if (!team || !!team.deleted) {
-            throw new ResponseError(ErrorCodes.NOT_FOUND, "A team with this ID could not be found");
+            throw new ResponseError(ErrorCodes.NOT_FOUND, "An organization with this ID could not be found");
         }
         const membershipRepo = await this.getMembershipRepo();
         const membership = await membershipRepo.findOne({ teamId, userId, deleted: false });
         if (!membership) {
-            throw new ResponseError(ErrorCodes.BAD_REQUEST, "You are not currently a member of this team");
+            throw new ResponseError(
+                ErrorCodes.BAD_REQUEST,
+                "The given user is not currently a member of this organization or does not exist.",
+            );
         }
         membership.deleted = true;
         await membershipRepo.save(membership);

--- a/components/server/src/user/user-controller.ts
+++ b/components/server/src/user/user-controller.ts
@@ -162,7 +162,7 @@ export class UserController {
                 });
 
                 // Simply redirect to the app for now
-                res.redirect("/teams/new", 307);
+                res.redirect("/orgs/new", 307);
             }, BUILTIN_INSTLLATION_ADMIN_USER_ID),
         );
         router.get(

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -2030,7 +2030,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
     protected async guardTeamOperation(teamId: string | undefined, op: ResourceAccessOp): Promise<Team> {
         const team = await this.teamDB.findTeamById(teamId || "");
         if (!team) {
-            throw new ResponseError(ErrorCodes.NOT_FOUND, "Team not found");
+            throw new ResponseError(ErrorCodes.NOT_FOUND, "Organization not found");
         }
         const members = await this.teamDB.findMembersByTeam(team.id);
         await this.guardAccess({ kind: "team", subject: team, members }, op);
@@ -2047,7 +2047,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         traceAPIParams(ctx, { teamId });
 
         if (!uuidValidate(teamId)) {
-            throw new ResponseError(ErrorCodes.BAD_REQUEST, "team ID must be a valid UUID");
+            throw new ResponseError(ErrorCodes.BAD_REQUEST, "organization ID must be a valid UUID");
         }
 
         this.checkAndBlockUser("getTeam");
@@ -2064,12 +2064,12 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         traceAPIParams(ctx, { teamId });
 
         if (!teamId || !uuidValidate(teamId)) {
-            throw new ResponseError(ErrorCodes.BAD_REQUEST, "team ID must be a valid UUID");
+            throw new ResponseError(ErrorCodes.BAD_REQUEST, "organization ID must be a valid UUID");
         }
         this.checkUser("updateTeam");
         const existingTeam = await this.teamDB.findTeamById(teamId);
         if (!existingTeam) {
-            throw new ResponseError(ErrorCodes.NOT_FOUND, `Team ${teamId} does not exist`);
+            throw new ResponseError(ErrorCodes.NOT_FOUND, `Organization ${teamId} does not exist`);
         }
         const members = await this.teamDB.findMembersByTeam(teamId);
         await this.guardAccess({ kind: "team", subject: existingTeam, members }, "update");
@@ -2082,7 +2082,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         traceAPIParams(ctx, { teamId });
 
         if (!uuidValidate(teamId)) {
-            throw new ResponseError(ErrorCodes.BAD_REQUEST, "team ID must be a valid UUID");
+            throw new ResponseError(ErrorCodes.BAD_REQUEST, "organization ID must be a valid UUID");
         }
 
         this.checkUser("getTeamMembers");
@@ -2152,7 +2152,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         traceAPIParams(ctx, { teamId, userId, role });
 
         if (!uuidValidate(teamId)) {
-            throw new ResponseError(ErrorCodes.BAD_REQUEST, "team ID must be a valid UUID");
+            throw new ResponseError(ErrorCodes.BAD_REQUEST, "organization ID must be a valid UUID");
         }
 
         if (!uuidValidate(userId)) {
@@ -2172,7 +2172,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         traceAPIParams(ctx, { teamId, userId });
 
         if (!uuidValidate(teamId)) {
-            throw new ResponseError(ErrorCodes.BAD_REQUEST, "team ID must be a valid UUID");
+            throw new ResponseError(ErrorCodes.BAD_REQUEST, "organization ID must be a valid UUID");
         }
 
         if (!uuidValidate(userId)) {
@@ -2184,7 +2184,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         await this.guardTeamOperation(teamId, user.id === userId ? "get" : "update");
         const membership = await this.teamDB.findTeamMembership(userId, teamId);
         if (!membership) {
-            throw new Error(`Could not find membership for user '${userId}' in team '${teamId}'`);
+            throw new Error(`Could not find membership for user '${userId}' in organization '${teamId}'`);
         }
         await this.teamDB.removeMemberFromTeam(userId, teamId);
         await this.onTeamMemberRemoved(userId, teamId, membership.id);
@@ -2202,7 +2202,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         traceAPIParams(ctx, { teamId });
 
         if (!uuidValidate(teamId)) {
-            throw new ResponseError(ErrorCodes.BAD_REQUEST, "team ID must be a valid UUID");
+            throw new ResponseError(ErrorCodes.BAD_REQUEST, "organization ID must be a valid UUID");
         }
 
         this.checkUser("getGenericInvite");
@@ -2218,7 +2218,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         traceAPIParams(ctx, { teamId });
 
         if (!uuidValidate(teamId)) {
-            throw new ResponseError(ErrorCodes.BAD_REQUEST, "team ID must be a valid UUID");
+            throw new ResponseError(ErrorCodes.BAD_REQUEST, "organization ID must be a valid UUID");
         }
 
         this.checkAndBlockUser("resetGenericInvite");


### PR DESCRIPTION
## Description
Renames all user visible occurences of the term team to organization

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
check the UI and verify that we are talking about organizations everywhere.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
teams are now called organizations
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

TODO

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-payment
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
