### PR TITLE
[server] set organizationid on workspace creation

### DIFF
--- a/components/gitpod-db/.vscode/launch.json
+++ b/components/gitpod-db/.vscode/launch.json
@@ -1,0 +1,26 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "env": {
+                "DB_PORT": "23306"
+            },
+            "name": "Run Mocha Test in Editor",
+            "program": "${workspaceFolder}/node_modules/.bin/_mocha",
+            "args": [
+                "--opts",
+                "${workspaceFolder}/mocha.opts",
+                "--colors",
+                "--timeout",
+                "999999",
+                "${file}",
+                "-g",
+                "${selectedText}"
+            ],
+            "internalConsoleOptions": "openOnSessionStart"
+        }
+    ],
+    "compounds": []
+}

--- a/components/gitpod-db/go/workspace.go
+++ b/components/gitpod-db/go/workspace.go
@@ -18,12 +18,13 @@ import (
 
 // Workspace represents the underlying DB object
 type Workspace struct {
-	ID          string         `gorm:"primary_key;column:id;type:char;size:36;" json:"id"`
-	OwnerID     uuid.UUID      `gorm:"column:ownerId;type:char;size:36;" json:"ownerId"`
-	ProjectID   sql.NullString `gorm:"column:projectId;type:char;size:36;" json:"projectId"`
-	Description string         `gorm:"column:description;type:varchar;size:255;" json:"description"`
-	Type        WorkspaceType  `gorm:"column:type;type:char;size:16;default:regular;" json:"type"`
-	CloneURL    string         `gorm:"column:cloneURL;type:varchar;size:255;" json:"cloneURL"`
+	ID             string         `gorm:"primary_key;column:id;type:char;size:36;" json:"id"`
+	OrganizationId *uuid.UUID     `gorm:"column:organizationId;type:char;size:36;" json:"organizationId"`
+	OwnerID        uuid.UUID      `gorm:"column:ownerId;type:char;size:36;" json:"ownerId"`
+	ProjectID      sql.NullString `gorm:"column:projectId;type:char;size:36;" json:"projectId"`
+	Description    string         `gorm:"column:description;type:varchar;size:255;" json:"description"`
+	Type           WorkspaceType  `gorm:"column:type;type:char;size:16;default:regular;" json:"type"`
+	CloneURL       string         `gorm:"column:cloneURL;type:varchar;size:255;" json:"cloneURL"`
 
 	ContextURL            string         `gorm:"column:contextURL;type:text;size:65535;" json:"contextURL"`
 	Context               datatypes.JSON `gorm:"column:context;type:text;size:65535;" json:"context"`

--- a/components/gitpod-db/src/typeorm/entity/db-workspace.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-workspace.ts
@@ -31,6 +31,13 @@ export class DBWorkspace implements Workspace {
     @Index("ind_creationTime")
     creationTime: string;
 
+    @Column({
+        ...TypeORM.UUID_COLUMN_TYPE,
+        transformer: Transformer.MAP_NULL_TO_UNDEFINED,
+    })
+    @Index()
+    organizationId?: string;
+
     @Column(TypeORM.UUID_COLUMN_TYPE)
     @Index()
     ownerId: string;

--- a/components/gitpod-db/src/typeorm/transformer.ts
+++ b/components/gitpod-db/src/typeorm/transformer.ts
@@ -23,6 +23,21 @@ export namespace Transformer {
         },
     };
 
+    export const MAP_NULL_TO_UNDEFINED: ValueTransformer = {
+        to(value: any): any {
+            if (value === undefined) {
+                return null;
+            }
+            return value;
+        },
+        from(value: any): any {
+            if (value === null) {
+                return undefined;
+            }
+            return value;
+        },
+    };
+
     export const MAP_ISO_STRING_TO_TIMESTAMP_DROP: ValueTransformer = {
         to(value: any): any {
             // DROP all input values as they are set by the DB 'ON UPDATE'/ as default value.

--- a/components/gitpod-db/src/user-to-team-migration-service.ts
+++ b/components/gitpod-db/src/user-to-team-migration-service.ts
@@ -117,6 +117,12 @@ export class UserToTeamMigrationService {
         );
         log.info(ctx, "Migrated workspace instances.", { teamId: team.id, result });
 
+        result = await conn.query(
+            "UPDATE d_b_workspace SET organizationId = ? WHERE id IN (SELECT workspaceid from d_b_workspace_instance where usageAttributionId = ?)",
+            [team.id, newAttribution],
+        );
+        log.info(ctx, "Migrated workspaces.", { teamId: team.id, result });
+
         result = await conn.query("UPDATE d_b_usage SET attributionId = ? WHERE attributionId = ?", [
             newAttribution,
             oldAttribution,

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -658,6 +658,10 @@ export type SnapshotState = "pending" | "available" | "error";
 export interface Workspace {
     id: string;
     creationTime: string;
+    /**
+     * undefined means it is owned by the user (legacy mode, soon to be removed)
+     */
+    organizationId?: string;
     contextURL: string;
     description: string;
     ownerId: string;

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -1221,6 +1221,11 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
             const project = CommitContext.is(context)
                 ? await this.projectDB.findProjectByCloneUrl(context.repository.cloneUrl)
                 : undefined;
+
+            //TODO(se) relying on the attribution mechanism is a temporary work around. We will go to explicit passing of organization IDs soon.
+            const attributionId = await this.userService.getWorkspaceUsageAttributionId(user, project?.id);
+            const organizationId = attributionId.kind === "team" ? attributionId.teamId : undefined;
+
             const prebuiltWorkspace = await this.findPrebuiltWorkspace(
                 ctx,
                 user,
@@ -1240,6 +1245,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
             const workspace = await this.workspaceFactory.createForContext(
                 ctx,
                 user,
+                organizationId,
                 project,
                 context,
                 normalizedContextUrl,

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -837,7 +837,12 @@ export class WorkspaceStarter {
             await this.tryEnableConnectionLimiting(featureFlags, user, billingTier);
             await this.tryEnablePSI(featureFlags, user, billingTier);
 
-            const usageAttributionId = await this.userService.getWorkspaceUsageAttributionId(user, workspace.projectId);
+            let usageAttributionId = await this.userService.getWorkspaceUsageAttributionId(user, workspace.projectId);
+            // if the workspace has been created in an organization, we need to use the organization's attribution ID
+            if (workspace.organizationId) {
+                const org = await this.teamDB.findTeamById(workspace.organizationId);
+                usageAttributionId = AttributionId.create(org!);
+            }
             let workspaceClass = await getWorkspaceClassForInstance(
                 ctx,
                 workspace,


### PR DESCRIPTION
## Description
Adds the application logic to set the organization id when a workspace is being created

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
See #16177

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`
- [ ] /werft publish-to-npm

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
