### PR TITLE
Show loading spinner when loading team members

### DIFF
--- a/components/dashboard/src/teams/Members.tsx
+++ b/components/dashboard/src/teams/Members.tsx
@@ -19,6 +19,7 @@ import searchIcon from "../icons/search.svg";
 import copy from "../images/copy.svg";
 import { teamsService } from "../service/public-api";
 import { useCurrentUser } from "../user-context";
+import { SpinnerLoader } from "../components/Loader";
 
 export default function MembersPage() {
     const user = useCurrentUser();
@@ -161,7 +162,7 @@ export default function MembersPage() {
                         </ItemField>
                     </Item>
                     {filteredMembers.length === 0 ? (
-                        <p className="pt-16 text-center">No members found</p>
+                        <SpinnerLoader />
                     ) : (
                         filteredMembers.map((m) => (
                             <Item className="grid grid-cols-3" key={m.userId}>


### PR DESCRIPTION
replaced "no members found" with a spinner

## Description
Replaced the "no members found" with a spinner

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #16241

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Show loading spinner when fetching organization members
```