### PR TITLE
feat: Improved UX for Environment Variable Item List ( Settings )

### DIFF
--- a/components/dashboard/src/user-settings/EnvironmentVariableEntry.tsx
+++ b/components/dashboard/src/user-settings/EnvironmentVariableEntry.tsx
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { UserEnvVarValue } from "@gitpod/gitpod-protocol";
+import { Item, ItemField, ItemFieldContextMenu } from "../components/ItemsList";
+import { useState } from "react";
+
+export const EnvironmentVariableEntry = (props: {
+    variable: UserEnvVarValue;
+    edit: (varible: UserEnvVarValue) => void;
+    confirmDeleteVariable: (varible: UserEnvVarValue) => void;
+}) => {
+    const [menuActive, setMenuActive] = useState(false);
+
+    const changeMenuState = (state: boolean) => {
+        setMenuActive(state);
+    };
+
+    return (
+        <Item className="whitespace-nowrap" solid={menuActive}>
+            <ItemField className="w-5/12 overflow-ellipsis truncate my-auto">{props.variable.name}</ItemField>
+            <ItemField className="w-5/12 overflow-ellipsis truncate text-sm text-gray-400 my-auto">
+                {props.variable.repositoryPattern}
+            </ItemField>
+            <ItemFieldContextMenu
+                changeMenuState={changeMenuState}
+                menuEntries={[
+                    {
+                        title: "Edit",
+                        onClick: () => props.edit(props.variable),
+                        separator: true,
+                    },
+                    {
+                        title: "Delete",
+                        customFontStyle: "text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-300",
+                        onClick: () => props.confirmDeleteVariable(props.variable),
+                    },
+                ]}
+            />
+        </Item>
+    );
+};

--- a/components/dashboard/src/user-settings/EnvironmentVariables.tsx
+++ b/components/dashboard/src/user-settings/EnvironmentVariables.tsx
@@ -7,10 +7,11 @@
 import { UserEnvVar, UserEnvVarValue } from "@gitpod/gitpod-protocol";
 import { useEffect, useRef, useState } from "react";
 import ConfirmationModal from "../components/ConfirmationModal";
-import { Item, ItemField, ItemFieldContextMenu, ItemsList } from "../components/ItemsList";
+import { Item, ItemField, ItemsList } from "../components/ItemsList";
 import Modal, { ModalBody, ModalFooter, ModalHeader } from "../components/Modal";
 import { getGitpodService } from "../service/service";
 import { PageWithSettingsSubMenu } from "./PageWithSettingsSubMenu";
+import { EnvironmentVariableEntry } from "./EnvironmentVariableEntry";
 
 interface EnvVarModalProps {
     envVar: UserEnvVarValue;
@@ -259,33 +260,13 @@ export default function EnvVars() {
                         <ItemField className="w-5/12 my-auto">Name</ItemField>
                         <ItemField className="w-5/12 my-auto">Scope</ItemField>
                     </Item>
-                    {envVars.map((variable) => {
-                        return (
-                            <Item className="whitespace-nowrap">
-                                <ItemField className="w-5/12 overflow-ellipsis truncate my-auto">
-                                    {variable.name}
-                                </ItemField>
-                                <ItemField className="w-5/12 overflow-ellipsis truncate text-sm text-gray-400 my-auto">
-                                    {variable.repositoryPattern}
-                                </ItemField>
-                                <ItemFieldContextMenu
-                                    menuEntries={[
-                                        {
-                                            title: "Edit",
-                                            onClick: () => edit(variable),
-                                            separator: true,
-                                        },
-                                        {
-                                            title: "Delete",
-                                            customFontStyle:
-                                                "text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-300",
-                                            onClick: () => confirmDeleteVariable(variable),
-                                        },
-                                    ]}
-                                />
-                            </Item>
-                        );
-                    })}
+                    {envVars.map((variable) => (
+                        <EnvironmentVariableEntry
+                            variable={variable}
+                            edit={edit}
+                            confirmDeleteVariable={confirmDeleteVariable}
+                        />
+                    ))}
                 </ItemsList>
             )}
         </PageWithSettingsSubMenu>


### PR DESCRIPTION
## Description
The below issues propose improvement for the UX of the Environment Variable Components in Settings, by keeping the hovered effect ( the background colors ) of the workspace items till the ItemOverflowMenu is expanded. Please refer the below graphics for reference of the improvement.

## Improvements
https://user-images.githubusercontent.com/72302948/217173813-084a8f18-92b9-46a0-af3c-3d5698c42e80.mov

## Related Issue(s)
* Fixes #4635 

## How to test
- Change your directory from /gitpod to /gitpod/component/dashboard
- Add your host and token as given in the readme
- Start the development server by `yarn run start` and check on `http://localhost:3000` for checking the dashboard

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Added Environment Variable Entry Component and associated it with Item List Context Menu, with ChangeMenuState Function, to keep the hovered effect
```


## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`
- [ ] /werft publish-to-npm

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
