### PR TITLE
Workspace Timeout improvements (JetBrains)

### DIFF
--- a/components/gitpod-cli/cmd/timeout-set.go
+++ b/components/gitpod-cli/cmd/timeout-set.go
@@ -23,8 +23,8 @@ var setTimeoutCmd = &cobra.Command{
 	Short: "Set timeout of current workspace",
 	Long: `Set timeout of current workspace.
 
-Duration must be in the format of <n>m (minutes), <n>h (hours), or <n>d (days).
-For example, 30m, 1h, 2d, etc.`,
+Duration must be in the format of <n>m (minutes), <n>h (hours) and cannot be longer than 24 hours.
+For example: 30m or 1h`,
 	Example: `gitpod timeout set 1h`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx, cancel := context.WithTimeout(cmd.Context(), 5*time.Second)

--- a/components/gitpod-cli/cmd/timeout-set.go
+++ b/components/gitpod-cli/cmd/timeout-set.go
@@ -45,13 +45,15 @@ For example: 30m or 1h`,
 		if err != nil {
 			return GpError{Err: err, OutCome: utils.Outcome_UserErr, ErrorCode: utils.UserErrorCode_InvalidArguments}
 		}
-		if _, err = client.SetWorkspaceTimeout(ctx, wsInfo.WorkspaceId, duration); err != nil {
+
+		res, err := client.SetWorkspaceTimeout(ctx, wsInfo.WorkspaceId, duration)
+		if err != nil {
 			if err, ok := err.(*jsonrpc2.Error); ok && err.Code == serverapi.PLAN_PROFESSIONAL_REQUIRED {
 				return GpError{OutCome: utils.Outcome_UserErr, Message: "Cannot extend workspace timeout for current plan, please upgrade your plan", ErrorCode: utils.UserErrorCode_NeedUpgradePlan}
 			}
 			return err
 		}
-		fmt.Printf("Workspace timeout has been set to %d minutes.\n", int(duration.Minutes()))
+		fmt.Printf("Workspace timeout has been set to %s.\n", res.HumanReadableDuration)
 		return nil
 	},
 }

--- a/components/gitpod-cli/cmd/timeout-show.go
+++ b/components/gitpod-cli/cmd/timeout-show.go
@@ -38,11 +38,7 @@ var showTimeoutCommand = &cobra.Command{
 			return err
 		}
 
-		duration, err := time.ParseDuration(res.Duration)
-		if err != nil {
-			return err
-		}
-		fmt.Printf("Workspace timeout is set to %d minutes.\n", int(duration.Minutes()))
+		fmt.Printf("Workspace timeout is set to %s.\n", res.HumanReadableDuration)
 		return nil
 	},
 }

