### PR TITLE
[db] optimize workspace update

### DIFF
--- a/components/gitpod-db/.vscode/launch.json
+++ b/components/gitpod-db/.vscode/launch.json
@@ -5,7 +5,8 @@
             "type": "node",
             "request": "launch",
             "env": {
-                "DB_PORT": "23306"
+                "DB_PORT": "23306",
+                "DB_ENCRYPTION_KEYS": "[{\"name\":\"general\",\"version\":1,\"primary\":true,\"material\":\"5vRrp0H4oRgdkPnX1qQcS54Q0xggr6iyho42IQ1rO+c=\"}]"
             },
             "name": "Run Mocha Test in Editor",
             "program": "${workspaceFolder}/node_modules/.bin/_mocha",

--- a/components/gitpod-db/src/user-to-team-migration-service.spec.db.ts
+++ b/components/gitpod-db/src/user-to-team-migration-service.spec.db.ts
@@ -30,6 +30,7 @@ describe("Migration Service", () => {
         await conn.query("DELETE FROM d_b_team");
         await conn.query("DELETE FROM d_b_stripe_customer");
         await conn.query("DELETE FROM d_b_workspace_instance");
+        await conn.query("DELETE FROM d_b_workspace");
         await conn.query("DELETE FROM d_b_usage");
         await conn.query("DELETE FROM d_b_cost_center");
     };

--- a/components/gitpod-db/src/user-to-team-migration-service.ts
+++ b/components/gitpod-db/src/user-to-team-migration-service.ts
@@ -118,7 +118,13 @@ export class UserToTeamMigrationService {
         log.info(ctx, "Migrated workspace instances.", { teamId: team.id, result });
 
         result = await conn.query(
-            "UPDATE d_b_workspace SET organizationId = ? WHERE id IN (SELECT workspaceid from d_b_workspace_instance where usageAttributionId = ?)",
+            `
+                UPDATE d_b_workspace w
+                JOIN d_b_workspace_instance wi
+                ON w.id = wi.workspaceid
+                SET w.organizationId = ?
+                WHERE wi.usageAttributionId = ?
+            `,
             [team.id, newAttribution],
         );
         log.info(ctx, "Migrated workspaces.", { teamId: team.id, result });


### PR DESCRIPTION
## Description
Turns out that MYSQL doesn't the optimize subquery in the IN clause of the UPDATE statement, and hence, the entire d_b_workspace table is being scanned.

This PR rewrites the update to use a JOIN, which will be optimized using the indices on d_b_workspace.id and d_b_workspace_instance.workspaceid and the UPDATE statement should be faster.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
