### PR TITLE
[db] d_b_workspace get organizationId

### DIFF
--- a/components/gitpod-db/src/typeorm/migration/1675744891502-WorkspaceOrganizationId.ts
+++ b/components/gitpod-db/src/typeorm/migration/1675744891502-WorkspaceOrganizationId.ts
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { MigrationInterface, QueryRunner } from "typeorm";
+import { columnExists, indexExists } from "./helper/helper";
+
+const table = "d_b_workspace";
+const column = "organizationId";
+const orgIndex = "idx_organizationId";
+
+export class WorkspaceOrganizationId1675744891502 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        if (!(await columnExists(queryRunner, table, column))) {
+            await queryRunner.query(
+                `ALTER TABLE ${table} ADD COLUMN ${column} varchar(36), ALGORITHM=INPLACE, LOCK=NONE`,
+            );
+        }
+
+        if (!(await indexExists(queryRunner, table, orgIndex))) {
+            await queryRunner.query(`CREATE INDEX \`${orgIndex}\` ON \`${table}\` (${column})`);
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {}
+}


### PR DESCRIPTION
## Description

This is the first change towards organization-owned workspaces. This PR
 - adds `organizationId` to `d_b_workspace`
 - updates existing workspaces based on the attribution id of their instances (if it's a team attribution)
 
 In prod the column is already created on both databases, so also the migration doesn't run there. We are going to run the migration manually.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
See #16177

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`
- [ ] /werft publish-to-npm

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
