### PR TITLE
[docker-up] update Docker Compose

### DIFF
--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -23,7 +23,7 @@ defaultArgs:
   REPLICATED_API_TOKEN: ""
   REPLICATED_APP: ""
   dockerVersion: 20.10.17
-  dockerComposeVersion: "2.10.0-gitpod.1"
+  dockerComposeVersion: "2.16.0-gitpod.0"
 provenance:
   enabled: true
   slsa: true

--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -23,6 +23,7 @@ defaultArgs:
   REPLICATED_API_TOKEN: ""
   REPLICATED_APP: ""
   dockerVersion: 20.10.17
+  dockerComposeVersion: "2.10.0-gitpod.1"
 provenance:
   enabled: true
   slsa: true

--- a/components/docker-up/BUILD.yaml
+++ b/components/docker-up/BUILD.yaml
@@ -10,10 +10,12 @@ packages:
       - components/common-go:lib
     argdeps:
       - dockerVersion
+      - dockerComposeVersion
     env:
       - CGO_ENABLED=0
       - GOOS=linux
       - DOCKER_VERSION=${dockerVersion}
+      - DOCKER_COMPOSE_VERSION=${dockerComposeVersion}
     prep:
       - ["mv", "docker-up/main.go", "."]
       - ["rmdir", "docker-up"]
@@ -44,12 +46,11 @@ packages:
     config:
       commands:
         - ["mv", "components-docker-up--bin-docker-up/docker-up", "docker-up"]
+        - ["mv", "components-docker-up--bin-docker-up/checksums.txt", "checksums.txt"]
+        - ["mv", "components-docker-up--bin-docker-up/docker-compose", "docker-compose-linux-x86_64"]
         - ["rm", "-r", "components-docker-up--bin-docker-up"]
         - ["mv", "components-docker-up--bin-runc-facade/docker-up", "runc-facade"]
         - ["rm", "-r", "components-docker-up--bin-runc-facade"]
-        # Override docker-compose with custom version https://github.com/gitpod-io/compose/pull/1
-        - ["curl", "--fail", "-sSL", "https://github.com/gitpod-io/compose/releases/download/v2.10.0-gitpod.0/docker-compose-linux-x86_64", "-o", "docker-compose-linux-x86_64"]
-        - ["curl", "--fail", "-sSL", "https://github.com/gitpod-io/compose/releases/download/v2.10.0-gitpod.0/checksums.txt", "-o", "checksums.txt"]
         - ["sha256sum", "-c", "checksums.txt"]
         - ["mv", "docker-compose-linux-x86_64", "docker-compose"]
         - ["chmod", "+x", "docker-compose"]

--- a/components/docker-up/dependencies.sh
+++ b/components/docker-up/dependencies.sh
@@ -5,9 +5,12 @@
 
 set -euo pipefail
 
-DOCKER_COMPOSE_VERSION=2.8.0-gitpod.0
 RUNC_VERSION=v1.1.4
 
+# DOCKER_VERSION and DOCKER_COMPOSE_VERSION are defined in WORKSPACE.yaml
 curl -o docker.tgz      -fsSL "https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz"
-curl -o docker-compose  -fsSL "https://github.com/gitpod-io/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-linux-x86_64"
+# Docker Compose is forked, we have to override the MTU
+curl -o docker-compose  -fsSL "https://github.com/gitpod-io/compose/releases/download/v${DOCKER_COMPOSE_VERSION}/docker-compose-linux-x86_64"
+curl -o checksums.txt  -fsSL "https://github.com/gitpod-io/compose/releases/download/v${DOCKER_COMPOSE_VERSION}/checksums.txt"
+
 curl -o runc            -fsSL "https://github.com/opencontainers/runc/releases/download/${RUNC_VERSION}/runc.amd64"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Context: https://github.com/gitpod-io/gitpod/pull/16368#issuecomment-1437114679

The related Docker Compose release: https://github.com/gitpod-io/compose/releases/tag/v2.16.0-gitpod.0

Also, refactored source of truth for Docker Compose version to WORKSPACE.yaml for consistency and consideration when changing Docker version for the future.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes # n/a

## How to test
<!-- Provide steps to test this PR -->
1. `docker-compose --version` matches https://github.com/gitpod-io/compose/releases/tag/v2.16.0-gitpod.0
2. https://github.com/gitpod-samples/template-docker-compose works in the preview environment (you should see image pulls and containers running)
3. `docker run hello-world` works

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [x] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
