### PR TITLE
[supervisor] analyze image file changes

### DIFF
--- a/components/supervisor/pkg/config/gitpod-config.go
+++ b/components/supervisor/pkg/config/gitpod-config.go
@@ -7,13 +7,14 @@ package config
 import (
 	"context"
 	"os"
+	"path/filepath"
 	"sync"
 	"time"
 
 	"github.com/fsnotify/fsnotify"
-	"github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 
+	"github.com/gitpod-io/gitpod/common-go/log"
 	gitpod "github.com/gitpod-io/gitpod/gitpod-protocol"
 )
 
@@ -23,19 +24,109 @@ type ConfigInterface interface {
 	Watch(ctx context.Context)
 	// Observe provides channels triggered whenever the config is changed
 	Observe(ctx context.Context) <-chan *gitpod.GitpodConfig
+	// Observe provides channels triggered whenever the image file is changed
+	ObserveImageFile(ctx context.Context) <-chan *struct{}
 }
 
 // ConfigService provides access to the gitpod config file.
 type ConfigService struct {
-	location      string
 	locationReady <-chan struct{}
 
-	cond   *sync.Cond
-	config *gitpod.GitpodConfig
+	configLocation string
+	configWatcher  *fileWatcher[gitpod.GitpodConfig]
+
+	imageWatcher *fileWatcher[struct{}]
+}
+
+// NewConfigService creates a new instance of ConfigService.
+func NewConfigService(configLocation string, locationReady <-chan struct{}) *ConfigService {
+	return &ConfigService{
+		locationReady:  locationReady,
+		configLocation: configLocation,
+		configWatcher: newFileWatcher(func(data []byte) (*gitpod.GitpodConfig, error) {
+			var config *gitpod.GitpodConfig
+			err := yaml.Unmarshal(data, &config)
+			return config, err
+		}),
+		imageWatcher: newFileWatcher(func(data []byte) (*struct{}, error) {
+			return &struct{}{}, nil
+		}),
+	}
+}
+
+// Observe provides channels triggered whenever the config is changed.
+func (service *ConfigService) Observe(ctx context.Context) <-chan *gitpod.GitpodConfig {
+	return service.configWatcher.observe(ctx)
+}
+
+// Observe provides channels triggered whenever the image file is changed
+func (service *ConfigService) ObserveImageFile(ctx context.Context) <-chan *struct{} {
+	return service.imageWatcher.observe(ctx)
+}
+
+// Watch starts the config watching.
+func (service *ConfigService) Watch(ctx context.Context) {
+	select {
+	case <-service.locationReady:
+	case <-ctx.Done():
+		return
+	}
+	go service.watchImageFile(ctx)
+	service.configWatcher.watch(ctx, service.configLocation)
+}
+
+func (service *ConfigService) watchImageFile(ctx context.Context) {
+	var (
+		imageLocation string
+		cancelWatch   func()
+	)
+	defer func() {
+		if cancelWatch != nil {
+			cancelWatch()
+		}
+	}()
+	cfgs := service.configWatcher.observe(ctx)
+	for {
+		select {
+		case cfg, ok := <-cfgs:
+			if !ok {
+				return
+			}
+			var currentImageLocation string
+			if cfg != nil {
+				switch img := cfg.Image.(type) {
+				case map[string]interface{}:
+					currentImageLocation = filepath.Join(filepath.Dir(service.configLocation), img["file"].(string))
+				}
+			}
+			if imageLocation == currentImageLocation {
+				continue
+			}
+			if cancelWatch != nil {
+				cancelWatch()
+				cancelWatch = nil
+				service.imageWatcher.reset()
+			}
+			imageLocation = currentImageLocation
+			if imageLocation == "" {
+				continue
+			}
+			watchCtx, cancel := context.WithCancel(ctx)
+			cancelWatch = cancel
+			go service.imageWatcher.watch(watchCtx, imageLocation)
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+type fileWatcher[T any] struct {
+	unmarshal func(data []byte) (*T, error)
+
+	cond *sync.Cond
+	data *T
 
 	pollTimer *time.Timer
-
-	log *logrus.Entry
 
 	ready     chan struct{}
 	readyOnce sync.Once
@@ -43,30 +134,26 @@ type ConfigService struct {
 	debounceDuration time.Duration
 }
 
-// NewConfigService creates a new instance of ConfigService.
-func NewConfigService(configLocation string, locationReady <-chan struct{}, log *logrus.Entry) *ConfigService {
-	return &ConfigService{
-		location:         configLocation,
-		locationReady:    locationReady,
+func newFileWatcher[T any](unmarshal func(data []byte) (*T, error)) *fileWatcher[T] {
+	return &fileWatcher[T]{
+		unmarshal:        unmarshal,
 		cond:             sync.NewCond(&sync.Mutex{}),
-		log:              log.WithField("location", configLocation),
 		ready:            make(chan struct{}),
 		debounceDuration: 100 * time.Millisecond,
 	}
 }
 
-// Observe provides channels triggered whenever the config is changed.
-func (service *ConfigService) Observe(ctx context.Context) <-chan *gitpod.GitpodConfig {
-	configs := make(chan *gitpod.GitpodConfig)
+func (service *fileWatcher[T]) observe(ctx context.Context) <-chan *T {
+	results := make(chan *T)
 	go func() {
-		defer close(configs)
+		defer close(results)
 
 		<-service.ready
 
 		service.cond.L.Lock()
 		defer service.cond.L.Unlock()
 		for {
-			configs <- service.config
+			results <- service.data
 
 			service.cond.Wait()
 			if ctx.Err() != nil {
@@ -74,58 +161,61 @@ func (service *ConfigService) Observe(ctx context.Context) <-chan *gitpod.Gitpod
 			}
 		}
 	}()
-	return configs
+	return results
 }
 
-// Watch starts the config watching.
-func (service *ConfigService) Watch(ctx context.Context) {
-	service.log.Info("gitpod config watcher: starting...")
-
-	select {
-	case <-service.locationReady:
-	case <-ctx.Done():
-		return
-	}
-
-	_, err := os.Stat(service.location)
-	if os.IsNotExist(err) {
-		service.poll(ctx)
-	}
-	service.watch(ctx)
-}
-
-func (service *ConfigService) markReady() {
+func (service *fileWatcher[T]) markReady() {
 	service.readyOnce.Do(func() {
 		close(service.ready)
 	})
 }
 
-func (service *ConfigService) watch(ctx context.Context) {
+func (service *fileWatcher[T]) reset() {
+	service.cond.L.Lock()
+	defer service.cond.L.Unlock()
+
+	if service.data != nil {
+		service.data = nil
+		service.cond.Broadcast()
+	}
+}
+
+func (service *fileWatcher[T]) watch(ctx context.Context, location string) {
+	log.WithField("location", location).Info("file watcher: starting...")
+
+	_, err := os.Stat(location)
+	if os.IsNotExist(err) {
+		service.poll(ctx, location)
+	}
+	service.doWatch(ctx, location)
+}
+
+func (service *fileWatcher[T]) doWatch(ctx context.Context, location string) {
 	watcher, err := fsnotify.NewWatcher()
 	defer func() {
 		if err != nil {
-			service.log.WithError(err).Error("gitpod config watcher: failed to start")
+			log.WithField("location", location).WithError(err).Error("file watcher: failed to start")
 			return
 		}
 
-		service.log.Info("gitpod config watcher: started")
+		log.WithField("location", location).Info("file watcher: started")
 	}()
 	if err != nil {
 		return
 	}
 
-	err = watcher.Add(service.location)
+	err = watcher.Add(location)
 	if err != nil {
 		watcher.Close()
 		return
 	}
 
 	go func() {
-		defer service.log.Info("gitpod config watcher: stopped")
+		defer log.WithField("location", location).Info("file watcher: stopped")
 		defer watcher.Close()
 
 		polling := make(chan struct{}, 1)
-		service.scheduleUpdateConfig(ctx, polling)
+		service.scheduleUpdate(ctx, polling, location)
 		for {
 			select {
 			case <-polling:
@@ -133,32 +223,32 @@ func (service *ConfigService) watch(ctx context.Context) {
 			case <-ctx.Done():
 				return
 			case err := <-watcher.Errors:
-				service.log.WithError(err).Error("gitpod config watcher: failed to watch")
+				log.WithField("location", location).WithError(err).Error("file watcher: failed to watch")
 			case <-watcher.Events:
-				service.scheduleUpdateConfig(ctx, polling)
+				service.scheduleUpdate(ctx, polling, location)
 			}
 		}
 	}()
 }
 
-func (service *ConfigService) scheduleUpdateConfig(ctx context.Context, polling chan<- struct{}) {
+func (service *fileWatcher[T]) scheduleUpdate(ctx context.Context, polling chan<- struct{}, location string) {
 	service.cond.L.Lock()
 	defer service.cond.L.Unlock()
 	if service.pollTimer != nil {
 		service.pollTimer.Stop()
 	}
 	service.pollTimer = time.AfterFunc(service.debounceDuration, func() {
-		err := service.updateConfig()
+		err := service.update(location)
 		if os.IsNotExist(err) {
 			polling <- struct{}{}
-			go service.poll(ctx)
+			go service.poll(ctx, location)
 		} else if err != nil {
-			service.log.WithError(err).Error("gitpod config watcher: failed to parse")
+			log.WithField("location", location).WithError(err).Error("file watcher: failed to parse")
 		}
 	})
 }
 
-func (service *ConfigService) poll(ctx context.Context) {
+func (service *fileWatcher[T]) poll(ctx context.Context, location string) {
 	service.markReady()
 
 	timer := time.NewTicker(2 * time.Second)
@@ -171,35 +261,33 @@ func (service *ConfigService) poll(ctx context.Context) {
 		case <-timer.C:
 		}
 
-		if _, err := os.Stat(service.location); !os.IsNotExist(err) {
-			service.watch(ctx)
+		if _, err := os.Stat(location); !os.IsNotExist(err) {
+			service.doWatch(ctx, location)
 			return
 		}
 	}
 }
 
-func (service *ConfigService) updateConfig() error {
+func (service *fileWatcher[T]) update(location string) error {
 	service.cond.L.Lock()
 	defer service.cond.L.Unlock()
 
-	config, err := service.parse()
+	data, err := service.parse(location)
 	if err == nil || os.IsNotExist(err) {
-		service.config = config
+		service.data = data
 		service.markReady()
 		service.cond.Broadcast()
 
-		service.log.WithField("config", service.config).Debug("gitpod config watcher: updated")
+		log.WithField("location", location).WithField("data", service.data).Debug("file watcher: updated")
 	}
 
 	return err
 }
 
-func (service *ConfigService) parse() (*gitpod.GitpodConfig, error) {
-	data, err := os.ReadFile(service.location)
+func (service *fileWatcher[T]) parse(location string) (*T, error) {
+	data, err := os.ReadFile(location)
 	if err != nil {
 		return nil, err
 	}
-	var config *gitpod.GitpodConfig
-	err = yaml.Unmarshal(data, &config)
-	return config, err
+	return service.unmarshal(data)
 }

--- a/components/supervisor/pkg/config/gitpod-config_analytics_test.go
+++ b/components/supervisor/pkg/config/gitpod-config_analytics_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
+	"github.com/gitpod-io/gitpod/common-go/log"
 	gitpod "github.com/gitpod-io/gitpod/gitpod-protocol"
 )
 
@@ -65,7 +66,7 @@ func TestAnalyzeGitpodConfig(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.Desc, func(t *testing.T) {
 			var fields []string
-			analyzer := NewConfigAnalyzer(log, 100*time.Millisecond, func(field string) {
+			analyzer := NewConfigAnalyzer(log.Log, 100*time.Millisecond, func(field string) {
 				fields = append(fields, field)
 			}, test.Prev)
 			<-analyzer.Analyse(test.Current)

--- a/components/supervisor/pkg/ports/ports-config_test.go
+++ b/components/supervisor/pkg/ports/ports-config_test.go
@@ -83,8 +83,10 @@ func TestPortsConfig(t *testing.T) {
 		t.Run(test.Desc, func(t *testing.T) {
 			configService := &testGitpodConfigService{
 				configs: make(chan *gitpod.GitpodConfig),
+				changes: make(chan *struct{}),
 			}
 			defer close(configService.configs)
+			defer close(configService.changes)
 
 			context, cancel := context.WithCancel(context.Background())
 			defer cancel()
@@ -128,6 +130,7 @@ type PortConfigTestExpectations struct {
 
 type testGitpodConfigService struct {
 	configs chan *gitpod.GitpodConfig
+	changes chan *struct{}
 }
 
 func (service *testGitpodConfigService) Watch(ctx context.Context) {
@@ -135,4 +138,8 @@ func (service *testGitpodConfigService) Watch(ctx context.Context) {
 
 func (service *testGitpodConfigService) Observe(ctx context.Context) <-chan *gitpod.GitpodConfig {
 	return service.configs
+}
+
+func (service *testGitpodConfigService) ObserveImageFile(ctx context.Context) <-chan *struct{} {
+	return service.changes
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Adds `gitpod_image_file_changed` to report when gitpod Dockerfile is changed debounced by 5 secs.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
fix https://github.com/gitpod-io/gitpod/issues/6898

## How to test
<!-- Provide steps to test this PR -->

- Open a workspace, configured gitpod Dockerfile as an image, do changes, check that events are reported debounced by 5 secs.
- Check for regressions, like changes ports and see that changes are reflected in ports view, and notifications.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft analytics=segment
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
