### PR TITLE
Add credentials token for browser IDE

### DIFF
--- a/components/dashboard/src/service/service.tsx
+++ b/components/dashboard/src/service/service.tsx
@@ -134,6 +134,7 @@ export class IDEFrontendService implements IDEFrontendDashboardService.IServer {
             statusPhase: workspace.latestInstance?.status.phase,
             workspaceDescription: workspace.workspace.description,
             workspaceType: workspace.workspace.type,
+            credentialsToken: workspace.workspace.config.ideCredentialsToken!,
         };
     }
 

--- a/components/gitpod-protocol/src/frontend-dashboard-service.ts
+++ b/components/gitpod-protocol/src/frontend-dashboard-service.ts
@@ -46,6 +46,7 @@ export namespace IDEFrontendDashboardService {
 
         workspaceDescription: string;
         workspaceType: string;
+        credentialsToken: string;
     }
 
     export interface SetStateData {

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -823,6 +823,7 @@ export interface WorkspaceConfig {
     vscode?: VSCodeConfig;
     jetbrains?: JetBrainsConfig;
     coreDump?: CoreDumpConfig;
+    ideCredentialsToken?: string;
 
     /** deprecated. Enabled by default **/
     experimentalNetwork?: boolean;

--- a/components/server/src/workspace/config-provider.ts
+++ b/components/server/src/workspace/config-provider.ts
@@ -7,6 +7,7 @@
 import { inject, injectable } from "inversify";
 import fetch from "node-fetch";
 import * as path from "path";
+import * as crypto from "crypto";
 
 import { log, LogContext } from "@gitpod/gitpod-protocol/lib/util/logging";
 import {
@@ -243,6 +244,7 @@ export class ConfigProvider {
             ports: [],
             tasks: [],
             image: this.config.workspaceDefaults.workspaceImage,
+            ideCredentialsToken: crypto.randomBytes(32).toString("base64"),
         };
     }
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Part 1/2

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #
Related https://github.com/gitpod-io/security/issues/121

## How to test
<!-- Provide steps to test this PR -->
Should test in https://github.com/gitpod-io/gitpod/pull/16179

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`
- [ ] /werft publish-to-npm

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
