### PR TITLE
[payment] Adjust BillingMode for PAYG transition

### DIFF
--- a/components/server/ee/src/billing/billing-mode.spec.db.ts
+++ b/components/server/ee/src/billing/billing-mode.spec.db.ts
@@ -280,6 +280,34 @@ class BillingModeSpec {
                     hasChargebeeTeamSubscription: true,
                 },
             },
+            // user: "Switch PAYG" transition chargebee -> UBB
+            {
+                name: "user: chargebee paid personal + UBB personal",
+                subject: user(),
+                config: {
+                    enablePayment: true,
+                    usageBasedPricingEnabled: true,
+                    subscriptions: [subscription(Plans.PERSONAL_EUR)],
+                    stripeSubscription: stripeSubscription(),
+                },
+                expectation: {
+                    mode: "usage-based", // here we have to rely on our automation to cancel the Chargebee plan, bc user will no longer see their "Plans"
+                },
+            },
+            {
+                name: "user: chargebee paid personal + chargebee team seat + UBB personal",
+                subject: user(),
+                config: {
+                    enablePayment: true,
+                    usageBasedPricingEnabled: true,
+                    subscriptions: [subscription(Plans.PERSONAL_EUR), teamSubscription(Plans.TEAM_PROFESSIONAL_EUR)],
+                    stripeSubscription: stripeSubscription(),
+                },
+                expectation: {
+                    mode: "usage-based", // here we have to rely on our automation to cancel the Chargebee plan, bc user will no longer see their "Plans"
+                    hasChargebeeTeamSubscription: true,
+                },
+            },
             // user: usage-based
             {
                 name: "user: stripe free, chargebee FREE (old)",


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
 - start [a workspace](https://gitpod.io/#https://github.com/gitpod-io/gitpod/pull/16552)
 - `leeway run components/gitpod-db:init-testdb`
 - `(cd components/server && yarn db-test)`

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
