### PR TITLE
[rebuild] remove notion of debug workspace from output

### DIFF
--- a/components/gitpod-cli/cmd/rebuild.go
+++ b/components/gitpod-cli/cmd/rebuild.go
@@ -174,10 +174,10 @@ func runRebuild(ctx context.Context, supervisorClient *supervisor.SupervisorClie
 	runLog.Logger.SetLevel(logrus.TraceLevel)
 	setLoggerFormatter(runLog.Logger)
 	runLog.Logger.SetOutput(os.Stdout)
-	runLog.Info("Starting the debug workspace...")
+	runLog.Info("Starting the workspace...")
 
 	if wsInfo.DebugWorkspaceType != api.DebugWorkspaceType_noDebug {
-		runLog.Error("It is not possible to restart the debug workspace while you are currently inside it.")
+		runLog.Error("It is not possible to restart the workspace while you are currently inside it.")
 		return GpError{Err: err, OutCome: utils.Outcome_UserErr, ErrorCode: utils.RebuildErrorCode_AlreadyInDebug, Silence: true}
 	}
 	stopDebugContainer(ctx, dockerPath)
@@ -293,7 +293,7 @@ func runRebuild(ctx context.Context, supervisorClient *supervisor.SupervisorClie
 
 		ssh := "ssh 'debug-" + wsInfo.WorkspaceId + "@" + workspaceUrl.Host + ".ssh." + wsInfo.WorkspaceClusterHost + "'"
 		sep := strings.Repeat("=", len(ssh))
-		runLog.Infof(`The Debug Workspace is UP!
+		runLog.Infof(`The workspace is UP!
 %s
 
 Open in Browser at:
@@ -303,7 +303,7 @@ Connect using SSH keys (https://gitpod.io/keys):
 %s
 
 %s`, sep, workspaceUrl, ssh, sep)
-		err := notify(ctx, supervisorClient, workspaceUrl.String(), "The Debug Workspace is UP.")
+		err := notify(ctx, supervisorClient, workspaceUrl.String(), "The workspace is UP.")
 		if err != nil && ctx.Err() == nil {
 			log.WithError(err).Error("failed to notify")
 		}
@@ -375,7 +375,7 @@ Connect using SSH keys (https://gitpod.io/keys):
 
 	err = runCmd.Start()
 	if err != nil {
-		fmt.Println("Failed to run a debug workspace")
+		fmt.Println("Failed to run a workspace")
 		return GpError{Err: err, OutCome: utils.Outcome_UserErr, ErrorCode: utils.RebuildErrorCode_DockerRunFailed, Silence: true}
 	}
 
@@ -388,7 +388,7 @@ Connect using SSH keys (https://gitpod.io/keys):
 	select {
 	case <-ctx.Done():
 		fmt.Println("")
-		logrus.Info("Gracefully stopping the debug workspace...")
+		logrus.Info("Gracefully stopping the workspace...")
 		stopDebugContainer(context.Background(), dockerPath)
 	case <-stopped:
 	}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

We don't want to introduce a new naming for workspace in workspace. This PR removes `debug` workspace notion from the output

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

- Open this PR on gitpod.io
- Run `go run . rebuild` to test.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
