### PR TITLE
[db] Improve findSessionsInPeriod perf by giving more data to hit ind…

### DIFF
--- a/components/gitpod-db/src/typeorm/workspace-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/workspace-db-impl.ts
@@ -521,6 +521,8 @@ export abstract class AbstractTypeORMWorkspaceDBImpl implements WorkspaceDB {
         periodStart: string,
         periodEnd: string,
     ): Promise<WorkspaceInstanceSessionWithWorkspace[]> {
+        // This is an optinmization, which also matches rules elsewhere. This is old code that's heading for the trash, so no need to couple it properly. :-)
+        const workspaceType: Workspace["type"] = "regular";
         const workspaceInstanceRepo = await this.getWorkspaceInstanceRepo();
         // The query basically selects all workspace instances for the given owner, whose startDate is within the period, and which are either:
         //  - not stopped yet, or
@@ -538,11 +540,12 @@ export abstract class AbstractTypeORMWorkspaceDBImpl implements WorkspaceDB {
                     FROM d_b_workspace_instance AS wsi
                     INNER JOIN d_b_workspace AS ws ON wsi.workspaceId = ws.id
                     WHERE ws.ownerId = ?
+                        AND ws.type = ?
                         AND wsi.startedTime < ?
                         AND (wsi.stoppedTime IS NULL OR wsi.stoppedTime = '' OR wsi.stoppedTime >= ? OR wsi.stoppingTime >= ?)
                     ORDER BY wsi.creationTime ASC;
             `,
-            [userId, periodEnd, periodStart, periodStart],
+            [userId, workspaceType, periodEnd, periodStart, periodStart],
         );
 
         const resultSessions: WorkspaceInstanceSessionWithWorkspace[] = [];


### PR DESCRIPTION
…exes

## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
 - Notice that test are running fine

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
