### PR TITLE
Hide the latest ide alert warning on workspace timeout

### DIFF
--- a/components/dashboard/src/start/StartWorkspace.tsx
+++ b/components/dashboard/src/start/StartWorkspace.tsx
@@ -450,6 +450,7 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
         const withPrebuild = WithPrebuild.is(this.state.workspace?.context);
         let phase: StartPhase | undefined = StartPhase.Preparing;
         let title = undefined;
+        let isTimedOut = false;
         let statusMessage = !!error ? undefined : <p className="text-base text-gray-400">Preparing workspace …</p>;
         const contextURL = ContextURL.getNormalizedURL(this.state.workspace)?.toString();
         const useLatest = !!this.state.workspaceInstance?.configuration?.ideConfig?.useLatest;
@@ -677,6 +678,7 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
                 }
                 if (!isPrebuild && this.state.workspaceInstance.status.conditions.timeout) {
                     title = "Timed Out";
+                    isTimedOut = true;
                 }
                 statusMessage = (
                     <div>
@@ -710,7 +712,7 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
                 break;
         }
         return (
-            <StartPage phase={phase} error={error} title={title} showLatestIdeWarning={useLatest}>
+            <StartPage phase={phase} error={error} title={title} showLatestIdeWarning={!isTimedOut && useLatest}>
                 {statusMessage}
             </StartPage>
         );


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
- Removes the latest ide alert warning on the workspace timeout page and only shows it during workspace (re)start.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Relates #11035

## How to test
<!-- Provide steps to test this PR -->
- Open workspace in preview env with a **latest** editor https://hide-editor-alert.preview.gitpod-dev.com/workspaces
- Alert should show during starting workspace
- Stop to see if the latest ide alert does not show up
- Open again with a stable editor
- Alert should not show during starting workspace
- Stop should have no alert

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
Removes the latest ide alert warning on the workspace timeout page
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [x] /werft with-werft
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
