### PR TITLE
[ws-manager-mk2] Controller env tests

### DIFF
--- a/components/ws-manager-mk2/controllers/suite_test.go
+++ b/components/ws-manager-mk2/controllers/suite_test.go
@@ -99,6 +99,8 @@ var _ = BeforeSuite(func() {
 				Name: "default",
 			},
 		},
+		WorkspaceURLTemplate: "{{ .ID }}-{{ .Prefix }}-{{ .Host }}",
+		GitpodHostURL:        "gitpod.io",
 	}, metrics.Registry)
 
 	Expect(err).ToNot(HaveOccurred())

--- a/components/ws-manager-mk2/controllers/workspace_controller.go
+++ b/components/ws-manager-mk2/controllers/workspace_controller.go
@@ -6,6 +6,7 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -14,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	wsk8s "github.com/gitpod-io/gitpod/common-go/kubernetes"
@@ -205,24 +207,14 @@ func (r *WorkspaceReconciler) actOnStatus(ctx context.Context, workspace *worksp
 
 	// we've disposed already - try to remove the finalizer and call it a day
 	case workspace.Status.Phase == workspacev1.WorkspacePhaseStopped:
-		var foundFinalizer bool
-		n := 0
-		for _, x := range pod.Finalizers {
-			if x != gitpodPodFinalizerName {
-				pod.Finalizers[n] = x
-				n++
-			} else {
-				foundFinalizer = true
-			}
-		}
-		pod.Finalizers = pod.Finalizers[:n]
-		err := r.Client.Update(ctx, pod)
-		if err != nil {
-			return ctrl.Result{Requeue: true}, err
+		hadFinalizer := controllerutil.ContainsFinalizer(pod, gitpodPodFinalizerName)
+		controllerutil.RemoveFinalizer(pod, gitpodPodFinalizerName)
+		if err := r.Client.Update(ctx, pod); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to remove gitpod finalizer: %w", err)
 		}
 
-		if foundFinalizer {
-			// reque to remove workspace
+		if hadFinalizer {
+			// Requeue to remove workspace.
 			return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 		}
 	}

--- a/components/ws-manager-mk2/controllers/workspace_controller_test.go
+++ b/components/ws-manager-mk2/controllers/workspace_controller_test.go
@@ -5,16 +5,19 @@
 package controllers
 
 import (
-	"context"
 	"fmt"
 	"time"
 
 	"github.com/aws/smithy-go/ptr"
+	wsk8s "github.com/gitpod-io/gitpod/common-go/kubernetes"
 	csapi "github.com/gitpod-io/gitpod/content-service/api"
 	workspacev1 "github.com/gitpod-io/gitpod/ws-manager/api/crd/v1"
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"google.golang.org/protobuf/proto"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	// . "github.com/onsi/ginkgo/extensions/table"
 
@@ -24,110 +27,375 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
+const (
+	timeout  = time.Second * 20
+	duration = time.Second * 2
+	interval = time.Millisecond * 250
+)
+
 var _ = Describe("WorkspaceController", func() {
-	Context("When starting workspaces", func() {
-		It("Should create Pods", func() {
-			const (
-				WorkspaceName      = "test-workspace"
-				WorkspaceNamespace = "default"
+	Context("with regular workspaces", func() {
+		It("should handle successful workspace creation and stop request", func() {
+			ws := newWorkspace(uuid.NewString(), "default")
+			pod := createWorkspaceExpectPod(ws)
 
-				timeout  = time.Second * 10
-				duration = time.Second * 2
-				interval = time.Millisecond * 250
-			)
+			Expect(controllerutil.ContainsFinalizer(pod, gitpodPodFinalizerName)).To(BeTrue())
 
-			By("creating a status")
-
-			ctx := context.Background()
-			initializer := &csapi.WorkspaceInitializer{
-				Spec: &csapi.WorkspaceInitializer_Empty{Empty: &csapi.EmptyInitializer{}},
-			}
-			initializerBytes, err := proto.Marshal(initializer)
-			Expect(err).ToNot(HaveOccurred())
-
-			workspace := &workspacev1.Workspace{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: "workspace.gitpod.io/v1",
-					Kind:       "Workspace",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      WorkspaceName,
-					Namespace: WorkspaceNamespace,
-				},
-				Spec: workspacev1.WorkspaceSpec{
-					Ownership: workspacev1.Ownership{
-						Owner:       "foobar",
-						WorkspaceID: "cool-workspace",
-					},
-					Type:  workspacev1.WorkspaceTypeRegular,
-					Class: "default",
-					Image: workspacev1.WorkspaceImages{
-						Workspace: workspacev1.WorkspaceImage{
-							Ref: ptr.String("alpine:latest"),
-						},
-						IDE: workspacev1.IDEImages{
-							Refs: []string{},
-						},
-					},
-					Ports:       []workspacev1.PortSpec{},
-					Initializer: initializerBytes,
-					Admission: workspacev1.AdmissionSpec{
-						Level: workspacev1.AdmissionLevelEveryone,
-					},
-				},
-			}
-			Expect(k8sClient.Create(ctx, workspace)).Should(Succeed())
-
-			By("creating a pod")
-			podLookupKey := types.NamespacedName{Name: "ws-" + WorkspaceName, Namespace: WorkspaceNamespace}
-			createdPod := &corev1.Pod{}
-
-			// We'll need to retry getting this newly created CronJob, given that creation may not immediately happen.
-			Eventually(func() bool {
-				err := k8sClient.Get(ctx, podLookupKey, createdPod)
-				return err == nil
-			}, timeout, interval).Should(BeTrue())
-
-			By("updating the pod starts value")
-			createdWS := &workspacev1.Workspace{}
+			By("controller updating the pod starts value")
 			Eventually(func() (int, error) {
-				err := k8sClient.Get(ctx, types.NamespacedName{Name: WorkspaceName, Namespace: WorkspaceNamespace}, createdWS)
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: ws.Name, Namespace: ws.Namespace}, ws)
 				if err != nil {
 					return 0, err
 				}
-
-				return createdWS.Status.PodStarts, nil
+				return ws.Status.PodStarts, nil
 			}, timeout, interval).Should(Equal(1))
 
-			By("Creating the pod only once")
-			// TODO(cw): remove this hell of a hack once we're on PVC and no longer need to rely on concurrent init processes.
-			// Here we assume that the controller will have deleted the pod because it failed,
-			// and we removed the finalizer.
-			createdPod.Finalizers = []string{}
-			Expect(k8sClient.Update(ctx, createdPod)).To(Succeed())
-			Expect(k8sClient.Delete(ctx, createdPod)).To(Succeed())
-			Eventually(func() bool {
-				err := k8sClient.Get(ctx, podLookupKey, createdPod)
-				if err != nil && errors.IsNotFound(err) {
-					// We have an error and assume we did not find the pod. This is what we want.
-					return true
+			// Deployed condition should be added.
+			expectConditionEventually(ws, string(workspacev1.WorkspaceConditionDeployed), string(metav1.ConditionTrue), "")
+
+			// Runtime status should be set.
+			expectRuntimeStatus(ws, pod)
+
+			By("controller setting status after creation")
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: ws.Name, Namespace: ws.Namespace}, ws)).To(Succeed())
+				g.Expect(ws.Status.OwnerToken).ToNot(BeEmpty())
+				g.Expect(ws.Status.URL).ToNot(BeEmpty())
+				g.Expect(ws.Status.Headless).To(BeFalse())
+			}, timeout, interval).Should(Succeed())
+
+			// TODO(wv): Once implemented, expect EverReady condition.
+
+			requestStop(ws)
+
+			expectFinalizerAndMarkBackupCompleted(ws, pod)
+
+			expectWorkspaceCleanup(ws, pod)
+
+			By("checking pod doesn't get recreated by controller")
+			Consistently(func() error {
+				return checkNotFound(pod)
+			}, duration, interval).Should(Succeed(), "pod came back")
+		})
+
+		It("should handle content init failure", func() {
+			ws := newWorkspace(uuid.NewString(), "default")
+			pod := createWorkspaceExpectPod(ws)
+
+			By("adding ws init failure condition")
+			updateObjWithRetries(ws, true, func(ws *workspacev1.Workspace) {
+				ws.Status.Conditions = wsk8s.AddUniqueCondition(ws.Status.Conditions, metav1.Condition{
+					Type:               string(workspacev1.WorkspaceConditionContentReady),
+					Status:             metav1.ConditionFalse,
+					Message:            "some failure",
+					Reason:             "InitializationFailure",
+					LastTransitionTime: metav1.Now(),
+				})
+			})
+
+			// On init failure, expect workspace cleans up without a backup.
+			expectWorkspaceCleanup(ws, pod)
+		})
+
+		It("should handle backup failure", func() {
+			ws := newWorkspace(uuid.NewString(), "default")
+			pod := createWorkspaceExpectPod(ws)
+
+			// Stop the workspace.
+			requestStop(ws)
+
+			// Indicate the backup failed.
+			expectFinalizerAndMarkBackupFailed(ws, pod)
+
+			// Workspace should get cleaned up.
+			expectWorkspaceCleanup(ws, pod)
+		})
+
+		It("should handle workspace failure", func() {
+			ws := newWorkspace(uuid.NewString(), "default")
+			pod := createWorkspaceExpectPod(ws)
+
+			// Update Pod with failed exit status.
+			updateObjWithRetries(pod, true, func(pod *corev1.Pod) {
+				pod.Status.ContainerStatuses = append(pod.Status.ContainerStatuses, corev1.ContainerStatus{
+					LastTerminationState: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{
+							ExitCode: 1,
+							Message:  "Error",
+						},
+					},
+				})
+			})
+
+			// Controller should detect container exit and add Failed condition.
+			expectConditionEventually(ws, string(workspacev1.WorkspaceConditionFailed), string(metav1.ConditionTrue), "")
+
+			expectFinalizerAndMarkBackupCompleted(ws, pod)
+
+			expectWorkspaceCleanup(ws, pod)
+		})
+	})
+
+	Context("with headless workspaces", func() {
+		var (
+			ws  *workspacev1.Workspace
+			pod *corev1.Pod
+		)
+		BeforeEach(func() {
+			Skip("TODO(wv): Enable once headless workspaces are implemented")
+			// TODO(wv): Test both image builds and prebuilds.
+			// TODO(wv): Test prebuild archive gets saved.
+
+			ws = newWorkspace(uuid.NewString(), "default")
+			ws.Spec.Type = workspacev1.WorkspaceTypePrebuild
+			pod = createWorkspaceExpectPod(ws)
+
+			// Expect headless status to be reported.
+			Eventually(func() (bool, error) {
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: ws.Name, Namespace: ws.Namespace}, ws)
+				if err != nil {
+					return false, err
 				}
+				return ws.Status.Headless, nil
+			}, timeout, interval).Should(BeTrue())
 
-				fmt.Println(createdPod.ResourceVersion)
-				return false
-			}, timeout, interval).Should(BeTrue(), "pod did not go away")
+			// Expect runtime status also gets reported for headless workspaces.
+			expectRuntimeStatus(ws, pod)
+		})
 
