### PR TITLE
[server] Guess workspace region

### DIFF
--- a/components/server/package.json
+++ b/components/server/package.json
@@ -54,6 +54,7 @@
     "cookie": "^0.4.2",
     "cookie-parser": "^1.4.6",
     "cors": "^2.8.4",
+    "countries-list": "^2.6.1",
     "deep-equal": "^2.0.5",
     "deepmerge": "^4.2.2",
     "express": "^4.17.3",

--- a/components/server/src/workspace/region-service.ts
+++ b/components/server/src/workspace/region-service.ts
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { countries, continents } from "countries-list";
+
+const NorthAmerica = "north-america";
+const Europe = "europe";
+const Unknown = "unknown";
+
+type WorkspaceRegion = "europe" | "north-america" | "unknown";
+
+export class RegionService {
+    public static countryCodeToNearestWorkspaceRegion(code: string): WorkspaceRegion {
+        if (!isCountryCode(code)) {
+            return Unknown;
+        }
+
+        const continent = countries[code].continent;
+
+        if (!isContinentCode(continent)) {
+            return Unknown;
+        }
+
+        return nearestWorkspaceRegion[continent];
+    }
+}
+
+export type CountryCode = keyof typeof countries;
+export type ContinentCode = keyof typeof continents;
+
+function isCountryCode(code: string): code is CountryCode {
+    return code in countries;
+}
+
+function isContinentCode(code: string): code is ContinentCode {
+    return code in continents;
+}
+
+const nearestWorkspaceRegion: { [continentCode in keyof typeof continents]: WorkspaceRegion } = {
+    // Africa
+    AF: Europe,
+    // Antarctica
+    AN: NorthAmerica,
+    // Asia
+    AS: NorthAmerica,
+    // Europe
+    EU: Europe,
+    // North America
+    NA: NorthAmerica,
+    // Oceania
+    OC: NorthAmerica,
+    // South America
+    SA: NorthAmerica,
+};

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -444,6 +444,7 @@ export class WorkspaceStarter {
         region?: string,
     ): Promise<StartWorkspaceResult> {
         const span = TraceContext.startSpan("actuallyStartWorkspace", ctx);
+        span.setTag("region_preference", region);
 
         try {
             // build workspace image

--- a/yarn.lock
+++ b/yarn.lock
@@ -6268,7 +6268,7 @@ cosmiconfig@^7.0.0, cosmiconfig@^7.0.1:
 
 countries-list@^2.6.1:
   version "2.6.1"
-  resolved "https://registry.npmjs.org/countries-list/-/countries-list-2.6.1.tgz"
+  resolved "https://registry.yarnpkg.com/countries-list/-/countries-list-2.6.1.tgz#d479757ac873b1e596ccea0a925962d20396c0cb"
   integrity sha512-jXM1Nv3U56dPQ1DsUSsEaGmLHburo4fnB7m+1yhWDUVvx5gXCd1ok/y3gXCjXzhqyawG+igcPYcAl4qjkvopaQ==
 
 create-ecdh@^4.0.0:


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Behind an experiment, attempts to guess the region where the user is, to select the appropriate WS cluster.

WS clusters do not have the region property set, yet. This means nothing changes in the current scheduling. Once we set them, and enable the experiment, we can determine which region the workspace should belong to.

Not too happy with this static approach, but see [thread](https://gitpod.slack.com/archives/C02EN94AEPL/p1675852587321389) for more details.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
