### PR TITLE
Add confetti after new onboarding flow

### DIFF
--- a/components/dashboard/package.json
+++ b/components/dashboard/package.json
@@ -30,6 +30,7 @@
     "react-popper": "^2.3.0",
     "react-portal": "^4.2.2",
     "react-router-dom": "^5.2.0",
+    "validator": "^13.9.0",
     "xterm": "^4.11.0",
     "xterm-addon-fit": "^0.5.0"
   },
@@ -50,6 +51,7 @@
     "@types/react-router": "^5.1.13",
     "@types/react-router-dom": "^5.1.7",
     "@types/uuid": "^8.3.1",
+    "@types/validator": "^13.7.12",
     "@typescript-eslint/eslint-plugin": "^4.21.0",
     "@typescript-eslint/parser": "^4.21.0",
     "autoprefixer": "^9.8.6",

--- a/components/dashboard/package.json
+++ b/components/dashboard/package.json
@@ -23,6 +23,7 @@
     "monaco-editor": "^0.25.2",
     "query-string": "^7.1.1",
     "react": "^17.0.1",
+    "react-confetti": "^6.1.0",
     "react-datepicker": "^4.8.0",
     "react-dom": "^17.0.1",
     "react-intl-tel-input": "^8.2.0",

--- a/components/dashboard/src/app/AppRoutes.tsx
+++ b/components/dashboard/src/app/AppRoutes.tsx
@@ -6,7 +6,7 @@
 
 import { ContextURL, Team, User } from "@gitpod/gitpod-protocol";
 import React, { FunctionComponent, useContext, useState } from "react";
-import { Redirect, Route, Switch, useLocation, useParams } from "react-router";
+import { Redirect, Route, Switch, useLocation } from "react-router";
 import { AppNotifications } from "../AppNotifications";
 import Menu from "../menu/Menu";
 import OAuthClientApproval from "../OauthClientApproval";

--- a/components/dashboard/src/contexts/ConfettiContext.tsx
+++ b/components/dashboard/src/contexts/ConfettiContext.tsx
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { lazy, createContext, FC, useMemo, useState, useContext } from "react";
+
+const Confetti = lazy(() => import(/* webpackPrefetch: true */ "react-confetti"));
+
+type ConfettiContextType = {
+    isConfettiShowing: boolean;
+    showConfetti(): void;
+    hideConfetti(): void;
+};
+const ConfettiContext = createContext<ConfettiContextType>({
+    isConfettiShowing: false,
+    showConfetti: () => undefined,
+    hideConfetti: () => undefined,
+});
+
+export const ConfettiContextProvider: FC = ({ children }) => {
+    const [showConfetti, setShowConfetti] = useState(false);
+    const value = useMemo(() => {
+        return {
+            isConfettiShowing: showConfetti,
+            showConfetti: () => setShowConfetti(true),
+            hideConfetti: () => setShowConfetti(false),
+        };
+    }, [showConfetti]);
+
+    return (
+        <ConfettiContext.Provider value={value}>
+            {children}
+            {showConfetti && (
+                <Confetti recycle={false} numberOfPieces={300} onConfettiComplete={() => setShowConfetti(false)} />
+            )}
+        </ConfettiContext.Provider>
+    );
+};
+
+export const useConfetti = () => {
+    return useContext(ConfettiContext);
+};

--- a/components/dashboard/src/contexts/ConfettiContext.tsx
+++ b/components/dashboard/src/contexts/ConfettiContext.tsx
@@ -4,7 +4,7 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { lazy, createContext, FC, useMemo, useState, useContext } from "react";
+import { lazy, createContext, FC, useMemo, useState, useContext, Suspense } from "react";
 
 const Confetti = lazy(() => import(/* webpackPrefetch: true */ "react-confetti"));
 
@@ -33,7 +33,9 @@ export const ConfettiContextProvider: FC = ({ children }) => {
         <ConfettiContext.Provider value={value}>
             {children}
             {isConfettiDropping && (
-                <Confetti recycle={false} numberOfPieces={300} onConfettiComplete={value.hideConfetti} />
+                <Suspense fallback={<></>}>
+                    <Confetti recycle={false} numberOfPieces={300} onConfettiComplete={value.hideConfetti} />
+                </Suspense>
             )}
         </ConfettiContext.Provider>
     );

