### PR TITLE
Simplify preview environment staleness check

### DIFF
--- a/dev/preview/previewctl/cmd/stale.go
+++ b/dev/preview/previewctl/cmd/stale.go
@@ -7,17 +7,10 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"io/fs"
-	"os"
-	"strings"
-	"sync"
 	"time"
 
-	"github.com/cockroachdb/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"golang.org/x/sync/errgroup"
-	"k8s.io/client-go/util/homedir"
 
 	"github.com/gitpod-io/gitpod/previewctl/pkg/preview"
 )
@@ -32,13 +25,6 @@ func newListStaleCmd(logger *logrus.Logger) *cobra.Command {
 		Use:   "stale",
 		Short: "Get preview envs that are inactive (no branch with recent commits, and no db activity in the last 48h)",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if _, err := os.Stat(opts.sshPrivateKeyPath); errors.Is(err, fs.ErrNotExist) {
-				opts.logger.Debug("Installing SSH keys")
-				if err := preview.InstallVMSSHKeys(); err != nil {
-					return err
-				}
-			}
-
 			statuses, err := opts.listWorskpaceStatus(ctx)
 			if err != nil {
 				return err
@@ -64,14 +50,14 @@ func newListStaleCmd(logger *logrus.Logger) *cobra.Command {
 
 	cmd.PersistentFlags().StringVar(&opts.TFDir, "tf-dir", "dev/preview/infrastructure", "TF working directory")
 	cmd.Flags().DurationVarP(&opts.timeout, "timeout", "t", 10*time.Minute, "Duration to wait for a preview enviroment contexts' to get installed")
-	cmd.PersistentFlags().StringVar(&opts.sshPrivateKeyPath, "private-key-path", fmt.Sprintf("%s/.ssh/vm_id_rsa", homedir.HomeDir()), "path to the private key used to authenticate with the VM")
 
 	return cmd
 }
 
 func (o *listWorkspaceOpts) listWorskpaceStatus(ctx context.Context) ([]preview.Status, error) {
+
 	o.logger.Debug("Getting recent branches")
-	branches, err := preview.GetRecentBranches(time.Now().AddDate(0, 0, -30))
+	branches, err := preview.GetRecentBranches(time.Now().AddDate(0, 0, -2))
 	if err != nil {
 		return nil, err
 	}
@@ -82,89 +68,41 @@ func (o *listWorkspaceOpts) listWorskpaceStatus(ctx context.Context) ([]preview.
 		return nil, err
 	}
 
-	o.logger.Debug("Finding workspaces without associated branches")
-	branchlessWorkspaces, err := getBranchlessWorkspaces(workspaces, branches)
-	if err != nil {
-		return nil, err
-	}
-
-	wg, ctx := errgroup.WithContext(ctx)
-	m := new(sync.Mutex)
-
 	statuses := make([]preview.Status, 0, len(workspaces))
 	for _, ws := range workspaces {
 		ws := ws
 
-		status := preview.Status{
-			Name:   ws,
-			Active: false,
-		}
-
-		if _, ok := branchlessWorkspaces[ws]; ok && !strings.HasPrefix(ws, "platform-") {
-			status.Reason = "branch doesn't exist, or last commit older than 30 days"
-			statuses = append(statuses, status)
-			continue
-			// there's (should be) nothing in the default worskpace, and we ignore main
-		} else if ws == "default" || ws == "main" {
-			continue
-		}
-
-		wg.Go(func() error {
-			p, err := preview.New(ws, o.logger)
-			if err != nil {
-				status.Reason = err.Error()
-				statuses = append(statuses, status)
-				return nil
-			}
-
-			o.logger.WithFields(logrus.Fields{
-				"preview": ws,
-			}).Debug("Installing context")
-
-			err = p.InstallContext(ctx, &preview.InstallCtxOpts{
-				Retry:                true,
-				RetryTimeout:         o.timeout,
-				KubeSavePath:         getKubeConfigPath(),
-				SSHPrivateKeyPath:    o.sshPrivateKeyPath,
-				KubeconfigWriteMutex: m,
+		if _, ok := branches[ws]; ok {
+			statuses = append(statuses, preview.Status{
+				Name:   ws,
+				Active: true,
+				Reason: "Branch has recent commits on it",
 			})
+			continue
+		}
 
-			if err != nil {
-				status.Reason = fmt.Sprintf("error installing context: [%v]", err)
-				statuses = append(statuses, status)
-				return nil
-			}
+		p, err := preview.New(ws, o.logger)
+		if err != nil {
+			statuses = append(statuses, preview.Status{
+				Name:   ws,
+				Active: false,
+				Reason: err.Error(),
+			})
+			continue
+		}
 
-			active, err := p.GetStatus(ctx)
-			if err != nil {
-				o.logger.WithFields(logrus.Fields{
-					"preview": ws,
-				}).Error(err)
-			}
-			statuses = append(statuses, active)
+		status, err := p.GetStatus(ctx)
+		if err != nil {
+			statuses = append(statuses, preview.Status{
+				Name:   ws,
+				Active: false,
+				Reason: err.Error(),
+			})
+			continue
+		}
 
-			return nil
-		})
-	}
-
-	err = wg.Wait()
-	if err != nil {
-		return nil, err
+		statuses = append(statuses, status)
 	}
 
 	return statuses, err
-}
-
-// getBranchlessWorkspaces Returns all workspaces for which there is no matching branch provided in the list
-func getBranchlessWorkspaces(workspaces []string, branches map[string]preview.BranchMap) (map[string]struct{}, error) {
-	nonExisting := map[string]struct{}{}
-	for _, p := range workspaces {
-		p := strings.TrimSpace(p)
-		if _, ok := branches[p]; p != "default" && !ok {
-			nonExisting[p] = struct{}{}
-			continue
-		}
-	}
-
-	return nonExisting, nil
 }

--- a/dev/preview/previewctl/cmd/workspaces.go
+++ b/dev/preview/previewctl/cmd/workspaces.go
@@ -17,8 +17,7 @@ import (
 )
 
 type listWorkspaceOpts struct {
-	TFDir             string
-	sshPrivateKeyPath string
+	TFDir string
 
 	logger  *logrus.Logger
 	timeout time.Duration
@@ -77,5 +76,12 @@ func (o *listWorkspaceOpts) getWorkspaces(ctx context.Context) ([]string, error)
 		return nil, errors.Wrap(err, "error running list")
 	}
 
-	return list, nil
+	filtered := []string{}
+	for i := range list {
+		if list[i] != "default" {
+			filtered = append(filtered, list[i])
+		}
+	}
+
+	return filtered, nil
 }

--- a/dev/preview/previewctl/pkg/preview/status.go
+++ b/dev/preview/previewctl/pkg/preview/status.go
@@ -7,19 +7,7 @@ package preview
 import (
 	"context"
 	"fmt"
-	"math/rand"
-	"strconv"
 	"time"
-
-	"github.com/cockroachdb/errors"
-	log "github.com/sirupsen/logrus"
-	"gorm.io/gorm"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	clog "github.com/gitpod-io/gitpod/common-go/log"
-	db "github.com/gitpod-io/gitpod/components/gitpod-db/go"
-
-	"github.com/gitpod-io/gitpod/previewctl/pkg/k8s"
 )
 
 type Status struct {
@@ -29,131 +17,27 @@ type Status struct {
 }
 
 var (
-	errDBPasswordNotFound = errors.New("db password not found")
-	errPortForwardTimeout = errors.New("timed out waiting for port forward")
+	HOURS_UNTIL_STALE = 48
 )
 
 func (c *Config) GetStatus(ctx context.Context) (Status, error) {
-	logEntry := c.logger.WithFields(log.Fields{
-		"preview": c.name,
-	})
-
 	// If the VM got created in the last 120 mins, always assume it's active
 	// clock skew can go to hell
 	c.ensureCreationTime()
-	if c.creationTime != nil && c.creationTime.After(time.Now().Add(-120*time.Minute)) {
-		logEntry.WithFields(log.Fields{
-			"created": c.creationTime,
-		}).Debug("VM created in the past 120 mins, assuming active")
 
+	if c.creationTime == nil {
 		c.status.Active = true
-		c.status.Reason = fmt.Sprintf("VM created in the past 120 mins, assuming active: [%v]", c.creationTime.Time)
+		c.status.Reason = "Failed to find creation time, assuming active"
 		return c.status, nil
 	}
 
-	return c.getDBStatus(ctx)
-}
-
-func (c *Config) getDBStatus(ctx context.Context) (Status, error) {
-	secret, err := c.previewClient.CoreClient.CoreV1().Secrets(metav1.NamespaceDefault).Get(ctx, "db-password", metav1.GetOptions{})
-	if err != nil {
-		c.status.Reason = errors.Wrap(err, errDBPasswordNotFound.Error()).Error()
+	if c.creationTime.After(time.Now().Add(-time.Duration(HOURS_UNTIL_STALE) * time.Hour)) {
+		c.status.Active = true
+		c.status.Reason = fmt.Sprintf("VM created in the past %d hours, assuming active: [%v]", HOURS_UNTIL_STALE, c.creationTime.Time)
 		return c.status, nil
 	}
 
-	dbPwd, ok := secret.Data["mysql-root-password"]
-	if !ok {
-		c.status.Reason = errors.Wrap(err, errDBPasswordNotFound.Error()).Error()
-		return c.status, nil
-	}
-
-	stopChan, readyChan, errChan := make(chan struct{}), make(chan struct{}, 1), make(chan error)
-
-	// pick a random port, so we avoid clashes if something else port-forwards to 2200
-	randPort := strconv.Itoa(rand.Intn(33999-30307) + 30307)
-
-	go func() {
-		err = c.previewClient.PortForward(ctx, k8s.PortForwardOpts{
-			Name:      "mysql-0",
-			Namespace: metav1.NamespaceDefault,
-			Ports: []string{
-				fmt.Sprintf("%s:3306", randPort),
-			},
-			ReadyChan: readyChan,
-			StopChan:  stopChan,
-			ErrChan:   errChan,
-		})
-
-		if err != nil {
-			errChan <- err
-			return
-		}
-	}()
-
-	select {
-	case <-readyChan:
-		return c.dbStatus(ctx, string(dbPwd), randPort)
-	case err := <-errChan:
-		c.status.Reason = err.Error()
-		return c.status, err
-	case <-time.After(time.Second * 30):
-		c.status.Reason = errPortForwardTimeout.Error()
-		return c.status, errPortForwardTimeout
-	case <-ctx.Done():
-		c.logger.Debug("context cancelled")
-		c.status.Reason = ctx.Err().Error()
-		return c.status, ctx.Err()
-	}
-}
-
-func (c *Config) dbStatus(ctx context.Context, password, port string) (Status, error) {
-	conn, err := db.Connect(db.ConnectionParams{
-		User:     "root",
-		Password: password,
-		Host:     fmt.Sprintf("127.0.0.1:%s", port),
-		Database: "gitpod",
-	})
-	if err != nil {
-		c.status.Reason = errors.Wrap(err, "error conencting to mysql").Error()
-		return c.status, err
-	}
-
-	// sets the logger that is used in the db lib to Warn
-	clog.Log.Logger.SetLevel(3)
-
-	queries := []string{
-		"SELECT TIMESTAMPDIFF(HOUR, _lastModified, NOW()) as timediff FROM d_b_user WHERE _lastModified > DATE_SUB(NOW(), INTERVAL 48 HOUR) ORDER BY _lastModified DESC LIMIT 1",
-		"SELECT TIMESTAMPDIFF(HOUR, lastSeen, NOW()) as timediff FROM d_b_workspace_instance_user WHERE lastSeen > DATE_SUB(NOW(), INTERVAL 48 HOUR) ORDER BY lastSeen DESC LIMIT 1",
-	}
-
-	for _, q := range queries {
-		res := map[string]interface{}{}
-
-		r := conn.WithContext(ctx).Raw(q).Take(&res)
-
-		if r.Error != nil {
-			if errors.Is(r.Error, gorm.ErrRecordNotFound) {
-				c.status.Reason = "last activity older than 48h"
-				continue
-			}
-
-			c.status.Reason = err.Error()
-			return c.status, err
-		}
-
-		if r.RowsAffected > 0 {
-			c.logger.WithFields(log.Fields{
-				"preview":  c.name,
-				"created":  c.creationTime,
-				"query":    q,
-				"activity": fmt.Sprintf("%v hours ago", res["timediff"]),
-			}).Debug("db has activity")
-
-			c.status.Active = true
-			c.status.Reason = fmt.Sprintf("last activity %v hours ago", res["timediff"])
-			return c.status, nil
-		}
-	}
-
+	c.status.Active = false
+	c.status.Reason = fmt.Sprintf("VM has existed for more than %d hours, assuming stale: [%v]", HOURS_UNTIL_STALE, c.creationTime.Time)
 	return c.status, nil
 }

--- a/dev/preview/previewctl/pkg/preview/util.go
+++ b/dev/preview/previewctl/pkg/preview/util.go
@@ -15,7 +15,6 @@ import (
 	"time"
 
 	"github.com/cockroachdb/errors"
-
 	"github.com/gitpod-io/gitpod/previewctl/pkg/util"
 )
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This changes the staleness heuristics so that we now use the following rules

1. If the preview environments was created in the last 48 hours we consider it active
2. If there is a branch for the preview environment and it was a commit in the last 48 hours we consider it active

This means that we no longer consider a preview environment stale just because the branch doesn't exist. This is okay because preview environments are being deleted when branches are deleted now by [preview-env-delete.yml](https://github.com/gitpod-io/gitpod/blob/main/.github/workflows/preview-env-delete.yml), so checking for missing branches is less important now. Should that trigger fail, we'll still delete the preview environments once the 48 hours are up.

There are two motivations for this.

1. With our new custom GitHub Actions to create preview environments we no longer require a branch to exist so we needed to change the heuristics to not garbage collect those preview environments. This allows such preview environments to live up to 48 hours (all workflows manually clean up their environments, so they will love much shorter than that)
4. We want to simplify the heuristics so it's easier for people to understand. See [Transitioning preview environments to be a collaborative effort](https://www.notion.so/gitpod/Transitioning-preview-environments-to-be-a-collaborative-effort-3de091ae455149b6adc2833073fc0f6a)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

No issue, (1) above was the primary motivation to make this change now.

## How to test
<!-- Provide steps to test this PR -->

```sh
export GOOGLE_APPLICATION_CREDENTIALS="$PREVIEW_ENV_DEV_SA_KEY_PATH"
leeway run dev/preview/previewctl:install
previewctl list stale
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

N/A

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`
- [ ] /werft publish-to-npm

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
