### PR TITLE
Schedule mk2 managed workspaces on separate node pools

### DIFF
--- a/components/registry-facade-api/go/config/config.go
+++ b/components/registry-facade-api/go/config/config.go
@@ -64,7 +64,7 @@ type Config struct {
 	Port               int              `json:"port"`
 	Prefix             string           `json:"prefix"`
 	StaticLayer        []StaticLayerCfg `json:"staticLayer"`
-	RemoteSpecProvider *RSProvider      `json:"remoteSpecProvider,omitempty"`
+	RemoteSpecProvider []*RSProvider    `json:"remoteSpecProvider,omitempty"`
 	FixedSpecProvider  string           `json:"fixedSpecFN,omitempty"`
 	Store              string           `json:"store"`
 	RequireAuth        bool             `json:"requireAuth"`

--- a/components/ws-manager-mk2/controllers/create.go
+++ b/components/ws-manager-mk2/controllers/create.go
@@ -385,6 +385,10 @@ func createDefiniteWorkspacePod(sctx *startWorkspaceContext) (*corev1.Pod, error
 								Key:      "gitpod.io/registry-facade_ready_ns_" + sctx.Config.Namespace,
 								Operator: corev1.NodeSelectorOpExists,
 							},
+							{
+								Key:      "gitpod.io/experimental",
+								Operator: corev1.NodeSelectorOpExists,
+							},
 						},
 					},
 				},

--- a/components/ws-manager/pkg/manager/create.go
+++ b/components/ws-manager/pkg/manager/create.go
@@ -511,6 +511,10 @@ func (m *Manager) createDefiniteWorkspacePod(startContext *startWorkspaceContext
 								Key:      "gitpod.io/registry-facade_ready_ns_" + m.Config.Namespace,
 								Operator: corev1.NodeSelectorOpExists,
 							},
+							{
+								Key:      "gitpod.io/experimental",
+								Operator: corev1.NodeSelectorOpDoesNotExist,
+							},
 						},
 					},
 				},

--- a/components/ws-manager/pkg/manager/testdata/cdwp_admission.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_admission.golden
@@ -247,6 +247,10 @@
                                     {
                                         "key": "gitpod.io/registry-facade_ready_ns_default",
                                         "operator": "Exists"
+                                    },
+                                    {
+                                        "key": "gitpod.io/experimental",
+                                        "operator": "DoesNotExist"
                                     }
                                 ]
                             }

--- a/components/ws-manager/pkg/manager/testdata/cdwp_affinity.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_affinity.golden
@@ -234,6 +234,10 @@
                                     {
                                         "key": "gitpod.io/registry-facade_ready_ns_default",
                                         "operator": "Exists"
+                                    },
+                                    {
+                                        "key": "gitpod.io/experimental",
+                                        "operator": "DoesNotExist"
                                     }
                                 ]
                             }

--- a/components/ws-manager/pkg/manager/testdata/cdwp_class.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_class.golden
@@ -256,6 +256,10 @@
                                         "operator": "Exists"
                                     },
                                     {
+                                        "key": "gitpod.io/experimental",
+                                        "operator": "DoesNotExist"
+                                    },
+                                    {
                                         "key": "gitpod.io/workspaceClass",
                                         "operator": "In",
                                         "values": [

--- a/components/ws-manager/pkg/manager/testdata/cdwp_class_notfound.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_class_notfound.golden
@@ -238,6 +238,10 @@
                                     {
                                         "key": "gitpod.io/registry-facade_ready_ns_default",
                                         "operator": "Exists"
+                                    },
+                                    {
+                                        "key": "gitpod.io/experimental",
+                                        "operator": "DoesNotExist"
                                     }
                                 ]
                             }

--- a/components/ws-manager/pkg/manager/testdata/cdwp_customcerts.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_customcerts.golden
@@ -256,6 +256,10 @@
                                     {
                                         "key": "gitpod.io/registry-facade_ready_ns_default",
                                         "operator": "Exists"
+                                    },
+                                    {
+                                        "key": "gitpod.io/experimental",
+                                        "operator": "DoesNotExist"
                                     }
                                 ]
                             }

--- a/components/ws-manager/pkg/manager/testdata/cdwp_debug_workspace_pod.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_debug_workspace_pod.golden
@@ -235,6 +235,10 @@
                                     {
                                         "key": "gitpod.io/registry-facade_ready_ns_default",
                                         "operator": "Exists"
+                                    },
+                                    {
+                                        "key": "gitpod.io/experimental",
+                                        "operator": "DoesNotExist"
                                     }
                                 ]
                             }

