### PR TITLE
Reuse the same workspace patterns

### DIFF
--- a/components/common-go/namegen/workspaceid.go
+++ b/components/common-go/namegen/workspaceid.go
@@ -13,11 +13,25 @@ import (
 	"strings"
 )
 
-// WorkspaceIDPattern is the expected Worksapce ID pattern
+// PossibleWorkspaceIDPatterns
 // gitpod-protocol/src/util/generate-workspace-id.ts is authoritative over the generation
 // ws-proxy/pkg/proxy/workspacerouter.go is authoritative for this regexp
+var PossibleWorkspaceIDPatterns = []string{
+	"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}",
+	"[0-9a-z]{2,16}-[0-9a-z]{2,16}-[0-9a-z]{8,11}",
+}
 
-var WorkspaceIDPattern = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$|^[0-9a-z]{2,16}-[0-9a-z]{2,16}-[0-9a-z]{8,11}$`)
+var workspaceIDPattern = regexp.MustCompile(getWorkspaceIDPatternStr())
+
+// getWorkspaceIDPatternStr is the expected Workspace ID pattern str
+// ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$|^[0-9a-z]{2,16}-[0-9a-z]{2,16}-[0-9a-z]{8,11}$
+func getWorkspaceIDPatternStr() string {
+	patterns := []string{}
+	for _, p := range PossibleWorkspaceIDPatterns {
+		patterns = append(patterns, fmt.Sprintf("^%s$", p))
+	}
+	return strings.Join(patterns, "|")
+}
 
 func GenerateWorkspaceID() (string, error) {
 	s1, err := chooseRandomly(colors, 1)
@@ -41,8 +55,8 @@ var (
 )
 
 func ValidateWorkspaceID(id string) error {
-	if !WorkspaceIDPattern.MatchString(id) {
-		return fmt.Errorf("id '%s' does not match workspace ID regex '%s': %w", id, WorkspaceIDPattern.String(), InvalidWorkspaceID)
+	if !workspaceIDPattern.MatchString(id) {
+		return fmt.Errorf("id '%s' does not match workspace ID regex '%s': %w", id, workspaceIDPattern.String(), InvalidWorkspaceID)
 	}
 
 	return nil

--- a/components/ws-proxy/pkg/proxy/workspacerouter.go
+++ b/components/ws-proxy/pkg/proxy/workspacerouter.go
@@ -5,6 +5,7 @@
 package proxy
 
 import (
+	"fmt"
 	"net/http"
 	"path/filepath"
 	"regexp"
@@ -13,6 +14,7 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/gitpod-io/gitpod/common-go/log"
+	"github.com/gitpod-io/gitpod/common-go/namegen"
 )
 
 const (
@@ -26,7 +28,6 @@ const (
 	forwardedHostnameHeader = "x-wsproxy-host"
 
 	// This pattern matches v4 UUIDs as well as the new generated workspace ids (e.g. pink-panda-ns35kd21).
-	workspaceIDRegex   = "(?P<" + workspaceIDIdentifier + ">[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}|[0-9a-z]{2,16}-[0-9a-z]{2,16}-[0-9a-z]{8,11})"
 	workspacePortRegex = "(?P<" + workspacePortIdentifier + ">[0-9]+)-"
 
 	debugWorkspaceIdentifier = "debugWorkspace"
@@ -34,6 +35,10 @@ const (
 
 	workspacePathPrefixIdentifier = "workspacePathPrefix"
 )
+
+// This pattern matches v4 UUIDs as well as the new generated workspace ids (e.g. pink-panda-ns35kd21).
+// "(?P<" + workspaceIDIdentifier + ">[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}|[0-9a-z]{2,16}-[0-9a-z]{2,16}-[0-9a-z]{8,11})"
+var workspaceIDRegex = fmt.Sprintf("(?P<%s>%s)", workspaceIDIdentifier, strings.Join(namegen.PossibleWorkspaceIDPatterns, "|"))
 
 // WorkspaceRouter is a function that configures subrouters (one for theia, one for the exposed ports) on the given router
 // which resolve workspace coordinates (ID, port?) from each request. The contract is to store those in the request's mux.Vars


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Have a shared regex pattern in `common-go`, and reuse in `ws-proxy`

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/pull/16144#discussion_r1095480371

## How to test
<!-- Provide steps to test this PR -->
Make sure workspace can be started

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`
- [ ] /werft publish-to-npm

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
