### PR TITLE
[installer] args to disable jobs

### DIFF
--- a/install/installer/pkg/components/server/configmap.go
+++ b/install/installer/pkg/components/server/configmap.go
@@ -115,6 +115,22 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 		return nil
 	})
 
+	disableLongRunningMigrationsJob := false
+	_ = ctx.WithExperimental(func(cfg *experimental.Config) error {
+		if cfg.WebApp != nil && cfg.WebApp.Server != nil {
+			disableLongRunningMigrationsJob = cfg.WebApp.Server.DisableLongRunningMigrationJob
+		}
+		return nil
+	})
+
+	disableCompleteSnapshotJob := false
+	_ = ctx.WithExperimental(func(cfg *experimental.Config) error {
+		if cfg.WebApp != nil && cfg.WebApp.Server != nil {
+			disableCompleteSnapshotJob = cfg.WebApp.Server.DisableCompleteSnapshotJob
+		}
+		return nil
+	})
+
 	githubApp := GitHubApp{}
 	_ = ctx.WithExperimental(func(cfg *experimental.Config) error {
 		if cfg.WebApp != nil && cfg.WebApp.Server != nil && cfg.WebApp.Server.GithubApp != nil {
@@ -217,6 +233,12 @@ func configmap(ctx *common.RenderContext) ([]runtime.Object, error) {
 			ContentChunkLimit:          100,
 			PurgeRetentionPeriodDays:   365,
 			PurgeChunkLimit:            5000,
+		},
+		LongRunningMigrationsJob: JobConfig{
+			Disabled: disableLongRunningMigrationsJob,
+		},
+		CompleteSnapshotJob: JobConfig{
+			Disabled: disableCompleteSnapshotJob,
 		},
 		EnableLocalApp: enableLocalApp,
 		AuthProviderConfigFiles: func() []string {

--- a/install/installer/pkg/config/v1/config.md
+++ b/install/installer/pkg/config/v1/config.md
@@ -140,6 +140,8 @@ Additional config parameters that are in experimental state
 |`experimental.webapp.server.enableLocalApp`|bool|N|  ||
 |`experimental.webapp.server.runDbDeleter`|bool|N|  ||
 |`experimental.webapp.server.disableWorkspaceGarbageCollection`|bool|N|  ||
+|`experimental.webapp.server.disableLongRunningMigrationJob`|bool|N|  ||
+|`experimental.webapp.server.disableCompleteSnapshotJob`|bool|N|  ||
 |`experimental.webapp.server.inactivityPeriodForReposInDays`|int|N|  ||
 |`experimental.webapp.server.defaultBaseImageRegistryWhitelist[ ]`|[]string|N|  |  @deprecated use containerRegistry.privateBaseImageAllowList instead|
 |`experimental.webapp.proxy.staticIP`|string|N|  ||

--- a/install/installer/pkg/config/v1/experimental/experimental.go
+++ b/install/installer/pkg/config/v1/experimental/experimental.go
@@ -262,6 +262,8 @@ type ServerConfig struct {
 	EnableLocalApp                    *bool             `json:"enableLocalApp"`
 	RunDbDeleter                      *bool             `json:"runDbDeleter"`
 	DisableWorkspaceGarbageCollection bool              `json:"disableWorkspaceGarbageCollection"`
+	DisableLongRunningMigrationJob    bool              `json:"disableLongRunningMigrationJob"`
+	DisableCompleteSnapshotJob        bool              `json:"disableCompleteSnapshotJob"`
 	InactivityPeriodForReposInDays    *int              `json:"inactivityPeriodForReposInDays"`
 	ShowSetupModal                    *bool             `json:"showSetupModal"`
 


### PR DESCRIPTION
## Description
Adds two optional arguments to the installer, that allow to disable server jobs.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
