### PR TITLE
[public-api] Only run breaking detector when public api defs change

### DIFF
--- a/.github/workflows/permissions.yml
+++ b/.github/workflows/permissions.yml
@@ -1,7 +1,8 @@
 name: permissions
-on: pull_request
+on:
+  pull_request:
     paths:
-      - install/installer/pkg/components/spicedb/data/schema.yaml
+    - install/installer/pkg/components/spicedb/data/schema.yaml
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/public-api.yml
+++ b/.github/workflows/public-api.yml
@@ -1,5 +1,8 @@
 name: public-api-compatibility
-on: pull_request
+on:
+  pull_request:
+    paths:
+    - components/public-api/**
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
