### PR TITLE
Rename "New" files back - add Tooltip to ws branch

### DIFF
--- a/components/dashboard/src/admin/WorkspaceDetail.tsx
+++ b/components/dashboard/src/admin/WorkspaceDetail.tsx
@@ -10,7 +10,7 @@ import dayjs from "dayjs";
 import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { getGitpodService } from "../service/service";
-import { getProjectPath } from "../workspaces/WorkspaceEntryNew";
+import { getProjectPath } from "../workspaces/WorkspaceEntry";
 import { WorkspaceStatusIndicator } from "../workspaces/WorkspaceStatusIndicator";
 import { getAdminLinks } from "./gcp-info";
 import Property from "./Property";

--- a/components/dashboard/src/admin/WorkspacesSearch.tsx
+++ b/components/dashboard/src/admin/WorkspacesSearch.tsx
@@ -21,7 +21,7 @@ import { useLocation } from "react-router";
 import { Link } from "react-router-dom";
 import Pagination from "../Pagination/Pagination";
 import { getGitpodService } from "../service/service";
-import { getProjectPath } from "../workspaces/WorkspaceEntryNew";
+import { getProjectPath } from "../workspaces/WorkspaceEntry";
 import WorkspaceDetail from "./WorkspaceDetail";
 import { PageWithAdminSubMenu } from "./PageWithAdminSubMenu";
 import Alert from "../components/Alert";

--- a/components/dashboard/src/app/AppRoutes.tsx
+++ b/components/dashboard/src/app/AppRoutes.tsx
@@ -46,7 +46,7 @@ import { WebsocketClients } from "./WebsocketClients";
 import { OrgRequiredRoute } from "./OrgRequiredRoute";
 
 const Setup = React.lazy(() => import(/* webpackPrefetch: true */ "../Setup"));
-const WorkspacesNew = React.lazy(() => import(/* webpackPrefetch: true */ "../workspaces/WorkspacesNew"));
+const Workspaces = React.lazy(() => import(/* webpackPrefetch: true */ "../workspaces/Workspaces"));
 const Account = React.lazy(() => import(/* webpackPrefetch: true */ "../user-settings/Account"));
 const Notifications = React.lazy(() => import(/* webpackPrefetch: true */ "../user-settings/Notifications"));
 const Billing = React.lazy(() => import(/* webpackPrefetch: true */ "../user-settings/Billing"));
@@ -170,7 +170,7 @@ export const AppRoutes: FunctionComponent<AppRoutesProps> = ({ user, teams }) =>
                     <Route path={projectsPathNew} exact component={NewProject} />
                     <Route path="/open" exact component={Open} />
                     <Route path="/setup" exact component={Setup} />
-                    <Route path={workspacesPathMain} exact component={WorkspacesNew} />
+                    <Route path={workspacesPathMain} exact component={Workspaces} />
                     <Route path={settingsPathAccount} exact component={Account} />
                     <Route path={usagePathMain} exact component={Usage} />
                     <Route path={settingsPathIntegrations} exact component={Integrations} />

--- a/components/dashboard/src/components/Tooltip.tsx
+++ b/components/dashboard/src/components/Tooltip.tsx
@@ -47,8 +47,10 @@ function Tooltip(props: TooltipProps) {
     }, [showTooltipTimeout]);
 
     return (
-        <div onMouseLeave={handleMouseLeave} onMouseEnter={handleMouseEnter} className="relative">
-            <div ref={setTriggerEl}>{props.children}</div>
+        <>
+            <span onMouseLeave={handleMouseLeave} onMouseEnter={handleMouseEnter} ref={setTriggerEl}>
+                {props.children}
+            </span>
             {expanded ? (
                 <Portal>
                     <div
@@ -64,7 +66,7 @@ function Tooltip(props: TooltipProps) {
                     </div>
                 </Portal>
             ) : null}
-        </div>
+        </>
     );
 }
 

--- a/components/dashboard/src/components/Tooltip.tsx
+++ b/components/dashboard/src/components/Tooltip.tsx
@@ -50,22 +50,22 @@ function Tooltip(props: TooltipProps) {
         <>
             <span onMouseLeave={handleMouseLeave} onMouseEnter={handleMouseEnter} ref={setTriggerEl}>
                 {props.children}
+                {expanded ? (
+                    <Portal>
+                        <div
+                            ref={setTooltipEl}
+                            style={styles.popper}
+                            className={
+                                `max-w-md z-50 py-1 px-2 bg-gray-900 text-gray-100 text-sm absolute flex flex-col border border-gray-200 dark:border-gray-800 rounded-md truncated ` +
+                                (props.allowWrap ? "whitespace-normal" : "whitespace-nowrap")
+                            }
+                            {...attributes.popper}
+                        >
+                            {props.content}
+                        </div>
+                    </Portal>
+                ) : null}
             </span>
-            {expanded ? (
-                <Portal>
-                    <div
-                        ref={setTooltipEl}
-                        style={styles.popper}
-                        className={
-                            `max-w-md z-50 py-1 px-2 bg-gray-900 text-gray-100 text-sm absolute flex flex-col border border-gray-200 dark:border-gray-800 rounded-md truncated ` +
-                            (props.allowWrap ? "whitespace-normal" : "whitespace-nowrap")
-                        }
-                        {...attributes.popper}
-                    >
-                        {props.content}
-                    </div>
-                </Portal>
-            ) : null}
         </>
     );
 }

--- a/components/dashboard/src/workspaces/WorkspaceEntry.tsx
+++ b/components/dashboard/src/workspaces/WorkspaceEntry.tsx
@@ -74,7 +74,9 @@ export const WorkspaceEntry: FunctionComponent<Props> = ({ info }) => {
                 </a>
             </ItemField>
             <ItemField className="w-2/12 flex flex-col my-auto">
-                <div className="text-gray-500 dark:text-gray-400 overflow-ellipsis truncate">{currentBranch}</div>
+                <div className="text-gray-500 dark:text-gray-400 overflow-ellipsis truncate">
+                    <Tooltip content={currentBranch}>{currentBranch}</Tooltip>
+                </div>
                 <div className="mr-auto">
                     <PendingChangesDropdown workspaceInstance={info.latestInstance} />
                 </div>

--- a/components/dashboard/src/workspaces/Workspaces.tsx
+++ b/components/dashboard/src/workspaces/Workspaces.tsx
@@ -6,7 +6,7 @@
 
 import { FunctionComponent, useCallback, useMemo, useState } from "react";
 import Header from "../components/Header";
-import { WorkspaceEntry } from "./WorkspaceEntryNew";
+import { WorkspaceEntry } from "./WorkspaceEntry";
 import { ItemsList } from "../components/ItemsList";
 import { useCurrentUser } from "../user-context";
 import { User, WorkspaceInfo } from "@gitpod/gitpod-protocol";


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
* Cleans up some filenames to remove the `New` from them after refactoring the Workspaces list components.
* Added a tooltip to the branch name as a small improvement for when it's cut off and you can't tell what the branch is.


## How to test
<!-- Provide steps to test this PR -->
* Verify Workspaces list view renders correctly.
* Hover over the branch name in the workspaces list and ensure there's a tooltip.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
