### PR TITLE
GHA support `with-large-vm`

### DIFF
--- a/.github/actions/preview-create/entrypoint.sh
+++ b/.github/actions/preview-create/entrypoint.sh
@@ -10,7 +10,7 @@ export PATH="$PATH:$HOME/bin"
 
 mkdir $HOME/bin
 
-echo "${INPUT_SA_KEY}" > "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
+echo "${INPUT_SA_KEY}" >"${PREVIEW_ENV_DEV_SA_KEY_PATH}"
 gcloud auth activate-service-account --key-file "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
 
 leeway run dev/preview/previewctl:download
@@ -19,6 +19,7 @@ previewctl get-credentials --gcp-service-account "${PREVIEW_ENV_DEV_SA_KEY_PATH}
 TF_VAR_preview_name="$(previewctl get-name --branch "${INPUT_NAME}")"
 export TF_VAR_preview_name
 export TF_VAR_infra_provider="${INPUT_INFRASTRUCTURE_PROVIDER}"
+export TF_VAR_with_large_vm="${INPUT_LARGE_VM}"
 export TF_INPUT=0
 export TF_IN_AUTOMATION=true
 leeway run dev/preview:create-preview

--- a/.github/actions/preview-create/metadata.yml
+++ b/.github/actions/preview-create/metadata.yml
@@ -7,6 +7,10 @@ inputs:
     infrastructure_provider:
         description: "The infrastructure provider to use"
         required: true
+    large_vm:
+        description: "Whether to use a larger VM for the env"
+        required: true
+        default: false
     sa_key:
         description: "The service account key to use when authenticating with GCP"
         required: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,7 @@ jobs:
       build_no_cache: ${{ steps.output.outputs.build_no_cache }}
       build_no_test: ${{ steps.output.outputs.build_no_test }}
       build_leeway_target: ${{ steps.output.outputs.build_leeway_target }}
+      with_large_vm: ${{ steps.output.outputs.with_large_vm }}
     steps:
       - name: "Determine Branch"
         id: branches
@@ -39,6 +40,7 @@ jobs:
             echo "build_no_cache=${{ contains(github.event.pull_request.body, '[x] leeway-no-cache') }}"
             echo "build_no_test=${{ contains(github.event.pull_request.body, '[x] /werft no-test') }}"
             echo "build_leeway_target=$(echo "$PR_DESC" | sed -n -e 's/^.*leeway-target=//p' | sed 's/\r$//')"
+            echo "with_large_vm=${{ contains(github.event.pull_request.body, '[X] /werft with-large-vm') }}"
           } >> $GITHUB_OUTPUT
 
   build-previewctl:
@@ -86,6 +88,7 @@ jobs:
           sa_key: ${{ secrets.GCP_CREDENTIALS }}
           infrastructure_provider: ${{ needs.configuration.outputs.preview_infra_provider }}
           previewctl_hash: ${{ needs.build-previewctl.outputs.previewctl_hash }}
+          large_vm: ${{ needs.configuration.outputs.with_large_vm }}
 
   build-gitpod:
     name: Build Gitpod

