### PR TITLE
adding new profile fields for new onboarding flow

### DIFF
--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -254,6 +254,16 @@ export interface ProfileDetails {
     companyName?: string;
     // the user's email
     emailAddress?: string;
+    // the user's company website
+    companyWebsite?: string;
+    // type of role user has in their job
+    jobRole?: string;
+    // freeform entry for job role user works in (when jobRole is "other")
+    jobRoleOther?: string;
+    // what user hopes to accomplish when they signed up
+    signupGoals?: string;
+    // freeform entry for signup goals (when signupGoals is "other")
+    signupGoalsOther?: string;
 }
 
 export interface EmailNotificationSettings {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Adding a few new optional profile fields that we'll collect during some upcoming onboarding flow changes.

* `companyWebsite` We'll be asking for a user's company website instead of company. Rather than re-purposing `company`, creating a new field as we experiment here.
* `jobRole` This will be a response to us asking what a user's role is at their job. It will be a string value that we'll map to a list of options, such as `frontend`, `backend`, data_analytics`, etc (actual list still tbd, but we'll keep this as a flexible string.
* `jobRoleOther` - When user selects "Other" as their jobRole, we'll allow them to optionally provide a freeform value here.
* `signupGoals` - This will be a response to us asking the user what they hope to accomplish when signing up with Gitpod. It will also be a string value that maps to a list of options we'll provide them.
* `signupGoalsOther` - When user selects "Other" for `signupGoals` we'll let them optionally provide a freeform value here.

## How to test
Nothing to test currently, this just sets up some new optional fields that we'll begin using in subsequent PRs.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
