### PR TITLE
Shift Org Selector to the right of main menu

### DIFF
--- a/components/dashboard/src/feedback-form/FeedbackComponent.tsx
+++ b/components/dashboard/src/feedback-form/FeedbackComponent.tsx
@@ -60,6 +60,7 @@ function FeedbackComponent(props: {
         ];
         return emojiList.map((emoji) => (
             <button
+                key={emoji.id}
                 className={
                     "hover:scale-150 transform bg-transparent bottom-5 right-5 cursor-pointer " +
                     (selectedEmoji === emoji.id ? "" : "grayed")

--- a/components/dashboard/src/menu/OrganizationSelector.tsx
+++ b/components/dashboard/src/menu/OrganizationSelector.tsx
@@ -188,7 +188,7 @@ export default function OrganizationSelector(p: OrganizationSelectorProps) {
     const classes =
         "flex h-full text-base py-0 text-gray-500 bg-gray-50  dark:bg-gray-800 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 dark:border-gray-700";
     return (
-        <ContextMenu customClasses="w-64 left-0" menuEntries={entries}>
+        <ContextMenu customClasses="w-64 right-0" menuEntries={entries}>
             <div className={`${classes} rounded-2xl pl-1`}>
                 <div className="py-1 pr-1 flex font-semibold whitespace-nowrap max-w-xs overflow-hidden">
                     <OrgIcon


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
As part of the org nav design updates, this shifts the Organization Selector to the right. It also moves the `Admin` and `Feedback` links into the User menu.

![image](https://user-images.githubusercontent.com/367275/219177364-a0631dd3-12eb-48f3-9c98-21f14e89e206.png)

![image](https://user-images.githubusercontent.com/367275/219204087-0476f6d7-484f-4075-864b-c1ff97fe8275.png)

Motivations for moving it are:
* Avoids having an org icon (and eventually logo) sit so close in proximity to the gitpod logo
* Allows the main nav links (Workspaces | Projects) to not shift as you change orgs (since org names vary in width)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #16046

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
The organization selector is now located in the top right of the header. Feedback can be accessed from the User menu, also in the top right of the header.
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
