### PR TITLE
[redis] Deploy component

### DIFF
--- a/install/installer/cmd/testdata/render/agent-smith/output.golden
+++ b/install/installer/cmd/testdata/render/agent-smith/output.golden
@@ -998,6 +998,18 @@ automountServiceAccountToken: true
 secrets:
   - name: messagebus
 ---
+# v1/ServiceAccount redis
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: redis
+  name: redis
+  namespace: default
+---
 # v1/ServiceAccount registry-facade
 apiVersion: v1
 automountServiceAccountToken: true
@@ -2938,6 +2950,37 @@ data:
         app: gitpod
         component: public-api-server
       name: public-api-server
+      namespace: default
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: redis
+      name: redis
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: redis
+        kind: service
+      name: redis
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: redis
+      name: redis
       namespace: default
     ---
     apiVersion: v1
@@ -7544,6 +7587,30 @@ spec:
 status:
   loadBalancer: {}
 ---
+# v1/Service redis
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: redis
+    kind: service
+  name: redis
+  namespace: default
+spec:
+  ports:
+  - name: api
+    port: 6379
+    protocol: TCP
+    targetPort: 6379
+  selector:
+    app: gitpod
+    component: redis
+  type: ClusterIP
+status:
+  loadBalancer: {}
+---
 # v1/Service registry
 # Source: docker-registry/charts/docker-registry/templates/service.yaml
 apiVersion: v1
@@ -10132,6 +10199,104 @@ spec:
       - name: database-config
         secret:
           secretName: mysql
+status: {}
+---
+# apps/v1/Deployment redis
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: redis
+  name: redis
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gitpod
+      component: redis
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: redis
+      name: redis
+      namespace: default
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: gitpod.io/workload_meta
+                operator: Exists
+      containers:
+      - command:
+        - redis-server
+        - --save ""
+        - --appendonly no
+        - --maxmemory 100mb
+        - --maxmemory-policy allkeys-lru
+        - --port 6379
+        env:
+        - name: GITPOD_DOMAIN
+          value: gitpod.example.com
+        - name: GITPOD_INSTALLATION_SHORTNAME
+          value: default
+        - name: GITPOD_REGION
+          value: local
+        - name: HOST_URL
+          value: https://gitpod.example.com
+        - name: KUBE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: KUBE_DOMAIN
+          value: svc.cluster.local
+        - name: LOG_LEVEL
+          value: info
+        image: registry.hub.docker.com/library/redis:7.0.8
+        imagePullPolicy: IfNotPresent
+        name: redis
+        ports:
+        - containerPort: 6379
+          name: api
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - /health/ping_readiness_local.sh 1
+          failureThreshold: 5
+          initialDelaySeconds: 5
+          periodSeconds: 30
+          successThreshold: 1
+          timeoutSeconds: 3
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128M
+        securityContext:
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
+      dnsPolicy: ClusterFirst
+      enableServiceLinks: false
+      priorityClassName: system-node-critical
+      restartPolicy: Always
+      securityContext:
+        runAsNonRoot: false
+      serviceAccountName: redis
+      terminationGracePeriodSeconds: 30
 status: {}
 ---
 # apps/v1/Deployment registry

--- a/install/installer/cmd/testdata/render/aws-setup/output.golden
+++ b/install/installer/cmd/testdata/render/aws-setup/output.golden
@@ -945,6 +945,18 @@ automountServiceAccountToken: true
 secrets:
   - name: messagebus
 ---
+# v1/ServiceAccount redis
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: redis
+  name: redis
+  namespace: default
+---
 # v1/ServiceAccount registry-facade
 apiVersion: v1
 automountServiceAccountToken: true
@@ -2551,6 +2563,37 @@ data:
         app: gitpod
         component: public-api-server
       name: public-api-server
+      namespace: default
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: redis
+      name: redis
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: redis
+        kind: service
+      name: redis
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: redis
+      name: redis
       namespace: default
     ---
     apiVersion: v1
@@ -6735,6 +6778,30 @@ spec:
 status:
   loadBalancer: {}
 ---
+# v1/Service redis
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: redis
+    kind: service
+  name: redis
+  namespace: default
+spec:
+  ports:
+  - name: api
+    port: 6379
+    protocol: TCP
+    targetPort: 6379
+  selector:
+    app: gitpod
+    component: redis
+  type: ClusterIP
+status:
+  loadBalancer: {}
+---
 # v1/Service registry-facade
 apiVersion: v1
 kind: Service
@@ -9032,6 +9099,104 @@ spec:
       - name: database-config
         secret:
           secretName: aws-database
+status: {}
+---
+# apps/v1/Deployment redis
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: redis
+  name: redis
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gitpod
+      component: redis
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: redis
+      name: redis
+      namespace: default
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: gitpod.io/workload_meta
+                operator: Exists
+      containers:
+      - command:
+        - redis-server
+        - --save ""
+        - --appendonly no
+        - --maxmemory 100mb
+        - --maxmemory-policy allkeys-lru
+        - --port 6379
+        env:
+        - name: GITPOD_DOMAIN
+          value: gitpod.example.com
+        - name: GITPOD_INSTALLATION_SHORTNAME
+          value: default
+        - name: GITPOD_REGION
+          value: eu-west-2
+        - name: HOST_URL
+          value: https://gitpod.example.com
+        - name: KUBE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: KUBE_DOMAIN
+          value: svc.cluster.local
+        - name: LOG_LEVEL
+          value: info
+        image: registry.hub.docker.com/library/redis:7.0.8
+        imagePullPolicy: IfNotPresent
+        name: redis
+        ports:
+        - containerPort: 6379
+          name: api
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - /health/ping_readiness_local.sh 1
+          failureThreshold: 5
+          initialDelaySeconds: 5
+          periodSeconds: 30
+          successThreshold: 1
+          timeoutSeconds: 3
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128M
+        securityContext:
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
+      dnsPolicy: ClusterFirst
+      enableServiceLinks: false
+      priorityClassName: system-node-critical
+      restartPolicy: Always
+      securityContext:
+        runAsNonRoot: false
+      serviceAccountName: redis
+      terminationGracePeriodSeconds: 30
 status: {}
 ---
 # apps/v1/Deployment server

--- a/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
+++ b/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
@@ -998,6 +998,18 @@ automountServiceAccountToken: true
 secrets:
   - name: messagebus
 ---
+# v1/ServiceAccount redis
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: redis
+  name: redis
+  namespace: default
+---
 # v1/ServiceAccount registry-facade
 apiVersion: v1
 automountServiceAccountToken: true
@@ -2755,6 +2767,37 @@ data:
         app: gitpod
         component: public-api-server
       name: public-api-server
+      namespace: default
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: redis
+      name: redis
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: redis
+        kind: service
+      name: redis
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: redis
+      name: redis
       namespace: default
     ---
     apiVersion: v1
@@ -7361,6 +7404,30 @@ spec:
 status:
   loadBalancer: {}
 ---
+# v1/Service redis
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: redis
+    kind: service
+  name: redis
+  namespace: default
+spec:
+  ports:
+  - name: api
+    port: 6379
+    protocol: TCP
+    targetPort: 6379
+  selector:
+    app: gitpod
+    component: redis
+  type: ClusterIP
+status:
+  loadBalancer: {}
+---
 # v1/Service registry
 # Source: docker-registry/charts/docker-registry/templates/service.yaml
 apiVersion: v1
@@ -9949,6 +10016,104 @@ spec:
       - name: database-config
         secret:
           secretName: mysql
+status: {}
+---
+# apps/v1/Deployment redis
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: redis
+  name: redis
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gitpod
+      component: redis
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: redis
+      name: redis
+      namespace: default
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: gitpod.io/workload_meta
+                operator: Exists
+      containers:
+      - command:
+        - redis-server
+        - --save ""
+        - --appendonly no
+        - --maxmemory 100mb
+        - --maxmemory-policy allkeys-lru
+        - --port 6379
+        env:
+        - name: GITPOD_DOMAIN
+          value: gitpod.example.com
+        - name: GITPOD_INSTALLATION_SHORTNAME
+          value: default
+        - name: GITPOD_REGION
+          value: local
+        - name: HOST_URL
+          value: https://gitpod.example.com
+        - name: KUBE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: KUBE_DOMAIN
+          value: svc.cluster.local
+        - name: LOG_LEVEL
+          value: info
+        image: registry.mydomain.com/namespace/library/redis:7.0.8
+        imagePullPolicy: IfNotPresent
+        name: redis
+        ports:
+        - containerPort: 6379
+          name: api
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - /health/ping_readiness_local.sh 1
+          failureThreshold: 5
+          initialDelaySeconds: 5
+          periodSeconds: 30
+          successThreshold: 1
+          timeoutSeconds: 3
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128M
+        securityContext:
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
+      dnsPolicy: ClusterFirst
+      enableServiceLinks: false
+      priorityClassName: system-node-critical
+      restartPolicy: Always
+      securityContext:
+        runAsNonRoot: false
+      serviceAccountName: redis
+      terminationGracePeriodSeconds: 30
 status: {}
 ---
 # apps/v1/Deployment registry

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -1078,6 +1078,23 @@ automountServiceAccountToken: true
 secrets:
   - name: messagebus
 ---
