### PR TITLE
Update search input style on project pages

### DIFF
--- a/components/dashboard/src/admin/TeamDetail.tsx
+++ b/components/dashboard/src/admin/TeamDetail.tsx
@@ -17,6 +17,7 @@ import { AttributionId } from "@gitpod/gitpod-protocol/lib/attribution";
 import { BillingMode } from "@gitpod/gitpod-protocol/lib/billing-mode";
 import { CostCenterJSON, CostCenter_BillingStrategy } from "@gitpod/gitpod-protocol/lib/usage";
 import Modal from "../components/Modal";
+import search from "../icons/search.svg";
 
 export default function TeamDetail(props: { team: Team }) {
     const { team } = props;
@@ -133,17 +134,22 @@ export default function TeamDetail(props: { team: Team }) {
                     </Property>
                 )}
             </div>
-            <div className="flex mt-4">
-                <div className="flex">
-                    <div className="py-4">
-                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 16 16" width="16" height="16">
-                            <path
-                                fill="#A8A29E"
-                                d="M6 2a4 4 0 100 8 4 4 0 000-8zM0 6a6 6 0 1110.89 3.477l4.817 4.816a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 010 6z"
-                            />
-                        </svg>
+            <div className="flex">
+                <div className="flex mt-3 pb-3">
+                    <div className="flex relative h-10 my-auto">
+                        <img
+                            src={search}
+                            title="Search"
+                            className="filter-grayscale absolute top-3 left-3"
+                            alt="search icon"
+                        />
+                        <input
+                            className="w-64 pl-9 border-0"
+                            type="search"
+                            placeholder="Search Members"
+                            onChange={(e) => setSearchText(e.target.value)}
+                        />
                     </div>
-                    <input type="search" placeholder="Search Members" onChange={(e) => setSearchText(e.target.value)} />
                 </div>
             </div>
 

--- a/components/dashboard/src/projects/Prebuilds.tsx
+++ b/components/dashboard/src/projects/Prebuilds.tsx
@@ -22,6 +22,7 @@ import { Link, Redirect } from "react-router-dom";
 import { Disposable } from "vscode-jsonrpc";
 import { useCurrentProject } from "./project-context";
 import { getProjectTabs } from "./projects.routes";
+import search from "../icons/search.svg";
 
 export default function PrebuildsPage(props: { project?: Project; isAdminDashboard?: boolean }) {
     const currentProject = useCurrentProject();
@@ -142,23 +143,16 @@ export default function PrebuildsPage(props: { project?: Project; isAdminDashboa
                 />
             )}
             <div className={props.isAdminDashboard ? "" : "app-container"}>
-                <div className={props.isAdminDashboard ? "flex" : "flex mt-8"}>
-                    <div className="flex">
-                        <div className="py-4">
-                            <svg
-                                xmlns="http://www.w3.org/2000/svg"
-                                fill="none"
-                                viewBox="0 0 16 16"
-                                width="16"
-                                height="16"
-                            >
-                                <path
-                                    fill="#A8A29E"
-                                    d="M6 2a4 4 0 100 8 4 4 0 000-8zM0 6a6 6 0 1110.89 3.477l4.817 4.816a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 010 6z"
-                                />
-                            </svg>
-                        </div>
+                <div className={props.isAdminDashboard ? "flex" : "flex mt-3 pb-3"}>
+                    <div className="flex relative h-10 my-auto">
+                        <img
+                            src={search}
+                            title="Search"
+                            className="filter-grayscale absolute top-3 left-3"
+                            alt="search icon"
+                        />
                         <input
+                            className="w-64 pl-9 border-0"
                             type="search"
                             placeholder="Search Prebuilds"
                             onChange={(e) => setSearchFilter(e.target.value)}

--- a/components/dashboard/src/projects/Project.tsx
+++ b/components/dashboard/src/projects/Project.tsx
@@ -22,6 +22,7 @@ import { prebuildStatusIcon, prebuildStatusLabel } from "./Prebuilds";
 import { useCurrentProject } from "./project-context";
 import { getProjectTabs } from "./projects.routes";
 import { shortCommitMessage, toRemoteURL } from "./render-utils";
+import search from "../icons/search.svg";
 
 export default function ProjectsPage() {
     const history = useHistory();
@@ -197,7 +198,7 @@ export default function ProjectsPage() {
                 subtitle={
                     <h2 className="tracking-wide">
                         View recent active branches for{" "}
-                        <a target="_blank" rel="noreferrer noopener" className="gp-link" href={project?.cloneUrl!}>
+                        <a className="gp-link" href={project?.cloneUrl!}>
                             {toRemoteURL(project?.cloneUrl || "")}
                         </a>
                         .
@@ -225,23 +226,16 @@ export default function ProjectsPage() {
                     </div>
                 ) : (
                     <>
-                        <div className="flex mt-8">
-                            <div className="flex">
-                                <div className="py-4">
-                                    <svg
-                                        xmlns="http://www.w3.org/2000/svg"
-                                        fill="none"
-                                        viewBox="0 0 16 16"
-                                        width="16"
-                                        height="16"
-                                    >
-                                        <path
-                                            fill="#A8A29E"
-                                            d="M6 2a4 4 0 100 8 4 4 0 000-8zM0 6a6 6 0 1110.89 3.477l4.817 4.816a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 010 6z"
-                                        />
-                                    </svg>
-                                </div>
+                        <div className="mt-3 pb-3 flex border-b border-gray-200 dark:border-gray-800">
+                            <div className="flex relative h-10 my-auto">
+                                <img
+                                    src={search}
+                                    title="Search"
+                                    className="filter-grayscale absolute top-3 left-3"
+                                    alt="search icon"
+                                />
                                 <input
+                                    className="w-64 pl-9 border-0"
                                     type="search"
                                     placeholder="Search Active Branches"
                                     onChange={(e) => setSearchFilter(e.target.value)}


### PR DESCRIPTION
## Description

Minor follow up from https://github.com/gitpod-io/gitpod/pull/16439 to apply the same search input style on project pages, _Branches_ & _Prebuilds_.

⚠️ Haven't tested this yet in a preview environment.

## How to test
1. Add a project
2. Notice the search input under project Branches and Prebuilds follows the changes of the search input style from the last improvements in https://github.com/gitpod-io/gitpod/pull/16439.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [X] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
