### PR TITLE
[server] Typed workspace region

### DIFF
--- a/components/gitpod-db/src/typeorm/entity/db-workspace-cluster.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-workspace-cluster.ts
@@ -13,6 +13,8 @@ import {
 } from "@gitpod/gitpod-protocol/lib/workspace-cluster";
 import { ValueTransformer } from "typeorm/decorator/options/ValueTransformer";
 
+export type WorkspaceRegion = "europe" | "north-america" | "south-america" | "africa" | "asia" | ""; // unknown;
+
 @Entity()
 // on DB but not Typeorm: @Index("ind_lastModified", ["_lastModified"])   // DBSync
 export class DBWorkspaceCluster implements WorkspaceCluster {
@@ -96,7 +98,7 @@ export class DBWorkspaceCluster implements WorkspaceCluster {
         type: "varchar",
         length: 60,
     })
-    region: string;
+    region: WorkspaceRegion;
 
     // This column triggers the db-sync deletion mechanism. It's not intended for public consumption.
     @Column()

--- a/components/gitpod-db/src/typeorm/workspace-cluster-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/workspace-cluster-db-impl.ts
@@ -78,6 +78,9 @@ export class WorkspaceClusterDBImpl implements WorkspaceClusterDB {
         if (predicate.url !== undefined) {
             qb = qb.andWhere("wsc.url = :url", predicate);
         }
+        if (predicate.region !== undefined && predicate.region !== "") {
+            qb = qb.andWhere("wsc.region = :region", predicate);
+        }
         return qb.getMany();
     }
 }

