### PR TITLE
Add missing options to gha build

### DIFF
--- a/.github/actions/deploy-gitpod/entrypoint.sh
+++ b/.github/actions/deploy-gitpod/entrypoint.sh
@@ -30,6 +30,11 @@ previewctl get-credentials --gcp-service-account "${PREVIEW_ENV_DEV_SA_KEY_PATH}
 PREVIEW_NAME="$(previewctl get-name --branch "${INPUT_NAME}")"
 export PREVIEW_NAME
 
+for var in WITH_WS_MANAGER_MK2 WITH_DEDICATED_EMU WITH_EE_LICENSE WITH_SLOW_DATABASE ANALYTICS WORKSPACE_FEATURE_FLAGS; do
+  input="INPUT_${var}"
+  export GITPOD_${var}=${!input}
+done
+
 previewctl install-context --branch "${PREVIEW_NAME}" --log-level debug --timeout 10m --gcp-service-account "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
 leeway run dev/preview:deploy-gitpod
 previewctl report >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/actions/deploy-gitpod/metadata.yml
+++ b/.github/actions/deploy-gitpod/metadata.yml
@@ -13,6 +13,24 @@ inputs:
     previewctl_hash:
         description: "The Leeway hash of the dev/preview/previewctl:docker package to be used when downloading previewclt"
         required: false
+    with_ws_manager_mk2:
+        description: "Use WS Manager MK2"
+        required: false
+    with_dedicated_emu:
+        description: "Dedicated Auth"
+        required: false
+    with_ee_licencse:
+        description: "Use EE license"
+        required: false
+    with_slow_database:
+        description: "Use slow database"
+        required: false
+    analytics:
+        description: "With analytics"
+        required: false
+    workspace_feature_flags:
+        description: "Workspace feature flags"
+        required: false
 runs:
     using: "docker"
     image: "Dockerfile"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -37,7 +37,24 @@ Does this PR require updates to the documentation at www.gitpod.io/docs?
       leeway-target=components:all
 - [ ] /werft no-test
       Run Leeway with `--dont-test`
+
+<details>
+<summary>Publish Options</summary>
+
 - [ ] /werft publish-to-npm
+- [ ] /werft publish-to-jb-marketplace
+</details>
+
+<details>
+<summary>Installer Options</summary>
+
+- [ ] with-ee-license
+- [ ] with-slow-database
+- [ ] with-dedicated-emulation
+- [ ] with-ws-manager-mk2
+- [ ] workspace-feature-flags
+  Add desired feature flags to the end of the line above, space separated
+</details>
 
 #### Preview Environment Options:
 - [ ] /werft with-local-preview

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,13 @@ jobs:
       build_leeway_target: ${{ steps.output.outputs.build_leeway_target }}
       with_large_vm: ${{ steps.output.outputs.with_large_vm }}
       publish_to_npm: ${{ steps.output.outputs.publish_to_npm }}
+      publish_to_jbmp: ${{ steps.output.outputs.publish_to_jbmp }}
+      with_ws_manager_mk2: ${{ steps.output.outputs.with_ws_manager_mk2 }}
+      with_dedicated_emulation: ${{ steps.output.outputs.with_dedicated_emulation }}
+      with_ee_license: ${{ steps.output.outputs.with_ee_license }}
+      with_slow_database: ${{ steps.output.outputs.with_slow_database }}
+      analytics: ${{ steps.output.outputs.analytics }}
+      workspace_feature_flags: ${{ steps.output.outputs.workspace_feature_flags }}
     steps:
       - name: "Determine Branch"
         id: branches
@@ -45,6 +52,13 @@ jobs:
             echo "build_leeway_target=$(echo "$PR_DESC" | sed -n -e 's/^.*leeway-target=//p' | sed 's/\r$//')"
             echo "with_large_vm=${{ contains(github.event.pull_request.body, '[X] /werft with-large-vm') }}"
             echo "publish_to_npm=${{ contains(github.event.pull_request.body, '[X] /werft publish-to-npm') }}"
