### PR TITLE
Implement basic preview environment regression check

### DIFF
--- a/.github/actions/deploy-gitpod/entrypoint.sh
+++ b/.github/actions/deploy-gitpod/entrypoint.sh
@@ -26,8 +26,10 @@ leeway run dev/preview/previewctl:download
 echo "Setting up access to core-dev and harvester"
 previewctl get-credentials --gcp-service-account "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
 
-echo "Install kubectx for the preview environment"
-previewctl install-context --log-level debug --timeout 10m --gcp-service-account "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
 
+PREVIEW_NAME="$(previewctl get-name --branch "${INPUT_NAME}")"
+export PREVIEW_NAME
+
+previewctl install-context --branch "${PREVIEW_NAME}" --log-level debug --timeout 10m --gcp-service-account "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
 leeway run dev/preview:deploy-gitpod
 previewctl report >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/actions/deploy-gitpod/metadata.yml
+++ b/.github/actions/deploy-gitpod/metadata.yml
@@ -4,6 +4,9 @@ inputs:
     sa_key:
         description: "The service account key to use when authenticating with GCP"
         required: true
+    name:
+        description: "The name of the preview environment to deploy Gitpod to"
+        required: false
     version:
         description: "The version of Gitpod to install"
         required: true

--- a/.github/actions/preview-create/entrypoint.sh
+++ b/.github/actions/preview-create/entrypoint.sh
@@ -6,8 +6,6 @@ export HOME=/home/gitpod
 export PREVIEW_ENV_DEV_SA_KEY_PATH="$HOME/.config/gcloud/preview-environment-dev-sa.json"
 # shellcheck disable=SC2155
 export LEEWAY_WORKSPACE_ROOT="$(pwd)"
-export TF_INPUT=0
-export TF_IN_AUTOMATION=true
 export PATH="$PATH:$HOME/bin"
 
 mkdir $HOME/bin
@@ -18,4 +16,9 @@ gcloud auth activate-service-account --key-file "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
 leeway run dev/preview/previewctl:download
 previewctl get-credentials --gcp-service-account "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
 
+TF_VAR_preview_name="$(previewctl get-name --branch "${INPUT_NAME}")"
+export TF_VAR_preview_name
+export TF_VAR_infra_provider="${INPUT_INFRASTRUCTURE_PROVIDER}"
+export TF_INPUT=0
+export TF_IN_AUTOMATION=true
 leeway run dev/preview:create-preview

--- a/.github/actions/preview-create/metadata.yml
+++ b/.github/actions/preview-create/metadata.yml
@@ -1,6 +1,12 @@
 name: "Create preview environment"
 description: "Creates the infrastructure for a preview environment"
 inputs:
+    name:
+        description: "The name of the preview environment to deploy Gitpod to"
+        required: false
+    infrastructure_provider:
+        description: "The infrastructure provider to use"
+        required: true
     sa_key:
         description: "The service account key to use when authenticating with GCP"
         required: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,12 +79,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Create preview environment infrastructure
-        env:
-          TF_VAR_infra_provider: ${{ needs.configuration.outputs.preview_infra_provider }}
         id: create
         uses: ./.github/actions/preview-create
         with:
+          name: ${{ github.head_ref || github.ref }}
           sa_key: ${{ secrets.GCP_CREDENTIALS }}
+          infrastructure_provider: ${{ needs.configuration.outputs.preview_infra_provider }}
           previewctl_hash: ${{ needs.build-previewctl.outputs.previewctl_hash }}
 
   build-gitpod:
@@ -210,8 +210,9 @@ jobs:
         id: deploy-gitpod
         uses: ./.github/actions/deploy-gitpod
         with:
-          sa_key: ${{ secrets.GCP_CREDENTIALS }}
+          name: ${{ github.head_ref || github.ref }}
           version: ${{needs.configuration.outputs.version}}
+          sa_key: ${{ secrets.GCP_CREDENTIALS }}
           previewctl_hash: ${{ needs.build-previewctl.outputs.previewctl_hash }}
 
   monitoring:

--- a/.github/workflows/preview-env-check-regressions.yml
+++ b/.github/workflows/preview-env-check-regressions.yml
@@ -1,11 +1,43 @@
 name: "Preview environment regression check"
 on:
     workflow_dispatch:
+        inputs:
+            name:
+                required: true
+                description: "The name of the preview environment"
+            version:
+                required: true
+                description: "The version of Gitpod to install"
+            infrastructure_provider:
+                description: "The infrastructure provider to use. Valid options: harvester, gcp"
+                required: false
+                default: harvester
 jobs:
     check:
         name: Check for regressions
         runs-on: [self-hosted]
         steps:
             - uses: actions/checkout@v3
+            - name: Create preview environment infrastructure
+              uses: ./.github/actions/preview-create
+              with:
+                  name: ${{ github.event.inputs.name }}
+                  infrastructure_provider: ${{ github.event.inputs.infrastructure_provider }}
+                  sa_key: ${{ secrets.GCP_CREDENTIALS }}
+            - name: Deploy Gitpod to the preview environment
+              id: deploy-gitpod
+              uses: ./.github/actions/deploy-gitpod
+              with:
+                  name: ${{ github.event.inputs.name }}
+                  sa_key: ${{ secrets.GCP_CREDENTIALS }}
+                  version: ${{ github.event.inputs.version}}
             - name: Check
-              run: echo "No regressions caught because I didn't check anything 🤡"
+              run: |
+                  echo "No regressions caught because I didn't check anything 🤡 Sleeping for 2 minutes."
+                  sleep 60
+            - name: Delete preview environment
+              if: always()
+              uses: ./.github/actions/delete-preview
+              with:
+                  name: ${{ github.event.inputs.name }}
+                  sa_key: ${{ secrets.GCP_CREDENTIALS }}

--- a/.github/workflows/preview-env-delete.yml
+++ b/.github/workflows/preview-env-delete.yml
@@ -1,4 +1,4 @@
-name: "Delete preview environment"
+name: "Preview environment delete"
 on:
     workflow_dispatch:
         inputs:


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This PR extends the preview regression check workflow so that it actually creates and then deletes the preview environment. For now it still has to be triggered manually.

I'll follow this up with a PR which triggers the workflow after each successful GHA build on main (which means we have to start running the GHA job on main too)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of https://github.com/gitpod-io/gitpod/issues/15869

## How to test
<!-- Provide steps to test this PR -->

- ✅ Workflow which ran as part of this PR [here](https://github.com/gitpod-io/gitpod/actions/runs/4052762337)
- ✅ Workflow that I triggered manually [here](https://github.com/gitpod-io/gitpod/actions/runs/4053074960/jobs/6973258362)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A

## Build Options:

- [x] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
