### PR TITLE
[ws-manager-mk2] Fix workspace container detection

### DIFF
--- a/components/ws-manager-mk2/controllers/create.go
+++ b/components/ws-manager-mk2/controllers/create.go
@@ -715,7 +715,8 @@ func newStartWorkspaceContext(ctx context.Context, cfg *config.Configuration, ws
 		Labels: map[string]string{
 			"app":                  "gitpod",
 			"component":            "workspace",
-			wsk8s.WorkspaceIDLabel: ws.Spec.Ownership.WorkspaceID,
+			wsk8s.MetaIDLabel:      ws.Spec.Ownership.WorkspaceID,
+			wsk8s.WorkspaceIDLabel: ws.Name,
 			wsk8s.OwnerLabel:       ws.Spec.Ownership.Owner,
 			wsk8s.TypeLabel:        strings.ToLower(string(ws.Spec.Type)),
 			instanceIDLabel:        ws.Name,


### PR DESCRIPTION
## Description
Fix workspace container detection. Depends on https://github.com/gitpod-io/gitpod/pull/16413. Without working workspace container detection resource constraints will not be applied to the workspace container.

## Related Issue(s)
n.a.

## How to test
- Open workspace
- Perform [common runtime tests](https://www.notion.so/Common-runtime-tests-4e3b05c3b81e4ff6810572aee66ffad3)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
