### PR TITLE
UX: Re-use left sub-menu for Settings and License page on admin dashboard

### DIFF
--- a/components/dashboard/src/admin/License.tsx
+++ b/components/dashboard/src/admin/License.tsx
@@ -17,7 +17,7 @@ import { ReactComponent as LinkSvg } from "../images/external-link.svg";
 import SolidCard from "../components/SolidCard";
 import Card from "../components/Card";
 import { isGitpodIo } from "../utils";
-import { AdminPageHeader } from "./AdminPageHeader";
+import { SettingsLayout } from "./Settings";
 
 export default function License() {
     const { license, setLicense } = useContext(LicenseContext);
@@ -42,54 +42,50 @@ export default function License() {
 
     return (
         <div>
-            <AdminPageHeader title="Admin" subtitle="Configure and manage instance settings.">
-                <div className="app-container mt-8">
-                    <div className="flex flex-row space-x-4">
-                        <Card className="w-72 h-64">
-                            <span>
-                                {licenseLevel}
-                                {paid}
-                                <div className="mt-4 font-semibold text-sm">Available features:</div>
-                                <div className="flex flex-col items-start text-sm">
-                                    {features &&
-                                        features.map((feat: string) => (
-                                            <span className="inline-flex space-x-1">
-                                                {featureList?.includes(feat) ? (
-                                                    <CheckSvg fill="currentColor" className="self-center mt-1" />
-                                                ) : (
-                                                    <XSvg fill="currentColor" className="self-center h-2 mt-1" />
-                                                )}
-                                                <span>{capitalizeInitials(feat)}</span>
-                                            </span>
-                                        ))}
+            <SettingsLayout>
+                <div className="flex flex-row space-x-4">
+                    <Card className="w-72 h-64">
+                        <span>
+                            {licenseLevel}
+                            {paid}
+                            <div className="mt-4 font-semibold text-sm">Available features:</div>
+                            <div className="flex flex-col items-start text-sm">
+                                {features &&
+                                    features.map((feat: string) => (
+                                        <span className="inline-flex space-x-1">
+                                            {featureList?.includes(feat) ? (
+                                                <CheckSvg fill="currentColor" className="self-center mt-1" />
+                                            ) : (
+                                                <XSvg fill="currentColor" className="self-center h-2 mt-1" />
+                                            )}
+                                            <span>{capitalizeInitials(feat)}</span>
+                                        </span>
+                                    ))}
+                            </div>
+                        </span>
+                    </Card>
+                    <SolidCard className="w-72 h-64">
+                        <span>
+                            <div className="my-2">{statusMessage}</div>
+                            <p className="dark:text-gray-500 font-semibold">Registered Users</p>
+                            <span className="dark:text-gray-300 text-lg">{license?.userCount || 0}</span>
+                            <span className="dark:text-gray-500 text-gray-400 pt-1 text-lg"> / {userLimit} </span>
+                            <p className="dark:text-gray-500 pt-2 font-semibold">License Type</p>
+                            <h4 className="dark:text-gray-300 text-lg">{capitalizeInitials(license?.type || "")}</h4>
+                            <a
+                                className="gp-link flex flex-row mr-2 justify-end font-semibold space-x-2 mt-6"
+                                href="https://www.gitpod.io/self-hosted"
+                                target="_blank"
+                            >
+                                <span className="text-sm">Compare Plans</span>
+                                <div className="self-end">
+                                    <LinkSvg />
                                 </div>
-                            </span>
-                        </Card>
-                        <SolidCard className="w-72 h-64">
-                            <span>
-                                <div className="my-2">{statusMessage}</div>
-                                <p className="dark:text-gray-500 font-semibold">Registered Users</p>
-                                <span className="dark:text-gray-300 text-lg">{license?.userCount || 0}</span>
-                                <span className="dark:text-gray-500 text-gray-400 pt-1 text-lg"> / {userLimit} </span>
-                                <p className="dark:text-gray-500 pt-2 font-semibold">License Type</p>
-                                <h4 className="dark:text-gray-300 text-lg">
-                                    {capitalizeInitials(license?.type || "")}
-                                </h4>
-                                <a
-                                    className="gp-link flex flex-row mr-2 justify-end font-semibold space-x-2 mt-6"
-                                    href="https://www.gitpod.io/self-hosted"
-                                    target="_blank"
-                                >
-                                    <span className="text-sm">Compare Plans</span>
-                                    <div className="self-end">
-                                        <LinkSvg />
-                                    </div>
-                                </a>
-                            </span>
-                        </SolidCard>
-                    </div>
+                            </a>
+                        </span>
+                    </SolidCard>
                 </div>
-            </AdminPageHeader>
+            </SettingsLayout>
         </div>
     );
 }

--- a/components/dashboard/src/admin/Settings.tsx
+++ b/components/dashboard/src/admin/Settings.tsx
@@ -4,7 +4,7 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { useContext } from "react";
+import React, { useContext } from "react";
 import { TelemetryData, InstallationAdminSettings } from "@gitpod/gitpod-protocol";
 import { AdminContext } from "../admin-context";
 import CheckBox from "../components/CheckBox";
@@ -12,7 +12,21 @@ import { getGitpodService } from "../service/service";
 import { useEffect, useState } from "react";
 import InfoBox from "../components/InfoBox";
 import { isGitpodIo } from "../utils";
-import { AdminPageHeader } from "./AdminPageHeader";
+import { PageWithSubMenu } from "../components/PageWithSubMenu";
+import { getAdminTabs, getAdminSettingsMenu } from "./admin.routes";
+
+export function SettingsLayout(props: { children: React.ReactNode }) {
+    return (
+        <PageWithSubMenu
+            subMenu={getAdminSettingsMenu()}
+            title="Admin"
+            subtitle="Configure and manage instance settings."
+            tabs={getAdminTabs()}
+        >
+            {props.children}
+        </PageWithSubMenu>
+    );
+}
 
 export default function Settings() {
     const { adminSettings, setAdminSettings } = useContext(AdminContext);
@@ -38,55 +52,53 @@ export default function Settings() {
 
     return (
         <div>
-            <AdminPageHeader title="Admin" subtitle="Configure and manage instance settings.">
-                <div className="app-container mt-8">
-                    <h3>Usage Statistics</h3>
-                    <p className="text-base text-gray-500 pb-4 max-w-2xl">
-                        We collect usage telemetry to gain insights on how you use your Gitpod instance, so we can
-                        provide a better overall experience.
-                    </p>
-                    <p>
-                        <a className="gp-link" href="https://www.gitpod.io/privacy">
-                            Read our Privacy Policy
-                        </a>
-                    </p>
-                    <CheckBox
-                        title="Enable usage telemetry"
-                        desc={
-                            <span>
-                                Enable usage telemetry on your Gitpod instance. A preview of your telemetry is available
-                                below.
-                            </span>
-                        }
-                        checked={adminSettings?.sendTelemetry ?? false}
-                        onChange={(evt) =>
-                            actuallySetTelemetryPrefs({
-                                ...adminSettings,
-                                sendTelemetry: evt.target.checked,
-                            } as InstallationAdminSettings)
-                        }
-                    />
-                    <CheckBox
-                        title="Include customer ID in telemetry"
-                        desc={
-                            <span>
-                                Include an optional customer ID in usage telemetry to provide individualized support.
-                            </span>
-                        }
-                        checked={adminSettings?.sendCustomerID ?? false}
-                        onChange={(evt) =>
-                            actuallySetTelemetryPrefs({
-                                ...adminSettings,
-                                sendCustomerID: evt.target.checked,
-                            } as InstallationAdminSettings)
-                        }
-                    />
-                    <h3 className="mt-4">Telemetry preview</h3>
-                    <InfoBox>
-                        <pre>{JSON.stringify(telemetryData, null, 2)}</pre>
-                    </InfoBox>
-                </div>
-            </AdminPageHeader>
+            <SettingsLayout>
+                <h3>Usage Statistics</h3>
+                <p className="text-base text-gray-500 pb-4 max-w-2xl">
+                    We collect usage telemetry to gain insights on how you use your Gitpod instance, so we can provide a
+                    better overall experience.
+                </p>
+                <p>
+                    <a className="gp-link" href="https://www.gitpod.io/privacy">
+                        Read our Privacy Policy
+                    </a>
+                </p>
+                <CheckBox
+                    title="Enable usage telemetry"
+                    desc={
+                        <span>
+                            Enable usage telemetry on your Gitpod instance. A preview of your telemetry is available
+                            below.
+                        </span>
+                    }
+                    checked={adminSettings?.sendTelemetry ?? false}
+                    onChange={(evt) =>
+                        actuallySetTelemetryPrefs({
+                            ...adminSettings,
+                            sendTelemetry: evt.target.checked,
+                        } as InstallationAdminSettings)
+                    }
+                />
+                <CheckBox
+                    title="Include customer ID in telemetry"
+                    desc={
+                        <span>
+                            Include an optional customer ID in usage telemetry to provide individualized support.
+                        </span>
+                    }
+                    checked={adminSettings?.sendCustomerID ?? false}
+                    onChange={(evt) =>
+                        actuallySetTelemetryPrefs({
+                            ...adminSettings,
+                            sendCustomerID: evt.target.checked,
+                        } as InstallationAdminSettings)
+                    }
+                />
+                <h3 className="mt-4">Telemetry preview</h3>
+                <InfoBox>
+                    <pre>{JSON.stringify(telemetryData, null, 2)}</pre>
+                </InfoBox>
+            </SettingsLayout>
         </div>
     );
 }

--- a/components/dashboard/src/admin/admin.routes.ts
+++ b/components/dashboard/src/admin/admin.routes.ts
@@ -29,12 +29,22 @@ export function getAdminTabs(): TabEntry[] {
             link: "/admin/blocked-repositories",
         },
         {
-            title: "License",
-            link: "/admin/license",
-        },
-        {
             title: "Settings",
             link: "/admin/settings",
+            alternatives: getAdminSettingsMenu().flatMap((e) => e.link),
+        },
+    ];
+}
+
+export function getAdminSettingsMenu() {
+    return [
+        {
+            title: "General",
+            link: ["/admin/settings"],
+        },
+        {
+            title: "License",
+            link: ["/admin/license"],
         },
     ];
 }

--- a/components/dashboard/src/menu/Menu.tsx
+++ b/components/dashboard/src/menu/Menu.tsx
@@ -68,7 +68,15 @@ export default function Menu() {
     const adminMenu: Entry = {
         title: "Admin",
         link: "/admin",
-        alternatives: [...getAdminTabs().map((entry) => entry.link)],
+        alternatives: [
+            ...getAdminTabs().reduce(
+                (prevEntry, currEntry) =>
+                    currEntry.alternatives
+                        ? [...prevEntry, ...currEntry.alternatives, currEntry.link]
+                        : [...prevEntry, currEntry.link],
+                [] as string[],
+            ),
+        ],
     };
 
     const handleFeedbackFormClick = () => {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
- Updates the Settings and License page layout to re-use the left sub-menu for better UX.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #16399 

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Update the Settings and License page layouts for the admin dashboard
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
