### PR TITLE
Update usage credits element

### DIFF
--- a/components/dashboard/src/components/UsageView.tsx
+++ b/components/dashboard/src/components/UsageView.tsx
@@ -18,7 +18,6 @@ import { Item, ItemField, ItemsList } from "../components/ItemsList";
 import Pagination from "../Pagination/Pagination";
 import Header from "../components/Header";
 import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
-import { ReactComponent as CreditsSvg } from "../images/credits.svg";
 import Spinner from "../icons/Spinner.svg";
 import { ReactComponent as UsageIcon } from "../images/usage-default.svg";
 import { toRemoteURL } from "../projects/render-utils";
@@ -260,10 +259,11 @@ function UsageView({ attributionId }: UsageViewProps) {
                                 {!isLoading && (
                                     <div>
                                         <div className="flex flex-col truncate">
-                                            <div className="text-base text-gray-500">Total Usage</div>
+                                            <div className="text-base text-gray-500">Credits</div>
                                             <div className="flex text-lg text-gray-600 font-semibold">
-                                                <CreditsSvg className="my-auto mr-1" />
-                                                <span>{totalCreditsUsed.toLocaleString()} Credits</span>
+                                                <span className="dark:text-gray-400">
+                                                    {totalCreditsUsed.toLocaleString()}
+                                                </span>
                                             </div>
                                         </div>
                                     </div>


### PR DESCRIPTION
## Description

Minor style changes for the credits element in the usage page.

| BEFORE | AFTER |
|-|-|
| ![credits-before](https://user-images.githubusercontent.com/120486/215616225-12c16baf-3e56-4f2e-ad16-44607bd0b1b4.png) | ![credits-after](https://user-images.githubusercontent.com/120486/215616175-cbf9e3b6-a3e8-4c10-be55-d67547105931.png) |

Related Issue(s)

Related to https://github.com/gitpod-io/gitpod/issues/15411.

## How to test
Check the changes in the credits element in the usage page.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [X] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
