### PR TITLE
Improve ready probe labeler

### DIFF
--- a/install/installer/cmd/testdata/render/agent-smith/output.golden
+++ b/install/installer/cmd/testdata/render/agent-smith/output.golden
@@ -8045,11 +8045,16 @@ spec:
         - /app/ready-probe-labeler
         - --label=gitpod.io/registry-facade_ready_ns_default
         - --probe-url=http://localhost:8086/ready
+        - --host-port=20000
         env:
         - name: NODENAME
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: NODEIP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
         image: eu.gcr.io/gitpod-core-dev/build/registry-facade:test
         imagePullPolicy: IfNotPresent
         lifecycle:
@@ -8268,11 +8273,16 @@ spec:
         - /app/ready-probe-labeler
         - --label=gitpod.io/ws-daemon_ready_ns_default
         - --probe-url=http://localhost:9501/ready
+        - --host-port=8080
         env:
         - name: NODENAME
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: NODEIP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
         image: eu.gcr.io/gitpod-core-dev/build/ws-daemon:test
         imagePullPolicy: IfNotPresent
         lifecycle:

--- a/install/installer/cmd/testdata/render/aws-setup/output.golden
+++ b/install/installer/cmd/testdata/render/aws-setup/output.golden
@@ -7213,11 +7213,16 @@ spec:
         - /app/ready-probe-labeler
         - --label=gitpod.io/registry-facade_ready_ns_default
         - --probe-url=http://localhost:8086/ready
+        - --host-port=20000
         env:
         - name: NODENAME
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: NODEIP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
         image: eu.gcr.io/gitpod-core-dev/build/registry-facade:test
         imagePullPolicy: IfNotPresent
         lifecycle:
@@ -7439,11 +7444,16 @@ spec:
         - /app/ready-probe-labeler
         - --label=gitpod.io/ws-daemon_ready_ns_default
         - --probe-url=http://localhost:9501/ready
+        - --host-port=8080
         env:
         - name: NODENAME
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: NODEIP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
         image: eu.gcr.io/gitpod-core-dev/build/ws-daemon:test
         imagePullPolicy: IfNotPresent
         lifecycle:

--- a/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
+++ b/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
@@ -7862,11 +7862,16 @@ spec:
         - /app/ready-probe-labeler
         - --label=gitpod.io/registry-facade_ready_ns_default
         - --probe-url=http://localhost:8086/ready
+        - --host-port=20000
         env:
         - name: NODENAME
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: NODEIP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
         image: registry.mydomain.com/namespace/registry-facade:test
         imagePullPolicy: IfNotPresent
         lifecycle:
@@ -8085,11 +8090,16 @@ spec:
         - /app/ready-probe-labeler
         - --label=gitpod.io/ws-daemon_ready_ns_default
         - --probe-url=http://localhost:9501/ready
+        - --host-port=8080
         env:
         - name: NODENAME
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: NODEIP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
         image: registry.mydomain.com/namespace/ws-daemon:test
         imagePullPolicy: IfNotPresent
         lifecycle:

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -8584,11 +8584,16 @@ spec:
         - /app/ready-probe-labeler
         - --label=gitpod.io/registry-facade_ready_ns_default
         - --probe-url=http://localhost:8086/ready
+        - --host-port=20000
         env:
         - name: NODENAME
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: NODEIP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
         image: eu.gcr.io/gitpod-core-dev/build/registry-facade:test
         imagePullPolicy: IfNotPresent
         lifecycle:
@@ -8816,11 +8821,16 @@ spec:
         - /app/ready-probe-labeler
         - --label=gitpod.io/ws-daemon_ready_ns_default
         - --probe-url=http://localhost:9501/ready
+        - --host-port=8080
         env:
         - name: NODENAME
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: NODEIP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
         image: eu.gcr.io/gitpod-core-dev/build/ws-daemon:test
         imagePullPolicy: IfNotPresent
         lifecycle:

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -7582,11 +7582,16 @@ spec:
         - /app/ready-probe-labeler
         - --label=gitpod.io/registry-facade_ready_ns_default
         - --probe-url=http://localhost:8086/ready
+        - --host-port=20000
         env:
         - name: NODENAME
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: NODEIP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
         image: eu.gcr.io/gitpod-core-dev/build/registry-facade:test
         imagePullPolicy: IfNotPresent
         lifecycle:
