### PR TITLE
Add scaffolding for IDE integration tests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -118,6 +118,8 @@
 /dev/preview/infrastructure/harvester @gitpod-io/engineering-delivery-operations-experience
 /dev/preview/workflow @gitpod-io/engineering-delivery-operations-experience
 
+.github/workflows/ide-*.yml @gitpod-io/engineering-ide
+
 #
 # Automation
 # The following files are updated automatically so we don't want to have a specific code-owner

--- a/.github/workflows/ide-integration-tests.yml
+++ b/.github/workflows/ide-integration-tests.yml
@@ -1,0 +1,58 @@
+name: "IDE integration tests"
+on:
+    workflow_dispatch:
+        inputs:
+            name:
+                required: true
+                description: "The name of the preview environment"
+            version:
+                required: true
+                description: "The version of Gitpod to install"
+jobs:
+    configuration:
+        name: Configuration
+        runs-on: [self-hosted]
+        outputs:
+            name: ${{ steps.configuration.outputs.name }}
+            version: ${{ steps.configuration.outputs.version }}
+        steps:
+            - name: "Set outputs"
+              id: configuration
+              run: |
+                  if [[ '${{ github.event.inputs.name }}' != '' ]]; then
+                      # The workflow was triggered by workflow_dispatch
+                      {
+                          echo "version=${{ github.event.inputs.version }}"
+                          echo "name=${{ github.event.inputs.name }}"
+                      } >> $GITHUB_OUTPUT
+                  fi
+    check:
+        name: Check for regressions
+        needs: [configuration]
+        runs-on: [self-hosted]
+        steps:
+            - uses: actions/checkout@v3
+            - name: Create preview environment infrastructure
+              uses: ./.github/actions/preview-create
+              with:
+                  name: ${{ needs.configuration.outputs.name }}
+                  infrastructure_provider: harvester
+                  large_vm: false
+                  sa_key: ${{ secrets.GCP_CREDENTIALS }}
+            - name: Deploy Gitpod to the preview environment
+              id: deploy-gitpod
+              uses: ./.github/actions/deploy-gitpod
+              with:
+                  name: ${{ needs.configuration.outputs.name }}
+                  sa_key: ${{ secrets.GCP_CREDENTIALS }}
+                  version: ${{ needs.configuration.outputs.version}}
+            - name: Check
+              run: |
+                  echo "IDE tests would run here. Good luck Pudong 🧡"
+                  sleep 60
+            - name: Delete preview environment
+              if: always()
+              uses: ./.github/actions/delete-preview
+              with:
+                  name: ${{ needs.configuration.outputs.name }}
+                  sa_key: ${{ secrets.GCP_CREDENTIALS }}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Scaffolding for running IDE integration test jobs.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of https://github.com/gitpod-io/gitpod/issues/15874

## How to test
<!-- Provide steps to test this PR -->

Can only be tested on main 😢 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
N/A

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`
- [ ] /werft publish-to-npm

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
