### PR TITLE
:bug: redirect to `/org-usage` if it's Org setting

### DIFF
--- a/components/dashboard/src/components/UsageBasedBillingConfig.tsx
+++ b/components/dashboard/src/components/UsageBasedBillingConfig.tsx
@@ -227,9 +227,15 @@ export default function UsageBasedBillingConfig({ attributionId }: Props) {
                             </div>
                             <div>
                                 <Link
-                                    to={`./usage#${billingCycleFrom.format("YYYY-MM-DD")}:${billingCycleTo.format(
-                                        "YYYY-MM-DD",
-                                    )}`}
+                                    to={
+                                        attributionId && AttributionId.parse(attributionId)?.kind === "user"
+                                            ? `/usage#${billingCycleFrom.format("YYYY-MM-DD")}:${billingCycleTo.format(
+                                                  "YYYY-MM-DD",
+                                              )}"`
+                                            : `/org-usage#${billingCycleFrom.format(
+                                                  "YYYY-MM-DD",
+                                              )}:${billingCycleTo.format("YYYY-MM-DD")}`
+                                    }
                                 >
                                     <button className="secondary">View Usage →</button>
                                 </Link>


### PR DESCRIPTION
## Description

Redirect to `/org-usage` if a user is coming from Org. Billing Settings.

|Before|After|
|:---:|:---:|
|<video src="https://user-images.githubusercontent.com/55068936/215965447-fc76ed9f-8f8a-4635-bb45-d8107d72841c.mov">|<video src="https://user-images.githubusercontent.com/55068936/215966127-da62da90-4fb0-49d2-b7ef-ad0b933e9c7a.mov">|


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes: Incorrect routes on Organization billing page

## How to test
<!-- Provide steps to test this PR -->

- See Video 👀 
- Open Preview
- Create an Organization
- Go to Organization settings
- Go to Billing 
- Click on `View Usage`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
