### PR TITLE
[dashboard] add switchToPAYG feature flag

### DIFF
--- a/components/dashboard/src/contexts/FeatureFlagContext.tsx
+++ b/components/dashboard/src/contexts/FeatureFlagContext.tsx
@@ -23,6 +23,7 @@ const FeatureFlagContext = createContext<{
     enablePersonalAccessTokens: boolean;
     oidcServiceEnabled: boolean;
     orgGitAuthProviders: boolean;
+    switchToPAYG: boolean;
 }>({
     startWithOptions: false,
     showUsageView: false,
@@ -32,6 +33,7 @@ const FeatureFlagContext = createContext<{
     enablePersonalAccessTokens: false,
     oidcServiceEnabled: false,
     orgGitAuthProviders: false,
+    switchToPAYG: false,
 });
 
 const FeatureFlagContextProvider: React.FC = ({ children }) => {
@@ -47,6 +49,7 @@ const FeatureFlagContextProvider: React.FC = ({ children }) => {
     const [usePublicApiWorkspacesService, setUsePublicApiWorkspacesService] = useState<boolean>(false);
     const [oidcServiceEnabled, setOidcServiceEnabled] = useState<boolean>(false);
     const [orgGitAuthProviders, setOrgGitAuthProviders] = useState<boolean>(false);
+    const [switchToPAYG, setSwitchToPAYG] = useState<boolean>(false);
 
     useEffect(() => {
         if (!user) return;
@@ -63,6 +66,7 @@ const FeatureFlagContextProvider: React.FC = ({ children }) => {
                 },
                 oidcServiceEnabled: { defaultValue: false, setter: setOidcServiceEnabled },
                 orgGitAuthProviders: { defaultValue: false, setter: setOrgGitAuthProviders },
+                switchToPAYG: { defaultValue: false, setter: setSwitchToPAYG },
             };
 
             for (const [flagName, config] of Object.entries(featureFlags)) {
@@ -110,6 +114,7 @@ const FeatureFlagContextProvider: React.FC = ({ children }) => {
                 usePublicApiWorkspacesService,
                 oidcServiceEnabled,
                 orgGitAuthProviders,
+                switchToPAYG,
             }}
         >
             {children}


### PR DESCRIPTION
Just adds the feature flag. No use of it in this PR.


## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
