### PR TITLE
[spicedb] Bootstrap schema

### DIFF
--- a/install/installer/BUILD.yaml
+++ b/install/installer/BUILD.yaml
@@ -12,6 +12,7 @@ packages:
       - "pkg/components/**/*.key"
       - "pkg/components/**/*.pem"
       - "pkg/components/**/*.sql"
+      - "pkg/components/spicedb/data/bootstrap.yaml"
       - "scripts/*.sh"
       - "third_party/charts/*/Chart.yaml"
       - "third_party/charts/*/values.yaml"

--- a/install/installer/pkg/components/spicedb/constants.go
+++ b/install/installer/pkg/components/spicedb/constants.go
@@ -31,4 +31,5 @@ const (
 	CloudSQLProxyPort = 3306
 
 	SecretPresharedKeyName = "presharedKey"
+	BootstrapConfigMapName = "spicedb-bootstrap"
 )

--- a/install/installer/pkg/components/spicedb/data/bootstrap.yaml
+++ b/install/installer/pkg/components/spicedb/data/bootstrap.yaml
@@ -1,0 +1,34 @@
+# Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+# Licensed under the GNU Affero General Public License (AGPL).
+# See License.AGPL.txt in the project root for license information.
+
+schema: |-
+  definition user {}
+
+  definition team {
+  	relation org: organisation
+  	relation member: user
+  	relation owner: user
+  	permission read_teams = owner + member + org->read_teams
+  	permission invite_members = owner
+  }
+
+  definition project {}
+
+  definition organisation {
+  	relation owner: user
+  	relation member: user
+  	relation service: service
+  	permission read_teams = owner + service
+  	permission write_teams = owner + service
+  	permission read_workspaces = owner + service
+  }
+
+  definition workspace {
+  	relation org: organisation
+  	relation owner: user
+  	permission create_workspace = org->member
+  	permission delete_workspace = owner + org->owner
+  }
+
+  definition service {}

--- a/install/installer/pkg/components/spicedb/objects.go
+++ b/install/installer/pkg/components/spicedb/objects.go
@@ -24,6 +24,7 @@ func Objects(ctx *common.RenderContext) ([]runtime.Object, error) {
 		migrations,
 		networkpolicy,
 		secret,
+		bootstrap,
 	)(ctx)
 }
 

--- a/install/installer/pkg/components/spicedb/schema.go
+++ b/install/installer/pkg/components/spicedb/schema.go
@@ -1,0 +1,116 @@
+// Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package spicedb
+
+import (
+	"embed"
+	"fmt"
+	"io/fs"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/gitpod-io/gitpod/installer/pkg/common"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+//go:embed data/*.yaml
+var bootstrapFiles embed.FS
+
+func bootstrap(ctx *common.RenderContext) ([]runtime.Object, error) {
+
+	files, err := getBootstrapFiles()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read bootstrap files: %w", err)
+	}
+
+	cmData := make(map[string]string)
+	for _, f := range files {
+		cmData[f.name] = f.data
+	}
+
+	return []runtime.Object{
+		&corev1.ConfigMap{
+			TypeMeta: common.TypeMetaConfigmap,
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        BootstrapConfigMapName,
+				Namespace:   ctx.Namespace,
+				Labels:      common.CustomizeLabel(ctx, Component, common.TypeMetaConfigmap),
+				Annotations: common.CustomizeAnnotation(ctx, Component, common.TypeMetaConfigmap),
+			},
+			Data: cmData,
+		},
+	}, nil
+}
+
+func getBootstrapConfig(ctx *common.RenderContext) (corev1.Volume, corev1.VolumeMount, []string, error) {
+	var volume corev1.Volume
+	var mount corev1.VolumeMount
+	var paths []string
+
+	mountPath := "/bootstrap"
+
+	volume = corev1.Volume{
+		Name: "spicedb-bootstrap",
+		VolumeSource: corev1.VolumeSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: BootstrapConfigMapName,
+				},
+			},
+		},
+	}
+
+	mount = corev1.VolumeMount{
+		Name:      "spicedb-bootstrap",
+		MountPath: mountPath,
+		ReadOnly:  true,
+	}
+
+	files, err := getBootstrapFiles()
+	if err != nil {
+		return corev1.Volume{}, corev1.VolumeMount{}, nil, fmt.Errorf("failed to get bootstrap files: %w", err)
+	}
+
+	for _, f := range files {
+		paths = append(paths, filepath.Join(mountPath, f.name))
+	}
+
+	return volume, mount, paths, nil
+}
+
+type file struct {
+	name string
+	data string
+}
+
+func getBootstrapFiles() ([]file, error) {
+	files, err := fs.ReadDir(bootstrapFiles, "data")
+	if err != nil {
+		return nil, fmt.Errorf("failed to read bootstrap files: %w", err)
+	}
+
+	var filesWithContents []file
+	for _, f := range files {
+		b, err := fs.ReadFile(bootstrapFiles, fmt.Sprintf("%s/%s", "data", f.Name()))
+		if err != nil {
+			return nil, err
+		}
+
+		filesWithContents = append(filesWithContents, file{
+			name: f.Name(),
+			data: string(b),
+		})
+	}
+
+	// ensure output is stable
+	sort.Slice(filesWithContents, func(i, j int) bool {
+		return strings.Compare(filesWithContents[i].name, filesWithContents[j].name) == -1
+	})
+
+	return filesWithContents, nil
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Includes spicedb schema in installer files to bootstrap the schema on startup

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
1. Preview
2. See logs for `spicedb`
3. `{"level":"info","filePath":"/bootstrap/bootstrap.yaml","schemaDefinitionCount":6,"time":"2023-01-27T10:17:58Z","message":"adding schema definitions"}`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
