### PR TITLE
[gp-cli] fix empty human readable timeout

### DIFF
--- a/components/gitpod-cli/cmd/timeout-set.go
+++ b/components/gitpod-cli/cmd/timeout-set.go
@@ -53,9 +53,17 @@ For example: 30m or 1h`,
 			}
 			return err
 		}
-		fmt.Printf("Workspace timeout has been set to %s.\n", res.HumanReadableDuration)
+		fmt.Printf("Workspace timeout has been set to %s.\n", getHumanReadableDuration(res.HumanReadableDuration, duration))
 		return nil
 	},
+}
+
+func getHumanReadableDuration(humanReadableDuration string, inputDuration time.Duration) string {
+	readable := humanReadableDuration
+	if humanReadableDuration == "" {
+		readable = fmt.Sprintf("%d minutes", int(inputDuration.Minutes()))
+	}
+	return readable
 }
 
 func init() {

--- a/components/gitpod-cli/cmd/timeout-show.go
+++ b/components/gitpod-cli/cmd/timeout-show.go
@@ -37,8 +37,12 @@ var showTimeoutCommand = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		duration, err := time.ParseDuration(res.Duration)
+		if err != nil {
+			return err
+		}
 
-		fmt.Printf("Workspace timeout is set to %s.\n", res.HumanReadableDuration)
+		fmt.Printf("Workspace timeout is set to %s.\n", getHumanReadableDuration(res.HumanReadableDuration, duration))
 		return nil
 	},
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

See [internal chat](https://gitpod.slack.com/archives/C03EG2PND38/p1676279217285779?thread_ts=1676278690.771969&cid=C03EG2PND38)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
- Open this PR in gitpod
- Change input of `res.HumanReadableDuration` to empty string `""`
- Exec `gp timeout show` and `gp timeout set 3h` should work

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
