### PR TITLE
[preview] Apply gitpod/monitoring-satellite resources if there's diff

### DIFF
--- a/dev/preview/workflow/lib/k8s-util.sh
+++ b/dev/preview/workflow/lib/k8s-util.sh
@@ -86,3 +86,16 @@ function readWerftSecret {
     get secret "${name}" -o jsonpath="{.data.${key}}" \
   | base64 -d
 }
+
+function diff-apply {
+  local context=$1
+  shift
+  local yaml=$1
+  yaml=$(realpath "${yaml}")
+
+  if kubectl --context "${context}" diff -f "${yaml}" > /dev/null; then
+    echo "Skipping ${yaml}, as it produced no diff"
+  else
+    kubectl --context "${context}" apply -f "${yaml}"
+  fi
+}

--- a/dev/preview/workflow/preview/deploy-gitpod.sh
+++ b/dev/preview/workflow/preview/deploy-gitpod.sh
@@ -135,35 +135,16 @@ EOF
 }
 
 function installRookCeph {
-  kubectl \
-    --kubeconfig "${PREVIEW_K3S_KUBE_PATH}" \
-    --context "${PREVIEW_K3S_KUBE_CONTEXT}" \
-    apply -f "$ROOT/.werft/vm/manifests/rook-ceph/crds.yaml" --server-side --force-conflicts
+  diff-apply "${PREVIEW_K3S_KUBE_CONTEXT}" "$ROOT/.werft/vm/manifests/rook-ceph/crds.yaml"
 
   kubectl \
     --kubeconfig "${PREVIEW_K3S_KUBE_PATH}" \
     --context "${PREVIEW_K3S_KUBE_CONTEXT}" \
     wait --for condition=established --timeout=120s crd/cephclusters.ceph.rook.io
 
-  kubectl \
-    --kubeconfig "${PREVIEW_K3S_KUBE_PATH}" \
-    --context "${PREVIEW_K3S_KUBE_CONTEXT}" \
-    apply -f "$ROOT/.werft/vm/manifests/rook-ceph/common.yaml" -f "$ROOT/.werft/vm/manifests/rook-ceph/operator.yaml"
-
-  kubectl \
-    --kubeconfig "${PREVIEW_K3S_KUBE_PATH}" \
-    --context "${PREVIEW_K3S_KUBE_CONTEXT}" \
-    apply -f "$ROOT/.werft/vm/manifests/rook-ceph/cluster-test.yaml"
-
-  kubectl \
-    --kubeconfig "${PREVIEW_K3S_KUBE_PATH}" \
-    --context "${PREVIEW_K3S_KUBE_CONTEXT}" \
-    apply -f "$ROOT/.werft/vm/manifests/rook-ceph/storageclass-test.yaml"
-
-  kubectl \
-    --kubeconfig "${PREVIEW_K3S_KUBE_PATH}" \
-    --context "${PREVIEW_K3S_KUBE_CONTEXT}" \
-    apply -f "$ROOT/.werft/vm/manifests/rook-ceph/snapshotclass.yaml"
+  for file in common operator cluster-test storageclass-test snapshotclass;do
+      diff-apply "${PREVIEW_K3S_KUBE_CONTEXT}" "$ROOT/.werft/vm/manifests/rook-ceph/$file.yaml"
+  done
 }
 
 # Install Fluent-Bit sending logs to GCP
@@ -376,7 +357,7 @@ then
   yq d -i admin-login-secret.yaml metadata.creationTimestamp
   yq d -i admin-login-secret.yaml metadata.uid
   yq d -i admin-login-secret.yaml metadata.resourceVersion
-  kubectl --kubeconfig "${PREVIEW_K3S_KUBE_PATH}" --context "${PREVIEW_K3S_KUBE_CONTEXT}" apply -f admin-login-secret.yaml
+  diff-apply "${PREVIEW_K3S_KUBE_CONTEXT}" admin-login-secret.yaml
   rm -f admin-login-secret.yaml
 
   yq w -i "${INSTALLER_CONFIG_PATH}" adminLoginSecret.kind "secret"
@@ -391,7 +372,7 @@ yq w -i stripe-api-keys.secret.yaml metadata.namespace "default"
 yq d -i stripe-api-keys.secret.yaml metadata.creationTimestamp
 yq d -i stripe-api-keys.secret.yaml metadata.uid
 yq d -i stripe-api-keys.secret.yaml metadata.resourceVersion
