### PR TITLE
[ws-manager-mk2] Aborted condition, grace period

### DIFF
--- a/components/ws-daemon/pkg/controller/controller.go
+++ b/components/ws-daemon/pkg/controller/controller.go
@@ -222,11 +222,16 @@ func (wsc *WorkspaceController) handleWorkspaceStop(ctx context.Context, ws *wor
 		return ctrl.Result{}, fmt.Errorf("workspace content was never ready")
 	}
 
-	if c := wsk8s.GetCondition(ws.Status.Conditions, string(workspacev1.WorkspaceConditionBackupComplete)); c != nil && c.Status == metav1.ConditionTrue {
+	if wsk8s.ConditionPresentAndTrue(ws.Status.Conditions, string(workspacev1.WorkspaceConditionBackupComplete)) {
 		return ctrl.Result{}, nil
 	}
 
-	if c := wsk8s.GetCondition(ws.Status.Conditions, string(workspacev1.WorkspaceConditionBackupFailure)); c != nil && c.Status == metav1.ConditionTrue {
+	if wsk8s.ConditionPresentAndTrue(ws.Status.Conditions, string(workspacev1.WorkspaceConditionBackupFailure)) {
+		return ctrl.Result{}, nil
+	}
+
+	if wsk8s.ConditionPresentAndTrue(ws.Status.Conditions, string(workspacev1.WorkspaceConditionAborted)) {
+		span.LogKV("event", "workspace was aborted")
 		return ctrl.Result{}, nil
 	}
 

--- a/components/ws-manager-api/go/crd/v1/workspace_types.go
+++ b/components/ws-manager-api/go/crd/v1/workspace_types.go
@@ -130,7 +130,7 @@ type WorkspaceStatus struct {
 	Runtime *WorkspaceRuntimeStatus `json:"runtime,omitempty"`
 }
 
-// +kubebuilder:validation:Enum=Deployed;Failed;Timeout;FirstUserActivity;Closed;HeadlessTaskFailed;StoppedByRequest;ContentReady;BackupComplete;BackupFailure
+// +kubebuilder:validation:Enum=Deployed;Failed;Timeout;FirstUserActivity;Closed;HeadlessTaskFailed;StoppedByRequest;Aborted;ContentReady;BackupComplete;BackupFailure
 type WorkspaceCondition string
 
 const (
@@ -153,8 +153,12 @@ const (
 	// HeadlessTaskFailed indicates that a headless workspace task failed
 	WorkspaceConditionsHeadlessTaskFailed WorkspaceCondition = "HeadlessTaskFailed"
 
-	// StoppedByRequest is true if the workspace was stopped using a StopWorkspace call
+	// StoppedByRequest is true if the workspace was stopped using a StopWorkspace call.
+	// The condition message will contain the requested grace period.
 	WorkspaceConditionStoppedByRequest WorkspaceCondition = "StoppedByRequest"
+
+	// Aborted is true if StopWorkspace was called with StopWorkspacePolicy set to ABORT
+	WorkspaceConditionAborted WorkspaceCondition = "Aborted"
 
 	// ContentReady is true once the content initialisation is complete
 	WorkspaceConditionContentReady WorkspaceCondition = "ContentReady"

--- a/components/ws-manager-mk2/controllers/create.go
+++ b/components/ws-manager-mk2/controllers/create.go
@@ -47,6 +47,10 @@ const (
 
 	// gitpodPodFinalizerName is the name of the finalizer we use on pods
 	gitpodPodFinalizerName = "gitpod.io/finalizer"
+
+	// Grace time until the process in the workspace is properly completed
+	// e.g. dockerd in the workspace may take some time to clean up the overlay directory.
+	gracePeriod = 3 * time.Minute
 )
 
 type startWorkspaceContext struct {
@@ -392,6 +396,7 @@ func createDefiniteWorkspacePod(sctx *startWorkspaceContext) (*corev1.Pod, error
 		},
 	}
 
+	graceSec := int64(gracePeriod.Seconds())
 	pod := corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        fmt.Sprintf("%s-%s", prefix, sctx.Workspace.Name),
@@ -418,8 +423,9 @@ func createDefiniteWorkspacePod(sctx *startWorkspaceContext) (*corev1.Pod, error
 			Containers: []corev1.Container{
 				*workspaceContainer,
 			},
-			RestartPolicy: corev1.RestartPolicyNever,
-			Volumes:       volumes,
+			RestartPolicy:                 corev1.RestartPolicyNever,
+			Volumes:                       volumes,
+			TerminationGracePeriodSeconds: &graceSec,
 			Tolerations: []corev1.Toleration{
 				{
 					Key:      "node.kubernetes.io/disk-pressure",

--- a/components/ws-manager-mk2/controllers/status.go
+++ b/components/ws-manager-mk2/controllers/status.go
@@ -124,6 +124,7 @@ func updateWorkspaceStatus(ctx context.Context, workspace *workspacev1.Workspace
 		if controllerutil.ContainsFinalizer(pod, gitpodPodFinalizerName) {
 			if wsk8s.ConditionPresentAndTrue(workspace.Status.Conditions, string(workspacev1.WorkspaceConditionBackupComplete)) ||
 				wsk8s.ConditionPresentAndTrue(workspace.Status.Conditions, string(workspacev1.WorkspaceConditionBackupFailure)) ||
+				wsk8s.ConditionPresentAndTrue(workspace.Status.Conditions, string(workspacev1.WorkspaceConditionAborted)) ||
 				wsk8s.ConditionWithStatusAndReason(workspace.Status.Conditions, string(workspacev1.WorkspaceConditionContentReady), false, "InitializationFailure") {
 
 				workspace.Status.Phase = workspacev1.WorkspacePhaseStopped


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

- Handle `Abort` workspace stop policy.
- Handle grace period in workspace stop request.
- Add termination timeout seconds to workspace Pods.
- Return `FinalBackupComplete` condition in API calls

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Relates to #11416 

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