--- a/components/ws-manager/pkg/manager/testdata/cdwp_empty_resource_req.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_empty_resource_req.golden
@@ -240,6 +240,10 @@
                                     {
                                         "key": "gitpod.io/registry-facade_ready_ns_default",
                                         "operator": "Exists"
+                                    },
+                                    {
+                                        "key": "gitpod.io/experimental",
+                                        "operator": "DoesNotExist"
                                     }
                                 ]
                             }

--- a/components/ws-manager/pkg/manager/testdata/cdwp_envvars.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_envvars.golden
@@ -280,6 +280,10 @@
                                     {
                                         "key": "gitpod.io/registry-facade_ready_ns_default",
                                         "operator": "Exists"
+                                    },
+                                    {
+                                        "key": "gitpod.io/experimental",
+                                        "operator": "DoesNotExist"
                                     }
                                 ]
                             }

--- a/components/ws-manager/pkg/manager/testdata/cdwp_fullworkspacebackup.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_fullworkspacebackup.golden
@@ -232,6 +232,10 @@
                                     {
                                         "key": "gitpod.io/registry-facade_ready_ns_default",
                                         "operator": "Exists"
+                                    },
+                                    {
+                                        "key": "gitpod.io/experimental",
+                                        "operator": "DoesNotExist"
                                     }
                                 ]
                             }

--- a/components/ws-manager/pkg/manager/testdata/cdwp_imagebuild.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_imagebuild.golden
@@ -265,6 +265,10 @@
                                     {
                                         "key": "gitpod.io/registry-facade_ready_ns_default",
                                         "operator": "Exists"
+                                    },
+                                    {
+                                        "key": "gitpod.io/experimental",
+                                        "operator": "DoesNotExist"
                                     }
                                 ]
                             }

--- a/components/ws-manager/pkg/manager/testdata/cdwp_imagebuild_template.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_imagebuild_template.golden
@@ -265,6 +265,10 @@
                                     {
                                         "key": "gitpod.io/registry-facade_ready_ns_default",
                                         "operator": "Exists"
+                                    },
+                                    {
+                                        "key": "gitpod.io/experimental",
+                                        "operator": "DoesNotExist"
                                     }
                                 ]
                             }

--- a/components/ws-manager/pkg/manager/testdata/cdwp_no_ideimage.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_no_ideimage.golden
@@ -237,6 +237,10 @@
                                     {
                                         "key": "gitpod.io/registry-facade_ready_ns_default",
                                         "operator": "Exists"
+                                    },
+                                    {
+                                        "key": "gitpod.io/experimental",
+                                        "operator": "DoesNotExist"
                                     }
                                 ]
                             }

--- a/components/ws-manager/pkg/manager/testdata/cdwp_prebuild.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_prebuild.golden
@@ -247,6 +247,10 @@
                                     {
                                         "key": "gitpod.io/registry-facade_ready_ns_default",
                                         "operator": "Exists"
+                                    },
+                                    {
+                                        "key": "gitpod.io/experimental",
+                                        "operator": "DoesNotExist"
                                     }
                                 ]
                             }

--- a/components/ws-manager/pkg/manager/testdata/cdwp_prebuild_template.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_prebuild_template.golden
@@ -247,6 +247,10 @@
                                     {
                                         "key": "gitpod.io/registry-facade_ready_ns_default",
                                         "operator": "Exists"
+                                    },
+                                    {
+                                        "key": "gitpod.io/experimental",
+                                        "operator": "DoesNotExist"
                                     }
                                 ]
                             }

--- a/components/ws-manager/pkg/manager/testdata/cdwp_prebuild_template_override_resources.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_prebuild_template_override_resources.golden
@@ -247,6 +247,10 @@
                                     {
                                         "key": "gitpod.io/registry-facade_ready_ns_default",
                                         "operator": "Exists"
+                                    },
+                                    {
+                                        "key": "gitpod.io/experimental",
+                                        "operator": "DoesNotExist"
                                     }
                                 ]
                             }

--- a/components/ws-manager/pkg/manager/testdata/cdwp_readinessprobe.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_readinessprobe.golden
@@ -243,6 +243,10 @@
                                     {
                                         "key": "gitpod.io/registry-facade_ready_ns_default",
                                         "operator": "Exists"
+                                    },
+                                    {
+                                        "key": "gitpod.io/experimental",
+                                        "operator": "DoesNotExist"
                                     }
                                 ]
                             }

--- a/components/ws-manager/pkg/manager/testdata/cdwp_secrets.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_secrets.golden
@@ -252,6 +252,10 @@
                                     {
                                         "key": "gitpod.io/registry-facade_ready_ns_default",
                                         "operator": "Exists"
+                                    },
+                                    {
+                                        "key": "gitpod.io/experimental",
+                                        "operator": "DoesNotExist"
                                     }
                                 ]
                             }

