### PR TITLE
Run regression check after each successful main build

### DIFF
--- a/.github/workflows/preview-env-check-regressions.yml
+++ b/.github/workflows/preview-env-check-regressions.yml
@@ -1,5 +1,9 @@
 name: "Preview environment regression check"
 on:
+    workflow_run:
+        workflows: ["Build"]
+        types: [completed]
+        branches: ["main"]
     workflow_dispatch:
         inputs:
             name:
@@ -13,24 +17,56 @@ on:
                 required: false
                 default: harvester
 jobs:
+    configuration:
+        name: Configuration
+        runs-on: [self-hosted]
+        outputs:
+            skip: ${{ steps.configuration.outputs.skip }}
+            name: ${{ steps.configuration.outputs.name }}
+            version: ${{ steps.configuration.outputs.version }}
+            infrastructure_provider: ${{ steps.configuration.outputs.infrastructure_provider }}
+        steps:
+            - name: "Set outputs"
+              id: configuration
+              run: |
+                  if [[ '${{ github.event.inputs.name }}' != '' ]]; then
+                      # The workflow was triggered by workflow_dispatch
+                      {
+                          echo "version=${{ github.event.inputs.version }}"
+                          echo "name=${{ github.event.inputs.name }}"
+                          echo "infrastructure_provider=${{ github.event.inputs.infrastructure_provider }}"
+                          echo "skip=false"
+                      } >> $GITHUB_OUTPUT
+                  else
+                      # The workflow was triggered by workflow_run
+                      {
+                          echo "version=main-gha.${{ github.event.workflow_run.run_number }}"
+                          echo "name=preview-regression-check-main-${{ github.run_id }}-${{ github.run_attempt }}"
+                          echo "infrastructure_provider=harvester"
+                          echo "skip=${{ github.event.workflow_run.conclusion == 'failure' }}"
+                      } >> $GITHUB_OUTPUT
+                  fi
     check:
         name: Check for regressions
+        needs: [configuration]
+        if: ${{ needs.configuration.outputs.skip == 'false' }}
         runs-on: [self-hosted]
         steps:
             - uses: actions/checkout@v3
             - name: Create preview environment infrastructure
               uses: ./.github/actions/preview-create
               with:
-                  name: ${{ github.event.inputs.name }}
-                  infrastructure_provider: ${{ github.event.inputs.infrastructure_provider }}
+                  name: ${{ needs.configuration.outputs.name }}
+                  infrastructure_provider: ${{ needs.configuration.outputs.infrastructure_provider }}
+                  large_vm: false
                   sa_key: ${{ secrets.GCP_CREDENTIALS }}
             - name: Deploy Gitpod to the preview environment
               id: deploy-gitpod
               uses: ./.github/actions/deploy-gitpod
               with:
-                  name: ${{ github.event.inputs.name }}
+                  name: ${{ needs.configuration.outputs.name }}
                   sa_key: ${{ secrets.GCP_CREDENTIALS }}
-                  version: ${{ github.event.inputs.version}}
+                  version: ${{ needs.configuration.outputs.version}}
             - name: Check
               run: |
                   echo "No regressions caught because I didn't check anything 🤡 Sleeping for 2 minutes."
@@ -39,5 +75,5 @@ jobs:
               if: always()
               uses: ./.github/actions/delete-preview
               with:
-                  name: ${{ github.event.inputs.name }}
+                  name: ${{ needs.configuration.outputs.name }}
                   sa_key: ${{ secrets.GCP_CREDENTIALS }}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Following up on https://github.com/gitpod-io/gitpod/pull/16123 this PR changes `Preview environment regression check` so that it gets triggered whenever the `Build` job completes.

We still maintain the ability to manually run the job as that makes debugging and working on the workflow so much easier.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of https://github.com/gitpod-io/gitpod/issues/15869

## How to test
<!-- Provide steps to test this PR -->

- ✅ Verify that I can still manually run the job ([job here](https://github.com/gitpod-io/gitpod/actions/runs/4062936632))
- To verify that the workflow gets triggered (and works) after each successful build on main we'll have to merge this PR and then check.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

N/A

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
