### PR TITLE
Add open desktop ide entrypoint for browser code

### DIFF
--- a/components/gitpod-protocol/src/typings/globals.ts
+++ b/components/gitpod-protocol/src/typings/globals.ts
@@ -9,5 +9,7 @@ interface Window {
     gitpod: {
         ideService?: import("../ide-frontend-service").IDEFrontendService;
         loggedUserID?: string;
+
+        openDesktopIDE(url: string): void;
     };
 }

--- a/components/supervisor/frontend/src/index.ts
+++ b/components/supervisor/frontend/src/index.ts
@@ -56,7 +56,7 @@ import * as IDEWebSocket from "./ide/ide-web-socket";
 import { SupervisorServiceClient } from "./ide/supervisor-service-client";
 import * as LoadingFrame from "./shared/loading-frame";
 
-window.gitpod = {};
+window.gitpod = {} as any;
 IDEWorker.install();
 IDEWebSocket.install();
 const ideService = IDEFrontendService.create();
@@ -74,6 +74,7 @@ LoadingFrame.load().then(async (loading) => {
 
     document.title = frontendDashboardServiceClient.latestStatus.workspaceDescription ?? "gitpod";
     window.gitpod.loggedUserID = frontendDashboardServiceClient.latestStatus.loggedUserId;
+    window.gitpod.openDesktopIDE = frontendDashboardServiceClient.openDesktopIDE.bind(frontendDashboardServiceClient);
 
     (async () => {
         const supervisorServiceClient = SupervisorServiceClient.get();


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Add open desktop ide entrypoint for browser code to avoid open in desktop IDE alert with workspace origin

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
- Open workspace in preview env with latest browser code
- Quick action with `Open in VS Code` should alert with `gitpod.io` or no alerts (configured in browser)

[Tested](https://github.com/gitpod-io/gitpod/pull/16260#pullrequestreview-1289144751)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`
- [ ] /werft publish-to-npm

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
