### PR TITLE
[dashboard, server] Add global custom timeout preference

### DIFF
--- a/components/dashboard/src/user-settings/Preferences.tsx
+++ b/components/dashboard/src/user-settings/Preferences.tsx
@@ -43,7 +43,7 @@ export default function Preferences() {
     const [allowConfigureWorkspaceTimeout, setAllowConfigureWorkspaceTimeout] = useState<boolean>(false);
     useEffect(() => {
         getGitpodService()
-            .server.supportConfigureWorkspaceTimeout()
+            .server.maySetTimeout()
             .then((r) => setAllowConfigureWorkspaceTimeout(r));
     }, []);
 

--- a/components/dashboard/src/user-settings/Preferences.tsx
+++ b/components/dashboard/src/user-settings/Preferences.tsx
@@ -4,15 +4,15 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { useContext, useState } from "react";
+import { useCallback, useContext, useEffect, useState } from "react";
 import { getGitpodService } from "../service/service";
 import { UserContext } from "../user-context";
 import { trackEvent } from "../Analytics";
 import SelectIDE from "./SelectIDE";
 import { PageWithSettingsSubMenu } from "./PageWithSettingsSubMenu";
 import { ThemeSelector } from "../components/ThemeSelector";
-import CheckBox from "../components/CheckBox";
-import { WorkspaceTimeoutDuration } from "@gitpod/gitpod-protocol";
+import Alert from "../components/Alert";
+import { Link } from "react-router-dom";
 
 export default function Preferences() {
     const { user } = useContext(UserContext);
@@ -31,31 +31,21 @@ export default function Preferences() {
         }
     };
 
-    const [disabledClosedTimeout, setDisabledClosedTimeout] = useState<boolean>(
-        user?.additionalData?.disabledClosedTimeout ?? false,
-    );
-    const actuallySetDisabledClosedTimeout = async (value: boolean) => {
-        try {
-            const additionalData = user?.additionalData || {};
-            additionalData.disabledClosedTimeout = value;
-            await getGitpodService().server.updateLoggedInUser({ additionalData });
-            setDisabledClosedTimeout(value);
-        } catch (e) {
-            alert("Cannot set custom workspace timeout: " + e.message);
-        }
-    };
-
     const [workspaceTimeout, setWorkspaceTimeout] = useState<string>(user?.additionalData?.workspaceTimeout ?? "");
-    const actuallySetWorkspaceTimeout = async (value: string) => {
+    const actuallySetWorkspaceTimeout = useCallback(async (value: string) => {
         try {
-            const timeout = WorkspaceTimeoutDuration.validate(value);
-            const additionalData = user?.additionalData || {};
-            additionalData.workspaceTimeout = timeout;
-            await getGitpodService().server.updateLoggedInUser({ additionalData });
+            await getGitpodService().server.updateWorkspaceTimeoutSetting({ workspaceTimeout: value });
         } catch (e) {
             alert("Cannot set custom workspace timeout: " + e.message);
         }
-    };
+    }, []);
+
+    const [allowConfigureWorkspaceTimeout, setAllowConfigureWorkspaceTimeout] = useState<boolean>(false);
+    useEffect(() => {
+        getGitpodService()
+            .server.supportConfigureWorkspaceTimeout()
+            .then((r) => setAllowConfigureWorkspaceTimeout(r));
+    }, []);
 
     return (
         <div>
@@ -103,38 +93,44 @@ export default function Preferences() {
 
                 <h3 className="mt-12">Inactivity Timeout </h3>
                 <p className="text-base text-gray-500 dark:text-gray-400">
-                    By default, workspaces stop following 30 minutes without user input (e.g. keystrokes or terminal
-                    input commands). You can increase the workspace timeout up to a maximum of 24 hours.
+                    Workspaces will stop after a period of inactivity without any user input.
                 </p>
                 <div className="mt-4 max-w-xl">
-                    <h4>Default Inactivity Timeout</h4>
-                    <span className="flex">
-                        <input
-                            type="text"
-                            className="w-96 h-9"
-                            value={workspaceTimeout}
-                            placeholder="timeout time, such as 30m, 1h, max 24h"
-                            onChange={(e) => setWorkspaceTimeout(e.target.value)}
-                        />
-                        <button
-                            className="secondary ml-2"
-                            onClick={() => actuallySetWorkspaceTimeout(workspaceTimeout)}
-                        >
-                            Save Changes
-                        </button>
-                    </span>
-                    <div className="mt-1">
-                        <p className="text-gray-500 dark:text-gray-400">
-                            Use minutes or hours, like <strong>30m</strong> or <strong>2h</strong>.
-                        </p>
-                    </div>
+                    <h4>Default Workspace Timeout</h4>
 
-                    <CheckBox
-                        title="Stop workspace when no active editor connection"
-                        desc={<span>Don't change workspace inactivity timeout when closing the editor.</span>}
-                        checked={disabledClosedTimeout}
-                        onChange={(e) => actuallySetDisabledClosedTimeout(e.target.checked)}
-                    />
+                    {!allowConfigureWorkspaceTimeout && (
+                        <Alert type="message">
+                            Upgrade organization <Link to="/billing">billing</Link> plan to use a custom inactivity
+                            timeout.
+                        </Alert>
+                    )}
+
+                    {allowConfigureWorkspaceTimeout && (
+                        <>
+                            <span className="flex mt-2">
+                                <input
+                                    type="text"
+                                    className="w-96 h-9"
+                                    value={workspaceTimeout}
+                                    disabled={!allowConfigureWorkspaceTimeout}
+                                    placeholder="e.g. 30m"
+                                    onChange={(e) => setWorkspaceTimeout(e.target.value)}
+                                />
+                                <button
+                                    className="secondary ml-2"
+                                    disabled={!allowConfigureWorkspaceTimeout}
+                                    onClick={() => actuallySetWorkspaceTimeout(workspaceTimeout)}
+                                >
+                                    Save Changes
+                                </button>
+                            </span>
+                            <div className="mt-1">
+                                <p className="text-gray-500 dark:text-gray-400">
+                                    Use minutes or hours, like <strong>30m</strong> or <strong>2h</strong>.
+                                </p>
+                            </div>
+                        </>
+                    )}
                 </div>
             </PageWithSettingsSubMenu>
         </div>

--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -313,7 +313,7 @@ export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, 
     getNotifications(): Promise<AppNotification[]>;
 
     getSupportedWorkspaceClasses(): Promise<SupportedWorkspaceClass[]>;
-    supportConfigureWorkspaceTimeout(): Promise<boolean>;
+    maySetTimeout(): Promise<boolean>;
     updateWorkspaceTimeoutSetting(setting: Partial<WorkspaceTimeoutSetting>): Promise<void>;
 }
 

--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -28,6 +28,7 @@ import {
     SSHPublicKeyValue,
     IDESettings,
     EnvVarWithValue,
+    WorkspaceTimeoutSetting,
 } from "./protocol";
 import {
     Team,
@@ -312,6 +313,8 @@ export interface GitpodServer extends JsonRpcServer<GitpodClient>, AdminServer, 
     getNotifications(): Promise<AppNotification[]>;
 
     getSupportedWorkspaceClasses(): Promise<SupportedWorkspaceClass[]>;
+    supportConfigureWorkspaceTimeout(): Promise<boolean>;
+    updateWorkspaceTimeoutSetting(setting: Partial<WorkspaceTimeoutSetting>): Promise<void>;
 }
 
 export interface AppNotification {

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -254,6 +254,9 @@ export interface AdditionalUserData {
     // whether the user has been migrated to team attribution.
     // a corresponding feature flag (team_only_attribution) triggers the migration.
     isMigratedToTeamOnlyAttribution?: boolean;
+    // user globol workspace timeout
+    workspaceTimeout?: string;
+    disabledClosedTimeout?: boolean;
 }
 export namespace AdditionalUserData {
     export function set(user: User, partialData: Partial<AdditionalUserData>): User {

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -256,6 +256,7 @@ export interface AdditionalUserData {
     isMigratedToTeamOnlyAttribution?: boolean;
     // user globol workspace timeout
     workspaceTimeout?: string;
+    // control whether to enable the closed timeout of a workspace, i.e. close web ide, disconnect ssh connection
     disabledClosedTimeout?: boolean;
 }
 export namespace AdditionalUserData {

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -233,7 +233,14 @@ export namespace User {
     }
 }
 
-export interface AdditionalUserData {
+export interface WorkspaceTimeoutSetting {
+    // user globol workspace timeout
+    workspaceTimeout: string;
+    // control whether to enable the closed timeout of a workspace, i.e. close web ide, disconnect ssh connection
+    disabledClosedTimeout: boolean;
+}
+
+export interface AdditionalUserData extends Partial<WorkspaceTimeoutSetting> {
     platforms?: UserPlatform[];
     emailNotificationSettings?: EmailNotificationSettings;
     featurePreview?: boolean;
@@ -254,10 +261,6 @@ export interface AdditionalUserData {
     // whether the user has been migrated to team attribution.
     // a corresponding feature flag (team_only_attribution) triggers the migration.
     isMigratedToTeamOnlyAttribution?: boolean;
-    // user globol workspace timeout
-    workspaceTimeout?: string;
-    // control whether to enable the closed timeout of a workspace, i.e. close web ide, disconnect ssh connection
-    disabledClosedTimeout?: boolean;
 }
 export namespace AdditionalUserData {
     export function set(user: User, partialData: Partial<AdditionalUserData>): User {

--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -411,7 +411,7 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
         await this.requireEELicense(Feature.FeatureSetTimeout);
         const user = this.checkUser("setWorkspaceTimeout");
 
-        if (!(await this.maySetTimeout(user))) {
+        if (!(await this.entitlementService.maySetTimeout(user, new Date()))) {
             throw new ResponseError(ErrorCodes.PLAN_PROFESSIONAL_REQUIRED, "Plan upgrade is required");
         }
 
@@ -455,7 +455,7 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
 
         const user = this.checkUser("getWorkspaceTimeout");
 
-        const canChange = await this.maySetTimeout(user);
+        const canChange = await this.entitlementService.maySetTimeout(user, new Date());
 
         const workspace = await this.internalGetWorkspace(workspaceId, this.workspaceDb.trace(ctx));
         const runningInstance = await this.workspaceDb.trace(ctx).findRunningInstance(workspaceId);
@@ -492,13 +492,6 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
         }
 
         return PrebuiltWorkspace.isDone(pws);
-    }
-
-    /**
-     * gitpod.io Extension point for implementing eligibility checks. Throws a ResponseError if not eligible.
-     */
-    protected async maySetTimeout(user: User): Promise<boolean> {
-        return this.entitlementService.maySetTimeout(user, new Date());
     }
 
     public async controlAdmission(ctx: TraceContext, workspaceId: string, level: "owner" | "everyone"): Promise<void> {

--- a/components/server/src/auth/rate-limiter.ts
+++ b/components/server/src/auth/rate-limiter.ts
@@ -232,7 +232,7 @@ const defaultFunctions: FunctionsConfig = {
     setUsageLimit: { group: "default", points: 1 },
     getNotifications: { group: "default", points: 1 },
     getSupportedWorkspaceClasses: { group: "default", points: 1 },
-    supportConfigureWorkspaceTimeout: { group: "default", points: 1 },
+    maySetTimeout: { group: "default", points: 1 },
     updateWorkspaceTimeoutSetting: { group: "default", points: 1 },
 };
 

--- a/components/server/src/auth/rate-limiter.ts
+++ b/components/server/src/auth/rate-limiter.ts
@@ -232,6 +232,8 @@ const defaultFunctions: FunctionsConfig = {
     setUsageLimit: { group: "default", points: 1 },
     getNotifications: { group: "default", points: 1 },
     getSupportedWorkspaceClasses: { group: "default", points: 1 },
+    supportConfigureWorkspaceTimeout: { group: "default", points: 1 },
+    updateWorkspaceTimeoutSetting: { group: "default", points: 1 },
 };
 
 function getConfig(config: RateLimiterConfig): RateLimiterConfig {

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -499,8 +499,8 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         return user;
     }
 
-    public async supportConfigureWorkspaceTimeout(ctx: TraceContext): Promise<boolean> {
-        const user = this.checkUser("supportConfigureWorkspaceTimeout");
+    public async maySetTimeout(ctx: TraceContext): Promise<boolean> {
+        const user = this.checkUser("maySetTimeout");
         await this.guardAccess({ kind: "user", subject: user }, "get");
 
         return await this.entitlementService.maySetTimeout(user, new Date());
@@ -515,7 +515,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
             WorkspaceTimeoutDuration.validate(setting.workspaceTimeout);
         }
 
-        const user = this.checkUser("updateWorkspaceTimeoutSetting");
+        const user = this.checkAndBlockUser("updateWorkspaceTimeoutSetting");
         await this.guardAccess({ kind: "user", subject: user }, "update");
 
         if (!(await this.entitlementService.maySetTimeout(user, new Date()))) {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
[dashboard, server] Add global custom timeout preference

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

Closes https://github.com/gitpod-io/gitpod/issues/16200

## How to test
<!-- Provide steps to test this PR -->
1. try enabling billing with your account, otherwise custom workspace timeout will disabled.
2. setting custom timeout in preference
3. start a workspace, use `kubectl describe pod ws-{instanceID}` to check your workspace timeout and closed timeout.

```
annotations `gitpod/customTimeout` is your workspace timeout.
```

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[dashboard, server] Add global custom timeout preference
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
