### PR TITLE
small improvements for gp rebuild

### DIFF
--- a/components/ide/code/codehelper/.gitignore
+++ b/components/ide/code/codehelper/.gitignore
@@ -1,0 +1,1 @@
+codehelper

--- a/components/ide/code/codehelper/main.go
+++ b/components/ide/code/codehelper/main.go
@@ -61,12 +61,16 @@ func main() {
 	}
 	phaseDone()
 
-	if err := prepareWebWorkbenchMain(wsInfo); err != nil {
-		log.WithError(err).Error("failed to prepare web workbench")
-	}
-
-	if err := prepareServerMain(wsInfo); err != nil {
-		log.WithError(err).Error("failed to prepare server")
+	if wsInfo.DebugWorkspaceType != supervisor.DebugWorkspaceType_noDebug {
+		// TODO actually should be performed always
+		// the better way would be to apply replacements during a workspace start
+		// to aling with content in blobserve
+		if err := prepareWebWorkbenchMain(wsInfo); err != nil {
+			log.WithError(err).Error("failed to prepare web workbench")
+		}
+		if err := prepareServerMain(wsInfo); err != nil {
+			log.WithError(err).Error("failed to prepare server")
+		}
 	}
 
 	// code server args install extension with id
@@ -277,7 +281,7 @@ func prepareServerMain(wsInfo *supervisor.WorkspaceInfoResponse) error {
 		return errors.New("failed to parse " + wsInfo.GitpodHost + ": " + err.Error())
 	}
 	domain := url.Hostname()
-	b = bytes.ReplaceAll(b, []byte("https://*.vscode-cdn.net"), []byte(fmt.Sprintf("https://*.vscode-cdn.net https://%s https://*.%s", domain, domain)))
+	b = bytes.ReplaceAll(b, []byte("https://*.vscode-cdn.net"), []byte(fmt.Sprintf("https://%s https://*.%s", domain, domain)))
 	if err := os.WriteFile(ServerMainLocation, b, 0644); err != nil {
 		return errors.New("failed to write " + ServerMainLocation + ": " + err.Error())
 	}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

- fix checkout and workspace locations
- don't generate dockerfile if image is specified to avoid sending build context to daemon over and over
- only do inline replacements for VS Code Server in debug mode


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

- Start a workspace, try to use image and dockerfile and verify that rebuild works in both cases.
- While using an image you should not see anymore transferring build context to daemon.
- Try to change a workspace location in .gitpod.yml, start using gp rebuild, check that checkout and workspace locations are proper.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`