+# v1/ServiceAccount redis
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  annotations:
+    gitpod.io: hello
+    hello: world
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: redis
+    gitpod.io: hello
+    hello: world
+  name: redis
+  namespace: default
+---
 # v1/ServiceAccount registry-facade
 apiVersion: v1
 automountServiceAccountToken: true
@@ -3155,6 +3172,52 @@ data:
         app: gitpod
         component: public-api-server
       name: public-api-server
+      namespace: default
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      annotations:
+        gitpod.io: hello
+        hello: world
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: redis
+        gitpod.io: hello
+        hello: world
+      name: redis
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      annotations:
+        gitpod.io: hello
+        hello: world
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: redis
+        gitpod.io: hello
+        hello: world
+        kind: service
+      name: redis
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      annotations:
+        gitpod.io: hello
+        hello: world
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: redis
+        gitpod.io: hello
+        hello: world
+      name: redis
       namespace: default
     ---
     apiVersion: v1
@@ -8012,6 +8075,35 @@ spec:
 status:
   loadBalancer: {}
 ---
+# v1/Service redis
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    gitpod.io: hello
+    hello: world
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: redis
+    gitpod.io: hello
+    hello: world
+    kind: service
+  name: redis
+  namespace: default
+spec:
+  ports:
+  - name: api
+    port: 6379
+    protocol: TCP
+    targetPort: 6379
+  selector:
+    app: gitpod
+    component: redis
+  type: ClusterIP
+status:
+  loadBalancer: {}
+---
 # v1/Service registry
 # Source: docker-registry/charts/docker-registry/templates/service.yaml
 apiVersion: v1
@@ -10747,6 +10839,114 @@ spec:
       - name: database-config
         secret:
           secretName: mysql
+status: {}
+---
+# apps/v1/Deployment redis
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    gitpod.io: hello
+    hello: world
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: redis
+    gitpod.io: hello
+    hello: world
+  name: redis
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gitpod
+      component: redis
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        gitpod.io: hello
+        hello: world
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: redis
+        gitpod.io: hello
+        hello: world
+      name: redis
+      namespace: default
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: gitpod.io/workload_meta
+                operator: Exists
+      containers:
+      - command:
+        - redis-server
+        - --save ""
+        - --appendonly no
+        - --maxmemory 100mb
+        - --maxmemory-policy allkeys-lru
+        - --port 6379
+        env:
+        - name: GITPOD_DOMAIN
+          value: gitpod.example.com
+        - name: GITPOD_INSTALLATION_SHORTNAME
+          value: default
+        - name: GITPOD_REGION
+          value: local
+        - name: HOST_URL
+          value: https://gitpod.example.com
+        - name: KUBE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: KUBE_DOMAIN
+          value: svc.cluster.local
+        - name: LOG_LEVEL
+          value: info
+        image: registry.hub.docker.com/library/redis:7.0.8
+        imagePullPolicy: IfNotPresent
+        name: redis
+        ports:
+        - containerPort: 6379
+          name: api
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - /health/ping_readiness_local.sh 1
+          failureThreshold: 5
+          initialDelaySeconds: 5
+          periodSeconds: 30
+          successThreshold: 1
+          timeoutSeconds: 3
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128M
+        securityContext:
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
+      dnsPolicy: ClusterFirst
+      enableServiceLinks: false
+      priorityClassName: system-node-critical
+      restartPolicy: Always
+      securityContext:
+        runAsNonRoot: false
+      serviceAccountName: redis
+      terminationGracePeriodSeconds: 30
 status: {}
 ---
 # apps/v1/Deployment registry

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -961,6 +961,18 @@ automountServiceAccountToken: true
 secrets:
   - name: messagebus
 ---
+# v1/ServiceAccount redis
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: redis
+  name: redis
+  namespace: default
+---
 # v1/ServiceAccount registry-facade
 apiVersion: v1
 automountServiceAccountToken: true
@@ -2649,6 +2661,37 @@ data:
         app: gitpod
         component: public-api-server
       name: public-api-server
+      namespace: default
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: redis
+      name: redis
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: redis
+        kind: service
+      name: redis
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: redis
+      name: redis
       namespace: default
     ---
     apiVersion: v1
@@ -7104,6 +7147,30 @@ spec:
 status:
   loadBalancer: {}
 ---
+# v1/Service redis
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: redis
+    kind: service
+  name: redis
+  namespace: default
+spec:
+  ports:
+  - name: api
+    port: 6379
+    protocol: TCP
+    targetPort: 6379
+  selector:
+    app: gitpod
+    component: redis
+  type: ClusterIP
+status:
+  loadBalancer: {}
+---
 # v1/Service registry-facade
 apiVersion: v1
 kind: Service
@@ -9659,6 +9726,104 @@ spec:
       - name: database-config
         secret:
           secretName: mysql
+status: {}
+---
+# apps/v1/Deployment redis
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: redis
+  name: redis
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gitpod
+      component: redis
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: redis
+      name: redis
+      namespace: default
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: gitpod.io/workload_meta
+                operator: Exists
+      containers:
+      - command:
+        - redis-server
+        - --save ""
+        - --appendonly no
+        - --maxmemory 100mb
+        - --maxmemory-policy allkeys-lru
+        - --port 6379
+        env:
+        - name: GITPOD_DOMAIN
+          value: gitpod.example.com
+        - name: GITPOD_INSTALLATION_SHORTNAME
+          value: default
+        - name: GITPOD_REGION
+          value: local
+        - name: HOST_URL
+          value: https://gitpod.example.com
+        - name: KUBE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: KUBE_DOMAIN
+          value: svc.cluster.local
+        - name: LOG_LEVEL
+          value: info
+        image: registry.hub.docker.com/library/redis:7.0.8
+        imagePullPolicy: IfNotPresent
+        name: redis
+        ports:
+        - containerPort: 6379
+          name: api
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - /health/ping_readiness_local.sh 1
+          failureThreshold: 5
+          initialDelaySeconds: 5
+          periodSeconds: 30
+          successThreshold: 1
+          timeoutSeconds: 3
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128M
+        securityContext:
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
+      dnsPolicy: ClusterFirst
+      enableServiceLinks: false
+      priorityClassName: system-node-critical
+      restartPolicy: Always
+      securityContext:
+        runAsNonRoot: false
+      serviceAccountName: redis
+      terminationGracePeriodSeconds: 30
 status: {}
 ---
 # apps/v1/Deployment server

--- a/install/installer/cmd/testdata/render/gcp-setup/output.golden
+++ b/install/installer/cmd/testdata/render/gcp-setup/output.golden
@@ -969,6 +969,18 @@ automountServiceAccountToken: true
 secrets:
   - name: messagebus
 ---
+# v1/ServiceAccount redis
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: redis
+  name: redis
+  namespace: default
+---
 # v1/ServiceAccount registry-facade
 apiVersion: v1
 automountServiceAccountToken: true
@@ -2646,6 +2658,37 @@ data:
         app: gitpod
         component: public-api-server
       name: public-api-server
+      namespace: default
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: redis
+      name: redis
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: redis
+        kind: service
+      name: redis
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: redis
+      name: redis
       namespace: default
     ---
     apiVersion: v1
@@ -6894,6 +6937,30 @@ spec:
 status:
   loadBalancer: {}
 ---
+# v1/Service redis
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: redis
+    kind: service
+  name: redis
+  namespace: default
+spec:
+  ports:
+  - name: api
+    port: 6379
+    protocol: TCP
+    targetPort: 6379
+  selector:
+    app: gitpod
+    component: redis
+  type: ClusterIP
+status:
+  loadBalancer: {}
+---
 # v1/Service registry-facade
 apiVersion: v1
 kind: Service
@@ -9319,6 +9386,104 @@ spec:
       - name: database-config
         secret:
           secretName: gcp-database
