### PR TITLE
:sparkles: standardize gp CLI timeout cmds output

### DIFF
--- a/components/gitpod-cli/cmd/timeout-extend.go
+++ b/components/gitpod-cli/cmd/timeout-extend.go
@@ -39,7 +39,7 @@ var extendTimeoutCmd = &cobra.Command{
 			}
 			fail(err.Error())
 		}
-		fmt.Println("Workspace timeout has been extended to three hours.")
+		fmt.Println("Workspace timeout extended to 180 minutes.")
 	},
 }
 

--- a/components/gitpod-cli/cmd/timeout-set.go
+++ b/components/gitpod-cli/cmd/timeout-set.go
@@ -22,9 +22,9 @@ var setTimeoutCmd = &cobra.Command{
 	Short: "Set timeout of current workspace",
 	Long: `Set timeout of current workspace.
 
-Duration must be in the format of <n>m (minutes), <n>h (hours), or <n>d (days).
-For example, 30m, 1h, 2d, etc.`,
-	Example: `gitpod timeout set 1h`,
+Duration must be in the format of <n>m (minutes) or <n>h (hours).
+For example, 30m, 1h`,
+	Example: `gitpod timeout set 30m`,
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()

--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/actions/ExtendWorkspaceTimeoutAction.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/actions/ExtendWorkspaceTimeoutAction.kt
@@ -31,10 +31,10 @@ class ExtendWorkspaceTimeoutAction : AnAction() {
                     thisLogger().error("gitpod: failed to extend workspace timeout", e)
                 } else {
                     if (result.resetTimeoutOnWorkspaces.isNotEmpty()) {
-                        message = "Workspace timeout has been extended to three hours. This reset the workspace timeout for other workspaces."
+                        message = "Workspace timeout extended to 180 minutes. This reset the workspace timeout for other workspaces."
                         notificationType = NotificationType.WARNING
                     } else {
-                        message = "Workspace timeout has been extended to three hours."
+                        message = "Workspace timeout extended to 180 minutes."
                         notificationType = NotificationType.INFORMATION
                     }
                 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Standardize the Gitpod CLI output in `timeout` commands. Also changes the JetBrains Plugin Message popup :smile: 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #16084, #15945

## How to test
<!-- Provide steps to test this PR -->
- Open [Preview](https://siddhant-kfd2c5d411d.preview.gitpod-dev.com/workspaces)
- Open any Workspace
- Run the following commands:

  ```bash
  gp timeout set 30m
  gp timeout extend
  gp timeout show
  ```

& Read through the outputs :eyes:

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

- https://github.com/gitpod-io/website/pull/3326

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
