### PR TITLE
Support forward https protocol port

### DIFF
--- a/components/gitpod-cli/cmd/ports-list.go
+++ b/components/gitpod-cli/cmd/ports-list.go
@@ -42,7 +42,7 @@ var listPortsCmd = &cobra.Command{
 		}
 
 		table := tablewriter.NewWriter(os.Stdout)
-		table.SetHeader([]string{"Port", "Status", "URL", "Name & Description"})
+		table.SetHeader([]string{"Port", "Status", "Protocol", "URL", "Name & Description"})
 		table.SetBorders(tablewriter.Border{Left: true, Top: false, Right: true, Bottom: false})
 		table.SetCenterSeparator("|")
 
@@ -101,7 +101,7 @@ var listPortsCmd = &cobra.Command{
 			}
 
 			table.Rich(
-				[]string{fmt.Sprint(port.LocalPort), status, exposedUrl, nameAndDescription},
+				[]string{fmt.Sprint(port.LocalPort), status, port.Exposed.Protocol.String(), exposedUrl, nameAndDescription},
 				colors,
 			)
 		}

--- a/components/supervisor/go.mod
+++ b/components/supervisor/go.mod
@@ -45,6 +45,8 @@ require (
 	gopkg.in/yaml.v3 v3.0.1
 )
 
+require inet.af/tcpproxy v0.0.0-20221017015627-91f861402626 // indirect
+
 require (
 	cloud.google.com/go v0.110.0 // indirect
 	cloud.google.com/go/compute v1.18.0 // indirect

--- a/components/supervisor/go.sum
+++ b/components/supervisor/go.sum
@@ -15,6 +15,7 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/HdrHistogram/hdrhistogram-go v1.1.0 h1:6dpdDPTRoo78HxAJ6T1HfMiKSnqhgRRqzCuPshRkQ7I=
 github.com/Netflix/go-env v0.0.0-20220526054621-78278af1949d h1:wvStE9wLpws31NiWUx+38wny1msZ/tm+eL5xmm4Y7So=
 github.com/Netflix/go-env v0.0.0-20220526054621-78278af1949d/go.mod h1:9XMFaCeRyW7fC9XJOWQ+NdAv8VLG7ys7l3x4ozEGLUQ=
+github.com/armon/go-proxyproto v0.0.0-20210323213023-7e956b284f0a/go.mod h1:QmP9hvJ91BbJmGVGSbutW19IC0Q9phDCLGaomwTJbgU=
 github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d h1:Byv0BzEl3/e6D5CLfI0j/7hiIEtvGVFPCZ7Ei2oq8iQ=
 github.com/aws/aws-sdk-go-v2 v1.17.1 h1:02c72fDJr87N8RAC2s3Qu0YuvMRZKNZJ9F+lAehCazk=
 github.com/aws/aws-sdk-go-v2 v1.17.1/go.mod h1:JLnGeGONAyi2lWXI1p0PCIOIy333JMVK1U7Hf0aRFLw=
@@ -468,5 +469,7 @@ gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
+inet.af/tcpproxy v0.0.0-20221017015627-91f861402626 h1:2dMP3Ox/Wh5BiItwOt4jxRsfzkgyBrHzx2nW28Yg6nc=
+inet.af/tcpproxy v0.0.0-20221017015627-91f861402626/go.mod h1:Tojt5kmHpDIR2jMojxzZK2w2ZR7OILODmUo2gaSwjrk=
 nhooyr.io/websocket v1.8.7 h1:usjR2uOr/zjjkVMy0lW+PPohFok7PCow5sDjLgX4P4g=
 nhooyr.io/websocket v1.8.7/go.mod h1:B70DZP8IakI65RVQ51MsWP/8jndNma26DVA/nFSCgW0=


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Support "Change port protocol" (HTTP/HTTPS)

Some user using `https` for their service, but now Gitpod only support forward `http` protocol, which means these service cannot visit in workspace ports url, they only can test it via local-desktop IDE (ssh port-forward)

This PR also changes supervisor port forward using nftable, it support any protocol, more fast and easy.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Part of #15915

## How to test
<!-- Provide steps to test this PR -->
1. start a workspace with this repo https://github.com/iQQBot/test.test/tree/https in [preview env](https://pd-port-15915.preview.gitpod-dev.com/workspaces)
2. it should able access port 5173 via workspace port url
3. use `curl https://localhost:5173 -v -k` make sure protocol is https
4. you can also using `gp ports protocol 5173:https` to change protocol
5. or define port protocol in `.gitpod.yml`
6. change `vite.config.ts`, remove line `host: '0.0.0.0',` and restart vite, make sure workspace port URL still can work.

if you run `sudo lsof -i :5173` you should see two listen, the one is from node, the other one is from supervisor
<img width="677" alt="image" src="https://github.com/gitpod-io/gitpod/assets/8299500/5249dac0-816a-48cd-9af8-e9e838394ad0">

if you close node server, run `sudo lsof -i :5173` again, you should see clean list
<img width="517" alt="image" src="https://github.com/gitpod-io/gitpod/assets/8299500/46ca1639-566c-4396-bd83-92635e9454f3">



## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Support forward https protocol port
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-dedicated-emulation
- [x] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