--- a/components/dashboard/src/contexts/ConfettiContext.tsx
+++ b/components/dashboard/src/contexts/ConfettiContext.tsx
@@ -9,31 +9,31 @@ import { lazy, createContext, FC, useMemo, useState, useContext } from "react";
 const Confetti = lazy(() => import(/* webpackPrefetch: true */ "react-confetti"));
 
 type ConfettiContextType = {
-    isConfettiShowing: boolean;
-    showConfetti(): void;
+    isConfettiDropping: boolean;
+    dropConfetti(): void;
     hideConfetti(): void;
 };
 const ConfettiContext = createContext<ConfettiContextType>({
-    isConfettiShowing: false,
-    showConfetti: () => undefined,
+    isConfettiDropping: false,
+    dropConfetti: () => undefined,
     hideConfetti: () => undefined,
 });
 
 export const ConfettiContextProvider: FC = ({ children }) => {
-    const [showConfetti, setShowConfetti] = useState(false);
+    const [isConfettiDropping, setIsConfettiDropping] = useState(false);
     const value = useMemo(() => {
         return {
-            isConfettiShowing: showConfetti,
-            showConfetti: () => setShowConfetti(true),
-            hideConfetti: () => setShowConfetti(false),
+            isConfettiDropping: isConfettiDropping,
+            dropConfetti: () => setIsConfettiDropping(true),
+            hideConfetti: () => setIsConfettiDropping(false),
         };
-    }, [showConfetti]);
+    }, [isConfettiDropping]);
 
     return (
         <ConfettiContext.Provider value={value}>
             {children}
-            {showConfetti && (
-                <Confetti recycle={false} numberOfPieces={300} onConfettiComplete={() => setShowConfetti(false)} />
+            {isConfettiDropping && (
+                <Confetti recycle={false} numberOfPieces={300} onConfettiComplete={value.hideConfetti} />
             )}
         </ConfettiContext.Provider>
     );

--- a/components/dashboard/src/index.tsx
+++ b/components/dashboard/src/index.tsx
@@ -25,6 +25,7 @@ import { isWebsiteSlug } from "./utils";
 
 import "./index.css";
 import { setupQueryClientProvider } from "./data/setup";
+import { ConfettiContextProvider } from "./contexts/ConfettiContext";
 
 const bootApp = () => {
     // gitpod.io specific boot logic
@@ -57,27 +58,29 @@ const bootApp = () => {
     ReactDOM.render(
         <React.StrictMode>
             <GitpodQueryClientProvider>
-                <UserContextProvider>
-                    <AdminContextProvider>
-                        <PaymentContextProvider>
-                            <LicenseContextProvider>
-                                <TeamsContextProvider>
-                                    <ProjectContextProvider>
-                                        <ThemeContextProvider>
-                                            <StartWorkspaceModalContextProvider>
-                                                <BrowserRouter>
-                                                    <FeatureFlagContextProvider>
-                                                        <App />
-                                                    </FeatureFlagContextProvider>
-                                                </BrowserRouter>
-                                            </StartWorkspaceModalContextProvider>
-                                        </ThemeContextProvider>
-                                    </ProjectContextProvider>
-                                </TeamsContextProvider>
-                            </LicenseContextProvider>
-                        </PaymentContextProvider>
-                    </AdminContextProvider>
-                </UserContextProvider>
+                <ConfettiContextProvider>
+                    <UserContextProvider>
+                        <AdminContextProvider>
+                            <PaymentContextProvider>
+                                <LicenseContextProvider>
+                                    <TeamsContextProvider>
+                                        <ProjectContextProvider>
+                                            <ThemeContextProvider>
+                                                <StartWorkspaceModalContextProvider>
+                                                    <BrowserRouter>
+                                                        <FeatureFlagContextProvider>
+                                                            <App />
+                                                        </FeatureFlagContextProvider>
+                                                    </BrowserRouter>
+                                                </StartWorkspaceModalContextProvider>
+                                            </ThemeContextProvider>
+                                        </ProjectContextProvider>
+                                    </TeamsContextProvider>
+                                </LicenseContextProvider>
+                            </PaymentContextProvider>
+                        </AdminContextProvider>
+                    </UserContextProvider>
+                </ConfettiContextProvider>
             </GitpodQueryClientProvider>
         </React.StrictMode>,
         document.getElementById("root"),

--- a/components/dashboard/src/onboarding/StepOrgInfo.tsx
+++ b/components/dashboard/src/onboarding/StepOrgInfo.tsx
@@ -15,6 +15,7 @@ import { getExplorationReasons } from "./exploration-reasons";
 import { getJobRoleOptions, JOB_ROLE_OTHER } from "./job-roles";
 import { OnboardingStep } from "./OnboardingStep";
 import { getSignupGoalsOptions, SIGNUP_GOALS_OTHER } from "./signup-goals";
+import isURL from "validator/lib/isURL";
 
 type Props = {
     user: User;
@@ -127,7 +128,9 @@ export const StepOrgInfo: FC<Props> = ({ user, onComplete }) => {
     ]);
 
     const jobRoleError = useOnBlurError("Please select one", !!jobRole);
-    const isValid = jobRoleError.isValid && signupGoals.length > 0;
+    const websiteError = useOnBlurError("Please enter a valid url", !companyWebsite || isURL(companyWebsite));
+    const isValid =
+        jobRoleError.isValid && websiteError.isValid && signupGoals.length > 0 && explorationReasons.length > 0;
 
     return (
         <OnboardingStep
@@ -178,9 +181,10 @@ export const StepOrgInfo: FC<Props> = ({ user, onComplete }) => {
             <TextInputField
                 value={companyWebsite}
                 label="Company Website (optional)"
-                type="url"
-                placeholder="https://"
+                placeholder="example.com"
+                error={websiteError.message}
                 onChange={setCompanyWebsite}
+                onBlur={websiteError.onBlur}
             />
 
             <InputField label="I'm exploring Gitpod..." />

--- a/components/dashboard/src/onboarding/UserOnboarding.tsx
+++ b/components/dashboard/src/onboarding/UserOnboarding.tsx
@@ -15,6 +15,7 @@ import { StepOrgInfo } from "./StepOrgInfo";
 import { StepPersonalize } from "./StepPersonalize";
 import { useUpdateCurrentUserMutation } from "../data/current-user/update-mutation";
 import Alert from "../components/Alert";
+import { useConfetti } from "../contexts/ConfettiContext";
 
 // This param is optionally present to force an onboarding flow
 // Can be used if other conditions aren't true, i.e. if user has already onboarded, but we want to force the flow again
@@ -34,6 +35,7 @@ const UserOnboarding: FunctionComponent<Props> = ({ user }) => {
     const location = useLocation();
     const { setUser } = useContext(UserContext);
     const updateUser = useUpdateCurrentUserMutation();
+    const { showConfetti } = useConfetti();
 
     const [step, setStep] = useState(STEPS.ONE);
     const [completingError, setCompletingError] = useState("");
@@ -73,6 +75,7 @@ const UserOnboarding: FunctionComponent<Props> = ({ user }) => {
 
                 try {
                     const onboardedUser = await updateUser.mutateAsync(updates);
+                    showConfetti();
                     setUser(onboardedUser);
 
                     // Look for the `onboarding=force` query param, and remove if present
@@ -101,6 +104,7 @@ const UserOnboarding: FunctionComponent<Props> = ({ user }) => {
             location.pathname,
             location.search,
             setUser,
+            showConfetti,
             updateUser,
         ],
     );

--- a/components/dashboard/src/onboarding/UserOnboarding.tsx
+++ b/components/dashboard/src/onboarding/UserOnboarding.tsx
@@ -35,7 +35,7 @@ const UserOnboarding: FunctionComponent<Props> = ({ user }) => {
     const location = useLocation();
     const { setUser } = useContext(UserContext);
     const updateUser = useUpdateCurrentUserMutation();
-    const { showConfetti } = useConfetti();
+    const { dropConfetti } = useConfetti();
 
     const [step, setStep] = useState(STEPS.ONE);
     const [completingError, setCompletingError] = useState("");
@@ -75,7 +75,7 @@ const UserOnboarding: FunctionComponent<Props> = ({ user }) => {
 
                 try {
                     const onboardedUser = await updateUser.mutateAsync(updates);
-                    showConfetti();
+                    dropConfetti();
                     setUser(onboardedUser);
 
                     // Look for the `onboarding=force` query param, and remove if present
@@ -104,7 +104,7 @@ const UserOnboarding: FunctionComponent<Props> = ({ user }) => {
             location.pathname,
             location.search,
             setUser,
-            showConfetti,
+            dropConfetti,
             updateUser,
         ],
     );

--- a/components/dashboard/src/onboarding/UserOnboarding.tsx
+++ b/components/dashboard/src/onboarding/UserOnboarding.tsx
@@ -89,6 +89,7 @@ const UserOnboarding: FunctionComponent<Props> = ({ user }) => {
                         });
                     }
                 } catch (e) {
+                    console.log("error caught", e);
                     console.error(e);
                     setCompletingError("There was a problem completing your onboarding");
                 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -15129,6 +15129,13 @@ react-app-polyfill@^2.0.0:
     regenerator-runtime "^0.13.7"
     whatwg-fetch "^3.4.1"
 
+react-confetti@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/react-confetti/-/react-confetti-6.1.0.tgz#03dc4340d955acd10b174dbf301f374a06e29ce6"
+  integrity sha512-7Ypx4vz0+g8ECVxr88W9zhcQpbeujJAVqL14ZnXJ3I23mOI9/oBVTQ3dkJhUmB0D6XOtCZEM6N0Gm9PMngkORw==
+  dependencies:
+    tween-functions "^1.2.0"
+
 react-datepicker@^4.8.0:
   version "4.8.0"
   resolved "https://registry.yarnpkg.com/react-datepicker/-/react-datepicker-4.8.0.tgz#11b8918d085a1ce4781eee4c8e4641b3cd592010"
@@ -17739,6 +17746,11 @@ tunnel@0.0.6:
   version "0.0.6"
   resolved "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz"
   integrity sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==
+
+tween-functions@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/tween-functions/-/tween-functions-1.2.0.tgz#1ae3a50e7c60bb3def774eac707acbca73bbc3ff"
+  integrity sha512-PZBtLYcCLtEcjL14Fzb1gSxPBeL7nWvGhO5ZFPGqziCcr8uvHp0NDmdjBchp6KHL+tExcg0m3NISmKxhU394dA==
 
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3428,6 +3428,11 @@
   resolved "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.1.tgz"
   integrity sha512-Y2mHTRAbqfFkpjldbkHGY8JIzRN6XqYRliG8/24FcHm2D2PwW24fl5xMRTVGdrb7iMrwCaIEbLWerGIkXuFWVg==
 
+"@types/validator@^13.7.12":
+  version "13.7.12"
+  resolved "https://registry.yarnpkg.com/@types/validator/-/validator-13.7.12.tgz#a285379b432cc8d103b69d223cbb159a253cf2f7"
+  integrity sha512-YVtyAPqpefU+Mm/qqnOANW6IkqKpCSrarcyV269C8MA8Ux0dbkEuQwM/4CjL47kVEM2LgBef/ETfkH+c6+moFA==
+
 "@types/webpack-sources@*":
   version "3.2.0"
   resolved "https://registry.npmjs.org/@types/webpack-sources/-/webpack-sources-3.2.0.tgz"
@@ -18263,6 +18268,11 @@ validate-npm-package-license@^3.0.1:
   dependencies:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
+
+validator@^13.9.0:
+  version "13.9.0"
+  resolved "https://registry.yarnpkg.com/validator/-/validator-13.9.0.tgz#33e7b85b604f3bbce9bb1a05d5c3e22e1c2ff855"
+  integrity sha512-B+dGG8U3fdtM0/aNK4/X8CXq/EcxU2WPrPEkJGslb47qyHsxmbggTWK0yEA4qnYVNF+nxNlN88o14hIcPmSIEA==
 
 value-equal@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
* Updates the `Company Website` input to accept any string that validates as a url and not use an `<input type="url"/>`, as it's more restrictive then we'd like. Also updated the placeholder to `example.com`

* Adds a `ConfettiContextProvider` to drop confetti on demand from any component. The end of the new onboarding flow drops confetti now with this change.

![image](https://user-images.githubusercontent.com/367275/221059333-93127da5-fdbe-4f58-a1d3-455330b583c8.png)

```ts
const { showConfetti } = useConfetti();

// walla, drop confetti
showConfetti();
```

Confetti will automatically hide after it's all been dropped. You can also manually hide it, or inspect the current status of it's it being shown via additional props returned from the `useConfetti()` hook.

```ts
const { isConfettiShowing, showConfetti, hideConfetti } = useConfetti();
```

* 2 new dependencies were added for this PR as well.
  * `validator` (we're using this on the www website already) to validate a url string
  * `react-confetti` For confetti dropping. I've set it up to bundle split and lazy load so it's not including in the main bundle.
 
## How to test
<!-- Provide steps to test this PR -->
* Ensure your email is added to the `newSignupFlow` feature flag.
* Preview Env: https://bmh-onboar77a0b587f5.preview.gitpod-dev.com/workspaces
* Complete the onboarding flow in the preview environment. 
* Company Website should accept a value like `gitpod.io` and not need a full url with a protocol.
* You should see confetti drop at the end of it.
* You can repeat the onboarding flow by visiting https://bmh-onboar77a0b587f5.preview.gitpod-dev.com/workspaces?onboarding=force

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
