### PR TITLE
[server] Log user errors as info

### DIFF
--- a/components/gitpod-protocol/src/messaging/error.ts
+++ b/components/gitpod-protocol/src/messaging/error.ts
@@ -4,8 +4,6 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { ResponseError } from "vscode-jsonrpc";
-
 export namespace ErrorCodes {
     // 400 Unauthorized
     export const BAD_REQUEST = 400;

--- a/components/gitpod-protocol/src/messaging/error.ts
+++ b/components/gitpod-protocol/src/messaging/error.ts
@@ -4,6 +4,8 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
+import { ResponseError } from "vscode-jsonrpc";
+
 export namespace ErrorCodes {
     // 400 Unauthorized
     export const BAD_REQUEST = 400;
@@ -103,4 +105,8 @@ export namespace ErrorCodes {
 
     // 650 Invalid Value
     export const INVALID_VALUE = 650;
+
+    export function isUserError(code: number): boolean {
+        return code >= 400 && code < 500;
+    }
 }

--- a/components/server/src/websocket/websocket-connection-manager.ts
+++ b/components/server/src/websocket/websocket-connection-manager.ts
@@ -457,8 +457,7 @@ class GitpodJsonRpcProxyFactory<T extends object> extends JsonRpcProxyFactory<T>
                 observeAPICallsDuration(method, err.code, timer());
                 TraceContext.setJsonRPCError(ctx, method, err, true);
 
-                log.error({ userId }, `JSON RPC Request ${method} failed with internal error`, e, { method, args });
-                e = err;
+                log.error({ userId }, `Request ${method} failed with internal server error`, e, { method, args });
             }
             throw e;
         } finally {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

* Log user errors as info, helps with filtering for actual system erorrs
* For non-specific errors, throw a generic server error rather than leaking error details

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
