### PR TITLE
At/page switch to payg next

### DIFF
--- a/components/dashboard/src/SwitchToPAYG.tsx
+++ b/components/dashboard/src/SwitchToPAYG.tsx
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { useCallback, useContext } from "react";
+import { Redirect, useLocation } from "react-router";
+import { useCurrentUser } from "./user-context";
+import { FeatureFlagContext } from "./contexts/FeatureFlagContext";
+
+const KEY_PERSONAL_SUB = "personalSubscription";
+const KEY_TEAM1_SUB = "teamSubscription";
+const KEY_TEAM2_SUB = "teamSubscription2";
+
+type SubscriptionType = typeof KEY_PERSONAL_SUB | typeof KEY_TEAM1_SUB | typeof KEY_TEAM2_SUB;
+type Params = { id: string; type: SubscriptionType };
+
+function SwitchToPAYG() {
+    const { switchToPAYG } = useContext(FeatureFlagContext);
+    const user = useCurrentUser();
+    const location = useLocation();
+    const params = parseSearchParams(location.search);
+
+    const onUpgradePlan = useCallback(() => {}, []);
+
+    if (!switchToPAYG || !user || !params) {
+        return (
+            <Redirect
+                to={{
+                    pathname: "/workspaces",
+                    state: { from: location },
+                }}
+            />
+        );
+    }
+
+    return (
+        <div className="flex flex-col mt-32 mx-auto ">
+            <div className="flex flex-col max-h-screen max-w-2xl mx-auto items-center w-full">
+                <h1>Switch to Pay-as-you-go</h1>
+                <div className="text-gray-500 text-center text-base">Pay-as-you-go has several clear benefits. ...</div>
+                <div className="text-gray-500 text-center text-base">How do you get started?</div>
+                <div className="-mx-6 px-6 mt-6 w-full">{JSON.stringify(params)}</div>
+                <div className="w-full flex justify-end mt-6 space-x-2 px-6">
+                    <button onClick={onUpgradePlan} disabled={true}>
+                        Upgrade Plan
+                    </button>
+                </div>
+                <div></div>
+            </div>
+        </div>
+    );
+}
+
+function parseSearchParams(search: string): Params | undefined {
+    const params = new URLSearchParams(search);
+    const keys = [KEY_TEAM1_SUB, KEY_TEAM2_SUB, KEY_PERSONAL_SUB];
+    for (const key of keys) {
+        let id = params.get(key);
+        if (id) {
+            return {
+                type: key as any,
+                id,
+            };
+        }
+    }
+}
+
+export default SwitchToPAYG;

--- a/components/dashboard/src/SwitchToPAYG.tsx
+++ b/components/dashboard/src/SwitchToPAYG.tsx
@@ -4,10 +4,16 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { useCallback, useContext } from "react";
+import { useCallback, useContext, useEffect, useState } from "react";
 import { Redirect, useLocation } from "react-router";
 import { useCurrentUser } from "./user-context";
 import { FeatureFlagContext } from "./contexts/FeatureFlagContext";
+import { BillingSetupModal } from "./components/UsageBasedBillingConfig";
+import { SpinnerLoader } from "./components/Loader";
+import { teamsService } from "./service/public-api";
+import { AttributionId } from "@gitpod/gitpod-protocol/lib/attribution";
+import { getGitpodService } from "./service/service";
+import Alert from "./components/Alert";
 
 const KEY_PERSONAL_SUB = "personalSubscription";
 const KEY_TEAM1_SUB = "teamSubscription";
