### PR TITLE
supervisor: only write /dev/termination-log in `init` or `run` command

### DIFF
--- a/components/supervisor/cmd/init.go
+++ b/components/supervisor/cmd/init.go
@@ -31,6 +31,8 @@ var initCmd = &cobra.Command{
 	Short: "init the supervisor",
 	Run: func(cmd *cobra.Command, args []string) {
 		log.Init(ServiceName, Version, true, false)
+		log.Log.Logger.AddHook(fatalTerminationLogHook{})
+
 		cfg, err := supervisor.GetConfig()
 		if err != nil {
 			log.WithError(err).Info("cannnot load config")

--- a/components/supervisor/cmd/root.go
+++ b/components/supervisor/cmd/root.go
@@ -31,7 +31,6 @@ var (
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
 	log.Init(ServiceName, Version, true, false)
-	log.Log.Logger.AddHook(fatalTerminationLogHook{})
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)

--- a/components/supervisor/cmd/run.go
+++ b/components/supervisor/cmd/run.go
@@ -24,6 +24,8 @@ var runCmd = &cobra.Command{
 
 	Run: func(cmd *cobra.Command, args []string) {
 		log.Init(ServiceName, Version, !runOpts.RunGP, os.Getenv("SUPERVISOR_DEBUG_ENABLE") == "true")
+		log.Log.Logger.AddHook(fatalTerminationLogHook{})
+
 		common_grpc.SetupLogging()
 		supervisor.Version = Version
 		supervisor.Run(supervisor.WithRunGP(runOpts.RunGP))


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
supervisor: only write /dev/termination-log in `init` or `run` command

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
