### PR TITLE
Unset CI for leeway build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,6 +64,7 @@ jobs:
 
   build-previewctl:
     name: Build previewctl
+    if: ${{ needs.configuration.outputs.is_main_branch == 'true' || needs.configuration.outputs.preview_enable == 'true' }}
     needs: [configuration]
     concurrency:
       group: ${{ github.head_ref || github.ref }}-build-previewctl
@@ -216,7 +217,8 @@ jobs:
 
           RESULT=0
           set -x
-          leeway build $PR_LEEWAY_TARGET \
+          # CI=true is a var set by GHA. Unsetting it for the build, as yarn builds treat warnings as errors if that var is set to true
+          CI= leeway build $PR_LEEWAY_TARGET \
             --cache $CACHE \
             $TEST \
             -Dversion=$VERSION \


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
CI=true is a var set by GHA. Unsetting it for the build, [as yarn builds treat warnings as errors if that var is set to true](https://github.com/gitpod-io/gitpod/actions/runs/4202509092)

<img width="1236" alt="image" src="https://user-images.githubusercontent.com/5501705/219680473-a799453c-783f-4614-a262-f6cf0753e405.png">


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [x] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
