### PR TITLE
[gorm] Ignore NotFound errors when logging

### DIFF
--- a/components/gitpod-db/go/conn.go
+++ b/components/gitpod-db/go/conn.go
@@ -74,8 +74,9 @@ func Connect(p ConnectionParams) (*gorm.DB, error) {
 	// refer to https://github.com/go-sql-driver/mysql#dsn-data-source-name for details
 	return gorm.Open(mysql.Open(cfg.FormatDSN()), &gorm.Config{
 		Logger: logger.New(log.Log, logger.Config{
-			SlowThreshold: 200 * time.Millisecond,
-			Colorful:      false,
+			SlowThreshold:             200 * time.Millisecond,
+			Colorful:                  false,
+			IgnoreRecordNotFoundError: true,
 			LogLevel: (func() logger.LogLevel {
 				switch log.Log.Level {
 				case logrus.PanicLevel, logrus.FatalLevel, logrus.ErrorLevel:


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Else we log the SQL query for every NotFound error, [see logs](https://cloudlogging.app.goo.gl/g9Co9dSinbpjSbeZ9)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
