### PR TITLE
[codeowner] Update ws-daemon-api owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -86,7 +86,7 @@
 /components/usage-api @gitpod-io/engineering-webapp
 /components/workspace-rollout-job @gitpod-io/engineering-security-infrastructure-and-delivery @gitpod-io/engineering-workspace
 /components/workspacekit @gitpod-io/engineering-workspace
-/components/ws-daemon-api @aledbf @Furisto
+/components/ws-daemon-api @gitpod-io/engineering-workspace
 /components/ws-daemon @gitpod-io/engineering-workspace
 /components/ws-manager-api @gitpod-io/engineering-workspace
 /components/ws-manager-bridge-api @gitpod-io/engineering-webapp


### PR DESCRIPTION
## Description
As discussed update ws-daemon api owner

## Related Issue(s)
n.a.

## How to test
n.a.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```
## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
