### PR TITLE
[FIX] Improved UX for Workspace Entry Component

### DIFF
--- a/components/dashboard/src/components/ContextMenu.tsx
+++ b/components/dashboard/src/components/ContextMenu.tsx
@@ -7,10 +7,12 @@
 import React, { HTMLAttributeAnchorTarget } from "react";
 import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
+import cn from "classnames";
 
 export interface ContextMenuProps {
     children?: React.ReactChild[] | React.ReactChild;
     menuEntries: ContextMenuEntry[];
+    changeMenuState?: (state: boolean) => void;
     customClasses?: string;
 }
 
@@ -33,8 +35,22 @@ export interface ContextMenuEntry {
 
 function ContextMenu(props: ContextMenuProps) {
     const [expanded, setExpanded] = useState(false);
+
+    const { changeMenuState } = props;
+
+    useEffect(() => {
+        return () => {
+            if (changeMenuState) {
+                changeMenuState(!expanded);
+            }
+        };
+    }, [expanded]);
+
     const toggleExpanded = () => {
         setExpanded(!expanded);
+        if (props.changeMenuState) {
+            props.changeMenuState(!expanded);
+        }
     };
 
     const keydownHandler = (evt: KeyboardEvent) => {
@@ -73,7 +89,10 @@ function ContextMenu(props: ContextMenuProps) {
     // Default 'children' is the three dots hamburger button.
     const children = props.children || (
         <svg
-            className="w-8 h-8 p-1 rounded-md text-gray-600 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700"
+            className={cn(
+                "w-8 h-8 p-1 rounded-md text-gray-600 dark:text-gray-300",
+                expanded ? "bg-gray-200 dark:bg-gray-700" : "hover:bg-gray-200 dark:hover:bg-gray-700",
+            )}
             xmlns="http://www.w3.org/2000/svg"
             viewBox="0 0 24 24"
         >

--- a/components/dashboard/src/components/ItemsList.tsx
+++ b/components/dashboard/src/components/ItemsList.tsx
@@ -12,7 +12,7 @@ export function ItemsList(props: { children?: React.ReactNode; className?: strin
 
 export function Item(props: { children?: React.ReactNode; className?: string; header?: boolean; solid?: boolean }) {
     // cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-700
-    const solidClassName = props.solid ? "bg-gray-50 dark:bg-gray-800" : "hover:bg-gray-100 dark:hover:bg-gray-800";
+    const solidClassName = props.solid ? "bg-gray-100 dark:bg-gray-800" : "hover:bg-gray-100 dark:hover:bg-gray-800";
     const headerClassName = "text-sm text-gray-400 border-t border-b border-gray-200 dark:border-gray-800";
     const notHeaderClassName = "rounded-xl focus:bg-gitpod-kumquat-light " + solidClassName;
     return (
@@ -38,15 +38,17 @@ export function ItemFieldContextMenu(props: {
     menuEntries: ContextMenuEntry[];
     className?: string;
     position?: "start" | "center" | "end";
+    changeMenuState?: (state: boolean) => void;
 }) {
     const cls = "self-" + (props.position ?? "center");
+
     return (
         <div
             className={`flex hover:bg-gray-200 dark:hover:bg-gray-700 rounded-md cursor-pointer w-8 ${cls} ${
                 props.className || ""
             }`}
         >
-            <ContextMenu menuEntries={props.menuEntries} />
+            <ContextMenu changeMenuState={props.changeMenuState} menuEntries={props.menuEntries} />
         </div>
     );
 }

--- a/components/dashboard/src/workspaces/WorkspaceEntryNew.tsx
+++ b/components/dashboard/src/workspaces/WorkspaceEntryNew.tsx
@@ -6,7 +6,7 @@
 
 import { CommitContext, Workspace, WorkspaceInfo, ContextURL } from "@gitpod/gitpod-protocol";
 import { GitpodHostUrl } from "@gitpod/gitpod-protocol/lib/util/gitpod-host-url";
-import { FunctionComponent, useMemo } from "react";
+import { FunctionComponent, useMemo, useState } from "react";
 import { Item, ItemField, ItemFieldIcon } from "../components/ItemsList";
 import PendingChangesDropdown from "../components/PendingChangesDropdown";
 import Tooltip from "../components/Tooltip";
@@ -19,12 +19,18 @@ type Props = {
 };
 
 export const WorkspaceEntry: FunctionComponent<Props> = ({ info }) => {
+    const [menuActive, setMenuActive] = useState(false);
+
     const workspace = info.workspace;
     const currentBranch =
         info.latestInstance?.status.repo?.branch || Workspace.getBranchName(info.workspace) || "<unknown>";
     const project = getProjectPath(workspace);
     const normalizedContextUrl = ContextURL.getNormalizedURL(workspace)?.toString();
     const normalizedContextUrlDescription = normalizedContextUrl || workspace.contextURL; // Instead of showing nothing, we prefer to show the raw content instead
+
+    const changeMenuState = (state: boolean) => {
+        setMenuActive(state);
+    };
 
     // Could this be `/start#${workspace.id}` instead?
     const startUrl = useMemo(
@@ -39,7 +45,7 @@ export const WorkspaceEntry: FunctionComponent<Props> = ({ info }) => {
     );
 
     return (
-        <Item className="whitespace-nowrap py-6 px-6">
+        <Item className="whitespace-nowrap py-6 px-6" solid={menuActive}>
             <ItemFieldIcon>
                 <WorkspaceStatusIndicator instance={info?.latestInstance} />
             </ItemFieldIcon>
@@ -80,7 +86,7 @@ export const WorkspaceEntry: FunctionComponent<Props> = ({ info }) => {
                     </div>
                 </Tooltip>
             </ItemField>
-            <WorkspaceEntryOverflowMenu info={info} />
+            <WorkspaceEntryOverflowMenu changeMenuState={changeMenuState} info={info} />
         </Item>
     );
 };

--- a/components/dashboard/src/workspaces/WorkspaceOverflowMenu.tsx
+++ b/components/dashboard/src/workspaces/WorkspaceOverflowMenu.tsx
@@ -19,9 +19,13 @@ import { RenameWorkspaceModal } from "./RenameWorkspaceModal";
 
 type WorkspaceEntryOverflowMenuProps = {
     info: WorkspaceInfo;
+    changeMenuState: (state: boolean) => void;
 };
 
-export const WorkspaceEntryOverflowMenu: FunctionComponent<WorkspaceEntryOverflowMenuProps> = ({ info }) => {
+export const WorkspaceEntryOverflowMenu: FunctionComponent<WorkspaceEntryOverflowMenuProps> = ({
+    info,
+    changeMenuState,
+}) => {
     const [isDeleteModalVisible, setDeleteModalVisible] = useState(false);
     const [isRenameModalVisible, setRenameModalVisible] = useState(false);
     const [isSSHModalVisible, setSSHModalVisible] = useState(false);
@@ -131,7 +135,7 @@ export const WorkspaceEntryOverflowMenu: FunctionComponent<WorkspaceEntryOverflo
 
     return (
         <>
-            <ItemFieldContextMenu menuEntries={menuEntries} />
+            <ItemFieldContextMenu changeMenuState={changeMenuState} menuEntries={menuEntries} />
             {isDeleteModalVisible && (
                 <DeleteWorkspaceModal workspace={workspace} onClose={() => setDeleteModalVisible(false)} />
             )}


### PR DESCRIPTION
## Description

The below issues propose improvement for the UX of the Workspace Entry Components, by keeping the hovered effect ( the background colors ) of the workspace items till the `WorkspaceOverflowMenu` is expanded. Please refer the below images for reference of the improvement.

<img width="1405" alt="image" src="https://user-images.githubusercontent.com/72302948/216028575-8a914a7a-ff24-48fb-84d8-bfcd733b791d.png">

<img width="1405" alt="image" src="https://user-images.githubusercontent.com/72302948/216028944-271ce0d8-4d4c-4bd6-89fe-0cf5bfd70ffd.png">


## Improvement Graphics 

https://user-images.githubusercontent.com/72302948/216030419-a1c4f4c6-9ce0-4beb-bd63-d1a2cd4a58a9.mov

## Related Issue(s)
* Closes #4635  
* Check a fix from #12033

## How to test
- Change your directory from /gitpod to /gitpod/component/dashboard
- Add your host and token as given in the readme
- Start the development server by `yarn run start` and check on `http://localhost:3000` for checking the dashboard


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Improve the ItemsList and ContextMenu components
```