+status: {}
+---
+# apps/v1/Deployment redis
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: redis
+  name: redis
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gitpod
+      component: redis
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: redis
+      name: redis
+      namespace: default
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: gitpod.io/workload_meta
+                operator: Exists
+      containers:
+      - command:
+        - redis-server
+        - --save ""
+        - --appendonly no
+        - --maxmemory 100mb
+        - --maxmemory-policy allkeys-lru
+        - --port 6379
+        env:
+        - name: GITPOD_DOMAIN
+          value: gitpod.example.com
+        - name: GITPOD_INSTALLATION_SHORTNAME
+          value: default
+        - name: GITPOD_REGION
+          value: europe-west2
+        - name: HOST_URL
+          value: https://gitpod.example.com
+        - name: KUBE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: KUBE_DOMAIN
+          value: svc.cluster.local
+        - name: LOG_LEVEL
+          value: info
+        image: registry.hub.docker.com/library/redis:7.0.8
+        imagePullPolicy: IfNotPresent
+        name: redis
+        ports:
+        - containerPort: 6379
+          name: api
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - /health/ping_readiness_local.sh 1
+          failureThreshold: 5
+          initialDelaySeconds: 5
+          periodSeconds: 30
+          successThreshold: 1
+          timeoutSeconds: 3
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128M
+        securityContext:
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
+      dnsPolicy: ClusterFirst
+      enableServiceLinks: false
+      priorityClassName: system-node-critical
+      restartPolicy: Always
+      securityContext:
+        runAsNonRoot: false
+      serviceAccountName: redis
+      terminationGracePeriodSeconds: 30
 status: {}
 ---
 # apps/v1/Deployment server

--- a/install/installer/cmd/testdata/render/http-proxy/output.golden
+++ b/install/installer/cmd/testdata/render/http-proxy/output.golden
@@ -998,6 +998,18 @@ automountServiceAccountToken: true
 secrets:
   - name: messagebus
 ---
+# v1/ServiceAccount redis
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: redis
+  name: redis
+  namespace: default
+---
 # v1/ServiceAccount registry-facade
 apiVersion: v1
 automountServiceAccountToken: true
@@ -2758,6 +2770,37 @@ data:
         app: gitpod
         component: public-api-server
       name: public-api-server
+      namespace: default
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: redis
+      name: redis
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: redis
+        kind: service
+      name: redis
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: redis
+      name: redis
       namespace: default
     ---
     apiVersion: v1
@@ -7364,6 +7407,30 @@ spec:
 status:
   loadBalancer: {}
 ---
+# v1/Service redis
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: redis
+    kind: service
+  name: redis
+  namespace: default
+spec:
+  ports:
+  - name: api
+    port: 6379
+    protocol: TCP
+    targetPort: 6379
+  selector:
+    app: gitpod
+    component: redis
+  type: ClusterIP
+status:
+  loadBalancer: {}
+---
 # v1/Service registry
 # Source: docker-registry/charts/docker-registry/templates/service.yaml
 apiVersion: v1
@@ -11074,6 +11141,144 @@ spec:
       - name: database-config
         secret:
           secretName: mysql
+status: {}
+---
+# apps/v1/Deployment redis
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: redis
+  name: redis
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gitpod
+      component: redis
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: redis
+      name: redis
+      namespace: default
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: gitpod.io/workload_meta
+                operator: Exists
+      containers:
+      - command:
+        - redis-server
+        - --save ""
+        - --appendonly no
+        - --maxmemory 100mb
+        - --maxmemory-policy allkeys-lru
+        - --port 6379
+        env:
+        - name: GITPOD_DOMAIN
+          value: gitpod.example.com
+        - name: GITPOD_INSTALLATION_SHORTNAME
+          value: default
+        - name: GITPOD_REGION
+          value: local
+        - name: HOST_URL
+          value: https://gitpod.example.com
+        - name: KUBE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: KUBE_DOMAIN
+          value: svc.cluster.local
+        - name: LOG_LEVEL
+          value: info
+        - name: HTTP_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: httpProxy
+              name: http-proxy-settings
+              optional: true
+        - name: http_proxy
+          valueFrom:
+            secretKeyRef:
+              key: httpProxy
+              name: http-proxy-settings
+              optional: true
+        - name: HTTPS_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: httpsProxy
+              name: http-proxy-settings
+              optional: true
+        - name: https_proxy
+          valueFrom:
+            secretKeyRef:
+              key: httpsProxy
+              name: http-proxy-settings
+              optional: true
+        - name: CUSTOM_NO_PROXY
+          valueFrom:
+            secretKeyRef:
+              key: noProxy
+              name: http-proxy-settings
+              optional: true
+        - name: custom_no_proxy
+          valueFrom:
+            secretKeyRef:
+              key: noProxy
+              name: http-proxy-settings
+              optional: true
+        - name: NO_PROXY
+          value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
+        - name: no_proxy
+          value: ws-manager,wsdaemon,$(CUSTOM_NO_PROXY)
+        image: registry.hub.docker.com/library/redis:7.0.8
+        imagePullPolicy: IfNotPresent
+        name: redis
+        ports:
+        - containerPort: 6379
+          name: api
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - /health/ping_readiness_local.sh 1
+          failureThreshold: 5
+          initialDelaySeconds: 5
+          periodSeconds: 30
+          successThreshold: 1
+          timeoutSeconds: 3
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128M
+        securityContext:
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
+      dnsPolicy: ClusterFirst
+      enableServiceLinks: false
+      priorityClassName: system-node-critical
+      restartPolicy: Always
+      securityContext:
+        runAsNonRoot: false
+      serviceAccountName: redis
+      terminationGracePeriodSeconds: 30
 status: {}
 ---
 # apps/v1/Deployment registry

--- a/install/installer/cmd/testdata/render/ide-config/output.golden
+++ b/install/installer/cmd/testdata/render/ide-config/output.golden
@@ -998,6 +998,18 @@ automountServiceAccountToken: true
 secrets:
   - name: messagebus
 ---
+# v1/ServiceAccount redis
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: redis
+  name: redis
+  namespace: default
+---
 # v1/ServiceAccount registry-facade
 apiVersion: v1
 automountServiceAccountToken: true
@@ -2771,6 +2783,37 @@ data:
         app: gitpod
         component: public-api-server
       name: public-api-server
+      namespace: default
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: redis
+      name: redis
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: redis
+        kind: service
+      name: redis
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: redis
+      name: redis
       namespace: default
     ---
     apiVersion: v1
@@ -7381,6 +7424,30 @@ spec:
 status:
   loadBalancer: {}
 ---
+# v1/Service redis
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: redis
+    kind: service
+  name: redis
+  namespace: default
+spec:
+  ports:
+  - name: api
+    port: 6379
+    protocol: TCP
+    targetPort: 6379
+  selector:
+    app: gitpod
+    component: redis
+  type: ClusterIP
+status:
+  loadBalancer: {}
+---
 # v1/Service registry
 # Source: docker-registry/charts/docker-registry/templates/service.yaml
 apiVersion: v1
@@ -9971,6 +10038,104 @@ spec:
       - name: database-config
         secret:
           secretName: mysql
+status: {}
+---
+# apps/v1/Deployment redis
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: redis
+  name: redis
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gitpod
+      component: redis
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: redis
+      name: redis
+      namespace: default
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: gitpod.io/workload_meta
+                operator: Exists
+      containers:
+      - command:
+        - redis-server
+        - --save ""
+        - --appendonly no
+        - --maxmemory 100mb
+        - --maxmemory-policy allkeys-lru
+        - --port 6379
+        env:
+        - name: GITPOD_DOMAIN
+          value: gitpod.example.com
+        - name: GITPOD_INSTALLATION_SHORTNAME
+          value: default
+        - name: GITPOD_REGION
+          value: local
+        - name: HOST_URL
+          value: https://gitpod.example.com
+        - name: KUBE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: KUBE_DOMAIN
+          value: svc.cluster.local
+        - name: LOG_LEVEL
+          value: info
+        image: registry.hub.docker.com/library/redis:7.0.8
+        imagePullPolicy: IfNotPresent
+        name: redis
+        ports:
+        - containerPort: 6379
+          name: api
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - /health/ping_readiness_local.sh 1
+          failureThreshold: 5
+          initialDelaySeconds: 5
+          periodSeconds: 30
+          successThreshold: 1
+          timeoutSeconds: 3
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128M
+        securityContext:
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
+      dnsPolicy: ClusterFirst
+      enableServiceLinks: false
+      priorityClassName: system-node-critical
+      restartPolicy: Always
+      securityContext:
+        runAsNonRoot: false
+      serviceAccountName: redis
+      terminationGracePeriodSeconds: 30
 status: {}
 ---
 # apps/v1/Deployment registry

