### PR TITLE
[installer] Replace flag withoutWorkspaceComponents with 'Kind != "Full"'

### DIFF
--- a/install/installer/cmd/testdata/render/kind-meta/output.golden
+++ b/install/installer/cmd/testdata/render/kind-meta/output.golden
@@ -7621,9 +7621,6 @@ spec:
         - mountPath: /twilio-config
           name: twilio-secret-volume
           readOnly: true
-        - mountPath: /ws-manager-client-tls-certs
-          name: ws-manager-client-tls-certs
-          readOnly: true
         - mountPath: /admin
           name: admin-login-key
           readOnly: true
@@ -7738,9 +7735,6 @@ spec:
         secret:
           optional: true
           secretName: twilio-secret
-      - name: ws-manager-client-tls-certs
-        secret:
-          secretName: ws-manager-client-tls
       - name: admin-login-key
         secret:
           secretName: server-admin-secret
@@ -7875,9 +7869,6 @@ spec:
         - mountPath: /config
           name: config
           readOnly: true
-        - mountPath: /ws-manager-client-tls-certs
-          name: ws-manager-client-tls-certs
-          readOnly: true
       - args:
         - --logtostderr
         - --insecure-listen-address=[$(IP)]:9500
@@ -7985,9 +7976,6 @@ spec:
       - configMap:
           name: ws-manager-bridge-config
         name: config
-      - name: ws-manager-client-tls-certs
-        secret:
-          secretName: ws-manager-client-tls
 status: {}
 ---
 # batch/v1/Job migrations

--- a/install/installer/cmd/testdata/render/kind-webapp/output.golden
+++ b/install/installer/cmd/testdata/render/kind-webapp/output.golden
@@ -4534,9 +4534,6 @@ spec:
         - mountPath: /twilio-config
           name: twilio-secret-volume
           readOnly: true
-        - mountPath: /ws-manager-client-tls-certs
-          name: ws-manager-client-tls-certs
-          readOnly: true
         - mountPath: /admin
           name: admin-login-key
           readOnly: true
@@ -4651,9 +4648,6 @@ spec:
         secret:
           optional: true
           secretName: twilio-secret
-      - name: ws-manager-client-tls-certs
-        secret:
-          secretName: ws-manager-client-tls
       - name: admin-login-key
         secret:
           secretName: server-admin-secret
@@ -4788,9 +4782,6 @@ spec:
         - mountPath: /config
           name: config
           readOnly: true
-        - mountPath: /ws-manager-client-tls-certs
-          name: ws-manager-client-tls-certs
-          readOnly: true
       - args:
         - --logtostderr
         - --insecure-listen-address=[$(IP)]:9500
@@ -4898,9 +4889,6 @@ spec:
       - configMap:
           name: ws-manager-bridge-config
         name: config
-      - name: ws-manager-client-tls-certs
-        secret:
-          secretName: ws-manager-client-tls
 status: {}
 ---
 # batch/v1/Job migrations

--- a/install/installer/pkg/common/common.go
+++ b/install/installer/pkg/common/common.go
@@ -804,3 +804,8 @@ func ExperimentalWebappConfig(ctx *RenderContext) *experimental.WebAppConfig {
 
 	return experimentalCfg.WebApp
 }
+
+// WithLocalWsManager returns true if the installed application cluster should connect to a local ws-manager
+func WithLocalWsManager(ctx *RenderContext) bool {
+	return ctx.Config.Kind == config.InstallationFull
+}

--- a/install/installer/pkg/components/server/deployment.go
+++ b/install/installer/pkg/components/server/deployment.go
@@ -305,14 +305,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 		return nil
 	})
 
