### PR TITLE
Update context dropdown element height

### DIFF
--- a/components/dashboard/src/components/DropDown2.tsx
+++ b/components/dashboard/src/components/DropDown2.tsx
@@ -177,7 +177,9 @@ export const DropDown2: FunctionComponent<DropDown2Props> = (props) => {
                                             key={element.id}
                                             id={element.id}
                                             tabIndex={0}
-                                            className={"h-16 rounded-lg flex items-center px-2 " + selectionClasses}
+                                            className={
+                                                "h-min rounded-lg flex items-center px-2 py-1.5 " + selectionClasses
+                                            }
                                             onMouseDown={() => {
                                                 if (element.isSelectable) {
                                                     setFocussedElement(element.id);


### PR DESCRIPTION
## Description

Decrease the context dropdown element min height.

See [relevant discussion](https://gitpod.slack.com/archives/C01KPEPQYE6/p1675276439778439) (internal). Cc @mbrevoort 

## How to test
Open the new workspace modal (`CMD`+`N`) and notice the context dropdown element height is no fitting the content of the repository name.

| BEFORE | AFTER |
|-|-|
| <img width="532" alt="dropdown-before" src="https://user-images.githubusercontent.com/120486/218744517-9610aa0a-a2f2-4aa7-83c5-d1e82ff2447c.png"> | <img width="532" alt="dropdown-after" src="https://user-images.githubusercontent.com/120486/218744526-6ee2ae27-0467-4c39-a6a5-87a080d3749f.png"> |

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Update context dropdown element height
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`
- [ ] /werft publish-to-npm

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [X] /werft with-preview
- [ ] /werft with-large-vm
- [X] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
