### PR TITLE
[server] Extend guardTeamResource with fine-grained ops

### DIFF
--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -1596,7 +1596,7 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
     // Team Subscriptions 2
     async getTeamSubscription(ctx: TraceContext, teamId: string): Promise<TeamSubscription2 | undefined> {
         this.checkUser("getTeamSubscription");
-        await this.guardTeamOperation(teamId, "get");
+        await this.guardTeamOperation(teamId, "get", ["not_implemented"]);
         return this.teamSubscription2DB.findForTeam(teamId, new Date().toISOString());
     }
 
@@ -2098,7 +2098,7 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
 
         try {
             if (attrId.kind == "team") {
-                await this.guardTeamOperation(attrId.teamId, "get");
+                await this.guardTeamOperation(attrId.teamId, "get", ["not_implemented"]);
             }
             const subscriptionId = await this.stripeService.findUncancelledSubscriptionByAttributionId(attributionId);
             return subscriptionId;
@@ -2119,7 +2119,7 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
         }
         let team: Team | undefined;
         if (attrId.kind === "team") {
-            team = (await this.guardTeamOperation(attrId.teamId, "update")).team;
+            team = (await this.guardTeamOperation(attrId.teamId, "update", ["not_implemented"])).team;
             await this.ensureStripeApiIsAllowed({ team });
         } else {
             if (attrId.userId !== user.id) {
@@ -2141,7 +2141,7 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
         }
         let team: Team | undefined;
         if (attrId.kind === "team") {
-            team = (await this.guardTeamOperation(attrId.teamId, "update")).team;
+            team = (await this.guardTeamOperation(attrId.teamId, "update", ["not_implemented"])).team;
             await this.ensureStripeApiIsAllowed({ team });
         } else {
             if (attrId.userId !== user.id) {
@@ -2211,7 +2211,7 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
         let team: Team | undefined;
         try {
             if (attrId.kind === "team") {
-                team = (await this.guardTeamOperation(attrId.teamId, "update")).team;
+                team = (await this.guardTeamOperation(attrId.teamId, "update", ["not_implemented"])).team;
                 await this.ensureStripeApiIsAllowed({ team });
             } else {
                 await this.ensureStripeApiIsAllowed({ user });
@@ -2257,7 +2257,7 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
         if (attrId.kind === "user") {
             await this.ensureStripeApiIsAllowed({ user });
         } else if (attrId.kind === "team") {
-            const team = (await this.guardTeamOperation(attrId.teamId, "update")).team;
+            const team = (await this.guardTeamOperation(attrId.teamId, "update", ["not_implemented"])).team;
             await this.ensureStripeApiIsAllowed({ team });
             returnUrl = this.config.hostUrl
                 .with(() => ({ pathname: `/org-billing`, search: `org=${team.id}` }))
@@ -2493,7 +2493,7 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
         traceAPIParams(ctx, { teamId });
 
         this.checkAndBlockUser("getBillingModeForTeam");
-        const { team } = await this.guardTeamOperation(teamId, "get");
+        const { team } = await this.guardTeamOperation(teamId, "get", ["not_implemented"]);
 
         return this.billingModes.getBillingModeForTeam(team, new Date());
     }

--- a/components/server/src/authorization/perms.ts
+++ b/components/server/src/authorization/perms.ts
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+export type OrganizationOperation =
+    // A not yet implemented operation at this time. This exists such that we can be explicit about what
+    // we have not yet migrated to fine-grained-permissions.
+    | "not_implemented"
+
+    // Ability to perform write actions an Organization, and all sub-resources of the organization.
+    | "org_write"
+
+    // Ability to update Organization metadata - name, and other general info.
+    | "org_metadata_write"
+    // Ability to read Organization metadata - name, and other general info.
+    | "org_metadata_read"
+
+    // Ability to access information about team members.
+    | "org_members_read"
+    // Ability to add, or remove, team members.
+    | "org_members_write"
+
+    // Ability to read projects in an Organization.
+    | "org_project_read"
+    // Ability to create/update/delete projects in an Organization.
+    | "org_project_write"
+
+    // Ability to create/update/delete Organization Auth Providers.
+    | "org_authprovider_write"
+    // Ability to read Organization Auth Providers.
+    | "org_authprovider_read";


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Adds fine-grained operations to teams, pre-cursor to actually start checking for the permissions. For now, these are logged, when the feature flag is enabled.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Part of https://github.com/gitpod-io/gitpod/issues/16102
* Depends on https://github.com/gitpod-io/gitpod/pull/16186

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`
- [ ] /werft publish-to-npm

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold for dependency