### PR TITLE
[ws-man-bridge] Adjust CPU alert to provide better signal

### DIFF
--- a/operations/observability/mixins/meta/rules/ws-manager-bridge.yaml
+++ b/operations/observability/mixins/meta/rules/ws-manager-bridge.yaml
@@ -10,15 +10,13 @@ spec:
   - name: ws-manager-bridge
     rules:
     - alert: WsManagerBridgeHighCPUUsage
-      # Reasoning: high rates of CPU consumption should only be temporary.
-      expr: avg(rate(container_cpu_usage_seconds_total{container!="POD", pod=~"ws-manager-bridge-.*"}[5m])) by (cluster) > 0.1
+      expr: sum(rate(process_cpu_seconds_total{job="ws-manager-bridge"}[5m])) by (cluster) > 0.5
       for: 10m
       labels:
-        # sent to the team internal channel until we fine tuned it
         severity: warning
         team: webapp
       annotations:
         runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/WebAppServicesHighCPUUsage.md
         summary: WS Manager Bridge has excessive CPU usage.
         description: WS Manager Bridge is consumming too much CPU. Please investigate.
-        dashboard_url: https://grafana.gitpod.io/d/6581e46e4e5c7ba40a07646395ef7b23/kubernetes-compute-resources-pod?var-cluster={{ $labels.cluster }}&var-namespace=default
+        dashboard_url: https://grafana.gitpod.io/d/AJKH-pJ4k/kubernetes-applications?var-cluster={{ $labels.cluster }}&var-job=ws-manager-bridge&var-pod=All


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

You can explore the past trend [with this explore page](https://grafana.gitpod.io/explore?orgId=1&left=%7B%22datasource%22:%22P4169E866C3094E38%22,%22queries%22:%5B%7B%22refId%22:%22B%22,%22datasource%22:%7B%22type%22:%22prometheus%22,%22uid%22:%22P4169E866C3094E38%22%7D,%22editorMode%22:%22code%22,%22expr%22:%22sum%28rate%28process_cpu_seconds_total%7Bjob%3D%5C%22ws-manager-bridge%5C%22%7D%5B5m%5D%29%29%20by%20%28cluster%29%22,%22legendFormat%22:%22__auto%22,%22range%22:true,%22instant%22:true%7D%5D,%22range%22:%7B%22from%22:%22now-2d%22,%22to%22:%22now%22%7D%7D)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
