### PR TITLE
Update button and navigation styles

### DIFF
--- a/components/dashboard/src/components/PillMenuItem.tsx
+++ b/components/dashboard/src/components/PillMenuItem.tsx
@@ -14,9 +14,9 @@ export default function PillMenuItem(p: {
     onClick?: (event: React.MouseEvent) => void;
 }) {
     let classes =
-        "flex block font-medium dark:text-gray-400 px-3 py-1 rounded-2xl transition ease-in-out font-semibold " +
+        "flex block font-medium dark:text-gray-400 px-3 py-1 rounded-2xl transition ease-in-out " +
         (p.selected
-            ? "text-gray-50 bg-gray-800 dark:text-gray-900 dark:bg-gray-50"
+            ? "text-gray-500 bg-gray-50 dark:text-gray-100 dark:bg-gray-700"
             : "hover:bg-gray-100 dark:hover:bg-gray-700");
     if (p.additionalClasses) {
         classes = classes + " " + p.additionalClasses;

--- a/components/dashboard/src/menu/OrganizationSelector.tsx
+++ b/components/dashboard/src/menu/OrganizationSelector.tsx
@@ -165,11 +165,11 @@ export default function OrganizationSelector(p: OrganizationSelectorProps) {
 
     const selectedTitle = currentOrg?.data ? currentOrg.data.name : userFullName;
     const classes =
-        "flex h-full text-base py-0 text-gray-500 bg-gray-50  dark:bg-gray-800 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 dark:border-gray-700";
+        "flex h-full text-base py-0 text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700";
     return (
         <ContextMenu customClasses="w-64 left-0" menuEntries={entries}>
             <div className={`${classes} rounded-2xl pl-1`}>
-                <div className="py-1 pr-1 flex font-semibold whitespace-nowrap max-w-xs overflow-hidden">
+                <div className="py-1 pr-1 flex font-medium whitespace-nowrap max-w-xs overflow-hidden">
                     <OrgIcon
                         id={currentOrg?.data?.id || user?.id || "empty"}
                         name={selectedTitle}


### PR DESCRIPTION
## Description

Style updates for the primary button, see [relevant discussion](https://gitpod.slack.com/archives/C01KPEPQYE6/p1676389006231579) (internal).

## How to test
Navigate through the dashboard and notice how the new button looks and feels alongside with the toned down top navigation. Notice how there's always only one CTA (call-to-action) per context with the strongest visual emphasis.

| BEFORE | AFTER |
|-|-|
| <img width="1512" alt="Screenshot 2023-02-16 at 17 38 40" src="https://user-images.githubusercontent.com/120486/219415408-c77f4ff2-9146-44b7-9b4f-c73fa2fbaeaf.png"> | <img width="1512" alt="Screenshot 2023-02-16 at 17 38 32" src="https://user-images.githubusercontent.com/120486/219415416-9f0418de-5630-476e-b0da-e9928af269d1.png"> |
| <img width="1512" alt="Screenshot 2023-02-16 at 17 37 51 (2)" src="https://user-images.githubusercontent.com/120486/219415494-73156539-31d4-4a42-ae6e-a38db206960b.png"> | <img width="1512" alt="Screenshot 2023-02-16 at 17 38 00 (2)" src="https://user-images.githubusercontent.com/120486/219415503-56b41d20-b329-4d84-bb0a-d2830bc2a3d3.png"> |
| <img width="1512" alt="Screenshot 2023-02-16 at 17 36 54 (2)" src="https://user-images.githubusercontent.com/120486/219416087-5625c2f6-117b-42bb-94a6-e9b65b61fbb1.png"> | <img width="1512" alt="Screenshot 2023-02-16 at 17 38 10 (2)" src="https://user-images.githubusercontent.com/120486/219416120-ecdd5a02-0877-4ec6-840d-c8805f9673ff.png"> |
 
## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Update button and navigation styles
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [X] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
