### PR TITLE
Adding an ErrorBoundary around Dashboard app

### DIFF
--- a/components/dashboard/package.json
+++ b/components/dashboard/package.json
@@ -26,6 +26,7 @@
     "react-confetti": "^6.1.0",
     "react-datepicker": "^4.8.0",
     "react-dom": "^17.0.1",
+    "react-error-boundary": "^3.1.4",
     "react-intl-tel-input": "^8.2.0",
     "react-popper": "^2.3.0",
     "react-portal": "^4.2.2",

--- a/components/dashboard/src/components/ErrorBoundary.tsx
+++ b/components/dashboard/src/components/ErrorBoundary.tsx
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { FC } from "react";
+import { ErrorBoundary, FallbackProps, ErrorBoundaryProps } from "react-error-boundary";
+import gitpodIcon from "../icons/gitpod.svg";
+
+export const GitpodErrorBoundary: FC = ({ children }) => {
+    return (
+        <ErrorBoundary FallbackComponent={DefaultErrorFallback} onReset={handleReset} onError={handleError}>
+            {children}
+        </ErrorBoundary>
+    );
+};
+
+export const DefaultErrorFallback: FC<FallbackProps> = ({ error, resetErrorBoundary }) => {
+    const emailSubject = encodeURIComponent("Gitpod Dashboard Error");
+    const emailBody = encodeURIComponent(`\n\nError: ${error.message}`);
+
+    return (
+        <div role="alert" className="app-container mt-14 flex flex-col items-center justify-center space-y-6">
+            <img src={gitpodIcon} className="h-16 mx-auto" alt="Gitpod's logo" />
+            <h1>Oh, no! Something went wrong!</h1>
+            <p className="text-lg">
+                Please try reloading the page. If the issue continues, please{" "}
+                <a className="gp-link" href={`mailto:support@gitpod.io?Subject=${emailSubject}&Body=${emailBody}`}>
+                    get in touch
+                </a>
+                .
+            </p>
+            <div>
+                <button onClick={resetErrorBoundary}>Reload</button>
+            </div>
+            <pre>{error.message}</pre>
+        </div>
+    );
+};
+
+export const handleReset: ErrorBoundaryProps["onReset"] = () => {
+    window.location.reload();
+};
+
+export const handleError: ErrorBoundaryProps["onError"] = (error, info) => {
+    // TODO: send metric for error boundary event
+    console.error(error);
+    console.info(info);
+};

--- a/components/dashboard/src/index.tsx
+++ b/components/dashboard/src/index.tsx
@@ -22,10 +22,10 @@ import relativeTime from "dayjs/plugin/relativeTime";
 import utc from "dayjs/plugin/utc";
 import { getURLHash, isGitpodIo } from "./utils";
 import { isWebsiteSlug } from "./utils";
-
-import "./index.css";
 import { setupQueryClientProvider } from "./data/setup";
 import { ConfettiContextProvider } from "./contexts/ConfettiContext";