@@ -7805,11 +7810,16 @@ spec:
         - /app/ready-probe-labeler
         - --label=gitpod.io/ws-daemon_ready_ns_default
         - --probe-url=http://localhost:9501/ready
+        - --host-port=8080
         env:
         - name: NODENAME
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: NODEIP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
         image: eu.gcr.io/gitpod-core-dev/build/ws-daemon:test
         imagePullPolicy: IfNotPresent
         lifecycle:

--- a/install/installer/cmd/testdata/render/gcp-setup/output.golden
+++ b/install/installer/cmd/testdata/render/gcp-setup/output.golden
@@ -7372,11 +7372,16 @@ spec:
         - /app/ready-probe-labeler
         - --label=gitpod.io/registry-facade_ready_ns_default
         - --probe-url=http://localhost:8086/ready
+        - --host-port=20000
         env:
         - name: NODENAME
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: NODEIP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
         image: eu.gcr.io/gitpod-core-dev/build/registry-facade:test
         imagePullPolicy: IfNotPresent
         lifecycle:
@@ -7598,11 +7603,16 @@ spec:
         - /app/ready-probe-labeler
         - --label=gitpod.io/ws-daemon_ready_ns_default
         - --probe-url=http://localhost:9501/ready
+        - --host-port=8080
         env:
         - name: NODENAME
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: NODEIP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
         image: eu.gcr.io/gitpod-core-dev/build/ws-daemon:test
         imagePullPolicy: IfNotPresent
         lifecycle:

--- a/install/installer/cmd/testdata/render/http-proxy/output.golden
+++ b/install/installer/cmd/testdata/render/http-proxy/output.golden
@@ -8025,11 +8025,16 @@ spec:
         - /app/ready-probe-labeler
         - --label=gitpod.io/registry-facade_ready_ns_default
         - --probe-url=http://localhost:8086/ready
+        - --host-port=20000
         env:
         - name: NODENAME
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: NODEIP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
         - name: HTTP_PROXY
           valueFrom:
             secretKeyRef:
@@ -8409,11 +8414,16 @@ spec:
         - /app/ready-probe-labeler
         - --label=gitpod.io/ws-daemon_ready_ns_default
         - --probe-url=http://localhost:9501/ready
+        - --host-port=8080
         env:
         - name: NODENAME
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: NODEIP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
         - name: HTTP_PROXY
           valueFrom:
             secretKeyRef:

--- a/install/installer/cmd/testdata/render/ide-config/output.golden
+++ b/install/installer/cmd/testdata/render/ide-config/output.golden
@@ -7882,11 +7882,16 @@ spec:
         - /app/ready-probe-labeler
         - --label=gitpod.io/registry-facade_ready_ns_default
         - --probe-url=http://localhost:8086/ready
+        - --host-port=20000
         env:
         - name: NODENAME
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: NODEIP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
         image: eu.gcr.io/gitpod-core-dev/build/registry-facade:test
         imagePullPolicy: IfNotPresent
         lifecycle:
@@ -8105,11 +8110,16 @@ spec:
         - /app/ready-probe-labeler
         - --label=gitpod.io/ws-daemon_ready_ns_default
         - --probe-url=http://localhost:9501/ready
+        - --host-port=8080
         env:
         - name: NODENAME
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: NODEIP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
         image: eu.gcr.io/gitpod-core-dev/build/ws-daemon:test
         imagePullPolicy: IfNotPresent
         lifecycle:

--- a/install/installer/cmd/testdata/render/kind-workspace/output.golden
+++ b/install/installer/cmd/testdata/render/kind-workspace/output.golden
@@ -3160,11 +3160,16 @@ spec:
         - /app/ready-probe-labeler
         - --label=gitpod.io/registry-facade_ready_ns_default
         - --probe-url=http://localhost:8086/ready
+        - --host-port=20000
         env:
         - name: NODENAME
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: NODEIP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
         image: eu.gcr.io/gitpod-core-dev/build/registry-facade:test
         imagePullPolicy: IfNotPresent
         lifecycle:
@@ -3383,11 +3388,16 @@ spec:
         - /app/ready-probe-labeler
         - --label=gitpod.io/ws-daemon_ready_ns_default
         - --probe-url=http://localhost:9501/ready
