### PR TITLE
Timeout tab for JetBrains

### DIFF
--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/GitpodTimeoutControlCenterTabProvider.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/GitpodTimeoutControlCenterTabProvider.kt
@@ -1,31 +1,121 @@
-// Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
 // Licensed under the GNU Affero General Public License (AGPL).
 // See License.AGPL.txt in the project root for license information.
 
 package io.gitpod.jetbrains.remote
 
-import com.intellij.openapi.actionSystem.AnAction
-import com.intellij.openapi.actionSystem.ActionManager
-import com.intellij.openapi.actionSystem.AnActionEvent
-import com.intellij.openapi.components.service
-import io.gitpod.jetbrains.remote.GitpodManager
-import org.apache.http.client.utils.URIBuilder
+import com.jetbrains.ide.model.uiautomation.BeControl
+import com.jetbrains.rd.ui.bedsl.dsl.*
+import com.jetbrains.rd.util.lifetime.Lifetime
+import com.jetbrains.rd.util.reactive.Property
+import com.jetbrains.rdserver.diagnostics.BackendDiagnosticsService
+import com.jetbrains.rdserver.unattendedHost.customization.controlCenter.GatewayControlCenterTabProvider
+import com.jetbrains.rdserver.unattendedHost.customization.controlCenter.performance.createProgressBar
+import com.jetbrains.rdserver.unattendedHost.customization.controlCenter.performance.createProgressRow
 
 class GitpodTimeoutControlCenterTabProvider : GatewayControlCenterTabProvider {
-    override val id = "gitpodTimeoutTab"
-    override val title = "Timeout"
-
+    override val title: String = "Timeout"
+    override val id: String = "gitpodTimeoutTab"
     override fun getControl(lifetime: Lifetime): BeControl {
-        return scrollablePanel(lifetime) {
-            verticalLayout {
-                label("Gitpod Tab")
-                label("Current workspace timeout: 30 minutes")
-                button("Extend workspace timeout") {
-                    action {
-                        actionManager.tryToExecute("io.gitpod.jetbrains.remote.actions.ExtendWorkspaceTimeoutAction", null, null, null, true)
+        val backendDiagnosticsService = BackendDiagnosticsService.Companion.getInstance()
+
+        return verticalGrid {
+            row {
+                horizontalGrid {
+                    column {
+                        label("Workspace")
                     }
                 }
             }
+            createWorkspaceHeaderRow(this, backendDiagnosticsService, lifetime)
+            row {
+                verticalGrid {
+                    createCpuControl(this, backendDiagnosticsService, lifetime)
+                    createMemoryControl(this, backendDiagnosticsService, lifetime)
+                }.withMargin { margin(0, 15, 0, 25) }
+            }
+            row {
+                horizontalGrid {
+                    column {
+                        label("Shared Node Resources")
+                    }
+                }.withMargin { margin(0, 0, 0, 15) }.withHelpTooltip("Shared Node Resources", "The shared metrics represent the used and available resources of the cluster node on which your workspace is running")
+            }
         }
+    }
+
+    private fun createWorkspaceHeaderRow(ctx: VerticalGridBuilder, backendDiagnosticsService: BackendDiagnosticsService, lifetime: Lifetime) {
+        val labelProperty = Property("")
+
+        val workspaceClassMetric = backendDiagnosticsService.getMetric("gitpod_workspace_class")
+        val workspaceClass = workspaceClassMetric.toString()
+
+        fun updateLabel() {
+            if (workspaceClass != "") {
+                labelProperty.set(workspaceClass)
+            }
+        }
+        updateLabel()
+
+        workspaceClassMetric.valueProperty.change.advise(lifetime) {
+            updateLabel()
+        }
+
+        if (workspaceClass == "") {
+            return
+        }
+
+        return ctx.row {
+            horizontalGrid {
+                column {
+                    label(workspaceClass)
+                }
+            }.withMargin { margin(0, 15, 0, 0) }
+        }
+    }
+
+    private fun createCpuControl(ctx: VerticalGridBuilder, backendDiagnosticsService: BackendDiagnosticsService, lifetime: Lifetime) {
+        val cpuUsed = backendDiagnosticsService.getMetric("gitpod_workspace_cpu_used")
+        val cpuTotal = backendDiagnosticsService.getMetric("gitpod_workspace_cpu_total")
+        val cpuPercentage = backendDiagnosticsService.getMetric("gitpod_workspace_cpu_percentage")
+        val cpuPercentageProperty = Property("$cpuPercentage %")
+        val label = "CPU"
+        val progressBar = createProgressBar(lifetime, cpuPercentage.valueProperty, cpuPercentageProperty)
+        val labelProperty = Property("")
+
+        fun updateLabel() {
+            labelProperty.set("${cpuUsed}m / ${cpuTotal}m")
+        }
+        updateLabel()
+        cpuUsed.valueProperty.change.advise(lifetime) {
+            updateLabel()
+        }
+        cpuTotal.valueProperty.change.advise(lifetime) {
+            updateLabel()
+        }
+        createProgressRow(ctx, lifetime, label, cpuPercentage.statusProperty, labelProperty, cpuPercentageProperty, progressBar)
+    }
+
+    private fun createMemoryControl(ctx: VerticalGridBuilder, backendDiagnosticsService: BackendDiagnosticsService, lifetime: Lifetime) {
+        val memoryUsed = backendDiagnosticsService.getMetric("gitpod_workspace_memory_used")
+        val memoryTotal = backendDiagnosticsService.getMetric("gitpod_workspace_memory_total")
+        val memoryPercentage = backendDiagnosticsService.getMetric("gitpod_workspace_memory_percentage")
+        val memoryPercentageProperty = Property("$memoryPercentage %")
+        val label = "Memory"
+        val progressBar = createProgressBar(lifetime, memoryPercentage.valueProperty, memoryPercentageProperty)
+        val labelProperty = Property("")
+
+        fun updateLabel() {
+            labelProperty.set("${memoryUsed}GB / ${memoryTotal}GB")
+        }
+        updateLabel()
+        memoryUsed.valueProperty.change.advise(lifetime) {
+            updateLabel()
+        }
+        memoryTotal.valueProperty.change.advise(lifetime) {
+            updateLabel()
+        }
+
+        createProgressRow(ctx, lifetime, label, memoryPercentage.statusProperty, labelProperty, memoryPercentageProperty, progressBar)
     }
 }

--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/GitpodTimeoutControlCenterTabProvider.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/GitpodTimeoutControlCenterTabProvider.kt
@@ -1,0 +1,31 @@
+// Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package io.gitpod.jetbrains.remote
+
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.ActionManager
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.components.service
+import io.gitpod.jetbrains.remote.GitpodManager
+import org.apache.http.client.utils.URIBuilder
+
+class GitpodTimeoutControlCenterTabProvider : GatewayControlCenterTabProvider {
+    override val id = "gitpodTimeoutTab"
+    override val title = "Timeout"
+
+    override fun getControl(lifetime: Lifetime): BeControl {
+        return scrollablePanel(lifetime) {
+            verticalLayout {
+                label("Gitpod Tab")
+                label("Current workspace timeout: 30 minutes")
+                button("Extend workspace timeout") {
+                    action {
+                        actionManager.tryToExecute("io.gitpod.jetbrains.remote.actions.ExtendWorkspaceTimeoutAction", null, null, null, true)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/components/ide/jetbrains/backend-plugin/src/main/resources/META-INF/plugin.xml
+++ b/components/ide/jetbrains/backend-plugin/src/main/resources/META-INF/plugin.xml
@@ -48,6 +48,7 @@
                                            implementation="io.gitpod.jetbrains.remote.GitpodMetricControlProvider"/>
         <gateway.customization.metrics id="gitpodMetricsProvider"
                                        implementation="io.gitpod.jetbrains.remote.GitpodMetricProvider"/>
+        <gateway.customization.tab id="gitpodTimeoutTab" order="after performanceTab" implementation="io.gitpod.jetbrains.remote.GitpodTimeoutControlCenterTabProvider"/>
 
         <registryKey key="gitpod.forceUpdateMavenProjects.disabled" defaultValue="false"
                      description="Disable the forced update of Maven projects when IDE opens."


### PR DESCRIPTION
## Description

### Development notes

> **Warning**: only for Filip, confidential information ahead

This is how it looks like with the same UI code that lives in the <kbd>Performance</kbd> tab
<img width="646" alt="image" src="https://user-images.githubusercontent.com/29888641/218710882-7488600a-9bb4-4597-bbc7-42cb906eb5e4.png">


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
