### PR TITLE
Do not try to connect to not ready ws-daemon pods

### DIFF
--- a/components/ws-manager/pkg/manager/manager_test.go
+++ b/components/ws-manager/pkg/manager/manager_test.go
@@ -322,7 +322,7 @@ func TestConnectToWorkspaceDaemon(t *testing.T) {
 					},
 				},
 			},
-			ExpectedErr: "no running ws-daemon pod found",
+			ExpectedErr: "timed out attempting to connect to Gitpod ws-daemon",
 		},
 		{
 			Name: "handles no endpoint on current node",
@@ -361,7 +361,7 @@ func TestConnectToWorkspaceDaemon(t *testing.T) {
 					},
 				},
 			},
-			ExpectedErr: "no running ws-daemon pod found",
+			ExpectedErr: "timed out attempting to connect to Gitpod ws-daemon",
 		},
 		{
 			Name: "finds endpoint on current node",


### PR DESCRIPTION
## Description

During scale-up events,` ws-manager ` tries to connect to pods that are not ready yet.

![Screenshot from 2023-01-25 00-44-01](https://user-images.githubusercontent.com/161571/215492076-c7f49598-ada0-495b-9bd1-b9c665c8cde4.png)


## Release Notes
```release-note
NONE
```

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [x] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft with-integration-tests=workspace
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
