### PR TITLE
filter out org auth providers from user providers

### DIFF
--- a/components/gitpod-db/src/auth-provider-entry-db.ts
+++ b/components/gitpod-db/src/auth-provider-entry-db.ts
@@ -20,6 +20,7 @@ export interface AuthProviderEntryDB {
      */
     findAllHosts(): Promise<string[]>;
     findByHost(host: string): Promise<AuthProviderEntry | undefined>;
+    findById(id: string): Promise<AuthProviderEntry | undefined>;
     findByUserId(userId: string): Promise<AuthProviderEntry[]>;
     findByOrgId(organizationId: string): Promise<AuthProviderEntry[]>;
 }

--- a/components/gitpod-db/src/typeorm/auth-provider-entry-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/auth-provider-entry-db-impl.ts
@@ -88,6 +88,7 @@ export class AuthProviderEntryDBImpl implements AuthProviderEntryDB {
         const query = repo
             .createQueryBuilder("auth_provider")
             .where(`auth_provider.ownerId = :ownerId`, { ownerId })
+            .andWhere("(auth_provider.organization_id IS NULL OR auth_provider.organization_id = '')")
             .andWhere("auth_provider.deleted != true");
         return query.getMany();
     }

--- a/components/gitpod-db/src/typeorm/auth-provider-entry-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/auth-provider-entry-db-impl.ts
@@ -83,6 +83,11 @@ export class AuthProviderEntryDBImpl implements AuthProviderEntryDB {
         return query.getOne();
     }
 
+    async findById(id: string): Promise<AuthProviderEntry | undefined> {
+        const repo = await this.getAuthProviderRepo();
+        return repo.findOne(id);
+    }
+
     async findByUserId(ownerId: string): Promise<AuthProviderEntry[]> {
         const repo = await this.getAuthProviderRepo();
         const query = repo

--- a/components/server/src/auth/auth-provider-service.ts
+++ b/components/server/src/auth/auth-provider-service.ts
@@ -201,6 +201,8 @@ export class AuthProviderService {
         const { ownerId, id } = params;
         let ap: AuthProviderEntry | undefined;
         try {
+            // TODO: Consider org auth providers that wouldn't be returned here
+            // Instead - query directly by id only, and ensure ownerId is a match
             let authProviders = await this.authProviderDB.findByUserId(ownerId);
             if (authProviders.length === 0) {
                 // "no-user" is the magic user id assigned during the initial setup

--- a/components/server/src/auth/auth-provider-service.ts
+++ b/components/server/src/auth/auth-provider-service.ts
@@ -200,8 +200,8 @@ export class AuthProviderService {
         };
     }
 
-    async markAsVerified(params: { ownerId: string; id: string }) {
-        const { ownerId, id } = params;
+    async markAsVerified(params: { userId: string; id: string }) {
+        const { userId, id } = params;
         let ap: AuthProviderEntry | undefined;
         try {
             const ap = await this.authProviderDB.findById(id);
@@ -212,7 +212,7 @@ export class AuthProviderService {
 
             // Check that user is allowed to verify the AuthProviderEntry
             if (ap.organizationId) {
-                const membership = await this.teamDB.findTeamMembership(ownerId, ap.organizationId);
+                const membership = await this.teamDB.findTeamMembership(userId, ap.organizationId);
                 if (!membership) {
                     log.warn("Failed to find the TeamMembership for Org AuthProviderEntry to be activated.", {
                         params,
@@ -234,7 +234,7 @@ export class AuthProviderService {
             } else {
                 // For a non-org AuthProviderEntry, user must be the owner, or it must be the special "no-user" entry
                 // "no-user" is the magic user id assigned during the initial setup
-                if (ownerId !== ap.ownerId && ap.ownerId !== "no-user") {
+                if (userId !== ap.ownerId && ap.ownerId !== "no-user") {
                     log.warn("User cannot active the AuthProviderEntry.", { params, id, ap });
                     return;
                 }
@@ -242,7 +242,7 @@ export class AuthProviderService {
 
             const updatedAP: AuthProviderEntry = {
                 ...ap,
-                ownerId,
+                ownerId: userId,
                 status: "verified",
             };
             await this.authProviderDB.storeAuthProvider(updatedAP, true);

--- a/components/server/src/auth/login-completion-handler.ts
+++ b/components/server/src/auth/login-completion-handler.ts
@@ -108,7 +108,7 @@ export class LoginCompletionHandler {
             const { id, verified, builtin } = config;
             if (!builtin && !verified) {
                 try {
-                    await this.authProviderService.markAsVerified({ id, ownerId: user.id });
+                    await this.authProviderService.markAsVerified({ id, userId: user.id });
                 } catch (error) {
                     log.error(LogContext.from({ user }), `Failed to mark AuthProvider as verified!`, { error });
                 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Filters out org auth providers from user's own auth providers. I went with filtering at the `findByUserId` db query level. This seemed like the best route to treat the two different versions of auth providers the way we want, but please let me know if I'm missing anything. Here's the places I could see that would be effected by this change:

---

I believe these places would function like we want if they don't get org auth providers.

### `AuthProviderService.getAuthProvidersOfUser()`
* `server.getOwnAuthProviders()`
* `server.deleteOwnAuthProvider()`
 
### `AuthProviderService.updateAuthProvider()`
* `server.updateOwnAuthProvider()`

This spot will need to be tweaked so that it accounts for org auth providers not being returned from a `findByUserId()` call. ATM I have some comments around how I believe we could address it. I haven't included that change in this PR though.

* `AuthProviderService.markAsVerified()`
  * `LoginCompletionHandler.updateAuthProviderAsVerified()`

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of #16285

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [x] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
