### PR TITLE
[spicedb] Remove dedicated cloud-sql-proxy config

### DIFF
--- a/install/installer/pkg/config/v1/experimental/experimental.go
+++ b/install/installer/pkg/config/v1/experimental/experimental.go
@@ -198,15 +198,6 @@ type SpiceDBConfig struct {
 	Enabled bool `json:"enabled"`
 
 	DisableMigrations bool `json:"disableMigrations"`
-
-	CloudSQL *struct {
-		Instance string `json:"instance"`
-		Database string `json:"database"`
-		// Credentials for CloudSQL proxy to authenticate with GCP
-		ProxySecretRef string `json:"proxySecretRef"`
-		// Username/Password to authenticate with the database
-		DatabaseSecretRef string `json:"databaseSecretRef"`
-	} `json:"cloudSql,omitempty"`
 }
 
 type WebAppConfig struct {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Unused, we use the `database.cloudSqlGlobal` config instead, related ops removal - https://github.com/gitpod-io/ops/pull/8023

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