+        - --host-port=8080
         env:
         - name: NODENAME
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: NODEIP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
         image: eu.gcr.io/gitpod-core-dev/build/ws-daemon:test
         imagePullPolicy: IfNotPresent
         lifecycle:

--- a/install/installer/cmd/testdata/render/message-bus-password/output.golden
+++ b/install/installer/cmd/testdata/render/message-bus-password/output.golden
@@ -7865,11 +7865,16 @@ spec:
         - /app/ready-probe-labeler
         - --label=gitpod.io/registry-facade_ready_ns_default
         - --probe-url=http://localhost:8086/ready
+        - --host-port=20000
         env:
         - name: NODENAME
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: NODEIP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
         image: eu.gcr.io/gitpod-core-dev/build/registry-facade:test
         imagePullPolicy: IfNotPresent
         lifecycle:
@@ -8088,11 +8093,16 @@ spec:
         - /app/ready-probe-labeler
         - --label=gitpod.io/ws-daemon_ready_ns_default
         - --probe-url=http://localhost:9501/ready
+        - --host-port=8080
         env:
         - name: NODENAME
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: NODEIP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
         image: eu.gcr.io/gitpod-core-dev/build/ws-daemon:test
         imagePullPolicy: IfNotPresent
         lifecycle:

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -7862,11 +7862,16 @@ spec:
         - /app/ready-probe-labeler
         - --label=gitpod.io/registry-facade_ready_ns_default
         - --probe-url=http://localhost:8086/ready
+        - --host-port=20000
         env:
         - name: NODENAME
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: NODEIP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
         image: eu.gcr.io/gitpod-core-dev/build/registry-facade:test
         imagePullPolicy: IfNotPresent
         lifecycle:
@@ -8085,11 +8090,16 @@ spec:
         - /app/ready-probe-labeler
         - --label=gitpod.io/ws-daemon_ready_ns_default
         - --probe-url=http://localhost:9501/ready
+        - --host-port=8080
         env:
         - name: NODENAME
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: NODEIP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
         image: eu.gcr.io/gitpod-core-dev/build/ws-daemon:test
         imagePullPolicy: IfNotPresent
         lifecycle:

--- a/install/installer/cmd/testdata/render/overrides-inline/output.golden
+++ b/install/installer/cmd/testdata/render/overrides-inline/output.golden
@@ -7872,11 +7872,16 @@ spec:
         - /app/ready-probe-labeler
         - --label=gitpod.io/registry-facade_ready_ns_default
         - --probe-url=http://localhost:8086/ready
+        - --host-port=20000
         env:
         - name: NODENAME
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: NODEIP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
         image: eu.gcr.io/gitpod-core-dev/build/registry-facade:test
         imagePullPolicy: IfNotPresent
         lifecycle:
@@ -8095,11 +8100,16 @@ spec:
         - /app/ready-probe-labeler
         - --label=gitpod.io/ws-daemon_ready_ns_default
         - --probe-url=http://localhost:9501/ready
+        - --host-port=8080
         env:
         - name: NODENAME
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: NODEIP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
         image: eu.gcr.io/gitpod-core-dev/build/ws-daemon:test
         imagePullPolicy: IfNotPresent
         lifecycle:

--- a/install/installer/cmd/testdata/render/pod-config/output.golden
+++ b/install/installer/cmd/testdata/render/pod-config/output.golden
@@ -7869,11 +7869,16 @@ spec:
         - /app/ready-probe-labeler
         - --label=gitpod.io/registry-facade_ready_ns_default
         - --probe-url=http://localhost:8086/ready
+        - --host-port=20000
         env:
         - name: NODENAME
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: NODEIP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
         image: eu.gcr.io/gitpod-core-dev/build/registry-facade:test
         imagePullPolicy: IfNotPresent
         lifecycle:
@@ -8092,11 +8097,16 @@ spec:
         - /app/ready-probe-labeler
         - --label=gitpod.io/ws-daemon_ready_ns_default
         - --probe-url=http://localhost:9501/ready
+        - --host-port=8080
         env:
         - name: NODENAME
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: NODEIP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
         image: eu.gcr.io/gitpod-core-dev/build/ws-daemon:test
         imagePullPolicy: IfNotPresent
         lifecycle:

--- a/install/installer/cmd/testdata/render/shortname/output.golden
+++ b/install/installer/cmd/testdata/render/shortname/output.golden
@@ -7862,11 +7862,16 @@ spec:
         - /app/ready-probe-labeler
         - --label=gitpod.io/registry-facade_ready_ns_default
         - --probe-url=http://localhost:8086/ready
