### PR TITLE
[admin] Add phone number to user page

### DIFF
--- a/components/dashboard/src/admin/UserDetail.tsx
+++ b/components/dashboard/src/admin/UserDetail.tsx
@@ -272,6 +272,7 @@ export default function UserDetail(p: { user: User }) {
                                 .map((i) => i.primaryEmail)
                                 .filter((e) => !!e)
                                 .join(", ")}
+                            {user.verificationPhoneNumber ? ` — ${user.verificationPhoneNumber}` : null}
                         </p>
                     </div>
                     {!user.lastVerificationTime ? (


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
When dealing with abuse checking what was the phone number used for account verification can be helpful. As such, this PR adds it in line with account email.

<img width="295" alt="image" src="https://user-images.githubusercontent.com/666176/214911483-e1005c7d-d275-461c-a304-ba6ba3fb271c.png">

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
N/A

## How to test
<!-- Provide steps to test this PR -->
- From a gitpod workspace, open preview (`leeway run dev:preview`)
- Signup in the url provided
- Unblock the user if needed (`leeway run components:unblock-user`) 
- Make it admin (`leeway run components:make-user-admin`)
- Check the admin user page
- Update DB [[1](https://www.notion.so/gitpod/How-we-develop-e8ce7e562478458a9223eb9b797415b2#c82bfeb6cbae46c79bfa2aee72769bed)] (`SET SQL_SAFE_UPDATES = 0; UPDATE d_b_user SET verificationPhoneNumber = '930000000'`)
- See change

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
