### PR TITLE
Move loading state and role check into OrgSettingsPage

### DIFF
--- a/components/dashboard/src/app/AppRoutes.tsx
+++ b/components/dashboard/src/app/AppRoutes.tsx
@@ -43,6 +43,7 @@ import PersonalAccessTokenCreateView from "../user-settings/PersonalAccessTokens
 import { StartWorkspaceModalContext } from "../workspaces/start-workspace-modal-context";
 import { StartWorkspaceOptions } from "../start/start-workspace-options";
 import { WebsocketClients } from "./WebsocketClients";
+import { OrgRequiredRoute } from "./OrgRequiredRoute";
 
 const Setup = React.lazy(() => import(/* webpackPrefetch: true */ "../Setup"));
 const WorkspacesNew = React.lazy(() => import(/* webpackPrefetch: true */ "../workspaces/WorkspacesNew"));
@@ -230,13 +231,16 @@ export const AppRoutes: FunctionComponent<AppRoutesProps> = ({ user, teams }) =>
                     <Route exact path="/teams/join" component={JoinTeam} />
                     <Route exact path="/orgs/new" component={NewTeam} />
                     <Route exact path="/orgs/join" component={JoinTeam} />
-                    <Route exact path="/members" component={Members} />
                     <Route exact path="/projects" component={Projects} />
-                    <Route exact path="/settings" component={TeamSettings} />
-                    <Route exact path="/settings/git" component={TeamGitIntegrations} />
-                    {/* TODO: migrate other org settings pages underneath /settings prefix */}
-                    <Route exact path="/billing" component={TeamBilling} />
-                    <Route exact path="/sso" component={SSO} />
+
+                    {/* These routes that require a selected organization, otherwise they redirect to "/" */}
+                    <OrgRequiredRoute exact path="/members" component={Members} />
+                    <OrgRequiredRoute exact path="/settings" component={TeamSettings} />
+                    <OrgRequiredRoute exact path="/settings/git" component={TeamGitIntegrations} />
+                    {/* TODO: migrate other org settings pages underneath /settings prefix so we can utilize nested routes */}
+                    <OrgRequiredRoute exact path="/billing" component={TeamBilling} />
+                    <OrgRequiredRoute exact path="/sso" component={SSO} />
+
                     <Route exact path={`/projects/:projectSlug`} component={Project} />
                     <Route exact path={`/projects/:projectSlug/events`} component={Events} />
                     <Route exact path={`/projects/:projectSlug/prebuilds`} component={Prebuilds} />

--- a/components/dashboard/src/app/OrgRequiredRoute.tsx
+++ b/components/dashboard/src/app/OrgRequiredRoute.tsx
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { Redirect, Route } from "react-router";
+import { useCurrentTeam } from "../teams/teams-context";
+
+// A wrapper for <Route> that redirects to "/" if there is not an organization currently selected
+// Having a check for an active org at the route level allows us to avoid any org-dependant api calls we might make
+// in page level components, and having to check for an org there
+export function OrgRequiredRoute({ component }: any) {
+    const org = useCurrentTeam();
+
+    return <Route render={({ location }: any) => (!!org ? <Route component={component} /> : <Redirect to={"/"} />)} />;
+}

--- a/components/dashboard/src/app/OrgRequiredRoute.tsx
+++ b/components/dashboard/src/app/OrgRequiredRoute.tsx
@@ -13,5 +13,5 @@ import { useCurrentTeam } from "../teams/teams-context";
 export function OrgRequiredRoute({ component }: any) {
     const org = useCurrentTeam();
 
-    return <Route render={({ location }: any) => (!!org ? <Route component={component} /> : <Redirect to={"/"} />)} />;
+    return <Route render={() => (!!org ? <Route component={component} /> : <Redirect to={"/"} />)} />;
 }

--- a/components/dashboard/src/data/organizations/org-members-query.ts
+++ b/components/dashboard/src/data/organizations/org-members-query.ts
@@ -37,12 +37,14 @@ export const useCurrentOrgMember = () => {
 
     return useMemo(() => {
         let member: TeamMemberInfo | undefined;
+        let isOwner = false;
 
         if (!isLoading && members && user) {
             member = members.find((m) => m.userId === user.id);
+            isOwner = member?.role === "owner";
         }
 
-        return { isLoading, member };
+        return { isLoading, member, isOwner };
     }, [isLoading, members, user]);
 };
 

--- a/components/dashboard/src/teams/OrgSettingsPage.tsx
+++ b/components/dashboard/src/teams/OrgSettingsPage.tsx
@@ -4,10 +4,14 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { useContext } from "react";
+import { useMemo } from "react";
+import { Redirect } from "react-router";
+import Header from "../components/Header";
+import { SpinnerLoader } from "../components/Loader";
 import { PageWithSubMenu } from "../components/PageWithSubMenu";
-import { FeatureFlagContext } from "../contexts/FeatureFlagContext";
+import { useFeatureFlags } from "../contexts/FeatureFlagContext";
 import { useOrgBillingMode } from "../data/billing-mode/org-billing-mode-query";
