### PR TITLE
[supervisor] use common-go grpc

### DIFF
--- a/components/common-go/grpc/grpc.go
+++ b/components/common-go/grpc/grpc.go
@@ -48,6 +48,12 @@ func ClientMetrics() prometheus.Collector {
 
 // DefaultClientOptions returns the default grpc client connection options
 func DefaultClientOptions() []grpc.DialOption {
+	return ClientOptionsWithInterceptors(nil, nil)
+}
+
+// ClientOptionsWithInterceptors returns the default ClientOption sets options for internal components with additional interceptors.
+func ClientOptionsWithInterceptors(stream []grpc.StreamClientInterceptor, unary []grpc.UnaryClientInterceptor) []grpc.DialOption {
+
 	bfConf := backoff.DefaultConfig
 	bfConf.MaxDelay = 5 * time.Second
 
@@ -63,6 +69,9 @@ func DefaultClientOptions() []grpc.DialOption {
 		unaryInterceptor = append(unaryInterceptor, defaultClientOptionsConfig.Metrics.UnaryClientInterceptor())
 		streamInterceptor = append(streamInterceptor, defaultClientOptionsConfig.Metrics.StreamClientInterceptor())
 	}
+
+	unaryInterceptor = append(unaryInterceptor, unary...)
+	streamInterceptor = append(streamInterceptor, stream...)
 
 	res := []grpc.DialOption{
 		grpc.WithUnaryInterceptor(grpc_middleware.ChainUnaryClient(unaryInterceptor...)),


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Use common-go grpc in supervisor PublicAPI

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related https://github.com/gitpod-io/gitpod/issues/15383

## How to test
<!-- Provide steps to test this PR -->
- Open workspace in preview env
- Monitoring workspace log and ide-metrics, make sure metrics and publicAPI still working

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
