### PR TITLE
[inner-loop] run Isolated docker in debug workspace

### DIFF
--- a/components/supervisor/pkg/supervisor/supervisor.go
+++ b/components/supervisor/pkg/supervisor/supervisor.go
@@ -398,7 +398,7 @@ func Run(options ...RunOption) {
 	tasksSuccessChan := make(chan taskSuccess, 1)
 	go taskManager.Run(ctx, &wg, tasksSuccessChan)
 
-	if !opts.RunGP && !cfg.isDebugWorkspace() {
+	if !opts.RunGP {
 		wg.Add(1)
 		go socketActivationForDocker(ctx, &wg, termMux, cfg, telemetry)
 	}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
[inner-loop] run Isolated docker in debug workspace

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
1. start a workspace preview env 
2. try `gp rebuild`
3. in debug workspace, try use docker, it should Isolated with regular workspace

<img width="1204" alt="image" src="https://user-images.githubusercontent.com/8299500/220394734-711da63b-c43b-482c-95a6-edf80189f13e.png">


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[inner-loop] run Isolated docker in debug workspace
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
