### PR TITLE
Implement 'Delete unused preview environments' workflow

### DIFF
--- a/.github/workflows/preview-env-gc.yml
+++ b/.github/workflows/preview-env-gc.yml
@@ -1,12 +1,57 @@
 name: "Preview environment garbage collection"
 on:
     workflow_dispatch:
+    schedule:
+        - cron: "0 */4 * * *"
 jobs:
-    gc:
-        name: "Delete unused preview environments"
+    stale:
+        name: "Find stale preview environments"
         runs-on: [self-hosted]
+        container:
+            image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:mads-leeway-v0.7.3.4
+        outputs:
+            names: ${{ steps.set-matrix.outputs.names }}
+            count: ${{ steps.set-matrix.outputs.count }}
         steps:
             - uses: actions/checkout@v3
-            - name: Garbage collect
+              with:
+                  fetch-depth: 0
+            - name: Compute matrix
+              id: set-matrix
+              shell: bash
+              env:
+                  PREVIEW_ENV_DEV_SA_KEY: ${{ secrets.GCP_CREDENTIALS }}
               run: |
-                  echo "Not implemented yet 🧹"
+                  set -euo pipefail
+
+                  export LEEWAY_WORKSPACE_ROOT="$(pwd)"
+                  export HOME="/home/gitpod"
+                  export PREVIEW_ENV_DEV_SA_KEY_PATH="/home/gitpod/.config/gcloud/preview-environment-dev-sa.json"
+                  # Used by 'previewctl list stale'
+                  export GOOGLE_APPLICATION_CREDENTIALS="/home/gitpod/.config/gcloud/preview-environment-dev-sa.json"
+
+                  echo "${PREVIEW_ENV_DEV_SA_KEY}" > "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
+                  gcloud auth activate-service-account --key-file "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
+
+                  leeway run dev/preview/previewctl:install
+
+                  previewctl get-credentials --gcp-service-account "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
+                  previewctl list stale | jq --null-input --raw-input --compact-output '[inputs | select(length>0)]' > /tmp/stale-json
+                  echo "names=$(cat /tmp/stale-json)" >> $GITHUB_OUTPUT
+                  echo "count=$(jq '. | length' /tmp/stale-json)" >> $GITHUB_OUTPUT
+
+    delete:
+        name: "Delete preview environment"
+        needs: [stale]
+        runs-on: [self-hosted]
+        if: ${{ needs.stale.outputs.count > 0 }}
+        strategy:
+            matrix:
+                name: ${{ fromJSON(needs.stale.outputs.names) }}
+        steps:
+            - uses: actions/checkout@v3
+            - name: Delete preview environment ${{ matrix.name }}
+              uses: ./.github/actions/delete-preview
+              with:
+                  name: ${{ matrix.name }}
+                  sa_key: ${{ secrets.GCP_CREDENTIALS }}

--- a/dev/preview/previewctl/cmd/stale.go
+++ b/dev/preview/previewctl/cmd/stale.go
@@ -67,16 +67,19 @@ func newListStaleCmd(logger *logrus.Logger) *cobra.Command {
 }
 
 func (o *listWorkspaceOpts) listWorskpaceStatus(ctx context.Context) ([]preview.Status, error) {
+	o.logger.Debug("Getting recent branches")
 	branches, err := preview.GetRecentBranches(time.Now().AddDate(0, 0, -30))
 	if err != nil {
 		return nil, err
 	}
 
+	o.logger.Debug("Getting terraform workspaces")
 	workspaces, err := o.getWorkspaces(ctx)
 	if err != nil {
 		return nil, err
 	}
 
+	o.logger.Debug("Finding workspaces without associated branches")
 	branchlessWorkspaces, err := getBranchlessWorkspaces(workspaces, branches)
 	if err != nil {
 		return nil, err

--- a/dev/preview/previewctl/cmd/stale.go
+++ b/dev/preview/previewctl/cmd/stale.go
@@ -33,7 +33,10 @@ func newListStaleCmd(logger *logrus.Logger) *cobra.Command {
 		Short: "Get preview envs that are inactive (no branch with recent commits, and no db activity in the last 48h)",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if _, err := os.Stat(opts.sshPrivateKeyPath); errors.Is(err, fs.ErrNotExist) {
-				return preview.InstallVMSSHKeys()
+				opts.logger.Debug("Installing SSH keys")
+				if err := preview.InstallVMSSHKeys(); err != nil {
+					return err
+				}
 			}
 
 			statuses, err := opts.listWorskpaceStatus(ctx)


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Implements the preview GC workflow and schedules it on a cron. Had to fix a minor bug in previewctl.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of https://github.com/gitpod-io/gitpod/issues/15870
Part of https://github.com/gitpod-io/gitpod/issues/15871

## How to test
<!-- Provide steps to test this PR -->

Manually triggered the job on this branch [here](https://github.com/gitpod-io/gitpod/actions/runs/4074759722). To create stale preview environments I simply ran `leeway run dev:preview` on a branch which I hadn't pushed.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

N/A

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