--- a/install/installer/cmd/testdata/render/kind-meta/output.golden
+++ b/install/installer/cmd/testdata/render/kind-meta/output.golden
@@ -628,6 +628,18 @@ automountServiceAccountToken: true
 secrets:
   - name: messagebus
 ---
+# v1/ServiceAccount redis
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: redis
+  name: redis
+  namespace: default
+---
 # v1/ServiceAccount server
 apiVersion: v1
 automountServiceAccountToken: true
@@ -2299,6 +2311,37 @@ data:
         app: gitpod
         component: public-api-server
       name: public-api-server
+      namespace: default
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: redis
+      name: redis
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: redis
+        kind: service
+      name: redis
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: redis
+      name: redis
       namespace: default
     ---
     apiVersion: v1
@@ -5374,6 +5417,30 @@ spec:
 status:
   loadBalancer: {}
 ---
+# v1/Service redis
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: redis
+    kind: service
+  name: redis
+  namespace: default
+spec:
+  ports:
+  - name: api
+    port: 6379
+    protocol: TCP
+    targetPort: 6379
+  selector:
+    app: gitpod
+    component: redis
+  type: ClusterIP
+status:
+  loadBalancer: {}
+---
 # v1/Service registry
 # Source: docker-registry/charts/docker-registry/templates/service.yaml
 apiVersion: v1
@@ -7108,6 +7175,104 @@ spec:
       - name: database-config
         secret:
           secretName: mysql
+status: {}
+---
+# apps/v1/Deployment redis
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: redis
+  name: redis
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gitpod
+      component: redis
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: redis
+      name: redis
+      namespace: default
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: gitpod.io/workload_meta
+                operator: Exists
+      containers:
+      - command:
+        - redis-server
+        - --save ""
+        - --appendonly no
+        - --maxmemory 100mb
+        - --maxmemory-policy allkeys-lru
+        - --port 6379
+        env:
+        - name: GITPOD_DOMAIN
+          value: gitpod.example.com
+        - name: GITPOD_INSTALLATION_SHORTNAME
+          value: default
+        - name: GITPOD_REGION
+          value: local
+        - name: HOST_URL
+          value: https://gitpod.example.com
+        - name: KUBE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: KUBE_DOMAIN
+          value: svc.cluster.local
+        - name: LOG_LEVEL
+          value: info
+        image: registry.hub.docker.com/library/redis:7.0.8
+        imagePullPolicy: IfNotPresent
+        name: redis
+        ports:
+        - containerPort: 6379
+          name: api
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - /health/ping_readiness_local.sh 1
+          failureThreshold: 5
+          initialDelaySeconds: 5
+          periodSeconds: 30
+          successThreshold: 1
+          timeoutSeconds: 3
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128M
+        securityContext:
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
+      dnsPolicy: ClusterFirst
+      enableServiceLinks: false
+      priorityClassName: system-node-critical
+      restartPolicy: Always
+      securityContext:
+        runAsNonRoot: false
+      serviceAccountName: redis
+      terminationGracePeriodSeconds: 30
 status: {}
 ---
 # apps/v1/Deployment registry

--- a/install/installer/cmd/testdata/render/kind-webapp/output.golden
+++ b/install/installer/cmd/testdata/render/kind-webapp/output.golden
@@ -461,6 +461,18 @@ automountServiceAccountToken: true
 secrets:
   - name: messagebus
 ---
+# v1/ServiceAccount redis
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: redis
+  name: redis
+  namespace: default
+---
 # v1/ServiceAccount server
 apiVersion: v1
 automountServiceAccountToken: true
@@ -1684,6 +1696,37 @@ data:
         app: gitpod
         component: public-api-server
       name: public-api-server
+      namespace: default
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: redis
+      name: redis
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: redis
+        kind: service
+      name: redis
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: redis
+      name: redis
       namespace: default
     ---
     apiVersion: v1
@@ -3144,6 +3187,30 @@ spec:
 status:
   loadBalancer: {}
 ---
+# v1/Service redis
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: redis
+    kind: service
+  name: redis
+  namespace: default
+spec:
+  ports:
+  - name: api
+    port: 6379
+    protocol: TCP
+    targetPort: 6379
+  selector:
+    app: gitpod
+    component: redis
+  type: ClusterIP
+status:
+  loadBalancer: {}
+---
 # v1/Service registry
 # Source: docker-registry/charts/docker-registry/templates/service.yaml
 apiVersion: v1
@@ -4261,6 +4328,104 @@ spec:
       - name: database-config
         secret:
           secretName: mysql
+status: {}
+---
+# apps/v1/Deployment redis
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: redis
+  name: redis
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gitpod
+      component: redis
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: redis
+      name: redis
+      namespace: default
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: gitpod.io/workload_meta
+                operator: Exists
+      containers:
+      - command:
+        - redis-server
+        - --save ""
+        - --appendonly no
+        - --maxmemory 100mb
+        - --maxmemory-policy allkeys-lru
+        - --port 6379
+        env:
+        - name: GITPOD_DOMAIN
+          value: gitpod.example.com
+        - name: GITPOD_INSTALLATION_SHORTNAME
+          value: default
+        - name: GITPOD_REGION
+          value: local
+        - name: HOST_URL
+          value: https://gitpod.example.com
+        - name: KUBE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: KUBE_DOMAIN
+          value: svc.cluster.local
+        - name: LOG_LEVEL
+          value: info
+        image: registry.hub.docker.com/library/redis:7.0.8
+        imagePullPolicy: IfNotPresent
+        name: redis
+        ports:
+        - containerPort: 6379
+          name: api
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - /health/ping_readiness_local.sh 1
+          failureThreshold: 5
+          initialDelaySeconds: 5
+          periodSeconds: 30
+          successThreshold: 1
+          timeoutSeconds: 3
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128M
+        securityContext:
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
+      dnsPolicy: ClusterFirst
+      enableServiceLinks: false
+      priorityClassName: system-node-critical
+      restartPolicy: Always
+      securityContext:
+        runAsNonRoot: false
+      serviceAccountName: redis
+      terminationGracePeriodSeconds: 30
 status: {}
 ---
 # apps/v1/Deployment registry

--- a/install/installer/cmd/testdata/render/message-bus-password/output.golden
+++ b/install/installer/cmd/testdata/render/message-bus-password/output.golden
@@ -998,6 +998,18 @@ automountServiceAccountToken: true
 secrets:
   - name: messagebus
 ---
+# v1/ServiceAccount redis
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: redis
+  name: redis
+  namespace: default
+---
 # v1/ServiceAccount registry-facade
 apiVersion: v1
 automountServiceAccountToken: true
@@ -2758,6 +2770,37 @@ data:
         app: gitpod
         component: public-api-server
       name: public-api-server
+      namespace: default
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: redis
+      name: redis
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: redis
+        kind: service
+      name: redis
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: redis
+      name: redis
       namespace: default
     ---
     apiVersion: v1
@@ -7364,6 +7407,30 @@ spec:
 status:
   loadBalancer: {}
 ---
+# v1/Service redis
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: redis
+    kind: service
+  name: redis
+  namespace: default
+spec:
+  ports:
+  - name: api
+    port: 6379
+    protocol: TCP
+    targetPort: 6379
+  selector:
+    app: gitpod
+    component: redis
+  type: ClusterIP
+status:
+  loadBalancer: {}
+---
 # v1/Service registry
 # Source: docker-registry/charts/docker-registry/templates/service.yaml
 apiVersion: v1
@@ -9952,6 +10019,104 @@ spec:
       - name: database-config
         secret:
           secretName: mysql