-kubectl --kubeconfig "${PREVIEW_K3S_KUBE_PATH}" --context "${PREVIEW_K3S_KUBE_CONTEXT}" apply -f stripe-api-keys.secret.yaml
+diff-apply "${PREVIEW_K3S_KUBE_CONTEXT}" stripe-api-keys.secret.yaml
 rm -f stripe-api-keys.secret.yaml
 
 #
@@ -401,8 +382,9 @@ kubectl --kubeconfig "${DEV_KUBE_PATH}" --context "${DEV_KUBE_CONTEXT}" --namesp
 | yq w - metadata.namespace ${PREVIEW_NAMESPACE} \
 | yq d - metadata.uid \
 | yq d - metadata.resourceVersion \
-| yq d - metadata.creationTimestamp \
-| kubectl --kubeconfig "${PREVIEW_K3S_KUBE_PATH}" --context "${PREVIEW_K3S_KUBE_CONTEXT}" apply -f -
+| yq d - metadata.creationTimestamp > host-key.yaml
+diff-apply "${PREVIEW_K3S_KUBE_CONTEXT}" host-key.yaml
+rm -f host-key.yaml
 
 yq w -i "${INSTALLER_CONFIG_PATH}" sshGatewayHostKey.kind "secret"
 yq w -i "${INSTALLER_CONFIG_PATH}" sshGatewayHostKey.name "host-key"
@@ -524,7 +506,7 @@ yq w -i spicedb-secret.yaml metadata.namespace "default"
 yq d -i spicedb-secret.yaml metadata.creationTimestamp
 yq d -i spicedb-secret.yaml metadata.uid
 yq d -i spicedb-secret.yaml metadata.resourceVersion
-kubectl --kubeconfig "${PREVIEW_K3S_KUBE_PATH}" --context "${PREVIEW_K3S_KUBE_CONTEXT}" apply -f spicedb-secret.yaml
+diff-apply "${PREVIEW_K3S_KUBE_CONTEXT}" spicedb-secret.yaml
 rm -f spicedb-secret.yaml
 
 #
@@ -626,7 +608,18 @@ rm -f /tmp/public-api
 log_info "Applying manifests (installing)"
 
 kubectl --kubeconfig "${PREVIEW_K3S_KUBE_PATH}" --context "${PREVIEW_K3S_KUBE_CONTEXT}" delete -n "${PREVIEW_NAMESPACE}" job migrations || true
-kubectl --kubeconfig "${PREVIEW_K3S_KUBE_PATH}" --context "${PREVIEW_K3S_KUBE_CONTEXT}" apply -f "${INSTALLER_RENDER_PATH}"
+# export the function so we can use it in xargs
+export -f diff-apply
+mkdir temp-installer || true
+pushd temp-installer
+# this will split the big yaml produced by the installer, so we can diff individual parts of it and run them in parallel
+yq4 -s '.kind + "_" + .metadata.name' "../${INSTALLER_RENDER_PATH}"
+rm .yml || true # this one is a leftover from the split
+# shellcheck disable=SC2038
+find . | xargs -n 1 -I {} -P 5 bash -c "diff-apply ${PREVIEW_K3S_KUBE_CONTEXT} {}"
+log_info "Applied all"
+popd
+rm -rf temp-installer
 rm -f "${INSTALLER_RENDER_PATH}"
 
 # =========================

--- a/dev/preview/workflow/preview/deploy-monitoring-satellite.sh
+++ b/dev/preview/workflow/preview/deploy-monitoring-satellite.sh
@@ -86,10 +86,7 @@ kubectl \
 echo "Applying generated manifests"
 for f in "${manifests_dir}"/*.yaml; do
     echo "Applying $f"
-    kubectl \
-        --kubeconfig "${PREVIEW_K3S_KUBE_PATH}" \
-        --context "${PREVIEW_K3S_KUBE_CONTEXT}" \
-        apply --server-side -f "${f}"
+    diff-apply "${PREVIEW_K3S_KUBE_CONTEXT}" "${f}"
 done
 
 echo "Patching grafana deployment"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Apply gitpod/monitoring-satellite resources only if there's a diff with the one in the cluster. Fixes some issues where resources exist when applied twice, and also should speed up the process somewhat

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [x] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
