### PR TITLE
GHA Publish to NPM

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -37,6 +37,7 @@ Does this PR require updates to the documentation at www.gitpod.io/docs?
       leeway-target=components:all
 - [ ] /werft no-test
       Run Leeway with `--dont-test`
+- [ ] /werft publish-to-npm
 
 #### Preview Environment Options:
 - [ ] /werft with-local-preview

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,7 @@ jobs:
       build_no_test: ${{ steps.output.outputs.build_no_test }}
       build_leeway_target: ${{ steps.output.outputs.build_leeway_target }}
       with_large_vm: ${{ steps.output.outputs.with_large_vm }}
+      publish_to_npm: ${{ steps.output.outputs.publish_to_npm }}
     steps:
       - name: "Determine Branch"
         id: branches
@@ -43,6 +44,7 @@ jobs:
             echo "build_no_test=${{ contains(github.event.pull_request.body, '[x] /werft no-test') }}"
             echo "build_leeway_target=$(echo "$PR_DESC" | sed -n -e 's/^.*leeway-target=//p' | sed 's/\r$//')"
             echo "with_large_vm=${{ contains(github.event.pull_request.body, '[X] /werft with-large-vm') }}"
+            echo "publish_to_npm=${{ contains(github.event.pull_request.body, '[X] /werft publish-to-npm') }}"
           } >> $GITHUB_OUTPUT
 
   build-previewctl:
@@ -165,6 +167,7 @@ jobs:
         with:
           secrets: |-
             segment-io-token:gitpod-core-dev/segment-io-token
+            npm-auth-token:gitpod-core-dev/npm-auth-token
       - name: Leeway Build
         id: leeway
         shell: bash
@@ -176,10 +179,13 @@ jobs:
           PR_NO_CACHE: ${{needs.configuration.outputs.build_no_cache}}
           PR_NO_TEST: ${{needs.configuration.outputs.build_no_test}}
           PR_LEEWAY_TARGET: ${{needs.configuration.outputs.build_leeway_target}}
+          NPM_AUTH_TOKEN: '${{ steps.secrets.outputs.npm-auth-token }}'
+          PUBLISH_TO_NPM: ${{ needs.configuration.outputs.publish_to_npm == 'true' || needs.configuration.outputs.is_main_branch == 'true' }}
         run: |
           [[ "$PR_NO_CACHE" = "true" ]] && CACHE="none"       || CACHE="remote"
           [[ "$PR_NO_TEST"  = "true" ]] && TEST="--dont-test" || TEST=""
           [[ -z "$PR_LEEWAY_TARGET" ]] && PR_LEEWAY_TARGET="components:all"
+          [[ "${PUBLISH_TO_NPM}" = 'true' ]] && NPM_PUBLISH_TRIGGER=$(date +%s%3N) || NPM_PUBLISH_TRIGGER="false"
 
           mkdir -p /__w/gitpod/gitpod/test-coverage-report
 
@@ -190,7 +196,8 @@ jobs:
             $TEST \
             -Dversion=$VERSION \
             -DSEGMENT_IO_TOKEN=$SEGMENT_IO_TOKEN \
-            -DpublishToNPM=false \
+            -DpublishToNPM="${PUBLISH_TO_NPM}" \
+            -DnpmPublishTrigger="${NPM_PUBLISH_TRIGGER}" \
             --coverage-output-path=/__w/gitpod/gitpod/test-coverage-report \
             --report report.html || RESULT=$?
           set +x

--- a/components/gitpod-protocol/scripts/publish.js
+++ b/components/gitpod-protocol/scripts/publish.js
@@ -36,6 +36,6 @@ fs.writeFileSync(path.join(pckDir, "package.json"), JSON.stringify(pck, undefine
 const tag = qualifier.substr(0, qualifier.lastIndexOf("."));
 
 child_process.execSync(
-    ["yarn", "--cwd", pckDir, "publish", "--tag", tag, "--access", "public", "--ignore-scripts"].join(" "),
+    ["yarn", "--cwd", pckDir, "publish", "--tag", tag, "--access", "public", "--ignore-scripts", "--network-timeout", "100000"].join(" "),
     { stdio: "inherit" },
 );


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
GHA option to publish packages to npm

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/15767

## How to test
<!-- Provide steps to test this PR -->
https://github.com/gitpod-io/gitpod/actions/runs/4073775749/jobs/7018111520

```
leeway build components:all --cache remote -Dversion=aa-publish-to-npm-gha.1442 -DSEGMENT_IO_TOKEN=*** -DpublishToNPM=true -DnpmPublishTrigger=1675251682713 --coverage-output-path=/__w/gitpod/gitpod/test-coverage-report --report report.html
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [x] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`
- [x] /werft publish-to-npm

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
