### PR TITLE
Update gitpod-web extension

### DIFF
--- a/install/installer/cmd/testdata/render/agent-smith/output.golden
+++ b/install/installer/cmd/testdata/render/agent-smith/output.golden
@@ -3893,11 +3893,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-b83d82b9ee293b0559f11d09977d0e8e914d73f5",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-8612f777fb5c44227ca6f2b91f40fa0929637e22",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-266edb36ec96f3f0613715c6967fd4591fdd0569",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-8612f777fb5c44227ca6f2b91f40fa0929637e22",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-266edb36ec96f3f0613715c6967fd4591fdd0569",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/aws-setup/output.golden
+++ b/install/installer/cmd/testdata/render/aws-setup/output.golden
@@ -3334,11 +3334,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-b83d82b9ee293b0559f11d09977d0e8e914d73f5",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-8612f777fb5c44227ca6f2b91f40fa0929637e22",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-266edb36ec96f3f0613715c6967fd4591fdd0569",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-8612f777fb5c44227ca6f2b91f40fa0929637e22",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-266edb36ec96f3f0613715c6967fd4591fdd0569",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
+++ b/install/installer/cmd/testdata/render/custom-pull-repository/output.golden
@@ -3710,11 +3710,11 @@ data:
             "image": "registry.mydomain.com/namespace/ide/code:commit-b83d82b9ee293b0559f11d09977d0e8e914d73f5",
             "latestImage": "registry.mydomain.com/namespace/ide/code:nightly",
             "imageLayers": [
-              "registry.mydomain.com/namespace/ide/gitpod-code-web:commit-8612f777fb5c44227ca6f2b91f40fa0929637e22",
+              "registry.mydomain.com/namespace/ide/gitpod-code-web:commit-266edb36ec96f3f0613715c6967fd4591fdd0569",
               "registry.mydomain.com/namespace/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "registry.mydomain.com/namespace/ide/gitpod-code-web:commit-8612f777fb5c44227ca6f2b91f40fa0929637e22",
+              "registry.mydomain.com/namespace/ide/gitpod-code-web:commit-266edb36ec96f3f0613715c6967fd4591fdd0569",
               "registry.mydomain.com/namespace/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/customization/output.golden
+++ b/install/installer/cmd/testdata/render/customization/output.golden
@@ -4262,11 +4262,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-b83d82b9ee293b0559f11d09977d0e8e914d73f5",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-8612f777fb5c44227ca6f2b91f40fa0929637e22",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-266edb36ec96f3f0613715c6967fd4591fdd0569",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-8612f777fb5c44227ca6f2b91f40fa0929637e22",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-266edb36ec96f3f0613715c6967fd4591fdd0569",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/external-registry/output.golden
+++ b/install/installer/cmd/testdata/render/external-registry/output.golden
@@ -3544,11 +3544,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-b83d82b9ee293b0559f11d09977d0e8e914d73f5",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-8612f777fb5c44227ca6f2b91f40fa0929637e22",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-266edb36ec96f3f0613715c6967fd4591fdd0569",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-8612f777fb5c44227ca6f2b91f40fa0929637e22",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-266edb36ec96f3f0613715c6967fd4591fdd0569",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/gcp-setup/output.golden
+++ b/install/installer/cmd/testdata/render/gcp-setup/output.golden
@@ -3429,11 +3429,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-b83d82b9ee293b0559f11d09977d0e8e914d73f5",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-8612f777fb5c44227ca6f2b91f40fa0929637e22",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-266edb36ec96f3f0613715c6967fd4591fdd0569",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-8612f777fb5c44227ca6f2b91f40fa0929637e22",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-266edb36ec96f3f0613715c6967fd4591fdd0569",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/http-proxy/output.golden
+++ b/install/installer/cmd/testdata/render/http-proxy/output.golden
@@ -3713,11 +3713,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-b83d82b9ee293b0559f11d09977d0e8e914d73f5",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-8612f777fb5c44227ca6f2b91f40fa0929637e22",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-266edb36ec96f3f0613715c6967fd4591fdd0569",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-8612f777fb5c44227ca6f2b91f40fa0929637e22",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-266edb36ec96f3f0613715c6967fd4591fdd0569",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/ide-config/output.golden
+++ b/install/installer/cmd/testdata/render/ide-config/output.golden
@@ -3726,11 +3726,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-b83d82b9ee293b0559f11d09977d0e8e914d73f5",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-8612f777fb5c44227ca6f2b91f40fa0929637e22",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-266edb36ec96f3f0613715c6967fd4591fdd0569",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-8612f777fb5c44227ca6f2b91f40fa0929637e22",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-266edb36ec96f3f0613715c6967fd4591fdd0569",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/kind-ide/output.golden
+++ b/install/installer/cmd/testdata/render/kind-ide/output.golden
@@ -1290,11 +1290,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-b83d82b9ee293b0559f11d09977d0e8e914d73f5",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-8612f777fb5c44227ca6f2b91f40fa0929637e22",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-266edb36ec96f3f0613715c6967fd4591fdd0569",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-8612f777fb5c44227ca6f2b91f40fa0929637e22",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-266edb36ec96f3f0613715c6967fd4591fdd0569",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/kind-meta/output.golden
+++ b/install/installer/cmd/testdata/render/kind-meta/output.golden
@@ -2678,11 +2678,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-b83d82b9ee293b0559f11d09977d0e8e914d73f5",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-8612f777fb5c44227ca6f2b91f40fa0929637e22",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-266edb36ec96f3f0613715c6967fd4591fdd0569",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-8612f777fb5c44227ca6f2b91f40fa0929637e22",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-266edb36ec96f3f0613715c6967fd4591fdd0569",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/message-bus-password/output.golden
+++ b/install/installer/cmd/testdata/render/message-bus-password/output.golden
@@ -3713,11 +3713,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-b83d82b9ee293b0559f11d09977d0e8e914d73f5",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-8612f777fb5c44227ca6f2b91f40fa0929637e22",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-266edb36ec96f3f0613715c6967fd4591fdd0569",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-8612f777fb5c44227ca6f2b91f40fa0929637e22",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-266edb36ec96f3f0613715c6967fd4591fdd0569",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/minimal/output.golden
+++ b/install/installer/cmd/testdata/render/minimal/output.golden
@@ -3710,11 +3710,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-b83d82b9ee293b0559f11d09977d0e8e914d73f5",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-8612f777fb5c44227ca6f2b91f40fa0929637e22",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-266edb36ec96f3f0613715c6967fd4591fdd0569",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-8612f777fb5c44227ca6f2b91f40fa0929637e22",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-266edb36ec96f3f0613715c6967fd4591fdd0569",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/overrides-inline/output.golden
+++ b/install/installer/cmd/testdata/render/overrides-inline/output.golden
@@ -3708,11 +3708,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-b83d82b9ee293b0559f11d09977d0e8e914d73f5",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-8612f777fb5c44227ca6f2b91f40fa0929637e22",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-266edb36ec96f3f0613715c6967fd4591fdd0569",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-8612f777fb5c44227ca6f2b91f40fa0929637e22",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-266edb36ec96f3f0613715c6967fd4591fdd0569",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/pod-config/output.golden
+++ b/install/installer/cmd/testdata/render/pod-config/output.golden
@@ -3717,11 +3717,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-b83d82b9ee293b0559f11d09977d0e8e914d73f5",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-8612f777fb5c44227ca6f2b91f40fa0929637e22",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-266edb36ec96f3f0613715c6967fd4591fdd0569",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-8612f777fb5c44227ca6f2b91f40fa0929637e22",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-266edb36ec96f3f0613715c6967fd4591fdd0569",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/shortname/output.golden
+++ b/install/installer/cmd/testdata/render/shortname/output.golden
@@ -3710,11 +3710,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-b83d82b9ee293b0559f11d09977d0e8e914d73f5",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-8612f777fb5c44227ca6f2b91f40fa0929637e22",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-266edb36ec96f3f0613715c6967fd4591fdd0569",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-8612f777fb5c44227ca6f2b91f40fa0929637e22",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-266edb36ec96f3f0613715c6967fd4591fdd0569",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/statefulset-customization/output.golden
+++ b/install/installer/cmd/testdata/render/statefulset-customization/output.golden
@@ -3722,11 +3722,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-b83d82b9ee293b0559f11d09977d0e8e914d73f5",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-8612f777fb5c44227ca6f2b91f40fa0929637e22",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-266edb36ec96f3f0613715c6967fd4591fdd0569",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-8612f777fb5c44227ca6f2b91f40fa0929637e22",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-266edb36ec96f3f0613715c6967fd4591fdd0569",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/telemetry/output.golden
+++ b/install/installer/cmd/testdata/render/telemetry/output.golden
@@ -3713,11 +3713,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-b83d82b9ee293b0559f11d09977d0e8e914d73f5",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-8612f777fb5c44227ca6f2b91f40fa0929637e22",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-266edb36ec96f3f0613715c6967fd4591fdd0569",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-8612f777fb5c44227ca6f2b91f40fa0929637e22",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-266edb36ec96f3f0613715c6967fd4591fdd0569",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
+++ b/install/installer/cmd/testdata/render/use-pod-security-policies/output.golden
@@ -4043,11 +4043,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-b83d82b9ee293b0559f11d09977d0e8e914d73f5",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-8612f777fb5c44227ca6f2b91f40fa0929637e22",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-266edb36ec96f3f0613715c6967fd4591fdd0569",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-8612f777fb5c44227ca6f2b91f40fa0929637e22",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-266edb36ec96f3f0613715c6967fd4591fdd0569",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
+++ b/install/installer/cmd/testdata/render/vsxproxy-pvc/output.golden
@@ -3713,11 +3713,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-b83d82b9ee293b0559f11d09977d0e8e914d73f5",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-8612f777fb5c44227ca6f2b91f40fa0929637e22",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-266edb36ec96f3f0613715c6967fd4591fdd0569",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-8612f777fb5c44227ca6f2b91f40fa0929637e22",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-266edb36ec96f3f0613715c6967fd4591fdd0569",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
+++ b/install/installer/cmd/testdata/render/workspace-requests-limits/output.golden
@@ -3713,11 +3713,11 @@ data:
             "image": "eu.gcr.io/gitpod-core-dev/build/ide/code:commit-b83d82b9ee293b0559f11d09977d0e8e914d73f5",
             "latestImage": "eu.gcr.io/gitpod-core-dev/build/ide/code:nightly",
             "imageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-8612f777fb5c44227ca6f2b91f40fa0929637e22",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-266edb36ec96f3f0613715c6967fd4591fdd0569",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ],
             "latestImageLayers": [
-              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-8612f777fb5c44227ca6f2b91f40fa0929637e22",
+              "eu.gcr.io/gitpod-core-dev/build/ide/gitpod-code-web:commit-266edb36ec96f3f0613715c6967fd4591fdd0569",
               "eu.gcr.io/gitpod-core-dev/build/ide/code-codehelper:test"
             ]
           },

