### PR TITLE
Improve ready probe labeler

### DIFF
--- a/dev/ready-probe-labeler/main.go
+++ b/dev/ready-probe-labeler/main.go
@@ -68,12 +68,13 @@ func main() {
 		log.Fatalf("Unexpected error: %v", err)
 	}
 
-	if opts.Shutdown {
-		err = updateLabel(opts.Label, false, nodeName, client)
-		if err != nil {
-			log.Fatalf("Unexpected error removing node label: %v", err)
-		}
+	// while we wait for the readiness probe, ensure the node does not have the label
+	err = updateLabel(opts.Label, false, nodeName, client)
+	if err != nil {
+		log.Fatalf("Unexpected error removing node label: %v", err)
+	}
 
+	if opts.Shutdown {
 		return
 	}
 


### PR DESCRIPTION
## Description

While we wait for the readiness probe, ensure the node does not have the label.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [x] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft with-integration-tests=workspace
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
