### PR TITLE
gp env to respect workspace env vars

### DIFF
--- a/components/gitpod-cli/pkg/supervisor/client.go
+++ b/components/gitpod-cli/pkg/supervisor/client.go
@@ -26,6 +26,7 @@ type SupervisorClient struct {
 	Info         api.InfoServiceClient
 	Notification api.NotificationServiceClient
 	Control      api.ControlServiceClient
+	Token        api.TokenServiceClient
 }
 
 type SupervisorClientOption struct {
@@ -51,6 +52,7 @@ func New(ctx context.Context, options ...*SupervisorClientOption) (*SupervisorCl
 		Info:         api.NewInfoServiceClient(conn),
 		Notification: api.NewNotificationServiceClient(conn),
 		Control:      api.NewControlServiceClient(conn),
+		Token:        api.NewTokenServiceClient(conn),
 	}, nil
 }
 

--- a/components/gitpod-protocol/go/gitpod-service.go
+++ b/components/gitpod-protocol/go/gitpod-service.go
@@ -63,7 +63,8 @@ type APIInterface interface {
 	ClosePort(ctx context.Context, workspaceID string, port float32) (err error)
 	GetUserStorageResource(ctx context.Context, options *GetUserStorageResourceOptions) (res string, err error)
 	UpdateUserStorageResource(ctx context.Context, options *UpdateUserStorageResourceOptions) (err error)
-	GetEnvVars(ctx context.Context) (res []*UserEnvVarValue, err error)
+	GetWorkspaceEnvVars(ctx context.Context, workspaceID string) (res []*EnvVar, err error)
+	GetEnvVars(ctx context.Context) (res []*EnvVar, err error)
 	SetEnvVar(ctx context.Context, variable *UserEnvVarValue) (err error)
 	DeleteEnvVar(ctx context.Context, variable *UserEnvVarValue) (err error)
 	HasSSHPublicKey(ctx context.Context) (res bool, err error)
@@ -1112,15 +1113,35 @@ func (gp *APIoverJSONRPC) UpdateUserStorageResource(ctx context.Context, options
 	return
 }
 
-// GetEnvVars calls getEnvVars on the server
-func (gp *APIoverJSONRPC) GetEnvVars(ctx context.Context) (res []*UserEnvVarValue, err error) {
+// GetWorkspaceEnvVars calls GetWorkspaceEnvVars on the server
+func (gp *APIoverJSONRPC) GetWorkspaceEnvVars(ctx context.Context, workspaceID string) (res []*EnvVar, err error) {
 	if gp == nil {
 		err = errNotConnected
 		return
 	}
 	var _params []interface{}
 
-	var result []*UserEnvVarValue
+	_params = append(_params, workspaceID)
+
+	var result []*EnvVar
+	err = gp.C.Call(ctx, "getWorkspaceEnvVars", _params, &result)
+	if err != nil {
+		return
+	}
+	res = result
+
+	return
+}
+
+// GetEnvVars calls getEnvVars on the server
+func (gp *APIoverJSONRPC) GetEnvVars(ctx context.Context) (res []*EnvVar, err error) {
+	if gp == nil {
+		err = errNotConnected
+		return
+	}
+	var _params []interface{}
+
+	var result []*EnvVar
 	err = gp.C.Call(ctx, "getEnvVars", _params, &result)
 	if err != nil {
 		return
@@ -1960,6 +1981,13 @@ type WhitelistedRepository struct {
 	Description string `json:"description,omitempty"`
 	Name        string `json:"name,omitempty"`
 	URL         string `json:"url,omitempty"`
+}
+
+// EnvVar is the EnvVar message type
+type EnvVar struct {
+	ID    string `json:"id,omitempty"`
+	Name  string `json:"name,omitempty"`
+	Value string `json:"value,omitempty"`
 }
 
 // UserEnvVarValue is the UserEnvVarValue message type

--- a/components/gitpod-protocol/go/mock.go
+++ b/components/gitpod-protocol/go/mock.go
@@ -357,11 +357,20 @@ func (mr *MockAPIInterfaceMockRecorder) GetContentBlobUploadURL(ctx, name interf
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetContentBlobUploadURL", reflect.TypeOf((*MockAPIInterface)(nil).GetContentBlobUploadURL), ctx, name)
 }
 
+// GetWorkspaceEnvVars mocks base method.
+func (m *MockAPIInterface) GetWorkspaceEnvVars(ctx context.Context, workspaceID string) ([]*EnvVar, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetWorkspaceEnvVars", ctx, workspaceID)
+	ret0, _ := ret[0].([]*EnvVar)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
 // GetEnvVars mocks base method.
-func (m *MockAPIInterface) GetEnvVars(ctx context.Context) ([]*UserEnvVarValue, error) {
+func (m *MockAPIInterface) GetEnvVars(ctx context.Context) ([]*EnvVar, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetEnvVars", ctx)
-	ret0, _ := ret[0].([]*UserEnvVarValue)
+	ret0, _ := ret[0].([]*EnvVar)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -27,6 +27,7 @@ import {
     UserSSHPublicKeyValue,
     SSHPublicKeyValue,
     IDESettings,
+    EnvVarWithValue,
 } from "./protocol";
 import {
     Team,
@@ -152,6 +153,9 @@ export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, 
     // User storage
     getUserStorageResource(options: GitpodServer.GetUserStorageResourceOptions): Promise<string>;
     updateUserStorageResource(options: GitpodServer.UpdateUserStorageResourceOptions): Promise<void>;
+
+    // Workspace env vars
+    getWorkspaceEnvVars(workspaceId: string): Promise<EnvVarWithValue[]>;
 
     // User env vars
     getEnvVars(): Promise<UserEnvVarValue[]>;

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -323,6 +323,8 @@ export namespace NamedWorkspaceFeatureFlag {
     }
 }
 
+export type EnvVar = UserEnvVar | ProjectEnvVarWithValue | EnvVarWithValue;
+
 export interface EnvVarWithValue {
     name: string;
     value: string;

--- a/components/server/src/auth/rate-limiter.ts
+++ b/components/server/src/auth/rate-limiter.ts
@@ -90,6 +90,7 @@ const defaultFunctions: FunctionsConfig = {
     closePort: { group: "default", points: 1 },
     getUserStorageResource: { group: "default", points: 1 },
     updateUserStorageResource: { group: "default", points: 1 },
+    getWorkspaceEnvVars: { group: "default", points: 1 },
     getEnvVars: { group: "default", points: 1 },
     getAllEnvVars: { group: "default", points: 1 },
     setEnvVar: { group: "default", points: 1 },

--- a/components/server/src/container-module.ts
+++ b/components/server/src/container-module.ts
@@ -114,6 +114,7 @@ import { retryMiddleware } from "nice-grpc-client-middleware-retry";
 import { IamSessionApp } from "./iam/iam-session-app";
 import { spicedbClientFromEnv, SpiceDBClient } from "./authorization/spicedb";
 import { Authorizer, PermissionChecker } from "./authorization/perms";
+import { EnvVarService } from "./workspace/env-var-service";
 
 export const productionContainerModule = new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(Config).toConstantValue(ConfigFile.fromFile());
@@ -255,6 +256,8 @@ export const productionContainerModule = new ContainerModule((bind, unbind, isBo
     bind(HeadlessLogController).toSelf().inSingletonScope();
 
     bind(ProjectsService).toSelf().inSingletonScope();
+
+    bind(EnvVarService).toSelf().inSingletonScope();
 
     bind(NewsletterSubscriptionController).toSelf().inSingletonScope();
 

--- a/components/server/src/workspace/env-var-service.spec.ts
+++ b/components/server/src/workspace/env-var-service.spec.ts
@@ -1,0 +1,185 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import "reflect-metadata";
+
+import { suite, test } from "@testdeck/mocha";
+import * as chai from "chai";
+import { EnvVarService } from "./env-var-service";
+import {
+    CommitContext,
+    EnvVarWithValue,
+    ProjectEnvVar,
+    ProjectEnvVarWithValue,
+    UserEnvVar,
+    WithEnvvarsContext,
+} from "@gitpod/gitpod-protocol";
+import { ProjectDB, UserDB } from "@gitpod/gitpod-db/lib";
+import { ProjectsService } from "../projects/projects-service";
+const expect = chai.expect;
+
+const commitContext = {
+    repository: {
+        owner: "gitpod",
+        name: "gitpod-io",
+    },
+    revision: "abcd123",
+    title: "test",
+} as CommitContext;
+
+const fooAnyUserEnvVar: UserEnvVar = {
+    id: "1",
+    name: "foo",
+    value: "any",
+    repositoryPattern: "gitpod/*",
+    userId: "1",
+};
+
+const barUserCommitEnvVar: UserEnvVar = {
+    id: "2",
+    name: "bar",
+    value: "commit",
+    repositoryPattern: "gitpod/gitpod-io",
+    userId: "1",
+};
+
+const barUserAnotherCommitEnvVar: UserEnvVar = {
+    id: "5",
+    name: "bar",
+    value: "commit",
+    repositoryPattern: "gitpod/openvscode-server",
+    userId: "1",
+};
+
+const barProjectCensoredEnvVar: ProjectEnvVarWithValue = {
+    id: "3",
+    name: "bar",
+    projectId: "1",
+    censored: true,
+    value: "project1",
+};
+
+const bazProjectEnvVar: ProjectEnvVarWithValue = {
+    id: "4",
+    name: "baz",
+    projectId: "1",
+    censored: false,
+    value: "project2",
+};
+
+const barContextEnvVar: EnvVarWithValue = {
+    name: "bar",
+    value: "context",
+};
+const contextEnvVars = {
+    envvars: [barContextEnvVar],
+} as WithEnvvarsContext;
+
+@suite
+class TestEnvVarService {
+    protected envVarService: EnvVarService;
+
+    public before() {
+        this.envVarService = new EnvVarService();
+        this.envVarService["userDB"] = {
+            getEnvVars: (_) => {
+                return Promise.resolve([fooAnyUserEnvVar, barUserCommitEnvVar, barUserAnotherCommitEnvVar]);
+            },
+        } as UserDB;
+        this.envVarService["projectsService"] = {
+            getProjectEnvironmentVariables: (_) => {
+                return Promise.resolve([barProjectCensoredEnvVar, bazProjectEnvVar] as ProjectEnvVar[]);
+            },
+        } as ProjectsService;
+        this.envVarService["projectDB"] = {
+            getProjectEnvironmentVariableValues: (envs) => {
+                return Promise.resolve(envs as ProjectEnvVarWithValue[]);
+            },
+        } as ProjectDB;
+    }
+
+    @test
+    public async testRegular() {
+        const envVars = await this.envVarService.resolve({
+            ownerId: "1",
+            type: "regular",
+            context: commitContext,
+        } as any);
+        expect(envVars).to.deep.equal({
+            project: [],
+            workspace: [fooAnyUserEnvVar, barUserCommitEnvVar],
+        });
+    }
+
+    @test
+    public async testPrebuild() {
+        const envVars = await this.envVarService.resolve({
+            ownerId: "1",
+            type: "prebuild",
+            context: commitContext,
+        } as any);
+        expect(envVars).to.deep.equal({
+            project: [],
+            workspace: [],
+        });
+    }
+
+    @test
+    public async testRegularWithProject() {
+        const envVars = await this.envVarService.resolve({
+            ownerId: "1",
+            type: "regular",
+            context: commitContext,
+            projectId: "1",
+        } as any);
+        expect(envVars).to.deep.equal({
+            project: [barProjectCensoredEnvVar, bazProjectEnvVar],
+            workspace: [fooAnyUserEnvVar, barUserCommitEnvVar, bazProjectEnvVar],
+        });
+    }
+
+    @test
+    public async testPrebuildWithProject() {
+        const envVars = await this.envVarService.resolve({
+            type: "prebuild",
+            context: commitContext,
+            projectId: "1",
+        } as any);
+        expect(envVars).to.deep.equal({
+            project: [barProjectCensoredEnvVar, bazProjectEnvVar],
+            workspace: [barProjectCensoredEnvVar, bazProjectEnvVar],
+        });
+    }
+
+    @test
+    public async testRegularFromContext() {
+        const envVars = await this.envVarService.resolve({
+            owerId: "1",
+            type: "regular",
+            context: { ...commitContext, ...contextEnvVars },
+        } as any);
+        expect(envVars).to.deep.equal({
+            project: [],
+            workspace: [fooAnyUserEnvVar, barContextEnvVar],
+        });
+    }
+
+    @test
+    public async testRegularFromContextWithProject() {
+        const envVars = await this.envVarService.resolve({
+            owerId: "1",
+            type: "regular",
+            context: { ...commitContext, ...contextEnvVars },
+            projectId: "1",
+        } as any);
+        expect(envVars).to.deep.equal({
+            project: [barProjectCensoredEnvVar, bazProjectEnvVar],
+            workspace: [fooAnyUserEnvVar, barContextEnvVar, bazProjectEnvVar],
+        });
+    }
+}
+
+module.exports = new TestEnvVarService();

--- a/components/server/src/workspace/env-var-service.ts
+++ b/components/server/src/workspace/env-var-service.ts
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { ProjectDB, UserDB } from "@gitpod/gitpod-db/lib";
+import {
+    CommitContext,
+    EnvVar,
+    ProjectEnvVar,
+    UserEnvVar,
+    WithEnvvarsContext,
+    Workspace,
+} from "@gitpod/gitpod-protocol";
+import { inject, injectable } from "inversify";
+import { ProjectsService } from "../projects/projects-service";
+
+export interface ResolvedEnvVars {
+    // all project env vars, censored included always
+    project: ProjectEnvVar[];
+    // merged workspace env vars
+    workspace: EnvVar[];
+}
+
+@injectable()
+export class EnvVarService {
+    @inject(UserDB)
+    private userDB: UserDB;
+
+    @inject(ProjectsService)
+    private projectsService: ProjectsService;
+
+    @inject(ProjectDB)
+    private projectDB: ProjectDB;
+
+    async resolve(workspace: Workspace): Promise<ResolvedEnvVars> {
+        const workspaceEnvVars = new Map<String, EnvVar>();
+        const merge = (envs: EnvVar[]) => {
+            for (const env of envs) {
+                workspaceEnvVars.set(env.name, env);
+            }
+        };
+
+        const projectEnvVars = workspace.projectId
+            ? await this.projectsService.getProjectEnvironmentVariables(workspace.projectId)
+            : [];
+        if (workspace.type === "prebuild") {
+            // prebuild does not have access to user env vars and cannot be started via prewfix URL
+            const withValues = await this.projectDB.getProjectEnvironmentVariableValues(projectEnvVars);
+            merge(withValues);
+            return {
+                project: projectEnvVars,
+                workspace: [...workspaceEnvVars.values()],
+            };
+        }
+
+        // 1. first merge user envs
+        if (CommitContext.is(workspace.context)) {
+            // this is a commit context, thus we can filter the env vars
+            const userEnvVars = await this.userDB.getEnvVars(workspace.ownerId);
+            merge(
+                UserEnvVar.filter(userEnvVars, workspace.context.repository.owner, workspace.context.repository.name),
+            );
+        }
+
+        // 2. then from the project
+        if (projectEnvVars.length) {
+            // Instead of using an access guard for Project environment variables, we let Project owners decide whether
+            // a variable should be:
+            //   - exposed in all workspaces (even for non-Project members when the repository is public), or
+            //   - censored from all workspaces (even for Project members)
+            const availablePrjEnvVars = projectEnvVars.filter((variable) => !variable.censored);
+            const withValues = await this.projectDB.getProjectEnvironmentVariableValues(availablePrjEnvVars);
+            merge(withValues);
+        }
+
+        // 3. then parsed from the context URL
+        if (WithEnvvarsContext.is(workspace.context)) {
+            merge(workspace.context.envvars);
+        }
+
+        return {
+            project: projectEnvVars,
+            workspace: [...workspaceEnvVars.values()],
+        };
+    }
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

`gp env` reflects workspace env vars, not only user env vars, i.e. as well coming from projects and context URL.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
fix #12208

## How to test
<!-- Provide steps to test this PR -->

- [x] Setup different project and user envs, for instance fork https://github.com/akosyakov/parcel-demo/tree/tes_gp_env
- [x] Test that `gp env` reflects visible project and context env vars.
- [x] Test that starting/restart prebuild picks up all project env vars, but not for user.
- [x] Test that starting/restart workspace picks up user, visible project and context env vars.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
`gp env` reflects workspace env vars, not only user env vars, i.e. as well coming from projects and context URL.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