--- a/components/ws-manager/pkg/manager/testdata/cdwp_sshkeys.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_sshkeys.golden
@@ -244,6 +244,10 @@
                                     {
                                         "key": "gitpod.io/registry-facade_ready_ns_default",
                                         "operator": "Exists"
+                                    },
+                                    {
+                                        "key": "gitpod.io/experimental",
+                                        "operator": "DoesNotExist"
                                     }
                                 ]
                             }

--- a/components/ws-manager/pkg/manager/testdata/cdwp_sys_envvars.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_sys_envvars.golden
@@ -284,6 +284,10 @@
                                     {
                                         "key": "gitpod.io/registry-facade_ready_ns_default",
                                         "operator": "Exists"
+                                    },
+                                    {
+                                        "key": "gitpod.io/experimental",
+                                        "operator": "DoesNotExist"
                                     }
                                 ]
                             }

--- a/components/ws-manager/pkg/manager/testdata/cdwp_tasks.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_tasks.golden
@@ -247,6 +247,10 @@
                                     {
                                         "key": "gitpod.io/registry-facade_ready_ns_default",
                                         "operator": "Exists"
+                                    },
+                                    {
+                                        "key": "gitpod.io/experimental",
+                                        "operator": "DoesNotExist"
                                     }
                                 ]
                             }

--- a/components/ws-manager/pkg/manager/testdata/cdwp_template.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_template.golden
@@ -243,6 +243,10 @@
                                     {
                                         "key": "gitpod.io/registry-facade_ready_ns_default",
                                         "operator": "Exists"
+                                    },
+                                    {
+                                        "key": "gitpod.io/experimental",
+                                        "operator": "DoesNotExist"
                                     }
                                 ]
                             }

--- a/components/ws-manager/pkg/manager/testdata/cdwp_timeout.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_timeout.golden
@@ -248,6 +248,10 @@
                                     {
                                         "key": "gitpod.io/registry-facade_ready_ns_default",
                                         "operator": "Exists"
+                                    },
+                                    {
+                                        "key": "gitpod.io/experimental",
+                                        "operator": "DoesNotExist"
                                     }
                                 ]
                             }

--- a/components/ws-manager/pkg/manager/testdata/cdwp_userns.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_userns.golden
@@ -243,6 +243,10 @@
                                     {
                                         "key": "gitpod.io/registry-facade_ready_ns_default",
                                         "operator": "Exists"
+                                    },
+                                    {
+                                        "key": "gitpod.io/experimental",
+                                        "operator": "DoesNotExist"
                                     }
                                 ]
                             }

--- a/components/ws-manager/pkg/manager/testdata/cdwp_with_ephemeral_storage.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_with_ephemeral_storage.golden
@@ -262,6 +262,10 @@
                                     {
                                         "key": "gitpod.io/registry-facade_ready_ns_default",
                                         "operator": "Exists"
+                                    },
+                                    {
+                                        "key": "gitpod.io/experimental",
+                                        "operator": "DoesNotExist"
                                     }
                                 ]
                             }

--- a/components/ws-manager/pkg/manager/testdata/cdwp_withaffinity_regular.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_withaffinity_regular.golden
@@ -243,6 +243,10 @@
                                     {
                                         "key": "gitpod.io/registry-facade_ready_ns_default",
                                         "operator": "Exists"
+                                    },
+                                    {
+                                        "key": "gitpod.io/experimental",
+                                        "operator": "DoesNotExist"
                                     }
                                 ]
                             }

--- a/components/ws-manager/pkg/manager/testdata/cdwp_withaffinityheadless.golden
+++ b/components/ws-manager/pkg/manager/testdata/cdwp_withaffinityheadless.golden
@@ -265,6 +265,10 @@
                                     {
                                         "key": "gitpod.io/registry-facade_ready_ns_default",
                                         "operator": "Exists"
+                                    },
+                                    {
+                                        "key": "gitpod.io/experimental",
+                                        "operator": "DoesNotExist"
                                     }
                                 ]
                             }

--- a/install/installer/cmd/testdata/render/agent-smith/output.golden
+++ b/install/installer/cmd/testdata/render/agent-smith/output.golden
@@ -5413,14 +5413,16 @@ data:
             "type": "image"
           }
         ],
