### PR TITLE
Small adjustments to org selector menu

### DIFF
--- a/components/dashboard/src/components/ContextMenu.tsx
+++ b/components/dashboard/src/components/ContextMenu.tsx
@@ -102,8 +102,9 @@ function ContextMenu(props: ContextMenuProps) {
     );
 
     return (
-        <div className="relative cursor-pointer">
+        <div className="relative">
             <div
+                className="cursor-pointer"
                 onClick={(e) => {
                     toggleExpanded();
                     // Don't use `e.stopPropagation();` because that prevents that clicks on other context menus closes this one.
@@ -114,7 +115,7 @@ function ContextMenu(props: ContextMenuProps) {
             </div>
             {expanded ? (
                 <div
-                    className={`cursor-default mt-2 z-50 bg-white dark:bg-gray-900 absolute flex flex-col border border-gray-200 dark:border-gray-800 rounded-lg truncated ${
+                    className={`mt-2 z-50 bg-white dark:bg-gray-900 absolute flex flex-col border border-gray-200 dark:border-gray-800 rounded-lg truncated ${
                         props.customClasses || "w-48 right-0"
                     }`}
                     data-analytics='{"button_type":"context_menu"}'

--- a/components/dashboard/src/components/org-icon/OrgIcon.tsx
+++ b/components/dashboard/src/components/org-icon/OrgIcon.tsx
@@ -33,7 +33,12 @@ export const OrgIcon: FunctionComponent<Props> = ({ id, name, size = "medium", c
 
     return (
         <div
-            className={classNames("rounded-full flex items-center justify-center", sizeClasses, logoBGClass, className)}
+            className={classNames(
+                "rounded-full flex items-center justify-center flex-shrink-0",
+                sizeClasses,
+                logoBGClass,
+                className,
+            )}
         >
             <span className={`text-white font-semibold ${textClass}`}>{initials}</span>
         </div>

--- a/components/dashboard/src/menu/OrganizationSelector.tsx
+++ b/components/dashboard/src/menu/OrganizationSelector.tsx
@@ -246,9 +246,13 @@ type CurrentOrgEntryProps = {
 };
 const CurrentOrgEntry: FunctionComponent<CurrentOrgEntryProps> = ({ title, subtitle }) => {
     return (
-        <div className="w-full text-gray-400 flex flex-col">
-            <span className="text-gray-800 dark:text-gray-300 text-base font-semibold">{title}</span>
-            <span>{subtitle}</span>
+        <div className="w-full text-gray-400 flex items-center justify-between">
+            <div className="flex flex-col">
+                <span className="text-gray-800 dark:text-gray-300 text-base font-semibold">{title}</span>
+                <span>{subtitle}</span>
+            </div>
+            {/* TODO: Replace this with an SVG icon */}
+            <div className="pl-1 font-semibold">&#x2713;</div>
         </div>
     );
 };


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Making a few adjustments to the org selector menu after some design reviews.

* Adding a checkmark to the selected org
* Fixing some cursor hover styles
* Preventing icon from shrinking with longer org names

![image](https://user-images.githubusercontent.com/367275/219155378-010aa0ba-5dab-4160-89e7-1292c8a111e3.png)

## How to test
<!-- Provide steps to test this PR -->
The changes should all be visually verifiable.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
