### PR TITLE
[server] Ignore old FREE/FREE_50 when evaluating BillingMode

### DIFF
--- a/components/server/ee/src/billing/billing-mode.spec.db.ts
+++ b/components/server/ee/src/billing/billing-mode.spec.db.ts
@@ -282,6 +282,18 @@ class BillingModeSpec {
             },
             // user: usage-based
             {
+                name: "user: stripe free, chargebee FREE (old)",
+                subject: user(),
+                config: {
+                    enablePayment: true,
+                    usageBasedPricingEnabled: true,
+                    subscriptions: [subscription(Plans.FREE)],
+                },
+                expectation: {
+                    mode: "usage-based",
+                },
+            },
+            {
                 name: "user: stripe free, chargebee paid personal (inactive) + team seat (inactive)",
                 subject: user(),
                 config: {

--- a/components/server/ee/src/billing/billing-mode.ts
+++ b/components/server/ee/src/billing/billing-mode.ts
@@ -127,7 +127,11 @@ export class BillingModesImpl implements BillingModes {
         const cbSubscriptions = await this.subscriptionSvc.getActivePaidSubscription(user.id, now);
         const cbTeamSubscriptions = cbSubscriptions.filter((s) => isOldTeamSubscription(s));
         const cbPersonalSubscriptions = cbSubscriptions.filter(
-            (s) => isPersonalSubscription(s) && s.planId !== Plans.FREE_OPEN_SOURCE.chargebeeId,
+            (s) =>
+                isPersonalSubscription(s) &&
+                ![Plans.FREE_OPEN_SOURCE.chargebeeId, Plans.FREE.chargebeeId, Plans.FREE_50.chargebeeId].includes(
+                    s.planId!,
+                ),
         );
         const cbOwnedTeamSubscriptions = (
             await this.teamSubscriptionDb.findTeamSubscriptions({ userId: user.id })


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/16231

## How to test

### Run DB tests
 - `leeway run components/gitpod-db:init-testdb`
 - `(cd components/server && yarn db-test)`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Fix evaluation of BillingMode: Ignore old "free" subscription entries
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`
- [ ] /werft publish-to-npm

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
