### PR TITLE
[gitpod-web-extension] fix supervisor notify request not await

### DIFF
--- a/install/installer/cmd/testdata/render/agent-smith/output.golden
+++ b/install/installer/cmd/testdata/render/agent-smith/output.golden
@@ -3851,11 +3851,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-b443118d7ef8fff4a8814e5c66cd11da3a87a211",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-759bd2da35066c4cca3f6b99f6ece91529bc45bd",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-759bd2da35066c4cca3f6b99f6ece91529bc45bd",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/aws-setup/output.golden
+++ b/install/installer/cmd/testdata/render/aws-setup/output.golden
@@ -3292,11 +3292,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-b443118d7ef8fff4a8814e5c66cd11da3a87a211",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-759bd2da35066c4cca3f6b99f6ece91529bc45bd",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-759bd2da35066c4cca3f6b99f6ece91529bc45bd",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
+++ b/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
@@ -3668,11 +3668,11 @@ data:
             "image": "registry.mydomain.com/namespace/ide/code:commit-b443118d7ef8fff4a8814e5c66cd11da3a87a211",
             "latestImage": "registry.mydomain.com/namespace/ide/code:nightly",
             "imageLayers": [
-              "registry.mydomain.com/namespace/ide/gitpod-code-web:commit-759bd2da35066c4cca3f6b99f6ece91529bc45bd",
+              "registry.mydomain.com/namespace/ide/gitpod-code-web:commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03",
               "registry.mydomain.com/namespace/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "registry.mydomain.com/namespace/ide/gitpod-code-web:commit-759bd2da35066c4cca3f6b99f6ece91529bc45bd",
+              "registry.mydomain.com/namespace/ide/gitpod-code-web:commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03",
               "registry.mydomain.com/namespace/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -4200,11 +4200,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-b443118d7ef8fff4a8814e5c66cd11da3a87a211",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-759bd2da35066c4cca3f6b99f6ece91529bc45bd",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-759bd2da35066c4cca3f6b99f6ece91529bc45bd",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -3502,11 +3502,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-b443118d7ef8fff4a8814e5c66cd11da3a87a211",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-759bd2da35066c4cca3f6b99f6ece91529bc45bd",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-759bd2da35066c4cca3f6b99f6ece91529bc45bd",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/gcp-setup/output.golden
+++ b/install/installer/cmd/testdata/render/gcp-setup/output.golden
@@ -3387,11 +3387,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-b443118d7ef8fff4a8814e5c66cd11da3a87a211",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-759bd2da35066c4cca3f6b99f6ece91529bc45bd",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-759bd2da35066c4cca3f6b99f6ece91529bc45bd",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/http-proxy/output.golden
+++ b/install/installer/cmd/testdata/render/http-proxy/output.golden
@@ -3671,11 +3671,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-b443118d7ef8fff4a8814e5c66cd11da3a87a211",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-759bd2da35066c4cca3f6b99f6ece91529bc45bd",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-759bd2da35066c4cca3f6b99f6ece91529bc45bd",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/ide-config/output.golden
+++ b/install/installer/cmd/testdata/render/ide-config/output.golden
@@ -3684,11 +3684,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-b443118d7ef8fff4a8814e5c66cd11da3a87a211",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-759bd2da35066c4cca3f6b99f6ece91529bc45bd",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-759bd2da35066c4cca3f6b99f6ece91529bc45bd",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/kind-ide/output.golden
+++ b/install/installer/cmd/testdata/render/kind-ide/output.golden
@@ -1291,11 +1291,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-b443118d7ef8fff4a8814e5c66cd11da3a87a211",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-759bd2da35066c4cca3f6b99f6ece91529bc45bd",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-759bd2da35066c4cca3f6b99f6ece91529bc45bd",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/kind-meta/output.golden
+++ b/install/installer/cmd/testdata/render/kind-meta/output.golden
@@ -2636,11 +2636,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-b443118d7ef8fff4a8814e5c66cd11da3a87a211",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-759bd2da35066c4cca3f6b99f6ece91529bc45bd",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-759bd2da35066c4cca3f6b99f6ece91529bc45bd",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/message-bus-password/output.golden
+++ b/install/installer/cmd/testdata/render/message-bus-password/output.golden
@@ -3671,11 +3671,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-b443118d7ef8fff4a8814e5c66cd11da3a87a211",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-759bd2da35066c4cca3f6b99f6ece91529bc45bd",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-759bd2da35066c4cca3f6b99f6ece91529bc45bd",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -3668,11 +3668,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-b443118d7ef8fff4a8814e5c66cd11da3a87a211",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-759bd2da35066c4cca3f6b99f6ece91529bc45bd",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-759bd2da35066c4cca3f6b99f6ece91529bc45bd",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/overrides-inline/output.golden
+++ b/install/installer/cmd/testdata/render/overrides-inline/output.golden
@@ -3666,11 +3666,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-b443118d7ef8fff4a8814e5c66cd11da3a87a211",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-759bd2da35066c4cca3f6b99f6ece91529bc45bd",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-759bd2da35066c4cca3f6b99f6ece91529bc45bd",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/pod-config/output.golden
+++ b/install/installer/cmd/testdata/render/pod-config/output.golden
@@ -3675,11 +3675,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-b443118d7ef8fff4a8814e5c66cd11da3a87a211",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-759bd2da35066c4cca3f6b99f6ece91529bc45bd",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-759bd2da35066c4cca3f6b99f6ece91529bc45bd",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/shortname/output.golden
+++ b/install/installer/cmd/testdata/render/shortname/output.golden
@@ -3668,11 +3668,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-b443118d7ef8fff4a8814e5c66cd11da3a87a211",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-759bd2da35066c4cca3f6b99f6ece91529bc45bd",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-759bd2da35066c4cca3f6b99f6ece91529bc45bd",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -3680,11 +3680,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-b443118d7ef8fff4a8814e5c66cd11da3a87a211",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-759bd2da35066c4cca3f6b99f6ece91529bc45bd",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-759bd2da35066c4cca3f6b99f6ece91529bc45bd",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/telemetry/output.golden
+++ b/install/installer/cmd/testdata/render/telemetry/output.golden
@@ -3671,11 +3671,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-b443118d7ef8fff4a8814e5c66cd11da3a87a211",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-759bd2da35066c4cca3f6b99f6ece91529bc45bd",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-759bd2da35066c4cca3f6b99f6ece91529bc45bd",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
+++ b/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
@@ -4001,11 +4001,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-b443118d7ef8fff4a8814e5c66cd11da3a87a211",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-759bd2da35066c4cca3f6b99f6ece91529bc45bd",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-759bd2da35066c4cca3f6b99f6ece91529bc45bd",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
+++ b/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
@@ -3671,11 +3671,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-b443118d7ef8fff4a8814e5c66cd11da3a87a211",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-759bd2da35066c4cca3f6b99f6ece91529bc45bd",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-759bd2da35066c4cca3f6b99f6ece91529bc45bd",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
+++ b/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
@@ -3671,11 +3671,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-b443118d7ef8fff4a8814e5c66cd11da3a87a211",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-759bd2da35066c4cca3f6b99f6ece91529bc45bd",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-759bd2da35066c4cca3f6b99f6ece91529bc45bd",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/pkg/components/workspace/ide/constants.go
+++ b/install/installer/pkg/components/workspace/ide/constants.go
@@ -9,7 +9,7 @@ const (
 	CodeIDEImageStableVersion   = "commit-b443118d7ef8fff4a8814e5c66cd11da3a87a211" // stable version that will be updated manually on demand
 	CodeHelperIDEImage          = "ide/code-codehelper"
 	CodeWebExtensionImage       = "ide/gitpod-code-web"
-	CodeWebExtensionVersion     = "commit-759bd2da35066c4cca3f6b99f6ece91529bc45bd" // gitpod-web extension version comes from https://github.com/gitpod-io/gitpod-code
+	CodeWebExtensionVersion     = "commit-57f10d5fd6d6a325b6d991b96a30fef9eb42ec03" // gitpod-web extension version comes from https://github.com/gitpod-io/gitpod-code
 	CodeDesktopIDEImage         = "ide/code-desktop"
 	CodeDesktopInsidersIDEImage = "ide/code-desktop-insiders"
 	IntelliJDesktopIDEImage     = "ide/intellij"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
changes https://github.com/gitpod-io/gitpod-code/commit/57f10d5fd6d6a325b6d991b96a30fef9eb42ec03

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/16283

## How to test
<!-- Provide steps to test this PR -->
- Open workpace in preview env
- Exec `/.supervisor/supervisor notify test --actions=open` to trigger notification in browser code / desktop code multiple times
- It should work and with correct selected action respond


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
