### PR TITLE
Outputs are strings so we have to check explicitly

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
 
   infrastructure:
     needs: [configuration, build-previewctl]
-    if: ${{ needs.configuration.outputs.preview_enable }}
+    if: ${{ needs.configuration.outputs.preview_enable == 'true' }}
     runs-on: [self-hosted]
     concurrency:
       group: ${{ github.head_ref || github.ref }}-infrastructure
@@ -90,7 +90,7 @@ jobs:
   build-gitpod:
     name: Build Gitpod
     needs: [configuration]
-    if: ${{ needs.configuration.outputs.build_enable }}
+    if: ${{ needs.configuration.outputs.build_enable == 'true' }}
     runs-on: [self-hosted]
     concurrency:
       group: ${{ github.head_ref || github.ref }}-build-gitpod


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Outputs are strings so we have to check explicitly. Previously the outputs would be "false" which is a non-empty string so it evaluates to true. See this job from main [here](https://github.com/gitpod-io/gitpod/actions/runs/4015920217/jobs/6898269981). The screenshots show the output values and that it decided to run the guarded jobs anyway.

![Screenshot 2023-01-26 at 15 19 15](https://user-images.githubusercontent.com/83561/214859401-b75a58a9-6787-4036-9df6-47dc924621a2.png)


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
N/A

## How to test
<!-- Provide steps to test this PR -->

I enabled GH on this PR but didn't enable preview, so it should be skipped.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [x] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
