### PR TITLE
[server] Add spicedb client

### DIFF
--- a/components/server/package.json
+++ b/components/server/package.json
@@ -27,6 +27,7 @@
     "/dist"
   ],
   "dependencies": {
+    "@authzed/authzed-node": "^0.10.0",
     "@gitbeaker/node": "^35.7.0",
     "@gitpod/content-service": "0.1.5",
     "@gitpod/gitpod-db": "0.1.5",

--- a/components/server/src/authorization/spicedb.ts
+++ b/components/server/src/authorization/spicedb.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { v1 } from "@authzed/authzed-node";
+import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
+
+export const SpiceDBClient = Symbol("SpiceDBClient");
+export type SpiceDBClient = v1.ZedPromiseClientInterface | undefined;
+
+export function spicedbClientFromEnv(): SpiceDBClient {
+    const token = process.env["SPICEDB_PRESHARED_KEY"];
+    if (!token) {
+        log.error("[spicedb] No preshared key configured.");
+        return;
+    }
+
+    const address = process.env["SPICEDB_ADDRESS"];
+    if (!address) {
+        log.error("[spicedb] No service address configured.");
+        return;
+    }
+
+    return v1.NewClient(token, address, v1.ClientSecurity.INSECURE_PLAINTEXT_CREDENTIALS).promises;
+}

--- a/components/server/src/container-module.ts
+++ b/components/server/src/container-module.ts
@@ -112,6 +112,7 @@ import { contentServiceBinder } from "./util/content-service-sugar";
 import { UbpResetOnCancel } from "@gitpod/gitpod-payment-endpoint/lib/chargebee/ubp-reset-on-cancel";
 import { retryMiddleware } from "nice-grpc-client-middleware-retry";
 import { IamSessionApp } from "./iam/iam-session-app";
+import { spicedbClientFromEnv, SpiceDBClient } from "./authorization/spicedb";
 
 export const productionContainerModule = new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(Config).toConstantValue(ConfigFile.fromFile());
@@ -307,4 +308,9 @@ export const productionContainerModule = new ContainerModule((bind, unbind, isBo
 
     // IAM Support
     bind(IamSessionApp).toSelf().inSingletonScope();
+
+    // Authorization & Perms
+    bind(SpiceDBClient)
+        .toDynamicValue(() => spicedbClientFromEnv())
+        .inSingletonScope();
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,16 @@
 # yarn lockfile v1
 
 
+"@authzed/authzed-node@^0.10.0":
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/@authzed/authzed-node/-/authzed-node-0.10.0.tgz#623e4911fde221bb526e7f2e9ca335d9f3b9072d"
+  integrity sha512-TnAnatcU5dHvyGqrWoZzPNaO1opPpVU1y7P5LrJsV2j54y0xvx/OFhYtfeguMxHSz2kpbdCuIvIKJuB8WFbRRA==
+  dependencies:
+    "@grpc/grpc-js" "^1.2.8"
+    "@protobuf-ts/runtime" "^2.8.1"
+    "@protobuf-ts/runtime-rpc" "^2.8.1"
+    google-protobuf "^3.15.3"
+
 "@babel/code-frame@7.10.4":
   version "7.10.4"
   resolved "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz"
@@ -1474,6 +1484,14 @@
     stream-events "^1.0.1"
     xdg-basedir "^4.0.0"
 
+"@grpc/grpc-js@^1.2.8":
+  version "1.8.7"
+  resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.8.7.tgz#2154fc0134462ad45f4134e8b54682a25ed05956"
+  integrity sha512-dRAWjRFN1Zy9mzPNLkFFIWT8T6C9euwluzCHZUKuhC+Bk3MayNPcpgDRyG+sg+n2sitEUySKxUynirVpu9ItKw==
+  dependencies:
+    "@grpc/proto-loader" "^0.7.0"
+    "@types/node" ">=12.12.47"
+
 "@grpc/grpc-js@^1.3.7":
   version "1.4.2"
   resolved "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.4.2.tgz"
@@ -2130,6 +2148,18 @@
     pump "^3.0.0"
     readable-stream "^3.6.0"
     split2 "^4.0.0"
+
+"@protobuf-ts/runtime-rpc@^2.8.1":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@protobuf-ts/runtime-rpc/-/runtime-rpc-2.8.2.tgz#8af6d5eab44e2fc92cfe9a83a5c351b5f2fcdfbe"
+  integrity sha512-vum/Y7AXdUTWGFu7dke/jCSB9dV3Oo3iVPcce3j7KudpzzWarDkEGvXjKv3Y8zJPj5waToyxwBNSb7eo5Vw5WA==
+  dependencies:
+    "@protobuf-ts/runtime" "^2.8.2"
+
+"@protobuf-ts/runtime@^2.8.1", "@protobuf-ts/runtime@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@protobuf-ts/runtime/-/runtime-2.8.2.tgz#5d5424a6ae7fb846c3f4d0f2dd6448db65bb69d6"
+  integrity sha512-PVxsH81y9kEbHldxxG/8Y3z2mTXWQytRl8zNS0mTPUjkEC+8GUX6gj6LsA8EFp25fAs9V0ruh+aNWmPccEI9MA==
 
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"
@@ -9090,6 +9120,11 @@ google-protobuf@3.15.8:
   version "3.15.8"
   resolved "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.15.8.tgz"
   integrity sha512-2jtfdqTaSxk0cuBJBtTTWsot4WtR9RVr2rXg7x7OoqiuOKopPrwXpM1G4dXIkLcUNRh3RKzz76C8IOkksZSeOw==
+
+google-protobuf@^3.15.3:
+  version "3.21.2"
+  resolved "https://registry.yarnpkg.com/google-protobuf/-/google-protobuf-3.21.2.tgz#4580a2bea8bbb291ee579d1fefb14d6fa3070ea4"
+  integrity sha512-3MSOYFO5U9mPGikIYCzK0SaThypfGgS6bHqrUGXG3DPHCrb+txNqeEcns1W0lkGfk0rCyNXm7xB9rMxnCiZOoA==
 
 google-protobuf@^3.19.1, google-protobuf@^3.6.1:
   version "3.19.1"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Adds basic spicedb client. We'll likely need to adjust a few things, but this helps keep subsequent changes smaller, and it ensures we land the spicedb dependency without too many other changes.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Part of https://github.com/gitpod-io/gitpod/issues/16102

## How to test
<!-- Provide steps to test this PR -->
1. Server comes up in preview

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`
- [ ] /werft publish-to-npm

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`