### PR TITLE
[rebuild] map workspace location properly

### DIFF
--- a/components/gitpod-cli/cmd/rebuild.go
+++ b/components/gitpod-cli/cmd/rebuild.go
@@ -222,9 +222,7 @@ func runRebuild(ctx context.Context, supervisorClient *supervisor.SupervisorClie
 		return err
 	}
 
-	// TODO project? - should not it be covered by gp env?
-	// Should we allow to provide additiona envs to test such, i.e. gp rebuild -e foo=bar
-	userEnvs, err := exec.CommandContext(ctx, "gp", "env").CombinedOutput()
+	workspaceEnvs, err := exec.CommandContext(ctx, "gp", "env").CombinedOutput()
 	if err != nil {
 		return err
 	}
@@ -233,7 +231,7 @@ func runRebuild(ctx context.Context, supervisorClient *supervisor.SupervisorClie
 	for _, env := range debugEnvs.Envs {
 		envs += env + "\n"
 	}
-	envs += string(userEnvs)
+	envs += string(workspaceEnvs)
 
 	envFile := filepath.Join(tmpDir, ".env")
 	err = os.WriteFile(envFile, []byte(envs), 0644)

--- a/components/supervisor/local-hot-swap.sh
+++ b/components/supervisor/local-hot-swap.sh
@@ -14,6 +14,6 @@ component=${PWD##*/}
 go build .
 echo "$component built"
 
-sudo rm /.supervisor/supervisor
+sudo rm /.supervisor/supervisor && true
 sudo mv ./"$component" /.supervisor
 echo "Local Swap complete"

--- a/components/supervisor/pkg/supervisor/services.go
+++ b/components/supervisor/pkg/supervisor/services.go
@@ -808,9 +808,9 @@ func (c *ControlService) CreateDebugEnv(ctx context.Context, req *api.CreateDebu
 	envs = append(envs, fmt.Sprintf("LOG_LEVEL=%s", req.GetLogLevel()))
 	envs = append(envs, fmt.Sprintf("GITPOD_TASKS=%s", req.GetTasks()))
 	envs = append(envs, fmt.Sprintf("GITPOD_WORKSPACE_URL=%s", req.GetWorkspaceUrl()))
-	envs = append(envs, fmt.Sprintf("GITPOD_REPO_ROOT=%s", req.GetWorkspaceLocation()))
-	envs = append(envs, fmt.Sprintf("GITPOD_REPO_ROOTS=%s", req.GetWorkspaceLocation()))
-	envs = append(envs, fmt.Sprintf("THEIA_WORKSPACE_ROOT=%s", req.GetCheckoutLocation()))
+	envs = append(envs, fmt.Sprintf("GITPOD_REPO_ROOT=%s", req.GetCheckoutLocation()))
+	envs = append(envs, fmt.Sprintf("GITPOD_REPO_ROOTS=%s", req.GetCheckoutLocation()))
+	envs = append(envs, fmt.Sprintf("THEIA_WORKSPACE_ROOT=%s", req.GetWorkspaceLocation()))
 	envs = append(envs, fmt.Sprintf("GITPOD_PREVENT_METADATA_ACCESS=%s", "false"))
 	return &api.CreateDebugEnvResponse{
 		Envs: envs,


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

- REPO_ROOT should point to the checkout location
- THEIA_WORKSPACE_ROOT should point to the workspace location from .gitpod.yml

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

You can see it is broken by running `gp rebuild` for gitpod-io/gitpod. With this PR it should work, i.e. open some repo, change `workspaceLocation` in .gitpod.yml and see whether it works with `gp rebuild`.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
