### PR TITLE
[ssh-gateway] support stderr forward in shell session

### DIFF
--- a/components/ws-proxy/pkg/sshproxy/forward.go
+++ b/components/ws-proxy/pkg/sshproxy/forward.go
@@ -63,6 +63,14 @@ func (s *Server) ChannelForward(ctx context.Context, session *Session, targetCon
 		originChan.CloseWrite()
 	}()
 
+	go func() {
+		io.Copy(targetChan.Stderr(), originChan.Stderr())
+	}()
+
+	go func() {
+		io.Copy(originChan.Stderr(), targetChan.Stderr())
+	}()
+
 	wg := sync.WaitGroup{}
 	forward := func(sourceReqs <-chan *ssh.Request, targetChan ssh.Channel) {
 		defer wg.Done()


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
[ssh-gateway] support stderr forward in shell session

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
1. start a workspace in preview env
2. copy ssh connection string
3. run `ssh 'workspaceId#ownerToken@host' 'ls ---- || sleep 2'`
4. it should be output stderr

```
ls: unrecognized option '----'
Try 'ls --help' for more information.
```

there still have issue if command too quick finish, gateway don't have enough time to forward message, but that not part for this PR, so add `sleep 2` to bypass this issue.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
[ssh-gateway] support stderr forward in shell session
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
