### PR TITLE
Always show all navigation menu items

### DIFF
--- a/components/dashboard/src/menu/Menu.tsx
+++ b/components/dashboard/src/menu/Menu.tsx
@@ -20,7 +20,7 @@ import PillMenuItem from "../components/PillMenuItem";
 import { getTeamSettingsMenu } from "../teams/TeamSettings";
 import { PaymentContext } from "../payment-context";
 import FeedbackFormModal from "../feedback-form/FeedbackModal";
-import { inResource, isGitpodIo } from "../utils";
+import { isGitpodIo } from "../utils";
 import { BillingMode } from "@gitpod/gitpod-protocol/lib/billing-mode";
 import { useFeatureFlags } from "../contexts/FeatureFlagContext";
 import OrganizationSelector from "./OrganizationSelector";
@@ -52,9 +52,6 @@ export default function Menu() {
         const path = location.pathname.toLowerCase();
         return all.some((n) => n === path || n + "/" === path);
     }
-
-    // Hide most of the top menu when in a full-page form.
-    const isMinimalUI = inResource(location.pathname, ["new", "orgs/new", "open"]);
 
     useEffect(() => {
         const { server } = getGitpodService();
@@ -150,21 +147,17 @@ export default function Menu() {
                             <img src={gitpodIcon} className="h-6" alt="Gitpod's logo" />
                         </Link>
                         <OrganizationSelector />
-                        {!isMinimalUI && (
-                            <>
-                                <div className="pl-2 text-base text-gray-500 dark:text-gray-400 flex max-w-lg overflow-hidden">
-                                    {leftMenu.map((entry) => (
-                                        <div className="p-1" key={entry.title}>
-                                            <PillMenuItem
-                                                name={entry.title}
-                                                selected={isSelected(entry, location)}
-                                                link={entry.link}
-                                            />
-                                        </div>
-                                    ))}
+                        <div className="pl-2 text-base text-gray-500 dark:text-gray-400 flex max-w-lg overflow-hidden">
+                            {leftMenu.map((entry) => (
+                                <div className="p-1" key={entry.title}>
+                                    <PillMenuItem
+                                        name={entry.title}
+                                        selected={isSelected(entry, location)}
+                                        link={entry.link}
+                                    />
                                 </div>
-                            </>
-                        )}
+                            ))}
+                        </div>
                     </div>
                     <div className="flex-1 flex items-center w-auto" id="menu">
                         <nav className="flex-1">


### PR DESCRIPTION
## Description

Removes the `isMinimalUI` function, always showing all navigation menu items.

See [relevant discussion](https://gitpod.slack.com/archives/C02EN94AEPL/p1675800615601449) (internal). Cc @selfcontained @atduarte @mbrevoort 

## How to test

Try adding a new :a: organization or :b: project and notice the navigation stays there.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Always show all navigation menu items
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [X] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