--- a/components/gitpod-protocol/go/gitpod-service.go
+++ b/components/gitpod-protocol/go/gitpod-service.go
@@ -1898,8 +1898,9 @@ type StartWorkspaceOptions struct {
 
 // GetWorkspaceTimeoutResult is the GetWorkspaceTimeoutResult message type
 type GetWorkspaceTimeoutResult struct {
-	CanChange bool   `json:"canChange,omitempty"`
-	Duration  string `json:"duration,omitempty"`
+	CanChange             bool   `json:"canChange,omitempty"`
+	Duration              string `json:"duration,omitempty"`
+	HumanReadableDuration string `json:"humanReadableDuration,omitempty"`
 }
 
 // WorkspaceInstancePort is the WorkspaceInstancePort message type

--- a/components/gitpod-protocol/go/gitpod-service.go
+++ b/components/gitpod-protocol/go/gitpod-service.go
@@ -2250,6 +2250,7 @@ type GetTokenSearchOptions struct {
 // SetWorkspaceTimeoutResult is the SetWorkspaceTimeoutResult message type
 type SetWorkspaceTimeoutResult struct {
 	ResetTimeoutOnWorkspaces []string `json:"resetTimeoutOnWorkspaces,omitempty"`
+	HumanReadableDuration    string   `json:"humanReadableDuration,omitempty"`
 }
 
 // UserMessage is the UserMessage message type

--- a/components/gitpod-protocol/java/src/main/java/io/gitpod/gitpodprotocol/api/entities/SetWorkspaceTimeoutResult.java
+++ b/components/gitpod-protocol/java/src/main/java/io/gitpod/gitpodprotocol/api/entities/SetWorkspaceTimeoutResult.java
@@ -6,12 +6,18 @@ package io.gitpod.gitpodprotocol.api.entities;
 
 public class SetWorkspaceTimeoutResult {
     private String[] resetTimeoutOnWorkspaces;
+    private String humanReadableDuration;
 
-    public SetWorkspaceTimeoutResult(String[] resetTimeoutOnWorkspaces) {
+    public SetWorkspaceTimeoutResult(String[] resetTimeoutOnWorkspaces, String humanReadableDuration) {
         this.resetTimeoutOnWorkspaces = resetTimeoutOnWorkspaces;
+        this.humanReadableDuration = humanReadableDuration;
     }
 
     public String[] getResetTimeoutOnWorkspaces() {
         return resetTimeoutOnWorkspaces;
+    }
+
+    public String getHumanReadableDuration() {
+        return humanReadableDuration;
     }
 }

--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -363,11 +363,12 @@ const WORKSPACE_MAXIMUM_TIMEOUT_HOURS = 24;
 export type WorkspaceTimeoutDuration = string;
 export namespace WorkspaceTimeoutDuration {
     export function validate(duration: string): WorkspaceTimeoutDuration {
+        duration = duration.toLowerCase();
         const unit = duration.slice(-1);
-        if (!["m", "h", "d"].includes(unit)) {
+        if (!["m", "h"].includes(unit)) {
             throw new Error(`Invalid timeout unit: ${unit}`);
         }
-        const value = parseInt(duration.slice(0, -1));
+        const value = parseInt(duration.slice(0, -1), 10);
         if (isNaN(value) || value <= 0) {
             throw new Error(`Invalid timeout value: ${duration}`);
         }
@@ -375,7 +376,7 @@ export namespace WorkspaceTimeoutDuration {
             (unit === "h" && value > WORKSPACE_MAXIMUM_TIMEOUT_HOURS) ||
             (unit === "m" && value > WORKSPACE_MAXIMUM_TIMEOUT_HOURS * 60)
         ) {
-            throw new Error(`Timeouts cannot extend to more than a day`);
+            throw new Error("Workspace inactivity timeout cannot exceed 24h");
         }
         return duration;
     }

--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -358,6 +358,8 @@ export interface ClientHeaderFields {
     clientRegion?: string;
 }
 
+const WORKSPACE_MAXIMUM_TIMEOUT_HOURS = 24;
+
 export type WorkspaceTimeoutDuration = string;
 export namespace WorkspaceTimeoutDuration {
     export function validate(duration: string): WorkspaceTimeoutDuration {
@@ -368,6 +370,12 @@ export namespace WorkspaceTimeoutDuration {
         const value = parseInt(duration.slice(0, -1));
         if (isNaN(value) || value <= 0) {
             throw new Error(`Invalid timeout value: ${duration}`);
+        }
+        if (
+            (unit === "h" && value > WORKSPACE_MAXIMUM_TIMEOUT_HOURS) ||
+            (unit === "m" && value > WORKSPACE_MAXIMUM_TIMEOUT_HOURS * 60)
+        ) {
+            throw new Error(`Timeouts cannot extend to more than a day`);
         }
         return duration;
     }

--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -417,6 +417,7 @@ export interface SetWorkspaceTimeoutResult {
 export interface GetWorkspaceTimeoutResult {
     duration: WorkspaceTimeoutDuration;
     canChange: boolean;
+    humanReadableDuration: string;
 }
 
 export interface StartWorkspaceResult {

--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -402,6 +402,7 @@ export const createServerMock = function <C extends GitpodClient, S extends Gitp
 
 export interface SetWorkspaceTimeoutResult {
     resetTimeoutOnWorkspaces: string[];
+    humanReadableDuration: string;
 }
 
 export interface GetWorkspaceTimeoutResult {

--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/actions/ExtendWorkspaceTimeoutAction.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/actions/ExtendWorkspaceTimeoutAction.kt
@@ -82,7 +82,7 @@ class ExtendWorkspaceTimeoutAction : AnAction() {
             val dialog = InputDurationDialog()
             if (dialog.showAndGet()) {
                 val duration = dialog.getDuration()
-                manager.client.server.setWorkspaceTimeout(workspaceInfo.workspaceId, duration.toString()).whenComplete { _, e ->
+                manager.client.server.setWorkspaceTimeout(workspaceInfo.workspaceId, duration.toString()).whenComplete { result, e ->
                     var message: String
                     var notificationType: NotificationType
 
@@ -91,7 +91,7 @@ class ExtendWorkspaceTimeoutAction : AnAction() {
                         notificationType = NotificationType.ERROR
                         thisLogger().error("gitpod: failed to extend workspace timeout", e)
                     } else {
-                        message = "Workspace timeout has been extended to ${duration}."
+                        message = "Workspace timeout has been extended to ${result.humanReadableDuration}."
                         notificationType = NotificationType.INFORMATION
                     }
 

--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -362,6 +362,38 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
         return { valid: true };
     }
 
+    goDurationToHumanReadable(goDuration: string): string {
+        const [, value, unit] = goDuration.match(/^(\d+)([mh])$/)!;
+        let duration = parseInt(value);
+
+        switch (unit) {
+            case "m":
+                duration *= 60;
+                break;
+            case "h":
+                duration *= 60 * 60;
+                break;
+        }
+
+        const hours = Math.floor(duration / 3600);
+        duration %= 3600;
+        const minutes = Math.floor(duration / 60);
+        duration %= 60;
+
+        let result = "";
+        if (hours) {
+            result += `${hours} hour${hours === 1 ? "" : "s"}`;
+            if (minutes) {
+                result += " and ";
+            }
+        }
+        if (minutes) {
+            result += `${minutes} minute${minutes === 1 ? "" : "s"}`;
+        }
+
+        return result;
+    }
+
     public async setWorkspaceTimeout(
         ctx: TraceContext,
         workspaceId: string,
@@ -404,6 +436,7 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
 
         return {
             resetTimeoutOnWorkspaces: [workspace.id],
+            humanReadableDuration: this.goDurationToHumanReadable(validatedDuration),
         };
     }
 

--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -456,7 +456,7 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
         if (!runningInstance) {
             log.warn({ userId: user.id, workspaceId }, "Can only get keep-alive for running workspaces");
             const duration = WORKSPACE_TIMEOUT_DEFAULT_SHORT;
-            return { duration, canChange };
+            return { duration, canChange, humanReadableDuration: this.goDurationToHumanReadable(duration) };
         }
         await this.guardAccess({ kind: "workspaceInstance", subject: runningInstance, workspace: workspace }, "get");
 
@@ -470,7 +470,7 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
         const desc = await client.describeWorkspace(ctx, req);
         const duration = desc.getStatus()!.getSpec()!.getTimeout();
 
-        return { duration, canChange };
+        return { duration, canChange, humanReadableDuration: this.goDurationToHumanReadable(duration) };
     }
 
     public async isPrebuildDone(ctx: TraceContext, pwsId: string): Promise<boolean> {


### PR DESCRIPTION
## PR progress
- [ ] Think about adding a separate command for a quick pre-set value (basically the old <kbd>Extend</kbd>)

## Description

This PR adds 5 workspace timeout-related features:
- a dialog in JetBrains IDEs so that one can make the workspace timeout anything they desire 

	<img width="360" alt="image" src="https://user-images.githubusercontent.com/29888641/217488867-3984fd8b-14ed-47ae-a46a-7cb13d001055.png">

- `humanReadableDuration` as a parameter of `SetWorkspaceTimeoutResult`, so that clients can echo the server-interpreted time duration of the timeout extension.

	![image](https://user-images.githubusercontent.com/29888641/217488967-15fae210-3c90-41f8-803e-e9caffda4982.png)

- a hard limit of 24 hours for timeouts
- better timeout validation: durations like `2H` or `20M` are now allowed, while values like `0xfd` have been excluded
- a prettier time output when setting a timeout with `gp timeout set`
		
	<img width="585" alt="image" src="https://user-images.githubusercontent.com/29888641/217815745-740bf517-dd56-4623-95b8-7a08ab3ffe3a.png">



## Related Issue(s)

Following https://github.com/gitpod-io/gitpod/pull/15815
Fixes https://github.com/gitpod-io/gitpod/issues/16107

## How to test

1. Open the preview environment
2. Select IntelliJ IDEA as your IDE of choice
3. Open any new workspace
4. Hit <kbd>Shift</kbd> twice and find `Gitpod: Extend Workspace Timeout`
5. Play around. As a wise man once told me: "The world's your oyster"

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation

This most likely will require updating the docs

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`
- [ ] /werft publish-to-npm

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=jetbrains
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
