### PR TITLE
[dashboard] fix org joining

### DIFF
--- a/components/dashboard/src/teams/JoinTeam.tsx
+++ b/components/dashboard/src/teams/JoinTeam.tsx
@@ -6,7 +6,7 @@
 
 import { useContext, useEffect, useMemo, useState } from "react";
 import { useHistory, useLocation } from "react-router-dom";
-import { publicApiTeamsToProtocol, teamsService } from "../service/public-api";
+import { publicApiTeamsToProtocol, publicApiTeamToProtocol, teamsService } from "../service/public-api";
 import { TeamsContext } from "./teams-context";
 
 export default function () {
@@ -23,11 +23,11 @@ export default function () {
                 if (!inviteId) {
                     throw new Error("This invite URL is incorrect.");
                 }
-
+                const team = publicApiTeamToProtocol((await teamsService.joinTeam({ invitationId: inviteId })).team!);
                 const teams = publicApiTeamsToProtocol((await teamsService.listTeams({})).teams);
                 setTeams(teams);
 
-                history.push(`/members`);
+                history.push(`/members?org=${team.id}`);
             } catch (error) {
                 console.error(error);
                 setJoinError(error);


### PR DESCRIPTION
## Description
Fixes the broken org joining.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #16135

## How to test
<!-- Provide steps to test this PR -->
Join here -> https://sefftinge-f0ccb32c12.preview.gitpod-dev.com/orgs/join?inviteId=ad811780-d6cd-4a06-86ed-b72db1f5f89e

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
