### PR TITLE
[workspace] change iface name to eth0

### DIFF
--- a/components/docker-up/docker-up/main.go
+++ b/components/docker-up/docker-up/main.go
@@ -59,7 +59,7 @@ var aptUpdated = false
 const (
 	dockerSocketFN = "/var/run/docker.sock"
 	gitpodUserId   = 33333
-	containerIf    = "ceth0"
+	containerIf    = "eth0"
 )
 
 func main() {

--- a/components/ws-daemon/nsinsider/main.go
+++ b/components/ws-daemon/nsinsider/main.go
@@ -270,7 +270,7 @@ func main() {
 					},
 				},
 				Action: func(c *cli.Context) error {
-					containerIf, vethIf, cethIf := "eth0", "veth0", "ceth0"
+					containerIf, vethIf, cethIf := "eth0", "veth0", "eth0"
 					mask := net.IPv4Mask(255, 255, 255, 0)
 					vethIp := net.IPNet{
 						IP:   net.IPv4(10, 0, 5, 1),
@@ -430,7 +430,7 @@ func main() {
 				Name:  "setup-peer-veth",
 				Usage: "set up a peer veth",
 				Action: func(c *cli.Context) error {
-					cethIf := "ceth0"
+					cethIf := "eth0"
 					mask := net.IPv4Mask(255, 255, 255, 0)
 					cethIp := net.IPNet{
 						IP:   net.IPv4(10, 0, 5, 2),


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
[workspace] change iface name to eth0

part of #16363

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

Test in #16363

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft with-integration-tests=workspace
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
