### PR TITLE
[gitpod-db] reduce migration batch size

### DIFF
--- a/components/gitpod-db/src/long-running-migration/workspace-organizationid-migration.ts
+++ b/components/gitpod-db/src/long-running-migration/workspace-organizationid-migration.ts
@@ -9,7 +9,7 @@ import { inject, injectable } from "inversify";
 import { TypeORM } from "../typeorm/typeorm";
 import { LongRunningMigration } from "./long-running-migration";
 
-const BATCH_OFFSET = 5 * 24 * 60 * 60 * 1000; /* 5 days */
+const BATCH_OFFSET = 1 * 60 * 60 * 1000; /* 1 hour */
 
 @injectable()
 export class WorkspaceOrganizationIdMigration implements LongRunningMigration {
@@ -56,9 +56,11 @@ export class WorkspaceOrganizationIdMigration implements LongRunningMigration {
                     w.softDeleted IS NULL
             `;
             result = await runner.query(query);
-            log.info(`Migrated ${result.affectedRows} workspaces. Start date: ${startDate}, end date: ${endDate}`, {
-                query,
-            });
+            if (result.affectedRows > 0) {
+                log.info(`Migrated ${result.affectedRows} workspaces. Start date: ${startDate}, end date: ${endDate}`, {
+                    query,
+                });
+            }
             endDate = new Date(endDate.getTime() - BATCH_OFFSET);
             startDate = new Date(startDate.getTime() - BATCH_OFFSET);
         } while (result.affectedRows === 0 && endDate.toISOString() > minCreationTimeTotal);


### PR DESCRIPTION
## Description
Reduces the batch size of the workspace migration to only handle workspaces created within an hour at most.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
