### PR TITLE
Followup Tasks for new Create Workspace page

### DIFF
--- a/components/dashboard/src/data/workspaces/create-workspace-mutation.ts
+++ b/components/dashboard/src/data/workspaces/create-workspace-mutation.ts
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { GitpodServer } from "@gitpod/gitpod-protocol";
+import { useMutation } from "@tanstack/react-query";
+import { getGitpodService } from "../../service/service";
+
+export const useCreateWorkspaceMutation = () => {
+    return useMutation({
+        mutationFn: async (options: GitpodServer.CreateWorkspaceOptions) => {
+            return await getGitpodService().server.createWorkspace(options);
+        },
+    });
+};

--- a/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
+++ b/components/dashboard/src/workspaces/CreateWorkspacePage.tsx
@@ -10,7 +10,7 @@ import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
 import { Deferred } from "@gitpod/gitpod-protocol/lib/util/deferred";
 import { FunctionComponent, useCallback, useState } from "react";
 import { useHistory, useLocation } from "react-router";
-import Modal from "../components/Modal";
+import Modal, { ModalBody, ModalFooter, ModalHeader } from "../components/Modal";
 import RepositoryFinder from "../components/RepositoryFinder";
 import SelectIDEComponent from "../components/SelectIDEComponent";
 import SelectWorkspaceClassComponent from "../components/SelectWorkspaceClassComponent";
@@ -308,8 +308,8 @@ const ExistingWorkspaceModal: FunctionComponent<ExistingWorkspaceModalProps> = (
 }) => {
     return (
         <Modal visible={true} closeable={true} onClose={onClose}>
-            <h3>Running Workspaces</h3>
-            <div className="border-t border-b border-gray-200 dark:border-gray-800 mt-4 -mx-6 px-6 py-2">
+            <ModalHeader>Running Workspaces</ModalHeader>
+            <ModalBody>
                 <p className="mt-1 mb-2 text-base">
                     You already have running workspaces with the same context. You can open an existing one or open a
                     new workspace.
@@ -336,12 +336,15 @@ const ExistingWorkspaceModal: FunctionComponent<ExistingWorkspaceModalProps> = (
                         );
                     })}
                 </>
-            </div>
-            <div className="flex justify-end mt-6">
+            </ModalBody>
+            <ModalFooter>
+                <button className="secondary" onClick={onClose}>
+                    Cancel
+                </button>
                 <button onClick={() => createWorkspace({ ignoreRunningWorkspaceOnSameCommit: true })}>
                     New Workspace
                 </button>
-            </div>
+            </ModalFooter>
         </Modal>
     );
 };


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
A few followup tasks from #16391 that added a new dedicated create workspace page. That page is still behind a flag, `start_with_options`, which is off everywhere. There were a few pieces of feedback on the initial review that this PR aims to address as an iteration.

* Shifts `createWorkspace` api call into a react query mutation. This allows us to drop tracking creating/error state manually.
* Handling closing of the existing workspaces modal (shifted it's rendering so it just overlays content instead of replacing too so it's less jarring)
* Adding "Cancel" button to existing workspaces modal for a consistent UX.

<img width="591" alt="image" src="https://user-images.githubusercontent.com/367275/221695060-1158deb2-56bf-4f7a-b255-284b2b23b650.png">


## How to test
<!-- Provide steps to test this PR -->
* Preview env: https://bmh-create09111b296b.preview.gitpod-dev.com/workspaces
* You'll need to have the `start_with_options` feature flag enabled for your user in non-prod.
* Clicking start new workspace on the Workspaces page should take you to the new create workspace page, or visit https://bmh-create09111b296b.preview.gitpod-dev.com/new/ directly.
* Ensure you can start a workspace by selecting a repo and hitting the New Workspace button.
* Try to start a 2nd workspace using the same repo (with the first one still running).
* You should see the Existing Workspaces modal. You should be able to close it now (couldn't before).

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