+status: {}
+---
+# apps/v1/Deployment redis
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: redis
+  name: redis
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gitpod
+      component: redis
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: redis
+      name: redis
+      namespace: default
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: gitpod.io/workload_meta
+                operator: Exists
+      containers:
+      - command:
+        - redis-server
+        - --save ""
+        - --appendonly no
+        - --maxmemory 100mb
+        - --maxmemory-policy allkeys-lru
+        - --port 6379
+        env:
+        - name: GITPOD_DOMAIN
+          value: gitpod.example.com
+        - name: GITPOD_INSTALLATION_SHORTNAME
+          value: default
+        - name: GITPOD_REGION
+          value: local
+        - name: HOST_URL
+          value: https://gitpod.example.com
+        - name: KUBE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: KUBE_DOMAIN
+          value: svc.cluster.local
+        - name: LOG_LEVEL
+          value: info
+        image: registry.hub.docker.com/library/redis:7.0.8
+        imagePullPolicy: IfNotPresent
+        name: redis
+        ports:
+        - containerPort: 6379
+          name: api
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - /health/ping_readiness_local.sh 1
+          failureThreshold: 5
+          initialDelaySeconds: 5
+          periodSeconds: 30
+          successThreshold: 1
+          timeoutSeconds: 3
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128M
+        securityContext:
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
+      dnsPolicy: ClusterFirst
+      enableServiceLinks: false
+      priorityClassName: system-node-critical
+      restartPolicy: Always
+      securityContext:
+        runAsNonRoot: false
+      serviceAccountName: redis
+      terminationGracePeriodSeconds: 30
 status: {}
 ---
 # apps/v1/Deployment registry

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -998,6 +998,18 @@ automountServiceAccountToken: true
 secrets:
   - name: messagebus
 ---
+# v1/ServiceAccount redis
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: redis
+  name: redis
+  namespace: default
+---
 # v1/ServiceAccount registry-facade
 apiVersion: v1
 automountServiceAccountToken: true
@@ -2755,6 +2767,37 @@ data:
         app: gitpod
         component: public-api-server
       name: public-api-server
+      namespace: default
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: redis
+      name: redis
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: redis
+        kind: service
+      name: redis
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: redis
+      name: redis
       namespace: default
     ---
     apiVersion: v1
@@ -7361,6 +7404,30 @@ spec:
 status:
   loadBalancer: {}
 ---
+# v1/Service redis
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: redis
+    kind: service
+  name: redis
+  namespace: default
+spec:
+  ports:
+  - name: api
+    port: 6379
+    protocol: TCP
+    targetPort: 6379
+  selector:
+    app: gitpod
+    component: redis
+  type: ClusterIP
+status:
+  loadBalancer: {}
+---
 # v1/Service registry
 # Source: docker-registry/charts/docker-registry/templates/service.yaml
 apiVersion: v1
@@ -9949,6 +10016,104 @@ spec:
       - name: database-config
         secret:
           secretName: mysql
+status: {}
+---
+# apps/v1/Deployment redis
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: redis
+  name: redis
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gitpod
+      component: redis
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: redis
+      name: redis
+      namespace: default
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: gitpod.io/workload_meta
+                operator: Exists
+      containers:
+      - command:
+        - redis-server
+        - --save ""
+        - --appendonly no
+        - --maxmemory 100mb
+        - --maxmemory-policy allkeys-lru
+        - --port 6379
+        env:
+        - name: GITPOD_DOMAIN
+          value: gitpod.example.com
+        - name: GITPOD_INSTALLATION_SHORTNAME
+          value: default
+        - name: GITPOD_REGION
+          value: local
+        - name: HOST_URL
+          value: https://gitpod.example.com
+        - name: KUBE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: KUBE_DOMAIN
+          value: svc.cluster.local
+        - name: LOG_LEVEL
+          value: info
+        image: registry.hub.docker.com/library/redis:7.0.8
+        imagePullPolicy: IfNotPresent
+        name: redis
+        ports:
+        - containerPort: 6379
+          name: api
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - /health/ping_readiness_local.sh 1
+          failureThreshold: 5
+          initialDelaySeconds: 5
+          periodSeconds: 30
+          successThreshold: 1
+          timeoutSeconds: 3
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128M
+        securityContext:
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
+      dnsPolicy: ClusterFirst
+      enableServiceLinks: false
+      priorityClassName: system-node-critical
+      restartPolicy: Always
+      securityContext:
+        runAsNonRoot: false
+      serviceAccountName: redis
+      terminationGracePeriodSeconds: 30
 status: {}
 ---
 # apps/v1/Deployment registry

--- a/install/installer/cmd/testdata/render/overrides-inline/output.golden
+++ b/install/installer/cmd/testdata/render/overrides-inline/output.golden
@@ -996,6 +996,18 @@ automountServiceAccountToken: true
 secrets:
   - name: messagebus
 ---
+# v1/ServiceAccount redis
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: redis
+  name: redis
+  namespace: default
+---
 # v1/ServiceAccount registry-facade
 apiVersion: v1
 automountServiceAccountToken: true
@@ -2753,6 +2765,37 @@ data:
         app: gitpod
         component: public-api-server
       name: public-api-server
+      namespace: default
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: redis
+      name: redis
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: redis
+        kind: service
+      name: redis
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: redis
+      name: redis
       namespace: default
     ---
     apiVersion: v1
@@ -7362,6 +7405,30 @@ spec:
 status:
   loadBalancer: {}
 ---
+# v1/Service redis
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: redis
+    kind: service
+  name: redis
+  namespace: default
+spec:
+  ports:
+  - name: api
+    port: 6379
+    protocol: TCP
+    targetPort: 6379
+  selector:
+    app: gitpod
+    component: redis
+  type: ClusterIP
+status:
+  loadBalancer: {}
+---
 # v1/Service registry
 # Source: docker-registry/charts/docker-registry/templates/service.yaml
 apiVersion: v1
@@ -9959,6 +10026,104 @@ spec:
       - name: database-config
         secret:
           secretName: mysql
+status: {}
+---
+# apps/v1/Deployment redis
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: redis
+  name: redis
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gitpod
+      component: redis
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: redis
+      name: redis
+      namespace: default
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: gitpod.io/workload_meta
+                operator: Exists
+      containers:
+      - command:
+        - redis-server
+        - --save ""
+        - --appendonly no
+        - --maxmemory 100mb
+        - --maxmemory-policy allkeys-lru
+        - --port 6379
+        env:
+        - name: GITPOD_DOMAIN
+          value: gitpod.example.com
+        - name: GITPOD_INSTALLATION_SHORTNAME
+          value: default
+        - name: GITPOD_REGION
+          value: local
+        - name: HOST_URL
+          value: https://gitpod.example.com
+        - name: KUBE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: KUBE_DOMAIN
+          value: svc.cluster.local
+        - name: LOG_LEVEL
+          value: info
+        image: registry.hub.docker.com/library/redis:7.0.8
+        imagePullPolicy: IfNotPresent
+        name: redis
+        ports:
+        - containerPort: 6379
+          name: api
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - /health/ping_readiness_local.sh 1
+          failureThreshold: 5
+          initialDelaySeconds: 5
+          periodSeconds: 30
+          successThreshold: 1
+          timeoutSeconds: 3
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128M
+        securityContext:
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
+      dnsPolicy: ClusterFirst
+      enableServiceLinks: false
+      priorityClassName: system-node-critical
+      restartPolicy: Always
+      securityContext:
+        runAsNonRoot: false
+      serviceAccountName: redis
+      terminationGracePeriodSeconds: 30
 status: {}
 ---
 # apps/v1/Deployment registry

--- a/install/installer/cmd/testdata/render/pod-config/output.golden
+++ b/install/installer/cmd/testdata/render/pod-config/output.golden
@@ -998,6 +998,18 @@ automountServiceAccountToken: true
 secrets:
   - name: messagebus
 ---
+# v1/ServiceAccount redis
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: redis
+  name: redis
+  namespace: default
+---
 # v1/ServiceAccount registry-facade
 apiVersion: v1
 automountServiceAccountToken: true
@@ -2762,6 +2774,37 @@ data:
         app: gitpod
         component: public-api-server
       name: public-api-server
+      namespace: default
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: redis
+      name: redis
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: redis
+        kind: service
+      name: redis
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: redis
+      name: redis
       namespace: default
     ---
     apiVersion: v1
@@ -7368,6 +7411,30 @@ spec:
 status:
   loadBalancer: {}
 ---
+# v1/Service redis
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: redis
+    kind: service
+  name: redis
+  namespace: default
+spec:
+  ports:
+  - name: api
+    port: 6379
+    protocol: TCP
+    targetPort: 6379
+  selector:
+    app: gitpod
+    component: redis
+  type: ClusterIP
+status:
+  loadBalancer: {}
+---
 # v1/Service registry
 # Source: docker-registry/charts/docker-registry/templates/service.yaml
 apiVersion: v1
@@ -9956,6 +10023,104 @@ spec:
       - name: database-config
         secret:
           secretName: mysql
