### PR TITLE
Add nav items and icons to org selector

### DIFF
--- a/components/dashboard/src/components/ContextMenu.tsx
+++ b/components/dashboard/src/components/ContextMenu.tsx
@@ -4,7 +4,7 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import React, { HTMLAttributeAnchorTarget } from "react";
+import React, { FunctionComponent, HTMLAttributeAnchorTarget } from "react";
 import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import cn from "classnames";
@@ -82,10 +82,6 @@ function ContextMenu(props: ContextMenuProps) {
         };
     }, []); // Empty array ensures that effect is only run on mount and unmount
 
-    const font = "text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-100";
-
-    const menuId = String(Math.random());
-
     // Default 'children' is the three dots hamburger button.
     const children = props.children || (
         <svg
@@ -118,7 +114,7 @@ function ContextMenu(props: ContextMenuProps) {
             </div>
             {expanded ? (
                 <div
-                    className={`mt-2 z-50 bg-white dark:bg-gray-900 absolute flex flex-col border border-gray-200 dark:border-gray-800 rounded-lg truncated ${
+                    className={`cursor-default mt-2 z-50 bg-white dark:bg-gray-900 absolute flex flex-col border border-gray-200 dark:border-gray-800 rounded-lg truncated ${
                         props.customClasses || "w-48 right-0"
                     }`}
                     data-analytics='{"button_type":"context_menu"}'
@@ -127,30 +123,14 @@ function ContextMenu(props: ContextMenuProps) {
                         <p className="px-4 py-3">No actions available</p>
                     ) : (
                         props.menuEntries.map((e, index) => {
-                            const clickable = e.href || e.onClick || e.link;
                             const entry = (
-                                <div
-                                    className={`px-4 flex py-3 ${
-                                        clickable ? "hover:bg-gray-100 dark:hover:bg-gray-700" : ""
-                                    } ${e.active ? "bg-gray-50 dark:bg-gray-800" : ""} ${
-                                        index === 0 ? "rounded-t-lg" : ""
-                                    } ${
-                                        index === props.menuEntries.length - 1 ? "rounded-b-lg" : ""
-                                    } text-sm leading-1 ${e.customFontStyle || font} ${
-                                        e.separator ? " border-b border-gray-200 dark:border-gray-800" : ""
-                                    }`}
-                                    title={e.title}
-                                >
-                                    {e.customContent || (
-                                        <>
-                                            <div className="truncate w-52">{e.title}</div>
-                                            <div className="flex-1"></div>
-                                            {e.active ? <div className="pl-1 font-semibold">&#x2713;</div> : null}
-                                        </>
-                                    )}
-                                </div>
+                                <MenuEntry
+                                    {...e}
+                                    isFirst={index === 0}
+                                    isLast={index === props.menuEntries.length - 1}
+                                />
                             );
-                            const key = `entry-${menuId}-${index}-${e.title}`;
+                            const key = `entry-${index}-${e.title}`;
                             if (e.link) {
                                 return (
                                     <Link key={key} to={e.link} onClick={e.onClick} target={e.target}>
@@ -185,3 +165,47 @@ function ContextMenu(props: ContextMenuProps) {
 }
 
 export default ContextMenu;
+
+type MenuEntryProps = ContextMenuEntry & {
+    isFirst: boolean;
+    isLast: boolean;
+};
+export const MenuEntry: FunctionComponent<MenuEntryProps> = ({
+    title,
+    href,
+    link,
+    active = false,
+    separator = false,
+    customContent,
+    customFontStyle,
+    isFirst,
+    isLast,
+    onClick,
+}) => {
+    const clickable = href || link || onClick;
+
+    return (
+        <div
+            title={title}
+            className={cn(
+                "px-4 py-2 flex leading-1 text-sm",
+                customFontStyle || "text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-100",
+                {
+                    "cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-700": clickable,
+                    "bg-gray-50 dark:bg-gray-800": active,
+                    "rounded-t-lg": isFirst,
+                    "rounded-b-lg": isLast,
+                    "border-b border-gray-200 dark:border-gray-800": separator,
+                },
+            )}
+        >
+            {customContent || (
+                <>
+                    <div className="truncate w-52">{title}</div>
+                    <div className="flex-1"></div>
+                    {active ? <div className="pl-1 font-semibold">&#x2713;</div> : null}
+                </>
+            )}
+        </div>
+    );
+};

--- a/components/dashboard/src/components/org-icon/OrgIcon.tsx
+++ b/components/dashboard/src/components/org-icon/OrgIcon.tsx
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import classNames from "classnames";
+import { FunctionComponent } from "react";
+import { consistentClassname } from "./consistent-classname";
+import "./styles.css";
+
+const SIZE_CLASSES = {
+    small: "w-6 h-6",
+    medium: "w-10 h-10",
+};
+
+const TEXT_SIZE_CLASSES = {
+    small: "text-sm",
+    medium: "text-xl",
+};
+
+type Props = {
+    id: string;
+    name: string;
+    size?: keyof typeof SIZE_CLASSES;
+    className?: string;
+};
+export const OrgIcon: FunctionComponent<Props> = ({ id, name, size = "medium", className }) => {
+    const logoBGClass = consistentClassname(id);
+    const initials = getOrgInitials(name);
+    const sizeClasses = SIZE_CLASSES[size];
+    const textClass = TEXT_SIZE_CLASSES[size];
+
+    return (
+        <div
+            className={classNames("rounded-full flex items-center justify-center", sizeClasses, logoBGClass, className)}
+        >
+            <span className={`text-white font-semibold ${textClass}`}>{initials}</span>
+        </div>
+    );
+};
+
+function getOrgInitials(name: string) {
+    // If for some reason there is no name, default to G for Gitpod
+    return (name || "G").charAt(0).toLocaleUpperCase();
+}

--- a/components/dashboard/src/components/org-icon/consistent-classname.test.ts
+++ b/components/dashboard/src/components/org-icon/consistent-classname.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { BG_CLASSES, consistentClassname } from "./consistent-classname";
+
+describe("consistentClassname()", () => {
+    test("empty string", () => {
+        const id = "";
+        const cn = consistentClassname(id);
+
+        expect(cn).toEqual(BG_CLASSES[0]);
+    });
+
+    test("max value", () => {
+        const id = "ffffffffffffffffffffffffffffffff";
+        const cn = consistentClassname(id);
+
+        expect(cn).toEqual(BG_CLASSES[BG_CLASSES.length - 1]);
+    });
+
+    test("with an id value", () => {
+        const id = "c5895528-23ac-4ebd-9d8b-464228d5755f";
+        const cn = consistentClassname(id);
+
+        expect(BG_CLASSES).toContain(cn);
+    });
+
+    test("with an id value without hyphens", () => {
+        const id = "c589552823ac4ebd9d8b464228d5755f";
+        const cn = consistentClassname(id);
+
+        expect(BG_CLASSES).toContain(cn);
+    });
+
+    test("with a shorter id value", () => {
+        const id = "c5895528";
+        const cn = consistentClassname(id);
+
+        expect(BG_CLASSES).toContain(cn);
+    });
+
+    test("returns the same classname for the same value", () => {
+        const id = "c5895528-23ac-4ebd-9d8b-464228d5755f";
+        const cn1 = consistentClassname(id);
+        const cn2 = consistentClassname(id);
+
+        expect(cn1).toEqual(cn2);
+        expect(BG_CLASSES).toContain(cn1);
+        expect(BG_CLASSES).toContain(cn2);
+    });
+});

--- a/components/dashboard/src/components/org-icon/consistent-classname.ts
+++ b/components/dashboard/src/components/org-icon/consistent-classname.ts
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+// Represents the max value our base16 guid can be, 32 "f"s
+const GUID_MAX = "".padEnd(32, "f");
+
+export const BG_CLASSES = [
+    "bg-gradient-1",
+    "bg-gradient-2",
+    "bg-gradient-3",
+    "bg-gradient-4",
+    "bg-gradient-5",
+    "bg-gradient-6",
+    "bg-gradient-7",
+    "bg-gradient-8",
+    "bg-gradient-9",
+];
+
+export const consistentClassname = (id: string) => {
+    // Turn id into a 32 char. guid, pad with "0" if it's not 32 chars already
+    const guid = id.replaceAll("-", "").substring(0, 32).padEnd(32, "0");
+
+    // Map guid into a 0,1 range by dividing by the max guid
+    var quotient = parseInt(guid, 16) / parseInt(GUID_MAX, 16);
+    var idx = Math.floor(quotient * (BG_CLASSES.length - 1));
+
+    return BG_CLASSES[idx];
+};

--- a/components/dashboard/src/components/org-icon/styles.css
+++ b/components/dashboard/src/components/org-icon/styles.css
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+
+@layer components {
+    .bg-gradient-1 {
+        background: linear-gradient(45deg, theme('colors.orange.500') 25%, theme('colors.orange.300') 75%);
+    }
+    .bg-gradient-2 {
+        background: linear-gradient(45deg, theme('colors.orange.500') 25%, theme('colors.pink.800') 75%);
+    }
+    .bg-gradient-3 {
+        background: linear-gradient(45deg, theme('colors.orange.500') 25%, theme('colors.red.500') 75%);
+    }
+    .bg-gradient-4 {
+        background: linear-gradient(45deg, theme('colors.orange.500') 25%, theme('colors.green.700') 75%);
+    }
+    .bg-gradient-5 {
+        background: linear-gradient(45deg, theme('colors.orange.500') 25%, theme('colors.yellow.300') 75%);
+    }
+    .bg-gradient-6 {
+        background: linear-gradient(45deg, theme('colors.orange.500') 25%, theme('colors.indigo.700') 75%);
+    }
+    .bg-gradient-7 {
+        background: linear-gradient(45deg, theme('colors.orange.500') 25%, theme('colors.teal.500') 75%);
+    }
+    .bg-gradient-8 {
+        background: linear-gradient(45deg, theme('colors.orange.500') 25%, theme('colors.sky.900') 75%);
+    }
+    .bg-gradient-9 {
+        background: linear-gradient(45deg, theme('colors.orange.500') 25%, theme('colors.rose.300') 75%);
+    }
+}

--- a/components/dashboard/src/data/billing-mode/user-billing-mode-query.ts
+++ b/components/dashboard/src/data/billing-mode/user-billing-mode-query.ts
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { BillingMode } from "@gitpod/gitpod-protocol/lib/billing-mode";
+import { useQuery } from "@tanstack/react-query";
+import { getGitpodService } from "../../service/service";
+import { useCurrentUser } from "../../user-context";
+
+type UserBillingModeQueryResult = BillingMode;
+
+export const useUserBillingMode = () => {
+    const user = useCurrentUser();
+
+    return useQuery<UserBillingModeQueryResult>({
+        queryKey: getUserBillingModeQueryKey(user?.id ?? ""),
+        queryFn: async () => {
+            if (!user) {
+                throw new Error("No current user, cannot load billing mode");
+            }
+            return await getGitpodService().server.getBillingModeForUser();
+        },
+        enabled: !!user,
+    });
+};
+
+export const getUserBillingModeQueryKey = (userId: string) => ["billing-mode", { userId }];

--- a/components/dashboard/src/menu/OrganizationSelector.tsx
+++ b/components/dashboard/src/menu/OrganizationSelector.tsx
@@ -4,65 +4,158 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { useMemo } from "react";
-import { useLocation } from "react-router-dom";
+import { FunctionComponent, useMemo } from "react";
 import ContextMenu, { ContextMenuEntry } from "../components/ContextMenu";
+import { OrgIcon } from "../components/org-icon/OrgIcon";
 import { useCurrentTeam, useTeamMemberInfos, useTeams } from "../teams/teams-context";
+import { useCurrentOrgMember } from "../data/organizations/org-members-query";
 import { useCurrentUser } from "../user-context";
+import { BillingMode } from "@gitpod/gitpod-protocol/lib/billing-mode";
+import { useUserBillingMode } from "../data/billing-mode/user-billing-mode-query";
+import { useOrgBillingMode } from "../data/billing-mode/org-billing-mode-query";
+import { useFeatureFlags } from "../contexts/FeatureFlagContext";
 
 export interface OrganizationSelectorProps {}
 
 export default function OrganizationSelector(p: OrganizationSelectorProps) {
     const user = useCurrentUser();
     const teams = useTeams();
-    const team = useCurrentTeam();
+    const currentOrg = useCurrentTeam();
     const teamMembers = useTeamMemberInfos();
-    const location = useLocation();
+    const { member: currentOrgMember } = useCurrentOrgMember();
+    const { data: userBillingMode } = useUserBillingMode();
+    const { data: orgBillingMode } = useOrgBillingMode();
+    const { showUsageView } = useFeatureFlags();
 
     const userFullName = user?.fullName || user?.name || "...";
-    const entries: ContextMenuEntry[] = useMemo(
-        () => [
-            ...(!user?.additionalData?.isMigratedToTeamOnlyAttribution
+
+    const entries: ContextMenuEntry[] = useMemo(() => {
+        let activeOrgEntry = !currentOrg
+            ? {
+                  title: userFullName,
+                  customContent: <CurrentOrgEntry title={userFullName} subtitle="Personal Account" />,
+                  active: false,
+                  separator: false,
+                  tight: true,
+              }
+            : {
+                  title: currentOrg.name,
+                  customContent: (
+                      <CurrentOrgEntry
+                          title={currentOrg.name}
+                          subtitle={
+                              !!teamMembers[currentOrg.id]
+                                  ? `${teamMembers[currentOrg.id].length} member${
+                                        teamMembers[currentOrg.id].length === 1 ? "" : "s"
+                                    }`
+                                  : "..."
+                          }
+                      />
+                  ),
+                  active: false,
+                  separator: false,
+                  tight: true,
+              };
+
+        const linkEntries: ContextMenuEntry[] = [];
+
+        // Show members if we have an org selected
+        if (currentOrg) {
+            linkEntries.push({
+                title: "Members",
+                customContent: <LinkEntry>Members</LinkEntry>,
+                active: false,
+                separator: true,
+                link: "/members",
+            });
+        }
+
+        // Show usage for personal account if usage based billing enabled for user
+        const showUsageForPersonalAccount =
+            !currentOrg &&
+            BillingMode.showUsageBasedBilling(userBillingMode) &&
+            !user?.additionalData?.isMigratedToTeamOnlyAttribution;
+
+        const showUsageForOrg =
+            currentOrg &&
+            currentOrgMember?.role === "owner" &&
+            (orgBillingMode?.mode === "usage-based" || showUsageView);
+
+        if (showUsageForPersonalAccount || showUsageForOrg) {
+            linkEntries.push({
+                title: "Usage",
+                customContent: <LinkEntry>Usage</LinkEntry>,
+                active: false,
+                separator: false,
+                link: "/usage",
+            });
+        }
+
+        // Show settings if user is an owner of current org
+        if (currentOrg && currentOrgMember?.role === "owner") {
+            linkEntries.push({
+                title: "Settings",
+                customContent: <LinkEntry>Settings</LinkEntry>,
+                active: false,
+                separator: false,
+                link: "/settings",
+            });
+        }
+
+        // Ensure only last link entry has a separator
+        linkEntries.forEach((e, idx) => {
+            e.separator = idx === linkEntries.length - 1;
+        });
+
+        const otherOrgEntries = (teams || [])
+            .filter((t) => t.id !== currentOrg?.id)
+            .sort((a, b) => a.name.localeCompare(b.name))
+            .map((t) => ({
+                title: t.name,
+                customContent: (
+                    <OrgEntry
+                        id={t.id}
+                        title={t.name}
+                        subtitle={
+                            !!teamMembers[t.id]
+                                ? `${teamMembers[t.id].length} member${teamMembers[t.id].length === 1 ? "" : "s"}`
+                                : "..."
+                        }
+                    />
+                ),
+                // marking as active for styles
+                active: true,
+                separator: true,
+                link: `/?org=${t.id}`,
+            }));
+
+        const userMigrated = user?.additionalData?.isMigratedToTeamOnlyAttribution ?? false;
+        const showPersonalEntry = !userMigrated && !!currentOrg;
+
+        return [
+            activeOrgEntry,
+            ...linkEntries,
+            // If user has not been migrated, and isn't currently selected, show personal account
+            ...(showPersonalEntry
                 ? [
                       {
                           title: userFullName,
                           customContent: (
-                              <div className="w-full text-gray-500 flex flex-col">
-                                  <span className="text-gray-800 dark:text-gray-100 text-base font-semibold">
-                                      {userFullName}
-                                  </span>
-                                  <span className="">Personal Account</span>
-                              </div>
+                              <OrgEntry id={user?.id ?? "self"} title={userFullName} subtitle="Personal Account" />
                           ),
-                          active: team === undefined,
+                          // marking as active for styles
+                          active: true,
                           separator: true,
                           link: `/?org=0`,
                       },
                   ]
                 : []),
-            ...(teams || [])
-                .map((t) => ({
-                    title: t.name,
-                    customContent: (
-                        <div className="w-full text-gray-400 flex flex-col">
-                            <span className="text-gray-800 dark:text-gray-300 text-base font-semibold">{t.name}</span>
-                            <span className="">
-                                {!!teamMembers[t.id]
-                                    ? `${teamMembers[t.id].length} member${teamMembers[t.id].length === 1 ? "" : "s"}`
-                                    : "..."}
-                            </span>
-                        </div>
-                    ),
-                    active: team?.id === t.id,
-                    separator: true,
-                    link: `/?org=${t.id}`,
-                }))
-                .sort((a, b) => (a.title.toLowerCase() > b.title.toLowerCase() ? 1 : -1)),
+            ...otherOrgEntries,
             {
                 title: "Create a new organization",
                 customContent: (
-                    <div className="w-full text-gray-400 flex items-center">
-                        <span className="flex-1 font-semibold">New Organization</span>
+                    <div className="w-full text-gray-500 flex items-center">
+                        <span className="flex-1">New Organization</span>
                         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 14 14" className="w-3.5">
                             <path
                                 fill="currentColor"
@@ -74,25 +167,37 @@ export default function OrganizationSelector(p: OrganizationSelectorProps) {
                     </div>
                 ),
                 link: "/orgs/new",
+                // marking as active for styles
+                active: true,
             },
-        ],
-        [
-            user?.additionalData?.isMigratedToTeamOnlyAttribution,
-            userFullName,
-            team,
-            location.pathname,
-            teams,
-            teamMembers,
-        ],
-    );
-    const selectedEntry = entries.find((e) => e.active) || entries[0];
+        ];
+    }, [
+        currentOrg,
+        userFullName,
+        user?.id,
+        user?.additionalData?.isMigratedToTeamOnlyAttribution,
+        teamMembers,
+        userBillingMode,
+        showUsageView,
+        currentOrgMember?.role,
+        orgBillingMode?.mode,
+        teams,
+    ]);
+
+    const selectedTitle = currentOrg ? currentOrg.name : userFullName;
     const classes =
         "flex h-full text-base py-0 text-gray-500 bg-gray-50  dark:bg-gray-800 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 dark:border-gray-700";
     return (
         <ContextMenu customClasses="w-64 left-0" menuEntries={entries}>
-            <div className={`${classes} rounded-2xl pl-3`}>
-                <div className="py-1 pr-2 font-semibold whitespace-nowrap max-w-xs overflow-hidden">
-                    {selectedEntry.title!}
+            <div className={`${classes} rounded-2xl pl-1`}>
+                <div className="py-1 pr-1 flex font-semibold whitespace-nowrap max-w-xs overflow-hidden">
+                    <OrgIcon
+                        id={currentOrg?.id || user?.id || "empty"}
+                        name={selectedTitle}
+                        size="small"
+                        className="mr-2"
+                    />
+                    {selectedTitle}
                 </div>
                 <div className="flex h-full pl-0 pr-1 py-1.5 text-gray-50">
                     <svg width="20" height="20" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -109,3 +214,41 @@ export default function OrganizationSelector(p: OrganizationSelectorProps) {
         </ContextMenu>
     );
 }
+
+const LinkEntry: FunctionComponent = ({ children }) => {
+    return (
+        <div className="w-full text-sm text-gray-500 dark:text-gray-400">
+            <span>{children}</span>
+        </div>
+    );
+};
+
+type OrgEntryProps = {
+    id: string;
+    title: string;
+    subtitle: string;
+};
+const OrgEntry: FunctionComponent<OrgEntryProps> = ({ id, title, subtitle }) => {
+    return (
+        <div className="w-full text-gray-400 flex items-center">
+            <OrgIcon id={id} name={title} className="mr-4" />
+            <div className="flex flex-col">
+                <span className="text-gray-800 dark:text-gray-300 text-base font-semibold">{title}</span>
+                <span>{subtitle}</span>
+            </div>
+        </div>
+    );
+};
+
+type CurrentOrgEntryProps = {
+    title: string;
+    subtitle: string;
+};
+const CurrentOrgEntry: FunctionComponent<CurrentOrgEntryProps> = ({ title, subtitle }) => {
+    return (
+        <div className="w-full text-gray-400 flex flex-col">
+            <span className="text-gray-800 dark:text-gray-300 text-base font-semibold">{title}</span>
+            <span>{subtitle}</span>
+        </div>
+    );
+};

--- a/components/dashboard/tailwind.config.js
+++ b/components/dashboard/tailwind.config.js
@@ -23,6 +23,10 @@ module.exports = {
                     DEFAULT: "#5C8DD6",
                     dark: "#265583",
                 },
+                // TODO: figure out if we want to just pull in the specific gitpod-* colors
+                teal: colors.teal,
+                sky: colors.sky,
+                rose: colors.rose,
                 "gitpod-black": "#161616",
                 "gitpod-gray": "#8E8787",
                 "gitpod-red": "#CE4A3E",


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Updates the Org Selector to include the following links if available:

* Members
* Usage
* Settings

| Light Mode      | Dark Mode |
| ----------- | ----------- |
| ![image](https://user-images.githubusercontent.com/367275/218192615-62cdfe10-e36f-4223-b86e-4686a041462b.png)      | ![image](https://user-images.githubusercontent.com/367275/218192772-23262a75-4858-4590-8da6-a07dbca6c953.png)      |

In addition, and to help call out the org entries in the selector, there are now icons for the orgs that use one of 9 available background gradients. This will help serve as a fallback/placeholder for when we add the ability to upload logos for an org.

The background gradient used is pegged to the corresponding `id` of the org, so it will be consistent across visits to the site. I've added some unit tests for that logic as well.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #16244

## How to test
<!-- Provide steps to test this PR -->
* Create several orgs and switch between them, ensuring the menu shows the links you'd expect.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Several links, such as Members, Usage and Settings have been moved into the organization selector in the top left of the Dashboard.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
