### PR TITLE
[ws-manager-mk2] Fix stuck on init/dispose failure

### DIFF
--- a/components/ws-daemon/pkg/controller/controller.go
+++ b/components/ws-daemon/pkg/controller/controller.go
@@ -29,6 +29,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
@@ -149,6 +150,7 @@ func (wsc *WorkspaceController) Reconcile(ctx context.Context, req ctrl.Request)
 }
 
 func (wsc *WorkspaceController) handleWorkspaceInit(ctx context.Context, ws *workspacev1.Workspace, req ctrl.Request) (result ctrl.Result, err error) {
+	log := log.FromContext(ctx)
 	span, ctx := opentracing.StartSpanFromContext(ctx, "handleWorkspaceInit")
 	defer tracing.FinishSpan(span, &err)
 
@@ -161,7 +163,7 @@ func (wsc *WorkspaceController) handleWorkspaceInit(ctx context.Context, ws *wor
 		}
 
 		initStart := time.Now()
-		alreadyInit, failure, err := wsc.operations.InitWorkspaceContent(ctx, InitContentOptions{
+		alreadyInit, failure, initErr := wsc.operations.InitWorkspaceContent(ctx, InitContentOptions{
 			Meta: WorkspaceMeta{
 				Owner:       ws.Spec.Ownership.Owner,
 				WorkspaceId: ws.Spec.Ownership.WorkspaceID,
@@ -170,10 +172,6 @@ func (wsc *WorkspaceController) handleWorkspaceInit(ctx context.Context, ws *wor
 			Initializer: &init,
 			Headless:    ws.Status.Headless,
 		})
-
-		if err != nil {
-			return ctrl.Result{}, fmt.Errorf("could not initialize workspace %s: %w", ws.Name, err)
-		}
 
 		if alreadyInit {
 			return ctrl.Result{}, nil
@@ -185,6 +183,7 @@ func (wsc *WorkspaceController) handleWorkspaceInit(ctx context.Context, ws *wor
 			}
 
 			if failure != "" {
+				log.Error(initErr, "could not initialize workspace", "name", ws.Name)
 				ws.Status.Conditions = wsk8s.AddUniqueCondition(ws.Status.Conditions, metav1.Condition{
 					Type:               string(workspacev1.WorkspaceConditionContentReady),
 					Status:             metav1.ConditionFalse,
@@ -215,6 +214,7 @@ func (wsc *WorkspaceController) handleWorkspaceInit(ctx context.Context, ws *wor
 }
 
 func (wsc *WorkspaceController) handleWorkspaceStop(ctx context.Context, ws *workspacev1.Workspace, req ctrl.Request) (result ctrl.Result, err error) {
+	log := log.FromContext(ctx)
 	span, ctx := opentracing.StartSpanFromContext(ctx, "handleWorkspaceStop")
 	defer tracing.FinishSpan(span, &err)
 
@@ -246,11 +246,6 @@ func (wsc *WorkspaceController) handleWorkspaceStop(ctx context.Context, ws *wor
 		BackupLogs:        ws.Spec.Type == workspacev1.WorkspaceTypePrebuild,
 	})
 
-	if disposeErr != nil {
-		err = fmt.Errorf("failed to dispose workspace %s: %w", ws.Name, disposeErr)
-		return ctrl.Result{}, err
-	}
-
 	if alreadyDisposing {
 		return ctrl.Result{}, nil
 	}
@@ -263,6 +258,7 @@ func (wsc *WorkspaceController) handleWorkspaceStop(ctx context.Context, ws *wor
 		ws.Status.GitStatus = toWorkspaceGitStatus(gitStatus)
 
 		if disposeErr != nil {
+			log.Error(disposeErr, "failed to dispose workspace", "name", ws.Name)
 			ws.Status.Conditions = wsk8s.AddUniqueCondition(ws.Status.Conditions, metav1.Condition{
 				Type:               string(workspacev1.WorkspaceConditionBackupFailure),
 				Status:             metav1.ConditionTrue,


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

If content init or dispose fails (e.g. backup not found during init), update the workspace status with the failure condition, otherwise the workspace gets stuck in the init or stopping state.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Relates to #11416 

## How to test
<!-- Provide steps to test this PR -->

1. Start workspace
2. Manually delete the workspace resource `kubectl delete ws <name>`
3. This causes the workspace to immediately stop without backup (will get fixed in https://github.com/gitpod-io/gitpod/pull/16400)
4. Restart the workspace
5. Workspace content init should fail as there's no backup
6. On the dashboard, you should see the workspace init failure, instead of stuck on "Starting"

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
