### PR TITLE
[proxy] Fix meta workspace-handler

### DIFF
--- a/components/proxy/conf/workspace-handler.meta
+++ b/components/proxy/conf/workspace-handler.meta
@@ -10,7 +10,7 @@ handle @workspace_port {
 
 @workspace header_regexp host Host ^(?P<workspaceID>[a-z0-9][0-9a-z\-]+).ws(?P<location>-[a-z0-9]+)?.{$GITPOD_DOMAIN}
 handle @workspace {
-	redir https://{$GITPOD_DOMAIN}/?not_found=true#{re.host.workspaceID} temporary
+	redir https://{$GITPOD_DOMAIN}/start/?not_found=true#{re.host.workspaceID} temporary
 }
 
 respond "Not found" 404


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
Fix-up for: https://github.com/gitpod-io/gitpod/pull/16104

## How to test

### Full
 - start a workspace in preview, and notice how that works :tm:  :heavy_check_mark: 

### Meta
 - `kubectl edit deployment proxy`
 - set env var `WORKSPACE_HANDLER_FILE` to meta, and wait for `proxy` to restart
 - open a tab on `https://gitpodsampl-templategol-s86kbhqyljp.ws-dev.gpl-decoupff9f3d899e.preview.gitpod-dev.com/` (made up workspaceId), and notice the redirect o `/start?not_found=true...` :heavy_check_mark: 
 - open a tab on `https://9001-gitpodsampl-templategol-s86kbhqyabc.ws-dev.gpl-decoupff9f3d899e.preview.gitpod-dev.com/test` and notice the `404` :heavy_check_mark: 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
