### PR TITLE
Trigger preview deletion on branch deletion

### DIFF
--- a/.github/actions/delete-preview/entrypoint.sh
+++ b/.github/actions/delete-preview/entrypoint.sh
@@ -19,5 +19,7 @@ previewctl get-credentials --gcp-service-account "${PREVIEW_ENV_DEV_SA_KEY_PATH}
 
 export TF_INPUT=0
 export TF_IN_AUTOMATION=true
-export TF_VAR_preview_name="${INPUT_NAME}"
+TF_VAR_preview_name="$(previewctl get-name --branch "${INPUT_NAME}")"
+export TF_VAR_preview_name
+
 leeway run dev/preview:delete-preview

--- a/.github/workflows/preview-env-delete.yml
+++ b/.github/workflows/preview-env-delete.yml
@@ -5,13 +5,15 @@ on:
             name:
                 required: true
                 description: "The name of the preview environment to delete"
+    delete:
 jobs:
     delete:
+        if: github.event.ref_type == 'branch' || github.event.inputs.name != ''
         runs-on: [self-hosted]
         steps:
             - uses: actions/checkout@v3
             - name: Delete preview environment
               uses: ./.github/actions/delete-preview
               with:
-                  name: ${{ github.event.inputs.name }}
+                  name: ${{ github.event.inputs.name || github.event.ref}}
                   sa_key: ${{ secrets.GCP_CREDENTIALS }}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Trigger the "Delete preview environment" workflow when branches are deleted.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
No issue, see internal discussion [here](https://gitpod.slack.com/archives/C032A46PWR0/p1674827280011619?thread_ts=1674826607.497579&cid=C032A46PWR0).

## How to test
<!-- Provide steps to test this PR -->

Triggered the job from this branch to verify that the "workflow_dispatch" hasn't broken - it seemed to work just fine ([link](https://github.com/gitpod-io/gitpod/actions/runs/4044681307/jobs/6955145260))

Once on main I can test if it gets triggered properly when branches are deleted and verify that the `github.event.ref` gets sanitized correctly. 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