-        "remoteSpecProvider": {
-          "addr": "dns:///ws-manager:8080",
-          "tls": {
-            "ca": "/ws-manager-client-tls-certs/ca.crt",
-            "crt": "/ws-manager-client-tls-certs/tls.crt",
-            "key": "/ws-manager-client-tls-certs/tls.key"
+        "remoteSpecProvider": [
+          {
+            "addr": "dns:///ws-manager:8080",
+            "tls": {
+              "ca": "/ws-manager-client-tls-certs/ca.crt",
+              "crt": "/ws-manager-client-tls-certs/tls.crt",
+              "key": "/ws-manager-client-tls-certs/tls.key"
+            }
           }
-        },
+        ],
         "store": "/mnt/cache/registry",
         "requireAuth": false,
         "tls": {
@@ -7923,7 +7925,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3e7db160db71491d8d16b0423783bf99a0dc293dc723960c9308756bdde69d3b
+        gitpod.io/checksum_config: 8b550110d60404fddff7b9f58346f214466970ebae7927d14398663a2e58e363
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/aws-setup/output.golden
+++ b/install/installer/cmd/testdata/render/aws-setup/output.golden
@@ -4754,14 +4754,16 @@ data:
             "type": "image"
           }
         ],
-        "remoteSpecProvider": {
-          "addr": "dns:///ws-manager:8080",
-          "tls": {
-            "ca": "/ws-manager-client-tls-certs/ca.crt",
-            "crt": "/ws-manager-client-tls-certs/tls.crt",
-            "key": "/ws-manager-client-tls-certs/tls.key"
+        "remoteSpecProvider": [
+          {
+            "addr": "dns:///ws-manager:8080",
+            "tls": {
+              "ca": "/ws-manager-client-tls-certs/ca.crt",
+              "crt": "/ws-manager-client-tls-certs/tls.crt",
+              "key": "/ws-manager-client-tls-certs/tls.key"
+            }
           }
-        },
+        ],
         "store": "/mnt/cache/registry",
         "requireAuth": false,
         "tls": {
@@ -7091,7 +7093,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 627e2d5a5d50e8eb2531bd494ceb9cd26315e43008248fb6825dfc2b5189a3d3
+        gitpod.io/checksum_config: b8db96b6f1363f6138d2804e360bcaad1c0badbe9a1ddf3efa81dc4fa1912643
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
+++ b/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
@@ -5230,14 +5230,16 @@ data:
             "type": "image"
           }
         ],
-        "remoteSpecProvider": {
-          "addr": "dns:///ws-manager:8080",
-          "tls": {
-            "ca": "/ws-manager-client-tls-certs/ca.crt",
-            "crt": "/ws-manager-client-tls-certs/tls.crt",
-            "key": "/ws-manager-client-tls-certs/tls.key"
+        "remoteSpecProvider": [
+          {
+            "addr": "dns:///ws-manager:8080",
+            "tls": {
+              "ca": "/ws-manager-client-tls-certs/ca.crt",
+              "crt": "/ws-manager-client-tls-certs/tls.crt",
+              "key": "/ws-manager-client-tls-certs/tls.key"
+            }
           }
-        },
+        ],
         "store": "/mnt/cache/registry",
         "requireAuth": false,
         "tls": {
@@ -7740,7 +7742,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: c89ca2c9729c189ef1739d1bfc113c8c52bc46f8155c4a9b195ccd4de910a23b
+        gitpod.io/checksum_config: ee0807f7ff85ffd1b86248b9fd88374a55921b62310110936095144377436d3a
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -5817,14 +5817,16 @@ data:
             "type": "image"
           }
         ],
-        "remoteSpecProvider": {
-          "addr": "dns:///ws-manager:8080",
-          "tls": {
-            "ca": "/ws-manager-client-tls-certs/ca.crt",
-            "crt": "/ws-manager-client-tls-certs/tls.crt",
-            "key": "/ws-manager-client-tls-certs/tls.key"
+        "remoteSpecProvider": [
+          {
+            "addr": "dns:///ws-manager:8080",
+            "tls": {
+              "ca": "/ws-manager-client-tls-certs/ca.crt",
+              "crt": "/ws-manager-client-tls-certs/tls.crt",
+              "key": "/ws-manager-client-tls-certs/tls.key"
+            }
           }
-        },
+        ],
         "store": "/mnt/cache/registry",
         "requireAuth": false,
         "tls": {
@@ -8459,7 +8461,7 @@ spec:
     metadata:
       annotations:
         gitpod.io: hello
-        gitpod.io/checksum_config: c218d6401941c1151e9352d943af91e5702230561bfe7bf6f82f98ec9b1bb4e2
+        gitpod.io/checksum_config: 55dae790b4d616e85abb79ca47d9146bd35daaf1eac479ab68337f80699ce374
         hello: world
       creationTimestamp: null
       labels:

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -5010,14 +5010,16 @@ data:
             "type": "image"
           }
         ],
