### PR TITLE
Make sure generated workspace id align to regexp

### DIFF
--- a/components/common-go/namegen/workspaceid.go
+++ b/components/common-go/namegen/workspaceid.go
@@ -15,13 +15,9 @@ import (
 
 // WorkspaceIDPattern is the expected Worksapce ID pattern
 // gitpod-protocol/src/util/generate-workspace-id.ts is authoritative over the generation
+// ws-proxy/pkg/proxy/workspacerouter.go is authoritative for this regexp
 
-/*
-  - Regex Pattern Description:
-    Repo. Owner & Repo. Name  	Random
-    3-23 chars  				11 chars
-*/
-var WorkspaceIDPattern = regexp.MustCompile(`^[a-z0-9-]{3,23}-[a-z0-9]{11}$`)
+var WorkspaceIDPattern = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$|^[0-9a-z]{2,16}-[0-9a-z]{2,16}-[0-9a-z]{8,11}$`)
 
 func GenerateWorkspaceID() (string, error) {
 	s1, err := chooseRandomly(colors, 1)

--- a/components/common-go/namegen/workspaceid_test.go
+++ b/components/common-go/namegen/workspaceid_test.go
@@ -5,8 +5,9 @@
 package namegen_test
 
 import (
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/gitpod-io/gitpod/common-go/namegen"
 )
@@ -28,12 +29,8 @@ func TestGenerateWorkspaceID(t *testing.T) {
 func TestValidateWorkspaceID(t *testing.T) {
 	valid := []string{
 		"gitpodio-gitpod-65k8jqq6up4",
-		"testeraccountw-demoskv1-q2pnb88pvuo",
 		"testeraccountwit-empty-g6024jgir2j",
-		"a-b-g6024jgir2j",
-		"a-bcdefghijklmnopqrstux-g6024jgir2j",
-		"abcdefghijklmnopqrstu-x-g6024jgir2j",
-		"abcdefghijklmnopqrs24-x-g6024jgir2j",
+		"largetextlargete-largetextlargete-g6024jgir2j",
 	}
 	for _, v := range valid {
 		require.NoError(t, namegen.ValidateWorkspaceID(v))


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Fix TestGenerateWorkspaceID failed with `aquamarine-tyrannosaurus-80wyuzuiizv` , see also [GH Action](https://github.com/gitpod-io/gitpod/actions/runs/4059518881/jobs/6987644369)

https://github.com/gitpod-io/gitpod/blob/2d707b214c863b52652da2f810586415654a3357/components/common-go/namegen/workspaceid.go#L24

The regexp for valid workspaceId should equal to `ws-proxy` otherwise you not able to open your workspace.

https://github.com/gitpod-io/gitpod/blob/25887cff15f4879e40b183445bedbac9e45dae5e/components/ws-proxy/pkg/proxy/workspacerouter.go#L29

And for `generateWorkspaceID` function, it also limited
1. we only allow 3 segment
2. each segment has at least 2 characters, and max is 16

https://github.com/gitpod-io/gitpod/blob/4f2ff28842d7dcefbb7fbb1e9f0474c8c3b7319a/components/gitpod-protocol/src/util/generate-workspace-id.ts#L9-L33

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
make sure we don't break #15539

- Open Following Repo. to VS Code Desktop:
    - https://github.com/testerAccountWithLengthEqualThirtyeight/testerAccountWithLengthEqualThirtyeight
    - https://github.com/testerAccountWithLengthEqualThirtyeight/demo.sk-v1
    - https://github.com/Siddhant-K-code/cal.com

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