+import { GitpodErrorBoundary } from "./components/ErrorBoundary";
+import "./index.css";
 
 const bootApp = () => {
     // gitpod.io specific boot logic
@@ -57,31 +57,33 @@ const bootApp = () => {
     // Render the App
     ReactDOM.render(
         <React.StrictMode>
-            <GitpodQueryClientProvider>
-                <ConfettiContextProvider>
-                    <UserContextProvider>
-                        <AdminContextProvider>
-                            <PaymentContextProvider>
-                                <LicenseContextProvider>
-                                    <TeamsContextProvider>
-                                        <ProjectContextProvider>
-                                            <ThemeContextProvider>
-                                                <StartWorkspaceModalContextProvider>
-                                                    <BrowserRouter>
-                                                        <FeatureFlagContextProvider>
-                                                            <App />
-                                                        </FeatureFlagContextProvider>
-                                                    </BrowserRouter>
-                                                </StartWorkspaceModalContextProvider>
-                                            </ThemeContextProvider>
-                                        </ProjectContextProvider>
-                                    </TeamsContextProvider>
-                                </LicenseContextProvider>
-                            </PaymentContextProvider>
-                        </AdminContextProvider>
-                    </UserContextProvider>
-                </ConfettiContextProvider>
-            </GitpodQueryClientProvider>
+            <GitpodErrorBoundary>
+                <GitpodQueryClientProvider>
+                    <ConfettiContextProvider>
+                        <UserContextProvider>
+                            <AdminContextProvider>
+                                <PaymentContextProvider>
+                                    <LicenseContextProvider>
+                                        <TeamsContextProvider>
+                                            <ProjectContextProvider>
+                                                <ThemeContextProvider>
+                                                    <StartWorkspaceModalContextProvider>
+                                                        <BrowserRouter>
+                                                            <FeatureFlagContextProvider>
+                                                                <App />
+                                                            </FeatureFlagContextProvider>
+                                                        </BrowserRouter>
+                                                    </StartWorkspaceModalContextProvider>
+                                                </ThemeContextProvider>
+                                            </ProjectContextProvider>
+                                        </TeamsContextProvider>
+                                    </LicenseContextProvider>
+                                </PaymentContextProvider>
+                            </AdminContextProvider>
+                        </UserContextProvider>
+                    </ConfettiContextProvider>
+                </GitpodQueryClientProvider>
+            </GitpodErrorBoundary>
         </React.StrictMode>,
         document.getElementById("root"),
     );

--- a/components/dashboard/src/workspaces/Workspaces.tsx
+++ b/components/dashboard/src/workspaces/Workspaces.tsx
@@ -31,6 +31,7 @@ const WorkspacesPage: FunctionComponent = () => {
     const isOnboardingUser = useMemo(() => user && User.isOnboardingUser(user), [user]);
     const deleteInactiveWorkspaces = useDeleteInactiveWorkspacesMutation();
     const { newSignupFlow } = useFeatureFlags();
+    const [testError, setTestError] = useState(false);
 
     // Sort workspaces into active/inactive groups
     const { activeWorkspaces, inactiveWorkspaces } = useMemo(() => {
@@ -81,10 +82,19 @@ const WorkspacesPage: FunctionComponent = () => {
         setDeleteModalVisible(false);
     }, [deleteInactiveWorkspaces, inactiveWorkspaces]);
 
+    if (testError) {
+        throw new Error();
+    }
     return (
         <>
             <Header title="Workspaces" subtitle="Manage recent and stopped workspaces." />
-
+            <button
+                onClick={() => {
+                    setTestError(true);
+                }}
+            >
+                error
+            </button>
             {deleteModalVisible && (
                 <ConfirmationModal
                     title="Delete Inactive Workspaces"

--- a/yarn.lock
+++ b/yarn.lock
@@ -15192,6 +15192,13 @@ react-dom@17.0.2, react-dom@^17.0.1:
     object-assign "^4.1.1"
     scheduler "^0.20.2"
 
+react-error-boundary@^3.1.4:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-3.1.4.tgz#255db92b23197108757a888b01e5b729919abde0"
+  integrity sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+
 react-error-overlay@^6.0.9:
   version "6.0.9"
   resolved "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
WIP (still need to remove some test code, and figure out if there's a decent way to test this)

This adds an [ErrorBoundary](https://reactjs.org/docs/error-boundaries.html) around the Dashboard app. If an uncaught error is thrown somewhere within a component that's rendering, instead of a white page and the app breaking, we'll render the following UI. The reload button will do a hard page reload, and the contact link is a mailto: our support email w/ some details that include the error message.

<img width="832" alt="image" src="https://user-images.githubusercontent.com/367275/221733526-652760c3-b72e-423d-a09c-c36b73a1921d.png">

Further iterations on this will include:

* Another ErrorBoundary at a lower level in the component hierarchy to maintain the top navigation menu of the app.
* Signal metrics when an error boundary is hit so we can have better visibility for how often it happens.

## How to test
<!-- Provide steps to test this PR -->
- TBD

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