-        "remoteSpecProvider": {
-          "addr": "dns:///ws-manager:8080",
-          "tls": {
-            "ca": "/ws-manager-client-tls-certs/ca.crt",
-            "crt": "/ws-manager-client-tls-certs/tls.crt",
-            "key": "/ws-manager-client-tls-certs/tls.key"
+        "remoteSpecProvider": [
+          {
+            "addr": "dns:///ws-manager:8080",
+            "tls": {
+              "ca": "/ws-manager-client-tls-certs/ca.crt",
+              "crt": "/ws-manager-client-tls-certs/tls.crt",
+              "key": "/ws-manager-client-tls-certs/tls.key"
+            }
           }
-        },
+        ],
         "store": "/mnt/cache/registry",
         "requireAuth": false,
         "tls": {
@@ -7460,7 +7462,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 627e2d5a5d50e8eb2531bd494ceb9cd26315e43008248fb6825dfc2b5189a3d3
+        gitpod.io/checksum_config: b8db96b6f1363f6138d2804e360bcaad1c0badbe9a1ddf3efa81dc4fa1912643
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/gcp-setup/output.golden
+++ b/install/installer/cmd/testdata/render/gcp-setup/output.golden
@@ -4839,14 +4839,16 @@ data:
             "type": "image"
           }
         ],
-        "remoteSpecProvider": {
-          "addr": "dns:///ws-manager:8080",
-          "tls": {
-            "ca": "/ws-manager-client-tls-certs/ca.crt",
-            "crt": "/ws-manager-client-tls-certs/tls.crt",
-            "key": "/ws-manager-client-tls-certs/tls.key"
+        "remoteSpecProvider": [
+          {
+            "addr": "dns:///ws-manager:8080",
+            "tls": {
+              "ca": "/ws-manager-client-tls-certs/ca.crt",
+              "crt": "/ws-manager-client-tls-certs/tls.crt",
+              "key": "/ws-manager-client-tls-certs/tls.key"
+            }
           }
-        },
+        ],
         "store": "/mnt/cache/registry",
         "requireAuth": false,
         "tls": {
@@ -7250,7 +7252,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 627e2d5a5d50e8eb2531bd494ceb9cd26315e43008248fb6825dfc2b5189a3d3
+        gitpod.io/checksum_config: b8db96b6f1363f6138d2804e360bcaad1c0badbe9a1ddf3efa81dc4fa1912643
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/http-proxy/output.golden
+++ b/install/installer/cmd/testdata/render/http-proxy/output.golden
@@ -5233,14 +5233,16 @@ data:
             "type": "image"
           }
         ],
-        "remoteSpecProvider": {
-          "addr": "dns:///ws-manager:8080",
-          "tls": {
-            "ca": "/ws-manager-client-tls-certs/ca.crt",
-            "crt": "/ws-manager-client-tls-certs/tls.crt",
-            "key": "/ws-manager-client-tls-certs/tls.key"
+        "remoteSpecProvider": [
+          {
+            "addr": "dns:///ws-manager:8080",
+            "tls": {
+              "ca": "/ws-manager-client-tls-certs/ca.crt",
+              "crt": "/ws-manager-client-tls-certs/tls.crt",
+              "key": "/ws-manager-client-tls-certs/tls.key"
+            }
           }
-        },
+        ],
         "store": "/mnt/cache/registry",
         "requireAuth": false,
         "tls": {
@@ -7823,7 +7825,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3e7db160db71491d8d16b0423783bf99a0dc293dc723960c9308756bdde69d3b
+        gitpod.io/checksum_config: 8b550110d60404fddff7b9f58346f214466970ebae7927d14398663a2e58e363
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/ide-config/output.golden
+++ b/install/installer/cmd/testdata/render/ide-config/output.golden
@@ -5246,14 +5246,16 @@ data:
             "type": "image"
           }
         ],
-        "remoteSpecProvider": {
-          "addr": "dns:///ws-manager:8080",
-          "tls": {
-            "ca": "/ws-manager-client-tls-certs/ca.crt",
-            "crt": "/ws-manager-client-tls-certs/tls.crt",
-            "key": "/ws-manager-client-tls-certs/tls.key"
+        "remoteSpecProvider": [
+          {
+            "addr": "dns:///ws-manager:8080",
+            "tls": {
+              "ca": "/ws-manager-client-tls-certs/ca.crt",
+              "crt": "/ws-manager-client-tls-certs/tls.crt",
+              "key": "/ws-manager-client-tls-certs/tls.key"
+            }
           }
-        },
+        ],
         "store": "/mnt/cache/registry",
         "requireAuth": false,
         "tls": {
@@ -7760,7 +7762,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3e7db160db71491d8d16b0423783bf99a0dc293dc723960c9308756bdde69d3b
+        gitpod.io/checksum_config: 8b550110d60404fddff7b9f58346f214466970ebae7927d14398663a2e58e363
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/kind-workspace/output.golden
+++ b/install/installer/cmd/testdata/render/kind-workspace/output.golden
@@ -1795,14 +1795,16 @@ data:
             "type": "image"
           }
         ],
