### PR TITLE
Re-render app on org change

### DIFF
--- a/components/dashboard/src/App.tsx
+++ b/components/dashboard/src/App.tsx
@@ -12,12 +12,14 @@ import { useUserAndTeamsLoader } from "./hooks/use-user-and-teams-loader";
 import { useAnalyticsTracking } from "./hooks/use-analytics-tracking";
 import { AppLoading } from "./app/AppLoading";
 import { AppRoutes } from "./app/AppRoutes";
+import { useCurrentTeam } from "./teams/teams-context";
 
 const Setup = React.lazy(() => import(/* webpackPrefetch: true */ "./Setup"));
 
 // Top level Dashboard App component
 const App: FunctionComponent = () => {
     const { user, teams, isSetupRequired, loading } = useUserAndTeamsLoader();
+    const currentOrg = useCurrentTeam();
 
     // Setup analytics/tracking
     useAnalyticsTracking();
@@ -53,7 +55,8 @@ const App: FunctionComponent = () => {
     // If we made it here, we have a logged in user w/ their teams. Yay.
     return (
         <Suspense fallback={<AppLoading />}>
-            <AppRoutes user={user} teams={teams} />
+            {/* Use org id as key to force re-render on org change */}
+            <AppRoutes key={currentOrg?.id ?? "no-org"} user={user} teams={teams} />
         </Suspense>
     );
 };

--- a/components/dashboard/src/teams/TeamSettings.tsx
+++ b/components/dashboard/src/teams/TeamSettings.tsx
@@ -6,7 +6,7 @@
 
 import { Team } from "@gitpod/gitpod-protocol";
 import { BillingMode } from "@gitpod/gitpod-protocol/lib/billing-mode";
-import React, { useCallback, useContext, useEffect, useState } from "react";
+import React, { useCallback, useContext, useState } from "react";
 import { Redirect } from "react-router";
 import Alert from "../components/Alert";
 import ConfirmationModal from "../components/ConfirmationModal";
@@ -63,15 +63,6 @@ export default function TeamSettings() {
     const [updated, setUpdated] = useState(false);
 
     const close = () => setModal(false);
-
-    // reset state if organization changes
-    useEffect(() => {
-        setModal(false);
-        setTeamNameToDelete("");
-        setTeamName(team?.name || "");
-        setErrorMessage(undefined);
-        setUpdated(false);
-    }, [team]);
 
     const updateTeamInformation = useCallback(async () => {
         if (!team || errorMessage || !teams) {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
When the org changes, we're best of forcing a re-render of the app to ensure clean state inside of components. This sets a `key` to the org id (w/ a fallback for when there is no org) on the `<AppRoutes/>` component.

## How to test
<!-- Provide steps to test this PR -->
* Create at least 2 orgs
* Visit the General Org Settings for one org.
* Switch orgs w/ the switcher, and ensure the UI updates to show the currently selected org
* It would be worthwhile to click around a few other places in the UI, and change orgs from them.


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