+status: {}
+---
+# apps/v1/Deployment redis
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: redis
+  name: redis
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gitpod
+      component: redis
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: redis
+      name: redis
+      namespace: default
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: gitpod.io/workload_meta
+                operator: Exists
+      containers:
+      - command:
+        - redis-server
+        - --save ""
+        - --appendonly no
+        - --maxmemory 100mb
+        - --maxmemory-policy allkeys-lru
+        - --port 6379
+        env:
+        - name: GITPOD_DOMAIN
+          value: gitpod.example.com
+        - name: GITPOD_INSTALLATION_SHORTNAME
+          value: default
+        - name: GITPOD_REGION
+          value: local
+        - name: HOST_URL
+          value: https://gitpod.example.com
+        - name: KUBE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: KUBE_DOMAIN
+          value: svc.cluster.local
+        - name: LOG_LEVEL
+          value: info
+        image: registry.hub.docker.com/library/redis:7.0.8
+        imagePullPolicy: IfNotPresent
+        name: redis
+        ports:
+        - containerPort: 6379
+          name: api
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - /health/ping_readiness_local.sh 1
+          failureThreshold: 5
+          initialDelaySeconds: 5
+          periodSeconds: 30
+          successThreshold: 1
+          timeoutSeconds: 3
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128M
+        securityContext:
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
+      dnsPolicy: ClusterFirst
+      enableServiceLinks: false
+      priorityClassName: system-node-critical
+      restartPolicy: Always
+      securityContext:
+        runAsNonRoot: false
+      serviceAccountName: redis
+      terminationGracePeriodSeconds: 30
 status: {}
 ---
 # apps/v1/Deployment registry

--- a/install/installer/cmd/testdata/render/shortname/output.golden
+++ b/install/installer/cmd/testdata/render/shortname/output.golden
@@ -998,6 +998,18 @@ automountServiceAccountToken: true
 secrets:
   - name: messagebus
 ---
+# v1/ServiceAccount redis
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: redis
+  name: redis
+  namespace: default
+---
 # v1/ServiceAccount registry-facade
 apiVersion: v1
 automountServiceAccountToken: true
@@ -2755,6 +2767,37 @@ data:
         app: gitpod
         component: public-api-server
       name: public-api-server
+      namespace: default
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: redis
+      name: redis
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: redis
+        kind: service
+      name: redis
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: redis
+      name: redis
       namespace: default
     ---
     apiVersion: v1
@@ -7361,6 +7404,30 @@ spec:
 status:
   loadBalancer: {}
 ---
+# v1/Service redis
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: redis
+    kind: service
+  name: redis
+  namespace: default
+spec:
+  ports:
+  - name: api
+    port: 6379
+    protocol: TCP
+    targetPort: 6379
+  selector:
+    app: gitpod
+    component: redis
+  type: ClusterIP
+status:
+  loadBalancer: {}
+---
 # v1/Service registry
 # Source: docker-registry/charts/docker-registry/templates/service.yaml
 apiVersion: v1
@@ -9949,6 +10016,104 @@ spec:
       - name: database-config
         secret:
           secretName: mysql
+status: {}
+---
+# apps/v1/Deployment redis
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: redis
+  name: redis
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gitpod
+      component: redis
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: redis
+      name: redis
+      namespace: default
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: gitpod.io/workload_meta
+                operator: Exists
+      containers:
+      - command:
+        - redis-server
+        - --save ""
+        - --appendonly no
+        - --maxmemory 100mb
+        - --maxmemory-policy allkeys-lru
+        - --port 6379
+        env:
+        - name: GITPOD_DOMAIN
+          value: gitpod.example.com
+        - name: GITPOD_INSTALLATION_SHORTNAME
+          value: dev
+        - name: GITPOD_REGION
+          value: local
+        - name: HOST_URL
+          value: https://gitpod.example.com
+        - name: KUBE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: KUBE_DOMAIN
+          value: svc.cluster.local
+        - name: LOG_LEVEL
+          value: info
+        image: registry.hub.docker.com/library/redis:7.0.8
+        imagePullPolicy: IfNotPresent
+        name: redis
+        ports:
+        - containerPort: 6379
+          name: api
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - /health/ping_readiness_local.sh 1
+          failureThreshold: 5
+          initialDelaySeconds: 5
+          periodSeconds: 30
+          successThreshold: 1
+          timeoutSeconds: 3
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128M
+        securityContext:
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
+      dnsPolicy: ClusterFirst
+      enableServiceLinks: false
+      priorityClassName: system-node-critical
+      restartPolicy: Always
+      securityContext:
+        runAsNonRoot: false
+      serviceAccountName: redis
+      terminationGracePeriodSeconds: 30
 status: {}
 ---
 # apps/v1/Deployment registry

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -998,6 +998,18 @@ automountServiceAccountToken: true
 secrets:
   - name: messagebus
 ---
+# v1/ServiceAccount redis
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: redis
+  name: redis
+  namespace: default
+---
 # v1/ServiceAccount registry-facade
 apiVersion: v1
 automountServiceAccountToken: true
@@ -2767,6 +2779,37 @@ data:
         app: gitpod
         component: public-api-server
       name: public-api-server
+      namespace: default
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: redis
+      name: redis
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: redis
+        kind: service
+      name: redis
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: redis
+      name: redis
       namespace: default
     ---
     apiVersion: v1
@@ -7373,6 +7416,30 @@ spec:
 status:
   loadBalancer: {}
 ---
+# v1/Service redis
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: redis
+    kind: service
+  name: redis
+  namespace: default
+spec:
+  ports:
+  - name: api
+    port: 6379
+    protocol: TCP
+    targetPort: 6379
+  selector:
+    app: gitpod
+    component: redis
+  type: ClusterIP
+status:
+  loadBalancer: {}
+---
 # v1/Service registry
 # Source: docker-registry/charts/docker-registry/templates/service.yaml
 apiVersion: v1
@@ -9961,6 +10028,104 @@ spec:
       - name: database-config
         secret:
           secretName: mysql
+status: {}
+---
+# apps/v1/Deployment redis
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: redis
+  name: redis
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gitpod
+      component: redis
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: redis
+      name: redis
+      namespace: default
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: gitpod.io/workload_meta
+                operator: Exists
+      containers:
+      - command:
+        - redis-server
+        - --save ""
+        - --appendonly no
+        - --maxmemory 100mb
+        - --maxmemory-policy allkeys-lru
+        - --port 6379
+        env:
+        - name: GITPOD_DOMAIN
+          value: gitpod.example.com
+        - name: GITPOD_INSTALLATION_SHORTNAME
+          value: default
+        - name: GITPOD_REGION
+          value: local
+        - name: HOST_URL
+          value: https://gitpod.example.com
+        - name: KUBE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: KUBE_DOMAIN
+          value: svc.cluster.local
+        - name: LOG_LEVEL
+          value: info
+        image: registry.hub.docker.com/library/redis:7.0.8
+        imagePullPolicy: IfNotPresent
+        name: redis
+        ports:
+        - containerPort: 6379
+          name: api
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - /health/ping_readiness_local.sh 1
+          failureThreshold: 5
+          initialDelaySeconds: 5
+          periodSeconds: 30
+          successThreshold: 1
+          timeoutSeconds: 3
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128M
+        securityContext:
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
+      dnsPolicy: ClusterFirst
+      enableServiceLinks: false
+      priorityClassName: system-node-critical
+      restartPolicy: Always
+      securityContext:
+        runAsNonRoot: false
+      serviceAccountName: redis
+      terminationGracePeriodSeconds: 30
 status: {}
 ---
 # apps/v1/Deployment registry

--- a/install/installer/cmd/testdata/render/telemetry/output.golden
+++ b/install/installer/cmd/testdata/render/telemetry/output.golden
@@ -998,6 +998,18 @@ automountServiceAccountToken: true
 secrets:
   - name: messagebus
 ---
+# v1/ServiceAccount redis
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: redis
+  name: redis
+  namespace: default
+---
 # v1/ServiceAccount registry-facade
 apiVersion: v1
 automountServiceAccountToken: true
@@ -2758,6 +2770,37 @@ data:
         app: gitpod
         component: public-api-server
       name: public-api-server
+      namespace: default
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: redis
+      name: redis
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: redis
+        kind: service
+      name: redis
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: redis
+      name: redis
       namespace: default
     ---
     apiVersion: v1
@@ -7364,6 +7407,30 @@ spec:
 status:
   loadBalancer: {}
 ---
+# v1/Service redis
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: redis
+    kind: service
+  name: redis
+  namespace: default
+spec:
+  ports:
+  - name: api
+    port: 6379
+    protocol: TCP
+    targetPort: 6379
+  selector:
+    app: gitpod
+    component: redis
+  type: ClusterIP
+status:
+  loadBalancer: {}
+---
 # v1/Service registry
 # Source: docker-registry/charts/docker-registry/templates/service.yaml
 apiVersion: v1
