### PR TITLE
[ws-manager-mk2] Support system environment variables

### DIFF
--- a/components/ws-manager-api/go/crd/v1/workspace_types.go
+++ b/components/ws-manager-api/go/crd/v1/workspace_types.go
@@ -24,7 +24,9 @@ type WorkspaceSpec struct {
 
 	Initializer []byte `json:"initializer"`
 
-	Envvars []corev1.EnvVar `json:"envvars,omitempty"`
+	UserEnvVars []corev1.EnvVar `json:"userEnvVars,omitempty"`
+
+	SysEnvVars []corev1.EnvVar `json:"sysEnvVars,omitempty"`
 
 	// +kubebuilder:validation:Required
 	WorkspaceLocation string `json:"workspaceLocation"`

--- a/components/ws-manager-api/go/crd/v1/zz_generated.deepcopy.go
+++ b/components/ws-manager-api/go/crd/v1/zz_generated.deepcopy.go
@@ -266,8 +266,15 @@ func (in *WorkspaceSpec) DeepCopyInto(out *WorkspaceSpec) {
 		*out = make([]byte, len(*in))
 		copy(*out, *in)
 	}
-	if in.Envvars != nil {
-		in, out := &in.Envvars, &out.Envvars
+	if in.UserEnvVars != nil {
+		in, out := &in.UserEnvVars, &out.UserEnvVars
+		*out = make([]corev1.EnvVar, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+	if in.SysEnvVars != nil {
+		in, out := &in.SysEnvVars, &out.SysEnvVars
 		*out = make([]corev1.EnvVar, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])

--- a/components/ws-manager-mk2/config/crd/bases/workspace.gitpod.io_workspaces.yaml
+++ b/components/ws-manager-mk2/config/crd/bases/workspace.gitpod.io_workspaces.yaml
@@ -81,7 +81,77 @@ spec:
                 type: object
               class:
                 type: string
-              envvars:
+              git:
+                properties:
+                  email:
+                    type: string
+                  username:
+                    type: string
+                required:
+                - email
+                - username
+                type: object
+              image:
+                properties:
+                  ide:
+                    properties:
+                      refs:
+                        items:
+                          type: string
+                        type: array
+                      supervisor:
+                        type: string
+                      web:
+                        type: string
+                    required:
+                    - supervisor
+                    - web
+                    type: object
+                  workspace:
+                    properties:
+                      ref:
+                        type: string
+                    type: object
+                required:
+                - ide
+                - workspace
+                type: object
+              initializer:
+                format: byte
+                type: string
+              ownership:
+                properties:
+                  owner:
+                    type: string
+                  team:
+                    type: string
+                  tenant:
+                    type: string
+                  workspaceID:
+                    type: string
+                required:
+                - owner
+                - workspaceID
+                type: object
+              ports:
+                items:
+                  properties:
+                    port:
+                      format: int32
+                      type: integer
+                    visibility:
+                      default: Owner
+                      enum:
+                      - Owner
+                      - Everyone
+                      type: string
+                  required:
+                  - port
+                  - visibility
+                  type: object
+                minItems: 0
+                type: array
+              sysEnvVars:
                 items:
                   description: EnvVar represents an environment variable present in
                     a Container.
@@ -189,76 +259,6 @@ spec:
                   - name
                   type: object
                 type: array
-              git:
-                properties:
-                  email:
-                    type: string
-                  username:
-                    type: string
-                required:
-                - email
-                - username
-                type: object
-              image:
-                properties:
-                  ide:
-                    properties:
-                      refs:
-                        items:
-                          type: string
-                        type: array
-                      supervisor:
-                        type: string
-                      web:
-                        type: string
-                    required:
-                    - supervisor
-                    - web
-                    type: object
-                  workspace:
-                    properties:
-                      ref:
-                        type: string
-                    type: object
-                required:
-                - ide
-                - workspace
-                type: object
-              initializer:
-                format: byte
-                type: string
-              ownership:
-                properties:
-                  owner:
-                    type: string
-                  team:
-                    type: string
-                  tenant:
-                    type: string
-                  workspaceID:
-                    type: string
-                required:
-                - owner
-                - workspaceID
-                type: object
-              ports:
-                items:
-                  properties:
-                    port:
-                      format: int32
-                      type: integer
-                    visibility:
-                      default: Owner
-                      enum:
-                      - Owner
-                      - Everyone
-                      type: string
-                  required:
-                  - port
-                  - visibility
-                  type: object
-                minItems: 0
-                type: array
               timeout:
                 properties:
                   time:
@@ -270,6 +270,114 @@ spec:
                 - Prebuild
                 - ImageBuild
                 type: string
+              userEnvVars:
+                items:
+                  description: EnvVar represents an environment variable present in
+                    a Container.
+                  properties:
+                    name:
+                      description: Name of the environment variable. Must be a C_IDENTIFIER.
+                      type: string
+                    value:
+                      description: 'Variable references $(VAR_NAME) are expanded using
+                        the previously defined environment variables in the container
+                        and any service environment variables. If a variable cannot
+                        be resolved, the reference in the input string will be unchanged.
+                        Double $$ are reduced to a single $, which allows for escaping
+                        the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the
+                        string literal "$(VAR_NAME)". Escaped references will never
+                        be expanded, regardless of whether the variable exists or
+                        not. Defaults to "".'
+                      type: string
+                    valueFrom:
+                      description: Source for the environment variable's value. Cannot
+                        be used if value is not empty.
+                      properties:
+                        configMapKeyRef:
+                          description: Selects a key of a ConfigMap.
+                          properties:
+                            key:
+                              description: The key to select.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap or its key
+                                must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fieldRef:
+                          description: 'Selects a field of the pod: supports metadata.name,
+                            metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
+                            spec.nodeName, spec.serviceAccountName, status.hostIP,
+                            status.podIP, status.podIPs.'
+                          properties:
+                            apiVersion:
+                              description: Version of the schema the FieldPath is
+                                written in terms of, defaults to "v1".
+                              type: string
+                            fieldPath:
+                              description: Path of the field to select in the specified
+                                API version.
+                              type: string
+                          required:
+                          - fieldPath
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        resourceFieldRef:
+                          description: 'Selects a resource of the container: only
+                            resources limits and requests (limits.cpu, limits.memory,
+                            limits.ephemeral-storage, requests.cpu, requests.memory
+                            and requests.ephemeral-storage) are currently supported.'
+                          properties:
+                            containerName:
+                              description: 'Container name: required for volumes,
+                                optional for env vars'
+                              type: string
+                            divisor:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Specifies the output format of the exposed
+                                resources, defaults to "1"
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            resource:
+                              description: 'Required: resource to select'
+                              type: string
+                          required:
+                          - resource
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        secretKeyRef:
+                          description: Selects a key of a secret in the pod's namespace
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
               workspaceLocation:
                 type: string
             required:

--- a/components/ws-manager-mk2/controllers/create.go
+++ b/components/ws-manager-mk2/controllers/create.go
@@ -584,8 +584,17 @@ func createWorkspaceEnvironment(sctx *startWorkspaceContext) ([]corev1.EnvVar, e
 		result = append(result, corev1.EnvVar{Name: "GITPOD_GIT_USER_EMAIL", Value: sctx.Workspace.Spec.Git.Email})
 	}
 
+	// System level env vars
+	for _, e := range sctx.Workspace.Spec.SysEnvVars {
+		env := corev1.EnvVar{
+			Name:  e.Name,
+			Value: e.Value,
+		}
+		result = append(result, env)
+	}
+
 	// User-defined env vars (i.e. those coming from the request)
-	for _, e := range sctx.Workspace.Spec.Envvars {
+	for _, e := range sctx.Workspace.Spec.UserEnvVars {
 		switch e.Name {
 		case "GITPOD_WORKSPACE_CONTEXT",
 			"GITPOD_WORKSPACE_CONTEXT_URL",

--- a/components/ws-manager-mk2/service/manager.go
+++ b/components/ws-manager-mk2/service/manager.go
@@ -21,9 +21,11 @@ import (
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
+	"github.com/gitpod-io/gitpod/common-go/kubernetes"
 	wsk8s "github.com/gitpod-io/gitpod/common-go/kubernetes"
 	"github.com/gitpod-io/gitpod/common-go/log"
 	"github.com/gitpod-io/gitpod/common-go/tracing"
+	"github.com/gitpod-io/gitpod/common-go/util"
 	"github.com/gitpod-io/gitpod/ws-manager-mk2/pkg/activity"
 	"github.com/gitpod-io/gitpod/ws-manager/api"
 	wsmanapi "github.com/gitpod-io/gitpod/ws-manager/api"
@@ -164,6 +166,38 @@ func (wsm *WorkspaceManagerServer) StartWorkspace(ctx context.Context, req *wsma
 		})
 	}
 
+	class, ok := wsm.Config.WorkspaceClasses[req.Spec.Class]
+	if !ok {
+		return nil, status.Errorf(codes.InvalidArgument, "workspace class \"%s\" is unknown", req.Spec.Class)
+	}
+
+	annotations := make(map[string]string)
+	for k, v := range req.Metadata.Annotations {
+		annotations[k] = v
+	}
+
+	for _, feature := range req.Spec.FeatureFlags {
+		switch feature {
+		case api.WorkspaceFeatureFlag_WORKSPACE_CLASS_LIMITING:
+			limits := class.Container.Limits
+			if limits != nil && limits.CPU != nil {
+				if limits.CPU.MinLimit != "" {
+					annotations[kubernetes.WorkspaceCpuMinLimitAnnotation] = limits.CPU.MinLimit
+				}
+
+				if limits.CPU.BurstLimit != "" {
+					annotations[kubernetes.WorkspaceCpuBurstLimitAnnotation] = limits.CPU.BurstLimit
+				}
+			}
+
+		case api.WorkspaceFeatureFlag_WORKSPACE_CONNECTION_LIMITING:
+			annotations[kubernetes.WorkspaceNetConnLimitAnnotation] = util.BooleanTrueString
+
+		case api.WorkspaceFeatureFlag_WORKSPACE_PSI:
+			annotations[kubernetes.WorkspacePressureStallInfoAnnotation] = util.BooleanTrueString
+		}
+	}
+
 	ws := workspacev1.Workspace{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: workspacev1.GroupVersion.String(),
@@ -171,7 +205,7 @@ func (wsm *WorkspaceManagerServer) StartWorkspace(ctx context.Context, req *wsma
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        req.Id,
-			Annotations: req.Metadata.Annotations,
+			Annotations: annotations,
 			Namespace:   wsm.Config.Namespace,
 			Labels: map[string]string{
 				wsk8s.WorkspaceIDLabel: req.Metadata.MetaId,


### PR DESCRIPTION
## Description
Support system environment variables. Depends on https://github.com/gitpod-io/gitpod/pull/16372

## Related Issue(s)
n.a.

## How to test
- Open workspace in [preview environment](https://fo-adv-2.preview.gitpod-dev.com/workspaces)
- Check that workspace CR contains a section for system environment variables and user environment variables
- Check that these environment variables have been defined for the workspace pod

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
