### PR TITLE
[gh-app] unsubscribe from pull_request.synchronize

### DIFF
--- a/components/server/ee/src/prebuilds/github-app.ts
+++ b/components/server/ee/src/prebuilds/github-app.ts
@@ -173,7 +173,7 @@ export class GithubApp {
             catchError(this.handlePushEvent(ctx));
         });
 
-        app.on(["pull_request.opened", "pull_request.synchronize", "pull_request.reopened"], (ctx) => {
+        app.on(["pull_request.opened", "pull_request.reopened"], (ctx) => {
             catchError(this.handlePullRequest(ctx));
         });
 


### PR DESCRIPTION
## Description
`pull_request.synchronize` events of Gitpod's GH App are generating noise, but the do not provide any value.

There is a general `push` event handler which takes care of the same thing basically. And what's more, both are receive when the author pushes updates to a PR's branch, which does mean we need to deduplicate on our end.

Check this DB query if you need to see the events rushing in, to verify they are always dupes:
```
select * from d_b_webhook_event   order by creationTime DESC limit 100;
```

To reviewers, if you read `handlePullRequest` you'll find no special handling for PRs in general. The relevant information bit is `contextURL: payload.pull_request.html_url`, which has an in equivalent in `push` event handler. 

Unsubscribing from `pull_request.synchronize` should be zero risk. 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`
- [ ] /werft publish-to-npm

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