@@ -22,7 +28,63 @@ function SwitchToPAYG() {
     const location = useLocation();
     const params = parseSearchParams(location.search);
 
-    const onUpgradePlan = useCallback(() => {}, []);
+    const [errorMessage, setErrorMessage] = useState<string | undefined>();
+    const [stripeSubscriptionId, setStripeSubscriptionId] = useState<string | undefined>();
+    const [showBillingSetupModal, setShowBillingSetupModal] = useState<boolean>(false);
+    const [attributionId, setAttributionId] = useState<string>("");
+    const [pendingStripeSubscription, setPendingStripeSubscription] = useState<boolean>(false);
+
+    useEffect(() => {
+        if (!attributionId) {
+            return;
+        }
+        const params = new URLSearchParams(location.search);
+        if (!params.get("setup_intent") || params.get("redirect_status") !== "succeeded") {
+            return;
+        }
+        const setupIntentId = params.get("setup_intent")!;
+        window.history.replaceState({}, "", location.pathname);
+        (async () => {
+            try {
+                setPendingStripeSubscription(true);
+                const limit = 1000;
+                await getGitpodService().server.subscribeToStripe(attributionId, setupIntentId, limit);
+            } catch (error) {
+                console.error("Could not subscribe to Stripe", error);
+                setPendingStripeSubscription(false);
+                setErrorMessage(`Could not subscribe to Stripe. ${error?.message || String(error)}`);
+                return;
+            }
+
+            // unfortunately, we need to poll for the subscription
+            const interval = setInterval(async () => {
+                try {
+                    const subscriptionId = await getGitpodService().server.findStripeSubscriptionId(attributionId);
+                    setStripeSubscriptionId(subscriptionId);
+                    clearInterval(interval);
+                    setPendingStripeSubscription(false);
+                    return subscriptionId;
+                } catch (error) {
+                    console.error("Could not find a subscription to be created", error);
+                }
+            }, 1000);
+        })();
+    }, [attributionId, location.pathname, location.search]);
+
+    const onUpgradePlan = useCallback(() => {
+        setShowBillingSetupModal(true);
+
+        // TODO(at) select/create Org based on `params.type` and convert to AttributionId
+        // for now always create new dummy Org
+        (async () => {
+            const response = await teamsService.createTeam({ name: `${user?.name || "Unknown"}'s Org` });
+            const teamId = response.team?.id;
+            if (!teamId) {
+                return;
+            }
+            setAttributionId(AttributionId.render({ kind: "team", teamId }));
+        })();
+    }, [user]);
 
     if (!switchToPAYG || !user || !params) {
         return (
@@ -42,11 +104,36 @@ function SwitchToPAYG() {
                 <div className="text-gray-500 text-center text-base">Pay-as-you-go has several clear benefits. ...</div>
                 <div className="text-gray-500 text-center text-base">How do you get started?</div>
                 <div className="-mx-6 px-6 mt-6 w-full">{JSON.stringify(params)}</div>
+                {errorMessage && (
+                    <Alert className="max-w-xl mt-2" closable={false} showIcon={true} type="error">
+                        {errorMessage}
+                    </Alert>
+                )}
+                {pendingStripeSubscription && (
+                    <div className="flex flex-col mt-4 h-52 p-4 rounded-xl bg-gray-50 dark:bg-gray-800">
+                        <div className="uppercase text-sm text-gray-400 dark:text-gray-500">Balance</div>
+                        <SpinnerLoader small={false} />
+                    </div>
+                )}
+                {stripeSubscriptionId && (
+                    <Alert className="max-w-xl mt-2" closable={false} showIcon={true} type="success">
+                        {stripeSubscriptionId} 🎉
+                    </Alert>
+                )}
                 <div className="w-full flex justify-end mt-6 space-x-2 px-6">
-                    <button onClick={onUpgradePlan} disabled={true}>
+                    <button onClick={onUpgradePlan} disabled={showBillingSetupModal}>
                         Upgrade Plan
                     </button>
                 </div>
+                {showBillingSetupModal &&
+                    (attributionId ? (
+                        <BillingSetupModal
+                            attributionId={attributionId}
+                            onClose={() => setShowBillingSetupModal(false)}
+                        />
+                    ) : (
+                        <SpinnerLoader small={true} />
+                    ))}
                 <div></div>
             </div>
         </div>
@@ -55,8 +142,7 @@ function SwitchToPAYG() {
 
 function parseSearchParams(search: string): Params | undefined {
     const params = new URLSearchParams(search);
-    const keys = [KEY_TEAM1_SUB, KEY_TEAM2_SUB, KEY_PERSONAL_SUB];
-    for (const key of keys) {
+    for (const key of [KEY_TEAM1_SUB, KEY_TEAM2_SUB, KEY_PERSONAL_SUB]) {
         let id = params.get(key);
         if (id) {
             return {

--- a/components/dashboard/src/app/AppRoutes.tsx
+++ b/components/dashboard/src/app/AppRoutes.tsx
@@ -27,6 +27,7 @@ import {
     settingsPathPreferences,
     settingsPathSSHKeys,
     settingsPathVariables,
+    switchToPAYGPathMain,
     usagePathMain,
 } from "../user-settings/settings.routes";
 import { getURLHash, isGitpodIo, isLocalPreview } from "../utils";
@@ -90,6 +91,7 @@ const TeamsSearch = React.lazy(() => import(/* webpackPrefetch: true */ "../admi
 const License = React.lazy(() => import(/* webpackPrefetch: true */ "../admin/License"));
 const Usage = React.lazy(() => import(/* webpackPrefetch: true */ "../Usage"));
 const UserOnboarding = React.lazy(() => import(/* webpackPrefetch: true */ "../onboarding/UserOnboarding"));
+const SwitchToPAYG = React.lazy(() => import(/* webpackPrefetch: true */ "../SwitchToPAYG"));
 
 type AppRoutesProps = {
     user: User;
@@ -189,6 +191,7 @@ export const AppRoutes: FunctionComponent<AppRoutesProps> = ({ user, teams }) =>
                     <Route path={workspacesPathMain} exact component={Workspaces} />
                     <Route path={settingsPathAccount} exact component={Account} />
                     <Route path={usagePathMain} exact component={Usage} />
+                    <Route path={switchToPAYGPathMain} exact component={SwitchToPAYG} />
                     <Route path={settingsPathIntegrations} exact component={Integrations} />
                     <Route path={settingsPathNotifications} exact component={Notifications} />
                     <Route path={settingsPathBilling} exact component={Billing} />

--- a/components/dashboard/src/components/UsageBasedBillingConfig.tsx
+++ b/components/dashboard/src/components/UsageBasedBillingConfig.tsx
@@ -334,7 +334,7 @@ export default function UsageBasedBillingConfig({ attributionId }: Props) {
     );
 }
 
-function BillingSetupModal(props: { attributionId: string; onClose: () => void }) {
+export function BillingSetupModal(props: { attributionId: string; onClose: () => void }) {
     const { isDark } = useContext(ThemeContext);
     const [stripePromise, setStripePromise] = useState<Promise<Stripe | null> | undefined>();
     const [stripeSetupIntentClientSecret, setStripeSetupIntentClientSecret] = useState<string | undefined>();

--- a/components/dashboard/src/user-settings/settings.routes.ts
+++ b/components/dashboard/src/user-settings/settings.routes.ts
@@ -6,6 +6,7 @@
 
 export const settingsPathMain = "/user/settings";
 export const usagePathMain = "/usage";
+export const switchToPAYGPathMain = "/switch-to-payg";
 
 export const settingsPathAccount = "/user/account";
 export const settingsPathIntegrations = "/user/integrations";


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
