### PR TITLE
Get repository root from initializer

### DIFF
--- a/components/ws-manager-mk2/config/manager/manager.yaml
+++ b/components/ws-manager-mk2/config/manager/manager.yaml
@@ -51,8 +51,6 @@ spec:
             port: 8081
           initialDelaySeconds: 5
           periodSeconds: 10
-        # TODO(user): Configure the resources accordingly based on the project requirements.
-        # More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
         resources:
           limits:
             cpu: 500m

--- a/components/ws-manager-mk2/config/samples/workspace_v1_workspace.yaml
+++ b/components/ws-manager-mk2/config/samples/workspace_v1_workspace.yaml
@@ -7,4 +7,3 @@ kind: Workspace
 metadata:
   name: workspace-sample
 spec:
-  # TODO(user): Add fields here

--- a/components/ws-manager-mk2/controllers/workspace_controller.go
+++ b/components/ws-manager-mk2/controllers/workspace_controller.go
@@ -63,7 +63,7 @@ type WorkspaceReconciler struct {
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
-// TODO(user): Modify the Reconcile function to compare the state specified by
+// Modify the Reconcile function to compare the state specified by
 // the Workspace object against the actual cluster state, and then
 // perform operations to make the cluster state reflect the state specified by
 // the user.
@@ -75,7 +75,6 @@ func (r *WorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	var workspace workspacev1.Workspace
 	if err := r.Get(ctx, req.NamespacedName, &workspace); err != nil {
-		// TODO(cw): create pdo
 		log.Error(err, "unable to fetch workspace")
 		// we'll ignore not-found errors, since they can't be fixed by an immediate
 		// requeue (we'll need to wait for a new notification), and we can get them

--- a/components/ws-manager-mk2/controllers/workspace_controller_test.go
+++ b/components/ws-manager-mk2/controllers/workspace_controller_test.go
@@ -17,6 +17,7 @@ import (
 	// . "github.com/onsi/ginkgo/extensions/table"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -99,8 +100,7 @@ var _ = Describe("WorkspaceController", func() {
 			Expect(k8sClient.Delete(ctx, createdPod)).To(Succeed())
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, podLookupKey, createdPod)
-				if err != nil {
-					// TODO(cw): check if this is a not found error
+				if err != nil && errors.IsNotFound(err) {
 					// We have an error and assume we did not find the pod. This is what we want.
 					return true
 				}
@@ -112,8 +112,7 @@ var _ = Describe("WorkspaceController", func() {
 			// Now we make sure the pod doesn't come back
 			Consistently(func() bool {
 				err := k8sClient.Get(ctx, podLookupKey, createdPod)
-				if err != nil {
-					// TODO(cw): check if this is a not found error
+				if err != nil && errors.IsNotFound(err) {
 					// We have an error and assume we did not find the pod. This is what we want.
 					return true
 				}

--- a/components/ws-manager-mk2/service/manager.go
+++ b/components/ws-manager-mk2/service/manager.go
@@ -230,8 +230,6 @@ func (wsm *WorkspaceManagerServer) StartWorkspace(ctx context.Context, req *wsma
 
 func (wsm *WorkspaceManagerServer) StopWorkspace(ctx context.Context, req *wsmanapi.StopWorkspaceRequest) (*wsmanapi.StopWorkspaceResponse, error) {
 	err := wsm.modifyWorkspace(ctx, req.Id, true, func(ws *workspacev1.Workspace) error {
-		// TODO(cw): stopping the workspace by modifying the status is nasty.
-		// 			 instead we should modify the spec or delete the workspace object.
 		ws.Status.Conditions = append(ws.Status.Conditions, metav1.Condition{
 			Type:               string(workspacev1.WorkspaceConditionStoppedByRequest),
 			Status:             metav1.ConditionTrue,


### PR DESCRIPTION
## Description
Get repository root from initializer

## Related Issue(s)
n.a.

## How to test
- Open workspace
- Correct repository root should be set

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```
## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
