### PR TITLE
Rename delivery team in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -27,13 +27,15 @@
 /components/image-builder-api @csweichel @geropl
 /components/image-builder-bob @gitpod-io/engineering-workspace
 /components/image-builder-mk3 @gitpod-io/engineering-workspace
-/components/installation-telemetry @gitpod-io/engineering-delivery-operations-experience
-/components/kots-config-check @gitpod-io/engineering-delivery-operations-experience
+/components/installation-telemetry @gitpod-io/engineering-security-infrastructure-and-delivery
+/components/kots-config-check @gitpod-io/engineering-security-infrastructure-and-delivery
 /components/toxic-config @gitpod-io/engineering-webapp
-/install @gitpod-io/engineering-delivery-operations-experience
-/install/installer @gitpod-io/engineering-delivery-operations-experience
+/install @gitpod-io/engineering-security-infrastructure-and-delivery
+/install/installer @gitpod-io/engineering-security-infrastructure-and-delivery
 # For testdata a single review from anyone who is allowed to review PRs is sufficent.
 /install/installer/cmd/testdata
+# Allow everyone to approve config changes
+/install/installer/pgk/config
 /install/installer/pkg/components/agent-smith @gitpod-io/engineering-workspace
 /install/installer/pkg/components/blobserve @gitpod-io/engineering-ide
 /install/installer/pkg/components/components-ide @gitpod-io/engineering-ide
@@ -82,7 +84,7 @@
 /components/supervisor @gitpod-io/engineering-ide
 /components/usage @gitpod-io/engineering-webapp
 /components/usage-api @gitpod-io/engineering-webapp
-/components/workspace-rollout-job @gitpod-io/engineering-delivery-operations-experience @gitpod-io/engineering-workspace
+/components/workspace-rollout-job @gitpod-io/engineering-security-infrastructure-and-delivery @gitpod-io/engineering-workspace
 /components/workspacekit @gitpod-io/engineering-workspace
 /components/ws-daemon-api @aledbf @Furisto
 /components/ws-daemon @gitpod-io/engineering-workspace
@@ -95,28 +97,28 @@
 /dev/gpctl @gitpod-io/engineering-workspace
 /dev/gpctl/api/ @gitpod-io/engineering-webapp
 /dev/loadgen @gitpod-io/engineering-workspace
-/dev/preview @gitpod-io/engineering-delivery-operations-experience
+/dev/preview @gitpod-io/engineering-security-infrastructure-and-delivery
 # The deploy-gitpod.sh is shared between all teams.
 /dev/preview/workflow/preview/deploy-gitpod.sh
-/operations/observability/mixins @gitpod-io/engineering-delivery-operations-experience
-/operations/observability/mixins/platform @gitpod-io/engineering-delivery-operations-experience
+/operations/observability/mixins @gitpod-io/engineering-security-infrastructure-and-delivery
+/operations/observability/mixins/platform @gitpod-io/engineering-security-infrastructure-and-delivery
 /operations/observability/mixins/IDE @gitpod-io/engineering-ide
 /operations/observability/mixins/meta @gitpod-io/engineering-webapp
 /operations/observability/mixins/workspace @gitpod-io/engineering-workspace
-/operations/observability/mixins/cross-teams @gitpod-io/engineering-workspace @gitpod-io/engineering-webapp @gitpod-io/engineering-ide @gitpod-io/engineering-delivery-operations-experience
+/operations/observability/mixins/cross-teams @gitpod-io/engineering-workspace @gitpod-io/engineering-webapp @gitpod-io/engineering-ide @gitpod-io/engineering-security-infrastructure-and-delivery
 
-/.werft/observability @gitpod-io/engineering-delivery-operations-experience
+/.werft/observability @gitpod-io/engineering-security-infrastructure-and-delivery
 
 /.werft/ide-* @gitpod-io/engineering-ide
-/.werft/platform-* @gitpod-io/engineering-delivery-operations-experience
+/.werft/platform-* @gitpod-io/engineering-security-infrastructure-and-delivery
 /.werft/webapp-* @gitpod-io/engineering-webapp
 /.werft/workspace-* @gitpod-io/engineering-workspace
-/.werft/self-hosted-* @gitpod-io/engineering-delivery-operations-experience
-/.werft/*installer-tests* @gitpod-io/engineering-delivery-operations-experience
-/.werft/jobs/build/self-hosted-* @gitpod-io/engineering-delivery-operations-experience
+/.werft/self-hosted-* @gitpod-io/engineering-security-infrastructure-and-delivery
+/.werft/*installer-tests* @gitpod-io/engineering-security-infrastructure-and-delivery
+/.werft/jobs/build/self-hosted-* @gitpod-io/engineering-security-infrastructure-and-delivery
 
-/dev/preview/infrastructure/harvester @gitpod-io/engineering-delivery-operations-experience
-/dev/preview/workflow @gitpod-io/engineering-delivery-operations-experience
+/dev/preview/infrastructure/harvester @gitpod-io/engineering-security-infrastructure-and-delivery
+/dev/preview/workflow @gitpod-io/engineering-security-infrastructure-and-delivery
 
 .github/workflows/ide-*.yml @gitpod-io/engineering-ide
 


### PR DESCRIPTION
## Description
Delivery team has a new name.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`
- [ ] /werft publish-to-npm

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
