### PR TITLE
[Dashboard] Deslugging

### DIFF
--- a/components/dashboard/src/AppNotifications.tsx
+++ b/components/dashboard/src/AppNotifications.tsx
@@ -51,7 +51,7 @@ export function AppNotifications() {
         if (notifications.length === 1) {
             href = `${gitpodHostUrl}billing`;
         } else if (notifications.length === 2) {
-            href = `${gitpodHostUrl}t/${notifications[notifications.length - 1]}/billing`;
+            href = `${gitpodHostUrl}/org-billing`;
         }
         return (
             <span>

--- a/components/dashboard/src/admin/ProjectDetail.tsx
+++ b/components/dashboard/src/admin/ProjectDetail.tsx
@@ -50,11 +50,11 @@ export default function ProjectDetail(props: { project: Project; owner: string |
                             <>
                                 <Link
                                     className="text-blue-400 dark:text-blue-600 hover:text-blue-600 dark:hover:text-blue-400 truncate"
-                                    to={"/admin/teams/" + props.project.teamId}
+                                    to={"/admin/orgs/" + props.project.teamId}
                                 >
                                     {props.owner}
                                 </Link>
-                                <span className="text-gray-400 dark:text-gray-500"> (Team)</span>
+                                <span className="text-gray-400 dark:text-gray-500"> (Organization)</span>
                             </>
                         </Property>
                     )}

--- a/components/dashboard/src/admin/TeamDetail.tsx
+++ b/components/dashboard/src/admin/TeamDetail.tsx
@@ -79,7 +79,7 @@ export default function TeamDetail(props: { team: Team }) {
                             </span>
                         )}
                     </div>
-                    <span className="mb-6 text-gray-400">/t/{team.slug}</span>
+                    <span className="mb-6 text-gray-400">{team.id}</span>
                     <span className="text-gray-400"> · </span>
                     <span className="text-gray-400">Created on {dayjs(team.creationTime).format("MMM D, YYYY")}</span>
                 </div>

--- a/components/dashboard/src/admin/admin-menu.ts
+++ b/components/dashboard/src/admin/admin-menu.ts
@@ -19,7 +19,7 @@ export function getAdminMenu() {
             link: ["/admin/projects"],
         },
         {
-            title: "Organizationss",
+            title: "Organizations",
             link: ["/admin/orgs"],
         },
         {

--- a/components/dashboard/src/app/AppRoutes.tsx
+++ b/components/dashboard/src/app/AppRoutes.tsx
@@ -24,11 +24,6 @@ import {
     settingsPathNotifications,
     settingsPathPlans,
     settingsPathPreferences,
-    settingsPathTeams,
-    settingsPathTeamsJoin,
-    settingsPathOrgs,
-    settingsPathOrgsJoin,
-    settingsPathOrgsNew,
     settingsPathVariables,
     settingsPathSSHKeys,
     usagePathMain,
@@ -36,12 +31,7 @@ import {
     settingsPathPersonalAccessTokenCreate,
     settingsPathPersonalAccessTokenEdit,
 } from "../settings/settings.routes";
-import {
-    projectsPathInstallGitHubApp,
-    projectsPathMain,
-    projectsPathMainWithParams,
-    projectsPathNew,
-} from "../projects/projects.routes";
+import { projectsPathInstallGitHubApp, projectsPathNew } from "../projects/projects.routes";
 import { workspacesPathMain } from "../workspaces/workspaces.routes";
 import { LocalPreviewAlert } from "./LocalPreviewAlert";
 import OAuthClientApproval from "../OauthClientApproval";
@@ -60,7 +50,7 @@ const Account = React.lazy(() => import(/* webpackPrefetch: true */ "../settings
 const Notifications = React.lazy(() => import(/* webpackPrefetch: true */ "../settings/Notifications"));
 const Billing = React.lazy(() => import(/* webpackPrefetch: true */ "../settings/Billing"));
 const Plans = React.lazy(() => import(/* webpackPrefetch: true */ "../settings/Plans"));
-const Teams = React.lazy(() => import(/* webpackPrefetch: true */ "../settings/Teams"));
+const ChargebeeTeams = React.lazy(() => import(/* webpackPrefetch: true */ "../settings/ChargebeeTeams"));
 const EnvironmentVariables = React.lazy(() => import(/* webpackPrefetch: true */ "../settings/EnvironmentVariables"));
 const SSHKeys = React.lazy(() => import(/* webpackPrefetch: true */ "../settings/SSHKeys"));
 const Integrations = React.lazy(() => import(/* webpackPrefetch: true */ "../settings/Integrations"));
@@ -228,79 +218,27 @@ export const AppRoutes: FunctionComponent<AppRoutesProps> = ({ user, teams }) =>
                             <p className="mt-4 text-lg text-gitpod-red">{decodeURIComponent(getURLHash())}</p>
                         </div>
                     </Route>
-                    <Route path={projectsPathMain}>
-                        <Route exact path={projectsPathMain} component={Projects} />
-                        <Route
-                            exact
-                            path={projectsPathMainWithParams}
-                            render={({ match }) => {
-                                const { resourceOrPrebuild } = match.params;
-                                switch (resourceOrPrebuild) {
-                                    case "events":
-                                        return <Events />;
-                                    case "prebuilds":
-                                        return <Prebuilds />;
-                                    case "settings":
-                                        return <ProjectSettings />;
-                                    case "variables":
-                                        return <ProjectVariables />;
-                                    default:
-                                        return resourceOrPrebuild ? <Prebuild /> : <Project />;
-                                }
-                            }}
-                        />
+                    <Route exact path="/old-team-plans" component={ChargebeeTeams} />
+                    {/* TODO remove the /teams/join navigation after a few weeks */}
+                    <Route exact path="/teams/join" component={JoinTeam} />
+                    <Route exact path="/orgs/new" component={NewTeam} />
+                    <Route exact path="/orgs/join" component={JoinTeam} />
+                    <Route exact path="/members" component={Members} />
+                    <Route exact path="/projects" component={Projects} />
+                    <Route exact path="/org-settings" component={TeamSettings} />
+                    <Route exact path="/org-billing" component={TeamBilling} />
+                    <Route exact path="/org-usage" component={TeamUsage} />
+                    <Route exact path="/sso" component={SSO} />
+                    <Route exact path={`/projects/:projectSlug`} component={Project} />
+                    <Route exact path={`/projects/:projectSlug/events`} component={Events} />
+                    <Route exact path={`/projects/:projectSlug/prebuilds`} component={Prebuilds} />
+                    <Route exact path={`/projects/:projectSlug/settings`} component={ProjectSettings} />
+                    <Route exact path={`/projects/:projectSlug/variables`} component={ProjectVariables} />
+                    <Route exact path={`/projects/:projectSlug/:prebuildId`} component={Prebuild} />
+                    {/* basic redirect for old team slugs */}
+                    <Route path={["/t/"]} exact>
+                        <Redirect to="/projects" />
                     </Route>
-                    {/* TODO remove these navigation after a few weeks */}
-                    <Route path={settingsPathTeams}>
-                        <Route exact path={settingsPathTeamsJoin} component={JoinTeam} />
-                    </Route>
-                    <Route path={settingsPathOrgs}>
-                        <Route exact path={settingsPathOrgs} component={Teams} />
-                        <Route exact path={settingsPathOrgsNew} component={NewTeam} />
-                        <Route exact path={settingsPathOrgsJoin} component={JoinTeam} />
-                    </Route>
-                    {(teams || []).map((team) => (
-                        <Route path={`/t/${team.slug}`} key={team.slug}>
-                            <Route exact path={`/t/${team.slug}`}>
-                                <Redirect to={`/t/${team.slug}/projects`} />
-                            </Route>
-                            <Route
-                                exact
-                                path={`/t/${team.slug}/:maybeProject/:resourceOrPrebuild?`}
-                                render={({ match }) => {
-                                    const { maybeProject, resourceOrPrebuild } = match.params;
-                                    switch (maybeProject) {
-                                        case "projects":
-                                            return <Projects />;
-                                        case "members":
-                                            return <Members />;
-                                        case "settings":
-                                            return <TeamSettings />;
-                                        case "billing":
-                                            return <TeamBilling />;
-                                        case "sso":
-                                            return <SSO />;
-                                        case "usage":
-                                            return <TeamUsage />;
-                                        default:
-                                            break;
-                                    }
-                                    switch (resourceOrPrebuild) {
-                                        case "events":
-                                            return <Events />;
-                                        case "prebuilds":
-                                            return <Prebuilds />;
-                                        case "settings":
-                                            return <ProjectSettings />;
-                                        case "variables":
-                                            return <ProjectVariables />;
-                                        default:
-                                            return resourceOrPrebuild ? <Prebuild /> : <Project />;
-                                    }
-                                }}
-                            />
-                        </Route>
-                    ))}
                     <Route
                         path="*"
                         render={(_match) => {

--- a/components/dashboard/src/components/BillingAccountSelector.tsx
+++ b/components/dashboard/src/components/BillingAccountSelector.tsx
@@ -8,7 +8,7 @@ import { useContext, useEffect, useState } from "react";
 import { Team, TeamMemberInfo } from "@gitpod/gitpod-protocol";
 import { AttributionId, AttributionTarget } from "@gitpod/gitpod-protocol/lib/attribution";
 import { getGitpodService } from "../service/service";
-import { TeamsContext } from "../teams/teams-context";
+import { useTeams } from "../teams/teams-context";
 import { UserContext } from "../user-context";
 import SelectableCardSolid from "../components/SelectableCardSolid";
 import { ReactComponent as Spinner } from "../icons/Spinner.svg";
@@ -17,7 +17,7 @@ import { publicApiTeamMembersToProtocol, teamsService } from "../service/public-
 
 export function BillingAccountSelector(props: { onSelected?: () => void }) {
     const { user, setUser } = useContext(UserContext);
-    const { teams } = useContext(TeamsContext);
+    const teams = useTeams();
     const [teamsAvailableForAttribution, setTeamsAvailableForAttribution] = useState<Team[] | undefined>();
     const [membersByTeam, setMembersByTeam] = useState<Record<string, TeamMemberInfo[]>>({});
     const [errorMessage, setErrorMessage] = useState<string | undefined>();

--- a/components/dashboard/src/components/UsageLimitReachedModal.tsx
+++ b/components/dashboard/src/components/UsageLimitReachedModal.tsx
@@ -6,14 +6,14 @@
 
 import { Team } from "@gitpod/gitpod-protocol";
 import { AttributionId } from "@gitpod/gitpod-protocol/lib/attribution";
-import { useContext, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { gitpodHostUrl } from "../service/service";
-import { TeamsContext } from "../teams/teams-context";
+import { useTeams } from "../teams/teams-context";
 import Alert from "./Alert";
 import Modal from "./Modal";
 
 export function UsageLimitReachedModal(p: { hints: any }) {
-    const { teams } = useContext(TeamsContext);
+    const teams = useTeams();
     // const [attributionId, setAttributionId] = useState<AttributionId | undefined>();
     const [attributedTeam, setAttributedTeam] = useState<Team | undefined>();
 

--- a/components/dashboard/src/contexts/FeatureFlagContext.tsx
+++ b/components/dashboard/src/contexts/FeatureFlagContext.tsx
@@ -5,10 +5,9 @@
  */
 
 import React, { createContext, useContext, useState, useEffect } from "react";
-import { useLocation } from "react-router";
 import { getExperimentsClient } from "../experiments/client";
 import { ProjectContext } from "../projects/project-context";
-import { getCurrentTeam, TeamsContext } from "../teams/teams-context";
+import { useCurrentTeam, useTeams } from "../teams/teams-context";
 import { UserContext } from "../user-context";
 
 interface FeatureFlagConfig {
@@ -33,10 +32,9 @@ const FeatureFlagContext = createContext<{
 
 const FeatureFlagContextProvider: React.FC = ({ children }) => {
     const { user } = useContext(UserContext);
-    const { teams } = useContext(TeamsContext);
+    const teams = useTeams();
     const { project } = useContext(ProjectContext);
-    const location = useLocation();
-    const team = getCurrentTeam(location, teams);
+    const team = useCurrentTeam();
     const [showUsageView, setShowUsageView] = useState<boolean>(false);
     const [isUsageBasedBillingEnabled, setIsUsageBasedBillingEnabled] = useState<boolean>(false);
     const [showUseLastSuccessfulPrebuild, setShowUseLastSuccessfulPrebuild] = useState<boolean>(false);

--- a/components/dashboard/src/projects/NewProject.tsx
+++ b/components/dashboard/src/projects/NewProject.tsx
@@ -7,9 +7,8 @@
 import { useContext, useEffect, useState } from "react";
 import { getGitpodService, gitpodHostUrl } from "../service/service";
 import { iconForAuthProvider, openAuthorizeWindow, simplifyProviderName } from "../provider-utils";
-import { AuthProviderInfo, Project, ProviderRepository, Team, TeamMemberInfo, User } from "@gitpod/gitpod-protocol";
-import { TeamsContext } from "../teams/teams-context";
-import { useLocation } from "react-router";
+import { AuthProviderInfo, Project, ProviderRepository, Team, User } from "@gitpod/gitpod-protocol";
+import { useCurrentTeam } from "../teams/teams-context";
 import ContextMenu, { ContextMenuEntry } from "../components/ContextMenu";
 import CaretDown from "../icons/CaretDown.svg";
 import Plus from "../icons/Plus.svg";
@@ -21,18 +20,10 @@ import { trackEvent } from "../Analytics";
 import exclamation from "../images/exclamation.svg";
 import ErrorMessage from "../components/ErrorMessage";
 import Spinner from "../icons/Spinner.svg";
-import {
-    publicApiTeamMembersToProtocol,
-    publicApiTeamsToProtocol,
-    publicApiTeamToProtocol,
-    teamsService,
-} from "../service/public-api";
-import { ConnectError } from "@bufbuild/connect-web";
 import { useRefreshProjects } from "../data/projects/list-projects-query";
 
 export default function NewProject() {
-    const location = useLocation();
-    const { teams } = useContext(TeamsContext);
+    const currentTeam = useCurrentTeam();
     const { user, setUser } = useContext(UserContext);
     const refreshProjects = useRefreshProjects();
 
@@ -42,9 +33,6 @@ export default function NewProject() {
     const [selectedAccount, setSelectedAccount] = useState<string | undefined>(undefined);
     const [showGitProviders, setShowGitProviders] = useState<boolean>(false);
     const [selectedRepo, setSelectedRepo] = useState<ProviderRepository | undefined>(undefined);
-    const [selectedTeamOrUser, setSelectedTeamOrUser] = useState<Team | User | undefined>(undefined);
-
-    const [showNewTeam, setShowNewTeam] = useState<boolean>(false);
     const [loaded, setLoaded] = useState<boolean>(false);
 
     const [project, setProject] = useState<Project | undefined>();
@@ -96,46 +84,10 @@ export default function NewProject() {
     }, [authProviders, isGitHubAppEnabled, selectedProviderHost]);
 
     useEffect(() => {
-        const params = new URLSearchParams(location.search);
-        const teamParam = params.get("team");
-        if (teamParam) {
-            window.history.replaceState({}, "", window.location.pathname);
-            const team = teams?.find((t) => t.slug === teamParam);
-            setSelectedTeamOrUser(team);
+        if (selectedRepo && user) {
+            createProject(currentTeam, user, selectedRepo);
         }
-        if (params.get("user")) {
-            window.history.replaceState({}, "", window.location.pathname);
-            setSelectedTeamOrUser(user);
-        }
-    }, []);
-
-    const [teamMembers, setTeamMembers] = useState<Record<string, TeamMemberInfo[]>>({});
-    useEffect(() => {
-        if (!teams) {
-            return;
-        }
-        (async () => {
-            const members: Record<string, TeamMemberInfo[]> = {};
-            await Promise.all(
-                teams.map(async (team) => {
-                    try {
-                        members[team.id] = publicApiTeamMembersToProtocol(
-                            (await teamsService.getTeam({ teamId: team!.id })).team?.members || [],
-                        );
-                    } catch (error) {
-                        console.error("Could not get members of team", team, error);
-                    }
-                }),
-            );
-            setTeamMembers(members);
-        })();
-    }, [teams]);
-
-    useEffect(() => {
-        if (selectedTeamOrUser && selectedRepo) {
-            createProject(selectedTeamOrUser, selectedRepo);
-        }
-    }, [selectedTeamOrUser, selectedRepo]);
+    }, [selectedRepo, currentTeam, user]);
 
     useEffect(() => {
         if (reposInAccounts.length === 0) {
@@ -227,7 +179,7 @@ export default function NewProject() {
     };
 
     // TODO: Look into making this a react-query mutation
-    const createProject = async (teamOrUser: Team | User, repo: ProviderRepository) => {
+    const createProject = async (team: Team | undefined, user: User, repo: ProviderRepository) => {
         if (!selectedProviderHost) {
             return;
         }
@@ -238,7 +190,7 @@ export default function NewProject() {
                 name: repo.name,
                 slug: repoSlug,
                 cloneUrl: repo.cloneUrl,
-                ...(User.is(teamOrUser) ? { userId: teamOrUser.id } : { teamId: teamOrUser.id }),
+                ...(team ? { teamId: team.id } : { userId: user.id }),
                 appInstallationId: String(repo.installationId),
             });
 
@@ -333,7 +285,7 @@ export default function NewProject() {
                 <p className="text-gray-500 text-center text-base">
                     Projects allow you to manage prebuilds and workspaces for your repository.{" "}
                     <a
-                        href="https://www.gitpod.io/docs/orgs-and-projects"
+                        href="https://www.gitpod.io/docs/configure/projects"
                         target="_blank"
                         rel="noreferrer"
                         className="gp-link"
@@ -526,58 +478,6 @@ export default function NewProject() {
         return renderRepos();
     };
 
-    const renderSelectTeam = () => {
-        const teamsToRender = teams || [];
-        return (
-            <>
-                <p className="mt-2 text-gray-500 text-center text-base">Select organization</p>
-                <div className="mt-14 flex flex-col space-y-2">
-                    {teamsToRender.map((t) => (
-                        <label
-                            key={`team-${t.name}`}
-                            className={`w-80 px-4 py-3 flex space-x-3 items-center cursor-pointer rounded-xl hover:bg-gray-100 dark:hover:bg-gray-800`}
-                            onClick={() => setSelectedTeamOrUser(t)}
-                        >
-                            <input type="radio" />
-                            <div className="flex-grow overflow-ellipsis truncate flex flex-col">
-                                <span className="font-semibold">{t.name}</span>
-                                <span className="text-sm text-gray-400">
-                                    {!!teamMembers[t.id]
-                                        ? `${teamMembers[t.id].length} member${
-                                              teamMembers[t.id].length === 1 ? "" : "s"
-                                          }`
-                                        : "Organization"}
-                                </span>
-                            </div>
-                        </label>
-                    ))}
-                    <label className="w-80 px-4 py-3 flex flex-col cursor-pointer rounded-xl hover:bg-gray-100 dark:hover:bg-gray-800">
-                        <div className="flex space-x-3 items-center relative">
-                            <input type="radio" onChange={() => setShowNewTeam(!showNewTeam)} />
-                            <div className="flex-grow overflow-ellipsis truncate flex flex-col">
-                                <span className="font-semibold">Create new organization</span>
-                                <span className="text-sm text-gray-400">Collaborate with others</span>
-                            </div>
-                            {teamsToRender.length > 0 && (
-                                <img
-                                    alt=""
-                                    src={CaretDown}
-                                    title="Select Account"
-                                    className={`${
-                                        showNewTeam ? "transform rotate-180" : ""
-                                    } filter-grayscale absolute top-1/2 right-3 cursor-pointer`}
-                                />
-                            )}
-                        </div>
-                        {(showNewTeam || teamsToRender.length === 0) && (
-                            <NewTeam onSuccess={(t) => setSelectedTeamOrUser(t)} />
-                        )}
-                    </label>
-                </div>
-            </>
-        );
-    };
-
     const onNewWorkspace = async () => {
         const redirectToNewWorkspace = () => {
             // instead of `history.push` we want forcibly to redirect here in order to avoid a following redirect from `/` -> `/projects` (cf. App.tsx)
@@ -596,25 +496,19 @@ export default function NewProject() {
                     <h1>New Project</h1>
 
                     {!selectedRepo && renderSelectRepository()}
-
-                    {selectedRepo && !selectedTeamOrUser && renderSelectTeam()}
-
-                    {selectedRepo && selectedTeamOrUser && <div></div>}
                 </>
             </div>
         );
     } else {
-        const projectLink = User.is(selectedTeamOrUser)
-            ? `/projects/${project.slug}`
-            : `/t/${selectedTeamOrUser?.slug}/${project.slug}`;
-        const location = User.is(selectedTeamOrUser) ? (
+        const projectLink = `/projects/${Project.slug(project!)}`;
+        const location = !currentTeam ? (
             ""
         ) : (
             <>
                 {" "}
                 in organization{" "}
-                <a className="gp-link" href={`/t/${selectedTeamOrUser?.slug}/projects`}>
-                    {selectedTeamOrUser?.name}
+                <a className="gp-link" href={`/projects`}>
+                    {currentTeam?.name}
                 </a>
             </>
         );
@@ -713,57 +607,6 @@ function GitProviders(props: {
                 {errorMessage && <ErrorMessage imgSrc={exclamation} message={errorMessage} />}
             </div>
         </div>
-    );
-}
-
-function NewTeam(props: { onSuccess: (team: Team) => void }) {
-    const { setTeams } = useContext(TeamsContext);
-
-    const [teamName, setTeamName] = useState<string | undefined>();
-    const [error, setError] = useState<string | undefined>();
-
-    const onNewTeam = async () => {
-        if (!teamName) {
-            return;
-        }
-
-        try {
-            const team = publicApiTeamToProtocol((await teamsService.createTeam({ name: teamName })).team!);
-            const teams = publicApiTeamsToProtocol((await teamsService.listTeams({})).teams);
-
-            setTeams(teams);
-            props.onSuccess(team);
-        } catch (error) {
-            console.error(error);
-            if (error instanceof ConnectError) {
-                setError(error.rawMessage);
-            } else {
-                setError(error?.message || "Failed to create new team!");
-            }
-        }
-    };
-
-    const onTeamNameChanged = (name: string) => {
-        setTeamName(name);
-        setError(undefined);
-    };
-
-    return (
-        <>
-            <div className="mt-6 mb-1 flex flex-row space-x-2">
-                <input
-                    type="text"
-                    className="py-1 min-w-0"
-                    name="new-team-inline"
-                    value={teamName}
-                    onChange={(e) => onTeamNameChanged(e.target.value)}
-                />
-                <button key={`new-team-inline-create`} disabled={!teamName} onClick={() => onNewTeam()}>
-                    Continue
-                </button>
-            </div>
-            {error && <p className="text-gitpod-red">{error}</p>}
-        </>
     );
 }
 

--- a/components/dashboard/src/projects/ProjectListItem.tsx
+++ b/components/dashboard/src/projects/ProjectListItem.tsx
@@ -4,12 +4,11 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { FunctionComponent, useContext, useMemo, useState } from "react";
+import { FunctionComponent, useContext, useState } from "react";
 import dayjs from "dayjs";
 import { Project } from "@gitpod/gitpod-protocol";
 import { Link } from "react-router-dom";
 import ContextMenu from "../components/ContextMenu";
-import { useCurrentTeam } from "../teams/teams-context";
 import { RemoveProjectModal } from "./RemoveProjectModal";
 import { toRemoteURL } from "./render-utils";
 import { prebuildStatusIcon } from "./Prebuilds";
@@ -23,21 +22,16 @@ type ProjectListItemProps = {
 };
 
 export const ProjectListItem: FunctionComponent<ProjectListItemProps> = ({ project, onProjectRemoved }) => {
-    const team = useCurrentTeam();
     const [showRemoveModal, setShowRemoveModal] = useState(false);
     const { data: prebuild, isLoading } = useLatestProjectPrebuildQuery({ projectId: project.id });
     const { setStartWorkspaceModalProps } = useContext(StartWorkspaceModalContext);
-
-    const teamOrUserSlug = useMemo(() => {
-        return !!team ? "t/" + team.slug : "projects";
-    }, [team]);
 
     return (
         <div key={`project-${project.id}`} className="h-52">
             <div className="h-42 border border-gray-100 dark:border-gray-800 rounded-t-xl">
                 <div className="h-32 p-6">
                     <div className="flex text-gray-700 dark:text-gray-200 font-medium">
-                        <ProjectLink project={project} teamOrUserSlug={teamOrUserSlug} />
+                        <ProjectLink project={project} />
                         <span className="flex-grow" />
                         <div className="justify-end">
                             <ContextMenu
@@ -74,11 +68,11 @@ export const ProjectListItem: FunctionComponent<ProjectListItemProps> = ({ proje
                 </div>
                 <div className="h-10 px-6 py-1 text-gray-400 text-sm">
                     <span className="hover:text-gray-600 dark:hover:text-gray-300">
-                        <Link to={`/${teamOrUserSlug}/${project.slug || project.name}`}>Branches</Link>
+                        <Link to={`/projects/${Project.slug(project!)}`}>Branches</Link>
                     </span>
                     <span className="mx-2 my-auto">·</span>
                     <span className="hover:text-gray-600 dark:hover:text-gray-300">
-                        <Link to={`/${teamOrUserSlug}/${project.slug || project.name}/prebuilds`}>Prebuilds</Link>
+                        <Link to={`/projects/${Project.slug(project!)}/prebuilds`}>Prebuilds</Link>
                     </span>
                 </div>
             </div>
@@ -86,7 +80,7 @@ export const ProjectListItem: FunctionComponent<ProjectListItemProps> = ({ proje
                 {prebuild ? (
                     <div className="flex flex-row h-full text-sm space-x-4">
                         <Link
-                            to={`/${teamOrUserSlug}/${project.slug || project.name}/${prebuild?.info?.id}`}
+                            to={`/projects/${Project.slug(project!)}/${prebuild?.info?.id}`}
                             className="flex-grow flex items-center group space-x-2 truncate"
                         >
                             {prebuildStatusIcon(prebuild)}
@@ -102,7 +96,7 @@ export const ProjectListItem: FunctionComponent<ProjectListItemProps> = ({ proje
                             </div>
                         </Link>
                         <Link
-                            to={`/${teamOrUserSlug}/${project.slug || project.name}/prebuilds`}
+                            to={`/projects/${Project.slug(project!)}/prebuilds`}
                             className="flex-shrink-0 flex items-center text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
                         >
                             View All &rarr;
@@ -131,22 +125,11 @@ export const ProjectListItem: FunctionComponent<ProjectListItemProps> = ({ proje
 
 type ProjectLinkProps = {
     project: Project;
-    teamOrUserSlug: string;
 };
-const ProjectLink: FunctionComponent<ProjectLinkProps> = ({ project, teamOrUserSlug }) => {
-    let slug = "";
-    const name = project.name;
-
-    if (project.slug) {
-        slug = project.slug;
-    } else {
-        // For existing GitLab projects that don't have a slug yet
-        slug = name;
-    }
-
+const ProjectLink: FunctionComponent<ProjectLinkProps> = ({ project }) => {
     return (
-        <Link to={`/${teamOrUserSlug}/${slug}`}>
-            <span className="text-xl font-semibold">{name}</span>
+        <Link to={`/projects/${Project.slug(project)}`}>
+            <span className="text-xl font-semibold">{project.name}</span>
         </Link>
     );
 };

--- a/components/dashboard/src/projects/ProjectSettings.tsx
+++ b/components/dashboard/src/projects/ProjectSettings.tsx
@@ -5,11 +5,11 @@
  */
 
 import { useCallback, useContext, useEffect, useState } from "react";
-import { useLocation, useHistory } from "react-router";
+import { useHistory } from "react-router";
 import { Project, ProjectSettings, Team } from "@gitpod/gitpod-protocol";
 import CheckBox from "../components/CheckBox";
 import { getGitpodService } from "../service/service";
-import { getCurrentTeam, TeamsContext } from "../teams/teams-context";
+import { useCurrentTeam } from "../teams/teams-context";
 import { PageWithSubMenu } from "../components/PageWithSubMenu";
 import PillLabel from "../components/PillLabel";
 import { ProjectContext } from "./project-context";
@@ -20,23 +20,20 @@ import { Link } from "react-router-dom";
 import { RemoveProjectModal } from "./RemoveProjectModal";
 
 export function getProjectSettingsMenu(project?: Project, team?: Team) {
-    const teamOrUserSlug = !!team ? "t/" + team.slug : "projects";
     return [
         {
             title: "General",
-            link: [`/${teamOrUserSlug}/${project?.slug || project?.name}/settings`],
+            link: [`/projects/${Project.slug(project!)}/settings`],
         },
         {
             title: "Variables",
-            link: [`/${teamOrUserSlug}/${project?.slug || project?.name}/variables`],
+            link: [`/projects/${Project.slug(project!)}/variables`],
         },
     ];
 }
 
 export function ProjectSettingsPage(props: { project?: Project; children?: React.ReactNode }) {
-    const location = useLocation();
-    const { teams } = useContext(TeamsContext);
-    const team = getCurrentTeam(location, teams);
+    const team = useCurrentTeam();
 
     return (
         <PageWithSubMenu
@@ -53,8 +50,7 @@ export default function () {
     const { project, setProject } = useContext(ProjectContext);
     const [billingMode, setBillingMode] = useState<BillingMode | undefined>(undefined);
     const [showRemoveModal, setShowRemoveModal] = useState(false);
-    const { teams } = useContext(TeamsContext);
-    const team = getCurrentTeam(useLocation(), teams);
+    const team = useCurrentTeam();
     const history = useHistory();
 
     useEffect(() => {
@@ -101,13 +97,8 @@ export default function () {
     );
 
     const onProjectRemoved = useCallback(() => {
-        // if there's a current team, navigate to team projects
-        if (team) {
-            history.push(`/t/${team.slug}/projects`);
-        } else {
-            history.push("/projects");
-        }
-    }, [history, team]);
+        history.push("/projects");
+    }, [history]);
 
     // TODO: Render a generic error screen for when an entity isn't found
     if (!project) return null;

--- a/components/dashboard/src/projects/ProjectVariables.tsx
+++ b/components/dashboard/src/projects/ProjectVariables.tsx
@@ -5,18 +5,18 @@
  */
 
 import { Project, ProjectEnvVar } from "@gitpod/gitpod-protocol";
-import { useContext, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import Alert from "../components/Alert";
 import CheckBox from "../components/CheckBox";
 import InfoBox from "../components/InfoBox";
 import { Item, ItemField, ItemFieldContextMenu, ItemsList } from "../components/ItemsList";
 import Modal from "../components/Modal";
 import { getGitpodService } from "../service/service";
-import { ProjectContext } from "./project-context";
+import { useCurrentProject } from "./project-context";
 import { ProjectSettingsPage } from "./ProjectSettings";
 
 export default function () {
-    const { project } = useContext(ProjectContext);
+    const project = useCurrentProject();
     const [envVars, setEnvVars] = useState<ProjectEnvVar[]>([]);
     const [showAddVariableModal, setShowAddVariableModal] = useState<boolean>(false);
 

--- a/components/dashboard/src/projects/Projects.tsx
+++ b/components/dashboard/src/projects/Projects.tsx
@@ -8,9 +8,9 @@ import { Link } from "react-router-dom";
 import Header from "../components/Header";
 import projectsEmpty from "../images/projects-empty.svg";
 import projectsEmptyDark from "../images/projects-empty-dark.svg";
-import { useHistory, useLocation } from "react-router";
+import { useHistory } from "react-router";
 import { useCallback, useContext, useMemo, useState } from "react";
-import { getCurrentTeam, TeamsContext } from "../teams/teams-context";
+import { useCurrentTeam } from "../teams/teams-context";
 import { ThemeContext } from "../theme-context";
 import { Project } from "@gitpod/gitpod-protocol";
 import Alert from "../components/Alert";
@@ -19,14 +19,12 @@ import { SpinnerLoader } from "../components/Loader";
 import { useListProjectsQuery } from "../data/projects/list-projects-query";
 
 export default function () {
-    const location = useLocation();
     const history = useHistory();
-    const { teams } = useContext(TeamsContext);
-    const team = getCurrentTeam(location, teams);
+    const team = useCurrentTeam();
     const { data, isLoading, isError, refetch } = useListProjectsQuery();
     const { isDark } = useContext(ThemeContext);
     const [searchFilter, setSearchFilter] = useState<string | undefined>();
-    const newProjectUrl = useMemo(() => (!!team ? `/new?team=${team.slug}` : "/new?user=1"), [team]);
+    const newProjectUrl = `/new`;
 
     const onNewProject = useCallback(() => {
         history.push(newProjectUrl);

--- a/components/dashboard/src/projects/project-context.tsx
+++ b/components/dashboard/src/projects/project-context.tsx
@@ -3,14 +3,9 @@
  * Licensed under the GNU Affero General Public License (AGPL).
  * See License.AGPL.txt in the project root for license information.
  */
-/**
- * Copyright (c) 2021 Gitpod GmbH. All rights reserved.
- * Licensed under the GNU Affero General Public License (AGPL).
- * See License.AGPL.txt in the project root for license information.
- */
 
 import { Project } from "@gitpod/gitpod-protocol";
-import React, { createContext, useState } from "react";
+import React, { createContext, useContext, useState } from "react";
 
 export const ProjectContext = createContext<{
     project?: Project;
@@ -23,3 +18,8 @@ export const ProjectContextProvider: React.FC = ({ children }) => {
     const [project, setProject] = useState<Project>();
     return <ProjectContext.Provider value={{ project, setProject }}>{children}</ProjectContext.Provider>;
 };
+
+export function useCurrentProject(): Project | undefined {
+    const { project } = useContext(ProjectContext);
+    return project;
+}

--- a/components/dashboard/src/settings/ChargebeeTeams.tsx
+++ b/components/dashboard/src/settings/ChargebeeTeams.tsx
@@ -25,12 +25,12 @@ import { PaymentContext } from "../payment-context";
 import { PageWithSettingsSubMenu } from "./PageWithSettingsSubMenu";
 import { FeatureFlagContext } from "../contexts/FeatureFlagContext";
 
-export default function Teams() {
+export default function ChargebeeTeams() {
     return (
         <div>
             <PageWithSettingsSubMenu
-                title="Organization Plans"
-                subtitle="View and manage subscriptions for your organization with one centralized billing."
+                title="Team Plans (deprecated)"
+                subtitle="View and manage subscriptions for entire teams with one centralized billing."
             >
                 <AllTeams />
             </PageWithSettingsSubMenu>
@@ -469,8 +469,8 @@ function AllTeams() {
             )}
             <div className="flex flex-row">
                 <div className="flex-grow ">
-                    <h3 className="self-center">All Organization Plans</h3>
-                    <h2>Manage organization plans and organization members.</h2>
+                    <h3 className="self-center">All Team Plans</h3>
+                    <h2>Manage team plans and members.</h2>
                 </div>
                 <div className="flex flex-end space-x-3">
                     {isChargebeeCustomer && (
@@ -488,7 +488,7 @@ function AllTeams() {
                             }
                             onClick={() => showCreateTeamModal()}
                         >
-                            Create Organization Plan
+                            Create Team Plan
                         </button>
                     )}
                 </div>
@@ -520,23 +520,13 @@ function AllTeams() {
             {getActiveSubs().length === 0 && !pendingPlanPurchase && !isUsageBasedBillingEnabled && (
                 <div className="w-full flex h-80 mt-2 rounded-xl bg-gray-100 dark:bg-gray-900">
                     <div className="m-auto text-center">
-                        <h3 className="self-center text-gray-500 dark:text-gray-400 mb-4">
-                            No Active Organization Plans
-                        </h3>
+                        <h3 className="self-center text-gray-500 dark:text-gray-400 mb-4">No Active Team Plans</h3>
                         <div className="text-gray-500 mb-6">
-                            Get started by creating an organization plan
+                            Get started by creating a team plan
                             <br /> and adding members.{" "}
-                            <a
-                                href="https://www.gitpod.io/docs/orgs/"
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                className="gp-link"
-                            >
-                                Learn more
-                            </a>
                         </div>
                         <button className="self-center" onClick={() => showCreateTeamModal()}>
-                            Create Organization Plan
+                            Create Team Plan
                         </button>
                     </div>
                 </div>
@@ -776,7 +766,7 @@ function NewTeamModal(props: {
     return (
         // TODO: Use title and buttons props
         <Modal visible={true} onClose={props.onClose}>
-            <h3 className="pb-2">New Organization Plan</h3>
+            <h3 className="pb-2">New Team Plan</h3>
             <div className="border-t border-b border-gray-200 dark:border-gray-800 mt-2 -mx-6 px-6 py-4 space-y-2">
                 <p className="pb-4 text-gray-500 text-base">Create a plan and add members.</p>
 

--- a/components/dashboard/src/settings/settings-menu.ts
+++ b/components/dashboard/src/settings/settings-menu.ts
@@ -13,7 +13,6 @@ import {
     settingsPathNotifications,
     settingsPathPlans,
     settingsPathPreferences,
-    settingsPathOrgs,
     settingsPathVariables,
     settingsPathSSHKeys,
     settingsPathPersonalAccessTokens,
@@ -80,8 +79,8 @@ function renderBillingMenuEntries(billingMode?: BillingMode) {
                     link: [settingsPathPlans],
                 },
                 {
-                    title: "Organization Plans",
-                    link: [settingsPathOrgs],
+                    title: "Team Plans (deprecated)",
+                    link: ["/old-team-plans"],
                 },
                 ...(BillingMode.showUsageBasedBilling(billingMode)
                     ? [
@@ -102,8 +101,8 @@ function renderBillingMenuEntries(billingMode?: BillingMode) {
                 ...(BillingMode.showTeamSubscriptionUI(billingMode)
                     ? [
                           {
-                              title: "Organization Plans",
-                              link: [settingsPathOrgs],
+                              title: "Team Plans (deprecated)",
+                              link: ["/old-team-plans"],
                           },
                       ]
                     : []),

--- a/components/dashboard/src/settings/settings.routes.ts
+++ b/components/dashboard/src/settings/settings.routes.ts
@@ -13,19 +13,6 @@ export const settingsPathNotifications = "/notifications";
 export const settingsPathBilling = "/billing";
 export const settingsPathPlans = "/plans";
 export const settingsPathPreferences = "/preferences";
-
-/**
- * @deprecated use settingsPathOrgs instead
- * we keep this for some time to not break links
- */
-export const settingsPathTeams = "/teams";
-export const settingsPathTeamsJoin = [settingsPathTeams, "join"].join("/");
-export const settingsPathTeamsNew = [settingsPathTeams, "new"].join("/");
-
-export const settingsPathOrgs = "/orgs";
-export const settingsPathOrgsJoin = [settingsPathOrgs, "join"].join("/");
-export const settingsPathOrgsNew = [settingsPathOrgs, "new"].join("/");
-
 export const settingsPathVariables = "/variables";
 export const settingsPathPersonalAccessTokens = "/tokens";
 export const settingsPathPersonalAccessTokenCreate = "/tokens/create";

--- a/components/dashboard/src/teams/JoinTeam.tsx
+++ b/components/dashboard/src/teams/JoinTeam.tsx
@@ -4,17 +4,18 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { useContext, useEffect, useState } from "react";
-import { useHistory } from "react-router-dom";
-import { publicApiTeamsToProtocol, publicApiTeamToProtocol, teamsService } from "../service/public-api";
+import { useContext, useEffect, useMemo, useState } from "react";
+import { useHistory, useLocation } from "react-router-dom";
+import { publicApiTeamsToProtocol, teamsService } from "../service/public-api";
 import { TeamsContext } from "./teams-context";
 
 export default function () {
     const { setTeams } = useContext(TeamsContext);
     const history = useHistory();
+    const location = useLocation();
 
     const [joinError, setJoinError] = useState<Error>();
-    const inviteId = new URL(window.location.href).searchParams.get("inviteId");
+    const inviteId = useMemo(() => new URLSearchParams(location.search).get("inviteId"), [location]);
 
     useEffect(() => {
         (async () => {
@@ -23,18 +24,16 @@ export default function () {
                     throw new Error("This invite URL is incorrect.");
                 }
 
-                const team = publicApiTeamToProtocol((await teamsService.joinTeam({ invitationId: inviteId })).team!);
                 const teams = publicApiTeamsToProtocol((await teamsService.listTeams({})).teams);
-
                 setTeams(teams);
 
-                history.push(`/t/${team.slug}/members`);
+                history.push(`/members`);
             } catch (error) {
                 console.error(error);
                 setJoinError(error);
             }
         })();
-    }, []);
+    }, [history, inviteId, setTeams]);
 
     useEffect(() => {
         document.title = "Joining Organization — Gitpod";

--- a/components/dashboard/src/teams/Members.tsx
+++ b/components/dashboard/src/teams/Members.tsx
@@ -7,7 +7,7 @@
 import { TeamMemberInfo, TeamMemberRole } from "@gitpod/gitpod-protocol";
 import dayjs from "dayjs";
 import { useContext, useEffect, useState } from "react";
-import { useHistory, useLocation } from "react-router";
+import { useHistory } from "react-router";
 import Header from "../components/Header";
 import DropDown from "../components/DropDown";
 import { ItemsList, Item, ItemField, ItemFieldContextMenu } from "../components/ItemsList";
@@ -15,18 +15,17 @@ import Modal from "../components/Modal";
 import Tooltip from "../components/Tooltip";
 import copy from "../images/copy.svg";
 import { UserContext } from "../user-context";
-import { TeamsContext, getCurrentTeam } from "./teams-context";
+import { TeamsContext, useCurrentTeam } from "./teams-context";
 import { trackEvent } from "../Analytics";
 import { publicApiTeamMembersToProtocol, publicApiTeamsToProtocol, teamsService } from "../service/public-api";
 import { TeamRole } from "@gitpod/public-api/lib/gitpod/experimental/v1/teams_pb";
 
 export default function () {
     const { user } = useContext(UserContext);
-    const { teams, setTeams } = useContext(TeamsContext);
+    const { setTeams } = useContext(TeamsContext);
 
     const history = useHistory();
-    const location = useLocation();
-    const team = getCurrentTeam(location, teams);
+    const team = useCurrentTeam();
     const [members, setMembers] = useState<TeamMemberInfo[]>([]);
     const [genericInviteId, setGenericInviteId] = useState<string>();
     const [showInviteModal, setShowInviteModal] = useState<boolean>(false);

--- a/components/dashboard/src/teams/NewTeam.tsx
+++ b/components/dashboard/src/teams/NewTeam.tsx
@@ -26,7 +26,7 @@ export default function () {
             const teams = publicApiTeamsToProtocol((await teamsService.listTeams({})).teams);
 
             setTeams(teams);
-            history.push(`/t/${team.slug}`);
+            history.push(`/?org=${team.id}`);
         } catch (error) {
             console.error(error);
             if (error instanceof ConnectError) {

--- a/components/dashboard/src/teams/SSO.tsx
+++ b/components/dashboard/src/teams/SSO.tsx
@@ -5,12 +5,12 @@
  */
 
 import { useContext, useEffect, useState } from "react";
-import { Redirect, useLocation } from "react-router";
+import { Redirect } from "react-router";
 import { TeamMemberInfo } from "@gitpod/gitpod-protocol";
 import { BillingMode } from "@gitpod/gitpod-protocol/lib/billing-mode";
 import { PageWithSubMenu } from "../components/PageWithSubMenu";
 import { ReactComponent as Spinner } from "../icons/Spinner.svg";
-import { getCurrentTeam, TeamsContext } from "./teams-context";
+import { useCurrentTeam } from "./teams-context";
 import { getTeamSettingsMenu } from "./TeamSettings";
 import { UserContext } from "../user-context";
 import { oidcService, publicApiTeamMembersToProtocol, teamsService } from "../service/public-api";
@@ -26,9 +26,7 @@ import exclamation from "../images/exclamation.svg";
 
 export default function SSO() {
     const { user } = useContext(UserContext);
-    const { teams } = useContext(TeamsContext);
-    const location = useLocation();
-    const team = getCurrentTeam(location, teams);
+    const team = useCurrentTeam();
     const [teamBillingMode, setTeamBillingMode] = useState<BillingMode | undefined>(undefined);
     const [isUserOwner, setIsUserOwner] = useState(true);
     const [isLoading, setIsLoading] = useState(true);
@@ -52,7 +50,7 @@ export default function SSO() {
     }, [team]);
 
     if (!isUserOwner) {
-        return <Redirect to={team ? `/t/${team.slug}` : "/"} />;
+        return <Redirect to={`/`} />;
     }
 
     return (

--- a/components/dashboard/src/teams/TeamBilling.tsx
+++ b/components/dashboard/src/teams/TeamBilling.tsx
@@ -4,38 +4,36 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import React, { useContext, useEffect, useState } from "react";
-import { Redirect, useLocation } from "react-router";
 import { TeamMemberInfo } from "@gitpod/gitpod-protocol";
 import { BillingMode } from "@gitpod/gitpod-protocol/lib/billing-mode";
 import { Currency, Plan, Plans, PlanType } from "@gitpod/gitpod-protocol/lib/plans";
 import { TeamSubscription2 } from "@gitpod/gitpod-protocol/lib/team-subscription-protocol";
+import React, { useContext, useEffect, useState } from "react";
+import { Redirect } from "react-router";
 import { ChargebeeClient } from "../chargebee/chargebee-client";
-import { PageWithSubMenu } from "../components/PageWithSubMenu";
+import Alert from "../components/Alert";
 import Card from "../components/Card";
 import DropDown from "../components/DropDown";
+import { PageWithSubMenu } from "../components/PageWithSubMenu";
 import PillLabel from "../components/PillLabel";
 import SolidCard from "../components/SolidCard";
-import { ReactComponent as CheckSvg } from "../images/check.svg";
+import { FeatureFlagContext } from "../contexts/FeatureFlagContext";
+import { getExperimentsClient } from "../experiments/client";
 import { ReactComponent as Spinner } from "../icons/Spinner.svg";
+import { ReactComponent as CheckSvg } from "../images/check.svg";
 import { PaymentContext } from "../payment-context";
+import { publicApiTeamMembersToProtocol, teamsService } from "../service/public-api";
 import { getGitpodService } from "../service/service";
-import { getCurrentTeam, TeamsContext } from "./teams-context";
+import { UserContext } from "../user-context";
+import { useCurrentTeam } from "./teams-context";
 import { getTeamSettingsMenu } from "./TeamSettings";
 import TeamUsageBasedBilling from "./TeamUsageBasedBilling";
-import { UserContext } from "../user-context";
-import { publicApiTeamMembersToProtocol, teamsService } from "../service/public-api";
-import Alert from "../components/Alert";
-import { getExperimentsClient } from "../experiments/client";
-import { FeatureFlagContext } from "../contexts/FeatureFlagContext";
 
 type PendingPlan = Plan & { pendingSince: number };
 
 export default function TeamBilling() {
     const { user } = useContext(UserContext);
-    const { teams } = useContext(TeamsContext);
-    const location = useLocation();
-    const team = getCurrentTeam(location, teams);
+    const team = useCurrentTeam();
     const [members, setMembers] = useState<TeamMemberInfo[]>([]);
     const [isUserOwner, setIsUserOwner] = useState(true);
     const [teamSubscription, setTeamSubscription] = useState<TeamSubscription2 | undefined>();
@@ -170,7 +168,7 @@ export default function TeamBilling() {
     };
 
     if (!isUserOwner) {
-        return <Redirect to={team ? `/t/${team.slug}` : "/"} />;
+        return <Redirect to={`/`} />;
     }
 
     function renderTeamBilling(): JSX.Element {

--- a/components/dashboard/src/teams/TeamSettings.tsx
+++ b/components/dashboard/src/teams/TeamSettings.tsx
@@ -18,24 +18,24 @@ import { useCurrentUser } from "../user-context";
 import { TeamsContext, useCurrentTeam } from "./teams-context";
 
 export function getTeamSettingsMenu(params: { team?: Team; billingMode?: BillingMode; ssoEnabled?: boolean }) {
-    const { team, billingMode, ssoEnabled } = params;
+    const { billingMode, ssoEnabled } = params;
     const result = [
         {
             title: "General",
-            link: [`/t/${team?.slug}/settings`],
+            link: [`/org-settings`],
         },
     ];
     if (ssoEnabled) {
         result.push({
             title: "SSO",
-            link: [`/t/${team?.slug}/sso`],
+            link: [`/sso`],
         });
     }
     if (billingMode?.mode !== "none") {
         // The Billing page contains both chargebee and usage-based components, so: always show them!
         result.push({
             title: "Billing",
-            link: [`/t/${team?.slug}/billing`],
+            link: [`/org-billing`],
         });
     }
     return result;
@@ -182,7 +182,7 @@ export default function TeamSettings() {
                 onConfirm={deleteTeam}
             >
                 <p className="text-base text-gray-500">
-                    You are about to permanently delete <b>{team?.slug}</b> including all associated data.
+                    You are about to permanently delete <b>{team?.name}</b> including all associated data.
                 </p>
                 <ol className="text-gray-500 text-m list-outside list-decimal">
                     <li className="ml-5">

--- a/components/dashboard/src/teams/TeamUsage.tsx
+++ b/components/dashboard/src/teams/TeamUsage.tsx
@@ -4,15 +4,11 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { useContext } from "react";
-import { useLocation } from "react-router";
-import { getCurrentTeam, TeamsContext } from "./teams-context";
+import { useCurrentTeam } from "./teams-context";
 import UsageView from "../components/UsageView";
 
 function TeamUsage() {
-    const { teams } = useContext(TeamsContext);
-    const location = useLocation();
-    const team = getCurrentTeam(location, teams);
+    const team = useCurrentTeam();
     if (!team) {
         return <></>;
     }

--- a/components/dashboard/src/teams/TeamUsageBasedBilling.tsx
+++ b/components/dashboard/src/teams/TeamUsageBasedBilling.tsx
@@ -4,18 +4,15 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { useContext, useEffect, useState } from "react";
-import { useLocation } from "react-router";
+import { useEffect, useState } from "react";
 import { BillingMode } from "@gitpod/gitpod-protocol/lib/billing-mode";
-import { getCurrentTeam, TeamsContext } from "./teams-context";
+import { useCurrentTeam } from "./teams-context";
 import { getGitpodService } from "../service/service";
 import UsageBasedBillingConfig from "../components/UsageBasedBillingConfig";
 import { AttributionId } from "@gitpod/gitpod-protocol/lib/attribution";
 
 export default function TeamUsageBasedBilling() {
-    const { teams } = useContext(TeamsContext);
-    const location = useLocation();
-    const team = getCurrentTeam(location, teams);
+    const team = useCurrentTeam();
     const [teamBillingMode, setTeamBillingMode] = useState<BillingMode | undefined>(undefined);
 
     useEffect(() => {

--- a/components/gitpod-protocol/src/teams-projects-protocol.ts
+++ b/components/gitpod-protocol/src/teams-projects-protocol.ts
@@ -48,6 +48,10 @@ export namespace Project {
         };
     };
 
+    export function slug(p: Project): string {
+        return p.slug || p.name || p.id;
+    }
+
     export interface Overview {
         branches: BranchDetails[];
         isConsideredInactive?: boolean;

--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -2259,7 +2259,9 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
         } else if (attrId.kind === "team") {
             const team = await this.guardTeamOperation(attrId.teamId, "update");
             await this.ensureStripeApiIsAllowed({ team });
-            returnUrl = this.config.hostUrl.with(() => ({ pathname: `/t/${team.slug}/billing` })).toString();
+            returnUrl = this.config.hostUrl
+                .with(() => ({ pathname: `/org-billing`, search: `org=${team.id}` }))
+                .toString();
         }
         let url: string;
         try {
@@ -2362,10 +2364,10 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
                         const teamOrUser = await this.teamDB.findTeamById(limit.attributionId.teamId);
                         if (teamOrUser) {
                             if (limit.reached) {
-                                result.push(teamOrUser?.slug);
+                                result.push(teamOrUser?.name);
                                 result.unshift(`Your team '${teamOrUser?.name}' has reached its usage limit.`);
                             } else if (limit.almostReached) {
-                                result.push(teamOrUser?.slug);
+                                result.push(teamOrUser?.name);
                                 result.unshift(
                                     `Your team '${teamOrUser?.name}' has reached 80% or more of its usage limit.`,
                                 );

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -2106,7 +2106,6 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
             properties: {
                 id: team.id,
                 name: team.name,
-                slug: team.slug,
                 created_at: team.creationTime,
                 invite_id: invite.id,
             },
@@ -2134,7 +2133,6 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
                 properties: {
                     team_id: invite.teamId,
                     team_name: team?.name,
-                    team_slug: team?.slug,
                     invite_id: inviteId,
                 },
             });


### PR DESCRIPTION
## Description

This change removes the team slugs and instead relies on a search param that if provided on any URL will switch the currently active org. I've decided not only add a generic redirect for old URLs (`/t/*`) under the assumption that those URLs are not (or super rarely) shared outside the app (I have no data 😇 )

**Attention:** This is a follow up and includes the changes in https://github.com/gitpod-io/gitpod/pull/16050, you can either review all changes together or separated

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #16053



## How to test
<!-- Provide steps to test this PR -->

Check all navigation paths and verify they work as intended.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
removed org slugs
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