-	addWsManagerTls := true
-	_ = ctx.WithExperimental(func(cfg *experimental.Config) error {
-		if cfg.WebApp != nil && cfg.WebApp.WithoutWorkspaceComponents {
-			// No ws-manager exists in the cluster, so no TLS secret to mount.
-			addWsManagerTls = false
-		}
-		return nil
-	})
+	addWsManagerTls := common.WithLocalWsManager(ctx)
 	if addWsManagerTls {
 		volumes = append(volumes, corev1.Volume{
 			Name: "ws-manager-client-tls-certs",

--- a/install/installer/pkg/components/slowserver/deployment.go
+++ b/install/installer/pkg/components/slowserver/deployment.go
@@ -340,14 +340,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 		}
 	}
 
-	addWsManagerTls := true
-	_ = ctx.WithExperimental(func(cfg *experimental.Config) error {
-		if cfg.WebApp != nil && cfg.WebApp.WithoutWorkspaceComponents {
-			// No ws-manager exists in the cluster, so no TLS secret to mount.
-			addWsManagerTls = false
-		}
-		return nil
-	})
+	addWsManagerTls := common.WithLocalWsManager(ctx)
 	if addWsManagerTls {
 		volumes = append(volumes, corev1.Volume{
 			Name: "ws-manager-client-tls-certs",

--- a/install/installer/pkg/components/ws-manager-bridge/deployment.go
+++ b/install/installer/pkg/components/ws-manager-bridge/deployment.go
@@ -11,7 +11,6 @@ import (
 	"github.com/gitpod-io/gitpod/installer/pkg/cluster"
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 	wsmanager "github.com/gitpod-io/gitpod/installer/pkg/components/ws-manager"
-	"github.com/gitpod-io/gitpod/installer/pkg/config/v1/experimental"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -34,14 +33,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 	var volumes []corev1.Volume
 	var volumeMounts []corev1.VolumeMount
 
-	addWsManagerTls := true
-	_ = ctx.WithExperimental(func(cfg *experimental.Config) error {
-		if cfg.WebApp != nil && cfg.WebApp.WithoutWorkspaceComponents {
-			// No ws-manager exists in the cluster, so no TLS secret to mount.
-			addWsManagerTls = false
-		}
-		return nil
-	})
+	addWsManagerTls := common.WithLocalWsManager(ctx)
 	if addWsManagerTls {
 		volumes = append(volumes, corev1.Volume{
 			Name: "ws-manager-client-tls-certs",

--- a/install/installer/pkg/components/ws-manager-bridge/objects.go
+++ b/install/installer/pkg/components/ws-manager-bridge/objects.go
@@ -28,7 +28,7 @@ func WSManagerList(ctx *common.RenderContext) []WorkspaceCluster {
 			skipSelf = cfg.WebApp.WorkspaceManagerBridge.SkipSelf
 		}
 
-		if cfg.WebApp != nil && cfg.WebApp.WithoutWorkspaceComponents {
+		if !common.WithLocalWsManager(ctx) {
 			// Must skip self if cluster does not contain ws-manager.
 			skipSelf = true
 		}

--- a/install/installer/pkg/components/ws-manager-bridge/objects_test.go
+++ b/install/installer/pkg/components/ws-manager-bridge/objects_test.go
@@ -17,15 +17,18 @@ import (
 
 func TestWorkspaceManagerList_WhenSkipSelfIsSet(t *testing.T) {
 	testCases := []struct {
+		Kind                    config.InstallationKind
 		SkipSelf                bool
 		ExpectWorkspaceClusters bool
 	}{
-		{SkipSelf: true, ExpectWorkspaceClusters: false},
-		{SkipSelf: false, ExpectWorkspaceClusters: true},
+		{Kind: config.InstallationMeta, SkipSelf: true, ExpectWorkspaceClusters: false},
+		{Kind: config.InstallationMeta, SkipSelf: false, ExpectWorkspaceClusters: false}, // cannot mount anything it if there is nothing to mount
+		{Kind: config.InstallationFull, SkipSelf: true, ExpectWorkspaceClusters: false},
+		{Kind: config.InstallationFull, SkipSelf: false, ExpectWorkspaceClusters: true},
 	}
 
 	for _, testCase := range testCases {
-		ctx := renderContextWithConfig(t, testCase.SkipSelf)
+		ctx := renderContextWithConfig(t, testCase.Kind, testCase.SkipSelf)
 
 		wsclusters := WSManagerList(ctx)
 		if testCase.ExpectWorkspaceClusters {
@@ -36,8 +39,9 @@ func TestWorkspaceManagerList_WhenSkipSelfIsSet(t *testing.T) {
 	}
 }
 
-func renderContextWithConfig(t *testing.T, skipSelf bool) *common.RenderContext {
+func renderContextWithConfig(t *testing.T, kind config.InstallationKind, skipSelf bool) *common.RenderContext {
 	ctx, err := common.NewRenderContext(config.Config{
+		Kind: kind,
 		Experimental: &experimental.Config{
 			WebApp: &experimental.WebAppConfig{
 				WorkspaceManagerBridge: &experimental.WsManagerBridgeConfig{

--- a/install/installer/pkg/config/v1/experimental/experimental.go
+++ b/install/installer/pkg/config/v1/experimental/experimental.go
@@ -205,21 +205,20 @@ type SpiceDBConfig struct {
 }
 
 type WebAppConfig struct {
-	PublicAPI                  *PublicAPIConfig       `json:"publicApi,omitempty"`
-	Server                     *ServerConfig          `json:"server,omitempty"`
-	ProxyConfig                *ProxyConfig           `json:"proxy,omitempty"`
-	WorkspaceManagerBridge     *WsManagerBridgeConfig `json:"wsManagerBridge,omitempty"`
-	Tracing                    *Tracing               `json:"tracing,omitempty"`
-	UsePodAntiAffinity         bool                   `json:"usePodAntiAffinity"`
-	DisableMigration           bool                   `json:"disableMigration"`
-	Usage                      *UsageConfig           `json:"usage,omitempty"`
-	ConfigcatKey               string                 `json:"configcatKey"`
-	WorkspaceClasses           []WebAppWorkspaceClass `json:"workspaceClasses"`
-	Stripe                     *StripeConfig          `json:"stripe,omitempty"`
-	SlowDatabase               string                 `json:"slowDatabase,omitempty"`
-	IAM                        *IAMConfig             `json:"iam,omitempty"`
-	WithoutWorkspaceComponents bool                   `json:"withoutWorkspaceComponents,omitempty"`
-	SpiceDB                    *SpiceDBConfig         `json:"spicedb,omitempty"`
+	PublicAPI              *PublicAPIConfig       `json:"publicApi,omitempty"`
+	Server                 *ServerConfig          `json:"server,omitempty"`
+	ProxyConfig            *ProxyConfig           `json:"proxy,omitempty"`
+	WorkspaceManagerBridge *WsManagerBridgeConfig `json:"wsManagerBridge,omitempty"`
+	Tracing                *Tracing               `json:"tracing,omitempty"`
+	UsePodAntiAffinity     bool                   `json:"usePodAntiAffinity"`
+	DisableMigration       bool                   `json:"disableMigration"`
+	Usage                  *UsageConfig           `json:"usage,omitempty"`
+	ConfigcatKey           string                 `json:"configcatKey"`
+	WorkspaceClasses       []WebAppWorkspaceClass `json:"workspaceClasses"`
+	Stripe                 *StripeConfig          `json:"stripe,omitempty"`
+	SlowDatabase           string                 `json:"slowDatabase,omitempty"`
+	IAM                    *IAMConfig             `json:"iam,omitempty"`
+	SpiceDB                *SpiceDBConfig         `json:"spicedb,omitempty"`
 }
 
 type WorkspaceDefaults struct {


### PR DESCRIPTION


## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
Context: https://github.com/gitpod-io/gitpod/pull/15276

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
