### PR TITLE
[papi] Add signing secret for JWTs

### DIFF
--- a/.werft/jobs/build/public-api/jwt-signing-key.yaml
+++ b/.werft/jobs/build/public-api/jwt-signing-key.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+data:
+  jwt-signing-key: and0LWtleS1mb3ItcHJldmlldy1lbnZzCg==
+kind: Secret
+metadata:
+  name: jwt-signing-key
+  namespace: default
+type: Opaque

--- a/components/public-api-server/pkg/server/server.go
+++ b/components/public-api-server/pkg/server/server.go
@@ -75,6 +75,15 @@ func Start(logger *logrus.Entry, version string, cfg *config.Configuration) erro
 		}
 	}
 
+	if cfg.JWTSigningSecretPath != "" {
+		_, err := readSecretFromFile(cfg.JWTSigningSecretPath)
+		if err != nil {
+			return fmt.Errorf("failed to read JWT signing secret: %w", err)
+		}
+	} else {
+		log.Info("No JWT signing secret is configured.")
+	}
+
 	var stripeWebhookHandler http.Handler = webhooks.NewNoopWebhookHandler()
 	if cfg.StripeWebhookSigningSecretPath != "" {
 		stripeWebhookSecret, err := readSecretFromFile(cfg.StripeWebhookSigningSecretPath)

--- a/components/public-api/go/config/config.go
+++ b/components/public-api/go/config/config.go
@@ -17,6 +17,9 @@ type Configuration struct {
 	// StripeWebhookSigningSecretPath is a filepath to a secret used to validate incoming webhooks from Stripe
 	StripeWebhookSigningSecretPath string `json:"stripeWebhookSigningSecretPath"`
 
+	// JWTSigningSecretPath is a filepath to a secret used to sign and validate JWTs used for OIDC flows
+	JWTSigningSecretPath string `json:"jwtSigningSecretPath"`
+
 	// Path to file which contains personal access token singing key
 	PersonalAccessTokenSigningKeyPath string `json:"personalAccessTokenSigningKeyPath"`
 

--- a/dev/preview/workflow/preview/deploy-gitpod.sh
+++ b/dev/preview/workflow/preview/deploy-gitpod.sh
@@ -418,6 +418,11 @@ yq w -i "${INSTALLER_CONFIG_PATH}" experimental.webapp.proxy.configcat.baseUrl "
 yq w -i "${INSTALLER_CONFIG_PATH}" experimental.webapp.proxy.configcat.pollInterval "1m"
 
 #
+# configure JWT signign key
+#
+yq w -i "${INSTALLER_CONFIG_PATH}" experimental.webapp.publicApi.jwtSigningKeySecretName "jwt-signing-key"
+
+#
 # configure Personal Access Token signign key
 #
 yq w -i "${INSTALLER_CONFIG_PATH}" experimental.webapp.publicApi.personalAccessTokenSigningKeySecretName "personal-access-token-signing-key"

--- a/install/installer/cmd/testdata/render/agent-smith/output.golden
+++ b/install/installer/cmd/testdata/render/agent-smith/output.golden
@@ -2901,7 +2901,7 @@ data:
     kind: Deployment
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3cc95f976fd2b074f33d82a494edf92c0b9b46962e03fd0689b885ad33836f4f
+        gitpod.io/checksum_config: 518e99b5e59306709e5a70b4e823104b79bbc2dd8b634e1d3cd4fe6319200e72
       creationTimestamp: null
       labels:
         app: gitpod
@@ -5299,6 +5299,7 @@ data:
       "billingServiceAddress": "usage.default.svc.cluster.local:9001",
       "sessionServiceAddress": "server.default.svc.cluster.local:9876",
       "stripeWebhookSigningSecretPath": "",
+      "jwtSigningSecretPath": "",
       "personalAccessTokenSigningKeyPath": "",
       "databaseConfigPath": "/secrets/database-config",
       "server": {
@@ -10167,7 +10168,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    gitpod.io/checksum_config: 3cc95f976fd2b074f33d82a494edf92c0b9b46962e03fd0689b885ad33836f4f
+    gitpod.io/checksum_config: 518e99b5e59306709e5a70b4e823104b79bbc2dd8b634e1d3cd4fe6319200e72
   creationTimestamp: null
   labels:
     app: gitpod

--- a/install/installer/cmd/testdata/render/aws-setup/output.golden
+++ b/install/installer/cmd/testdata/render/aws-setup/output.golden
@@ -2518,7 +2518,7 @@ data:
     kind: Deployment
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3cc95f976fd2b074f33d82a494edf92c0b9b46962e03fd0689b885ad33836f4f
+        gitpod.io/checksum_config: 518e99b5e59306709e5a70b4e823104b79bbc2dd8b634e1d3cd4fe6319200e72
       creationTimestamp: null
       labels:
         app: gitpod
@@ -4681,6 +4681,7 @@ data:
       "billingServiceAddress": "usage.default.svc.cluster.local:9001",
       "sessionServiceAddress": "server.default.svc.cluster.local:9876",
       "stripeWebhookSigningSecretPath": "",
+      "jwtSigningSecretPath": "",
       "personalAccessTokenSigningKeyPath": "",
       "databaseConfigPath": "/secrets/database-config",
       "server": {
@@ -9071,7 +9072,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    gitpod.io/checksum_config: 3cc95f976fd2b074f33d82a494edf92c0b9b46962e03fd0689b885ad33836f4f
+    gitpod.io/checksum_config: 518e99b5e59306709e5a70b4e823104b79bbc2dd8b634e1d3cd4fe6319200e72
   creationTimestamp: null
   labels:
     app: gitpod

--- a/install/installer/cmd/testdata/render/azure-setup/output.golden
+++ b/install/installer/cmd/testdata/render/azure-setup/output.golden
@@ -2536,7 +2536,7 @@ data:
     kind: Deployment
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3cc95f976fd2b074f33d82a494edf92c0b9b46962e03fd0689b885ad33836f4f
+        gitpod.io/checksum_config: 518e99b5e59306709e5a70b4e823104b79bbc2dd8b634e1d3cd4fe6319200e72
       creationTimestamp: null
       labels:
         app: gitpod
@@ -4747,6 +4747,7 @@ data:
       "billingServiceAddress": "usage.default.svc.cluster.local:9001",
       "sessionServiceAddress": "server.default.svc.cluster.local:9876",
       "stripeWebhookSigningSecretPath": "",
+      "jwtSigningSecretPath": "",
       "personalAccessTokenSigningKeyPath": "",
       "databaseConfigPath": "/secrets/database-config",
       "server": {
@@ -9268,7 +9269,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    gitpod.io/checksum_config: 3cc95f976fd2b074f33d82a494edf92c0b9b46962e03fd0689b885ad33836f4f
+    gitpod.io/checksum_config: 518e99b5e59306709e5a70b4e823104b79bbc2dd8b634e1d3cd4fe6319200e72
   creationTimestamp: null
   labels:
     app: gitpod

--- a/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
+++ b/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
@@ -2719,7 +2719,7 @@ data:
     kind: Deployment
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3cc95f976fd2b074f33d82a494edf92c0b9b46962e03fd0689b885ad33836f4f
+        gitpod.io/checksum_config: 518e99b5e59306709e5a70b4e823104b79bbc2dd8b634e1d3cd4fe6319200e72
       creationTimestamp: null
       labels:
         app: gitpod
@@ -5117,6 +5117,7 @@ data:
       "billingServiceAddress": "usage.default.svc.cluster.local:9001",
       "sessionServiceAddress": "server.default.svc.cluster.local:9876",
       "stripeWebhookSigningSecretPath": "",
+      "jwtSigningSecretPath": "",
       "personalAccessTokenSigningKeyPath": "",
       "databaseConfigPath": "/secrets/database-config",
       "server": {
@@ -9985,7 +9986,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    gitpod.io/checksum_config: 3cc95f976fd2b074f33d82a494edf92c0b9b46962e03fd0689b885ad33836f4f
+    gitpod.io/checksum_config: 518e99b5e59306709e5a70b4e823104b79bbc2dd8b634e1d3cd4fe6319200e72
   creationTimestamp: null
   labels:
     app: gitpod

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -3111,7 +3111,7 @@ data:
     metadata:
       annotations:
         gitpod.io: hello
-        gitpod.io/checksum_config: 8f9715de0ca5459f27239b0de167ca51f970b650173d793545278bf049b47465
+        gitpod.io/checksum_config: 888e7ab783689e4f15ab609b620fb15a55efdc130b50f24a051948292e3d8ace
         hello: world
       creationTimestamp: null
       labels:
@@ -5684,6 +5684,7 @@ data:
       "billingServiceAddress": "usage.default.svc.cluster.local:9001",
       "sessionServiceAddress": "server.default.svc.cluster.local:9876",
       "stripeWebhookSigningSecretPath": "",
+      "jwtSigningSecretPath": "",
       "personalAccessTokenSigningKeyPath": "",
       "databaseConfigPath": "/secrets/database-config",
       "server": {
@@ -10785,7 +10786,7 @@ kind: Deployment
 metadata:
   annotations:
     gitpod.io: hello
-    gitpod.io/checksum_config: 8f9715de0ca5459f27239b0de167ca51f970b650173d793545278bf049b47465
+    gitpod.io/checksum_config: 888e7ab783689e4f15ab609b620fb15a55efdc130b50f24a051948292e3d8ace
     hello: world
   creationTimestamp: null
   labels:

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -2613,7 +2613,7 @@ data:
     kind: Deployment
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3cc95f976fd2b074f33d82a494edf92c0b9b46962e03fd0689b885ad33836f4f
+        gitpod.io/checksum_config: 518e99b5e59306709e5a70b4e823104b79bbc2dd8b634e1d3cd4fe6319200e72
       creationTimestamp: null
       labels:
         app: gitpod
@@ -4934,6 +4934,7 @@ data:
       "billingServiceAddress": "usage.default.svc.cluster.local:9001",
       "sessionServiceAddress": "server.default.svc.cluster.local:9876",
       "stripeWebhookSigningSecretPath": "",
+      "jwtSigningSecretPath": "",
       "personalAccessTokenSigningKeyPath": "",
       "databaseConfigPath": "/secrets/database-config",
       "server": {
@@ -9695,7 +9696,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    gitpod.io/checksum_config: 3cc95f976fd2b074f33d82a494edf92c0b9b46962e03fd0689b885ad33836f4f
+    gitpod.io/checksum_config: 518e99b5e59306709e5a70b4e823104b79bbc2dd8b634e1d3cd4fe6319200e72
   creationTimestamp: null
   labels:
     app: gitpod

--- a/install/installer/cmd/testdata/render/gcp-setup/output.golden
+++ b/install/installer/cmd/testdata/render/gcp-setup/output.golden
@@ -2555,7 +2555,7 @@ data:
     kind: Deployment
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3cc95f976fd2b074f33d82a494edf92c0b9b46962e03fd0689b885ad33836f4f
+        gitpod.io/checksum_config: 518e99b5e59306709e5a70b4e823104b79bbc2dd8b634e1d3cd4fe6319200e72
       creationTimestamp: null
       labels:
         app: gitpod
@@ -4708,6 +4708,7 @@ data:
       "billingServiceAddress": "usage.default.svc.cluster.local:9001",
       "sessionServiceAddress": "server.default.svc.cluster.local:9876",
       "stripeWebhookSigningSecretPath": "",
+      "jwtSigningSecretPath": "",
       "personalAccessTokenSigningKeyPath": "",
       "databaseConfigPath": "/secrets/database-config",
       "server": {
@@ -9200,7 +9201,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    gitpod.io/checksum_config: 3cc95f976fd2b074f33d82a494edf92c0b9b46962e03fd0689b885ad33836f4f
+    gitpod.io/checksum_config: 518e99b5e59306709e5a70b4e823104b79bbc2dd8b634e1d3cd4fe6319200e72
   creationTimestamp: null
   labels:
     app: gitpod

--- a/install/installer/cmd/testdata/render/http-proxy/output.golden
+++ b/install/installer/cmd/testdata/render/http-proxy/output.golden
@@ -2722,7 +2722,7 @@ data:
     kind: Deployment
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3cc95f976fd2b074f33d82a494edf92c0b9b46962e03fd0689b885ad33836f4f
+        gitpod.io/checksum_config: 518e99b5e59306709e5a70b4e823104b79bbc2dd8b634e1d3cd4fe6319200e72
       creationTimestamp: null
       labels:
         app: gitpod
@@ -5120,6 +5120,7 @@ data:
       "billingServiceAddress": "usage.default.svc.cluster.local:9001",
       "sessionServiceAddress": "server.default.svc.cluster.local:9876",
       "stripeWebhookSigningSecretPath": "",
+      "jwtSigningSecretPath": "",
       "personalAccessTokenSigningKeyPath": "",
       "databaseConfigPath": "/secrets/database-config",
       "server": {
@@ -10990,7 +10991,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    gitpod.io/checksum_config: 3cc95f976fd2b074f33d82a494edf92c0b9b46962e03fd0689b885ad33836f4f
+    gitpod.io/checksum_config: 518e99b5e59306709e5a70b4e823104b79bbc2dd8b634e1d3cd4fe6319200e72
   creationTimestamp: null
   labels:
     app: gitpod

--- a/install/installer/cmd/testdata/render/kind-meta/output.golden
+++ b/install/installer/cmd/testdata/render/kind-meta/output.golden
@@ -2263,7 +2263,7 @@ data:
     kind: Deployment
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3cc95f976fd2b074f33d82a494edf92c0b9b46962e03fd0689b885ad33836f4f
+        gitpod.io/checksum_config: 518e99b5e59306709e5a70b4e823104b79bbc2dd8b634e1d3cd4fe6319200e72
       creationTimestamp: null
       labels:
         app: gitpod
@@ -4042,6 +4042,7 @@ data:
       "billingServiceAddress": "usage.default.svc.cluster.local:9001",
       "sessionServiceAddress": "server.default.svc.cluster.local:9876",
       "stripeWebhookSigningSecretPath": "",
+      "jwtSigningSecretPath": "",
       "personalAccessTokenSigningKeyPath": "",
       "databaseConfigPath": "/secrets/database-config",
       "server": {
@@ -7147,7 +7148,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    gitpod.io/checksum_config: 3cc95f976fd2b074f33d82a494edf92c0b9b46962e03fd0689b885ad33836f4f
+    gitpod.io/checksum_config: 518e99b5e59306709e5a70b4e823104b79bbc2dd8b634e1d3cd4fe6319200e72
   creationTimestamp: null
   labels:
     app: gitpod

--- a/install/installer/cmd/testdata/render/kind-webapp/output.golden
+++ b/install/installer/cmd/testdata/render/kind-webapp/output.golden
@@ -1638,7 +1638,7 @@ data:
     kind: Deployment
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3cc95f976fd2b074f33d82a494edf92c0b9b46962e03fd0689b885ad33836f4f
+        gitpod.io/checksum_config: 518e99b5e59306709e5a70b4e823104b79bbc2dd8b634e1d3cd4fe6319200e72
       creationTimestamp: null
       labels:
         app: gitpod
@@ -2132,6 +2132,7 @@ data:
       "billingServiceAddress": "usage.default.svc.cluster.local:9001",
       "sessionServiceAddress": "server.default.svc.cluster.local:9876",
       "stripeWebhookSigningSecretPath": "",
+      "jwtSigningSecretPath": "",
       "personalAccessTokenSigningKeyPath": "",
       "databaseConfigPath": "/secrets/database-config",
       "server": {
@@ -4076,7 +4077,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    gitpod.io/checksum_config: 3cc95f976fd2b074f33d82a494edf92c0b9b46962e03fd0689b885ad33836f4f
+    gitpod.io/checksum_config: 518e99b5e59306709e5a70b4e823104b79bbc2dd8b634e1d3cd4fe6319200e72
   creationTimestamp: null
   labels:
     app: gitpod

--- a/install/installer/cmd/testdata/render/message-bus-password/output.golden
+++ b/install/installer/cmd/testdata/render/message-bus-password/output.golden
@@ -2722,7 +2722,7 @@ data:
     kind: Deployment
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3cc95f976fd2b074f33d82a494edf92c0b9b46962e03fd0689b885ad33836f4f
+        gitpod.io/checksum_config: 518e99b5e59306709e5a70b4e823104b79bbc2dd8b634e1d3cd4fe6319200e72
       creationTimestamp: null
       labels:
         app: gitpod
@@ -5120,6 +5120,7 @@ data:
       "billingServiceAddress": "usage.default.svc.cluster.local:9001",
       "sessionServiceAddress": "server.default.svc.cluster.local:9876",
       "stripeWebhookSigningSecretPath": "",
+      "jwtSigningSecretPath": "",
       "personalAccessTokenSigningKeyPath": "",
       "databaseConfigPath": "/secrets/database-config",
       "server": {
@@ -9988,7 +9989,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    gitpod.io/checksum_config: 3cc95f976fd2b074f33d82a494edf92c0b9b46962e03fd0689b885ad33836f4f
+    gitpod.io/checksum_config: 518e99b5e59306709e5a70b4e823104b79bbc2dd8b634e1d3cd4fe6319200e72
   creationTimestamp: null
   labels:
     app: gitpod

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -2719,7 +2719,7 @@ data:
     kind: Deployment
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3cc95f976fd2b074f33d82a494edf92c0b9b46962e03fd0689b885ad33836f4f
+        gitpod.io/checksum_config: 518e99b5e59306709e5a70b4e823104b79bbc2dd8b634e1d3cd4fe6319200e72
       creationTimestamp: null
       labels:
         app: gitpod
@@ -5117,6 +5117,7 @@ data:
       "billingServiceAddress": "usage.default.svc.cluster.local:9001",
       "sessionServiceAddress": "server.default.svc.cluster.local:9876",
       "stripeWebhookSigningSecretPath": "",
+      "jwtSigningSecretPath": "",
       "personalAccessTokenSigningKeyPath": "",
       "databaseConfigPath": "/secrets/database-config",
       "server": {
@@ -9985,7 +9986,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    gitpod.io/checksum_config: 3cc95f976fd2b074f33d82a494edf92c0b9b46962e03fd0689b885ad33836f4f
+    gitpod.io/checksum_config: 518e99b5e59306709e5a70b4e823104b79bbc2dd8b634e1d3cd4fe6319200e72
   creationTimestamp: null
   labels:
     app: gitpod

--- a/install/installer/cmd/testdata/render/overrides-inline/output.golden
+++ b/install/installer/cmd/testdata/render/overrides-inline/output.golden
@@ -2717,7 +2717,7 @@ data:
     kind: Deployment
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3cc95f976fd2b074f33d82a494edf92c0b9b46962e03fd0689b885ad33836f4f
+        gitpod.io/checksum_config: 518e99b5e59306709e5a70b4e823104b79bbc2dd8b634e1d3cd4fe6319200e72
       creationTimestamp: null
       labels:
         app: gitpod
@@ -5115,6 +5115,7 @@ data:
       "billingServiceAddress": "usage.default.svc.cluster.local:9001",
       "sessionServiceAddress": "server.default.svc.cluster.local:9876",
       "stripeWebhookSigningSecretPath": "",
+      "jwtSigningSecretPath": "",
       "personalAccessTokenSigningKeyPath": "",
       "databaseConfigPath": "/secrets/database-config",
       "server": {
@@ -9995,7 +9996,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    gitpod.io/checksum_config: 3cc95f976fd2b074f33d82a494edf92c0b9b46962e03fd0689b885ad33836f4f
+    gitpod.io/checksum_config: 518e99b5e59306709e5a70b4e823104b79bbc2dd8b634e1d3cd4fe6319200e72
   creationTimestamp: null
   labels:
     app: gitpod

--- a/install/installer/cmd/testdata/render/pod-config/output.golden
+++ b/install/installer/cmd/testdata/render/pod-config/output.golden
@@ -2725,7 +2725,7 @@ data:
     kind: Deployment
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3cc95f976fd2b074f33d82a494edf92c0b9b46962e03fd0689b885ad33836f4f
+        gitpod.io/checksum_config: 518e99b5e59306709e5a70b4e823104b79bbc2dd8b634e1d3cd4fe6319200e72
       creationTimestamp: null
       labels:
         app: gitpod
@@ -5123,6 +5123,7 @@ data:
       "billingServiceAddress": "usage.default.svc.cluster.local:9001",
       "sessionServiceAddress": "server.default.svc.cluster.local:9876",
       "stripeWebhookSigningSecretPath": "",
+      "jwtSigningSecretPath": "",
       "personalAccessTokenSigningKeyPath": "",
       "databaseConfigPath": "/secrets/database-config",
       "server": {
@@ -9991,7 +9992,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    gitpod.io/checksum_config: 3cc95f976fd2b074f33d82a494edf92c0b9b46962e03fd0689b885ad33836f4f
+    gitpod.io/checksum_config: 518e99b5e59306709e5a70b4e823104b79bbc2dd8b634e1d3cd4fe6319200e72
   creationTimestamp: null
   labels:
     app: gitpod

--- a/install/installer/cmd/testdata/render/shortname/output.golden
+++ b/install/installer/cmd/testdata/render/shortname/output.golden
@@ -2719,7 +2719,7 @@ data:
     kind: Deployment
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3cc95f976fd2b074f33d82a494edf92c0b9b46962e03fd0689b885ad33836f4f
+        gitpod.io/checksum_config: 518e99b5e59306709e5a70b4e823104b79bbc2dd8b634e1d3cd4fe6319200e72
       creationTimestamp: null
       labels:
         app: gitpod
@@ -5117,6 +5117,7 @@ data:
       "billingServiceAddress": "usage.default.svc.cluster.local:9001",
       "sessionServiceAddress": "server.default.svc.cluster.local:9876",
       "stripeWebhookSigningSecretPath": "",
+      "jwtSigningSecretPath": "",
       "personalAccessTokenSigningKeyPath": "",
       "databaseConfigPath": "/secrets/database-config",
       "server": {
@@ -9985,7 +9986,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    gitpod.io/checksum_config: 3cc95f976fd2b074f33d82a494edf92c0b9b46962e03fd0689b885ad33836f4f
+    gitpod.io/checksum_config: 518e99b5e59306709e5a70b4e823104b79bbc2dd8b634e1d3cd4fe6319200e72
   creationTimestamp: null
   labels:
     app: gitpod

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -2731,7 +2731,7 @@ data:
     kind: Deployment
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3cc95f976fd2b074f33d82a494edf92c0b9b46962e03fd0689b885ad33836f4f
+        gitpod.io/checksum_config: 518e99b5e59306709e5a70b4e823104b79bbc2dd8b634e1d3cd4fe6319200e72
       creationTimestamp: null
       labels:
         app: gitpod
@@ -5129,6 +5129,7 @@ data:
       "billingServiceAddress": "usage.default.svc.cluster.local:9001",
       "sessionServiceAddress": "server.default.svc.cluster.local:9876",
       "stripeWebhookSigningSecretPath": "",
+      "jwtSigningSecretPath": "",
       "personalAccessTokenSigningKeyPath": "",
       "databaseConfigPath": "/secrets/database-config",
       "server": {
@@ -9997,7 +9998,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    gitpod.io/checksum_config: 3cc95f976fd2b074f33d82a494edf92c0b9b46962e03fd0689b885ad33836f4f
+    gitpod.io/checksum_config: 518e99b5e59306709e5a70b4e823104b79bbc2dd8b634e1d3cd4fe6319200e72
   creationTimestamp: null
   labels:
     app: gitpod

--- a/install/installer/cmd/testdata/render/telemetry/output.golden
+++ b/install/installer/cmd/testdata/render/telemetry/output.golden
@@ -2722,7 +2722,7 @@ data:
     kind: Deployment
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3cc95f976fd2b074f33d82a494edf92c0b9b46962e03fd0689b885ad33836f4f
+        gitpod.io/checksum_config: 518e99b5e59306709e5a70b4e823104b79bbc2dd8b634e1d3cd4fe6319200e72
       creationTimestamp: null
       labels:
         app: gitpod
@@ -5120,6 +5120,7 @@ data:
       "billingServiceAddress": "usage.default.svc.cluster.local:9001",
       "sessionServiceAddress": "server.default.svc.cluster.local:9876",
       "stripeWebhookSigningSecretPath": "",
+      "jwtSigningSecretPath": "",
       "personalAccessTokenSigningKeyPath": "",
       "databaseConfigPath": "/secrets/database-config",
       "server": {
@@ -9988,7 +9989,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    gitpod.io/checksum_config: 3cc95f976fd2b074f33d82a494edf92c0b9b46962e03fd0689b885ad33836f4f
+    gitpod.io/checksum_config: 518e99b5e59306709e5a70b4e823104b79bbc2dd8b634e1d3cd4fe6319200e72
   creationTimestamp: null
   labels:
     app: gitpod

--- a/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
+++ b/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
@@ -3007,7 +3007,7 @@ data:
     kind: Deployment
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3cc95f976fd2b074f33d82a494edf92c0b9b46962e03fd0689b885ad33836f4f
+        gitpod.io/checksum_config: 518e99b5e59306709e5a70b4e823104b79bbc2dd8b634e1d3cd4fe6319200e72
       creationTimestamp: null
       labels:
         app: gitpod
@@ -5450,6 +5450,7 @@ data:
       "billingServiceAddress": "usage.default.svc.cluster.local:9001",
       "sessionServiceAddress": "server.default.svc.cluster.local:9876",
       "stripeWebhookSigningSecretPath": "",
+      "jwtSigningSecretPath": "",
       "personalAccessTokenSigningKeyPath": "",
       "databaseConfigPath": "/secrets/database-config",
       "server": {
@@ -10429,7 +10430,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    gitpod.io/checksum_config: 3cc95f976fd2b074f33d82a494edf92c0b9b46962e03fd0689b885ad33836f4f
+    gitpod.io/checksum_config: 518e99b5e59306709e5a70b4e823104b79bbc2dd8b634e1d3cd4fe6319200e72
   creationTimestamp: null
   labels:
     app: gitpod

--- a/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
+++ b/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
@@ -2721,7 +2721,7 @@ data:
     kind: Deployment
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3cc95f976fd2b074f33d82a494edf92c0b9b46962e03fd0689b885ad33836f4f
+        gitpod.io/checksum_config: 518e99b5e59306709e5a70b4e823104b79bbc2dd8b634e1d3cd4fe6319200e72
       creationTimestamp: null
       labels:
         app: gitpod
@@ -5119,6 +5119,7 @@ data:
       "billingServiceAddress": "usage.default.svc.cluster.local:9001",
       "sessionServiceAddress": "server.default.svc.cluster.local:9876",
       "stripeWebhookSigningSecretPath": "",
+      "jwtSigningSecretPath": "",
       "personalAccessTokenSigningKeyPath": "",
       "databaseConfigPath": "/secrets/database-config",
       "server": {
@@ -9975,7 +9976,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    gitpod.io/checksum_config: 3cc95f976fd2b074f33d82a494edf92c0b9b46962e03fd0689b885ad33836f4f
+    gitpod.io/checksum_config: 518e99b5e59306709e5a70b4e823104b79bbc2dd8b634e1d3cd4fe6319200e72
   creationTimestamp: null
   labels:
     app: gitpod

--- a/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
+++ b/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
@@ -2722,7 +2722,7 @@ data:
     kind: Deployment
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3cc95f976fd2b074f33d82a494edf92c0b9b46962e03fd0689b885ad33836f4f
+        gitpod.io/checksum_config: 518e99b5e59306709e5a70b4e823104b79bbc2dd8b634e1d3cd4fe6319200e72
       creationTimestamp: null
       labels:
         app: gitpod
@@ -5120,6 +5120,7 @@ data:
       "billingServiceAddress": "usage.default.svc.cluster.local:9001",
       "sessionServiceAddress": "server.default.svc.cluster.local:9876",
       "stripeWebhookSigningSecretPath": "",
+      "jwtSigningSecretPath": "",
       "personalAccessTokenSigningKeyPath": "",
       "databaseConfigPath": "/secrets/database-config",
       "server": {
@@ -9988,7 +9989,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    gitpod.io/checksum_config: 3cc95f976fd2b074f33d82a494edf92c0b9b46962e03fd0689b885ad33836f4f
+    gitpod.io/checksum_config: 518e99b5e59306709e5a70b4e823104b79bbc2dd8b634e1d3cd4fe6319200e72
   creationTimestamp: null
   labels:
     app: gitpod

--- a/install/installer/pkg/components/public-api-server/configmap_test.go
+++ b/install/installer/pkg/components/public-api-server/configmap_test.go
@@ -31,6 +31,12 @@ func TestConfigMap(t *testing.T) {
 		return nil
 	})
 
+	var jwtSigningSecretPath string
+	_ = ctx.WithExperimental(func(ucfg *experimental.Config) error {
+		_, _, jwtSigningSecretPath, _ = getJWTSecretConfig(ucfg)
+		return nil
+	})
+
 	var personalAccessTokenSigningKeyPath string
 	_ = ctx.WithExperimental(func(ucfg *experimental.Config) error {
 		_, _, personalAccessTokenSigningKeyPath, _ = getPersonalAccessTokenSigningKey(ucfg)
@@ -41,6 +47,7 @@ func TestConfigMap(t *testing.T) {
 		GitpodServiceURL:                  fmt.Sprintf("ws://server.%s.svc.cluster.local:3000", ctx.Namespace),
 		BillingServiceAddress:             fmt.Sprintf("usage.%s.svc.cluster.local:9001", ctx.Namespace),
 		SessionServiceAddress:             fmt.Sprintf("server.%s.svc.cluster.local:9876", ctx.Namespace),
+		JWTSigningSecretPath:              jwtSigningSecretPath,
 		StripeWebhookSigningSecretPath:    stripeSecretPath,
 		PersonalAccessTokenSigningKeyPath: personalAccessTokenSigningKeyPath,
 		DatabaseConfigPath:                "/secrets/database-config",

--- a/install/installer/pkg/components/public-api-server/constants.go
+++ b/install/installer/pkg/components/public-api-server/constants.go
@@ -14,6 +14,7 @@ const (
 	HTTPServicePort   = 9002
 	HTTPPortName      = "http"
 
+	jwtSigningKeyMountPath                 = "/secrets/jwt-signing-key"
 	stripeSecretMountPath                  = "/secrets/stripe-webhook-secret"
 	personalAccessTokenSigningKeyMountPath = "/secrets/personal-access-token-signing-key"
 )

--- a/install/installer/pkg/components/public-api-server/deployment.go
+++ b/install/installer/pkg/components/public-api-server/deployment.go
@@ -59,6 +59,17 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 	}
 
 	_ = ctx.WithExperimental(func(cfg *experimental.Config) error {
+		volume, mount, _, ok := getJWTSecretConfig(cfg)
+		if !ok {
+			return nil
+		}
+
+		volumes = append(volumes, volume)
+		volumeMounts = append(volumeMounts, mount)
+		return nil
+	})
+
+	_ = ctx.WithExperimental(func(cfg *experimental.Config) error {
 		volume, mount, _, ok := getStripeConfig(cfg)
 		if !ok {
 			return nil

--- a/install/installer/pkg/components/public-api-server/deployment_test.go
+++ b/install/installer/pkg/components/public-api-server/deployment_test.go
@@ -65,6 +65,15 @@ func TestDeployment_ServerArguments(t *testing.T) {
 			},
 		},
 		{
+			Name: "jwt-signing-key",
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: "jwt-signing-key",
+					Optional:   pointer.Bool(true),
+				},
+			},
+		},
+		{
 			Name: "stripe-secret",
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{

--- a/install/installer/pkg/components/public-api-server/objects_test.go
+++ b/install/installer/pkg/components/public-api-server/objects_test.go
@@ -30,6 +30,7 @@ func renderContextWithPublicAPI(t *testing.T) *common.RenderContext {
 			WebApp: &experimental.WebAppConfig{
 				PublicAPI: &experimental.PublicAPIConfig{
 					StripeSecretName:                        "stripe-webhook-secret",
+					JWTSigningKeySecretName:                 "jwt-signing-key",
 					PersonalAccessTokenSigningKeySecretName: "personal-access-token-signing-key",
 				},
 			},

--- a/install/installer/pkg/config/v1/config.md
+++ b/install/installer/pkg/config/v1/config.md
@@ -120,6 +120,7 @@ Additional config parameters that are in experimental state
 |`experimental.workspace.wsProxy`||N|  ||
 |`experimental.workspace.contentService`||N|  ||
 |`experimental.workspace.enableProtectedSecrets`|bool|N|  ||
+|`experimental.webapp.publicApi.jwtSigningSecretName`|string|N|  |  Name of the kubernetes secret to use for JWT signatures|
 |`experimental.webapp.publicApi.stripeSecretName`|string|N|  |  Name of the kubernetes secret to use for Stripe secrets|
 |`experimental.webapp.publicApi.personalAccessTokenSigningKeySecretName`|string|N|  |  Name of the kubernetes secret to use for signature of Personal Access Tokens|
 |`experimental.webapp.server.workspaceDefaults.workspaceImage`|string|N|  |  @deprecated use workspace.workspaceImage instead|

--- a/install/installer/pkg/config/v1/experimental/experimental.go
+++ b/install/installer/pkg/config/v1/experimental/experimental.go
@@ -294,6 +294,9 @@ type PublicAPIConfig struct {
 	// Name of the kubernetes secret to use for Stripe secrets
 	StripeSecretName string `json:"stripeSecretName"`
 
+	// Name of the kubernetes secret to use for signing JWTs
+	JWTSigningKeySecretName string `json:"jwtSigningKeySecretName"`
+
 	// Name of the kubernetes secret to use for signature of Personal Access Tokens
 	PersonalAccessTokenSigningKeySecretName string `json:"personalAccessTokenSigningKeySecretName"`
 }


### PR DESCRIPTION
Praparation to use with `golang-jwt/jwt`

## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all-ci
- [ ] /werft no-test
      Run Leeway with `--dont-test`

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
