### PR TITLE
Pass in -Dversion so hash matches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,7 @@ jobs:
 
           export LEEWAY_WORKSPACE_ROOT="$(pwd)"
           leeway build dev/preview/previewctl:docker -Dversion="${{needs.configuration.outputs.version}}"
-          echo "previewctl_hash=$(leeway describe dev/preview/previewctl:docker -t '{{ .Metadata.Version }}')" >> $GITHUB_OUTPUT
+          echo "previewctl_hash=$(leeway describe dev/preview/previewctl:docker -Dversion="${{needs.configuration.outputs.version}}" -t '{{ .Metadata.Version }}')" >> $GITHUB_OUTPUT
 
   infrastructure:
     needs: [configuration, build-previewctl]


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

The previewctl hash that we store as output doesn't match the hash that was built because I had forgotten to pass in the `-Dversion` argument 🤦 

![Screenshot 2023-01-31 at 10 35 16](https://user-images.githubusercontent.com/83561/215723356-09bbfade-4bc9-42e8-a7a8-85ee7f0d6708.png)


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
No issue

## How to test
<!-- Provide steps to test this PR -->

See screenshot. Will also run this PR with preview and GHA enabled to check.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A

## Build Options:

- [x] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
