### PR TITLE
Add encryption endpoint in supervisor frontend

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,6 +18,7 @@
 /components/gitpod-messagebus @gitpod-io/engineering-webapp
 /components/gitpod-protocol @gitpod-io/engineering-webapp
 /components/gitpod-protocol/java @gitpod-io/engineering-ide
+/components/gitpod-protocol/src/typings/globals.ts @gitpod-io/engineering-ide
 /components/ide @gitpod-io/engineering-ide
 /components/ide-metrics @gitpod-io/engineering-ide
 /components/ide-metrics-api @gitpod-io/engineering-ide

--- a/components/gitpod-protocol/src/typings/globals.ts
+++ b/components/gitpod-protocol/src/typings/globals.ts
@@ -11,5 +11,9 @@ interface Window {
         loggedUserID?: string;
 
         openDesktopIDE(url: string): void;
+
+        encrypt(content: string): string;
+        decrypt(content: string): string;
+        isEncryptedData(content: string): boolean;
     };
 }

--- a/components/supervisor/frontend/src/ide/ide-metrics-service-client.ts
+++ b/components/supervisor/frontend/src/ide/ide-metrics-service-client.ts
@@ -36,10 +36,10 @@ export class IDEMetricsServiceClient {
     static serviceClient: FrontendDashboardServiceClient;
 
     static get instanceId(): string {
-        return this.serviceClient.latestStatus?.instanceId ?? "";
+        return this.serviceClient.latestInfo?.instanceId ?? "";
     }
     static get userId(): string {
-        return this.serviceClient.latestStatus?.loggedUserId ?? "";
+        return this.serviceClient.latestInfo?.loggedUserId ?? "";
     }
 
     static async addCounter(

--- a/components/supervisor/frontend/src/shared/frontend-dashboard-service.ts
+++ b/components/supervisor/frontend/src/shared/frontend-dashboard-service.ts
@@ -4,16 +4,18 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
+import * as crypto from "crypto";
 import { IDEFrontendDashboardService } from "@gitpod/gitpod-protocol/lib/frontend-dashboard-service";
 import { RemoteTrackMessage } from "@gitpod/gitpod-protocol/lib/analytics";
 import { Emitter } from "@gitpod/gitpod-protocol/lib/util/event";
 import { workspaceUrl, serverUrl } from "./urls";
 
 export class FrontendDashboardServiceClient implements IDEFrontendDashboardService.IClient {
-    public latestStatus!: IDEFrontendDashboardService.Status;
+    public latestInfo!: IDEFrontendDashboardService.Info;
+    private credentialsToken?: Uint8Array;
 
-    private readonly onDidChangeEmitter = new Emitter<IDEFrontendDashboardService.Status>();
-    readonly onStatusUpdate = this.onDidChangeEmitter.event;
+    private readonly onDidChangeEmitter = new Emitter<IDEFrontendDashboardService.Info>();
+    readonly onInfoUpdate = this.onDidChangeEmitter.event;
 
     private readonly onOpenBrowserIDEEmitter = new Emitter<void>();
     readonly onOpenBrowserIDE = this.onOpenBrowserIDEEmitter.event;
@@ -28,11 +30,16 @@ export class FrontendDashboardServiceClient implements IDEFrontendDashboardServi
             if (event.origin !== serverUrl.url.origin) {
                 return;
             }
-            if (IDEFrontendDashboardService.isStatusUpdateEventData(event.data)) {
+            if (IDEFrontendDashboardService.isInfoUpdateEventData(event.data)) {
                 this.version = event.data.version;
-                this.latestStatus = event.data.status;
+                this.latestInfo = event.data.info;
+                if (event.data.info.credentialsToken?.length > 0) {
+                    this.credentialsToken = Uint8Array.from(atob(event.data.info.credentialsToken), (c) =>
+                        c.charCodeAt(0),
+                    );
+                }
                 this.resolveInit();
-                this.onDidChangeEmitter.fire(this.latestStatus);
+                this.onDidChangeEmitter.fire(this.latestInfo);
             }
             if (IDEFrontendDashboardService.isRelocateEventData(event.data)) {
                 window.location.href = event.data.url;
@@ -44,6 +51,50 @@ export class FrontendDashboardServiceClient implements IDEFrontendDashboardServi
     }
     initialize(): Promise<void> {
         return this.initPromise;
+    }
+
+    decrypt(str: string): string {
+        if (!this.credentialsToken) {
+            throw new Error("no credentials token available");
+        }
+        const obj = JSON.parse(str);
+        if (!isSerializedEncryptedData(obj)) {
+            throw new Error("incorrect encrypted data");
+        }
+        const data = {
+            ...obj,
+            iv: Buffer.from(obj.iv, "base64"),
+            tag: Buffer.from(obj.tag, "base64"),
+        };
+        const decipher = crypto.createDecipheriv("aes-256-gcm", this.credentialsToken, data.iv);
+        decipher.setAuthTag(data.tag);
+        const decrypted = decipher.update(data.encrypted, "hex", "utf8");
+        return decrypted + decipher.final("utf8");
+    }
+
+    encrypt(content: string): string {
+        if (!this.credentialsToken) {
+            throw new Error("no credentials token available");
+        }
+        const iv = crypto.randomBytes(12);
+        const cipher = crypto.createCipheriv("aes-256-gcm", this.credentialsToken, iv);
+        let encrypted = cipher.update(content, "utf8", "hex");
+        encrypted += cipher.final("hex");
+        const tag = cipher.getAuthTag();
+        return JSON.stringify({
+            iv: iv.toString("base64"),
+            tag: tag.toString("base64"),
+            encrypted,
+        });
+    }
+
+    isEncryptedData(content: string): boolean {
+        try {
+            const obj = JSON.parse(content);
+            return isSerializedEncryptedData(obj);
+        } catch (e) {
+            return false;
+        }
     }
 
     trackEvent(msg: RemoteTrackMessage): void {
@@ -77,4 +128,14 @@ export class FrontendDashboardServiceClient implements IDEFrontendDashboardServi
             serverUrl.url.origin,
         );
     }
+}
+
+function isSerializedEncryptedData(obj: any): obj is { iv: string; encrypted: string; tag: string } {
+    return (
+        obj != null &&
+        typeof obj === "object" &&
+        typeof obj.iv === "string" &&
+        typeof obj.encrypted === "string" &&
+        typeof obj.tag === "string"
+    );
 }

--- a/components/supervisor/frontend/webpack.config.js
+++ b/components/supervisor/frontend/webpack.config.js
@@ -55,7 +55,7 @@ module.exports = {
         fs: "empty",
         child_process: "empty",
         net: "empty",
-        crypto: "empty",
+        crypto: true,
         tls: "empty",
     },
     devtool: "source-map",


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #
Relates https://github.com/gitpod-io/security/issues/121

## How to test
<!-- Provide steps to test this PR -->
- Open workspace in preview env with latest browser code
- Check localStorage if `credentials.providers` is encrypted

**compatible#1**
- Close workspace and change default IDE to stable browser code
- Re-open workspace, check if everything is alright (compatible)

**compatible#2 old workspace reopen**
- Copy credentials.provider from production and set
- Re-open workspace use stable browser code
- Check if it encrypted again and the decrypted value is the same with just copied value

----
✅ Use latest browser code to start a workspace in preview env confirmed that it's encrypted, change it's value (add copy and change service name) refresh still exists, restart workspace still exists
|Change Value|Restart Workspace|
|:-:|:-:|
|![SCR-20230215-ux6](https://user-images.githubusercontent.com/20944364/219054052-4b54b5c7-1a39-46ee-8c13-b9c7a9602886.png)|![SCR-20230215-uxv](https://user-images.githubusercontent.com/20944364/219054007-e4a21dd7-1a0c-4b78-8674-4380369769bf.png)|

✅ Start with stable browser code, credentials should not be encrypted, change it's value and stop workspace, restart with latest code, it should work
|Change Value|Restart Workspace with IDE Changed|
|:-:|:-:|
|<img width="1918" alt="image" src="https://user-images.githubusercontent.com/20944364/219055229-af1462ad-0f15-4cff-8198-0cc267390d1f.png">|<img width="853" alt="image" src="https://user-images.githubusercontent.com/20944364/219055848-bc5d747f-5b79-49d1-b30f-4fb20f31e5e3.png">|

✅ Override supervisor-frontend script to not set credentailsToken (mock server rollback), it should failed and use plain text again (user may need to re-auth), add new service name and refresh, it's still here with plain text
|Override|Plain Text|Add One|
|:-:|:-:|:-:|
|<img width="1249" alt="image" src="https://user-images.githubusercontent.com/20944364/219060149-2ba67bd5-71f5-4654-90b9-19d7579573ac.png">|![image](https://user-images.githubusercontent.com/20944364/219060021-24c4726e-254f-4634-a5d4-9cf9ee73cac6.png)|<img width="808" alt="image" src="https://user-images.githubusercontent.com/20944364/219060767-1a8f60ee-81b0-4162-892c-7059c3d026ac.png">|




## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`
- [ ] /werft publish-to-npm

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