@@ -9952,6 +10019,104 @@ spec:
       - name: database-config
         secret:
           secretName: mysql
+status: {}
+---
+# apps/v1/Deployment redis
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: redis
+  name: redis
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gitpod
+      component: redis
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: redis
+      name: redis
+      namespace: default
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: gitpod.io/workload_meta
+                operator: Exists
+      containers:
+      - command:
+        - redis-server
+        - --save ""
+        - --appendonly no
+        - --maxmemory 100mb
+        - --maxmemory-policy allkeys-lru
+        - --port 6379
+        env:
+        - name: GITPOD_DOMAIN
+          value: gitpod.example.com
+        - name: GITPOD_INSTALLATION_SHORTNAME
+          value: default
+        - name: GITPOD_REGION
+          value: local
+        - name: HOST_URL
+          value: https://gitpod.example.com
+        - name: KUBE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: KUBE_DOMAIN
+          value: svc.cluster.local
+        - name: LOG_LEVEL
+          value: info
+        image: registry.hub.docker.com/library/redis:7.0.8
+        imagePullPolicy: IfNotPresent
+        name: redis
+        ports:
+        - containerPort: 6379
+          name: api
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - /health/ping_readiness_local.sh 1
+          failureThreshold: 5
+          initialDelaySeconds: 5
+          periodSeconds: 30
+          successThreshold: 1
+          timeoutSeconds: 3
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128M
+        securityContext:
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
+      dnsPolicy: ClusterFirst
+      enableServiceLinks: false
+      priorityClassName: system-node-critical
+      restartPolicy: Always
+      securityContext:
+        runAsNonRoot: false
+      serviceAccountName: redis
+      terminationGracePeriodSeconds: 30
 status: {}
 ---
 # apps/v1/Deployment registry

--- a/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
+++ b/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
@@ -1220,6 +1220,18 @@ automountServiceAccountToken: true
 secrets:
   - name: messagebus
 ---
+# v1/ServiceAccount redis
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: redis
+  name: redis
+  namespace: default
+---
 # v1/ServiceAccount registry-facade
 apiVersion: v1
 automountServiceAccountToken: true
@@ -3043,6 +3055,37 @@ data:
         app: gitpod
         component: public-api-server
       name: public-api-server
+      namespace: default
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: redis
+      name: redis
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: redis
+        kind: service
+      name: redis
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: redis
+      name: redis
       namespace: default
     ---
     apiVersion: v1
@@ -7805,6 +7848,30 @@ spec:
 status:
   loadBalancer: {}
 ---
+# v1/Service redis
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: redis
+    kind: service
+  name: redis
+  namespace: default
+spec:
+  ports:
+  - name: api
+    port: 6379
+    protocol: TCP
+    targetPort: 6379
+  selector:
+    app: gitpod
+    component: redis
+  type: ClusterIP
+status:
+  loadBalancer: {}
+---
 # v1/Service registry
 # Source: docker-registry/charts/docker-registry/templates/service.yaml
 apiVersion: v1
@@ -10393,6 +10460,104 @@ spec:
       - name: database-config
         secret:
           secretName: mysql
+status: {}
+---
+# apps/v1/Deployment redis
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: redis
+  name: redis
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gitpod
+      component: redis
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: redis
+      name: redis
+      namespace: default
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: gitpod.io/workload_meta
+                operator: Exists
+      containers:
+      - command:
+        - redis-server
+        - --save ""
+        - --appendonly no
+        - --maxmemory 100mb
+        - --maxmemory-policy allkeys-lru
+        - --port 6379
+        env:
+        - name: GITPOD_DOMAIN
+          value: gitpod.example.com
+        - name: GITPOD_INSTALLATION_SHORTNAME
+          value: default
+        - name: GITPOD_REGION
+          value: local
+        - name: HOST_URL
+          value: https://gitpod.example.com
+        - name: KUBE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: KUBE_DOMAIN
+          value: svc.cluster.local
+        - name: LOG_LEVEL
+          value: info
+        image: registry.hub.docker.com/library/redis:7.0.8
+        imagePullPolicy: IfNotPresent
+        name: redis
+        ports:
+        - containerPort: 6379
+          name: api
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - /health/ping_readiness_local.sh 1
+          failureThreshold: 5
+          initialDelaySeconds: 5
+          periodSeconds: 30
+          successThreshold: 1
+          timeoutSeconds: 3
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128M
+        securityContext:
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
+      dnsPolicy: ClusterFirst
+      enableServiceLinks: false
+      priorityClassName: system-node-critical
+      restartPolicy: Always
+      securityContext:
+        runAsNonRoot: false
+      serviceAccountName: redis
+      terminationGracePeriodSeconds: 30
 status: {}
 ---
 # apps/v1/Deployment registry

--- a/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
+++ b/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
@@ -998,6 +998,18 @@ automountServiceAccountToken: true
 secrets:
   - name: messagebus
 ---
+# v1/ServiceAccount redis
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: redis
+  name: redis
+  namespace: default
+---
 # v1/ServiceAccount registry-facade
 apiVersion: v1
 automountServiceAccountToken: true
@@ -2758,6 +2770,37 @@ data:
         app: gitpod
         component: public-api-server
       name: public-api-server
+      namespace: default
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: redis
+      name: redis
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: redis
+        kind: service
+      name: redis
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: redis
+      name: redis
       namespace: default
     ---
     apiVersion: v1
@@ -7364,6 +7407,30 @@ spec:
 status:
   loadBalancer: {}
 ---
+# v1/Service redis
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: redis
+    kind: service
+  name: redis
+  namespace: default
+spec:
+  ports:
+  - name: api
+    port: 6379
+    protocol: TCP
+    targetPort: 6379
+  selector:
+    app: gitpod
+    component: redis
+  type: ClusterIP
+status:
+  loadBalancer: {}
+---
 # v1/Service registry
 # Source: docker-registry/charts/docker-registry/templates/service.yaml
 apiVersion: v1
@@ -9940,6 +10007,104 @@ spec:
       - name: database-config
         secret:
           secretName: mysql
+status: {}
+---
+# apps/v1/Deployment redis
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: redis
+  name: redis
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gitpod
+      component: redis
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: redis
+      name: redis
+      namespace: default
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: gitpod.io/workload_meta
+                operator: Exists
+      containers:
+      - command:
+        - redis-server
+        - --save ""
+        - --appendonly no
+        - --maxmemory 100mb
+        - --maxmemory-policy allkeys-lru
+        - --port 6379
+        env:
+        - name: GITPOD_DOMAIN
+          value: gitpod.example.com
+        - name: GITPOD_INSTALLATION_SHORTNAME
+          value: default
+        - name: GITPOD_REGION
+          value: local
+        - name: HOST_URL
+          value: https://gitpod.example.com
+        - name: KUBE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: KUBE_DOMAIN
+          value: svc.cluster.local
+        - name: LOG_LEVEL
+          value: info
+        image: registry.hub.docker.com/library/redis:7.0.8
+        imagePullPolicy: IfNotPresent
+        name: redis
+        ports:
+        - containerPort: 6379
+          name: api
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - /health/ping_readiness_local.sh 1
+          failureThreshold: 5
+          initialDelaySeconds: 5
+          periodSeconds: 30
+          successThreshold: 1
+          timeoutSeconds: 3
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128M
+        securityContext:
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
+      dnsPolicy: ClusterFirst
+      enableServiceLinks: false
+      priorityClassName: system-node-critical
+      restartPolicy: Always
+      securityContext:
+        runAsNonRoot: false
+      serviceAccountName: redis
+      terminationGracePeriodSeconds: 30
 status: {}
 ---
 # apps/v1/Deployment registry

--- a/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
+++ b/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
@@ -998,6 +998,18 @@ automountServiceAccountToken: true
 secrets:
   - name: messagebus
 ---
+# v1/ServiceAccount redis
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: redis
+  name: redis
+  namespace: default
+---
 # v1/ServiceAccount registry-facade
 apiVersion: v1
 automountServiceAccountToken: true
@@ -2758,6 +2770,37 @@ data:
         app: gitpod
         component: public-api-server
       name: public-api-server
+      namespace: default
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: redis
+      name: redis
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: redis
+        kind: service
+      name: redis
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: redis
+      name: redis
       namespace: default
     ---
     apiVersion: v1
@@ -7364,6 +7407,30 @@ spec:
 status:
   loadBalancer: {}
 ---
