### PR TITLE
Add IDE Code linker workflow

### DIFF
--- a/.github/workflows/ide-linker.yml
+++ b/.github/workflows/ide-linker.yml
@@ -22,6 +22,7 @@ jobs:
           node-version: '18'
       - run: yarn --cwd scripts/gitpod-code-linker
       - run: npm i -g @vercel/ncc
+      - run: go install github.com/csweichel/oci-tool@latest
       - run: ncc run index.ts
         working-directory: scripts/gitpod-code-linker
         env:

--- a/.github/workflows/ide-linker.yml
+++ b/.github/workflows/ide-linker.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
 
   build:

--- a/.github/workflows/ide-linker.yml
+++ b/.github/workflows/ide-linker.yml
@@ -22,7 +22,7 @@ jobs:
           node-version: '18'
       - run: yarn --cwd scripts/gitpod-code-linker
       - run: npm i -g @vercel/ncc
-      - run: go install github.com/csweichel/oci-tool@latest
+      - run: go install github.com/csweichel/oci-tool@latest && export PATH=$PATH:$HOME/go/bin
       - run: ncc run index.ts
         working-directory: scripts/gitpod-code-linker
         env:

--- a/.github/workflows/ide-linker.yml
+++ b/.github/workflows/ide-linker.yml
@@ -1,0 +1,22 @@
+name: Code Linker
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          repository: gitpod-io/openvscode-releases
+          ref: 'ft/ide-linker'
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - run: yarn --cwd scripts/gitpod-code-linker
+      - run: npm i -g @vercel/ncc
+      - run: ncc run index.ts
+        working-directory: scripts/gitpod-code-linker

--- a/.github/workflows/ide-linker.yml
+++ b/.github/workflows/ide-linker.yml
@@ -24,3 +24,5 @@ jobs:
       - run: npm i -g @vercel/ncc
       - run: ncc run index.ts
         working-directory: scripts/gitpod-code-linker
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -7,7 +7,7 @@ defaultArgs:
   publishToNPM: true
   publishToJBMarketplace: true
   localAppVersion: unknown
-  codeCommit: 489a1527b01edb22d898b95b1abea30f8900c972
+  codeCommit: 20aac231f5899e884b18f85e2b550fec12fa886c
   codeVersion: 1.75.1
   codeQuality: stable
   noVerifyJBPlugin: false

--- a/install/installer/pkg/components/workspace/ide/constants.go
+++ b/install/installer/pkg/components/workspace/ide/constants.go
@@ -9,7 +9,7 @@ const (
 	CodeIDEImageStableVersion   = "commit-b83d82b9ee293b0559f11d09977d0e8e914d73f5" // stable version that will be updated manually on demand
 	CodeHelperIDEImage          = "ide/code-codehelper"
 	CodeWebExtensionImage       = "ide/gitpod-code-web"
-	CodeWebExtensionVersion     = "commit-266edb36ec96f3f0613715c6967fd4591fdd0569" // gitpod-web extension version comes from https://github.com/gitpod-io/gitpod-code
+	CodeWebExtensionVersion     = "commit-8612f777fb5c44227ca6f2b91f40fa0929637e22" // gitpod-web extension version comes from https://github.com/gitpod-io/gitpod-code
 	CodeDesktopIDEImage         = "ide/code-desktop"
 	CodeDesktopInsidersIDEImage = "ide/code-desktop-insiders"
 	IntelliJDesktopIDEImage     = "ide/intellij"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