-			// Now we make sure the pod doesn't come back
-			Consistently(func() bool {
-				err := k8sClient.Get(ctx, podLookupKey, createdPod)
-				if err != nil && errors.IsNotFound(err) {
-					// We have an error and assume we did not find the pod. This is what we want.
-					return true
-				}
+		It("should cleanup on successful exit", func() {
+			// Manually update pod phase & delete pod to simulate pod exiting successfully.
+			updateObjWithRetries(pod, true, func(p *corev1.Pod) {
+				p.Status.Phase = corev1.PodSucceeded
+			})
+			Expect(k8sClient.Delete(ctx, pod)).To(Succeed())
 
-				fmt.Println(createdPod.ResourceVersion)
-				return false
-			}, duration, interval).Should(BeTrue(), "pod came back")
+			// No backup for headless workspace.
+			expectWorkspaceCleanup(ws, pod)
+		})
+
+		It("should cleanup on failed exit", func() {
+			// Manually update pod phase & delete pod to simulate pod exiting with failure.
+			updateObjWithRetries(pod, true, func(p *corev1.Pod) {
+				p.Status.Phase = corev1.PodFailed
+			})
+			Expect(k8sClient.Delete(ctx, pod)).To(Succeed())
+
+			// No backup for headless workspace.
+			expectWorkspaceCleanup(ws, pod)
 		})
 	})
 })
