### PR TITLE
Update prebuild and incremental prebuild emojis

### DIFF
--- a/components/dashboard/package.json
+++ b/components/dashboard/package.json
@@ -29,8 +29,9 @@
     "react-popper": "^2.3.0",
     "react-portal": "^4.2.2",
     "react-router-dom": "^5.2.0",
-    "xterm": "^4.11.0",
-    "xterm-addon-fit": "^0.5.0"
+    "xterm": "^5.1.0",
+    "xterm-addon-fit": "^0.7.0",
+    "xterm-addon-canvas" : "^0.3.0"
   },
   "devDependencies": {
     "@craco/craco": "^6.1.2",

--- a/components/dashboard/src/components/WorkspaceLogs.tsx
+++ b/components/dashboard/src/components/WorkspaceLogs.tsx
@@ -8,6 +8,7 @@ import EventEmitter from "events";
 import { useContext, useEffect, useRef } from "react";
 import { Terminal, ITerminalOptions, ITheme } from "xterm";
 import { FitAddon } from "xterm-addon-fit";
+import { CanvasAddon } from "xterm-addon-canvas";
 import "xterm/css/xterm.css";
 import { ThemeContext } from "../theme-context";
 
@@ -30,6 +31,7 @@ export default function WorkspaceLogs(props: WorkspaceLogsProps) {
     const xTermParentRef = useRef<HTMLDivElement>(null);
     const terminalRef = useRef<Terminal>();
     const fitAddon = new FitAddon();
+    const canvasAddon = new CanvasAddon();
     const { isDark } = useContext(ThemeContext);
 
     useEffect(() => {
@@ -46,6 +48,7 @@ export default function WorkspaceLogs(props: WorkspaceLogsProps) {
         const terminal = new Terminal(options);
         terminalRef.current = terminal;
         terminal.loadAddon(fitAddon);
+        terminal.loadAddon(canvasAddon);
         terminal.open(xTermParentRef.current);
         props.logsEmitter.on("logs", (logs) => {
             if (terminal && logs) {
@@ -82,7 +85,7 @@ export default function WorkspaceLogs(props: WorkspaceLogsProps) {
         if (!terminalRef.current) {
             return;
         }
-        terminalRef.current.setOption("theme", isDark ? darkTheme : lightTheme);
+        terminalRef.current.options.theme = isDark ? darkTheme : lightTheme;
     }, [terminalRef.current, isDark]);
 
     return (

--- a/components/supervisor/pkg/supervisor/tasks.go
+++ b/components/supervisor/pkg/supervisor/tasks.go
@@ -498,7 +498,7 @@ func (tm *tasksManager) watch(task *task, term *terminal.Term) {
 		duration := ""
 		if elapsed >= 1*time.Minute {
 			elapsedInMinutes := strconv.Itoa(int(math.Round(elapsed.Minutes())))
-			duration = "⏱️ Well done on saving " + elapsedInMinutes + " minute"
+			duration = "⏱  Well done on saving " + elapsedInMinutes + " minute"
 			if elapsedInMinutes != "1" {
 				duration += "s"
 			}
@@ -526,7 +526,7 @@ func importParentLogAndGetDuration(fn string, out io.Writer) time.Duration {
 	}
 	defer file.Close()
 
-	defer out.Write([]byte("♻️ Re-running task as an incremental workspace prebuild\r\n\r\n"))
+	defer out.Write([]byte("📦 Re-running task for incremental prebuild\r\n\r\n"))
 
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
@@ -539,7 +539,7 @@ func importParentLogAndGetDuration(fn string, out io.Writer) time.Duration {
 	if !scanner.Scan() {
 		return 0
 	}
-	reg, err := regexp.Compile(`⏱️ Well done on saving (\d+) minute`)
+	reg, err := regexp.Compile(`⏱  Well done on saving (\d+) minute`)
 	if err != nil {
 		return 0
 	}

--- a/yarn.lock
+++ b/yarn.lock
@@ -19086,15 +19086,20 @@ xtend@^4.0.0, xtend@^4.0.2, xtend@~4.0.0, xtend@~4.0.1:
   resolved "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
 
-xterm-addon-fit@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.npmjs.org/xterm-addon-fit/-/xterm-addon-fit-0.5.0.tgz"
-  integrity sha512-DsS9fqhXHacEmsPxBJZvfj2la30Iz9xk+UKjhQgnYNkrUIN5CYLbw7WEfz117c7+S86S/tpHPfvNxJsF5/G8wQ==
+xterm-addon-canvas@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/xterm-addon-canvas/-/xterm-addon-canvas-0.3.0.tgz#8cfb5a13297f4a31a12870c1119af2c139392b50"
+  integrity sha512-2deF4ev6T+NjgSM56H+jcAWz4k5viEoaBtuDEyfo5Qdh1r7HOvNzLC45HSeegdH38qmEcL9XIt0KXyOINpSFRA==
 
-xterm@^4.11.0:
-  version "4.14.1"
-  resolved "https://registry.npmjs.org/xterm/-/xterm-4.14.1.tgz"
-  integrity sha512-jgzNg5BuGPwq5/M4dGnmbghZvHx2jaj+9crSEt15bV34Za49VziBmCu7zIy88zUKKiGTxeo7aVzirFSJArIMFw==
+xterm-addon-fit@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/xterm-addon-fit/-/xterm-addon-fit-0.7.0.tgz#b8ade6d96e63b47443862088f6670b49fb752c6a"
+  integrity sha512-tQgHGoHqRTgeROPnvmtEJywLKoC/V9eNs4bLLz7iyJr1aW/QFzRwfd3MGiJ6odJd9xEfxcW36/xRU47JkD5NKQ==
+
+xterm@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/xterm/-/xterm-5.1.0.tgz#3e160d60e6801c864b55adf19171c49d2ff2b4fc"
+  integrity sha512-LovENH4WDzpwynj+OTkLyZgJPeDom9Gra4DMlGAgz6pZhIDCQ+YuO7yfwanY+gVbn/mmZIStNOnVRU/ikQuAEQ==
 
 y18n@^3.2.1:
   version "3.2.2"


### PR DESCRIPTION
## Description

An attempt to resolve https://github.com/gitpod-io/gitpod/issues/15508, see relevant comment in https://github.com/gitpod-io/gitpod/issues/15508#issuecomment-1371148330.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/15508

## How to test
Add a project and open the logs of a successful prebuild.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Update prebuild and incremental prebuild emojis
```

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
