### PR TITLE
[ws-manager-mk2] Ensure prebuilds can start and stop

### DIFF
--- a/components/ws-daemon/pkg/controller/workspace_operations.go
+++ b/components/ws-daemon/pkg/controller/workspace_operations.go
@@ -86,7 +86,7 @@ func NewWorkspaceOperations(config content.Config, store *session.Store, reg pro
 func (wso *WorkspaceOperations) InitWorkspaceContent(ctx context.Context, options InitContentOptions) (bool, string, error) {
 	res, err := wso.store.NewWorkspace(
 		ctx, options.Meta.InstanceId, filepath.Join(wso.store.Location, options.Meta.InstanceId),
-		wso.creator(options.Meta.Owner, options.Meta.WorkspaceId, options.Meta.InstanceId, options.Initializer, options.Headless))
+		wso.creator(options.Meta.Owner, options.Meta.WorkspaceId, options.Meta.InstanceId, options.Initializer, false))
 	if errors.Is(err, storage.ErrNotFound) {
 		return false, "", nil
 	}

--- a/components/ws-manager-mk2/controllers/status.go
+++ b/components/ws-manager-mk2/controllers/status.go
@@ -171,6 +171,10 @@ func updateWorkspaceStatus(ctx context.Context, workspace *workspacev1.Workspace
 	case workspace.IsHeadless() && (pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed):
 		workspace.Status.Phase = workspacev1.WorkspacePhaseStopping
 
+		if isDisposalFinished(workspace) {
+			workspace.Status.Phase = workspacev1.WorkspacePhaseStopped
+		}
+
 	case pod.Status.Phase == corev1.PodUnknown:
 		workspace.Status.Phase = workspacev1.WorkspacePhaseUnknown
 


### PR DESCRIPTION
## Description
Note: This depends on https://github.com/gitpod-io/gitpod/pull/16471

Ensures that prebuilds can initialize successfully (before storage access was missing) and stopping successfully (by ensuring workspaces enter stopped phase once backup has been taken and deleting the prebuild pod so that workspace CR deletion can be performed)

## Related Issue(s)
n.a.

## How to test
- Create project in [preview environment](https://fo-mk2-prebuilds.preview.gitpod-dev.com/)
- Start prebuild
- Prebuild should initialize and run successfully and enter stopped phase once completed. Afterwards the workspace CR should be deleted.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
