### PR TITLE
[server] Perform authorization checks for Orgs against spicedb

### DIFF
--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -1596,7 +1596,7 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
     // Team Subscriptions 2
     async getTeamSubscription(ctx: TraceContext, teamId: string): Promise<TeamSubscription2 | undefined> {
         this.checkUser("getTeamSubscription");
-        await this.guardTeamOperation(teamId, "get", ["not_implemented"]);
+        await this.guardTeamOperation(teamId, "get", "not_implemented");
         return this.teamSubscription2DB.findForTeam(teamId, new Date().toISOString());
     }
 
@@ -2098,7 +2098,7 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
 
         try {
             if (attrId.kind == "team") {
-                await this.guardTeamOperation(attrId.teamId, "get", ["not_implemented"]);
+                await this.guardTeamOperation(attrId.teamId, "get", "not_implemented");
             }
             const subscriptionId = await this.stripeService.findUncancelledSubscriptionByAttributionId(attributionId);
             return subscriptionId;
@@ -2119,7 +2119,7 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
         }
         let team: Team | undefined;
         if (attrId.kind === "team") {
-            team = (await this.guardTeamOperation(attrId.teamId, "update", ["not_implemented"])).team;
+            team = (await this.guardTeamOperation(attrId.teamId, "update", "not_implemented")).team;
             await this.ensureStripeApiIsAllowed({ team });
         } else {
             if (attrId.userId !== user.id) {
@@ -2141,7 +2141,7 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
         }
         let team: Team | undefined;
         if (attrId.kind === "team") {
-            team = (await this.guardTeamOperation(attrId.teamId, "update", ["not_implemented"])).team;
+            team = (await this.guardTeamOperation(attrId.teamId, "update", "not_implemented")).team;
             await this.ensureStripeApiIsAllowed({ team });
         } else {
             if (attrId.userId !== user.id) {
@@ -2211,7 +2211,7 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
         let team: Team | undefined;
         try {
             if (attrId.kind === "team") {
-                team = (await this.guardTeamOperation(attrId.teamId, "update", ["not_implemented"])).team;
+                team = (await this.guardTeamOperation(attrId.teamId, "update", "not_implemented")).team;
                 await this.ensureStripeApiIsAllowed({ team });
             } else {
                 await this.ensureStripeApiIsAllowed({ user });
@@ -2260,7 +2260,7 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
             await this.ensureStripeApiIsAllowed({ user });
             returnUrl = this.config.hostUrl.with(() => ({ pathname: `/user/billing`, search: `org=0` })).toString();
         } else if (attrId.kind === "team") {
-            const team = (await this.guardTeamOperation(attrId.teamId, "update", ["not_implemented"])).team;
+            const team = (await this.guardTeamOperation(attrId.teamId, "update", "not_implemented")).team;
             await this.ensureStripeApiIsAllowed({ team });
         }
         let url: string;
@@ -2493,7 +2493,7 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
         traceAPIParams(ctx, { teamId });
 
         this.checkAndBlockUser("getBillingModeForTeam");
-        const { team } = await this.guardTeamOperation(teamId, "get", ["not_implemented"]);
+        const { team } = await this.guardTeamOperation(teamId, "get", "not_implemented");
 
         return this.billingModes.getBillingModeForTeam(team, new Date());
     }

--- a/components/server/src/authorization/checks.ts
+++ b/components/server/src/authorization/checks.ts
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { v1 } from "@authzed/authzed-node";
+import { ResourceType, SubjectType } from "./perms";
+
+const FULLY_CONSISTENT = v1.Consistency.create({
+    requirement: {
+        oneofKind: "fullyConsistent",
+        fullyConsistent: true,
+    },
+});
+
+type SubjectResourceCheckFn = (subjectID: string, resourceID: string) => v1.CheckPermissionRequest;
+
+function check(subjectT: SubjectType, op: string, resourceT: ResourceType): SubjectResourceCheckFn {
+    return (subjectID, resourceID) =>
+        v1.CheckPermissionRequest.create({
+            subject: v1.SubjectReference.create({
+                object: v1.ObjectReference.create({
+                    objectId: subjectID,
+                    objectType: subjectT,
+                }),
+            }),
+            permission: op,
+            resource: v1.ObjectReference.create({
+                objectId: resourceID,
+                objectType: resourceT,
+            }),
+            consistency: FULLY_CONSISTENT,
+        });
+}
+
+export const ReadOrganizationMetadata = check("user", "organization_metadata_read", "organization");
+export const WriteOrganizationMetadata = check("user", "organization_metadata_write", "organization");
+
+export const ReadOrganizationMembers = check("user", "organization_members_read", "organization");
+export const WriteOrganizationMembers = check("user", "organization_members_write", "organization");

--- a/components/server/src/authorization/perms.ts
+++ b/components/server/src/authorization/perms.ts
@@ -4,6 +4,17 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
+import { v1 } from "@authzed/authzed-node";
+import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
+import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
+import { inject, injectable } from "inversify";
+import { ResponseError } from "vscode-ws-jsonrpc";
+import {
+    observespicedbClientLatency as observeSpicedbClientLatency,
+    spicedbClientLatency,
+} from "../prometheus-metrics";
+import { SpiceDBClient } from "./spicedb";
+
 export type OrganizationOperation =
     // A not yet implemented operation at this time. This exists such that we can be explicit about what
     // we have not yet migrated to fine-grained-permissions.
@@ -31,3 +42,66 @@ export type OrganizationOperation =
     | "org_authprovider_write"
     // Ability to read Organization Auth Providers.
     | "org_authprovider_read";
+
+export type ResourceType = "organization";
+
+export type SubjectType = "user";
+
+export type CheckResult = {
+    permitted: boolean;
+    err?: Error;
+    response?: v1.CheckPermissionResponse;
+};
+
+export const NotPermitted = { permitted: false };
+
+export const PermissionChecker = Symbol("PermissionChecker");
+
+export interface PermissionChecker {
+    check(req: v1.CheckPermissionRequest): Promise<CheckResult>;
+}
+
+@injectable()
+export class Authorizer implements PermissionChecker {
+    @inject(SpiceDBClient)
+    private client: SpiceDBClient;
+
+    async check(req: v1.CheckPermissionRequest): Promise<CheckResult> {
+        if (!this.client) {
+            return {
+                permitted: false,
+                err: new Error("Authorization client not available."),
+                response: v1.CheckPermissionResponse.create({}),
+            };
+        }
+
+        const timer = spicedbClientLatency.startTimer();
+        try {
+            const response = await this.client.checkPermission(req);
+            const permitted = response.permissionship === v1.CheckPermissionResponse_Permissionship.HAS_PERMISSION;
+            const err = !permitted ? newUnathorizedError(req.resource!, req.permission, req.subject!) : undefined;
+
+            observeSpicedbClientLatency("check", req.permission, undefined, timer());
+
+            return { permitted, response, err };
+        } catch (err) {
+            log.error("[spicedb] Failed to perform authorization check.", err, { req });
+            observeSpicedbClientLatency("check", req.permission, err, timer());
+
+            throw err;
+        }
+    }
+}
+
+function newUnathorizedError(resource: v1.ObjectReference, relation: string, subject: v1.SubjectReference) {
+    return new ResponseError(
+        ErrorCodes.PERMISSION_DENIED,
+        `Subject (${objString(subject.object)}) is not permitted to perform ${relation} on resource ${objString(
+            resource,
+        )}.`,
+    );
+}
+
+function objString(obj?: v1.ObjectReference): string {
+    return `${obj?.objectType}:${obj?.objectId}`;
+}

--- a/components/server/src/container-module.ts
+++ b/components/server/src/container-module.ts
@@ -113,6 +113,7 @@ import { UbpResetOnCancel } from "@gitpod/gitpod-payment-endpoint/lib/chargebee/
 import { retryMiddleware } from "nice-grpc-client-middleware-retry";
 import { IamSessionApp } from "./iam/iam-session-app";
 import { spicedbClientFromEnv, SpiceDBClient } from "./authorization/spicedb";
+import { Authorizer, PermissionChecker } from "./authorization/perms";
 
 export const productionContainerModule = new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(Config).toConstantValue(ConfigFile.fromFile());
@@ -313,4 +314,5 @@ export const productionContainerModule = new ContainerModule((bind, unbind, isBo
     bind(SpiceDBClient)
         .toDynamicValue(() => spicedbClientFromEnv())
         .inSingletonScope();
+    bind(PermissionChecker).to(Authorizer).inSingletonScope();
 });


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Behind an experiment, performs authorization checks for Organizaitons against SpiceDB, and reports the outcome. Whether the outcome matches, or not, we always return the result of the existing authorization check.

Effectively, this change allows us to being checking perms against spicedb, without affecting the system, only collecting data.

We do not yet create any relationships against spicedb. As a result, all of these checks will return "NO_PERMISSION" initially. That's desired. We want to have the checks in place, and incrementally start adding these relationships, either from a batch job, or when resources are actually created. This will be done in subsequent PR(s).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Part of https://github.com/gitpod-io/gitpod/issues/16103
* Depends on https://github.com/gitpod-io/gitpod/pull/16197

## How to test
<!-- Provide steps to test this PR -->
1. Preview
2. Sign in, create organization, interact with organization in any way
3. There is no change in behaviour
4. There are logs indicating the permission checks are happening
5. Metrics are reported

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`
- [ ] /werft publish-to-npm

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
