### PR TITLE
Reverse order of Feedback emojis

### DIFF
--- a/components/dashboard/src/feedback-form/FeedbackComponent.tsx
+++ b/components/dashboard/src/feedback-form/FeedbackComponent.tsx
@@ -53,10 +53,10 @@ function FeedbackComponent(props: {
 
     const emojiGroup = (width: number) => {
         const emojiList = [
-            { id: 4, name: "starry", src: starry },
-            { id: 3, name: "happy", src: happy },
-            { id: 2, name: "meh", src: meh },
             { id: 1, name: "crying", src: crying },
+            { id: 2, name: "meh", src: meh },
+            { id: 3, name: "happy", src: happy },
+            { id: 4, name: "starry", src: starry },
         ];
         return emojiList.map((emoji) => (
             <button


### PR DESCRIPTION
## Description

Currently the emoji order is from good to bad which seems weird.
| Before Change      | 
| ----------- | 
| <img src="https://user-images.githubusercontent.com/666176/217501912-3b69c895-08e6-4192-8810-add1a1c938ff.png"  width="300">

This PR changes it go from bad to good. This change can have an impact on scores.

See [relevant discussion](https://gitpod.slack.com/archives/C01KPEPNBD0/p1675824030623679) (internal). Cc @mbrevoort @chrifro 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
N/A

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE