### PR TITLE
Fix delete-preview action

### DIFF
--- a/.github/actions/delete-preview/entrypoint.sh
+++ b/.github/actions/delete-preview/entrypoint.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 
 export HOME=/home/gitpod
 export PREVIEW_ENV_DEV_SA_KEY_PATH="$HOME/.config/gcloud/preview-environment-dev-sa.json"
+# shellcheck disable=SC2155
+export LEEWAY_WORKSPACE_ROOT="$(pwd)"
 export PATH="$PATH:$HOME/bin"
 
 mkdir $HOME/bin

--- a/dev/preview/previewctl/BUILD.yaml
+++ b/dev/preview/previewctl/BUILD.yaml
@@ -16,6 +16,7 @@ packages:
     deps:
       - :cli
     argdeps:
+      - version
       - imageRepoBase
     config:
       dockerfile: leeway.Dockerfile


### PR DESCRIPTION
## Description

Fixes minor regression in the delete-preview action. See error [here](https://github.com/gitpod-io/gitpod/actions/runs/4015673449/jobs/6897686910). Depends on https://github.com/gitpod-io/gitpod/pull/16051 so that we start publishing the previewctl image from main.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
No issue

## How to test
<!-- Provide steps to test this PR -->

Triggered a job manually [here](https://github.com/gitpod-io/gitpod/actions/runs/4016198016/jobs/6898894723) after having run `leeway build dev/preview/previewctl:docker -Dversion=main.1063` manually.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