+
+func updateObjWithRetries[O client.Object](obj O, updateStatus bool, update func(obj O)) {
+	Eventually(func() error {
+		var err error
+		if err = k8sClient.Get(ctx, types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}, obj); err != nil {
+			return err
+		}
+		// Apply update.
+		update(obj)
+		if updateStatus {
+			err = k8sClient.Status().Update(ctx, obj)
+		} else {
+			err = k8sClient.Update(ctx, obj)
+		}
+		return err
+	}, timeout, interval).Should(Succeed())
+}
+
+// createWorkspaceExpectPod creates the workspace resource, and expects
+// the controller to eventually create the workspace Pod. The created Pod
+// is returned.
+func createWorkspaceExpectPod(ws *workspacev1.Workspace) *corev1.Pod {
+	By("creating workspace")
+	Expect(k8sClient.Create(ctx, ws)).To(Succeed())
+
+	By("controller creating workspace pod")
+	pod := &corev1.Pod{}
+	var podPrefix string
+	switch ws.Spec.Type {
+	case workspacev1.WorkspaceTypeRegular:
+		podPrefix = "ws"
+	case workspacev1.WorkspaceTypePrebuild:
+		podPrefix = "prebuild"
+	case workspacev1.WorkspaceTypeImageBuild:
+		podPrefix = "imagebuild"
+	}
+	Eventually(func() error {
+		return k8sClient.Get(ctx, types.NamespacedName{Name: fmt.Sprintf("%s-%s", podPrefix, ws.Name), Namespace: ws.Namespace}, pod)
+	}, timeout, interval).Should(Succeed())
+	return pod
+}
+
+func expectConditionEventually(ws *workspacev1.Workspace, tpe string, status string, reason string) {
+	By(fmt.Sprintf("controller setting workspace condition %s to %s", tpe, status))
+	Eventually(func(g Gomega) {
+		g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: ws.Name, Namespace: ws.Namespace}, ws)).To(Succeed())
+		c := wsk8s.GetCondition(ws.Status.Conditions, tpe)
+		g.Expect(c).ToNot(BeNil())
+		g.Expect(c.Status).To(Equal(metav1.ConditionStatus(status)))
+		if reason != "" {
+			g.Expect(c.Reason).To(Equal(reason))
+		}
+	}, timeout, interval).Should(Succeed())
+}
+
+func expectRuntimeStatus(ws *workspacev1.Workspace, pod *corev1.Pod) {
+	By("artificially setting the pod's status")
+	// Since there are no Pod controllers running in the EnvTest cluster to populate the Pod status,
+	// we artificially update the created Pod's status here, and verify later that the workspace
+	// controller reconciles this and puts it in the workspace status.
+	var (
+		hostIP = "1.2.3.4"
+		podIP  = "10.0.0.0"
+	)
+	updateObjWithRetries(pod, true, func(p *corev1.Pod) {
+		p.Status.HostIP = hostIP
+		p.Status.PodIP = podIP
+	})
+
+	By("controller adding pod status to the workspace status")
+	Eventually(func(g Gomega) {
+		g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: ws.Name, Namespace: ws.Namespace}, ws)).To(Succeed())
+		g.Expect(ws.Status.Runtime).ToNot(BeNil())
+		g.Expect(ws.Status.Runtime.HostIP).To(Equal(hostIP))
+		g.Expect(ws.Status.Runtime.PodIP).To(Equal(podIP))
+		g.Expect(ws.Status.Runtime.PodName).To(Equal(pod.Name))
+	}, timeout, interval).Should(Succeed())
+}
+
+func requestStop(ws *workspacev1.Workspace) {
+	By("adding stop signal")
+	updateObjWithRetries(ws, true, func(ws *workspacev1.Workspace) {
+		ws.Status.Conditions = wsk8s.AddUniqueCondition(ws.Status.Conditions, metav1.Condition{
+			Type:               string(workspacev1.WorkspaceConditionStoppedByRequest),
+			Status:             metav1.ConditionTrue,
+			LastTransitionTime: metav1.Now(),
+		})
+	})
+}
+
+func expectFinalizerAndMarkBackupCompleted(ws *workspacev1.Workspace, pod *corev1.Pod) {
+	// Checking for the finalizer enforces our expectation that the workspace
+	// should be waiting for a backup to be taken.
+	By("checking finalizer exists for backup")
+	Consistently(func() (bool, error) {
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: pod.GetName(), Namespace: pod.GetNamespace()}, pod); err != nil {
+			return false, err
+		}
+		return controllerutil.ContainsFinalizer(pod, gitpodPodFinalizerName), nil
+	}, duration, interval).Should(BeTrue(), "missing gitpod finalizer on pod, expected one to wait for backup to succeed")
+
+	By("signalling backup completed")
+	updateObjWithRetries(ws, true, func(ws *workspacev1.Workspace) {
+		ws.Status.Conditions = wsk8s.AddUniqueCondition(ws.Status.Conditions, metav1.Condition{
+			Type:               string(workspacev1.WorkspaceConditionBackupComplete),
+			Status:             metav1.ConditionTrue,
+			Reason:             "BackupComplete",
+			LastTransitionTime: metav1.Now(),
+		})
+	})
+}
+
+func expectFinalizerAndMarkBackupFailed(ws *workspacev1.Workspace, pod *corev1.Pod) {
+	// Checking for the finalizer enforces our expectation that the workspace
+	// should be waiting for a backup to be taken (or fail).
+	By("checking finalizer exists for backup")
+	Consistently(func() (bool, error) {
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: pod.GetName(), Namespace: pod.GetNamespace()}, pod); err != nil {
+			return false, err
+		}
+		return controllerutil.ContainsFinalizer(pod, gitpodPodFinalizerName), nil
+	}, duration, interval).Should(BeTrue(), "missing gitpod finalizer on pod, expected one to wait for backup to succeed")
+
+	By("signalling backup completed")
+	updateObjWithRetries(ws, true, func(ws *workspacev1.Workspace) {
+		ws.Status.Conditions = wsk8s.AddUniqueCondition(ws.Status.Conditions, metav1.Condition{
+			Type:               string(workspacev1.WorkspaceConditionBackupFailure),
+			Status:             metav1.ConditionTrue,
+			Reason:             "BackupFailed",
+			LastTransitionTime: metav1.Now(),
+		})
+	})
+}
+
+func expectWorkspaceCleanup(ws *workspacev1.Workspace, pod *corev1.Pod) {
+	By("controller removing pod finalizers")
+	Eventually(func() (int, error) {
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: pod.GetName(), Namespace: pod.GetNamespace()}, pod); err != nil {
+			if errors.IsNotFound(err) {
+				// Pod got deleted, because finalizers got removed.
+				return 0, nil
+			}
+			return 0, err
+		}
+		return len(pod.ObjectMeta.Finalizers), nil
+
+	}, timeout, interval).Should(Equal(0), "pod finalizers did not go away")
+
+	By("cleaning up the workspace pod")
+	Eventually(func() error {
+		return checkNotFound(pod)
+	}, timeout, interval).Should(Succeed(), "pod did not go away")
+
+	By("cleaning up the workspace resource")
+	Eventually(func() error {
+		return checkNotFound(ws)
+	}, timeout, interval).Should(Succeed(), "workspace did not go away")
+}
+
+// checkNotFound returns nil if the object does not exist.
+// Otherwise, it returns an error.
+func checkNotFound(obj client.Object) error {
+	err := k8sClient.Get(ctx, types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}, obj)
+	if err == nil {
+		// Object exists, return as an error.
+		return fmt.Errorf("object exists")
+	}
+	if errors.IsNotFound(err) {
+		// Object doesn't exist, this is what we want.
+		return nil
+	}
+	return err
+}
+
+func newWorkspace(name, namespace string) *workspacev1.Workspace {
+	initializer := &csapi.WorkspaceInitializer{
+		Spec: &csapi.WorkspaceInitializer_Empty{Empty: &csapi.EmptyInitializer{}},
+	}
+	initializerBytes, err := proto.Marshal(initializer)
+	Expect(err).ToNot(HaveOccurred())
+
+	return &workspacev1.Workspace{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "workspace.gitpod.io/v1",
+			Kind:       "Workspace",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: workspacev1.WorkspaceSpec{
+			Ownership: workspacev1.Ownership{
+				Owner:       "foobar",
+				WorkspaceID: "cool-workspace",
+			},
+			Type:  workspacev1.WorkspaceTypeRegular,
+			Class: "default",
+			Image: workspacev1.WorkspaceImages{
+				Workspace: workspacev1.WorkspaceImage{
+					Ref: ptr.String("alpine:latest"),
+				},
+				IDE: workspacev1.IDEImages{
+					Refs: []string{},
+				},
+			},
+			Ports:       []workspacev1.PortSpec{},
+			Initializer: initializerBytes,
+			Admission: workspacev1.AdmissionSpec{
+				Level: workspacev1.AdmissionLevelEveryone,
+			},
+		},
+	}
+}

--- a/components/ws-manager-mk2/ws-manager-mk2.code-workspace
+++ b/components/ws-manager-mk2/ws-manager-mk2.code-workspace
@@ -1,6 +1,7 @@
 {
     "folders": [
        { "path": "../common-go" },
+       { "path": "../ws-daemon" },
        { "path": "../ws-manager" },
        { "path": "../ws-manager-api" },
        { "path": "../ws-manager-mk2" },


### PR DESCRIPTION
## Description
Create/update tests for the workspace controller, using the EnvTest suite.

Also contains some cleanup using e.g. `controllerutil` to manage finalizers.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Relates to #11416

## How to test
<!-- Provide steps to test this PR -->

```
cd components/ws-manager-mk2
go test ./...
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
