### PR TITLE
Make Gitpod cookie "stricter"

### DIFF
--- a/components/server/src/session-handler.ts
+++ b/components/server/src/session-handler.ts
@@ -27,10 +27,10 @@ export class SessionHandlerProvider {
     public init() {
         const options: SessionOptions = {} as SessionOptions;
         options.cookie = this.getCookieOptions(this.config);
-        (options.genid = function (req: any) {
+        options.genid = function (req: any) {
             return uuidv4(); // use UUIDs for session IDs
-        }),
-            (options.name = SessionHandlerProvider.getCookieName(this.config));
+        };
+        options.name = SessionHandlerProvider.getCookieName(this.config);
         // options.proxy = true    // TODO SSL Proxy
         options.resave = true; // TODO Check with store! See docu
         options.rolling = true; // default, new cookie and maxAge

--- a/components/server/src/session-handler.ts
+++ b/components/server/src/session-handler.ts
@@ -53,7 +53,7 @@ export class SessionHandlerProvider {
             httpOnly: true, // default
             secure: false, // default, TODO SSL! Config proxy
             maxAge: config.session.maxAgeMs, // configured in Helm chart, defaults to 3 days.
-            sameSite: "lax", // default: true. "Lax" needed for OAuth.
+            sameSite: "strict",
         };
     }
 


### PR DESCRIPTION
## Description
This PR changes the way we're managing [sameSite](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite) setting of the Gitpod cookie (aka session cookie). 

We know, having them on `lax` mode in general comes with a reduction of browser based security mechanism. OTOH the current OAuth2 implementation relies on the session cookie being present on redirects. Also, during the OAuth2 flow, the mentioned browser security model might be neglected, at least there would be other measures possible to harden that process not relying on the browser agent. Given that, we can improve the security posture, by switching to `lax` mode for OAuth2 processes and back to `strict` mode when the process is done.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
1. Try to login with GitHub and GitLab.
2. Repeat after signing out of GitHub and GitLab to simulate a cold start of IdP session, which should lead to 
<!-- Provide steps to test this PR -->
<img width="1162" alt="Screenshot 2023-02-15 at 10 07 13" src="https://user-images.githubusercontent.com/914497/218983098-c67f4105-b771-4518-89fa-705842b741d9.png">


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
