### PR TITLE
[ide-service] Always send IdeImageLayers

### DIFF
--- a/components/ide-service/pkg/server/server.go
+++ b/components/ide-service/pkg/server/server.go
@@ -251,6 +251,7 @@ func (s *IDEServiceServer) ResolveWorkspaceConfig(ctx context.Context, req *api.
 	resp = &api.ResolveWorkspaceConfigResponse{
 		SupervisorImage: ideConfig.SupervisorImage,
 		WebImage:        defaultIde.Image,
+		IdeImageLayers:  defaultIde.ImageLayers,
 	}
 
 	var wsConfig *gitpodapi.GitpodConfig
@@ -320,7 +321,7 @@ func (s *IDEServiceServer) ResolveWorkspaceConfig(ctx context.Context, req *api.
 
 		// we always need WebImage for when the user chooses a desktop ide
 		resp.WebImage = getUserIDEImage(defaultIde)
-		webUserImageLayers := getUserImageLayers(defaultIde)
+		resp.IdeImageLayers = getUserImageLayers(defaultIde)
 
 		var desktopImageLayer string
 		var desktopUserImageLayers []string
@@ -329,7 +330,7 @@ func (s *IDEServiceServer) ResolveWorkspaceConfig(ctx context.Context, req *api.
 			desktopUserImageLayers = getUserImageLayers(chosenIDE)
 		} else {
 			resp.WebImage = getUserIDEImage(chosenIDE)
-			webUserImageLayers = getUserImageLayers(chosenIDE)
+			resp.IdeImageLayers = getUserImageLayers(chosenIDE)
 		}
 
 		ideName, referrer := s.resolveReferrerIDE(ideConfig, wsContext, userIdeName)
@@ -339,7 +340,6 @@ func (s *IDEServiceServer) ResolveWorkspaceConfig(ctx context.Context, req *api.
 			desktopUserImageLayers = getUserImageLayers(referrer)
 		}
 
-		resp.IdeImageLayers = append(resp.IdeImageLayers, webUserImageLayers...)
 		if desktopImageLayer != "" {
 			resp.IdeImageLayers = append(resp.IdeImageLayers, desktopImageLayer)
 			resp.IdeImageLayers = append(resp.IdeImageLayers, desktopUserImageLayers...)


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Always send IdeImageLayers in ide-service

## How to test
<!-- Provide steps to test this PR -->
Start a prebuild check it runs successfully

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [x] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`
- [ ] /werft publish-to-npm

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft with-integration-tests=workspace
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
