### PR TITLE
[gp-cli] fix sync-await cannot interrupt

### DIFF
--- a/components/gitpod-cli/cmd/sync-await.go
+++ b/components/gitpod-cli/cmd/sync-await.go
@@ -40,8 +40,12 @@ var awaitSyncCmd = &cobra.Command{
 			done <- true
 		}()
 
-		<-done
-		fmt.Printf("%s done\n", args[0])
+		select {
+		case <-cmd.Context().Done():
+		case <-done:
+			fmt.Printf("%s done\n", args[0])
+		}
+
 		return nil
 	},
 }


### PR DESCRIPTION
A copy from https://github.com/gitpod-io/gitpod/pull/16330

## Description
<!-- Describe your changes in detail -->
Fix `gp sync-await` command cannot interrupt problem. 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/pull/16330

## How to test
<!-- Provide steps to test this PR -->
- Open workspace in preview env
- Exec command `gp sync-await a`
- Interrupt command `Ctrl+C`
- Exec command `gp sync-await a` and `gp sync-done a`, make sure first command respond ok

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
