### PR TITLE
[ws-manager-mk2] Add finalizer on workspace, handle ws deletion

### DIFF
--- a/components/ws-manager-api/go/crd/v1/workspace_types.go
+++ b/components/ws-manager-api/go/crd/v1/workspace_types.go
@@ -9,6 +9,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	// GitpodFinalizerName is the name of the finalizer we use on workspaces and their pods.
+	GitpodFinalizerName = "gitpod.io/finalizer"
+)
+
 // WorkspaceSpec defines the desired state of Workspace
 type WorkspaceSpec struct {
 	// +kubebuilder:validation:Required

--- a/components/ws-manager-mk2/controllers/create.go
+++ b/components/ws-manager-mk2/controllers/create.go
@@ -45,9 +45,6 @@ const (
 	// TODO(furisto): remove this label once we have moved ws-daemon to a controller setup
 	instanceIDLabel = "gitpod.io/instanceID"
 
-	// gitpodPodFinalizerName is the name of the finalizer we use on pods
-	gitpodPodFinalizerName = "gitpod.io/finalizer"
-
 	// Grace time until the process in the workspace is properly completed
 	// e.g. dockerd in the workspace may take some time to clean up the overlay directory.
 	gracePeriod = 3 * time.Minute
@@ -407,7 +404,7 @@ func createDefiniteWorkspacePod(sctx *startWorkspaceContext) (*corev1.Pod, error
 			Namespace:   sctx.Config.Namespace,
 			Labels:      labels,
 			Annotations: annotations,
-			Finalizers:  []string{gitpodPodFinalizerName},
+			Finalizers:  []string{workspacev1.GitpodFinalizerName},
 		},
 		Spec: corev1.PodSpec{
 			Hostname:                     sctx.Workspace.Spec.Ownership.WorkspaceID,

--- a/components/ws-manager-mk2/controllers/status.go
+++ b/components/ws-manager-mk2/controllers/status.go
@@ -121,7 +121,7 @@ func updateWorkspaceStatus(ctx context.Context, workspace *workspacev1.Workspace
 	case isPodBeingDeleted(pod):
 		workspace.Status.Phase = workspacev1.WorkspacePhaseStopping
 
-		if controllerutil.ContainsFinalizer(pod, gitpodPodFinalizerName) {
+		if controllerutil.ContainsFinalizer(pod, workspacev1.GitpodFinalizerName) {
 			if wsk8s.ConditionPresentAndTrue(workspace.Status.Conditions, string(workspacev1.WorkspaceConditionBackupComplete)) ||
 				wsk8s.ConditionPresentAndTrue(workspace.Status.Conditions, string(workspacev1.WorkspaceConditionBackupFailure)) ||
 				wsk8s.ConditionPresentAndTrue(workspace.Status.Conditions, string(workspacev1.WorkspaceConditionAborted)) ||

--- a/components/ws-manager-mk2/controllers/workspace_controller.go
+++ b/components/ws-manager-mk2/controllers/workspace_controller.go
@@ -162,10 +162,18 @@ func (r *WorkspaceReconciler) actOnStatus(ctx context.Context, workspace *worksp
 			r.metrics.rememberWorkspace(workspace)
 
 		case workspace.Status.Phase == workspacev1.WorkspacePhaseStopped:
-			err := r.Client.Delete(ctx, workspace)
-			if err != nil {
-				return ctrl.Result{Requeue: true}, err
+			// Done stopping workspace - remove finalizer.
+			if controllerutil.ContainsFinalizer(workspace, workspacev1.GitpodFinalizerName) {
+				controllerutil.RemoveFinalizer(workspace, workspacev1.GitpodFinalizerName)
+				if err := r.Update(ctx, workspace); err != nil {
+					return ctrl.Result{}, client.IgnoreNotFound(err)
+				}
 			}
+
+			// Workspace might have already been in a deleting state,
+			// but not guaranteed, so try deleting anyway.
+			err := r.Client.Delete(ctx, workspace)
+			return ctrl.Result{}, client.IgnoreNotFound(err)
 		}
 
 		return ctrl.Result{}, nil
@@ -223,10 +231,20 @@ func (r *WorkspaceReconciler) actOnStatus(ctx context.Context, workspace *worksp
 			return ctrl.Result{Requeue: true}, err
 		}
 
+	case isWorkspaceBeingDeleted(workspace) && !isPodBeingDeleted(pod):
+		// Workspace was requested to be deleted, propagate by deleting the Pod.
+		// The Pod deletion will then trigger workspace disposal steps.
+		err := r.Client.Delete(ctx, pod)
+		if errors.IsNotFound(err) {
+			// pod is gone - nothing to do here
+		} else {
+			return ctrl.Result{Requeue: true}, err
+		}
+
 	// we've disposed already - try to remove the finalizer and call it a day
 	case workspace.Status.Phase == workspacev1.WorkspacePhaseStopped:
-		hadFinalizer := controllerutil.ContainsFinalizer(pod, gitpodPodFinalizerName)
-		controllerutil.RemoveFinalizer(pod, gitpodPodFinalizerName)
+		hadFinalizer := controllerutil.ContainsFinalizer(pod, workspacev1.GitpodFinalizerName)
+		controllerutil.RemoveFinalizer(pod, workspacev1.GitpodFinalizerName)
 		if err := r.Client.Update(ctx, pod); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to remove gitpod finalizer: %w", err)
 		}

--- a/components/ws-manager-mk2/service/manager.go
+++ b/components/ws-manager-mk2/service/manager.go
@@ -41,6 +41,7 @@ import (
 	"k8s.io/client-go/util/retry"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 const (
@@ -208,6 +209,7 @@ func (wsm *WorkspaceManagerServer) StartWorkspace(ctx context.Context, req *wsma
 			Ports: ports,
 		},
 	}
+	controllerutil.AddFinalizer(&ws, workspacev1.GitpodFinalizerName)
 
 	wsm.metrics.recordWorkspaceStart(&ws)
 	err = wsm.Client.Create(ctx, &ws)


### PR DESCRIPTION
## Description

- Add finalizer on the Workspace resource as well - such that deleting the workspace resource directly (instead of the Pod) still gracefully stops the workspace.
- Handle deleting the workspace resource, by propagating the deletion to the Pod, which then continuous deletion as normal.
- Once the workspace transitions to a `Stopped` phase, remove the finalizer on the workspace and finish deletion.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of #11416 

## How to test
<!-- Provide steps to test this PR -->

- Open a workspace
- `kubectl delete ws <name>`
- Observe the workspace gracefully shuts down with a backup, and eventually disappears from the cluster in `kubectl get ws`.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
