### PR TITLE
[slow-server] Change flag from bool to string (DB_HOST)

### DIFF
--- a/dev/preview/workflow/preview/deploy-gitpod.sh
+++ b/dev/preview/workflow/preview/deploy-gitpod.sh
@@ -442,7 +442,7 @@ yq w -i "${INSTALLER_CONFIG_PATH}" 'experimental.workspace.classes.small.templat
 #
 if [[ "${GITPOD_WITH_SLOW_DATABASE}" == "true" ]]
 then
-  yq w -i "${INSTALLER_CONFIG_PATH}" "experimental.webapp.slowDatabase" "true"
+  yq w -i "${INSTALLER_CONFIG_PATH}" "experimental.webapp.slowDatabase" "toxiproxy"
 fi
 
 #

--- a/install/installer/pkg/components/slowserver/deployment.go
+++ b/install/installer/pkg/components/slowserver/deployment.go
@@ -324,11 +324,18 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 		return nil
 	})
 
+	var slowDatabaseHost string
+	_ = ctx.WithExperimental(func(cfg *experimental.Config) error {
+		if cfg.WebApp != nil {
+			slowDatabaseHost = cfg.WebApp.SlowDatabase
+		}
+		return nil
+	})
 	dbWaiterDbEnv := common.DatabaseEnv(&ctx.Config)
 	for i := range dbWaiterDbEnv {
 		if dbWaiterDbEnv[i].Name == "DB_HOST" {
 			dbWaiterDbEnv[i].ValueFrom = nil
-			dbWaiterDbEnv[i].Value = toxiproxy.Component
+			dbWaiterDbEnv[i].Value = slowDatabaseHost
 		}
 	}
 

--- a/install/installer/pkg/components/slowserver/objects.go
+++ b/install/installer/pkg/components/slowserver/objects.go
@@ -13,7 +13,7 @@ import (
 
 func Objects(ctx *common.RenderContext) ([]runtime.Object, error) {
 	cfg := common.ExperimentalWebappConfig(ctx)
-	if cfg == nil || !cfg.SlowDatabase {
+	if cfg == nil || cfg.SlowDatabase == "" {
 		return nil, nil
 	}
 

--- a/install/installer/pkg/components/slowserver/render_test.go
+++ b/install/installer/pkg/components/slowserver/render_test.go
@@ -189,6 +189,10 @@ func TestServerDeployment_UsesTracingConfig(t *testing.T) {
 func renderContext(t *testing.T, podConfig map[string]*config.PodConfig, slowDatabase bool) *common.RenderContext {
 	var samplerType experimental.TracingSampleType = "probabilistic"
 
+	var slowDbHost string
+	if slowDatabase {
+		slowDbHost = toxiproxy.Component
+	}
 	ctx, err := common.NewRenderContext(config.Config{
 		Database: config.Database{
 			InCluster: pointer.Bool(true),
@@ -209,7 +213,7 @@ func renderContext(t *testing.T, podConfig map[string]*config.PodConfig, slowDat
 					SamplerType:  &samplerType,
 					SamplerParam: pointer.Float64(12.5),
 				},
-				SlowDatabase: slowDatabase,
+				SlowDatabase: slowDbHost,
 				Server: &experimental.ServerConfig{
 					GithubApp: &experimental.GithubApp{
 						AppId:           0,

--- a/install/installer/pkg/components/toxiproxy/objects.go
+++ b/install/installer/pkg/components/toxiproxy/objects.go
@@ -11,7 +11,7 @@ import (
 
 func Objects(ctx *common.RenderContext) ([]runtime.Object, error) {
 	cfg := common.ExperimentalWebappConfig(ctx)
-	if cfg == nil || !cfg.SlowDatabase {
+	if cfg == nil || cfg.SlowDatabase == "" {
 		return nil, nil
 	}
 

--- a/install/installer/pkg/components/toxiproxy/objects_test.go
+++ b/install/installer/pkg/components/toxiproxy/objects_test.go
@@ -38,7 +38,7 @@ func renderContextWithSlowDatabaseEnabled(t *testing.T) *common.RenderContext {
 	ctx, err := common.NewRenderContext(config.Config{
 		Experimental: &experimental.Config{
 			WebApp: &experimental.WebAppConfig{
-				SlowDatabase: true,
+				SlowDatabase: "toxiproxy",
 			},
 		},
 	}, versions.Manifest{

--- a/install/installer/pkg/config/v1/experimental/experimental.go
+++ b/install/installer/pkg/config/v1/experimental/experimental.go
@@ -221,7 +221,7 @@ type WebAppConfig struct {
 	ConfigcatKey               string                 `json:"configcatKey"`
 	WorkspaceClasses           []WebAppWorkspaceClass `json:"workspaceClasses"`
 	Stripe                     *StripeConfig          `json:"stripe,omitempty"`
-	SlowDatabase               bool                   `json:"slowDatabase,omitempty"`
+	SlowDatabase               string                 `json:"slowDatabase,omitempty"`
 	IAM                        *IAMConfig             `json:"iam,omitempty"`
 	WithoutWorkspaceComponents bool                   `json:"withoutWorkspaceComponents,omitempty"`
 	SpiceDB                    *SpiceDBConfig         `json:"spicedb,omitempty"`


### PR DESCRIPTION
## Description
Allow us to point slow-server to different DBs.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
