### PR TITLE
[gpctl] Expose region in cluster list

### DIFF
--- a/dev/gpctl/cmd/clusters-list.go
+++ b/dev/gpctl/cmd/clusters-list.go
@@ -33,9 +33,9 @@ var clustersListCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		tpl := `NAME	APPCLUSTER	URL	STATIC	STATE	SCORE	GOVERNED	ADMISSION CONSTRAINTS
+		tpl := `NAME	APPCLUSTER	URL	STATIC	STATE	SCORE	GOVERNED	REGION	ADMISSION CONSTRAINTS
 {{- range .Status }}
-{{ .Name }}	{{ .ApplicationCluster }}	{{ .Url }}	{{ .Static }}	{{ .State }}	{{ .Score }}	{{ .Governed }}	{{ .AdmissionConstraint -}}
+{{ .Name }}	{{ .ApplicationCluster }}	{{ .Url }}	{{ .Static }}	{{ .State }}	{{ .Score }}	{{ .Governed }}	{{ .Region }}	{{ .AdmissionConstraint -}}
 {{ end }}
 `
 		err = getOutputFormat(tpl, "{..name}").Print(resp)


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Adds Region to the list of clusters

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
* Depends on https://github.com/gitpod-io/gitpod/pull/16343
* Part of https://github.com/gitpod-io/gitpod/issues/16271

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`

/hold for dependency PR