### PR TITLE
Build previewctl using GitHub actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,13 +2,14 @@ name: Build
 on:
   pull_request:
     types: [opened, synchronize, edited]
+  push:
+    branches: [main]
 
 jobs:
 
   configuration:
     name: Configure job parameters
     runs-on: [self-hosted]
-    if: ${{ contains(github.event.pull_request.body, '[x] /werft with-github-actions') }}
     concurrency:
       group: ${{ github.head_ref || github.ref }}-configuration
       cancel-in-progress: true
@@ -16,6 +17,7 @@ jobs:
       version: ${{ steps.output.outputs.version }}
       preview_enable: ${{ steps.output.outputs.preview_enable }}
       preview_infra_provider: ${{ steps.output.outputs.preview_infra_provider }}
+      build_enable: ${{ steps.output.outputs.build_enable }}
       build_no_cache: ${{ steps.output.outputs.build_no_cache }}
       build_no_test: ${{ steps.output.outputs.build_no_test }}
       build_leeway_target: ${{ steps.output.outputs.build_leeway_target }}
@@ -33,6 +35,7 @@ jobs:
             echo "version=${{ steps.branches.outputs.sanitized-branch-name }}.${{github.run_number}}"
             echo "preview_enable=${{ contains(github.event.pull_request.body, '[x] /werft with-preview') }}"
             echo "preview_infra_provider=${{ contains(github.event.pull_request.body, '[X] /werft with-gce-vm') && 'gce' || 'harvester' }}"
+            echo "build_enable=${{ contains(github.event.pull_request.body, '[x] /werft with-github-actions') }}"
             echo "build_no_cache=${{ contains(github.event.pull_request.body, '[x] leeway-no-cache') }}"
             echo "build_no_test=${{ contains(github.event.pull_request.body, '[x] /werft no-test') }}"
             echo "build_leeway_target=$(echo "$PR_DESC" | sed -n -e 's/^.*leeway-target=//p' | sed 's/\r$//')"
@@ -51,7 +54,7 @@ jobs:
       previewctl_hash: ${{ steps.build.outputs.previewctl_hash }}
     steps:
       - uses: actions/checkout@v3
-      - name: Build dev:all
+      - name: Build previewctl
         id: build
         shell: bash
         env:
@@ -87,6 +90,7 @@ jobs:
   build-gitpod:
     name: Build Gitpod
     needs: [configuration]
+    if: ${{ needs.configuration.outputs.build_enable }}
     runs-on: [self-hosted]
     concurrency:
       group: ${{ github.head_ref || github.ref }}-build-gitpod


### PR DESCRIPTION
## Description

This changes the GitHub Actions build so that it is triggered on pushes to main too. It will only build previewctl however, and not Gitpod. This is needed to make the previewctl Docker image available. I could have added it to the Werft build but I'd rather move ahead with GH actions and this is a good way to start sending a bit of load to the self-hosted runners.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

No specific issue

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
