### PR TITLE
Track ide changed event during onboarding

### DIFF
--- a/components/dashboard/src/onboarding/UserOnboarding.tsx
+++ b/components/dashboard/src/onboarding/UserOnboarding.tsx
@@ -16,6 +16,7 @@ import { StepPersonalize } from "./StepPersonalize";
 import { useUpdateCurrentUserMutation } from "../data/current-user/update-mutation";
 import Alert from "../components/Alert";
 import { useConfetti } from "../contexts/ConfettiContext";
+import { getGitpodService } from "../service/service";
 
 // This param is optionally present to force an onboarding flow
 // Can be used if other conditions aren't true, i.e. if user has already onboarded, but we want to force the flow again
@@ -74,7 +75,19 @@ const UserOnboarding: FunctionComponent<Props> = ({ user }) => {
                 };
 
                 try {
+                    // TODO: extract the IDE updating into it's own step, and add a mutation for it once we don't rely on it to consider a user being "onboarded"
+                    // We can do this once we rely on the profile.onboardedTimestamp instead.
                     const onboardedUser = await updateUser.mutateAsync(updates);
+
+                    // TODO: move this into a mutation side effect once we have a specific mutation for updating the IDE (see above TODO)
+                    getGitpodService().server.trackEvent({
+                        event: "ide_configuration_changed",
+                        properties: {
+                            ...(onboardedUser.additionalData?.ideSettings ?? {}),
+                            location: "onboarding",
+                        },
+                    });
+
                     dropConfetti();
                     setUser(onboardedUser);
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Adds tracking for the `ide_configuration_changed` during onboarding. 

I intentionally avoided re-using the `updateUserIDEInfo()` function for now in `components/dashboard/src/user-settings/SelectIDE.tsx` as I'd like to shift to moving these kinds of api calls (and associated tracking) to react query mutations. I couldn't quite put this in a new mutation yet though, as there's some dependency on decoupling our onboarded logic check from an IDE being set, and also setting the new `onboardedTimestamp` value, but then we should be able to clean this up a bit.

## How to test
<!-- Provide steps to test this PR -->
* Run through the onboarding flow - https://bmh-onboarb9a608477f.preview.gitpod-dev.com/workspaces?onboarding=force
* Check Segment in the Staging Trusted source for the `ide_configuration_changed` event after you've completed onboarding.

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
- [x] /werft analytics=segment