### PR TITLE
[server] disable long migrations via config

### DIFF
--- a/components/server/ee/src/server.ts
+++ b/components/server/ee/src/server.ts
@@ -27,8 +27,11 @@ export class ServerEE<C extends GitpodClient, S extends GitpodServer> extends Se
     public async init(app: express.Application) {
         await super.init(app);
 
-        // Start Snapshot Service
-        await this.snapshotService.start();
+        if (!this.config.completeSnapshotJob?.disabled) {
+            // Start Snapshot Service
+            log.info("Starting snapshot completion job...");
+            await this.snapshotService.start();
+        }
     }
 
     protected async registerRoutes(app: express.Application): Promise<void> {

--- a/components/server/src/config.ts
+++ b/components/server/src/config.ts
@@ -117,6 +117,8 @@ export interface ConfigSerialized {
     definitelyGpDisabled: boolean;
 
     workspaceGarbageCollection: WorkspaceGarbageCollection;
+    completeSnapshotJob?: { disabled?: boolean };
+    longRunningMigrationsJob?: { disabled?: boolean };
 
     enableLocalApp: boolean;
 

--- a/components/server/src/server.ts
+++ b/components/server/src/server.ts
@@ -297,6 +297,10 @@ export class Server<C extends GitpodClient, S extends GitpodServer> {
     }
 
     protected async startLongRunningMigrations(): Promise<void> {
+        if (this.config.longRunningMigrationsJob?.disabled) {
+            return;
+        }
+        log.info("Starting long running migrations job...");
         let completed = false;
         while (!completed) {
             if (await this.qorum.areWeLeader()) {

--- a/install/installer/cmd/testdata/render/agent-smith/output.golden
+++ b/install/installer/cmd/testdata/render/agent-smith/output.golden
@@ -5510,6 +5510,12 @@ data:
         "purgeRetentionPeriodDays": 365,
         "purgeChunkLimit": 5000
       },
+      "completeSnapshotJob": {
+        "disabled": false
+      },
+      "longRunningMigrationsJob": {
+        "disabled": false
+      },
       "authProviderConfigFiles": [],
       "incrementalPrebuilds": {
         "repositoryPasslist": [],
@@ -10410,7 +10416,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 28344080ba3478c4e4eef76de95e6b69b85082b5c278e3c1d28080b7c490ffbe
+        gitpod.io/checksum_config: 3b028b705e7974d991b2e95eb1810c588d61f71f88685d474475982f5e8e97e5
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/aws-setup/output.golden
+++ b/install/installer/cmd/testdata/render/aws-setup/output.golden
@@ -4851,6 +4851,12 @@ data:
         "purgeRetentionPeriodDays": 365,
         "purgeChunkLimit": 5000
       },
+      "completeSnapshotJob": {
+        "disabled": false
+      },
+      "longRunningMigrationsJob": {
+        "disabled": false
+      },
       "authProviderConfigFiles": [],
       "incrementalPrebuilds": {
         "repositoryPasslist": [],
@@ -9223,7 +9229,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 938492fbac2160e885f758966c5ba0ba3aeb759c5943b98109dbdf95921a9a78
+        gitpod.io/checksum_config: e641db8210464747aa714799870c610059b5c4880a288a9da91a843660ae9cb0
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
+++ b/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
@@ -5327,6 +5327,12 @@ data:
         "purgeRetentionPeriodDays": 365,
         "purgeChunkLimit": 5000
       },
+      "completeSnapshotJob": {
+        "disabled": false
+      },
+      "longRunningMigrationsJob": {
+        "disabled": false
+      },
       "authProviderConfigFiles": [],
       "incrementalPrebuilds": {
         "repositoryPasslist": [],
@@ -10227,7 +10233,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 6c2df486462e6c299dc826001d920c0a65368f5b83d89efe55b411d9de4a8a82
+        gitpod.io/checksum_config: 39d3eba34aee9b750a147454c59cc518708d37c10eb67ea51e7f25c825a63001
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -5919,6 +5919,12 @@ data:
         "purgeRetentionPeriodDays": 365,
         "purgeChunkLimit": 5000
       },
+      "completeSnapshotJob": {
+        "disabled": false
+      },
+      "longRunningMigrationsJob": {
+        "disabled": false
+      },
       "authProviderConfigFiles": [],
       "incrementalPrebuilds": {
         "repositoryPasslist": [],
@@ -11071,7 +11077,7 @@ spec:
     metadata:
       annotations:
         gitpod.io: hello
-        gitpod.io/checksum_config: e6d05fffcf5e9ac587d92811be31ad9dc44b346e423c57418d858e26bcf9552b
+        gitpod.io/checksum_config: bd1abec4fc8b94c536ffa2f49b5973514fa5312e26118b91586341dad4028ca9
         hello: world
       creationTimestamp: null
       labels:

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -5107,6 +5107,12 @@ data:
         "purgeRetentionPeriodDays": 365,
         "purgeChunkLimit": 5000
       },
+      "completeSnapshotJob": {
+        "disabled": false
+      },
+      "longRunningMigrationsJob": {
+        "disabled": false
+      },
       "authProviderConfigFiles": [],
       "incrementalPrebuilds": {
         "repositoryPasslist": [],
@@ -9850,7 +9856,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 28344080ba3478c4e4eef76de95e6b69b85082b5c278e3c1d28080b7c490ffbe
+        gitpod.io/checksum_config: 3b028b705e7974d991b2e95eb1810c588d61f71f88685d474475982f5e8e97e5
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/gcp-setup/output.golden
+++ b/install/installer/cmd/testdata/render/gcp-setup/output.golden
@@ -4936,6 +4936,12 @@ data:
         "purgeRetentionPeriodDays": 365,
         "purgeChunkLimit": 5000
       },
+      "completeSnapshotJob": {
+        "disabled": false
+      },
+      "longRunningMigrationsJob": {
+        "disabled": false
+      },
       "authProviderConfigFiles": [],
       "incrementalPrebuilds": {
         "repositoryPasslist": [],
@@ -9510,7 +9516,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: be4fde9dc3a3ea33cfb5e2a1ca27c9b0b2ae985bd440ee621b55540e4b8d92cd
+        gitpod.io/checksum_config: bd821d26b89c21e21f9cdfd552b0202e07684f85a91a4f2c9ea03e6133222677
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/http-proxy/output.golden
+++ b/install/installer/cmd/testdata/render/http-proxy/output.golden
@@ -5330,6 +5330,12 @@ data:
         "purgeRetentionPeriodDays": 365,
         "purgeChunkLimit": 5000
       },
+      "completeSnapshotJob": {
+        "disabled": false
+      },
+      "longRunningMigrationsJob": {
+        "disabled": false
+      },
       "authProviderConfigFiles": [],
       "incrementalPrebuilds": {
         "repositoryPasslist": [],
@@ -11392,7 +11398,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 28344080ba3478c4e4eef76de95e6b69b85082b5c278e3c1d28080b7c490ffbe
+        gitpod.io/checksum_config: 3b028b705e7974d991b2e95eb1810c588d61f71f88685d474475982f5e8e97e5
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/ide-config/output.golden
+++ b/install/installer/cmd/testdata/render/ide-config/output.golden
@@ -5343,6 +5343,12 @@ data:
         "purgeRetentionPeriodDays": 365,
         "purgeChunkLimit": 5000
       },
+      "completeSnapshotJob": {
+        "disabled": false
+      },
+      "longRunningMigrationsJob": {
+        "disabled": false
+      },
       "authProviderConfigFiles": [],
       "incrementalPrebuilds": {
         "repositoryPasslist": [],
@@ -10249,7 +10255,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 28344080ba3478c4e4eef76de95e6b69b85082b5c278e3c1d28080b7c490ffbe
+        gitpod.io/checksum_config: 3b028b705e7974d991b2e95eb1810c588d61f71f88685d474475982f5e8e97e5
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/kind-meta/output.golden
+++ b/install/installer/cmd/testdata/render/kind-meta/output.golden
@@ -4200,6 +4200,12 @@ data:
         "purgeRetentionPeriodDays": 365,
         "purgeChunkLimit": 5000
       },
+      "completeSnapshotJob": {
+        "disabled": false
+      },
+      "longRunningMigrationsJob": {
+        "disabled": false
+      },
       "authProviderConfigFiles": [],
       "incrementalPrebuilds": {
         "repositoryPasslist": [],
@@ -7386,7 +7392,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 28344080ba3478c4e4eef76de95e6b69b85082b5c278e3c1d28080b7c490ffbe
+        gitpod.io/checksum_config: 3b028b705e7974d991b2e95eb1810c588d61f71f88685d474475982f5e8e97e5
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/kind-webapp/output.golden
+++ b/install/installer/cmd/testdata/render/kind-webapp/output.golden
@@ -2292,6 +2292,12 @@ data:
         "purgeRetentionPeriodDays": 365,
         "purgeChunkLimit": 5000
       },
+      "completeSnapshotJob": {
+        "disabled": false
+      },
+      "longRunningMigrationsJob": {
+        "disabled": false
+      },
       "authProviderConfigFiles": [],
       "incrementalPrebuilds": {
         "repositoryPasslist": [],
@@ -4539,7 +4545,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 28344080ba3478c4e4eef76de95e6b69b85082b5c278e3c1d28080b7c490ffbe
+        gitpod.io/checksum_config: 3b028b705e7974d991b2e95eb1810c588d61f71f88685d474475982f5e8e97e5
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/message-bus-password/output.golden
+++ b/install/installer/cmd/testdata/render/message-bus-password/output.golden
@@ -5330,6 +5330,12 @@ data:
         "purgeRetentionPeriodDays": 365,
         "purgeChunkLimit": 5000
       },
+      "completeSnapshotJob": {
+        "disabled": false
+      },
+      "longRunningMigrationsJob": {
+        "disabled": false
+      },
       "authProviderConfigFiles": [],
       "incrementalPrebuilds": {
         "repositoryPasslist": [],
@@ -10230,7 +10236,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 28344080ba3478c4e4eef76de95e6b69b85082b5c278e3c1d28080b7c490ffbe
+        gitpod.io/checksum_config: 3b028b705e7974d991b2e95eb1810c588d61f71f88685d474475982f5e8e97e5
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -5327,6 +5327,12 @@ data:
         "purgeRetentionPeriodDays": 365,
         "purgeChunkLimit": 5000
       },
+      "completeSnapshotJob": {
+        "disabled": false
+      },
+      "longRunningMigrationsJob": {
+        "disabled": false
+      },
       "authProviderConfigFiles": [],
       "incrementalPrebuilds": {
         "repositoryPasslist": [],
@@ -10227,7 +10233,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 28344080ba3478c4e4eef76de95e6b69b85082b5c278e3c1d28080b7c490ffbe
+        gitpod.io/checksum_config: 3b028b705e7974d991b2e95eb1810c588d61f71f88685d474475982f5e8e97e5
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/overrides-inline/output.golden
+++ b/install/installer/cmd/testdata/render/overrides-inline/output.golden
@@ -5325,6 +5325,12 @@ data:
         "purgeRetentionPeriodDays": 365,
         "purgeChunkLimit": 5000
       },
+      "completeSnapshotJob": {
+        "disabled": false
+      },
+      "longRunningMigrationsJob": {
+        "disabled": false
+      },
       "authProviderConfigFiles": [],
       "incrementalPrebuilds": {
         "repositoryPasslist": [],
@@ -10237,7 +10243,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 28344080ba3478c4e4eef76de95e6b69b85082b5c278e3c1d28080b7c490ffbe
+        gitpod.io/checksum_config: 3b028b705e7974d991b2e95eb1810c588d61f71f88685d474475982f5e8e97e5
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/pod-config/output.golden
+++ b/install/installer/cmd/testdata/render/pod-config/output.golden
@@ -5334,6 +5334,12 @@ data:
         "purgeRetentionPeriodDays": 365,
         "purgeChunkLimit": 5000
       },
+      "completeSnapshotJob": {
+        "disabled": false
+      },
+      "longRunningMigrationsJob": {
+        "disabled": false
+      },
       "authProviderConfigFiles": [],
       "incrementalPrebuilds": {
         "repositoryPasslist": [],
@@ -10234,7 +10240,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 28344080ba3478c4e4eef76de95e6b69b85082b5c278e3c1d28080b7c490ffbe
+        gitpod.io/checksum_config: 3b028b705e7974d991b2e95eb1810c588d61f71f88685d474475982f5e8e97e5
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/shortname/output.golden
+++ b/install/installer/cmd/testdata/render/shortname/output.golden
@@ -5327,6 +5327,12 @@ data:
         "purgeRetentionPeriodDays": 365,
         "purgeChunkLimit": 5000
       },
+      "completeSnapshotJob": {
+        "disabled": false
+      },
+      "longRunningMigrationsJob": {
+        "disabled": false
+      },
       "authProviderConfigFiles": [],
       "incrementalPrebuilds": {
         "repositoryPasslist": [],
@@ -10227,7 +10233,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 0317d2afe5c5cf527048e00a9fbe21f26baab83268e5ecc8d29cc457766afc56
+        gitpod.io/checksum_config: 1cbc27f47f6fd77248e1d48e029b52338da69c5a3abe4e15d2cd976008189aa8
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -5339,6 +5339,12 @@ data:
         "purgeRetentionPeriodDays": 365,
         "purgeChunkLimit": 5000
       },
+      "completeSnapshotJob": {
+        "disabled": false
+      },
+      "longRunningMigrationsJob": {
+        "disabled": false
+      },
       "authProviderConfigFiles": [],
       "incrementalPrebuilds": {
         "repositoryPasslist": [],
@@ -10239,7 +10245,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 28344080ba3478c4e4eef76de95e6b69b85082b5c278e3c1d28080b7c490ffbe
+        gitpod.io/checksum_config: 3b028b705e7974d991b2e95eb1810c588d61f71f88685d474475982f5e8e97e5
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/telemetry/output.golden
+++ b/install/installer/cmd/testdata/render/telemetry/output.golden
@@ -5330,6 +5330,12 @@ data:
         "purgeRetentionPeriodDays": 365,
         "purgeChunkLimit": 5000
       },
+      "completeSnapshotJob": {
+        "disabled": false
+      },
+      "longRunningMigrationsJob": {
+        "disabled": false
+      },
       "authProviderConfigFiles": [],
       "incrementalPrebuilds": {
         "repositoryPasslist": [],
@@ -10230,7 +10236,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 28344080ba3478c4e4eef76de95e6b69b85082b5c278e3c1d28080b7c490ffbe
+        gitpod.io/checksum_config: 3b028b705e7974d991b2e95eb1810c588d61f71f88685d474475982f5e8e97e5
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
+++ b/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
@@ -5660,6 +5660,12 @@ data:
         "purgeRetentionPeriodDays": 365,
         "purgeChunkLimit": 5000
       },
+      "completeSnapshotJob": {
+        "disabled": false
+      },
+      "longRunningMigrationsJob": {
+        "disabled": false
+      },
       "authProviderConfigFiles": [],
       "incrementalPrebuilds": {
         "repositoryPasslist": [],
@@ -10671,7 +10677,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 28344080ba3478c4e4eef76de95e6b69b85082b5c278e3c1d28080b7c490ffbe
+        gitpod.io/checksum_config: 3b028b705e7974d991b2e95eb1810c588d61f71f88685d474475982f5e8e97e5
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
+++ b/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
@@ -5330,6 +5330,12 @@ data:
         "purgeRetentionPeriodDays": 365,
         "purgeChunkLimit": 5000
       },
+      "completeSnapshotJob": {
+        "disabled": false
+      },
+      "longRunningMigrationsJob": {
+        "disabled": false
+      },
       "authProviderConfigFiles": [],
       "incrementalPrebuilds": {
         "repositoryPasslist": [],
@@ -10218,7 +10224,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 28344080ba3478c4e4eef76de95e6b69b85082b5c278e3c1d28080b7c490ffbe
+        gitpod.io/checksum_config: 3b028b705e7974d991b2e95eb1810c588d61f71f88685d474475982f5e8e97e5
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
+++ b/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
@@ -5330,6 +5330,12 @@ data:
         "purgeRetentionPeriodDays": 365,
         "purgeChunkLimit": 5000
       },
+      "completeSnapshotJob": {
+        "disabled": false
+      },
+      "longRunningMigrationsJob": {
+        "disabled": false
+      },
       "authProviderConfigFiles": [],
       "incrementalPrebuilds": {
         "repositoryPasslist": [],
@@ -10230,7 +10236,7 @@ spec:
   template:
     metadata:
       annotations:
-        gitpod.io/checksum_config: 28344080ba3478c4e4eef76de95e6b69b85082b5c278e3c1d28080b7c490ffbe
+        gitpod.io/checksum_config: 3b028b705e7974d991b2e95eb1810c588d61f71f88685d474475982f5e8e97e5
       creationTimestamp: null
       labels:
         app: gitpod

--- a/install/installer/pkg/components/server/types.go
+++ b/install/installer/pkg/components/server/types.go
@@ -45,6 +45,8 @@ type ConfigSerialized struct {
 	Session                    Session                    `json:"session"`
 	GitHubApp                  GitHubApp                  `json:"githubApp"`
 	WorkspaceGarbageCollection WorkspaceGarbageCollection `json:"workspaceGarbageCollection"`
+	CompleteSnapshotJob        JobConfig                  `json:"completeSnapshotJob"`
+	LongRunningMigrationsJob   JobConfig                  `json:"longRunningMigrationsJob"`
 	AuthProviderConfigFiles    []string                   `json:"authProviderConfigFiles"`
 	IncrementalPrebuilds       IncrementalPrebuilds       `json:"incrementalPrebuilds"`
 	BlockNewUsers              config.BlockNewUsers       `json:"blockNewUsers"`
@@ -105,6 +107,10 @@ type WorkspaceGarbageCollection struct {
 	ContentChunkLimit          int32 `json:"contentChunkLimit"`
 	PurgeRetentionPeriodDays   int32 `json:"purgeRetentionPeriodDays"`
 	PurgeChunkLimit            int32 `json:"purgeChunkLimit"`
+}
+
+type JobConfig struct {
+	Disabled bool `json:"disabled"`
 }
 
 type GitHubApp struct {


### PR DESCRIPTION
## Description
Allow to disable long running jobs vis config

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
