### PR TITLE
Add workspacecontexturl to gpcli

### DIFF
--- a/components/gitpod-cli/cmd/info.go
+++ b/components/gitpod-cli/cmd/info.go
@@ -40,11 +40,12 @@ var infoCmd = &cobra.Command{
 		wsInfo, err := client.Info.WorkspaceInfo(ctx, &api.WorkspaceInfoRequest{})
 
 		data := &infoData{
-			WorkspaceId:    wsInfo.WorkspaceId,
-			InstanceId:     wsInfo.InstanceId,
-			WorkspaceClass: wsInfo.WorkspaceClass,
-			WorkspaceUrl:   wsInfo.WorkspaceUrl,
-			ClusterHost:    wsInfo.WorkspaceClusterHost,
+			WorkspaceId:         wsInfo.WorkspaceId,
+			InstanceId:          wsInfo.InstanceId,
+			WorkspaceClass:      wsInfo.WorkspaceClass,
+			WorkspaceUrl:        wsInfo.WorkspaceUrl,
+			WorkspaceContextUrl: wsInfo.WorkspaceContextUrl,
+			ClusterHost:         wsInfo.WorkspaceClusterHost,
 		}
 
 		if err != nil {
@@ -62,11 +63,12 @@ var infoCmd = &cobra.Command{
 }
 
 type infoData struct {
-	WorkspaceId    string                                    `json:"workspace_id"`
-	InstanceId     string                                    `json:"instance_id"`
-	WorkspaceClass *api.WorkspaceInfoResponse_WorkspaceClass `json:"workspace_class"`
-	WorkspaceUrl   string                                    `json:"workspace_url"`
-	ClusterHost    string                                    `json:"cluster_host"`
+	WorkspaceId         string                                    `json:"workspace_id"`
+	InstanceId          string                                    `json:"instance_id"`
+	WorkspaceClass      *api.WorkspaceInfoResponse_WorkspaceClass `json:"workspace_class"`
+	WorkspaceUrl        string                                    `json:"workspace_url"`
+	WorkspaceContextUrl string                                    `json:"workspace_context_url"`
+	ClusterHost         string                                    `json:"cluster_host"`
 }
 
 func outputInfo(info *infoData) {
@@ -78,6 +80,7 @@ func outputInfo(info *infoData) {
 	table.Append([]string{"Instance ID", info.InstanceId})
 	table.Append([]string{"Workspace class", fmt.Sprintf("%s: %s", info.WorkspaceClass.DisplayName, info.WorkspaceClass.Description)})
 	table.Append([]string{"Workspace URL", info.WorkspaceUrl})
+	table.Append([]string{"Workspace Context URL", info.WorkspaceContextUrl})
 	table.Append([]string{"Cluster host", info.ClusterHost})
 	table.Render()
 }


### PR DESCRIPTION
## Description
Added workspaceContextUrl to gp-cli. 

I've appended the workspaceContextUrl response from the supervisor API to the `gp info` command. See #14923

## Related Issue(s)
Fixes #14923

## How to test
- Run gitpod in gitpod --> [gitpod.io#https://github.com/Kwok-he-Chu/gitpod/tree/add-workspacecontexturl-to-gpicli](gitpod.io#https://github.com/Kwok-he-Chu/gitpod/tree/add-workspacecontexturl-to-gpicli)
- Run `cd components/gitpod-cli`
- Run `go run . 'info'`
- Verify whether the WorkspaceContextUrl is shown

## Release Notes
```release-note
Added `Workspace Context Url` to `gp info`
```

## Documentation
The documentation can be found [here](https://www.gitpod.io/docs/references/gitpod-cli#info). From what I see, we do not need to update it. However it would be nice to complete the list. I can forward a documentation request if needed to append the following 5 (+1) variables to the list:
- Workspace ID
- Instance ID
- Workspace class
- Workspace URL
- Workspace Context URL `// This is the one I added` +1
- Cluster host

If you think it's a good idea, I'll create a [docs issue](https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E).

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
