### PR TITLE
[dashboard, server] App-level notifications to switch to Pay-as-you-go

### DIFF
--- a/components/dashboard/src/AppNotifications.tsx
+++ b/components/dashboard/src/AppNotifications.tsx
@@ -51,17 +51,22 @@ export function AppNotifications() {
     return (
         <div className="app-container pt-2">
             <Alert
-                type={"warning"}
-                closable={true}
+                type={"message"}
+                closable={!topNotification.notClosable}
                 onClose={() => dismissNotification()}
                 showIcon={true}
                 className="flex rounded mb-2 w-full"
             >
                 {topNotification.message}
                 {topNotification.action && (
-                    <Link to={topNotification.action.url}>
-                        <button className="ml-2">{topNotification.action.label}</button>
-                    </Link>
+                    <>
+                        {" "}
+                        <Link to={topNotification.action.url}>
+                            <a className="gp-link" href={topNotification.action.url}>
+                                {topNotification.action.label}
+                            </a>
+                        </Link>
+                    </>
                 )}
             </Alert>
         </div>

--- a/components/dashboard/src/teams/TeamBilling.tsx
+++ b/components/dashboard/src/teams/TeamBilling.tsx
@@ -9,14 +9,12 @@ import { Currency, Plan, Plans, PlanType } from "@gitpod/gitpod-protocol/lib/pla
 import { TeamSubscription2 } from "@gitpod/gitpod-protocol/lib/team-subscription-protocol";
 import React, { FunctionComponent, useCallback, useContext, useEffect, useState } from "react";
 import { ChargebeeClient } from "../chargebee/chargebee-client";
-import Alert from "../components/Alert";
 import Card from "../components/Card";
 import DropDown from "../components/DropDown";
 import PillLabel from "../components/PillLabel";
 import SolidCard from "../components/SolidCard";
 import { useOrgBillingMode } from "../data/billing-mode/org-billing-mode-query";
 import { useOrgMembers } from "../data/organizations/org-members-query";
-import { getExperimentsClient } from "../experiments/client";
 import { ReactComponent as Spinner } from "../icons/Spinner.svg";
 import { ReactComponent as CheckSvg } from "../images/check.svg";
 import { PaymentContext } from "../payment-context";
@@ -43,7 +41,6 @@ const TeamBilling: FunctionComponent = () => {
     const { data: members, isLoading: membersLoading } = useOrgMembers();
     const [teamSubscription, setTeamSubscription] = useState<TeamSubscription2 | undefined>();
     const { currency, setCurrency } = useContext(PaymentContext);
-    const [isUsageBasedBillingEnabled, setIsUsageBasedBillingEnabled] = useState<boolean>(false);
     const [pendingTeamPlan, setPendingTeamPlan] = useState<PendingPlan | undefined>();
     const [pollTeamSubscriptionTimeout, setPollTeamSubscriptionTimeout] = useState<NodeJS.Timeout | undefined>();
 
@@ -106,20 +103,6 @@ const TeamBilling: FunctionComponent = () => {
         };
     }, [pendingTeamPlan, pollTeamSubscriptionTimeout, team, teamSubscription]);
 
-    useEffect(() => {
-        if (!team || !user) {
-            return;
-        }
-        (async () => {
-            const isEnabled = await getExperimentsClient().getValueAsync("isUsageBasedBillingEnabled", false, {
-                user,
-                teamId: team.id,
-                teamName: team.name,
-            });
-            setIsUsageBasedBillingEnabled(isEnabled);
-        })();
-    }, [team, user]);
-
     const availableTeamPlans = Plans.getAvailableTeamPlans(currency || "USD").filter((p) => p.type !== "student");
 
     const checkout = useCallback(
@@ -166,20 +149,6 @@ const TeamBilling: FunctionComponent = () => {
     function renderTeamBilling(): JSX.Element {
         return (
             <>
-                {isUsageBasedBillingEnabled && (
-                    <Alert type="message" className="mb-4">
-                        To access{" "}
-                        <a className="gp-link" href="https://www.gitpod.io/docs/configure/workspaces/workspace-classes">
-                            large workspaces
-                        </a>{" "}
-                        and{" "}
-                        <a className="gp-link" href="https://www.gitpod.io/docs/configure/billing/pay-as-you-go">
-                            pay-as-you-go
-                        </a>
-                        , first cancel your existing plan. Existing plans will keep working until the end of March,
-                        2023.
-                    </Alert>
-                )}
                 <h3>{!teamPlan ? "Select Plan" : "Current Plan"}</h3>
                 <h2 className="text-gray-500">
                     {!teamPlan ? (

--- a/components/dashboard/src/user-settings/ChargebeeTeams.tsx
+++ b/components/dashboard/src/user-settings/ChargebeeTeams.tsx
@@ -454,19 +454,6 @@ function AllTeams() {
 
     return (
         <div>
-            {isUsageBasedBillingEnabled && (
-                <Alert type="message" className="mb-4">
-                    To access{" "}
-                    <a className="gp-link" href="https://www.gitpod.io/docs/configure/workspaces/workspace-classes">
-                        large workspaces
-                    </a>{" "}
-                    and{" "}
-                    <a className="gp-link" href="https://www.gitpod.io/docs/configure/billing/pay-as-you-go">
-                        pay-as-you-go
-                    </a>
-                    , first cancel your existing plan. Existing plans will keep working until the end of March, 2023.
-                </Alert>
-            )}
             <div className="flex flex-row">
                 <div className="flex-grow ">
                     <h3 className="self-center">All Team Plans</h3>

--- a/components/dashboard/src/user-settings/Plans.tsx
+++ b/components/dashboard/src/user-settings/Plans.tsx
@@ -636,20 +636,6 @@ export default function PlansPage() {
     return (
         <div>
             <PageWithSettingsSubMenu>
-                {isUsageBasedBillingEnabled && (
-                    <Alert type="message" className="mb-4">
-                        To access{" "}
-                        <a className="gp-link" href="https://www.gitpod.io/docs/configure/workspaces/workspace-classes">
-                            large workspaces
-                        </a>{" "}
-                        and{" "}
-                        <a className="gp-link" href="https://www.gitpod.io/docs/configure/billing/pay-as-you-go">
-                            pay-as-you-go
-                        </a>
-                        , first cancel your existing plan. Existing plans will keep working until the end of March,
-                        2023.
-                    </Alert>
-                )}
                 <div className="w-full text-center">
                     <p className="text-xl text-gray-500">
                         You are currently using the{" "}

--- a/components/gitpod-protocol/src/accounting-protocol.ts
+++ b/components/gitpod-protocol/src/accounting-protocol.ts
@@ -5,6 +5,7 @@
  */
 
 import { v4 as uuidv4 } from "uuid";
+import { Plans } from "./plans";
 import { User } from "./protocol";
 import { oneMonthLater } from "./util/timeutil";
 
@@ -212,6 +213,14 @@ export namespace Subscription {
             nextStartDate = oneMonthLater(startDate, new Date(startDate).getDate());
         } while (nextStartDate < now.toISOString());
         return { startDate, endDate: nextStartDate };
+    }
+
+    export function isOldTeamSubscription(s: Subscription): boolean {
+        return Plans.isTeamPlan(s.planId) && !s.teamMembershipId;
+    }
+
+    export function isTeamSubscription2(s: Subscription): boolean {
+        return Plans.isTeamPlan(s.planId) && !!s.teamMembershipId;
     }
 }
 

--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -305,9 +305,22 @@ export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, 
     /**
      * Frontend notifications
      */
-    getNotifications(): Promise<string[]>;
+    getNotifications(): Promise<AppNotification[]>;
 
     getSupportedWorkspaceClasses(): Promise<SupportedWorkspaceClass[]>;
+}
+
+export interface AppNotification {
+    message: string;
+    action?: {
+        url: string;
+        label: string;
+    };
+}
+export namespace AppNotification {
+    export function is(data: any): data is AppNotification {
+        return data && typeof data === "object" && data.hasOwnProperty("message");
+    }
 }
 
 export interface RateLimiterError {

--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -316,6 +316,7 @@ export interface AppNotification {
         url: string;
         label: string;
     };
+    notClosable?: boolean;
 }
 export namespace AppNotification {
     export function is(data: any): data is AppNotification {

--- a/components/gitpod-protocol/src/plans.ts
+++ b/components/gitpod-protocol/src/plans.ts
@@ -490,6 +490,22 @@ export namespace Plans {
         return chargebeeId === Plans.FREE_OPEN_SOURCE.chargebeeId;
     }
 
+    export function isPersonalPlan(planId: string | undefined): boolean {
+        const plan = Plans.getById(planId);
+        if (!plan) {
+            return false;
+        }
+        return !plan.team;
+    }
+
+    export function isTeamPlan(planId: string | undefined): boolean {
+        const plan = Plans.getById(planId);
+        if (!plan) {
+            return false;
+        }
+        return !!plan.team;
+    }
+
     export function getHoursPerMonth(plan: Plan): number {
         return plan.hoursPerMonth == "unlimited" ? ABSOLUTE_MAX_USAGE : plan.hoursPerMonth;
     }

--- a/components/server/ee/src/billing/billing-mode.ts
+++ b/components/server/ee/src/billing/billing-mode.ts
@@ -118,20 +118,10 @@ export class BillingModesImpl implements BillingModes {
 
         // 2. Any personal subscriptions?
         // Chargebee takes precedence
-        function isPersonalSubscription(s: Subscription): boolean {
-            return !Plans.getById(s.planId)?.team;
-        }
-        function isOldTeamSubscription(s: Subscription): boolean {
-            return !!Plans.getById(s.planId)?.team && !s.teamMembershipId;
-        }
         const cbSubscriptions = await this.subscriptionSvc.getActivePaidSubscription(user.id, now);
-        const cbTeamSubscriptions = cbSubscriptions.filter((s) => isOldTeamSubscription(s));
+        const cbTeamSubscriptions = cbSubscriptions.filter((s) => Subscription.isOldTeamSubscription(s));
         const cbPersonalSubscriptions = cbSubscriptions.filter(
-            (s) =>
-                isPersonalSubscription(s) &&
-                ![Plans.FREE_OPEN_SOURCE.chargebeeId, Plans.FREE.chargebeeId, Plans.FREE_50.chargebeeId].includes(
-                    s.planId!,
-                ),
+            (s) => Plans.isPersonalPlan(s.planId) && !Plans.isFreePlan(s.planId),
         );
         const cbOwnedTeamSubscriptions = (
             await this.teamSubscriptionDb.findTeamSubscriptions({ userId: user.id })

--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -2444,6 +2444,92 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
             log.warn({ userId: user.id }, "Could not get usage-based notifications for user", { error });
         }
 
+        // Calculates Pay-as-you-go nudges
+        try {
+            const now = new Date();
+            const cbSubscriptions = await this.subscriptionService.getActivePaidSubscription(user.id, now);
+            // Personal subscription
+            const cbPersonalSubscriptions = cbSubscriptions.filter(
+                (s) => Plans.isPersonalPlan(s.planId) && !Plans.isFreePlan(s.planId),
+            );
+
+            // Old "Team Subscription"
+            const cbOwnedTeamSubscriptions = (
+                await this.teamSubscriptionDB.findTeamSubscriptions({ userId: user.id })
+            ).filter((ts) => TeamSubscription.isActive(ts, now.toISOString()));
+
+            // "Team Subscription 2" (already attached to an Organization)
+            const cbOwnedTeamSubscriptions2 = [];
+            const teams = await this.teamDB.findTeamsByUser(user.id);
+            for (const team of teams) {
+                const ts2 = await this.teamSubscription2DB.findForTeam(team.id, now.toISOString());
+                if (
+                    !ts2 ||
+                    !TeamSubscription2.isActive(ts2, now.toISOString()) ||
+                    TeamSubscription2.isCancelled(ts2, now.toISOString())
+                ) {
+                    // We only care about existing, active, not-yet-cancelled subs
+                    continue;
+                }
+
+                const teamMembership = await this.teamDB.findTeamMembership(user.id, team.id);
+                if (!teamMembership || teamMembership.deleted || teamMembership.role !== "owner") {
+                    // We only care about subscriptions owned by this user
+                    continue;
+                }
+                cbOwnedTeamSubscriptions2.push({
+                    ownedTeamSubscription2: ts2,
+                    team,
+                });
+            }
+
+            // Add nudges, last has highest priority
+            for (const personalSubscription of cbPersonalSubscriptions) {
+                const plan = Plans.getById(personalSubscription.planId);
+                if (!plan) {
+                    continue;
+                }
+                result.unshift({
+                    message: `Your old subscription '${plan.name}' will be deprecated end of March.`,
+                    action: {
+                        url: "https://www.gitpod.io/docs/configure/billing#configure-personal-billing",
+                        label: "Switch to pay-as-you-go",
+                    },
+                    notClosable: true,
+                });
+            }
+            for (const ownedTeamSubscription of cbOwnedTeamSubscriptions) {
+                const plan = Plans.getById(ownedTeamSubscription.planId);
+                if (!plan) {
+                    continue;
+                }
+                result.unshift({
+                    message: `Your old Team Subscription '${plan.name}' will be deprecated soon.`,
+                    action: {
+                        url: "https://www.gitpod.io/docs/configure/billing/org-plans",
+                        label: "Switch to pay-as-you-go",
+                    },
+                    notClosable: true,
+                });
+            }
+            for (const { ownedTeamSubscription2, team } of cbOwnedTeamSubscriptions2) {
+                const plan = Plans.getById(ownedTeamSubscription2.planId);
+                if (!plan) {
+                    continue;
+                }
+                result.unshift({
+                    message: `The subscription '${plan.name}' for team '${team.name}' will be deprecated soon.`,
+                    action: {
+                        url: "https://www.gitpod.io/docs/configure/billing#configure-organization-billing",
+                        label: "Switch to pay-as-you-go",
+                    },
+                    notClosable: true,
+                });
+            }
+        } catch (err) {
+            log.warn({ userId: user.id }, "Could not calculate PAYG nudges for user", err);
+        }
+
         return result;
     }
 

--- a/components/server/reset-chargebee-test-subs.sh
+++ b/components/server/reset-chargebee-test-subs.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+if [ -z "$USER_ID" ]; then
+    echo "USER_ID must be set!";
+    exit 1;
+fi
+
+
+DB_USERNAME=$(kubectl get secrets mysql -o jsonpath="{.data.username}" | base64 -d)
+DB_PASSWORD=$(kubectl get secrets mysql -o jsonpath="{.data.password}" | base64 -d)
+
+# Make sure there are no existing port-forwards blocking us
+pkill -f "kubectl port-forward (.*) 33306:3306"
+
+kubectl port-forward statefulset/mysql 33306:3306 &
+
+sleep 2;
+
+mysql -u "$DB_USERNAME" -h 127.0.0.1 -P 33306 -p"$DB_PASSWORD" gitpod -e "DELETE FROM d_b_team_subscription; DELETE FROM d_b_subscription; DELETE FROM d_b_team; DELETE FROM d_b_team_membership; DELETE FROM d_b_team_subscription2;";
+
+# Team Subscription (owner does not necessarily have to have a seat!)
+mysql -u "$DB_USERNAME" -h 127.0.0.1 -P 33306 -p"$DB_PASSWORD" gitpod -e "INSERT INTO d_b_team_subscription (id,userId,paymentReference,startDate,endDate,planId,quantity,cancellationDate,deleted,excludeFromMoreResources) VALUES ('00000000-0000-0000-0000-111111111111','$USER_ID','fake-personal-payment-ref','2021-02-09T10:13:02.000Z','','team-professional-new-eur',1,'',0,0);";
+
+# Personal Subscription
+mysql -u "$DB_USERNAME" -h 127.0.0.1 -P 33306 -p"$DB_PASSWORD" gitpod -e "INSERT INTO d_b_subscription (userId,startDate,amount,uid,planId,paymentReference,deleted,cancellationDate,paymentData,teamSubscriptionSlotId) VALUES ('$USER_ID','2021-02-09T10:13:02.000Z',11904.0,'00000000-0000-0000-0000-222222222222','professional-eur','fake-ts-payment-ref',0,'',NULL,'');";
+
+# Team Subscription (aka Team/Org. Billing with Chargebee plan)
+mysql -u "$DB_USERNAME" -h 127.0.0.1 -P 33306 -p"$DB_PASSWORD" gitpod -e "INSERT INTO d_b_team (id, name, slug, creationTime, deleted, _lastModified, markedDeleted) VALUES ('00000000-0000-0000-0000-333333333333', 'team1', 'team1', '2022-10-06T21:25:00.562Z', '0', '2022-10-06 21:25:00.565828', '0')";
+mysql -u "$DB_USERNAME" -h 127.0.0.1 -P 33306 -p"$DB_PASSWORD" gitpod -e "INSERT INTO d_b_team_membership (id, teamId, userId, role, creationTime, deleted, _lastModified, subscriptionId) VALUES ('00000000-0000-0000-0000-444444444444', '00000000-0000-0000-0000-333333333333', '$USER_ID', 'owner', '2022-10-06T21:25:00.562Z', '0', '2022-10-07 10:57:32.992862', 'b33ad778-2f12-429a-9f35-9aa5e275df3d')";
+mysql -u "$DB_USERNAME" -h 127.0.0.1 -P 33306 -p"$DB_PASSWORD" gitpod -e "INSERT INTO d_b_team_subscription2 (id, teamId, paymentReference, startDate, endDate, planId, quantity, cancellationDate, deleted, _lastModified, excludeFromMoreResources) VALUES ('00000000-0000-0000-0000-555555555555', '00000000-0000-0000-0000-333333333333', 'fake-ts2-payment-ref', '2022-10-07T10:57:23.000Z', '', 'team-professional-eur', '1', '', '0', '2022-10-07 10:57:32.946359', '1')";

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -78,6 +78,7 @@ import {
     SSHPublicKeyValue,
     UserSSHPublicKeyValue,
     PrebuildEvent,
+    AppNotification,
 } from "@gitpod/gitpod-protocol";
 import { AccountStatement } from "@gitpod/gitpod-protocol/lib/accounting-protocol";
 import { BlockedRepository } from "@gitpod/gitpod-protocol/lib/blocked-repositories-protocol";
@@ -3544,7 +3545,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         return this.imagebuilderClientProvider.getClient(this.config.installationShortname, user, workspace, instance);
     }
 
-    async getNotifications(ctx: TraceContext): Promise<string[]> {
+    async getNotifications(ctx: TraceContext): Promise<AppNotification[]> {
         this.checkAndBlockUser("getNotifications");
         return [];
     }


### PR DESCRIPTION
## Description

This PR introduces new app-level notifications by re-using and slightly extending the existing `getNotifications` mechanism.
Those are nudges to switch from old Chargebee:
 - Personal Subscriptions
 - owned Team Subscriptions
 - (co-) owned Team Subscriptions 2
![image](https://user-images.githubusercontent.com/32448529/220387067-de4fe017-1002-4205-8f5e-3f3052f02f9b.png)

This is feature flagged mostly for piece of mind. :lotus_position: 


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test

 - Start [a workspace on this branch](https://gitpod.io/#https://github.com/gitpod-io/gitpod/pull/16490)
 - get your user ID (from websocket responses, for instance)
 - `cd components/server && USER_ID="" ./reset-chargebee-test-subs.sh`
 - Notice the sticky notification following you on each page :heavy_check_mark: 

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
add app-level notifications for switching to Pay-as-you-go
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