--- a/components/gitpod-db/src/workspace-cluster-db.spec.db.ts
+++ b/components/gitpod-db/src/workspace-cluster-db.spec.db.ts
@@ -40,7 +40,7 @@ export class WorkspaceClusterDBSpec {
         const wsc1: DBWorkspaceCluster = dbWorkspaceCluster({
             name: "eu71",
             applicationCluster: "eu02",
-            region: "europe-west1",
+            region: "europe",
             url: "some-url",
             state: "available",
             score: 100,
@@ -50,7 +50,7 @@ export class WorkspaceClusterDBSpec {
         const wsc1a: DBWorkspaceCluster = dbWorkspaceCluster({
             name: "eu71",
             applicationCluster: "us02",
-            region: "us-west1",
+            region: "north-america",
             url: "some-url",
             state: "cordoned",
             score: 0,
@@ -60,7 +60,7 @@ export class WorkspaceClusterDBSpec {
         const wsc2: DBWorkspaceCluster = dbWorkspaceCluster({
             name: "us71",
             applicationCluster: "eu02",
-            region: "europe-west1",
+            region: "europe",
             url: "some-url",
             state: "cordoned",
             score: 0,
@@ -95,7 +95,7 @@ export class WorkspaceClusterDBSpec {
         const wsc1: DBWorkspaceCluster = dbWorkspaceCluster({
             name: "eu71",
             applicationCluster: "eu02",
-            region: "europe-west1",
+            region: "europe",
             url: "some-url",
             state: "available",
             score: 100,
@@ -105,7 +105,7 @@ export class WorkspaceClusterDBSpec {
         const wsc1a: DBWorkspaceCluster = dbWorkspaceCluster({
             name: "eu71",
             applicationCluster: "us02",
-            region: "us-west1",
+            region: "north-america",
             url: "some-url",
             state: "cordoned",
             score: 0,
@@ -115,7 +115,7 @@ export class WorkspaceClusterDBSpec {
         const wsc2: DBWorkspaceCluster = dbWorkspaceCluster({
             name: "us71",
             applicationCluster: "eu02",
-            region: "europe-west1",
+            region: "europe",
             url: "some-url",
             state: "cordoned",
             score: 0,
@@ -138,7 +138,7 @@ export class WorkspaceClusterDBSpec {
         const wsc1: DBWorkspaceCluster = dbWorkspaceCluster({
             name: "eu71",
             applicationCluster: "eu02",
-            region: "europe-west1",
+            region: "europe",
             url: "some-url",
             state: "available",
             score: 100,
@@ -148,7 +148,7 @@ export class WorkspaceClusterDBSpec {
         const wsc1a: DBWorkspaceCluster = dbWorkspaceCluster({
             name: "eu71",
             applicationCluster: "us02",
-            region: "us-west1",
+            region: "north-america",
             url: "some-url",
             state: "cordoned",
             score: 0,
@@ -158,7 +158,7 @@ export class WorkspaceClusterDBSpec {
         const wsc2: DBWorkspaceCluster = dbWorkspaceCluster({
             name: "us71",
             applicationCluster: "eu02",
-            region: "europe-west1",
+            region: "europe",
             url: "some-url",
             state: "cordoned",
             score: 0,
@@ -180,7 +180,7 @@ export class WorkspaceClusterDBSpec {
         const wsc1: DBWorkspaceCluster = dbWorkspaceCluster({
             name: "eu71",
             applicationCluster: "eu02",
-            region: "europe-west1",
+            region: "europe",
             url: "some-url",
             state: "available",
             score: 100,
@@ -190,7 +190,7 @@ export class WorkspaceClusterDBSpec {
         const wsc1a: DBWorkspaceCluster = dbWorkspaceCluster({
             name: "eu71",
             applicationCluster: "us02",
-            region: "us-west1",
+            region: "north-america",
             url: "some-url",
             state: "cordoned",
             score: 0,
@@ -200,7 +200,7 @@ export class WorkspaceClusterDBSpec {
         const wsc2: DBWorkspaceCluster = dbWorkspaceCluster({
             name: "us71",
             applicationCluster: "us02",
-            region: "us-west1",
+            region: "north-america",
             url: "some-url",
             state: "available",
             score: 100,
@@ -216,7 +216,7 @@ export class WorkspaceClusterDBSpec {
             {
                 name: "eu71",
                 applicationCluster: "eu02",
-                region: "europe-west1",
+                region: "europe",
                 url: "some-url",
                 state: "available",
                 score: 100,
@@ -233,7 +233,7 @@ export class WorkspaceClusterDBSpec {
             {
                 name: "eu71",
                 applicationCluster: "us02",
-                region: "us-west1",
+                region: "north-america",
                 url: "some-url",
                 state: "cordoned",
                 score: 0,
@@ -244,7 +244,7 @@ export class WorkspaceClusterDBSpec {
             {
                 name: "us71",
                 applicationCluster: "us02",
-                region: "us-west1",
+                region: "north-america",
                 url: "some-url",
                 state: "available",
                 score: 100,
@@ -262,7 +262,7 @@ export class WorkspaceClusterDBSpec {
         const wsc1: DBWorkspaceCluster = dbWorkspaceCluster({
             name: "eu71",
             applicationCluster: "eu02",
-            region: "europe-west1",
+            region: "europe",
             url: "some-url",
             state: "available",
             score: 100,
@@ -272,7 +272,7 @@ export class WorkspaceClusterDBSpec {
         const wsc1a: DBWorkspaceCluster = dbWorkspaceCluster({
             name: "eu71",
             applicationCluster: "us02",
-            region: "us-west1",
+            region: "north-america",
             url: "some-url",
             state: "cordoned",
             score: 0,
@@ -282,7 +282,7 @@ export class WorkspaceClusterDBSpec {
         const wsc2: DBWorkspaceCluster = dbWorkspaceCluster({
             name: "us71",
             applicationCluster: "us02",
-            region: "us-west1",
+            region: "north-america",
             url: "some-url",
             state: "available",
             score: 100,
@@ -300,6 +300,51 @@ export class WorkspaceClusterDBSpec {
         expect(wscs.length).to.equal(1);
         wscs = await this.db.findFiltered({ applicationCluster: "eu02" });
         expect(wscs.length).to.equal(1);
+    }
+
+    @test public async testFindFilteredWithRegion() {
+        const clusters: DBWorkspaceCluster[] = [
+            dbWorkspaceCluster({
+                name: "eu71",
+                applicationCluster: "eu02",
+                region: "europe",
+                url: "some-url",
+                state: "available",
+                score: 100,
+                maxScore: 100,
+                govern: true,
+            }),
+            dbWorkspaceCluster({
+                name: "eu72",
+                applicationCluster: "eu02",
+                region: "",
+                url: "some-url",
+                state: "cordoned",
+                score: 0,
+                maxScore: 0,
+                govern: false,
+            }),
+            dbWorkspaceCluster({
+                name: "us71",
+                applicationCluster: "eu02",
+                region: "",
+                url: "some-url",
+                state: "available",
+                score: 100,
+                maxScore: 100,
+                govern: true,
+            }),
+        ];
+
+        for (const cluster of clusters) {
+            await this.db.save(cluster);
+        }
+
+        const withoutRegionFilter = await this.db.findFiltered({ applicationCluster: "eu02" });
+        expect(withoutRegionFilter.length).to.equal(3);
+
+        const matchingEurope = await this.db.findFiltered({ applicationCluster: "eu02", region: "europe" });
+        expect(matchingEurope.length).to.equal(1);
     }
 }
 

--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -62,6 +62,7 @@ import { IDEServer } from "./ide-protocol";
 import { ListUsageRequest, ListUsageResponse, CostCenterJSON } from "./usage";
 import { SupportedWorkspaceClass } from "./workspace-class";
 import { BillingMode } from "./billing-mode";
+import { WorkspaceRegion } from "./workspace-cluster";
 
 export interface GitpodClient {
     onInstanceUpdate(instance: WorkspaceInstance): void;
@@ -439,7 +440,7 @@ export namespace GitpodServer {
         forceDefaultImage?: boolean;
         workspaceClass?: string;
         ideSettings?: IDESettings;
-        region?: string;
+        region?: WorkspaceRegion;
     }
     export interface TakeSnapshotOptions {
         workspaceId: string;

--- a/components/gitpod-protocol/src/workspace-cluster.ts
+++ b/components/gitpod-protocol/src/workspace-cluster.ts
@@ -9,6 +9,13 @@ import { filePathTelepresenceAware } from "./env";
 import { DeepPartial } from "./util/deep-partial";
 import { PermissionName } from "./permission";
 
+const workspaceRegions = ["europe", "north-america", "south-america", "africa", "asia", ""] as const;
+export type WorkspaceRegion = typeof workspaceRegions[number];
+
+export function isWorkspaceRegion(s: string): s is WorkspaceRegion {
+    return workspaceRegions.indexOf(s as any) !== -1;
+}
+
 export interface WorkspaceCluster {
     // Name of the workspace cluster.
     // This is the string set in each
@@ -19,9 +26,9 @@ export interface WorkspaceCluster {
     // The name can be at most 60 characters.
     applicationCluster: string;
 
-    // The name of the region this cluster belongs to. E.g. us-west1 or europe-west1
+    // The name of the region this cluster belongs to. E.g. europe or north-america
     // The name can be at most 60 characters.
-    region: string;
+    region: WorkspaceRegion;
 
     // URL of the cluster's ws-manager API
     url: string;
@@ -110,5 +117,5 @@ export interface WorkspaceClusterDB {
 }
 
 export type WorkspaceClusterFilter = Pick<WorkspaceCluster, "applicationCluster"> &
-    DeepPartial<Pick<WorkspaceCluster, "name" | "state" | "govern" | "url">> &
+    DeepPartial<Pick<WorkspaceCluster, "name" | "state" | "govern" | "url" | "region">> &
     Partial<{ minScore: number }>;

--- a/components/server/src/workspace/region-service.ts
+++ b/components/server/src/workspace/region-service.ts
@@ -4,24 +4,22 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
+import { WorkspaceRegion } from "@gitpod/gitpod-protocol/lib/workspace-cluster";
 import { countries, continents } from "countries-list";
 
-const NorthAmerica = "north-america";
-const Europe = "europe";
-const Unknown = "unknown";
-
-type WorkspaceRegion = "europe" | "north-america" | "unknown";
+const NorthAmerica: WorkspaceRegion = "north-america";
+const Europe: WorkspaceRegion = "europe";
 
 export class RegionService {
     public static countryCodeToNearestWorkspaceRegion(code: string): WorkspaceRegion {
         if (!isCountryCode(code)) {
-            return Unknown;
+            return "";
         }
 
         const continent = countries[code].continent;
 
         if (!isContinentCode(continent)) {
-            return Unknown;
+            return "";
         }
 
         return nearestWorkspaceRegion[continent];

--- a/components/server/src/workspace/workspace-cluster-imagebuilder-client-provider.ts
+++ b/components/server/src/workspace/workspace-cluster-imagebuilder-client-provider.ts
@@ -6,6 +6,7 @@
 
 import { User, Workspace, WorkspaceInstance } from "@gitpod/gitpod-protocol";
 import { defaultGRPCOptions, IClientCallMetrics } from "@gitpod/gitpod-protocol/lib/util/grpc";
+import { WorkspaceRegion } from "@gitpod/gitpod-protocol/lib/workspace-cluster";
 import {
     ImageBuilderClient,
     ImageBuilderClientCallMetrics,
@@ -35,7 +36,7 @@ export class WorkspaceClusterImagebuilderClientProvider implements ImageBuilderC
         user: User,
         workspace: Workspace,
         instance: WorkspaceInstance,
-        region?: string,
+        region?: WorkspaceRegion,
     ): Promise<PromisifiedImageBuilderClient> {
         const clusters = await this.clientProvider.getStartClusterSets(
             applicationCluster,

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -126,6 +126,7 @@ import { BillingModes } from "../../ee/src/billing/billing-mode";
 import { AttributionId } from "@gitpod/gitpod-protocol/lib/attribution";
 import { LogContext } from "@gitpod/gitpod-protocol/lib/util/logging";
 import { repeat } from "@gitpod/gitpod-protocol/lib/util/repeat";
+import { WorkspaceRegion } from "@gitpod/gitpod-protocol/lib/workspace-cluster";
 
 export interface StartWorkspaceOptions extends GitpodServer.StartWorkspaceOptions {
     rethrow?: boolean;
@@ -441,7 +442,7 @@ export class WorkspaceStarter {
         projectEnvVars: ProjectEnvVar[],
         rethrow?: boolean,
         forceRebuild?: boolean,
-        region?: string,
+        region?: WorkspaceRegion,
     ): Promise<StartWorkspaceResult> {
         const span = TraceContext.startSpan("actuallyStartWorkspace", ctx);
         span.setTag("region_preference", region);
@@ -638,7 +639,7 @@ export class WorkspaceStarter {
         user: User,
         workspace: Workspace,
         instance: WorkspaceInstance,
-        region?: string,
+        region?: WorkspaceRegion,
     ): Promise<StartWorkspaceResponse.AsObject | undefined> {
         let lastInstallation = "";
         const clusters = await this.clientProvider.getStartClusterSets(
@@ -1067,7 +1068,7 @@ export class WorkspaceStarter {
         workspace: Workspace,
         instance: WorkspaceInstance,
         additionalAuth: Map<string, string>,
-        region?: string,
+        region?: WorkspaceRegion,
     ): Promise<boolean> {
         const span = TraceContext.startSpan("needsImageBuild", ctx);
         try {
@@ -1107,7 +1108,7 @@ export class WorkspaceStarter {
         ideConfig: IdeServiceApi.ResolveWorkspaceConfigResponse,
         ignoreBaseImageresolvedAndRebuildBase: boolean = false,
         forceRebuild: boolean = false,
-        region?: string,
+        region?: WorkspaceRegion,
     ): Promise<WorkspaceInstance> {
         const span = TraceContext.startSpan("buildWorkspaceImage", ctx);
 
@@ -1842,7 +1843,7 @@ export class WorkspaceStarter {
         user: User,
         workspace: Workspace,
         instance?: WorkspaceInstance,
-        region?: string,
+        region?: WorkspaceRegion,
     ) {
         return this.imagebuilderClientProvider.getClient(
             this.config.installationShortname,

--- a/components/ws-manager-api/typescript/src/client-provider.spec.ts
+++ b/components/ws-manager-api/typescript/src/client-provider.spec.ts
@@ -40,7 +40,7 @@ class TestClientProvider {
                         url: "",
                         admissionConstraints: [],
                         applicationCluster: "xx01",
-                        region: "us-west1",
+                        region: "north-america",
                     },
                     {
                         name: "c2",
@@ -51,7 +51,7 @@ class TestClientProvider {
                         url: "",
                         admissionConstraints: [],
                         applicationCluster: "xx01",
-                        region: "us-west1",
+                        region: "north-america",
                     },
                     {
                         name: "c3",
@@ -62,7 +62,7 @@ class TestClientProvider {
                         url: "",
                         admissionConstraints: [],
                         applicationCluster: "xx01",
-                        region: "us-west1",
+                        region: "north-america",
                     },
                     {
                         name: "a1",
@@ -73,7 +73,7 @@ class TestClientProvider {
                         url: "",
                         admissionConstraints: [],
                         applicationCluster: "xx01",
-                        region: "us-west1",
+                        region: "north-america",
                     },
                     {
                         name: "a2",
@@ -84,7 +84,7 @@ class TestClientProvider {
                         url: "",
                         admissionConstraints: [],
                         applicationCluster: "xx01",
-                        region: "us-west1",
+                        region: "north-america",
                     },
                     {
                         name: "a3",
@@ -95,7 +95,7 @@ class TestClientProvider {
                         url: "",
                         admissionConstraints: [],
                         applicationCluster: "xx01",
-                        region: "europe-west1",
+                        region: "europe",
                     },
                     {
                         name: "con1",
@@ -106,7 +106,7 @@ class TestClientProvider {
                         url: "",
                         admissionConstraints: [{ type: "has-permission", permission: "new-workspace-cluster" }],
                         applicationCluster: "xx01",
-                        region: "europe-west1",
+                        region: "europe",
                     },
                     {
                         name: "con2",
@@ -119,7 +119,7 @@ class TestClientProvider {
                             { type: "has-permission", permission: "monitor" }, // This is meant to represent a permission that does not take special precedence (cmp. constraints.ts)
                         ],
                         applicationCluster: "xx01",
-                        region: "europe-west1",
+                        region: "europe",
                     },
                 ];
                 return <WorkspaceManagerClientProviderSource>{
@@ -183,7 +183,7 @@ class TestClientProvider {
                 {} as User,
                 {} as Workspace,
                 {} as WorkspaceInstance,
-                "europe-west1",
+                "europe",
             ),
             "regional cluster set",
         );

--- a/components/ws-manager-api/typescript/src/client-provider.ts
+++ b/components/ws-manager-api/typescript/src/client-provider.ts
@@ -8,7 +8,11 @@ import { createClientCallMetricsInterceptor, IClientCallMetrics } from "@gitpod/
 import { Disposable, User, Workspace, WorkspaceInstance } from "@gitpod/gitpod-protocol";
 import { defaultGRPCOptions } from "@gitpod/gitpod-protocol/lib/util/grpc";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
-import { WorkspaceClusterWoTLS, WorkspaceManagerConnectionInfo } from "@gitpod/gitpod-protocol/lib/workspace-cluster";
+import {
+    WorkspaceClusterWoTLS,
+    WorkspaceManagerConnectionInfo,
+    WorkspaceRegion,
+} from "@gitpod/gitpod-protocol/lib/workspace-cluster";
 import * as grpc from "@grpc/grpc-js";
 import { inject, injectable, optional } from "inversify";
 import {
@@ -50,7 +54,7 @@ export class WorkspaceManagerClientProvider implements Disposable {
         user: User,
         workspace: Workspace,
         instance: WorkspaceInstance,
-        region?: string,
+        region?: WorkspaceRegion,
     ): Promise<IWorkspaceClusterStartSet> {
         const allClusters = await this.source.getAllWorkspaceClusters(applicationCluster);
         const availableClusters = allClusters.filter((c) => c.score > 0 && c.state === "available");

--- a/components/ws-manager-bridge/src/cluster-service-server.ts
+++ b/components/ws-manager-bridge/src/cluster-service-server.ts
@@ -45,6 +45,7 @@ import { getSupportedWorkspaceClasses } from "./cluster-sync-service";
 import { Configuration } from "./config";
 import { getExperimentsClientForBackend } from "@gitpod/gitpod-protocol/lib/experiments/configcat-server";
 import { GRPCError } from "./rpc";
+import { isWorkspaceRegion } from "@gitpod/gitpod-protocol/src/workspace-cluster";
 
 export interface ClusterServiceServerOptions {
     port: number;
@@ -86,6 +87,10 @@ export class ClusterService implements IClusterServiceServer {
             try {
                 // check if the name or URL are already registered/in use
                 const req = call.request.toObject();
+
+                if (!isWorkspaceRegion(req.region)) {
+                    throw new GRPCError(grpc.status.INVALID_ARGUMENT, `Invalid value for workspace region.`);
+                }
 
                 const clusterByNamePromise = this.clusterDB.findByName(req.name, this.config.installation);
                 const clusterByUrlPromise = this.clusterDB.findFiltered({


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Adds high level geographic regions as possible WorkspaceRegions. This achieves the following:
* We can fail early, if we attempt to register a cluster with an invalid region value
* We get better type-safety when dealing with regions
* It actually encodes somewhere what are the possible values for a region

As a drive-by,
* Fixes querying for WS clusters with a region filter, this was missed in https://github.com/gitpod-io/gitpod/pull/16136
* Updates tests to also use the same values

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Part of https://github.com/gitpod-io/gitpod/issues/16271

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