+        - --host-port=20000
         env:
         - name: NODENAME
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: NODEIP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
         image: eu.gcr.io/gitpod-core-dev/build/registry-facade:test
         imagePullPolicy: IfNotPresent
         lifecycle:
@@ -8085,11 +8090,16 @@ spec:
         - /app/ready-probe-labeler
         - --label=gitpod.io/ws-daemon_ready_ns_default
         - --probe-url=http://localhost:9501/ready
+        - --host-port=8080
         env:
         - name: NODENAME
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: NODEIP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
         image: eu.gcr.io/gitpod-core-dev/build/ws-daemon:test
         imagePullPolicy: IfNotPresent
         lifecycle:

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -7874,11 +7874,16 @@ spec:
         - /app/ready-probe-labeler
         - --label=gitpod.io/registry-facade_ready_ns_default
         - --probe-url=http://localhost:8086/ready
+        - --host-port=20000
         env:
         - name: NODENAME
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: NODEIP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
         image: eu.gcr.io/gitpod-core-dev/build/registry-facade:test
         imagePullPolicy: IfNotPresent
         lifecycle:
@@ -8097,11 +8102,16 @@ spec:
         - /app/ready-probe-labeler
         - --label=gitpod.io/ws-daemon_ready_ns_default
         - --probe-url=http://localhost:9501/ready
+        - --host-port=8080
         env:
         - name: NODENAME
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: NODEIP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
         image: eu.gcr.io/gitpod-core-dev/build/ws-daemon:test
         imagePullPolicy: IfNotPresent
         lifecycle:

--- a/install/installer/cmd/testdata/render/telemetry/output.golden
+++ b/install/installer/cmd/testdata/render/telemetry/output.golden
@@ -7865,11 +7865,16 @@ spec:
         - /app/ready-probe-labeler
         - --label=gitpod.io/registry-facade_ready_ns_default
         - --probe-url=http://localhost:8086/ready
+        - --host-port=20000
         env:
         - name: NODENAME
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: NODEIP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
         image: eu.gcr.io/gitpod-core-dev/build/registry-facade:test
         imagePullPolicy: IfNotPresent
         lifecycle:
@@ -8088,11 +8093,16 @@ spec:
         - /app/ready-probe-labeler
         - --label=gitpod.io/ws-daemon_ready_ns_default
         - --probe-url=http://localhost:9501/ready
+        - --host-port=8080
         env:
         - name: NODENAME
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: NODEIP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
         image: eu.gcr.io/gitpod-core-dev/build/ws-daemon:test
         imagePullPolicy: IfNotPresent
         lifecycle:

--- a/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
+++ b/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
@@ -8306,11 +8306,16 @@ spec:
         - /app/ready-probe-labeler
         - --label=gitpod.io/registry-facade_ready_ns_default
         - --probe-url=http://localhost:8086/ready
+        - --host-port=20000
         env:
         - name: NODENAME
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: NODEIP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
         image: eu.gcr.io/gitpod-core-dev/build/registry-facade:test
         imagePullPolicy: IfNotPresent
         lifecycle:
@@ -8529,11 +8534,16 @@ spec:
         - /app/ready-probe-labeler
         - --label=gitpod.io/ws-daemon_ready_ns_default
         - --probe-url=http://localhost:9501/ready
+        - --host-port=8080
         env:
         - name: NODENAME
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: NODEIP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
         image: eu.gcr.io/gitpod-core-dev/build/ws-daemon:test
         imagePullPolicy: IfNotPresent
         lifecycle:

--- a/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
+++ b/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
@@ -7865,11 +7865,16 @@ spec:
         - /app/ready-probe-labeler
         - --label=gitpod.io/registry-facade_ready_ns_default
         - --probe-url=http://localhost:8086/ready
+        - --host-port=20000
         env:
         - name: NODENAME
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: NODEIP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
         image: eu.gcr.io/gitpod-core-dev/build/registry-facade:test
         imagePullPolicy: IfNotPresent
         lifecycle:
@@ -8088,11 +8093,16 @@ spec:
         - /app/ready-probe-labeler
         - --label=gitpod.io/ws-daemon_ready_ns_default
         - --probe-url=http://localhost:9501/ready