--- a/install/installer/pkg/components/workspace/ide/constants.go
+++ b/install/installer/pkg/components/workspace/ide/constants.go
@@ -9,7 +9,7 @@ const (
 	CodeIDEImageStableVersion   = "commit-b83d82b9ee293b0559f11d09977d0e8e914d73f5" // stable version that will be updated manually on demand
 	CodeHelperIDEImage          = "ide/code-codehelper"
 	CodeWebExtensionImage       = "ide/gitpod-code-web"
-	CodeWebExtensionVersion     = "commit-8612f777fb5c44227ca6f2b91f40fa0929637e22" // gitpod-web extension version comes from https://github.com/gitpod-io/gitpod-code
+	CodeWebExtensionVersion     = "commit-266edb36ec96f3f0613715c6967fd4591fdd0569" // gitpod-web extension version comes from https://github.com/gitpod-io/gitpod-code
 	CodeDesktopIDEImage         = "ide/code-desktop"
 	CodeDesktopInsidersIDEImage = "ide/code-desktop-insiders"
 	IntelliJDesktopIDEImage     = "ide/intellij"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Related https://github.com/gitpod-io/gitpod/issues/16376#

## How to test
<!-- Provide steps to test this PR -->
1. Check port status bar distinguishes between public and private ports

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
