### PR TITLE
[obs] Refactor alerts for image builds

### DIFF
--- a/operations/observability/mixins/workspace/rules/central/workspaces.yaml
+++ b/operations/observability/mixins/workspace/rules/central/workspaces.yaml
@@ -91,25 +91,26 @@ spec:
       expr: |
         sum(time() - kube_pod_deletion_timestamp{namespace="default", pod=~"^ws-.*", cluster!~"ephemeral.*"}) by (pod) > 24 * 60 * 60
 
-    - alert: GitpodImagebuildSuccessRate
-      labels:
-        severity: warning
-        team: workspace
-      annotations:
-        runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodImagebuildSuccessRate.md
-        summary: imagebuild success rate is low in cluster {{ $labels.cluster }}.
-        description: imagebuild are failing at too high of a rate in cluster {{ $labels.cluster }}.
-      expr: |
-        (1 - (sum(rate(gitpod_image_builder_builds_done_total{success="false", cluster!~"ephemeral.*"}[4h])) / sum(rate(gitpod_image_builder_builds_done_total{cluster!~"ephemeral.*"}[4h])))) < 0.75
-
-    - alert: GitpodImagebuildSuccessFailing
+    - alert: GitpodImagebuildDoneSuccess
       labels:
         severity: critical
         team: workspace
-      for: 3h
+      for: 4h
       annotations:
-        runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodImagebuildSuccessRate.md
-        summary: imagebuild success rate is failing in cluster {{ $labels.cluster }}.
-        description: imagebuild are failing at too high of a rate in cluster {{ $labels.cluster }}.
+        runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodImagebuildDoneSuccess.md
+        summary: imagebuilds done are failing at a high rate in cluster {{ $labels.cluster }}.
+        description: imagebuilds`s are not reaching done at too high of a rate in cluster {{ $labels.cluster }}.
       expr: |
-        (1 - (sum(rate(gitpod_image_builder_builds_done_total{success="false", cluster!~"ephemeral.*"}[4h])) / sum(rate(gitpod_image_builder_builds_done_total{cluster!~"ephemeral.*"}[4h])))) < 0.50
+        (1 - (sum(rate(gitpod_image_builder_builds_done_total{success="false", cluster!~"ephemeral.*"}[4h])) / sum(rate(gitpod_image_builder_builds_done_total{cluster!~"ephemeral.*"}[4h])))) < 0.60
+
+    - alert: GitpodImagebuildStartSuccess
+      labels:
+        severity: critical
+        team: workspace
+      for: 2h
+      annotations:
+        runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodImagebuildStartSuccess.md
+        summary: imagebuild start success rate is failing in cluster {{ $labels.cluster }}.
+        description: imagebuild starts are failing at too high of a rate in cluster {{ $labels.cluster }}.
+      expr: |
+        (1 - (sum(rate(gitpod_ws_manager_workspace_starts_failure_total{type="IMAGEBUILD",cluster!~"ephemeral.*"}[4h])) / sum(rate(gitpod_ws_manager_workspace_starts_total{type="IMAGEBUILD", cluster!~"ephemeral.*"}[4h])))) < 0.99


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
For the last 30 days:

This new **GitpodImagebuildDoneSuccess** would have triggered once, on January 26 if set to 2h, instead of 4h.  A customer was potentially struggling with the outer loop. [We hit a 60% error rate in Pyrra briefly for image builds done](https://pyrra.gitpod.io/objectives?expr={__name__=%22workspace-imagebuild-buildsdone-success-ratio%22,%20namespace=%22monitoring-central%22,%20team=%22workspace%22}&grouping={}&from=1673297716785&to=1675716916785).

This new **GitpodImagebuildStartSuccess** would have fired once, on Jan 8, [when GCP was having scaling issues](https://gitpod.slack.com/archives/C01TNS8EVQT/p1673173223060219), and would have been correct to do so.

Also, removed the warnings, as Pyrra sends them now for SLOs to #team-workspace-alerts when error budgets burn.

The related runbook are here: https://github.com/gitpod-io/runbooks/pull/410

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes # n/a

Related internal thread: https://gitpod.slack.com/archives/C02EN94AEPL/p1675723039909239?thread_ts=1675503506.839219&cid=C02EN94AEPL

## How to test
<!-- Provide steps to test this PR -->
n/a

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`
- [ ] /werft publish-to-npm

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
