### PR TITLE
Update settings section header semantics

### DIFF
--- a/components/dashboard/src/components/UsageBasedBillingConfig.tsx
+++ b/components/dashboard/src/components/UsageBasedBillingConfig.tsx
@@ -167,11 +167,11 @@ export default function UsageBasedBillingConfig({ attributionId }: Props) {
 
     return (
         <div className="mb-16">
-            <h2 className="text-gray-500">
+            <p className="text-gray-500 text-base">
                 {attributionId && AttributionId.parse(attributionId)?.kind === "user"
                     ? "Manage billing for your personal account."
                     : "Manage billing for your organization."}
-            </h2>
+            </p>
             <div className="max-w-xl flex flex-col">
                 {errorMessage && (
                     <Alert className="max-w-xl mt-2" closable={false} showIcon={true} type="error">


### PR DESCRIPTION
## Description

Minor semantics update for the billing section header.

See [relevant discussion](https://gitpod.slack.com/archives/C01KPEPQYE6/p1675717801989549?thread_ts=1675450979.289809&cid=C01KPEPQYE6) (internal). Cc @selfcontained 

## How to test

Go to billing settings.

1. There should be no visual difference.
2. The section subheading should now use a `<p>` element instead of an `<h2>` element.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`
- [ ] /werft publish-to-npm

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [X] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
