### PR TITLE
[server] pass organizationId to create ws

### DIFF
--- a/components/gitpod-protocol/src/attribution.ts
+++ b/components/gitpod-protocol/src/attribution.ts
@@ -22,6 +22,10 @@ export interface TeamAttributionId {
 export namespace AttributionId {
     const SEPARATOR = ":";
 
+    export function createFromOrganizationId(organizationId?: string): AttributionId | undefined {
+        return organizationId ? { kind: "team", teamId: organizationId } : undefined;
+    }
+
     export function create(userOrTeam: User | Team): AttributionId {
         if (User.is(userOrTeam)) {
             return { kind: "user", userId: userOrTeam.id };

--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -439,6 +439,7 @@ export namespace GitpodServer {
     }
     export interface CreateWorkspaceOptions extends StartWorkspaceOptions {
         contextUrl: string;
+        organizationId?: string;
 
         // whether running workspaces on the same context should be ignored. If false (default) users will be asked.
         ignoreRunningWorkspaceOnSameCommit?: boolean;

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -8,6 +8,7 @@ import { WorkspaceInstance, PortVisibility } from "./workspace-instance";
 import { RoleOrPermission } from "./permission";
 import { Project } from "./teams-projects-protocol";
 import { createHash } from "crypto";
+import { AttributionId } from "./attribution";
 
 export interface UserInfo {
     name?: string;
@@ -176,6 +177,17 @@ export namespace User {
         user.additionalData.profile.lastUpdatedDetailsNudge = new Date().toISOString();
 
         return user;
+    }
+
+    export function getDefaultAttributionId(user: User): AttributionId {
+        if (user.usageAttributionId) {
+            const result = AttributionId.parse(user.usageAttributionId);
+            if (!result) {
+                throw new Error("Invalid attribution ID: " + user.usageAttributionId);
+            }
+            return result;
+        }
+        return AttributionId.create(user);
     }
 
     // The actual Profile of a User

--- a/components/server/ee/src/billing/entitlement-service-chargebee.ts
+++ b/components/server/ee/src/billing/entitlement-service-chargebee.ts
@@ -9,7 +9,6 @@ import { Accounting, SubscriptionService } from "@gitpod/gitpod-payment-endpoint
 import {
     BillingTier,
     User,
-    Workspace,
     WorkspaceInstance,
     WorkspaceTimeoutDuration,
     WORKSPACE_TIMEOUT_DEFAULT_LONG,
@@ -38,7 +37,7 @@ export class EntitlementServiceChargebee implements EntitlementService {
 
     async mayStartWorkspace(
         user: User,
-        workspace: Workspace,
+        organizationId: string | undefined,
         date: Date,
         runningInstances: Promise<WorkspaceInstance[]>,
     ): Promise<MayStartWorkspaceResult> {

--- a/components/server/ee/src/billing/entitlement-service-license.ts
+++ b/components/server/ee/src/billing/entitlement-service-license.ts
@@ -8,7 +8,6 @@ import { UserDB } from "@gitpod/gitpod-db/lib";
 import {
     BillingTier,
     User,
-    Workspace,
     WorkspaceInstance,
     WorkspaceTimeoutDuration,
     WORKSPACE_TIMEOUT_DEFAULT_LONG,
@@ -28,7 +27,7 @@ export class EntitlementServiceLicense implements EntitlementService {
 
     async mayStartWorkspace(
         user: User,
-        workspace: Pick<Workspace, "projectId">,
+        organizationId: string | undefined,
         date: Date,
         runningInstances: Promise<WorkspaceInstance[]>,
     ): Promise<MayStartWorkspaceResult> {

--- a/components/server/ee/src/billing/entitlement-service-ubp.ts
+++ b/components/server/ee/src/billing/entitlement-service-ubp.ts
@@ -9,7 +9,6 @@ import {
     BillingTier,
     Team,
     User,
-    Workspace,
     WorkspaceInstance,
     WorkspaceTimeoutDuration,
     WORKSPACE_TIMEOUT_DEFAULT_LONG,
@@ -47,7 +46,7 @@ export class EntitlementServiceUBP implements EntitlementService {
 
     async mayStartWorkspace(
         user: User,
-        workspace: Pick<Workspace, "projectId">,
+        organizationId: string | undefined,
         date: Date,
         runningInstances: Promise<WorkspaceInstance[]>,
     ): Promise<MayStartWorkspaceResult> {
@@ -64,7 +63,7 @@ export class EntitlementServiceUBP implements EntitlementService {
             }
         };
         const [usageLimitReachedOnCostCenter, hitParallelWorkspaceLimit] = await Promise.all([
-            this.checkUsageLimitReached(user, workspace, date),
+            this.checkUsageLimitReached(user, organizationId, date),
             hasHitParallelWorkspaceLimit(),
         ]);
         return {
@@ -75,10 +74,10 @@ export class EntitlementServiceUBP implements EntitlementService {
 
     protected async checkUsageLimitReached(
         user: User,
-        workspace: Pick<Workspace, "projectId">,
+        organizationId: string | undefined,
         date: Date,
     ): Promise<AttributionId | undefined> {
-        const result = await this.userService.checkUsageLimitReached(user, workspace);
+        const result = await this.userService.checkUsageLimitReached(user, organizationId);
         if (result.reached) {
             return result.attributionId;
         }

--- a/components/server/ee/src/billing/entitlement-service.ts
+++ b/components/server/ee/src/billing/entitlement-service.ts
@@ -7,7 +7,6 @@
 import {
     BillingTier,
     User,
-    Workspace,
     WorkspaceInstance,
     WorkspaceTimeoutDuration,
     WORKSPACE_TIMEOUT_DEFAULT_LONG,
@@ -38,7 +37,7 @@ export class EntitlementServiceImpl implements EntitlementService {
 
     async mayStartWorkspace(
         user: User,
-        workspace: Workspace,
+        organizationId: string | undefined,
         date: Date = new Date(),
         runningInstances: Promise<WorkspaceInstance[]>,
     ): Promise<MayStartWorkspaceResult> {
@@ -52,11 +51,11 @@ export class EntitlementServiceImpl implements EntitlementService {
             const billingMode = await this.billingModes.getBillingModeForUser(user, date);
             switch (billingMode.mode) {
                 case "none":
-                    return this.license.mayStartWorkspace(user, workspace, date, runningInstances);
+                    return this.license.mayStartWorkspace(user, organizationId, date, runningInstances);
                 case "chargebee":
-                    return this.chargebee.mayStartWorkspace(user, workspace, date, runningInstances);
+                    return this.chargebee.mayStartWorkspace(user, organizationId, date, runningInstances);
                 case "usage-based":
-                    return this.ubp.mayStartWorkspace(user, workspace, date, runningInstances);
+                    return this.ubp.mayStartWorkspace(user, organizationId, date, runningInstances);
                 default:
                     throw new Error("Unsupported billing mode: " + (billingMode as any).mode); // safety net
             }

--- a/components/server/ee/src/prebuilds/prebuild-manager.ts
+++ b/components/server/ee/src/prebuilds/prebuild-manager.ts
@@ -139,7 +139,7 @@ export class PrebuildManager {
                     `Running prebuilds without a project is no longer supported. Please add '${cloneURL}' as a project in a team.`,
                 );
             }
-            await this.checkUsageLimitReached(user, project); // throws if true
+            await this.checkUsageLimitReached(user, project.teamId); // throws if out of credits
 
             const config = await this.fetchConfig({ span }, user, context);
 
@@ -296,17 +296,17 @@ export class PrebuildManager {
         }
     }
 
-    protected async checkUsageLimitReached(user: User, project: Project): Promise<void> {
+    protected async checkUsageLimitReached(user: User, organizationId?: string): Promise<void> {
         let result: MayStartWorkspaceResult = {};
         try {
             result = await this.entitlementService.mayStartWorkspace(
                 user,
-                { projectId: project.id },
+                organizationId,
                 new Date(),
                 Promise.resolve([]),
             );
         } catch (err) {
-            log.error({ userId: user.id }, "EntitlementSerivce.mayStartWorkspace error", err);
+            log.error({ userId: user.id }, "EntitlementService.mayStartWorkspace error", err);
             return; // we don't want to block workspace starts because of internal errors
         }
         if (!!result.usageLimitReachedOnCostCenter) {

--- a/components/server/src/billing/entitlement-service.ts
+++ b/components/server/src/billing/entitlement-service.ts
@@ -6,7 +6,6 @@
 
 import {
     User,
-    Workspace,
     WorkspaceInstance,
     WorkspaceTimeoutDuration,
     WORKSPACE_TIMEOUT_DEFAULT_SHORT,
@@ -43,7 +42,7 @@ export interface EntitlementService {
      */
     mayStartWorkspace(
         user: User,
-        workspace: Pick<Workspace, "projectId">,
+        organizationId: string | undefined,
         date: Date,
         runningInstances: Promise<WorkspaceInstance[]>,
     ): Promise<MayStartWorkspaceResult>;
@@ -89,7 +88,7 @@ export interface EntitlementService {
 export class CommunityEntitlementService implements EntitlementService {
     async mayStartWorkspace(
         user: User,
-        workspace: Workspace,
+        organizationId: string | undefined,
         date: Date,
         runningInstances: Promise<WorkspaceInstance[]>,
     ): Promise<MayStartWorkspaceResult> {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Adds `organizationId` to the create workspace options. Also removes dependencies on implicit org retrieval from some of the create Workspace logic.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of https://github.com/gitpod-io/gitpod/issues/16362

## How to test
<!-- Provide steps to test this PR -->
Start workspaces and verify that the usage attribution is the same as it usually is.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