+        - --host-port=8080
         env:
         - name: NODENAME
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: NODEIP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
         image: eu.gcr.io/gitpod-core-dev/build/ws-daemon:test
         imagePullPolicy: IfNotPresent
         lifecycle:

--- a/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
+++ b/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
@@ -7865,11 +7865,16 @@ spec:
         - /app/ready-probe-labeler
         - --label=gitpod.io/registry-facade_ready_ns_default
         - --probe-url=http://localhost:8086/ready
+        - --host-port=20000
         env:
         - name: NODENAME
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: NODEIP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
         image: eu.gcr.io/gitpod-core-dev/build/registry-facade:test
         imagePullPolicy: IfNotPresent
         lifecycle:
@@ -8088,11 +8093,16 @@ spec:
         - /app/ready-probe-labeler
         - --label=gitpod.io/ws-daemon_ready_ns_default
         - --probe-url=http://localhost:9501/ready
+        - --host-port=8080
         env:
         - name: NODENAME
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: NODEIP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
         image: eu.gcr.io/gitpod-core-dev/build/ws-daemon:test
         imagePullPolicy: IfNotPresent
         lifecycle:

--- a/install/installer/pkg/common/common.go
+++ b/install/installer/pkg/common/common.go
@@ -789,6 +789,15 @@ func NodeNameEnv(context *RenderContext) []corev1.EnvVar {
 	}}
 }
 
+func NodeHostIPEnv(context *RenderContext) []corev1.EnvVar {
+	return []corev1.EnvVar{{
+		Name: "NODEIP",
+		ValueFrom: &corev1.EnvVarSource{
+			FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.hostIP"},
+		},
+	}}
+}
+
 // ExperimentalWebappConfig extracts webapp experimental config from the render context.
 // When the experimental config is not defined, the result will be nil.
 func ExperimentalWebappConfig(ctx *RenderContext) *experimental.WebAppConfig {

--- a/install/installer/pkg/components/registry-facade/daemonset.go
+++ b/install/installer/pkg/components/registry-facade/daemonset.go
@@ -324,9 +324,11 @@ func daemonset(ctx *common.RenderContext) ([]runtime.Object, error) {
 								"/app/ready-probe-labeler",
 								fmt.Sprintf("--label=gitpod.io/registry-facade_ready_ns_%v", ctx.Namespace),
 								fmt.Sprintf(`--probe-url=http://localhost:%v/ready`, ReadinessPort),
+								fmt.Sprintf(`--host-port=%v`, ServicePort),
 							},
 							Env: common.CustomizeEnvvar(ctx, Component, common.MergeEnv(
 								common.NodeNameEnv(ctx),
+								common.NodeHostIPEnv(ctx),
 								common.ProxyEnv(&ctx.Config),
 							)),
 							LivenessProbe: &corev1.Probe{

--- a/install/installer/pkg/components/ws-daemon/daemonset.go
+++ b/install/installer/pkg/components/ws-daemon/daemonset.go
@@ -276,9 +276,11 @@ func daemonset(ctx *common.RenderContext) ([]runtime.Object, error) {
 					"/app/ready-probe-labeler",
 					fmt.Sprintf("--label=gitpod.io/ws-daemon_ready_ns_%v", ctx.Namespace),
 					fmt.Sprintf(`--probe-url=http://localhost:%v/ready`, ReadinessPort),
+					fmt.Sprintf(`--host-port=%v`, ServicePort),
 				},
 				Env: common.CustomizeEnvvar(ctx, Component, common.MergeEnv(
 					common.NodeNameEnv(ctx),
+					common.NodeHostIPEnv(ctx),
 					common.ProxyEnv(&ctx.Config),
 				)),
 				ImagePullPolicy: corev1.PullIfNotPresent,


### PR DESCRIPTION
## Description

Running Gitpod in dedicated (AWS) with the AWS CNI plugin we see a delay with pods using `hostPort`. This  delay introduces unexpected errors in pulling images (registry-facade) or connectivity between components (ws-manager -> ws-daemon) during a scale-up event.

<img width="1254" alt="image" src="https://user-images.githubusercontent.com/161571/219047747-98cf3ec2-928b-44d3-bb9d-e5f6e5bb22c2.png">

## Release Notes
```release-note
NONE
```

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [x] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft with-integration-tests=workspace
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
