### PR TITLE
[Dashboard] Open Project Context URLs in new tab

### DIFF
--- a/components/dashboard/src/projects/Project.tsx
+++ b/components/dashboard/src/projects/Project.tsx
@@ -197,7 +197,7 @@ export default function ProjectsPage() {
                 subtitle={
                     <h2 className="tracking-wide">
                         View recent active branches for{" "}
-                        <a className="gp-link" href={project?.cloneUrl!}>
+                        <a target="_blank" rel="noreferrer noopener" className="gp-link" href={project?.cloneUrl!}>
                             {toRemoteURL(project?.cloneUrl || "")}
                         </a>
                         .

--- a/components/dashboard/src/projects/ProjectListItem.tsx
+++ b/components/dashboard/src/projects/ProjectListItem.tsx
@@ -66,7 +66,7 @@ export const ProjectListItem: FunctionComponent<ProjectListItemProps> = ({ proje
                             />
                         </div>
                     </div>
-                    <a href={project.cloneUrl.replace(/\.git$/, "")}>
+                    <a target="_blank" rel="noreferrer noopener" href={project.cloneUrl.replace(/\.git$/, "")}>
                         <p className="hover:text-gray-600 dark:hover:text-gray-400 dark:text-gray-500 pr-10 truncate">
                             {toRemoteURL(project.cloneUrl)}
                         </p>


### PR DESCRIPTION
## Description
Always Open Project Context URLs (i.e. Repository URL of GitHub/GitLab/Bitbucket URLs) in new tab to not loose context of Gitpod Dashboard.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

- Go to `/projects` or `/projects/<YOUR_PROJECT_NAME>`
- Find your Repository URL & Click on it :smile:

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`


> Signed-off-by: Siddhant Khare <siddhant@gitpod.io>
