### PR TITLE
[content-service] Move CPU alert to team Workspace

### DIFF
--- a/operations/observability/mixins/workspace/rules/central/content-service.yaml
+++ b/operations/observability/mixins/workspace/rules/central/content-service.yaml
@@ -4,19 +4,17 @@ metadata:
   labels:
     prometheus: k8s
     role: alert-rules
-  name: server-monitoring-rules
+  name: content-service-monitoring-rules
 spec:
   groups:
   - name: content-service
     rules:
     - alert: ContentServiceHighCPUUsage
-      # Reasoning: high rates of CPU consumption should only be temporary.
       expr: avg(rate(container_cpu_usage_seconds_total{container!="POD", pod=~"content-service-.*"}[5m])) by (cluster) > 0.1
       for: 10m
       labels:
-        # sent to the team internal channel until we fine tuned it
         severity: warning
-        team: webapp
+        team: workspace
       annotations:
         runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/WebAppServicesHighCPUUsage.md
         summary: Content Service has excessive CPU usage.


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Team Webapp [are not owners](https://github.com/gitpod-io/gitpod/blob/main/.github/CODEOWNERS#L10) of the Content Service, team Workspace is so we move the alert.

Feel free to remove/update/change the alert once you take ownership.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