+import { useCurrentOrgMember } from "../data/organizations/org-members-query";
 import { useCurrentTeam } from "./teams-context";
 import { getTeamSettingsMenu } from "./TeamSettings";
 
@@ -17,17 +21,47 @@ export interface OrgSettingsPageProps {
 
 export function OrgSettingsPage({ children }: OrgSettingsPageProps) {
     const team = useCurrentTeam();
-    const { data: teamBillingMode } = useOrgBillingMode();
-    const { oidcServiceEnabled, orgGitAuthProviders } = useContext(FeatureFlagContext);
-    const menu = getTeamSettingsMenu({
-        team,
-        billingMode: teamBillingMode,
-        ssoEnabled: oidcServiceEnabled,
-        orgGitAuthProviders,
-    });
+    const { data: teamBillingMode, isLoading: isBillingModeLoading } = useOrgBillingMode();
+    const { isOwner, isLoading: isMemberInfoLoading } = useCurrentOrgMember();
+    const { oidcServiceEnabled, orgGitAuthProviders } = useFeatureFlags();
+
+    const isLoading = useMemo(
+        () => isBillingModeLoading || isMemberInfoLoading,
+        [isBillingModeLoading, isMemberInfoLoading],
+    );
+
+    const menu = useMemo(
+        () =>
+            getTeamSettingsMenu({
+                team,
+                billingMode: teamBillingMode,
+                ssoEnabled: oidcServiceEnabled,
+                orgGitAuthProviders,
+            }),
+        [oidcServiceEnabled, orgGitAuthProviders, team, teamBillingMode],
+    );
+
+    const title = "Organization Settings";
+    const subtitle = "Manage your organization's settings.";
+
+    // Render as much of the page as we can in a loading state to avoid content shift
+    if (isLoading) {
+        return (
+            <div className="w-full">
+                <Header title={title} subtitle={subtitle} />
+                <div className="w-full">
+                    <SpinnerLoader />
+                </div>
+            </div>
+        );
+    }
+
+    if (!isOwner || !team) {
+        return <Redirect to={"/"} />;
+    }
 
     return (
-        <PageWithSubMenu subMenu={menu} title="Organization Settings" subtitle="Manage your organization's settings.">
+        <PageWithSubMenu subMenu={menu} title={title} subtitle={subtitle}>
             {children}
         </PageWithSubMenu>
     );

--- a/components/dashboard/src/teams/OrgSettingsPage.tsx
+++ b/components/dashboard/src/teams/OrgSettingsPage.tsx
@@ -24,11 +24,7 @@ export function OrgSettingsPage({ children }: OrgSettingsPageProps) {
     const { data: teamBillingMode, isLoading: isBillingModeLoading } = useOrgBillingMode();
     const { isOwner, isLoading: isMemberInfoLoading } = useCurrentOrgMember();
     const { oidcServiceEnabled, orgGitAuthProviders } = useFeatureFlags();
-
-    const isLoading = useMemo(
-        () => isBillingModeLoading || isMemberInfoLoading,
-        [isBillingModeLoading, isMemberInfoLoading],
-    );
+    const isLoading = isBillingModeLoading || isMemberInfoLoading;
 
     const menu = useMemo(
         () =>

--- a/components/dashboard/src/teams/OrgSettingsPage.tsx
+++ b/components/dashboard/src/teams/OrgSettingsPage.tsx
@@ -52,7 +52,8 @@ export function OrgSettingsPage({ children }: OrgSettingsPageProps) {
         );
     }
 
-    if (!isOwner || !team) {
+    // After we've loaded, ensure user is an owner, if not, redirect
+    if (!isOwner) {
         return <Redirect to={"/"} />;
     }
 

--- a/components/dashboard/src/teams/SSO.tsx
+++ b/components/dashboard/src/teams/SSO.tsx
@@ -4,13 +4,9 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { useCallback, useContext, useEffect, useState } from "react";
-import { Redirect } from "react-router";
-import { TeamMemberInfo } from "@gitpod/gitpod-protocol";
-import { ReactComponent as Spinner } from "../icons/Spinner.svg";
+import { useCallback, useEffect, useState } from "react";
 import { useCurrentTeam } from "./teams-context";
-import { UserContext } from "../user-context";
-import { oidcService, publicApiTeamMembersToProtocol, teamsService } from "../service/public-api";
+import { oidcService } from "../service/public-api";
 import { OIDCClientConfig } from "@gitpod/public-api/lib/gitpod/experimental/v1/oidc_pb";
 import { gitpodHostUrl } from "../service/service";
 import { Item, ItemField, ItemFieldContextMenu, ItemFieldIcon, ItemsList } from "../components/ItemsList";
@@ -22,41 +18,9 @@ import exclamation from "../images/exclamation.svg";
 import { OrgSettingsPage } from "./OrgSettingsPage";
 
 export default function SSO() {
-    const { user } = useContext(UserContext);
     const team = useCurrentTeam();
-    const [isUserOwner, setIsUserOwner] = useState(true);
-    const [isLoading, setIsLoading] = useState(true);
 
-    useEffect(() => {
-        if (!team) {
-            return;
-        }
-        (async () => {
-            const memberInfos = await teamsService.getTeam({ teamId: team!.id }).then((resp) => {
-                return publicApiTeamMembersToProtocol(resp.team?.members || []);
-            });
-
-            const currentUserInTeam = memberInfos.find((member: TeamMemberInfo) => member.userId === user?.id);
-            const isUserOwner = currentUserInTeam?.role === "owner";
-            setIsUserOwner(isUserOwner);
-            setIsLoading(false);
-        })();
-    }, [team, user?.id]);
-
-    if (!isUserOwner) {
-        return <Redirect to={`/`} />;
-    }
-
-    return (
-        <OrgSettingsPage>
-            {isLoading && (
-                <div className="p-20">
-                    <Spinner className="h-5 w-5 animate-spin" />
-                </div>
-            )}
-            {!isLoading && team && isUserOwner && <OIDCClients organizationId={team.id} />}
-        </OrgSettingsPage>
-    );
+    return <OrgSettingsPage>{team && <OIDCClients organizationId={team.id} />}</OrgSettingsPage>;
 }
 
 function OIDCClients(props: { organizationId: string }) {

--- a/components/dashboard/src/teams/TeamSettings.tsx
+++ b/components/dashboard/src/teams/TeamSettings.tsx
@@ -7,14 +7,13 @@
 import { Team } from "@gitpod/gitpod-protocol";
 import { BillingMode } from "@gitpod/gitpod-protocol/lib/billing-mode";
 import React, { useCallback, useContext, useState } from "react";
-import { Redirect } from "react-router";
 import Alert from "../components/Alert";
 import ConfirmationModal from "../components/ConfirmationModal";
 import { teamsService } from "../service/public-api";
 import { getGitpodService, gitpodHostUrl } from "../service/service";
 import { useCurrentUser } from "../user-context";
 import { OrgSettingsPage } from "./OrgSettingsPage";
-import { TeamsContext, useCurrentTeam, useIsOwnerOfCurrentTeam } from "./teams-context";
+import { TeamsContext, useCurrentTeam } from "./teams-context";
 
 export function getTeamSettingsMenu(params: {
     team?: Team;
@@ -54,7 +53,6 @@ export function getTeamSettingsMenu(params: {
 export default function TeamSettings() {
     const user = useCurrentUser();
     const team = useCurrentTeam();
-    const isUserOwner = useIsOwnerOfCurrentTeam();
     const { teams, setTeams } = useContext(TeamsContext);
     const [modal, setModal] = useState(false);
     const [teamNameToDelete, setTeamNameToDelete] = useState("");
@@ -109,10 +107,6 @@ export default function TeamSettings() {
 
         document.location.href = gitpodHostUrl.asDashboard().toString();
     }, [team, user]);
-
-    if (!isUserOwner || !team) {
-        return <Redirect to="/" />;
-    }
 
     return (
         <>

--- a/components/dashboard/src/teams/teams-context.tsx
+++ b/components/dashboard/src/teams/teams-context.tsx
@@ -54,6 +54,7 @@ export function useTeams(): Team[] | undefined {
     return teams;
 }
 
+// TODO: deprecate and use the react-query hook for team members
 export function useTeamMemberInfos(): Record<string, TeamMemberInfo[]> {
     const [teamMembers, setTeamMembers] = useState<Record<string, TeamMemberInfo[]>>({});
     const teams = useTeams();
@@ -77,14 +78,4 @@ export function useTeamMemberInfos(): Record<string, TeamMemberInfo[]> {
         })();
     }, [teams]);
     return teamMembers;
-}
-
-export function useIsOwnerOfCurrentTeam(): boolean {
-    const team = useCurrentTeam();
-    const teamMemberInfos = useTeamMemberInfos();
-
-    if (!team || !teamMemberInfos[team.id]) {
-        return true;
-    }
-    return teamMemberInfos[team.id]?.some((tmi) => tmi.role === "owner") || false;
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This shifts the loading state and role check that happens on each org settings page into the `<OrgSettingsPage/>` component. This has the additional benefit of not reloading the same data on each page before we render it.

I've also swapped what was happening in the `useIsOwnerOfCurrentTeam` hook to a newer react-query backed `useCurrentOrgMember` hook. I have a todo to also deprecate the `useTeamMemberInfos` hook in favor of the react-query equivalent. In general not managing that state manually, and deferring to react-query for that will help simplify things, and avoid stale state, or having to manually refresh it in many places.


## How to test
<!-- Provide steps to test this PR -->
The changes here are scoped to the Org Settings pages. Opening each and verifying they load as expected should be sufficient.
* Create an Org
* Visit the Org Settings
* Open each of the left-hand nav pages for org settings, verifying they open as expected.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
