### PR TITLE
[server] Don't start a prebuild if the usage limit got reached

### DIFF
--- a/components/server/ee/src/billing/entitlement-service-license.ts
+++ b/components/server/ee/src/billing/entitlement-service-license.ts
@@ -28,7 +28,7 @@ export class EntitlementServiceLicense implements EntitlementService {
 
     async mayStartWorkspace(
         user: User,
-        workspace: Workspace,
+        workspace: Pick<Workspace, "projectId">,
         date: Date,
         runningInstances: Promise<WorkspaceInstance[]>,
     ): Promise<MayStartWorkspaceResult> {

--- a/components/server/ee/src/billing/entitlement-service-ubp.ts
+++ b/components/server/ee/src/billing/entitlement-service-ubp.ts
@@ -47,7 +47,7 @@ export class EntitlementServiceUBP implements EntitlementService {
 
     async mayStartWorkspace(
         user: User,
-        workspace: Workspace,
+        workspace: Pick<Workspace, "projectId">,
         date: Date,
         runningInstances: Promise<WorkspaceInstance[]>,
     ): Promise<MayStartWorkspaceResult> {
@@ -75,7 +75,7 @@ export class EntitlementServiceUBP implements EntitlementService {
 
     protected async checkUsageLimitReached(
         user: User,
-        workspace: Workspace,
+        workspace: Pick<Workspace, "projectId">,
         date: Date,
     ): Promise<AttributionId | undefined> {
         const result = await this.userService.checkUsageLimitReached(user, workspace);

--- a/components/server/src/billing/entitlement-service.ts
+++ b/components/server/src/billing/entitlement-service.ts
@@ -17,6 +17,7 @@ import { injectable } from "inversify";
 
 export interface MayStartWorkspaceResult {
     hitParallelWorkspaceLimit?: HitParallelWorkspaceLimit;
+    //** Out of Chargebee credits? */
     oufOfCredits?: boolean;
 
     needsVerification?: boolean;
@@ -42,7 +43,7 @@ export interface EntitlementService {
      */
     mayStartWorkspace(
         user: User,
-        workspace: Workspace,
+        workspace: Pick<Workspace, "projectId">,
         date: Date,
         runningInstances: Promise<WorkspaceInstance[]>,
     ): Promise<MayStartWorkspaceResult>;

--- a/components/server/src/user/user-service.ts
+++ b/components/server/src/user/user-service.ts
@@ -244,7 +244,10 @@ export class UserService {
      * @param workspace - optional, in which case the default billing account will be checked
      * @returns
      */
-    async checkUsageLimitReached(user: User, workspace?: Workspace): Promise<UsageLimitReachedResult> {
+    async checkUsageLimitReached(
+        user: User,
+        workspace?: Pick<Workspace, "projectId">,
+    ): Promise<UsageLimitReachedResult> {
         const attributionId = await this.getWorkspaceUsageAttributionId(user, workspace?.projectId);
         const creditBalance = await this.usageService.getCurrentBalance(attributionId);
         const currentInvoiceCredits = creditBalance.usedCredits;


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
