### PR TITLE
Revert "[supervisor] improve config watch logging"

### DIFF
--- a/components/supervisor/pkg/config/gitpod-config.go
+++ b/components/supervisor/pkg/config/gitpod-config.go
@@ -87,7 +87,11 @@ func (service *ConfigService) Watch(ctx context.Context) {
 		return
 	}
 
-	service.waitUntilExistsAndWatch(ctx)
+	_, err := os.Stat(service.location)
+	if os.IsNotExist(err) {
+		service.poll(ctx)
+	}
+	service.watch(ctx)
 }
 
 func (service *ConfigService) markReady() {
@@ -147,14 +151,14 @@ func (service *ConfigService) scheduleUpdateConfig(ctx context.Context, polling 
 		err := service.updateConfig()
 		if os.IsNotExist(err) {
 			polling <- struct{}{}
-			go service.waitUntilExistsAndWatch(ctx)
+			go service.poll(ctx)
 		} else if err != nil {
 			service.log.WithError(err).Error("gitpod config watcher: failed to parse")
 		}
 	})
 }
 
-func (service *ConfigService) waitUntilExistsAndWatch(ctx context.Context) {
+func (service *ConfigService) poll(ctx context.Context) {
 	service.markReady()
 
 	timer := time.NewTicker(2 * time.Second)


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This reverts commit 224077d6569960e643c553d916cd45cf7d8b3f2c.

It seems to break watch readiness contract, since we always report it now before event trying to watch. I suggest we revert, and then someone can find a better way with less noisy logging.

See internal discussion: https://gitpod.slack.com/archives/C01KGM9BH54/p1676644967865359

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