-        "remoteSpecProvider": {
-          "addr": "dns:///ws-manager:8080",
-          "tls": {
-            "ca": "/ws-manager-client-tls-certs/ca.crt",
-            "crt": "/ws-manager-client-tls-certs/tls.crt",
-            "key": "/ws-manager-client-tls-certs/tls.key"
+        "remoteSpecProvider": [
+          {
+            "addr": "dns:///ws-manager:8080",
+            "tls": {
+              "ca": "/ws-manager-client-tls-certs/ca.crt",
+              "crt": "/ws-manager-client-tls-certs/tls.crt",
+              "key": "/ws-manager-client-tls-certs/tls.key"
+            }
           }
-        },
+        ],
         "store": "/mnt/cache/registry",
         "requireAuth": false,
         "tls": {
@@ -3038,7 +3040,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3e7db160db71491d8d16b0423783bf99a0dc293dc723960c9308756bdde69d3b
+        gitpod.io/checksum_config: 8b550110d60404fddff7b9f58346f214466970ebae7927d14398663a2e58e363
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/message-bus-password/output.golden
+++ b/install/installer/cmd/testdata/render/message-bus-password/output.golden
@@ -5233,14 +5233,16 @@ data:
             "type": "image"
           }
         ],
-        "remoteSpecProvider": {
-          "addr": "dns:///ws-manager:8080",
-          "tls": {
-            "ca": "/ws-manager-client-tls-certs/ca.crt",
-            "crt": "/ws-manager-client-tls-certs/tls.crt",
-            "key": "/ws-manager-client-tls-certs/tls.key"
+        "remoteSpecProvider": [
+          {
+            "addr": "dns:///ws-manager:8080",
+            "tls": {
+              "ca": "/ws-manager-client-tls-certs/ca.crt",
+              "crt": "/ws-manager-client-tls-certs/tls.crt",
+              "key": "/ws-manager-client-tls-certs/tls.key"
+            }
           }
-        },
+        ],
         "store": "/mnt/cache/registry",
         "requireAuth": false,
         "tls": {
@@ -7743,7 +7745,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3e7db160db71491d8d16b0423783bf99a0dc293dc723960c9308756bdde69d3b
+        gitpod.io/checksum_config: 8b550110d60404fddff7b9f58346f214466970ebae7927d14398663a2e58e363
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -5230,14 +5230,16 @@ data:
             "type": "image"
           }
         ],
-        "remoteSpecProvider": {
-          "addr": "dns:///ws-manager:8080",
-          "tls": {
-            "ca": "/ws-manager-client-tls-certs/ca.crt",
-            "crt": "/ws-manager-client-tls-certs/tls.crt",
-            "key": "/ws-manager-client-tls-certs/tls.key"
+        "remoteSpecProvider": [
+          {
+            "addr": "dns:///ws-manager:8080",
+            "tls": {
+              "ca": "/ws-manager-client-tls-certs/ca.crt",
+              "crt": "/ws-manager-client-tls-certs/tls.crt",
+              "key": "/ws-manager-client-tls-certs/tls.key"
+            }
           }
-        },
+        ],
         "store": "/mnt/cache/registry",
         "requireAuth": false,
         "tls": {
@@ -7740,7 +7742,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3e7db160db71491d8d16b0423783bf99a0dc293dc723960c9308756bdde69d3b
+        gitpod.io/checksum_config: 8b550110d60404fddff7b9f58346f214466970ebae7927d14398663a2e58e363
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/overrides-inline/output.golden
+++ b/install/installer/cmd/testdata/render/overrides-inline/output.golden
@@ -5228,14 +5228,16 @@ data:
             "type": "image"
           }
         ],
-        "remoteSpecProvider": {
-          "addr": "dns:///ws-manager:8080",
-          "tls": {
-            "ca": "/ws-manager-client-tls-certs/ca.crt",
-            "crt": "/ws-manager-client-tls-certs/tls.crt",
-            "key": "/ws-manager-client-tls-certs/tls.key"
+        "remoteSpecProvider": [
+          {
+            "addr": "dns:///ws-manager:8080",
+            "tls": {
+              "ca": "/ws-manager-client-tls-certs/ca.crt",
+              "crt": "/ws-manager-client-tls-certs/tls.crt",
+              "key": "/ws-manager-client-tls-certs/tls.key"
+            }
           }
-        },
+        ],
         "store": "/mnt/cache/registry",
         "requireAuth": false,
         "tls": {
@@ -7750,7 +7752,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3e7db160db71491d8d16b0423783bf99a0dc293dc723960c9308756bdde69d3b
+        gitpod.io/checksum_config: 8b550110d60404fddff7b9f58346f214466970ebae7927d14398663a2e58e363
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/pod-config/output.golden
+++ b/install/installer/cmd/testdata/render/pod-config/output.golden
@@ -5237,14 +5237,16 @@ data:
             "type": "image"
           }
         ],
