### PR TITLE
Remove scenario assuming workspace clusters run in GCP

### DIFF
--- a/install/installer/cmd/testdata/render/kind-workspace/output.golden
+++ b/install/installer/cmd/testdata/render/kind-workspace/output.golden
@@ -1508,8 +1508,6 @@ data:
     apiVersion: v1
     kind: Service
     metadata:
-      annotations:
-        cloud.google.com/neg: '{"exposed_ports": {"80":{},"443": {}}}'
       creationTimestamp: null
       labels:
         app: gitpod
@@ -2867,8 +2865,6 @@ status:
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    cloud.google.com/neg: '{"exposed_ports": {"80":{},"443": {}}}'
   creationTimestamp: null
   labels:
     app: gitpod
@@ -2897,7 +2893,7 @@ spec:
   selector:
     app: gitpod
     component: ws-proxy
-  type: LoadBalancer
+  type: ClusterIP
 status:
   loadBalancer: {}
 ---

--- a/install/installer/pkg/components/ws-proxy/objects.go
+++ b/install/installer/pkg/components/ws-proxy/objects.go
@@ -7,8 +7,6 @@ package wsproxy
 import (
 	"github.com/gitpod-io/gitpod/common-go/baseserver"
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
-	config "github.com/gitpod-io/gitpod/installer/pkg/config/v1"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -41,14 +39,7 @@ var Objects = common.CompositeRenderFunc(
 				ServicePort:   SSHServicePort,
 			},
 		}
-		return common.GenerateService(Component, ports, func(service *corev1.Service) {
-			// In the case of Workspace only setup, `ws-proxy` service is the entrypoint
-			// Hence we use LoadBalancer type for the service
-			if cfg.Config.Kind == config.InstallationWorkspace {
-				service.Spec.Type = corev1.ServiceTypeLoadBalancer
-				service.Annotations["cloud.google.com/neg"] = `{"exposed_ports": {"80":{},"443": {}}}`
-			}
-		})(cfg)
+		return common.GenerateService(Component, ports)(cfg)
 	},
 	common.DefaultServiceAccount(Component),
 )


### PR DESCRIPTION
## Release Notes
```release-note
NONE
```

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [x] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft with-integration-tests=workspace
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
