### PR TITLE
Aborted prebuilds may cause workspace_starts_failure to increment

### DIFF
--- a/components/ws-manager/pkg/manager/metrics.go
+++ b/components/ws-manager/pkg/manager/metrics.go
@@ -325,12 +325,17 @@ func (m *metrics) OnChange(status *api.WorkspaceStatus) {
 			}
 
 			// avoid incrementing when the workspace start was aborted, or cancelled by the user
-			// TODO: what is the reason when stoppedByRequest is used? Ref: https://github.com/gitpod-io/gitpod/pull/6218
+			// TODO: when is stoppedByRequest used? Ref: https://github.com/gitpod-io/gitpod/pull/6218
 
 			// stoppedByRequest received on the workspace side: https://cloudlogging.app.goo.gl/yrAkZvxPFAvMwK4r7
 			// aborted on the webapp side:
 			// https://console.cloud.google.com/logs/query;cursorTimestamp=2023-01-26T19:22:03.856Z;query=resource.labels.project_id%3D%22gitpod-191109%22%0A%22c2653377-aa64-4b99-a1e0-d89e7c6392e0%22%0Atimestamp%3D%222023-01-26T19:22:03.772Z%22%0AinsertId%3D%227gi8qlbaxscrk7fy%22;timeRange=PT2H?project=gitpod-191109
 			// https://github.com/gitpod-io/gitpod/blob/f9b3c4fc4a824aa72278b4f5ddb0bd015c4b8c8e/components/server/ee/src/prebuilds/prebuild-manager.ts#L80-L88
+
+			// use cases from webapp:
+			// cancelled in dashboard -> increments workspace_starts_failure_total
+			// a new commit arrived
+			// rate limited
 
 			if reason != "aborted" {
 				startC.Inc()


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