-        "remoteSpecProvider": {
-          "addr": "dns:///ws-manager:8080",
-          "tls": {
-            "ca": "/ws-manager-client-tls-certs/ca.crt",
-            "crt": "/ws-manager-client-tls-certs/tls.crt",
-            "key": "/ws-manager-client-tls-certs/tls.key"
+        "remoteSpecProvider": [
+          {
+            "addr": "dns:///ws-manager:8080",
+            "tls": {
+              "ca": "/ws-manager-client-tls-certs/ca.crt",
+              "crt": "/ws-manager-client-tls-certs/tls.crt",
+              "key": "/ws-manager-client-tls-certs/tls.key"
+            }
           }
-        },
+        ],
         "store": "/mnt/cache/registry",
         "requireAuth": false,
         "tls": {
@@ -7747,7 +7749,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3e7db160db71491d8d16b0423783bf99a0dc293dc723960c9308756bdde69d3b
+        gitpod.io/checksum_config: 8b550110d60404fddff7b9f58346f214466970ebae7927d14398663a2e58e363
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/shortname/output.golden
+++ b/install/installer/cmd/testdata/render/shortname/output.golden
@@ -5230,14 +5230,16 @@ data:
             "type": "image"
           }
         ],
-        "remoteSpecProvider": {
-          "addr": "dns:///ws-manager:8080",
-          "tls": {
-            "ca": "/ws-manager-client-tls-certs/ca.crt",
-            "crt": "/ws-manager-client-tls-certs/tls.crt",
-            "key": "/ws-manager-client-tls-certs/tls.key"
+        "remoteSpecProvider": [
+          {
+            "addr": "dns:///ws-manager:8080",
+            "tls": {
+              "ca": "/ws-manager-client-tls-certs/ca.crt",
+              "crt": "/ws-manager-client-tls-certs/tls.crt",
+              "key": "/ws-manager-client-tls-certs/tls.key"
+            }
           }
-        },
+        ],
         "store": "/mnt/cache/registry",
         "requireAuth": false,
         "tls": {
@@ -7740,7 +7742,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3e7db160db71491d8d16b0423783bf99a0dc293dc723960c9308756bdde69d3b
+        gitpod.io/checksum_config: 8b550110d60404fddff7b9f58346f214466970ebae7927d14398663a2e58e363
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -5242,14 +5242,16 @@ data:
             "type": "image"
           }
         ],
-        "remoteSpecProvider": {
-          "addr": "dns:///ws-manager:8080",
-          "tls": {
-            "ca": "/ws-manager-client-tls-certs/ca.crt",
-            "crt": "/ws-manager-client-tls-certs/tls.crt",
-            "key": "/ws-manager-client-tls-certs/tls.key"
+        "remoteSpecProvider": [
+          {
+            "addr": "dns:///ws-manager:8080",
+            "tls": {
+              "ca": "/ws-manager-client-tls-certs/ca.crt",
+              "crt": "/ws-manager-client-tls-certs/tls.crt",
+              "key": "/ws-manager-client-tls-certs/tls.key"
+            }
           }
-        },
+        ],
         "store": "/mnt/cache/registry",
         "requireAuth": false,
         "tls": {
@@ -7752,7 +7754,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3e7db160db71491d8d16b0423783bf99a0dc293dc723960c9308756bdde69d3b
+        gitpod.io/checksum_config: 8b550110d60404fddff7b9f58346f214466970ebae7927d14398663a2e58e363
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/telemetry/output.golden
+++ b/install/installer/cmd/testdata/render/telemetry/output.golden
@@ -5233,14 +5233,16 @@ data:
             "type": "image"
           }
         ],
-        "remoteSpecProvider": {
-          "addr": "dns:///ws-manager:8080",
-          "tls": {
-            "ca": "/ws-manager-client-tls-certs/ca.crt",
-            "crt": "/ws-manager-client-tls-certs/tls.crt",
-            "key": "/ws-manager-client-tls-certs/tls.key"
+        "remoteSpecProvider": [
+          {
+            "addr": "dns:///ws-manager:8080",
+            "tls": {
+              "ca": "/ws-manager-client-tls-certs/ca.crt",
+              "crt": "/ws-manager-client-tls-certs/tls.crt",
+              "key": "/ws-manager-client-tls-certs/tls.key"
+            }
           }
-        },
+        ],
         "store": "/mnt/cache/registry",
         "requireAuth": false,
         "tls": {
@@ -7743,7 +7745,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3e7db160db71491d8d16b0423783bf99a0dc293dc723960c9308756bdde69d3b
+        gitpod.io/checksum_config: 8b550110d60404fddff7b9f58346f214466970ebae7927d14398663a2e58e363
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
+++ b/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
@@ -5563,14 +5563,16 @@ data:
             "type": "image"
           }
         ],
