### PR TITLE
:seedling: reflect docs breaking changes

### DIFF
--- a/components/dashboard/src/workspaces/WorkspacesNew.tsx
+++ b/components/dashboard/src/workspaces/WorkspacesNew.tsx
@@ -136,8 +136,10 @@ const WorkspacesPage: FunctionComponent = () => {
                                                 Workspaces that have been stopped for more than 24 hours. Inactive
                                                 workspaces are automatically deleted after 14 days.{" "}
                                                 <a
+                                                    target="_blank"
+                                                    rel="noreferrer"
                                                     className="gp-link"
-                                                    href="https://www.gitpod.io/docs/life-of-workspace/#garbage-collection"
+                                                    href="https://www.gitpod.io/docs/configure/workspaces/workspace-lifecycle#workspace-deletion"
                                                     onClick={(evt) => evt.stopPropagation()}
                                                 >
                                                     Learn more


### PR DESCRIPTION
## Description
Reflect breaking changes of https://github.com/gitpod-io/website/pull/3326

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`
- [ ] /werft publish-to-npm

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
