### PR TITLE
[oidc] encode and validate state params

### DIFF
--- a/components/public-api-server/go.mod
+++ b/components/public-api-server/go.mod
@@ -42,6 +42,7 @@ require (
 	github.com/felixge/httpsnoop v1.0.1 // indirect
 	github.com/go-jose/go-jose/v3 v3.0.0 // indirect
 	github.com/go-sql-driver/mysql v1.6.0 // indirect
+	github.com/golang-jwt/jwt/v4 v4.4.3 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect

--- a/components/public-api-server/go.sum
+++ b/components/public-api-server/go.sum
@@ -121,6 +121,8 @@ github.com/gofrs/uuid v4.0.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRx
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
+github.com/golang-jwt/jwt/v4 v4.4.3 h1:Hxl6lhQFj4AnOX6MLrsCb/+7tCj7DxP7VA+2rDIq5AU=
+github.com/golang-jwt/jwt/v4 v4.4.3/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe/go.mod h1:8vg3r2VgvsThLBIFL93Qb5yWzgyZWhEmBwUJWevAkK0=
 github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 h1:au07oEsX2xN0ktxqI+Sida1w446QrXBRJ0nee3SNZlA=
 github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9/go.mod h1:8vg3r2VgvsThLBIFL93Qb5yWzgyZWhEmBwUJWevAkK0=

--- a/components/public-api-server/pkg/oidc/oauth2.go
+++ b/components/public-api-server/pkg/oidc/oauth2.go
@@ -66,7 +66,7 @@ func (s *Service) OAuth2Middleware(next http.Handler) http.Handler {
 			return
 		}
 
-		state, err := decodeStateParam(stateParam)
+		state, err := s.decodeStateParam(stateParam)
 		if err != nil {
 			http.Error(rw, "bad state param", http.StatusBadRequest)
 			return

--- a/components/public-api-server/pkg/oidc/router_test.go
+++ b/components/public-api-server/pkg/oidc/router_test.go
@@ -22,7 +22,7 @@ func TestRoute_start(t *testing.T) {
 	idpUrl := newFakeIdP(t)
 
 	// setup test server with client routes
-	baseUrl, _, configId := newTestServer(t, testServerParams{
+	baseUrl, _, configId, _ := newTestServer(t, testServerParams{
 		issuer:      idpUrl,
 		returnToURL: "",
 	})
@@ -50,11 +50,11 @@ func TestRoute_callback(t *testing.T) {
 	idpUrl := newFakeIdP(t)
 
 	// setup test server with client routes
-	baseUrl, stateParam, _ := newTestServer(t, testServerParams{
+	baseUrl, stateParam, _, service := newTestServer(t, testServerParams{
 		issuer:      idpUrl,
 		returnToURL: "/relative/url/to/some/page",
 	})
-	state, err := encodeStateParam(*stateParam)
+	state, err := service.encodeStateParam(*stateParam)
 	require.NoError(t, err)
 
 	// hit the /callback endpoint
@@ -92,7 +92,7 @@ type testServerParams struct {
 	clientID    string
 }
 
-func newTestServer(t *testing.T, params testServerParams) (url string, state *StateParam, configId string) {
+func newTestServer(t *testing.T, params testServerParams) (url string, state *StateParam, configId string, oidcService *Service) {
 	router := chi.NewRouter()
 	oidcService, dbConn := setupOIDCServiceForTests(t)
 	router.Mount("/oidc", Router(oidcService))
@@ -124,5 +124,5 @@ func newTestServer(t *testing.T, params testServerParams) (url string, state *St
 		ReturnToURL:    params.returnToURL,
 	}
 
-	return url, stateParam, configId
+	return url, stateParam, configId, oidcService
 }

--- a/components/public-api-server/pkg/oidc/service_test.go
+++ b/components/public-api-server/pkg/oidc/service_test.go
@@ -120,13 +120,13 @@ func TestGetClientConfigFromCallbackRequest(t *testing.T) {
 		OAuth2Config:   &oauth2.Config{},
 	})
 
-	state, err := encodeStateParam(StateParam{
+	state, err := service.encodeStateParam(StateParam{
 		ClientConfigID: configID,
 		ReturnToURL:    "",
 	})
 	require.NoError(t, err, "failed encode state param")
 
-	state_unknown, err := encodeStateParam(StateParam{
+	state_unknown, err := service.encodeStateParam(StateParam{
 		ClientConfigID: "UNKNOWN",
 		ReturnToURL:    "",
 	})
@@ -209,10 +209,12 @@ func setupOIDCServiceForTests(t *testing.T) (*Service, *gorm.DB) {
 
 	dbConn := dbtest.ConnectForTests(t)
 	cipher := dbtest.CipherSet(t)
+	stateJWT := newTestStateJWT([]byte("ANY KEY"), 5*time.Minute)
 
 	sessionServerAddress := newFakeSessionServer(t)
 
-	service := newTestService(sessionServerAddress, dbConn, cipher)
+	service := NewService(sessionServerAddress, dbConn, cipher, stateJWT)
+	service.skipVerifyIdToken = true
 	return service, dbConn
 }
 

--- a/components/public-api-server/pkg/oidc/state_jwt.go
+++ b/components/public-api-server/pkg/oidc/state_jwt.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package oidc
+
+import (
+	"time"
+
+	"github.com/golang-jwt/jwt/v4"
+)
+
+type StateJWT struct {
+	key       []byte
+	expiresIn time.Duration
+}
+
+func NewStateJWT(key []byte) *StateJWT {
+	return &StateJWT{
+		key:       key,
+		expiresIn: 5 * time.Minute,
+	}
+}
+
+func newTestStateJWT(key []byte, expiresIn time.Duration) *StateJWT {
+	thing := NewStateJWT(key)
+	thing.expiresIn = expiresIn
+	return thing
+}
+
+type StateClaims struct {
+	// Internal client ID
+	ClientConfigID string `json:"clientId"`
+	ReturnToURL    string `json:"returnTo"`
+
+	jwt.RegisteredClaims
+}
+
+func (s *StateJWT) Encode(claims StateClaims) (string, error) {
+
+	expirationTime := time.Now().Add(s.expiresIn)
+	claims.ExpiresAt = jwt.NewNumericDate(expirationTime)
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	encodedToken, err := token.SignedString(s.key)
+
+	return encodedToken, err
+}
+
+func (s *StateJWT) Decode(tokenString string) (*StateClaims, error) {
+	claims := &StateClaims{}
+	_, err := jwt.ParseWithClaims(
+		tokenString,
+		claims,
+		func(token *jwt.Token) (interface{}, error) {
+			return []byte(s.key), nil
+		},
+	)
+
+	return claims, err
+}

--- a/components/public-api-server/pkg/oidc/state_jwt_test.go
+++ b/components/public-api-server/pkg/oidc/state_jwt_test.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package oidc
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Encode(t *testing.T) {
+	stateJWT := NewStateJWT([]byte("ANY KEY"))
+	encodedState, err := stateJWT.Encode(StateClaims{
+		ClientConfigID: "test-id",
+		ReturnToURL:    "test-url",
+	})
+	require.NoError(t, err)
+	// check for header: { "alg": "HS256", "typ": "JWT" }
+	require.Contains(t, encodedState, "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.", "")
+}
+
+func Test_Decode(t *testing.T) {
+
+	testCases := []struct {
+		Label         string
+		Key4Encode    string
+		expiresIn     time.Duration
+		Key4Decode    string
+		ExpectedError string
+	}{
+		{
+			Label:         "happy path",
+			Key4Encode:    "ANY KEY",
+			expiresIn:     5 * time.Minute,
+			Key4Decode:    "ANY KEY",
+			ExpectedError: "",
+		},
+		{
+			Label:         "expired state token",
+			Key4Encode:    "ANY KEY",
+			expiresIn:     0 * time.Second,
+			Key4Decode:    "ANY KEY",
+			ExpectedError: "token is expired",
+		},
+		{
+			Label:         "signature is invalid",
+			Key4Encode:    "OTHER KEY",
+			expiresIn:     5 * time.Minute,
+			Key4Decode:    "ANY KEY",
+			ExpectedError: jwt.ErrSignatureInvalid.Error(),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Label, func(t *testing.T) {
+			encoder := newTestStateJWT([]byte(tc.Key4Encode), tc.expiresIn)
+			decoder := NewStateJWT([]byte(tc.Key4Decode))
+			encodedState, err := encoder.Encode(StateClaims{
+				ClientConfigID: "test-id",
+				ReturnToURL:    "test-url",
+			})
+			if err != nil && tc.ExpectedError == "" {
+				require.FailNowf(t, "Unexpected error on `Encode`.", "Error: %", err)
+			}
+			_, err = decoder.Decode(encodedState)
+			if err != nil && tc.ExpectedError == "" {
+				require.FailNowf(t, "Unexpected error on `Decode`.", "Error: %", err)
+			}
+			if err != nil && !strings.Contains(err.Error(), tc.ExpectedError) {
+				require.FailNowf(t, "Unmatched error.", "Got error: %", err.Error())
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
After this PR is merged, the state param of the OIDC/OAuth2 gets signed and verified. Validating of integrity is crucial, as this piece of information contains the ID of the OIDC client to continue with when Gitpod receives the callback from a 3rd party. Tests should show that expiration time is checked and signature validation is effective.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of #15956

## How to test
See [internal post](https://gitpod.slack.com/archives/C02EN94AEPL/p1674209948602029?thread_ts=1674207266.608869&cid=C02EN94AEPL) for test credentials. 
1. Create new Org
2. Create new SSO client under settings
3. Select `Login` from actions menu (three dot button) 
4. Copy the full URL (starting with `https://accounts.google.com/o/oauth2/v2/auth/oauthchooseaccount?`) from browser's location bar.
5. Now, first see a working login into your `@gitpod.io` account if you proceed.
6. Take the URL from step 4.), find the `state` query param, alter the last segment (they are separated by `.`), then paste it into a new tab. You should see `client config not found`. The logs will contain the `bad state param` as reason. 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