-        "remoteSpecProvider": {
-          "addr": "dns:///ws-manager:8080",
-          "tls": {
-            "ca": "/ws-manager-client-tls-certs/ca.crt",
-            "crt": "/ws-manager-client-tls-certs/tls.crt",
-            "key": "/ws-manager-client-tls-certs/tls.key"
+        "remoteSpecProvider": [
+          {
+            "addr": "dns:///ws-manager:8080",
+            "tls": {
+              "ca": "/ws-manager-client-tls-certs/ca.crt",
+              "crt": "/ws-manager-client-tls-certs/tls.crt",
+              "key": "/ws-manager-client-tls-certs/tls.key"
+            }
           }
-        },
+        ],
         "store": "/mnt/cache/registry",
         "requireAuth": false,
         "tls": {
@@ -8184,7 +8186,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3e7db160db71491d8d16b0423783bf99a0dc293dc723960c9308756bdde69d3b
+        gitpod.io/checksum_config: 8b550110d60404fddff7b9f58346f214466970ebae7927d14398663a2e58e363
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
+++ b/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
@@ -5233,14 +5233,16 @@ data:
             "type": "image"
           }
         ],
-        "remoteSpecProvider": {
-          "addr": "dns:///ws-manager:8080",
-          "tls": {
-            "ca": "/ws-manager-client-tls-certs/ca.crt",
-            "crt": "/ws-manager-client-tls-certs/tls.crt",
-            "key": "/ws-manager-client-tls-certs/tls.key"
+        "remoteSpecProvider": [
+          {
+            "addr": "dns:///ws-manager:8080",
+            "tls": {
+              "ca": "/ws-manager-client-tls-certs/ca.crt",
+              "crt": "/ws-manager-client-tls-certs/tls.crt",
+              "key": "/ws-manager-client-tls-certs/tls.key"
+            }
           }
-        },
+        ],
         "store": "/mnt/cache/registry",
         "requireAuth": false,
         "tls": {
@@ -7743,7 +7745,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3e7db160db71491d8d16b0423783bf99a0dc293dc723960c9308756bdde69d3b
+        gitpod.io/checksum_config: 8b550110d60404fddff7b9f58346f214466970ebae7927d14398663a2e58e363
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
+++ b/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
@@ -5233,14 +5233,16 @@ data:
             "type": "image"
           }
         ],
-        "remoteSpecProvider": {
-          "addr": "dns:///ws-manager:8080",
-          "tls": {
-            "ca": "/ws-manager-client-tls-certs/ca.crt",
-            "crt": "/ws-manager-client-tls-certs/tls.crt",
-            "key": "/ws-manager-client-tls-certs/tls.key"
+        "remoteSpecProvider": [
+          {
+            "addr": "dns:///ws-manager:8080",
+            "tls": {
+              "ca": "/ws-manager-client-tls-certs/ca.crt",
+              "crt": "/ws-manager-client-tls-certs/tls.crt",
+              "key": "/ws-manager-client-tls-certs/tls.key"
+            }
           }
-        },
+        ],
         "store": "/mnt/cache/registry",
         "requireAuth": false,
         "tls": {
@@ -7743,7 +7745,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 3e7db160db71491d8d16b0423783bf99a0dc293dc723960c9308756bdde69d3b
+        gitpod.io/checksum_config: 8b550110d60404fddff7b9f58346f214466970ebae7927d14398663a2e58e363
       creationTimestamp: null
       labels:
         app: gitpod


### PR DESCRIPTION
## Description
Relies on https://github.com/gitpod-io/ops/pull/8253 which introduces experimental nodes that are labelled with `experimental`. 
- Introduce affinity constraint so that workspaces scheduled with mk1 are not allowed to be scheduled on experimental nodes
- Introduce affinity constraint so that workspaces scheduled with mk2 require to be scheduled on experimental nodes
- Registry facade needs to talk to both ws-managers in order to get the image spec for the workspace. Support multiple remote image spec providers (for mk1 and mk2).

## Related Issue(s)
n.a.

## How to test
- Create ephemeral cluster with https://github.com/gitpod-io/ops/pull/8253 or use the new workspace permission in order to get the current test cluster if still available (ephemeral-fo-n2)
- The cluster will be registered twice. Once for mk1 and once for mk2
- Cordon the mk2 registration
- Start workspace
- Cordon mk1 and uncordon mk2
- Start workspace

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
