### PR TITLE
[spicedb] Add github action to validate schema

### DIFF
--- a/.github/workflows/permissions.yml
+++ b/.github/workflows/permissions.yml
@@ -1,5 +1,7 @@
 name: permissions
 on: pull_request
+    paths:
+      - install/installer/pkg/components/spicedb/data/schema.yaml
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/permissions.yml
+++ b/.github/workflows/permissions.yml
@@ -1,0 +1,10 @@
+name: permissions
+on: pull_request
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: "authzed/action-spicedb-validate@v1"
+      with:
+        validationfile: "install/installer/pkg/components/spicedb/data/schema.yaml"

--- a/install/installer/BUILD.yaml
+++ b/install/installer/BUILD.yaml
@@ -12,7 +12,7 @@ packages:
       - "pkg/components/**/*.key"
       - "pkg/components/**/*.pem"
       - "pkg/components/**/*.sql"
-      - "pkg/components/spicedb/data/bootstrap.yaml"
+      - "pkg/components/spicedb/data/*.yaml"
       - "scripts/*.sh"
       - "third_party/charts/*/Chart.yaml"
       - "third_party/charts/*/values.yaml"

--- a/install/installer/pkg/components/spicedb/data/schema.yaml
+++ b/install/installer/pkg/components/spicedb/data/schema.yaml
@@ -32,3 +32,17 @@ schema: |-
   }
 
   definition service {}
+
+# relationships to be used for assertions
+relationships: >-
+  organisation:org1#owner@user:user1
+
+assertions:
+  assertTrue:
+    - "organisation:org1#owner@user:user1"
+    - "organisation:org1#read_teams@user:user1"
+    - "organisation:org1#write_teams@user:user1"
+    - "organisation:org1#read_workspaces@user:user1"
+
+  assertFalse:
+    - "organisation:org2#owner@user:user1"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Adds a github action which validates SpiceDB schema against the defined schema and assertions


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

Example failure - https://github.com/gitpod-io/gitpod/actions/runs/4044919425/jobs/6955679551
See success in CI run results

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
