### PR TITLE
happy smoke test

### DIFF
--- a/.github/workflows/preview-env-check-regressions.yml
+++ b/.github/workflows/preview-env-check-regressions.yml
@@ -51,6 +51,8 @@ jobs:
         needs: [configuration]
         if: ${{ needs.configuration.outputs.skip == 'false' }}
         runs-on: [self-hosted]
+        container:
+            image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:kylos101-kubecdl-home.1
         steps:
             - uses: actions/checkout@v3
             - name: Create preview environment infrastructure
@@ -68,7 +70,58 @@ jobs:
                   sa_key: ${{ secrets.GCP_CREDENTIALS }}
                   version: ${{ needs.configuration.outputs.version}}
             - name: Check
+              shell: bash
+              env:
+                  ROBOQUAT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  USERNAME: ${{ secrets.IDE_INTEGRATION_TEST_USERNAME }}
+                  USER_TOKEN: ${{ secrets.IDE_INTEGRATION_TEST_USER_TOKEN }}
+                  PREVIEW_ENV_DEV_SA_KEY: ${{ secrets.GCP_CREDENTIALS }}
+                  PREVIEW_NAME: ${{ needs.configuration.outputs.name }}
               run: |
+                  set -euo pipefail
+
+                  export LEEWAY_WORKSPACE_ROOT="$(pwd)"
+                  export HOME="/home/gitpod"
+                  export PREVIEW_ENV_DEV_SA_KEY_PATH="/home/gitpod/.config/gcloud/preview-environment-dev-sa.json"
+
+                  echo "${PREVIEW_ENV_DEV_SA_KEY}" > "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
+                  gcloud auth activate-service-account --key-file "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
+
+                  leeway run dev/preview/previewctl:install
+
+                  echo "Setting up access to core-dev and harvester"
+                  previewctl get-credentials --gcp-service-account "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
+
+                  previewctl install-context --branch "${PREVIEW_NAME}" --log-level debug --timeout 1m --gcp-service-account "${PREVIEW_ENV_DEV_SA_KEY_PATH}"
+
+                  # start integration test
+                  args=()
+                  args+=( "-kubeconfig=/home/gitpod/.kube/config" )
+                  args+=( "-namespace=default" )
+                  [[ "$USERNAME" != "" ]] && args+=( "-username=$USERNAME" )
+                  args+=( "-timeout=60m" )
+
+                  TESTS_DIR="$GITHUB_WORKSPACE/test/tests/smoke-test"
+
+                  go install github.com/jstemmer/go-junit-report/v2@latest
+
+                  echo "running integration for smoke test"
+
+                  cd "${TESTS_DIR}"
+                  set +e
+                  go test -v ./... "${args[@]}" 2>&1 | go-junit-report -subtest-mode=exclude-parents -set-exit-code -out "TEST.xml" -iocopy
+                  RC=${PIPESTATUS[0]}
+                  set -e
+
+                  if [ "${RC}" -ne "0" ]; then
+                    exit ${RC}
+                  fi
+            - name: Test Summary
+              id: test_summary
+              uses: test-summary/action@v2
+              with:
+                  paths: "test/tests/**/TEST.xml"
+              if: always()
                   echo "No regressions caught because I didn't check anything 🤡 Sleeping for 2 minutes."
                   sleep 60
             - name: Delete preview environment

--- a/test/tests/smoke-test/main_test.go
+++ b/test/tests/smoke-test/main_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package smoketest
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/gitpod-io/gitpod/test/pkg/integration"
+	"sigs.k8s.io/e2e-framework/pkg/env"
+)
+
+var (
+	testEnv    env.Environment
+	username   string
+	namespace  string
+	kubeconfig string
+	gitlab     bool
+)
+
+func TestMain(m *testing.M) {
+	username, namespace, testEnv, _, kubeconfig, gitlab = integration.Setup(context.Background())
+	os.Exit(testEnv.Run(m))
+}

--- a/test/tests/smoke-test/smoke_test.go
+++ b/test/tests/smoke-test/smoke_test.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package smoketest
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+
+	"github.com/gitpod-io/gitpod/test/pkg/integration"
+)
+
+func TestStartWorkspaceWithImageBuild(t *testing.T) {
+	userToken, _ := os.LookupEnv("USER_TOKEN")
+	integration.SkipWithoutUsername(t, username)
+	integration.SkipWithoutUserToken(t, userToken)
+
+	f := features.New("Start regular workspace").
+		Assess("it can start a regular workspace with image build", func(_ context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+			defer cancel()
+
+			api := integration.NewComponentAPI(ctx, cfg.Namespace(), kubeconfig, cfg.Client())
+			t.Cleanup(func() {
+				api.Done(t)
+			})
+
+			_, err := api.CreateUser(username, userToken)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			_, stopWs, err := integration.LaunchWorkspaceFromContextURL(t, ctx, "imagebuild/https://github.com/gitpod-integration-test/example", username, api)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() {
+				sctx, scancel := context.WithTimeout(context.Background(), 5*time.Minute)
+				defer scancel()
+
+				sapi := integration.NewComponentAPI(sctx, cfg.Namespace(), kubeconfig, cfg.Client())
+				defer sapi.Done(t)
+
+				_, _ = stopWs(true, sapi)
+			}()
+			return ctx
+		}).
+		Feature()
+	testEnv.Test(t, f)
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

We want to improve gitpod to be more reliable, in case someone changes the common path, but does not verify, we want to run a simple smoke test for each successful main build

This test only contains
- start a private repo workspace with image build and stop it.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of #16196

## How to test
<!-- Provide steps to test this PR -->
1. go to [github action](https://github.com/gitpod-io/gitpod/actions/workflows/preview-env-check-regressions.yml) , run this action from this branch
2. make sure the test is pass.

e.g. https://github.com/gitpod-io/gitpod/actions/runs/4253507307

FYI, I change some code for wait image build, and already run integration test for workspace and ide, make sure it don't break anything (some failed are expected)

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
