### PR TITLE
Update gitpod-schema.json and add some doc links

### DIFF
--- a/components/gitpod-protocol/data/gitpod-schema.json
+++ b/components/gitpod-protocol/data/gitpod-schema.json
@@ -6,7 +6,7 @@
     "properties": {
         "ports": {
             "type": "array",
-            "description": "List of exposed ports.",
+            "description": "List of exposed ports. See https://www.gitpod.io/docs/configure/workspaces/ports for more info",
             "items": {
                 "type": "object",
                 "required": [
@@ -35,7 +35,7 @@
                             "public"
                         ],
                         "default": "private",
-                        "description": "Whether the port visibility should be private or public. 'private' (default) will only allow users with workspace access to access the port. 'public' will allow everyone with the port URL to access the port."
+                        "description": "Whether the port visibility should be private or public. 'private' (default) will only allow users with workspace access to access the port. 'public' will allow everyone with the port URL to access the port, can help with CORS issues."
                     },
                     "name": {
                         "type": "string",
@@ -61,7 +61,7 @@
         },
         "tasks": {
             "type": "array",
-            "description": "List of tasks to run on start. Each task will open a terminal in the IDE.",
+            "description": "List of tasks to run on start. Each task will open a terminal in the IDE. See https://www.gitpod.io/docs/configure/workspaces/tasks for more info.",
             "items": {
                 "type": "object",
                 "properties": {
@@ -71,11 +71,11 @@
                     },
                     "before": {
                         "type": "string",
-                        "description": "A shell command to run before `init` and the main `command`. This command is executed on every start and is expected to terminate. If it fails, the following commands will not be executed."
+                        "description": "A shell command to run before `init` and the main `command`."
                     },
                     "init": {
                         "type": "string",
-                        "description": "A shell command to run between `before` and the main `command`. This command is executed only on after initializing a workspace with a fresh clone, but not on restarts and snapshots. This command is expected to terminate. If it fails, the `command` property will not be executed."
+                        "description": "A shell command to run between `before` and the main `command`. It can only modify the `/workspace` directory, other modifications will be lost on start when prebuilds are used."
                     },
                     "prebuild": {
                         "type": "string",
@@ -88,7 +88,7 @@
                     },
                     "env": {
                         "type": "object",
-                        "description": "Environment variables to set."
+                        "description": "Environment variables to set. See https://www.gitpod.io/docs/configure/projects/environment-variables#task-terminal-specific-environment-variables for more info"
                     },
                     "openIn": {
                         "type": "string",
@@ -119,7 +119,7 @@
                 "object",
                 "string"
             ],
-            "description": "The Docker image to run your workspace in.",
+            "description": "The Docker image to run your workspace in. See https://www.gitpod.io/docs/configure/workspaces/workspace-image for more info.",
             "default": "gitpod/workspace-full",
             "required": [
                 "file"
@@ -138,7 +138,7 @@
         },
         "additionalRepositories": {
             "type": "array",
-            "description": "List of additional repositories that are part of this project.",
+            "description": "List of additional repositories that are part of this project. See https://www.gitpod.io/docs/configure/workspaces/multi-repo for more info.",
             "items": {
                 "type": "object",
                 "required": [
@@ -180,7 +180,7 @@
         },
         "github": {
             "type": "object",
-            "description": "Configures Gitpod's GitHub app",
+            "description": "Configures Gitpod's GitHub app. See https://www.gitpod.io/docs/configure/projects/prebuilds#github-specific-configuration for more info.",
             "properties": {
                 "prebuilds": {
                     "type": [
@@ -240,7 +240,7 @@
             "properties": {
                 "extensions": {
                     "type": "array",
-                    "description": "List of extensions which should be installed for users of this workspace. The identifier of an extension is always '${publisher}.${name}'. For example: 'vscode.csharp'.",
+                    "description": "List of extensions which should be installed for users of this workspace. The identifier of an extension is always '${publisher}.${name}'. For example: 'vscode.csharp'. See https://www.gitpod.io/docs/references/ides-and-editors/vscode-extensions for more info.",
                     "items": {
                         "type": "string"
                     }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Helps with https://github.com/gitpod-io/gitpod/issues/15731

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Add documentation links to Gitpod schema
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`
- [ ] /werft publish-to-npm

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
