### PR TITLE
Update layout for admin dashboard pages

### DIFF
--- a/components/dashboard/src/admin/ProjectDetail.tsx
+++ b/components/dashboard/src/admin/ProjectDetail.tsx
@@ -13,61 +13,63 @@ import dayjs from "dayjs";
 export default function ProjectDetail(props: { project: Project; owner: string | undefined }) {
     return (
         <>
-            <div className="flex">
-                <div className="flex-1">
-                    <div className="flex">
-                        <h3>{props.project.name}</h3>
-                        <span className="my-auto"></span>
+            <div className="app-container">
+                <div className="flex">
+                    <div className="flex-1">
+                        <div className="flex">
+                            <h3>{props.project.name}</h3>
+                            <span className="my-auto"></span>
+                        </div>
+                        <p>{props.project.cloneUrl}</p>
                     </div>
-                    <p>{props.project.cloneUrl}</p>
                 </div>
-            </div>
-            <div className="flex flex-col w-full">
-                <div className="flex w-full mt-6">
-                    <Property name="Created">{dayjs(props.project.creationTime).format("MMM D, YYYY")}</Property>
-                    <Property name="Repository">
-                        <a
-                            className="text-blue-400 dark:text-blue-600 hover:text-blue-600 dark:hover:text-blue-400 truncate"
-                            href={props.project.cloneUrl}
-                        >
-                            {props.project.name}
-                        </a>
-                    </Property>
-                    {props.project.userId ? (
-                        <Property name="Owner">
-                            <>
-                                <Link
-                                    className="text-blue-400 dark:text-blue-600 hover:text-blue-600 dark:hover:text-blue-400 truncate"
-                                    to={"/admin/users/" + props.project.userId}
-                                >
-                                    {props.owner}
-                                </Link>
-                                <span className="text-gray-400 dark:text-gray-500"> (User)</span>
-                            </>
+                <div className="flex flex-col w-full">
+                    <div className="flex w-full mt-6">
+                        <Property name="Created">{dayjs(props.project.creationTime).format("MMM D, YYYY")}</Property>
+                        <Property name="Repository">
+                            <a
+                                className="text-blue-400 dark:text-blue-600 hover:text-blue-600 dark:hover:text-blue-400 truncate"
+                                href={props.project.cloneUrl}
+                            >
+                                {props.project.name}
+                            </a>
                         </Property>
-                    ) : (
-                        <Property name="Owner">
-                            <>
-                                <Link
-                                    className="text-blue-400 dark:text-blue-600 hover:text-blue-600 dark:hover:text-blue-400 truncate"
-                                    to={"/admin/orgs/" + props.project.teamId}
-                                >
-                                    {props.owner}
-                                </Link>
-                                <span className="text-gray-400 dark:text-gray-500"> (Organization)</span>
-                            </>
+                        {props.project.userId ? (
+                            <Property name="Owner">
+                                <>
+                                    <Link
+                                        className="text-blue-400 dark:text-blue-600 hover:text-blue-600 dark:hover:text-blue-400 truncate"
+                                        to={"/admin/users/" + props.project.userId}
+                                    >
+                                        {props.owner}
+                                    </Link>
+                                    <span className="text-gray-400 dark:text-gray-500"> (User)</span>
+                                </>
+                            </Property>
+                        ) : (
+                            <Property name="Owner">
+                                <>
+                                    <Link
+                                        className="text-blue-400 dark:text-blue-600 hover:text-blue-600 dark:hover:text-blue-400 truncate"
+                                        to={"/admin/orgs/" + props.project.teamId}
+                                    >
+                                        {props.owner}
+                                    </Link>
+                                    <span className="text-gray-400 dark:text-gray-500"> (Organization)</span>
+                                </>
+                            </Property>
+                        )}
+                    </div>
+                    <div className="flex w-full mt-6">
+                        <Property name="Incremental Prebuilds">
+                            {props.project.settings?.useIncrementalPrebuilds ? "Yes" : "No"}
                         </Property>
-                    )}
+                        <Property name="Marked Deleted">{props.project.markedDeleted ? "Yes" : "No"}</Property>
+                    </div>
                 </div>
-                <div className="flex w-full mt-6">
-                    <Property name="Incremental Prebuilds">
-                        {props.project.settings?.useIncrementalPrebuilds ? "Yes" : "No"}
-                    </Property>
-                    <Property name="Marked Deleted">{props.project.markedDeleted ? "Yes" : "No"}</Property>
+                <div className="mt-6">
+                    <Prebuilds project={props.project} isAdminDashboard={true} />
                 </div>
-            </div>
-            <div className="mt-6">
-                <Prebuilds project={props.project} isAdminDashboard={true} />
             </div>
         </>
     );

--- a/components/dashboard/src/admin/ProjectDetail.tsx
+++ b/components/dashboard/src/admin/ProjectDetail.tsx
@@ -14,7 +14,7 @@ export default function ProjectDetail(props: { project: Project; owner: string |
     return (
         <>
             <div className="app-container">
-                <div className="flex">
+                <div className="flex mt-8">
                     <div className="flex-1">
                         <div className="flex">
                             <h3>{props.project.name}</h3>

--- a/components/dashboard/src/admin/TeamDetail.tsx
+++ b/components/dashboard/src/admin/TeamDetail.tsx
@@ -69,7 +69,7 @@ export default function TeamDetail(props: { team: Team }) {
     };
     return (
         <>
-            <div className="flex">
+            <div className="flex mt-8">
                 <div className="flex-1">
                     <div className="flex">
                         <h3>{team.name}</h3>

--- a/components/dashboard/src/admin/UserDetail.tsx
+++ b/components/dashboard/src/admin/UserDetail.tsx
@@ -260,7 +260,7 @@ export default function UserDetail(p: { user: User }) {
         <>
             <AdminPageHeader title="Admin" subtitle="Configure and manage instance settings.">
                 <div className="app-container">
-                    <div className="flex">
+                    <div className="flex mt-8">
                         <div className="flex-1">
                             <div className="flex">
                                 <h3>{user.fullName}</h3>

--- a/components/dashboard/src/admin/UserSearch.tsx
+++ b/components/dashboard/src/admin/UserSearch.tsx
@@ -109,9 +109,18 @@ export default function UserSearch() {
                 </div>
                 <div className="flex flex-col space-y-2">
                     <div className="px-6 py-3 flex justify-between space-x-2 text-sm text-gray-400 border-t border-b border-gray-200 dark:border-gray-800 mb-2">
-                        <div className="w-1/12"></div>
-                        <div className="w-6/12">Name</div>
-                        <div className="w-5/12">Created</div>
+                        <div className="w-7/12">Name</div>
+                        <div className="w-5/12 flex items-center">
+                            <span>Created</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" className="h-4 w-4" viewBox="0 0 16 16">
+                                <path
+                                    fill="#A8A29E"
+                                    fill-rule="evenodd"
+                                    d="M13.366 8.234a.8.8 0 010 1.132l-4.8 4.8a.8.8 0 01-1.132 0l-4.8-4.8a.8.8 0 111.132-1.132L7.2 11.67V2.4a.8.8 0 111.6 0v9.269l3.434-3.435a.8.8 0 011.132 0z"
+                                    clip-rule="evenodd"
+                                />
+                            </svg>
+                        </div>
                     </div>
                     {searchResult.rows
                         .filter((u) => u.identities.length > 0)

--- a/components/dashboard/src/admin/WorkspaceDetail.tsx
+++ b/components/dashboard/src/admin/WorkspaceDetail.tsx
@@ -58,7 +58,7 @@ export default function WorkspaceDetail(props: { workspace: WorkspaceAndInstance
     return (
         <>
             <div className="app-container">
-                <div className="flex">
+                <div className="flex mt-8">
                     <div className="flex-1">
                         <div className="flex">
                             <h3>{workspace.workspaceId}</h3>

--- a/components/dashboard/src/admin/WorkspaceDetail.tsx
+++ b/components/dashboard/src/admin/WorkspaceDetail.tsx
@@ -57,104 +57,106 @@ export default function WorkspaceDetail(props: { workspace: WorkspaceAndInstance
     );
     return (
         <>
-            <div className="flex">
-                <div className="flex-1">
-                    <div className="flex">
-                        <h3>{workspace.workspaceId}</h3>
-                        <span className="my-auto ml-3">
-                            <WorkspaceStatusIndicator instance={WorkspaceAndInstance.toInstance(workspace)} />
-                        </span>
+            <div className="app-container">
+                <div className="flex">
+                    <div className="flex-1">
+                        <div className="flex">
+                            <h3>{workspace.workspaceId}</h3>
+                            <span className="my-auto ml-3">
+                                <WorkspaceStatusIndicator instance={WorkspaceAndInstance.toInstance(workspace)} />
+                            </span>
+                        </div>
+                        <p>{getProjectPath(WorkspaceAndInstance.toWorkspace(workspace))}</p>
                     </div>
-                    <p>{getProjectPath(WorkspaceAndInstance.toWorkspace(workspace))}</p>
+                    <button
+                        className="secondary ml-3"
+                        onClick={() => {
+                            window.location.href = new GitpodHostUrl(window.location.href)
+                                .with({
+                                    pathname: `/workspace-download/get/${workspace.workspaceId}`,
+                                })
+                                .toString();
+                        }}
+                    >
+                        Download Workspace
+                    </button>
+                    <button
+                        className="danger ml-3"
+                        disabled={activity || workspace.phase === "stopped"}
+                        onClick={stopWorkspace}
+                    >
+                        Stop Workspace
+                    </button>
                 </div>
-                <button
-                    className="secondary ml-3"
-                    onClick={() => {
-                        window.location.href = new GitpodHostUrl(window.location.href)
-                            .with({
-                                pathname: `/workspace-download/get/${workspace.workspaceId}`,
-                            })
-                            .toString();
-                    }}
-                >
-                    Download Workspace
-                </button>
-                <button
-                    className="danger ml-3"
-                    disabled={activity || workspace.phase === "stopped"}
-                    onClick={stopWorkspace}
-                >
-                    Stop Workspace
-                </button>
-            </div>
-            <div className="flex mt-6">
-                <div className="flex flex-col w-full">
-                    <div className="flex w-full mt-6">
-                        <Property name="Created">
-                            {dayjs(workspace.workspaceCreationTime).format("MMM D, YYYY")}
-                        </Property>
-                        <Property name="Last Start">{dayjs(workspace.instanceCreationTime).fromNow()}</Property>
-                        <Property name="Context">
-                            <a
-                                className="text-blue-400 dark:text-blue-600 hover:text-blue-600 dark:hover:text-blue-400"
-                                href={ContextURL.getNormalizedURL(workspace)?.toString()}
-                            >
-                                {workspace.context.title}
-                            </a>
-                        </Property>
-                    </div>
-                    <div className="flex w-full mt-6">
-                        <Property name="User">
-                            <Link
-                                className="text-blue-400 dark:text-blue-600 hover:text-blue-600 dark:hover:text-blue-400"
-                                to={"/admin/users/" + props.workspace.ownerId}
-                            >
-                                {user?.name || props.workspace.ownerId}
-                            </Link>
-                        </Property>
-                        <Property name="Sharing">{workspace.shareable ? "Enabled" : "Disabled"}</Property>
-                        <Property
-                            name="Soft Deleted"
-                            actions={
-                                !!workspace.softDeleted && !workspace.contentDeletedTime
-                                    ? [
-                                          {
-                                              label: "Restore & Pin",
-                                              onClick: async () => {
-                                                  await getGitpodService().server.adminRestoreSoftDeletedWorkspace(
-                                                      workspace.workspaceId,
-                                                  );
-                                                  await reload();
+                <div className="flex mt-6">
+                    <div className="flex flex-col w-full">
+                        <div className="flex w-full mt-6">
+                            <Property name="Created">
+                                {dayjs(workspace.workspaceCreationTime).format("MMM D, YYYY")}
+                            </Property>
+                            <Property name="Last Start">{dayjs(workspace.instanceCreationTime).fromNow()}</Property>
+                            <Property name="Context">
+                                <a
+                                    className="text-blue-400 dark:text-blue-600 hover:text-blue-600 dark:hover:text-blue-400"
+                                    href={ContextURL.getNormalizedURL(workspace)?.toString()}
+                                >
+                                    {workspace.context.title}
+                                </a>
+                            </Property>
+                        </div>
+                        <div className="flex w-full mt-6">
+                            <Property name="User">
+                                <Link
+                                    className="text-blue-400 dark:text-blue-600 hover:text-blue-600 dark:hover:text-blue-400"
+                                    to={"/admin/users/" + props.workspace.ownerId}
+                                >
+                                    {user?.name || props.workspace.ownerId}
+                                </Link>
+                            </Property>
+                            <Property name="Sharing">{workspace.shareable ? "Enabled" : "Disabled"}</Property>
+                            <Property
+                                name="Soft Deleted"
+                                actions={
+                                    !!workspace.softDeleted && !workspace.contentDeletedTime
+                                        ? [
+                                              {
+                                                  label: "Restore & Pin",
+                                                  onClick: async () => {
+                                                      await getGitpodService().server.adminRestoreSoftDeletedWorkspace(
+                                                          workspace.workspaceId,
+                                                      );
+                                                      await reload();
+                                                  },
                                               },
-                                          },
-                                      ]
-                                    : undefined
-                            }
-                        >
-                            {workspace.softDeleted
-                                ? `'${workspace.softDeleted}' ${dayjs(workspace.softDeletedTime).fromNow()}`
-                                : "No"}
-                        </Property>
+                                          ]
+                                        : undefined
+                                }
+                            >
+                                {workspace.softDeleted
+                                    ? `'${workspace.softDeleted}' ${dayjs(workspace.softDeletedTime).fromNow()}`
+                                    : "No"}
+                            </Property>
+                        </div>
+                        <div className="flex w-full mt-12">
+                            <Property name="Latest Instance ID">
+                                <div className="overflow-scroll">{workspace.instanceId}</div>
+                            </Property>
+                            <Property name="Region">{workspace.region}</Property>
+                            <Property name="Stopped">
+                                {workspace.stoppedTime ? dayjs(workspace.stoppedTime).fromNow() : "---"}
+                            </Property>
+                        </div>
+                        <div className="flex w-full mt-12">
+                            <Property name="Node">
+                                <div className="overflow-scroll">{workspace.status.nodeName ?? "not assigned"}</div>
+                            </Property>
+                            <Property name="Class">
+                                <div>{workspace.workspaceClass ?? "unknown"}</div>
+                            </Property>
+                        </div>
+                        <div className="flex w-full mt-6">{[0, 1, 2].map(adminLink)}</div>
+                        <div className="flex w-full mt-6">{[3, 4, 5].map(adminLink)}</div>
                     </div>
-                    <div className="flex w-full mt-12">
-                        <Property name="Latest Instance ID">
-                            <div className="overflow-scroll">{workspace.instanceId}</div>
-                        </Property>
-                        <Property name="Region">{workspace.region}</Property>
-                        <Property name="Stopped">
-                            {workspace.stoppedTime ? dayjs(workspace.stoppedTime).fromNow() : "---"}
-                        </Property>
-                    </div>
-                    <div className="flex w-full mt-12">
-                        <Property name="Node">
-                            <div className="overflow-scroll">{workspace.status.nodeName ?? "not assigned"}</div>
-                        </Property>
-                        <Property name="Class">
-                            <div>{workspace.workspaceClass ?? "unknown"}</div>
-                        </Property>
-                    </div>
-                    <div className="flex w-full mt-6">{[0, 1, 2].map(adminLink)}</div>
-                    <div className="flex w-full mt-6">{[3, 4, 5].map(adminLink)}</div>
                 </div>
             </div>
         </>

--- a/components/dashboard/src/admin/WorkspacesSearch.tsx
+++ b/components/dashboard/src/admin/WorkspacesSearch.tsx
@@ -161,9 +161,8 @@ export function WorkspaceSearch(props: Props) {
                 </Alert>
                 <div className="flex flex-col space-y-2">
                     <div className="px-6 py-3 flex justify-between text-sm text-gray-400 border-t border-b border-gray-200 dark:border-gray-800 mb-2">
-                        <div className="w-8"></div>
-                        <div className="w-5/12">Name</div>
-                        <div className="w-5/12">Context</div>
+                        <div className="w-4/12">Name</div>
+                        <div className="w-6/12">Context</div>
                         <div className="w-2/12">Last Started</div>
                     </div>
                     {searchResult.rows.map((ws) => (


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
- Fixes page layout for workspace and project pages.
- Add top margin to user, workspace, project, and organization pages.
- Fix column header alignment for user and workspace pages, and add missing sorting icons.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #16408 

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Update spacing layout for user, workspace, project, and organization in the admin dashboard
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
