### PR TITLE
Revert "[gh-app] unsubscribe from pull_request.synchronize"

### DIFF
--- a/components/server/ee/src/prebuilds/github-app.ts
+++ b/components/server/ee/src/prebuilds/github-app.ts
@@ -173,7 +173,7 @@ export class GithubApp {
             catchError(this.handlePushEvent(ctx));
         });
 
-        app.on(["pull_request.opened", "pull_request.reopened"], (ctx) => {
+        app.on(["pull_request.opened", "pull_request.synchronize", "pull_request.reopened"], (ctx) => {
             catchError(this.handlePullRequest(ctx));
         });
 


### PR DESCRIPTION
Reverts gitpod-io/gitpod#16193

Reverting after internal discussion. Turns out we might miss webhook events in certain cases, where the config is default.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```