### PR TITLE
[server] Send users to "/switch-to-payg?..." if switchToPAYG is set

### DIFF
--- a/components/server/ee/src/workspace/gitpod-server-impl.ts
+++ b/components/server/ee/src/workspace/gitpod-server-impl.ts
@@ -2462,6 +2462,11 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
             return [];
         }
 
+        // The "switchToPAYG" flag guards the new UI in Dashboard
+        const switchToPAYG = await this.configCatClientFactory().getValueAsync("switchToPAYG", false, {
+            user: this.user,
+        });
+
         const result: AppNotification[] = [];
         const now = new Date();
         const cbSubscriptions = await this.subscriptionService.getActivePaidSubscription(user.id, now);
@@ -2506,10 +2511,13 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
             if (!plan) {
                 continue;
             }
+            const url = switchToPAYG
+                ? `/switch-to-payg?personalSubscription=${personalSubscription.uid}`
+                : "https://www.gitpod.io/docs/configure/billing#configure-personal-billing";
             result.unshift({
                 message: `Your old subscription '${plan.name}' will be deprecated end of March.`,
                 action: {
-                    url: "https://www.gitpod.io/docs/configure/billing#configure-personal-billing",
+                    url,
                     label: "Switch to pay-as-you-go",
                 },
                 notClosable: true,
@@ -2520,10 +2528,13 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
             if (!plan) {
                 continue;
             }
+            const url = switchToPAYG
+                ? `/switch-to-payg?teamSubscription=${ownedTeamSubscription.id}`
+                : "https://www.gitpod.io/docs/configure/billing/org-plans";
             result.unshift({
                 message: `Your old Team Subscription '${plan.name}' will be deprecated soon.`,
                 action: {
-                    url: "https://www.gitpod.io/docs/configure/billing/org-plans",
+                    url,
                     label: "Switch to pay-as-you-go",
                 },
                 notClosable: true,
@@ -2534,10 +2545,13 @@ export class GitpodServerEEImpl extends GitpodServerImpl {
             if (!plan) {
                 continue;
             }
+            const url = switchToPAYG
+                ? `/switch-to-payg?teamSubscription2=${ownedTeamSubscription2.id}`
+                : "https://www.gitpod.io/docs/configure/billing#configure-organization-billing";
             result.unshift({
                 message: `The subscription '${plan.name}' for team '${team.name}' will be deprecated soon.`,
                 action: {
-                    url: "https://www.gitpod.io/docs/configure/billing#configure-organization-billing",
+                    url,
                     label: "Switch to pay-as-you-go",
                 },
                 notClosable: true,


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related to: https://github.com/gitpod-io/ops/issues/8388

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
