### PR TITLE
Introduce empty preview environment garbage collection job

### DIFF
--- a/.github/workflows/preview-env-gc.yml
+++ b/.github/workflows/preview-env-gc.yml
@@ -1,0 +1,12 @@
+name: "Preview environment garbage collection"
+on:
+    workflow_dispatch:
+jobs:
+    gc:
+        name: "Delete unused preview environments"
+        runs-on: [self-hosted]
+        steps:
+            - uses: actions/checkout@v3
+            - name: Garbage collect
+              run: |
+                  echo "Not implemented yet 🧹"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

We're migrating our jobs to GitHub Actions. This is a step towards https://github.com/gitpod-io/gitpod/issues/15870 - for now I'm just introducing a new workflow that we can manually trigger so I can iterate on the implementation in a new branch.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of https://github.com/gitpod-io/gitpod/issues/15870

## How to test
<!-- Provide steps to test this PR -->

N/A

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
