### PR TITLE
[ws-manager-mk2] Support deployment to ephemeral clusters

### DIFF
--- a/components/ws-daemon/pkg/daemon/daemon.go
+++ b/components/ws-daemon/pkg/daemon/daemon.go
@@ -147,9 +147,11 @@ func NewDaemon(config Config, reg prometheus.Registerer) (*Daemon, error) {
 	var mgr manager.Manager
 	if config.WorkspaceController.Enabled {
 		mgr, err = ctrl.NewManager(restCfg, ctrl.Options{
-			Scheme:    scheme,
-			Port:      9443,
-			Namespace: config.Runtime.KubernetesNamespace,
+			Scheme:                 scheme,
+			Port:                   9443,
+			Namespace:              config.Runtime.KubernetesNamespace,
+			HealthProbeBindAddress: "0",
+			MetricsBindAddress:     "0",
 		})
 		if err != nil {
 			return nil, err

--- a/components/ws-manager-mk2/BUILD.yaml
+++ b/components/ws-manager-mk2/BUILD.yaml
@@ -14,6 +14,7 @@ packages:
         - components/content-service:lib
         - components/registry-facade-api/go:lib
         - components/ws-manager-api/go:lib
+        - components/image-builder-api/go:lib
       config:
         packaging: app
         buildCommand: ["go", "build", "-trimpath", "-ldflags", "-buildid= -w -s -X 'github.com/gitpod-io/gitpod/ws-manager-mk2/cmd.Version=commit-${__git_commit}'"]

--- a/components/ws-manager-mk2/controllers/create.go
+++ b/components/ws-manager-mk2/controllers/create.go
@@ -680,31 +680,13 @@ func newStartWorkspaceContext(ctx context.Context, cfg *config.Configuration, ws
 	span, _ := tracing.FromContext(ctx, "newStartWorkspaceContext")
 	defer tracing.FinishSpan(span, &err)
 
-	if ws.Spec.Type != workspacev1.WorkspaceTypeRegular {
-		ws.Status.Headless = true
-	}
-
-	if ws.Status.URL == "" {
-		ws.Status.URL, err = config.RenderWorkspaceURL(cfg.WorkspaceURLTemplate, ws.Name, ws.Spec.Ownership.WorkspaceID, cfg.GitpodHostURL)
-		if err != nil {
-			return nil, xerrors.Errorf("cannot get workspace URL: %w", err)
-		}
-	}
-
-	if ws.Status.OwnerToken == "" {
-		ws.Status.OwnerToken, err = getRandomString(32)
-		if err != nil {
-			return nil, xerrors.Errorf("cannot create owner token: %w", err)
-		}
-	}
-
 	return &startWorkspaceContext{
 		Labels: map[string]string{
 			"app":                  "gitpod",
 			"component":            "workspace",
 			wsk8s.WorkspaceIDLabel: ws.Spec.Ownership.WorkspaceID,
 			wsk8s.OwnerLabel:       ws.Spec.Ownership.Owner,
-			wsk8s.TypeLabel:        string(ws.Spec.Type),
+			wsk8s.TypeLabel:        strings.ToLower(string(ws.Spec.Type)),
 			instanceIDLabel:        ws.Name,
 			headlessLabel:          strconv.FormatBool(ws.Status.Headless),
 		},

--- a/components/ws-manager-mk2/controllers/suite_test.go
+++ b/components/ws-manager-mk2/controllers/suite_test.go
@@ -91,7 +91,7 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).ToNot(HaveOccurred())
 
-	wsReconciler, err := NewWorkspaceReconciler(k8sManager.GetClient(), k8sManager.GetScheme(), config.Configuration{
+	wsReconciler, err := NewWorkspaceReconciler(k8sManager.GetClient(), k8sManager.GetScheme(), &config.Configuration{
 		Namespace:      "default",
 		SeccompProfile: "default.json",
 		WorkspaceClasses: map[string]*config.WorkspaceClass{
@@ -100,6 +100,7 @@ var _ = BeforeSuite(func() {
 			},
 		},
 	}, metrics.Registry)
+
 	Expect(err).ToNot(HaveOccurred())
 	err = wsReconciler.SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())

--- a/components/ws-manager-mk2/controllers/workspace_controller.go
+++ b/components/ws-manager-mk2/controllers/workspace_controller.go
@@ -29,7 +29,7 @@ const (
 	kubernetesOperationTimeout = 5 * time.Second
 )
 
-func NewWorkspaceReconciler(c client.Client, scheme *runtime.Scheme, cfg config.Configuration, reg prometheus.Registerer) (*WorkspaceReconciler, error) {
+func NewWorkspaceReconciler(c client.Client, scheme *runtime.Scheme, cfg *config.Configuration, reg prometheus.Registerer) (*WorkspaceReconciler, error) {
 	reconciler := &WorkspaceReconciler{
 		Client: c,
 		Scheme: scheme,
@@ -51,7 +51,7 @@ type WorkspaceReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
 
-	Config      config.Configuration
+	Config      *config.Configuration
 	metrics     *controllerMetrics
 	OnReconcile func(ctx context.Context, ws *workspacev1.Workspace)
 }
@@ -98,7 +98,7 @@ func (r *WorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return ctrl.Result{}, err
 	}
 
-	err = updateWorkspaceStatus(ctx, &workspace, workspacePods)
+	err = updateWorkspaceStatus(ctx, &workspace, workspacePods, r.Config)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -130,7 +130,7 @@ func (r *WorkspaceReconciler) actOnStatus(ctx context.Context, workspace *worksp
 		// if there isn't a workspace pod and we're not currently deleting this workspace,// create one.
 		switch {
 		case workspace.Status.PodStarts == 0:
-			sctx, err := newStartWorkspaceContext(ctx, &r.Config, workspace)
+			sctx, err := newStartWorkspaceContext(ctx, r.Config, workspace)
 			if err != nil {
 				log.Error(err, "unable to create startWorkspace context")
 				return ctrl.Result{Requeue: true}, err

--- a/components/ws-manager-mk2/go.mod
+++ b/components/ws-manager-mk2/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/aws/smithy-go v1.13.3
 	github.com/gitpod-io/gitpod/common-go v0.0.0-00010101000000-000000000000
 	github.com/gitpod-io/gitpod/content-service/api v0.0.0-00010101000000-000000000000
+	github.com/gitpod-io/gitpod/image-builder/api v0.0.0-00010101000000-000000000000
 	github.com/gitpod-io/gitpod/registry-facade/api v0.0.0-00010101000000-000000000000
 	github.com/gitpod-io/gitpod/ws-manager/api v0.0.0-00010101000000-000000000000
 	github.com/go-logr/logr v1.2.3
@@ -13,11 +14,11 @@ require (
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/hashicorp/golang-lru v0.5.1
 	github.com/imdario/mergo v0.3.13
-	github.com/mwitkow/grpc-proxy v0.0.0-20220126150247-db34e7bfee32
 	github.com/onsi/ginkgo/v2 v2.8.0
 	github.com/onsi/gomega v1.25.0
 	github.com/opentracing/opentracing-go v1.2.0
 	github.com/prometheus/client_golang v1.13.0
+	github.com/sirupsen/logrus v1.8.1
 	golang.org/x/xerrors v0.0.0-20220609144429-65e65417b02f
 	google.golang.org/grpc v1.49.0
 	google.golang.org/protobuf v1.28.1
@@ -78,7 +79,6 @@ require (
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.37.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect
-	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/slok/go-http-metrics v0.10.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/testify v1.7.0 // indirect
@@ -117,11 +117,11 @@ replace github.com/gitpod-io/gitpod/content-service => ../content-service // lee
 
 replace github.com/gitpod-io/gitpod/content-service/api => ../content-service-api/go // leeway
 
-replace github.com/gitpod-io/gitpod/image-builder/api => ../image-builder-api/go // leeway
-
 replace github.com/gitpod-io/gitpod/registry-facade/api => ../registry-facade-api/go // leeway
 
 replace github.com/gitpod-io/gitpod/ws-manager/api => ../ws-manager-api/go // leeway
+
+replace github.com/gitpod-io/gitpod/image-builder/api => ../image-builder-api/go // leeway
 
 replace k8s.io/api => k8s.io/api v0.24.4 // leeway indirect from components/common-go:lib
 

--- a/components/ws-manager-mk2/go.sum
+++ b/components/ws-manager-mk2/go.sum
@@ -423,8 +423,6 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
-github.com/mwitkow/grpc-proxy v0.0.0-20220126150247-db34e7bfee32 h1:CC9KzU7WPrK6DTppkUGiwmttoHCNwOLT7Z+stp1eIpU=
-github.com/mwitkow/grpc-proxy v0.0.0-20220126150247-db34e7bfee32/go.mod h1:MvMXoufZAtqExNexqi4cjrNYE9MefKddKylxjS+//n0=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
@@ -689,7 +687,6 @@ golang.org/x/net v0.0.0-20201209123823-ac852fbbde11/go.mod h1:m0MpNAwzfU5UDzcl9v
 golang.org/x/net v0.0.0-20210119194325-5f4716e94777/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210316092652-d523dce5a7f4/go.mod h1:RBQZq4jEuRlivfhVLdyRGr576XBO4/greRjx4P4O3yc=
-golang.org/x/net v0.0.0-20210331212208-0fccb6fa2b5c/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20210503060351-7fd8e65b6420/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210525063256-abc453219eb5/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
@@ -791,7 +788,6 @@ golang.org/x/sys v0.0.0-20210305230114-8fe3ee5dd75b/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210315160823-c6e025ad8005/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210331175145-43e1dd70ce54/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210403161142-5e06dd20ab57/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -1004,7 +1000,6 @@ google.golang.org/genproto v0.0.0-20210303154014-9728d6b83eeb/go.mod h1:FWY/as6D
 google.golang.org/genproto v0.0.0-20210310155132-4ce2db91004e/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20210319143718-93e7006c17a6/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20210329143202-679c6ae281ee/go.mod h1:9lPAdzaEmUacj36I+k7YKbEc5CXzPIeORRgDAUOu28A=
-google.golang.org/genproto v0.0.0-20210401141331-865547bb08e2/go.mod h1:9lPAdzaEmUacj36I+k7YKbEc5CXzPIeORRgDAUOu28A=
 google.golang.org/genproto v0.0.0-20210402141018-6c239bbf2bb1/go.mod h1:9lPAdzaEmUacj36I+k7YKbEc5CXzPIeORRgDAUOu28A=
 google.golang.org/genproto v0.0.0-20210513213006-bf773b8c8384/go.mod h1:P3QM42oQyzQSnHPnZ/vqoCdDmzH28fzWByN9asMeM8A=
 google.golang.org/genproto v0.0.0-20210602131652-f16073e35f0c/go.mod h1:UODoCrxHCcBojKKwX1terBiRUaqAsFqJiF615XL43r0=
@@ -1137,7 +1132,6 @@ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
-honnef.co/go/tools v0.1.3/go.mod h1:NgwopIslSNH47DimFoV78dnkksY2EFtX0ajyb3K/las=
 k8s.io/api v0.24.4 h1:I5Y645gJ8zWKawyr78lVfDQkZrAViSbeRXsPZWTxmXk=
 k8s.io/api v0.24.4/go.mod h1:42pVfA0NRxrtJhZQOvRSyZcJihzAdU59WBtTjYcB0/M=
 k8s.io/apiextensions-apiserver v0.24.4 h1:w53Pm4zu8fCt9WfiRgS2YI6LE6I4NJ5aUi78GElD3K8=

--- a/components/ws-manager-mk2/main.go
+++ b/components/ws-manager-mk2/main.go
@@ -95,7 +95,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	reconciler, err := controllers.NewWorkspaceReconciler(mgr.GetClient(), mgr.GetScheme(), cfg.Manager, metrics.Registry)
+	reconciler, err := controllers.NewWorkspaceReconciler(mgr.GetClient(), mgr.GetScheme(), &cfg.Manager, metrics.Registry)
 	if err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Workspace")
 		os.Exit(1)
@@ -168,8 +168,6 @@ func setupGRPCService(cfg *config.ServiceConfiguration, k8s client.Client, activ
 	}
 
 	grpcServer := grpc.NewServer(grpcOpts...)
-
-	//grpcOpts = append(grpcOpts, grpc.UnknownServiceHandler(proxy.TransparentHandler(imagebuilderDirector(cfg.ImageBuilderProxy.TargetAddr))))
 
 	if cfg.ImageBuilderProxy.TargetAddr != "" {
 		creds := insecure.NewCredentials()

--- a/components/ws-manager-mk2/pkg/proxy/imagebuilder.go
+++ b/components/ws-manager-mk2/pkg/proxy/imagebuilder.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package proxy
+
+import (
+	"context"
+
+	"github.com/gitpod-io/gitpod/image-builder/api"
+	"google.golang.org/protobuf/proto"
+)
+
+type ImageBuilder struct {
+	D api.ImageBuilderClient
+
+	api.UnimplementedImageBuilderServer
+}
+
+func (p ImageBuilder) ResolveBaseImage(ctx context.Context, req *api.ResolveBaseImageRequest) (*api.ResolveBaseImageResponse, error) {
+	return p.D.ResolveBaseImage(ctx, req)
+}
+
+func (p ImageBuilder) ResolveWorkspaceImage(ctx context.Context, req *api.ResolveWorkspaceImageRequest) (*api.ResolveWorkspaceImageResponse, error) {
+	return p.D.ResolveWorkspaceImage(ctx, req)
+}
+
+func (p ImageBuilder) Build(req *api.BuildRequest, srv api.ImageBuilder_BuildServer) error {
+	c, err := p.D.Build(srv.Context(), req)
+	if err != nil {
+		return err
+	}
+	defer c.CloseSend()
+
+	return forwardStream(srv.Context(), c.Recv, srv.Send)
+}
+
+func (p ImageBuilder) Logs(req *api.LogsRequest, srv api.ImageBuilder_LogsServer) error {
+	c, err := p.D.Logs(srv.Context(), req)
+	if err != nil {
+		return err
+	}
+	defer c.CloseSend()
+
+	return forwardStream(srv.Context(), c.Recv, srv.Send)
+}
+
+func (p ImageBuilder) ListBuilds(ctx context.Context, req *api.ListBuildsRequest) (*api.ListBuildsResponse, error) {
+	return p.D.ListBuilds(ctx, req)
+}
+
+type ProtoMessage interface {
+	proto.Message
+	comparable
+}
+
+func forwardStream[R ProtoMessage](ctx context.Context, recv func() (R, error), send func(R) error) error {
+	for {
+		resp, err := recv()
+		if err != nil {
+			return err
+		}
+
+		// generic hack, can't compare R to nil because R's default value is unclear (not even sure this is nil)
+		// But, we can get the default value which will be nil because underneath R is an interface.
+		var defaultResp R
+		if resp == defaultResp {
+			break
+		}
+		err = send(resp)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Description
Make ws-manager-mk2 work in ephemeral clusters
- Support tls for image builder proxy
- Resolve port bind conflict (ws-daemon controller manager tried to bind to port 8080 which is also the port the grpc service binds to). We will expose metrics from the already existing ws-daemon metric endpoint instead (to be added later).
- Ensure that owner token and workspace url are set even if there is a conflict updating the workspace CR

## Related Issue(s)
n.a.

## How to test
- Create ephemeral cluster (did not see the port bind issue in preview environments). Use [this branch](https://github.com/gitpod-io/ops/pull/8240) when creating the cluster.
- ws-daemon should start up 
- You should not see tls errors during startup

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
