### PR TITLE
[ws-manager-bridge] fix incorrect module import

### DIFF
--- a/components/ws-manager-bridge/src/cluster-service-server.ts
+++ b/components/ws-manager-bridge/src/cluster-service-server.ts
@@ -45,7 +45,7 @@ import { getSupportedWorkspaceClasses } from "./cluster-sync-service";
 import { Configuration } from "./config";
 import { getExperimentsClientForBackend } from "@gitpod/gitpod-protocol/lib/experiments/configcat-server";
 import { GRPCError } from "./rpc";
-import { isWorkspaceRegion } from "@gitpod/gitpod-protocol/src/workspace-cluster";
+import { isWorkspaceRegion } from "@gitpod/gitpod-protocol/lib/workspace-cluster";
 
 export interface ClusterServiceServerOptions {
     port: number;

--- a/components/ws-manager-bridge/src/cluster-sync-service.ts
+++ b/components/ws-manager-bridge/src/cluster-sync-service.ts
@@ -16,7 +16,7 @@ import {
     WorkspaceClass,
     WorkspaceManagerClient,
 } from "@gitpod/ws-manager/lib";
-import { AdmissionConstraintHasClass } from "@gitpod/gitpod-protocol/src/workspace-cluster";
+import { AdmissionConstraintHasClass } from "@gitpod/gitpod-protocol/lib/workspace-cluster";
 import { GRPCError } from "./rpc";
 import * as grpc from "@grpc/grpc-js";
 import { defaultGRPCOptions } from "@gitpod/gitpod-protocol/lib/util/grpc";

--- a/components/ws-manager-bridge/src/config.ts
+++ b/components/ws-manager-bridge/src/config.ts
@@ -4,7 +4,7 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { WorkspaceCluster } from "@gitpod/gitpod-protocol/src/workspace-cluster";
+import { WorkspaceCluster } from "@gitpod/gitpod-protocol/lib/workspace-cluster";
 import { ClusterServiceServerOptions } from "./cluster-service-server";
 
 export const Configuration = Symbol("Configuration");

--- a/components/ws-manager-bridge/src/prometheus-metrics-exporter.ts
+++ b/components/ws-manager-bridge/src/prometheus-metrics-exporter.ts
@@ -7,7 +7,7 @@
 import * as prom from "prom-client";
 import { injectable } from "inversify";
 import { WorkspaceInstance } from "@gitpod/gitpod-protocol";
-import { WorkspaceClusterWoTLS } from "@gitpod/gitpod-protocol/src/workspace-cluster";
+import { WorkspaceClusterWoTLS } from "@gitpod/gitpod-protocol/lib/workspace-cluster";
 import { WorkspaceType } from "@gitpod/ws-manager/lib/core_pb";
 
 @injectable()


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Fix preview env ws-manager-bridge crash loop
<details>
<summary>
Error Log
</summary>
<pre>
<code>
gitpod /workspace/gitpod/components/gitpod-cli (hw/fix-gp-open) $ kubectl get pods
NAME                                      READY   STATUS             RESTARTS       AGE
agent-smith-t628n                         2/2     Running            0              44m
blobserve-55874b8f89-2mnwm                2/2     Running            0              44m
content-service-69479c77b6-qpxlc          2/2     Running            0              44m
dashboard-c65446588-tdbpb                 1/1     Running            0              44m
fluent-bit-s76lj                          1/1     Running            0              45m
ide-metrics-8556bf4dbf-5hsfz              2/2     Running            0              44m
ide-proxy-56d6dd7d9c-hs8h8                1/1     Running            0              44m
ide-service-57fb8c8c76-vq8gh              2/2     Running            0              44m
image-builder-mk3-684bbdc88f-6n4tn        2/2     Running            0              44m
messagebus-0                              1/1     Running            0              44m
minio-c8b6c7cb7-6sl2x                     1/1     Running            0              44m
mysql-0                                   1/1     Running            0              44m
openvsx-proxy-0                           3/3     Running            0              44m
payment-endpoint-59977796c9-5hm7r         1/1     Running            0              44m
proxy-667b7944d7-87vkc                    2/2     Running            0              44m
public-api-server-6678d4f9fb-smtfb        2/2     Running            0              44m
redis-65cf4895cc-d8qv5                    0/1     Running            0              44m
registry-facade-jjzfz                     3/3     Running            0              44m
server-576fd46bdf-8jnqn                   2/2     Running            0              44m
spicedb-85b68856b6-tv5d4                  2/2     Running            1 (42m ago)    44m
usage-5d57d55c59-7hdq4                    2/2     Running            0              44m
ws-0ebec82e-3386-4d3d-a2f0-4216ca996a4c   1/1     Running            0              23m
ws-daemon-4wv4p                           3/3     Running            0              44m
ws-e66d8671-63cd-4aa5-9c50-f71949803f55   1/1     Running            0              78s
ws-manager-84c78455b5-ckgsl               2/2     Running            0              44m
ws-manager-bridge-85f48c796f-xwwjg        1/2     CrashLoopBackOff   13 (43s ago)   44m
ws-proxy-64d866b797-wk564                 2/2     Running            0              44m
gitpod /workspace/gitpod/components/gitpod-cli (hw/fix-gp-open) $ kubectl logs -f ws-manager-bridge-85f48c796f-xwwjg
Defaulted container "ws-manager-bridge" out of: ws-manager-bridge, kube-rbac-proxy, database-waiter (init), msgbus-waiter (init)
yarn run v1.22.15
warning Skipping preferred cache folder "/.cache/yarn" because it is not writable.
warning Selected the next writable cache folder in the list, will be "/tmp/.yarn-cache-31001".
$ node ./dist/ee/src/index.js
warning Cannot find a suitable global folder. Tried these: "/usr/local, /.yarn"
node:internal/modules/cjs/loader:936
  throw err;
  ^

Error: Cannot find module '@gitpod/gitpod-protocol/src/workspace-cluster'
Require stack:
- /app/node_modules/@gitpod/ws-manager-bridge/dist/src/cluster-service-server.js
- /app/node_modules/@gitpod/ws-manager-bridge/dist/src/main.js
- /app/node_modules/@gitpod/ws-manager-bridge/dist/ee/src/index.js
    at Function.Module._resolveFilename (node:internal/modules/cjs/loader:933:15)
    at Function.Module._load (node:internal/modules/cjs/loader:778:27)
    at Module.require (node:internal/modules/cjs/loader:1005:19)
    at require (node:internal/modules/cjs/helpers:102:18)
    at Object.<anonymous> (/app/node_modules/@gitpod/ws-manager-bridge/dist/src/cluster-service-server.js:33:29)
    at Module._compile (node:internal/modules/cjs/loader:1101:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1153:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Module.require (node:internal/modules/cjs/loader:1005:19)
    at require (node:internal/modules/cjs/helpers:102:18)
    at Object.<anonymous> (/app/node_modules/@gitpod/ws-manager-bridge/dist/src/main.js:16:34)
    at Module._compile (node:internal/modules/cjs/loader:1101:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1153:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/app/node_modules/@gitpod/ws-manager-bridge/dist/src/cluster-service-server.js',
    '/app/node_modules/@gitpod/ws-manager-bridge/dist/src/main.js',
    '/app/node_modules/@gitpod/ws-manager-bridge/dist/ee/src/index.js'
  ]
}
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
</code>
</pre>
</details>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
- Make sure workspace can be start in preview env

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
