### PR TITLE
[vscode] allow user custom workspace timeout

### DIFF
--- a/install/installer/cmd/testdata/render/agent-smith/output.golden
+++ b/install/installer/cmd/testdata/render/agent-smith/output.golden
@@ -3894,11 +3894,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-b443118d7ef8fff4a8814e5c66cd11da3a87a211",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-b513e548113c7cddeb2d12e8e1a20f56245a8224",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-b513e548113c7cddeb2d12e8e1a20f56245a8224",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/aws-setup/output.golden
+++ b/install/installer/cmd/testdata/render/aws-setup/output.golden
@@ -3335,11 +3335,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-b443118d7ef8fff4a8814e5c66cd11da3a87a211",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-b513e548113c7cddeb2d12e8e1a20f56245a8224",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-b513e548113c7cddeb2d12e8e1a20f56245a8224",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
+++ b/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
@@ -3711,11 +3711,11 @@ data:
             "image": "registry.mydomain.com/namespace/ide/code:commit-b443118d7ef8fff4a8814e5c66cd11da3a87a211",
             "latestImage": "registry.mydomain.com/namespace/ide/code:nightly",
             "imageLayers": [
-              "registry.mydomain.com/namespace/ide/gitpod-code-web:commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03",
+              "registry.mydomain.com/namespace/ide/gitpod-code-web:commit-b513e548113c7cddeb2d12e8e1a20f56245a8224",
               "registry.mydomain.com/namespace/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "registry.mydomain.com/namespace/ide/gitpod-code-web:commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03",
+              "registry.mydomain.com/namespace/ide/gitpod-code-web:commit-b513e548113c7cddeb2d12e8e1a20f56245a8224",
               "registry.mydomain.com/namespace/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -4263,11 +4263,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-b443118d7ef8fff4a8814e5c66cd11da3a87a211",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-b513e548113c7cddeb2d12e8e1a20f56245a8224",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-b513e548113c7cddeb2d12e8e1a20f56245a8224",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -3545,11 +3545,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-b443118d7ef8fff4a8814e5c66cd11da3a87a211",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-b513e548113c7cddeb2d12e8e1a20f56245a8224",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-b513e548113c7cddeb2d12e8e1a20f56245a8224",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/gcp-setup/output.golden
+++ b/install/installer/cmd/testdata/render/gcp-setup/output.golden
@@ -3430,11 +3430,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-b443118d7ef8fff4a8814e5c66cd11da3a87a211",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-b513e548113c7cddeb2d12e8e1a20f56245a8224",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-b513e548113c7cddeb2d12e8e1a20f56245a8224",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/http-proxy/output.golden
+++ b/install/installer/cmd/testdata/render/http-proxy/output.golden
@@ -3714,11 +3714,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-b443118d7ef8fff4a8814e5c66cd11da3a87a211",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-b513e548113c7cddeb2d12e8e1a20f56245a8224",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-b513e548113c7cddeb2d12e8e1a20f56245a8224",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/ide-config/output.golden
+++ b/install/installer/cmd/testdata/render/ide-config/output.golden
@@ -3727,11 +3727,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-b443118d7ef8fff4a8814e5c66cd11da3a87a211",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-b513e548113c7cddeb2d12e8e1a20f56245a8224",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-b513e548113c7cddeb2d12e8e1a20f56245a8224",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/kind-ide/output.golden
+++ b/install/installer/cmd/testdata/render/kind-ide/output.golden
@@ -1291,11 +1291,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-b443118d7ef8fff4a8814e5c66cd11da3a87a211",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-b513e548113c7cddeb2d12e8e1a20f56245a8224",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-b513e548113c7cddeb2d12e8e1a20f56245a8224",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/kind-meta/output.golden
+++ b/install/installer/cmd/testdata/render/kind-meta/output.golden
@@ -2679,11 +2679,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-b443118d7ef8fff4a8814e5c66cd11da3a87a211",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-b513e548113c7cddeb2d12e8e1a20f56245a8224",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-b513e548113c7cddeb2d12e8e1a20f56245a8224",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/message-bus-password/output.golden
+++ b/install/installer/cmd/testdata/render/message-bus-password/output.golden
@@ -3714,11 +3714,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-b443118d7ef8fff4a8814e5c66cd11da3a87a211",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-b513e548113c7cddeb2d12e8e1a20f56245a8224",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-b513e548113c7cddeb2d12e8e1a20f56245a8224",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -3711,11 +3711,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-b443118d7ef8fff4a8814e5c66cd11da3a87a211",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-b513e548113c7cddeb2d12e8e1a20f56245a8224",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-b513e548113c7cddeb2d12e8e1a20f56245a8224",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/overrides-inline/output.golden
+++ b/install/installer/cmd/testdata/render/overrides-inline/output.golden
@@ -3709,11 +3709,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-b443118d7ef8fff4a8814e5c66cd11da3a87a211",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-b513e548113c7cddeb2d12e8e1a20f56245a8224",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-b513e548113c7cddeb2d12e8e1a20f56245a8224",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/pod-config/output.golden
+++ b/install/installer/cmd/testdata/render/pod-config/output.golden
@@ -3718,11 +3718,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-b443118d7ef8fff4a8814e5c66cd11da3a87a211",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-b513e548113c7cddeb2d12e8e1a20f56245a8224",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-b513e548113c7cddeb2d12e8e1a20f56245a8224",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/shortname/output.golden
+++ b/install/installer/cmd/testdata/render/shortname/output.golden
@@ -3711,11 +3711,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-b443118d7ef8fff4a8814e5c66cd11da3a87a211",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-b513e548113c7cddeb2d12e8e1a20f56245a8224",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-b513e548113c7cddeb2d12e8e1a20f56245a8224",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -3723,11 +3723,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-b443118d7ef8fff4a8814e5c66cd11da3a87a211",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-b513e548113c7cddeb2d12e8e1a20f56245a8224",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-b513e548113c7cddeb2d12e8e1a20f56245a8224",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/telemetry/output.golden
+++ b/install/installer/cmd/testdata/render/telemetry/output.golden
@@ -3714,11 +3714,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-b443118d7ef8fff4a8814e5c66cd11da3a87a211",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-b513e548113c7cddeb2d12e8e1a20f56245a8224",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-b513e548113c7cddeb2d12e8e1a20f56245a8224",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
+++ b/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
@@ -4044,11 +4044,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-b443118d7ef8fff4a8814e5c66cd11da3a87a211",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-b513e548113c7cddeb2d12e8e1a20f56245a8224",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-b513e548113c7cddeb2d12e8e1a20f56245a8224",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
+++ b/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
@@ -3714,11 +3714,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-b443118d7ef8fff4a8814e5c66cd11da3a87a211",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-b513e548113c7cddeb2d12e8e1a20f56245a8224",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-b513e548113c7cddeb2d12e8e1a20f56245a8224",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
+++ b/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
@@ -3714,11 +3714,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-b443118d7ef8fff4a8814e5c66cd11da3a87a211",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-b513e548113c7cddeb2d12e8e1a20f56245a8224",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-b513e548113c7cddeb2d12e8e1a20f56245a8224",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/pkg/components/workspace/ide/constants.go
+++ b/install/installer/pkg/components/workspace/ide/constants.go
@@ -9,7 +9,7 @@ const (
 	CodeIDEImageStableVersion   = "commit-b443118d7ef8fff4a8814e5c66cd11da3a87a211" // stable version that will be updated manually on demand
 	CodeHelperIDEImage          = "ide/code-codehelper"
 	CodeWebExtensionImage       = "ide/gitpod-code-web"
-	CodeWebExtensionVersion     = "commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03" // gitpod-web extension version comes from https://github.com/gitpod-io/gitpod-code
+	CodeWebExtensionVersion     = "commit-b513e548113c7cddeb2d12e8e1a20f56245a8224" // gitpod-web extension version comes from https://github.com/gitpod-io/gitpod-code
 	CodeDesktopIDEImage         = "ide/code-desktop"
 	CodeDesktopInsidersIDEImage = "ide/code-desktop-insiders"
 	IntelliJDesktopIDEImage     = "ide/intellij"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
[vscode] allow user custom workspace timeout

Review should happen in https://github.com/gitpod-io/gitpod-code/pull/2, this PR only update `gitpod-web` extension

<img width="683" alt="image" src="https://user-images.githubusercontent.com/8299500/217327919-61dd01cf-7dbd-4051-be95-c61b10d6c581.png">

![image](https://user-images.githubusercontent.com/8299500/217328094-c7a52143-c092-49b5-8d1f-2c2bcb1e66fb.png)

<img width="598" alt="image" src="https://user-images.githubusercontent.com/8299500/217328080-db8924d7-5478-4780-af1e-89a6f84c9446.png">


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #16157

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Allow user custom workspace timeout in vscode.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`
- [ ] /werft publish-to-npm

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-payment 
- [x] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
