### PR TITLE
Build Gitpod with GHA on main (too)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,7 @@ jobs:
       group: ${{ github.head_ref || github.ref }}-configuration
       cancel-in-progress: true
     outputs:
+      is_main_branch: ${{ steps.output.outputs.is_main_branch }}
       version: ${{ steps.output.outputs.version }}
       preview_enable: ${{ steps.output.outputs.preview_enable }}
       preview_infra_provider: ${{ steps.output.outputs.preview_infra_provider }}
@@ -32,7 +33,8 @@ jobs:
         shell: bash
         run: |
           {
-            echo "version=${{ steps.branches.outputs.sanitized-branch-name }}.${{github.run_number}}"
+            echo "is_main_branch=${{ (github.head_ref || github.ref) == 'refs/heads/main' }}"
+            echo "version=${{ steps.branches.outputs.sanitized-branch-name }}-gha.${{github.run_number}}"
             echo "with_github_actions=${{ contains(github.event.pull_request.body, '[x] /werft with-github-actions') }}"
             echo "preview_enable=${{ contains(github.event.pull_request.body, '[x] /werft with-preview') }}"
             echo "preview_infra_provider=${{ contains(github.event.pull_request.body, '[X] /werft with-gce-vm') && 'gce' || 'harvester' }}"
@@ -90,11 +92,13 @@ jobs:
   build-gitpod:
     name: Build Gitpod
     needs: [configuration]
-    if: ${{ needs.configuration.outputs.with_github_actions == 'true' }}
+    if: ${{ needs.configuration.outputs.is_main_branch == 'true' || needs.configuration.outputs.with_github_actions == 'true' }}
     runs-on: [self-hosted]
     concurrency:
       group: ${{ github.head_ref || github.ref }}-build-gitpod
-      cancel-in-progress: true
+      # For the main branch we always want the build job to run to completion
+      # For other branches we only care about the "latest" version, so it is fine to cancel in-progress builds
+      cancel-in-progress: ${{ needs.configuration.outputs.is_main_branch == 'false' }}
     services:
       mysql:
         image: mysql:5.7

--- a/dev/preview/previewctl/BUILD.yaml
+++ b/dev/preview/previewctl/BUILD.yaml
@@ -47,7 +47,7 @@ scripts:
         # If a specific hash isn't provided we'll use the latest image off main
         PREVIEWCTL_VERSION=$(\
             gcloud container images list-tags eu.gcr.io/gitpod-core-dev/build/previewctl \
-                --filter="tags:main.*" \
+                --filter="tags:main-gha.*" \
                 --limit=1 \
                 --format=json \
             | jq --raw-output '.[0].tags[0]' \


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This builds Gitpod on main using GitHub Actions. We're still building with Werft too of course. I changed the versioning scheme we use in GHA to contain `gha` so that we have separate "streams" for the werft "main.xxx" and GHA "main-gha.xxx" versions.

Enabling this has two functions

1. By running the main build on GHA I can trigger the preview environment regression check workflow after each successful main build. This is what I have been working towards in https://github.com/gitpod-io/gitpod/issues/15869
1. We start to load test our self-hosted runners a little bit 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of https://github.com/gitpod-io/gitpod/issues/15869

## How to test
<!-- Provide steps to test this PR -->

I'm not enabling GHA on this PR to ensure that the flag is still respected and that we don't start building Gitpod in GHA on all PRs.

Once merged on main I'll see if the main build works as commits start rolling in on main.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
