### PR TITLE
[gha] enable gha build by default

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -31,8 +31,8 @@ Does this PR require updates to the documentation at www.gitpod.io/docs?
 
 ## Build Options:
 
-- [ ] /werft with-github-actions
-      Experimental feature to run the build with GitHub Actions (and not in Werft).
+- [ ] /werft with-werft
+      Run the build with werft instead of GHA
 - [ ] leeway-no-cache
       leeway-target=components:all
 - [ ] /werft no-test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,6 @@ jobs:
     outputs:
       is_main_branch: ${{ (github.head_ref || github.ref) == 'refs/heads/main' }}
       version: ${{ steps.branches.outputs.sanitized-branch-name }}-gha.${{github.run_number}}
-      with_github_actions: ${{ contains( steps.pr-details.outputs.pr_body, '[x] /werft with-github-actions') }}
       preview_enable: ${{ contains( steps.pr-details.outputs.pr_body, '[x] /werft with-preview') }}
       preview_infra_provider: ${{ contains( steps.pr-details.outputs.pr_body, '[X] /werft with-gce-vm') && 'gce' || 'harvester' }}
       build_no_cache: ${{ contains( steps.pr-details.outputs.pr_body, '[x] leeway-no-cache') }}
@@ -37,6 +36,7 @@ jobs:
       analytics: ${{ contains( steps.pr-details.outputs.pr_body, '[X] analytics') }}
       workspace_feature_flags: ${{ steps.output.outputs.workspace_feature_flags }}
       pr_no_diff_skip: ${{ steps.pr-diff.outputs.pr_no_diff_skip }}
+      with_werft: ${{ steps.output.outputs.with-werft }}
     steps:
       - name: "Determine Branch"
         id: branches
@@ -74,7 +74,7 @@ jobs:
     name: Build previewctl
     if: |
       (needs.configuration.outputs.pr_no_diff_skip != 'true') &&
-      (needs.configuration.outputs.is_main_branch == 'true' || needs.configuration.outputs.preview_enable == 'true')
+      (needs.configuration.outputs.preview_enable == 'true')
     needs: [ configuration ]
     concurrency:
       group: ${{ github.head_ref || github.ref }}-build-previewctl
@@ -112,7 +112,7 @@ jobs:
     needs: [ configuration, build-previewctl ]
     if: |
       (needs.configuration.outputs.pr_no_diff_skip != 'true') &&
-      (needs.configuration.outputs.preview_enable == 'true' && needs.configuration.outputs.with_github_actions == 'true')
+      (needs.configuration.outputs.preview_enable == 'true')
     runs-on: [ self-hosted ]
     concurrency:
       group: ${{ github.head_ref || github.ref }}-infrastructure
@@ -134,7 +134,7 @@ jobs:
     needs: [ configuration ]
     if: |
       (needs.configuration.outputs.pr_no_diff_skip != 'true') &&
-      (needs.configuration.outputs.is_main_branch == 'true' || needs.configuration.outputs.with_github_actions == 'true')
+      (needs.configuration.outputs.with_github_actions == 'true')
     runs-on: [ self-hosted ]
     concurrency:
       group: ${{ github.head_ref || github.ref }}-build-gitpod
@@ -223,9 +223,9 @@ jobs:
           PR_NO_TEST: ${{needs.configuration.outputs.build_no_test}}
           PR_LEEWAY_TARGET: ${{needs.configuration.outputs.build_leeway_target}}
           NPM_AUTH_TOKEN: '${{ steps.secrets.outputs.npm-auth-token }}'
-          PUBLISH_TO_NPM: ${{ needs.configuration.outputs.publish_to_npm == 'true' }}
+          PUBLISH_TO_NPM: ${{ needs.configuration.outputs.publish_to_npm == 'true'  || needs.configuration.outputs.is_main_branch == 'true' }}
           JB_MARKETPLACE_PUBLISH_TOKEN: '${{ steps.secrets.outputs.jb-marketplace-publish-token }}'
-          PUBLISH_TO_JBPM: ${{ needs.configuration.outputs.publish_to_jbmp == 'true' }}
+          PUBLISH_TO_JBPM: ${{ needs.configuration.outputs.publish_to_jbmp == 'true'  || needs.configuration.outputs.is_main_branch == 'true' }}
           CODECOV_TOKEN: '${{ steps.secrets.outputs.codecov-token }}'
         run: |
           [[ "$PR_NO_CACHE" = "true" ]] && CACHE="none"       || CACHE="remote"

--- a/.werft/build.ts
+++ b/.werft/build.ts
@@ -54,7 +54,7 @@ Tracing.initialize()
 async function run(context: any) {
     const config = jobConfig(werft, context);
 
-    if(config.withGitHubActions) {
+    if(!config.withWerft) {
         werft.phase("Build Disabled");
         werft.log("(not building)","The build is being performed via GitHub Actions; Thus, this Werft build does not run");
         werft.done("(not building)");

--- a/.werft/jobs/build/job-config.ts
+++ b/.werft/jobs/build/job-config.ts
@@ -44,7 +44,7 @@ export interface JobConfig {
     certIssuer: string;
     recreatePreview: boolean;
     recreateVm: boolean;
-    withGitHubActions: boolean;
+    withWerft: boolean;
     useWsManagerMk2: boolean;
     withGceVm: boolean;
 }
@@ -116,7 +116,7 @@ export function jobConfig(werft: Werft, context: any): JobConfig {
     const analytics = parseAnalytics(werft, sliceId, buildConfig["analytics"])
     const withIntegrationTests = parseWithIntegrationTests(werft, sliceId, buildConfig["with-integration-tests"]);
     const withPreview = decideWithPreview({werft, sliceID: sliceId, buildConfig, mainBuild, withIntegrationTests})
-    const withGitHubActions = "with-github-actions" in buildConfig;
+    const withWerft = "with-werft" in buildConfig;
     const withGceVm = "with-gce-vm" in buildConfig;
 
     switch (buildConfig["cert-issuer"]) {
@@ -188,7 +188,7 @@ export function jobConfig(werft: Werft, context: any): JobConfig {
         recreatePreview,
         recreateVm,
         withSlowDatabase,
-        withGitHubActions,
+        withWerft,
         withDedicatedEmulation,
         useWsManagerMk2,
         withGceVm,


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Enable GHA by default, with werft as an additional option.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [X] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [X] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