--- a/.werft/jobs/build/prepare.ts
+++ b/.werft/jobs/build/prepare.ts
@@ -40,8 +40,6 @@ async function decideHarvesterVMCreation(werft: Werft, config: JobConfig) {
 // createVM only triggers the VM creation.
 // Readiness is not guaranted.
 async function createVM(werft: Werft, config: JobConfig) {
-    const cpu = config.withLargeVM ? 12 : 6;
-    const memory = config.withLargeVM ? 24 : 12;
     const infra = config.withGceVm ? "gce" : "harvester"
     const replace = config.withGceVm ? "module.preview_gce[0].google_compute_instance.default" : "module.preview_harvester[0].harvester_virtualmachine.harvester"
 
@@ -51,15 +49,13 @@ async function createVM(werft: Werft, config: JobConfig) {
         "GOOGLE_APPLICATION_CREDENTIALS": GCLOUD_SERVICE_ACCOUNT_PATH,
         "TF_VAR_cert_issuer": config.certIssuer,
         "TF_VAR_preview_name": config.previewEnvironment.destname,
-        "TF_VAR_vm_cpu": `${cpu}`,
-        "TF_VAR_vm_memory": `${memory}Gi`,
+        "TF_VAR_with_large_vm": `${config.withLargeVM}`,
         "TF_VAR_infra_provider": `${infra}`,
     }
 
     if (config.storageClass.length > 0) {
         environment["TF_VAR_vm_storage_class"] = config.storageClass
     }
-
 
     const variables = Object
         .entries(environment)

--- a/dev/preview/infrastructure/modules/gce/proxy.tf
+++ b/dev/preview/infrastructure/modules/gce/proxy.tf
@@ -3,6 +3,8 @@ resource "kubernetes_pod" "proxy" {
   metadata {
     name      = "proxy"
     namespace = var.preview_namespace
+    # this label should match the one in ../../svc.tf
+    # and is the same as the one that a pod running a harvester vm has
     labels = {
       "harvesterhci.io/vmName" = var.preview_name
     }

--- a/dev/preview/infrastructure/modules/gce/variables.tf
+++ b/dev/preview/infrastructure/modules/gce/variables.tf
@@ -15,7 +15,7 @@ variable "preview_namespace" {
 
 variable "vm_type" {
   type    = string
-  default = "n2-standard-8"
+  default = "n2d-standard-8"
 }
 
 variable "ssh_key" {
@@ -63,4 +63,10 @@ variable "use_spot" {
   type        = bool
   default     = false
   description = "Flag to decide whether to use spot instances"
+}
+
+variable "with_large_vm" {
+  type        = bool
+  default     = false
+  description = "Flag to decide whether to use a larger VM"
 }

--- a/dev/preview/infrastructure/modules/gce/vm.tf
+++ b/dev/preview/infrastructure/modules/gce/vm.tf
@@ -5,9 +5,10 @@ data "google_compute_default_service_account" "default" {
 resource "google_compute_instance" "default" {
   provider = google
 
-  name         = var.preview_name
-  machine_type = var.vm_type
-  zone         = "us-central1-a"
+  name                      = var.preview_name
+  machine_type              = local.machine_type
+  zone                      = "us-central1-a"
+  allow_stopping_for_update = true
 
   boot_disk {
     initialize_params {
@@ -16,6 +17,7 @@ resource "google_compute_instance" "default" {
   }
 
   tags = ["preview"]
+
 
   dynamic "scheduling" {
     for_each = var.use_spot == true ? [1] : []
@@ -76,4 +78,6 @@ locals {
     vm_name             = var.preview_name
     ssh_authorized_keys = var.ssh_key
   })
+
+  machine_type = var.with_large_vm ? "n2d-standard-16" : var.vm_type
 }

--- a/dev/preview/infrastructure/modules/harvester/variables.tf
+++ b/dev/preview/infrastructure/modules/harvester/variables.tf
@@ -25,18 +25,6 @@ variable "dev_kube_context" {
   description = "The name of the dev kube context"
 }
 
-variable "vm_memory" {
-  type        = string
-  default     = "12Gi"
-  description = "Memory for the VM"
-}
-
-variable "vm_cpu" {
-  type        = number
-  default     = 6
-  description = "CPU for the VM"
-}
-
 variable "ssh_key" {
   type        = string
   description = "ssh public key used for access to the vm"
@@ -64,4 +52,10 @@ variable "gcp_project_dns" {
   type        = string
   default     = "gitpod-core-dev"
   description = "The GCP project in which to create DNS records"
+}
+
+variable "with_large_vm" {
+  type        = bool
+  default     = false
+  description = "Flag to decide whether to use a larger VM"
 }

--- a/dev/preview/infrastructure/modules/harvester/vm.tf
+++ b/dev/preview/infrastructure/modules/harvester/vm.tf
@@ -17,8 +17,8 @@ resource "harvester_virtualmachine" "harvester" {
     harvester_ssh_key.harvester_ssh_key.id
   ]
 
-  cpu    = var.vm_cpu
-  memory = var.vm_memory
+  cpu    = local.vm_cpu
+  memory = local.vm_memory
 
   run_strategy = "RerunOnFailure"
   machine_type = "q35"
@@ -99,4 +99,7 @@ locals {
       vm_name = var.preview_name
     })
   })
+
+  vm_cpu    = var.with_large_vm ? 12 : 6
+  vm_memory = var.with_large_vm ? "24Gi" : "12Gi"
 }

--- a/dev/preview/infrastructure/preview.tf
+++ b/dev/preview/infrastructure/preview.tf
@@ -7,6 +7,8 @@ module "preview_gce" {
   preview_namespace = kubernetes_namespace.preview_namespace.metadata[0].name
   ssh_key           = local.ssh_key
   use_spot          = var.gce_use_spot
+  with_large_vm     = var.with_large_vm
+  vm_type           = var.vm_type
 
   providers = {
     google           = google,
@@ -25,6 +27,7 @@ module "preview_harvester" {
   cert_issuer       = var.cert_issuer
   preview_namespace = kubernetes_namespace.preview_namespace.metadata[0].name
   ssh_key           = local.ssh_key
+  with_large_vm     = var.with_large_vm
 
   providers = {
     google              = google,

--- a/dev/preview/infrastructure/variables.tf
+++ b/dev/preview/infrastructure/variables.tf
@@ -27,21 +27,9 @@ variable "dev_kube_context" {
   description = "The name of the dev kube context"
 }
 
-variable "vm_memory" {
-  type        = string
-  default     = "12Gi"
-  description = "Memory for the VM"
-}
-
-variable "vm_cpu" {
-  type        = number
-  default     = 6
-  description = "CPU for the VM"
-}
-
 variable "vm_type" {
   type    = string
-  default = "n2-standard-8"
+  default = "n2d-standard-8"
 }
 
 variable "vm_image" {
@@ -66,4 +54,10 @@ variable "gce_use_spot" {
   type        = bool
   default     = false
   description = "Flag to decide whether to use spot instances"
+}
+
+variable "with_large_vm" {
+  type        = bool
+  default     = false
+  description = "Flag to decide whether to use a larger VM"
 }

--- a/dev/preview/previewctl/BUILD.yaml
+++ b/dev/preview/previewctl/BUILD.yaml
@@ -57,6 +57,6 @@ scripts:
         PREVIEWCTL_IMAGE="eu.gcr.io/gitpod-core-dev/build/previewctl:hash-$INPUT_PREVIEWCTL_HASH"
       fi
 
-      echo "Downloading previewctil for $PREVIEWCTL_IMAGE"
+      echo "Downloading previewctl for $PREVIEWCTL_IMAGE"
       oci-tool fetch file -o $HOME/bin/previewctl --platform=linux-amd64 "$PREVIEWCTL_IMAGE" app/previewctl
       chmod +x $HOME/bin/previewctl


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

* adds support for `with-large-vm`
* changes the logic so it's a flag in TF, not configured in werft/gha
* also change the gce default machine type (`n2` -> `n2d`), as that's what we use in prod


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/15768

## How to test
<!-- Provide steps to test this PR -->

<img width="1369" alt="image" src="https://user-images.githubusercontent.com/5501705/215757651-708a42f1-e944-48fd-a9b9-26222cd82c67.png">


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [X] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [X] /werft with-preview
- [X] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