+# v1/Service redis
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: redis
+    kind: service
+  name: redis
+  namespace: default
+spec:
+  ports:
+  - name: api
+    port: 6379
+    protocol: TCP
+    targetPort: 6379
+  selector:
+    app: gitpod
+    component: redis
+  type: ClusterIP
+status:
+  loadBalancer: {}
+---
 # v1/Service registry
 # Source: docker-registry/charts/docker-registry/templates/service.yaml
 apiVersion: v1
@@ -9952,6 +10019,104 @@ spec:
       - name: database-config
         secret:
           secretName: mysql
+status: {}
+---
+# apps/v1/Deployment redis
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gitpod
+    component: redis
+  name: redis
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gitpod
+      component: redis
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: gitpod
+        component: redis
+      name: redis
+      namespace: default
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: gitpod.io/workload_meta
+                operator: Exists
+      containers:
+      - command:
+        - redis-server
+        - --save ""
+        - --appendonly no
+        - --maxmemory 100mb
+        - --maxmemory-policy allkeys-lru
+        - --port 6379
+        env:
+        - name: GITPOD_DOMAIN
+          value: gitpod.example.com
+        - name: GITPOD_INSTALLATION_SHORTNAME
+          value: default
+        - name: GITPOD_REGION
+          value: local
+        - name: HOST_URL
+          value: https://gitpod.example.com
+        - name: KUBE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: KUBE_DOMAIN
+          value: svc.cluster.local
+        - name: LOG_LEVEL
+          value: info
+        image: registry.hub.docker.com/library/redis:7.0.8
+        imagePullPolicy: IfNotPresent
+        name: redis
+        ports:
+        - containerPort: 6379
+          name: api
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - /health/ping_readiness_local.sh 1
+          failureThreshold: 5
+          initialDelaySeconds: 5
+          periodSeconds: 30
+          successThreshold: 1
+          timeoutSeconds: 3
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128M
+        securityContext:
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
+      dnsPolicy: ClusterFirst
+      enableServiceLinks: false
+      priorityClassName: system-node-critical
+      restartPolicy: Always
+      securityContext:
+        runAsNonRoot: false
+      serviceAccountName: redis
+      terminationGracePeriodSeconds: 30
 status: {}
 ---
 # apps/v1/Deployment registry

--- a/install/installer/pkg/components/components-webapp/components.go
+++ b/install/installer/pkg/components/components-webapp/components.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gitpod-io/gitpod/installer/pkg/components/proxy"
 	public_api_server "github.com/gitpod-io/gitpod/installer/pkg/components/public-api-server"
 	"github.com/gitpod-io/gitpod/installer/pkg/components/rabbitmq"
+	"github.com/gitpod-io/gitpod/installer/pkg/components/redis"
 	"github.com/gitpod-io/gitpod/installer/pkg/components/server"
 	"github.com/gitpod-io/gitpod/installer/pkg/components/slowserver"
 	"github.com/gitpod-io/gitpod/installer/pkg/components/spicedb"
@@ -37,6 +38,7 @@ var Objects = common.CompositeRenderFunc(
 	usage.Objects,
 	toxiproxy.Objects,
 	spicedb.Objects,
+	redis.Objects,
 )
 
 var Helm = common.CompositeHelmFunc(

--- a/install/installer/pkg/components/redis/constants.go
+++ b/install/installer/pkg/components/redis/constants.go
@@ -1,0 +1,21 @@
+// Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package redis
+
+const (
+	Component = "redis"
+
+	PortName = "api"
+	Port     = 6379
+
+	ContainerPrometheusPort  = 9090
+	ContainterPrometheusName = "prometheus"
+
+	RegistryRepo  = "registry.hub.docker.com"
+	RegistryImage = "library/redis"
+	ImageTag      = "7.0.8"
+
+	ContainerName = "redis"
+)

--- a/install/installer/pkg/components/redis/deployment.go
+++ b/install/installer/pkg/components/redis/deployment.go
@@ -1,0 +1,109 @@
+// Copyright (c) 2021 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package redis
+
+import (
+	"fmt"
+
+	"github.com/gitpod-io/gitpod/installer/pkg/cluster"
+	"github.com/gitpod-io/gitpod/installer/pkg/common"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/pointer"
+)
+
+func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
+	labels := common.CustomizeLabel(ctx, Component, common.TypeMetaDeployment)
+
+	return []runtime.Object{
+		&appsv1.Deployment{
+			TypeMeta: common.TypeMetaDeployment,
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        Component,
+				Namespace:   ctx.Namespace,
+				Labels:      labels,
+				Annotations: common.CustomizeAnnotation(ctx, Component, common.TypeMetaDeployment),
+			},
+			Spec: appsv1.DeploymentSpec{
+				Selector: &metav1.LabelSelector{MatchLabels: common.DefaultLabels(Component)},
+				Replicas: common.Replicas(ctx, Component),
+				Strategy: common.DeploymentStrategy,
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        Component,
+						Namespace:   ctx.Namespace,
+						Labels:      labels,
+						Annotations: common.CustomizeAnnotation(ctx, Component, common.TypeMetaDeployment),
+					},
+					Spec: corev1.PodSpec{
+						Affinity:                      common.NodeAffinity(cluster.AffinityLabelMeta),
+						PriorityClassName:             common.SystemNodeCritical,
+						ServiceAccountName:            Component,
+						EnableServiceLinks:            pointer.Bool(false),
+						DNSPolicy:                     "ClusterFirst",
+						RestartPolicy:                 "Always",
+						TerminationGracePeriodSeconds: pointer.Int64(30),
+						SecurityContext: &corev1.PodSecurityContext{
+							RunAsNonRoot: pointer.Bool(false),
+						},
+						Containers: []corev1.Container{
+							{
+								Name:            ContainerName,
+								Image:           ctx.ImageName(common.ThirdPartyContainerRepo(ctx.Config.Repository, RegistryRepo), RegistryImage, ImageTag),
+								ImagePullPolicy: corev1.PullIfNotPresent,
+								Command: []string{
+									"redis-server",
+									`--save ""`,       // disable persistence
+									"--appendonly no", // disable persistence
+									"--maxmemory 100mb",
+									"--maxmemory-policy allkeys-lru", // evict on LRU basis,
+									fmt.Sprintf("--port %d", Port),
+								},
+								Env: common.CustomizeEnvvar(ctx, Component, common.MergeEnv(
+									common.DefaultEnv(&ctx.Config),
+								)),
+								Ports: []corev1.ContainerPort{
+									{
+										ContainerPort: Port,
+										Name:          PortName,
+										Protocol:      *common.TCPProtocol,
+									},
+								},
+								Resources: common.ResourceRequirements(ctx, Component, ContainerName, corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										"cpu":    resource.MustParse("0.1"),
+										"memory": resource.MustParse("128M"),
+									},
+								}),
+								SecurityContext: &corev1.SecurityContext{
+									RunAsGroup:   pointer.Int64(65532),
+									RunAsNonRoot: pointer.Bool(true),
+									RunAsUser:    pointer.Int64(65532),
+								},
+								ReadinessProbe: &corev1.Probe{
+									ProbeHandler: corev1.ProbeHandler{
+										Exec: &v1.ExecAction{
+											Command: []string{"sh", "-c", "/health/ping_readiness_local.sh 1"},
+										},
+									},
+									InitialDelaySeconds: 5,
+									PeriodSeconds:       30,
+									FailureThreshold:    5,
+									SuccessThreshold:    1,
+									TimeoutSeconds:      3,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}, nil
+}

--- a/install/installer/pkg/components/redis/objects.go
+++ b/install/installer/pkg/components/redis/objects.go
@@ -1,0 +1,18 @@
+// Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package redis
+
+import (
+	"github.com/gitpod-io/gitpod/installer/pkg/common"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func Objects(ctx *common.RenderContext) ([]runtime.Object, error) {
+	return common.CompositeRenderFunc(
+		deployment,
+		service,
+		common.DefaultServiceAccount(Component),
+	)(ctx)
+}

--- a/install/installer/pkg/components/redis/service.go
+++ b/install/installer/pkg/components/redis/service.go
@@ -1,0 +1,20 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+/// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package redis
+
+import (
+	"github.com/gitpod-io/gitpod/installer/pkg/common"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func service(ctx *common.RenderContext) ([]runtime.Object, error) {
+	return common.GenerateService(Component, []common.ServicePort{
+		{
+			Name:          PortName,
+			ContainerPort: Port,
+			ServicePort:   Port,
+		},
+	})(ctx)
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Deploys redis into application cluster.

* No persistence
* Single instance setup

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
1. Redis comes up in preview k8s

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