+            echo "publish_to_jbmp=${{ contains(github.event.pull_request.body, '[X] /werft publish-to-jb-marketplace') }}"
+            echo "with_ws_manager_mk2=${{ contains(github.event.pull_request.body, '[X] with-ws-manager-mk2') }}"
+            echo "with_dedicated_emulation=${{ contains(github.event.pull_request.body, '[X] with-dedicated-emulation') }}"
+            echo "with_ee_license=${{ contains(github.event.pull_request.body, '[X] with-ee-license') }}"
+            echo "with_slow_database=${{ contains(github.event.pull_request.body, '[X] with-slow-database') }}"
+            echo "analytics=${{ contains(github.event.pull_request.body, '[X] analytics') }}"
+            echo "workspace_feature_flags=$(echo "$PR_DESC" | grep -oP '(?<=\[X\] workspace-feature-flags).*')"
           } >> $GITHUB_OUTPUT
 
   build-previewctl:
@@ -168,6 +182,8 @@ jobs:
           secrets: |-
             segment-io-token:gitpod-core-dev/segment-io-token
             npm-auth-token:gitpod-core-dev/npm-auth-token
+            jb-marketplace-publish-token:gitpod-core-dev/jb-marketplace-publish-token
+            codecov-token:gitpod-core-dev/codecov
       - name: Leeway Build
         id: leeway
         shell: bash
@@ -181,6 +197,9 @@ jobs:
           PR_LEEWAY_TARGET: ${{needs.configuration.outputs.build_leeway_target}}
           NPM_AUTH_TOKEN: '${{ steps.secrets.outputs.npm-auth-token }}'
           PUBLISH_TO_NPM: ${{ needs.configuration.outputs.publish_to_npm == 'true' }}
+          JB_MARKETPLACE_PUBLISH_TOKEN: '${{ steps.secrets.outputs.jb-marketplace-publish-token }}'
+          PUBLISH_TO_JBPM: ${{ needs.configuration.outputs.publish_to_jbmp == 'true' }}
+          CODECOV_TOKEN: '${{ steps.secrets.outputs.codecov-token }}'
         run: |
           [[ "$PR_NO_CACHE" = "true" ]] && CACHE="none"       || CACHE="remote"
           [[ "$PR_NO_TEST"  = "true" ]] && TEST="--dont-test" || TEST=""
@@ -195,9 +214,11 @@ jobs:
             --cache $CACHE \
             $TEST \
             -Dversion=$VERSION \
+            -DlocalAppVersion=$VERSION \
             -DSEGMENT_IO_TOKEN=$SEGMENT_IO_TOKEN \
             -DpublishToNPM="${PUBLISH_TO_NPM}" \
             -DnpmPublishTrigger="${NPM_PUBLISH_TRIGGER}" \
+            -DpublishToJBMarketplace="${PUBLISH_TO_JBPM}" \
             --coverage-output-path=/__w/gitpod/gitpod/test-coverage-report \
             --report report.html || RESULT=$?
           set +x
@@ -229,6 +250,12 @@ jobs:
           version: ${{needs.configuration.outputs.version}}
           sa_key: ${{ secrets.GCP_CREDENTIALS }}
           previewctl_hash: ${{ needs.build-previewctl.outputs.previewctl_hash }}
+          with_ws_manager_mk2: ${{needs.configuration.outputs.with_ws_manager_mk2}}
+          with_dedicated_emulation: ${{needs.configuration.outputs.with_dedicated_emulation}}
+          with_ee_license: ${{needs.configuration.outputs.with_ee_license}}
+          with_slow_database: ${{needs.configuration.outputs.with_slow_database}}
+          analytics: ${{needs.configuration.outputs.analytics}}
+          workspace_feature_flags: ${{needs.configuration.outputs.workspace_feature_flags}}
 
   monitoring:
     name: "Install Monitoring Satellite"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Doesn't have an issue, but drive by fixing stuff needed to enable GHA as main build. Mostly things missing for the [installer options](https://github.com/gitpod-io/gitpod/blob/main/.werft/jobs/build/installer/installer.ts#L25) (added as a toggle block) and an option to publish to JB marketplace.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [x] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] use-ws-manager-mk2
- [ ] workspace-feature-flags
      Add desired feature flags to the end of the line above, space separated
</details>


#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

