### PR TITLE
[ws-manager-mk2] Remove headless from status

### DIFF
--- a/components/ws-daemon/pkg/controller/workspace_controller.go
+++ b/components/ws-daemon/pkg/controller/workspace_controller.go
@@ -147,7 +147,7 @@ func (wsc *WorkspaceController) handleWorkspaceInit(ctx context.Context, ws *wor
 				InstanceId:  ws.Name,
 			},
 			Initializer: &init,
-			Headless:    ws.Status.Headless,
+			Headless:    ws.IsHeadless(),
 		})
 
 		if alreadyInit {

--- a/components/ws-manager-api/go/crd/v1/workspace_types.go
+++ b/components/ws-manager-api/go/crd/v1/workspace_types.go
@@ -250,6 +250,15 @@ type WorkspaceList struct {
 	Items           []Workspace `json:"items"`
 }
 
+// IsHeadless returns whether the workspace is a headless type.
+// This is added as a function on the workspace, instead of a field
+// in the status, to make it easier to consume and not e.g. have to
+// wait for the first reconcile of a workspace to set the status
+// resource.
+func (w *Workspace) IsHeadless() bool {
+	return w.Spec.Type != WorkspaceTypeRegular
+}
+
 func init() {
 	SchemeBuilder.Register(&Workspace{}, &WorkspaceList{})
 }

--- a/components/ws-manager-mk2/controllers/timeout_controller.go
+++ b/components/ws-manager-mk2/controllers/timeout_controller.go
@@ -182,7 +182,7 @@ func (r *TimeoutReconciler) isWorkspaceTimedOut(ws *workspacev1.Workspace) (reas
 			timeout = util.Duration(customTimeout.Duration)
 		}
 		activity := activityNone
-		if ws.Status.Headless {
+		if ws.IsHeadless() {
 			timeout = timeouts.HeadlessWorkspace
 			lastActivity = &start
 			activity = activityRunningHeadless

--- a/components/ws-manager-mk2/controllers/workspace_controller_test.go
+++ b/components/ws-manager-mk2/controllers/workspace_controller_test.go
@@ -54,7 +54,6 @@ var _ = Describe("WorkspaceController", func() {
 				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: ws.Name, Namespace: ws.Namespace}, ws)).To(Succeed())
 				g.Expect(ws.Status.OwnerToken).ToNot(BeEmpty())
 				g.Expect(ws.Status.URL).ToNot(BeEmpty())
-				g.Expect(ws.Status.Headless).To(BeFalse())
 			}, timeout, interval).Should(Succeed())
 
 			// TODO(wv): Once implemented, expect EverReady condition.
@@ -196,14 +195,8 @@ var _ = Describe("WorkspaceController", func() {
 			ws.Spec.Type = workspacev1.WorkspaceTypePrebuild
 			pod = createWorkspaceExpectPod(ws)
 
-			// Expect headless status to be reported.
-			Eventually(func() (bool, error) {
-				err := k8sClient.Get(ctx, types.NamespacedName{Name: ws.Name, Namespace: ws.Namespace}, ws)
-				if err != nil {
-					return false, err
-				}
-				return ws.Status.Headless, nil
-			}, timeout, interval).Should(BeTrue())
+			// Expect headless.
+			Expect(ws.IsHeadless()).To(BeTrue())
 
 			// Expect runtime status also gets reported for headless workspaces.
 			expectRuntimeStatus(ws, pod)

--- a/components/ws-manager-mk2/service/manager.go
+++ b/components/ws-manager-mk2/service/manager.go
@@ -819,7 +819,7 @@ func extractWorkspaceStatus(ws *workspacev1.Workspace) *wsmanapi.WorkspaceStatus
 				SupervisorRef: ws.Spec.Image.IDE.Supervisor,
 			},
 			IdeImageLayers: ws.Spec.Image.IDE.Refs,
-			Headless:       ws.Status.Headless,
+			Headless:       ws.IsHeadless(),
 			Url:            ws.Status.URL,
 			Type:           tpe,
 			Timeout:        timeout,


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Remove `Headless` from the workspace status, and instead introduce a `IsHeadless()` function on the `Workspace` type which uses the spec to determine if it's headless. Fixes a race where the status might not yet be set after creation, causing `Headless` to be false

## Related Issue(s)
<!-- List the issue(s) this PR solves -->

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
