### PR TITLE
Use the actual current period on the usage page

### DIFF
--- a/components/dashboard/src/components/UsageView.tsx
+++ b/components/dashboard/src/components/UsageView.tsx
@@ -41,9 +41,14 @@ function UsageView({ attributionId }: UsageViewProps) {
         const match = /#(\d{4}-\d{2}-\d{2}):(\d{4}-\d{2}-\d{2})/.exec(location.hash);
         if (match) {
             try {
-                setStartDate(dayjs(match[1], "YYYY-MM-DD"));
-                setEndDate(dayjs(match[2], "YYYY-MM-DD"));
+                const today = new Date();
+                const prevMonth = new Date(today.getFullYear(), today.getMonth() - 1, today.getDate());
+                const todayStr = today.toISOString().slice(0, 10);
+                const prevMonthStr = prevMonth.toISOString().slice(0, 10);
+                setStartDate(dayjs(prevMonthStr));
+                setEndDate(dayjs(todayStr));
             } catch (e) {
+                // Catches the Error
                 console.error(e);
             }
         }


### PR DESCRIPTION
## Description

from date = previous month date
to date = current date

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/issues/15544

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Use the actual current period when visiting the usage page
```


## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
