### PR TITLE
[spicedb] Add kube-rbac-proxy to expose metrics endpoint

### DIFF
--- a/install/installer/pkg/components/public-api-server/deployment.go
+++ b/install/installer/pkg/components/public-api-server/deployment.go
@@ -181,7 +181,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 								},
 								VolumeMounts: volumeMounts,
 							},
-							*common.KubeRBACProxyContainerWithConfig(ctx),
+							*common.KubeRBACProxyContainer(ctx),
 						},
 						Volumes: volumes,
 					},

--- a/install/installer/pkg/components/spicedb/deployment.go
+++ b/install/installer/pkg/components/spicedb/deployment.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/gitpod-io/gitpod/common-go/baseserver"
 	"github.com/gitpod-io/gitpod/installer/pkg/cluster"
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 	"github.com/gitpod-io/gitpod/installer/pkg/components/database/cloudsql"
@@ -91,6 +92,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 										fmt.Sprintf("--datastore-bootstrap-files=%s", strings.Join(bootstrapFiles, ",")),
 										"--dispatch-cluster-enabled=true",
 										"--datastore-bootstrap-overwrite=true",
+										fmt.Sprintf("--metrics-addr=:%d", baseserver.BuiltinMetricsPort),
 									}
 
 									// Dispatching only makes sense, when we have more than one replica
@@ -157,6 +159,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 									bootstrapVolumeMount,
 								},
 							},
+							*common.KubeRBACProxyContainer(ctx),
 						},
 						Volumes: []v1.Volume{
 							bootstrapVolume,

--- a/install/installer/pkg/components/spicedb/rolebinding.go
+++ b/install/installer/pkg/components/spicedb/rolebinding.go
@@ -37,5 +37,22 @@ func rolebinding(ctx *common.RenderContext) ([]runtime.Object, error) {
 				},
 			},
 		},
+		&rbacv1.ClusterRoleBinding{
+			TypeMeta: common.TypeMetaClusterRoleBinding,
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   fmt.Sprintf("%s-%s-kube-rbac-proxy", ctx.Namespace, Component),
+				Labels: labels,
+			},
+			RoleRef: rbacv1.RoleRef{
+				Kind:     "ClusterRole",
+				Name:     fmt.Sprintf("%s-kube-rbac-proxy", ctx.Namespace),
+				APIGroup: "rbac.authorization.k8s.io",
+			},
+			Subjects: []rbacv1.Subject{{
+				Kind:      "ServiceAccount",
+				Name:      Component,
+				Namespace: ctx.Namespace,
+			}},
+		},
 	}, nil
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Binds metrics server, and adds kube-rbac-proxy sidecar to allow us to scrape metrics.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`
- [ ] /werft publish-to-npm

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
