### PR TITLE
:sparkles: revamp Product Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@
   </a>
 </p>
 
-Gitpod is an open-source Kubernetes application for ready-to-code cloud development environments that spins up fresh, automated dev environments
-for each task, in the cloud, in seconds. It enables you to describe your dev environment as code and start instant, remote and cloud development environments directly from your browser or your Desktop IDE.
+Gitpod is an open-source Kubernetes application for ready-to-code cloud development environments ([CDEs](https://www.gitpod.io/cde)) that spins up fresh, automated dev environments
+for each task, in the cloud, in seconds. It enables you to describe your dev environment as code and start instant, remote and cloud development environments directly from your browser or your [Desktop IDEs](https://www.gitpod.io/docs/references/ides-and-editors).
 
-Tightly integrated with GitLab, GitHub, and Bitbucket, Gitpod automatically and continuously prebuilds dev environments for all your branches. As a result, team members can instantly start coding with fresh, ephemeral, and fully-compiled dev environments - no matter if you are building a new feature, want to fix a bug, or do a code review.
+Tightly integrated with GitLab, GitHub, and Bitbucket, Gitpod automatically and continuously prebuilds dev environments for all your branches. As a result, team members can instantly start coding with fresh, ephemeral, and fully compiled dev environments - no matter if you are building a new feature, want to fix a bug, or do a code review.
 
 ![browser-vscode](https://user-images.githubusercontent.com/22498066/135150975-23bba3a6-f099-48c5-83ed-a1a6627ff0e9.png)
 
@@ -30,36 +30,42 @@ Tightly integrated with GitLab, GitHub, and Bitbucket, Gitpod automatically and 
 
 🏗 [Dev environments as code](https://www.gitpod.io/docs/#-dev-environments-as-code) - Gitpod applies lessons learned from infrastructure-as-code. Spinning up dev environments is easily repeatable and reproducible empowering you to automate, version-control, and share dev environments across your team.
 
-⚡️ [Prebuilt dev environments](https://www.gitpod.io/docs/#prebuilds) - Gitpod continuously prebuilds all your git branches similar to a CI server. Control how Gitpod pre-configures and initializes environments before you even start a workspace through `init` commands in your `.gitpod.yml`.
+⚡️ [**Prebuilt dev environments**](https://www.gitpod.io/docs/configure/projects/prebuilds) - Gitpod continuously prebuilds all your git branches similar to a CI server. Control how Gitpod pre-configures and initializes environments before you even start a workspace through [`tasks` commands](https://www.gitpod.io/docs/introduction/learn-gitpod/gitpod-yaml) in your `.gitpod.yml`.
 
-🐳 [Integrated Docker build](https://www.gitpod.io/docs/config-docker/) - Gitpod instantly starts a container in the cloud based on your Docker image. Tools that are required for your project are easy to install and configure.
+💪 [**Secure**](https://www.gitpod.io/security) - Each Gitpod workspace or prebuild runs on a secured single-use container providing fast startup times without compromising on security. Gitpod generates SLSA level 1 compliant provenance. Gitpod is also GDPR and SOC2 compliant. And, of course, Gitpod is open-source and available for review by everyone.
 
-👐 [GitLab, GitHub, and Bitbucket integration](https://www.gitpod.io/docs/integrations/) - Gitpod seamlessly integrates into your workflow and works with all major git hosting platforms including GitHub, GitLab and Bitbucket.
+🐳 [**Integrated Docker build**](https://www.gitpod.io/docs/config-docker/) - Gitpod instantly starts a container in the cloud based on your Docker image. Tools that are required for your project are easy to install and configure.
 
-👀 [Integrated code reviews](https://www.gitpod.io/docs/context-urls#pullmerge-request-context) - with Gitpod you can do native code reviews on any PR/MR. No need to switch context anymore and clutter your local machine with your colleagues' PR/MR.
+👐 [**GitLab, GitHub, and Bitbucket integration**](https://www.gitpod.io/docs/configure/authentication) - Gitpod seamlessly integrates into your workflow and works with all major git hosting platforms including GitHub, GitLab and Bitbucket.
 
-👯‍♀️ [Collaboration](https://www.gitpod.io/docs/sharing-and-collaboration/) - invite team members to your dev environment or snapshot any state of your dev environment to share it with your team asynchronously.
+👀 [**Integrated code reviews**](https://www.gitpod.io/docs/introduction/learn-gitpod/context-url#pullmerge-request-context) - with Gitpod you can do native code reviews on any PR/MR. No need to switch contexts anymore and clutter your local machine with your colleagues' PR/MR.
 
-🛠 Professional & customizable developer experience - a Gitpod workspace gives you the same capabilities (yes, even [root & docker](https://www.gitpod.io/docs/config-docker#configure-a-custom-dockerfile)) as your Linux machine - pre-configured and optimized for your individual development workflow. Install any [VS Code extension](https://www.gitpod.io/docs/vscode-extensions/) with one click on a user and/or team level.
+👯‍♀️ [**Collaboration**](https://www.gitpod.io/docs/configure/workspaces/collaboration) - invite team members to your dev environment or snapshot of any state of your dev environment to share it with your team asynchronously.
+
+🛠 **Professional & customizable developer experience** - a Gitpod workspace gives you the same capabilities (yes, even [root & docker](https://www.gitpod.io/docs/configure/workspaces/workspace-image#configure-a-custom-dockerfile)) as your Linux machine - pre-configured and optimized for your development workflow. Install any [VS Code extension](https://www.gitpod.io/docs/references/ides-and-editors/vscode-extensions) with one click on a user and/or team level. You can also bring your [dotfiles](https://www.gitpod.io/docs/configure/user-settings/dotfiles#dotfiles) and customize your dev environment as you like.
 
 [Learn more 👉](https://www.gitpod.io/)
+
+### 🔐 Gitpod Dedicated
+
+Wanted to run Gitpod in an isolated, single-tenant installation environment? Check out [**Gitpod Dedicated**](https://www.gitpod.io/dedicated).
 
 ## Getting Started
 
 You can start using Gitpod in one or more of the following ways:
 
 1. Quickstart using an [Example Project](https://www.gitpod.io/docs/quickstart) or [OSS Project](https://contribute.dev/)
-1. Getting started with [one of your existing projects](https://www.gitpod.io/docs/getting-started)
-1. [Use a Prefixed URL](https://www.gitpod.io/docs/getting-started/#prefixed-url)
-1. [Install Browser Extension](https://www.gitpod.io/docs/getting-started#browser-extension)
-1. [Enable GitLab Integration](https://www.gitpod.io/docs/gitlab-integration#gitlab-integration)
+2. Getting started with [one of your existing projects](https://www.gitpod.io/docs/getting-started)
+3. [Use a Prefixed URL](https://www.gitpod.io/docs/getting-started/#prefixed-url)
+4. [Install Browser Extension](https://www.gitpod.io/docs/getting-started#browser-extension)
+5. [Enable GitLab Integration](https://www.gitpod.io/docs/gitlab-integration#gitlab-integration)
 
 ## Documentation
 
-All documentation can be found on https://www.gitpod.io/docs.
-For example, see [Introduction](https://www.gitpod.io/docs) and [Getting Started](https://www.gitpod.io/docs/getting-started) sections. 📚
+📚 All documentation can be found on [gitpod.io/docs](https://www.gitpod.io/docs).
+For example, see the [Introduction](https://www.gitpod.io/docs) and [Getting Started](https://www.gitpod.io/docs/getting-started) sections.
 
-Also check out [**awesome-gitpod**](https://github.com/Gitpod-Samples/awesome-gitpod) ✨
+🚀 Looking for some samples for inspiration to configure your project? Check out [**gitpod-samples**](https://github.com/gitpod-samples)
 
 ## Questions
 
@@ -70,7 +76,7 @@ You can also follow [`@gitpod`](https://twitter.com/gitpod) for announcements an
 
 ## Issues
 
-The issue tracker is used for tracking **bug reports** and **feature requests** for the Gitpod open source project as well as planning current and future development efforts. 🗺️
+The issue tracker is used for tracking **bug reports** and **feature requests** for the Gitpod open-source project as well as planning current and future development efforts. 🗺️
 
 You can upvote [popular feature requests](https://github.com/gitpod-io/gitpod/issues?q=is%3Aissue+is%3Aopen+sort%3Areactions-%2B1-desc) or [create a new one](https://github.com/gitpod-io/gitpod/issues/new?template=feature_request.md).
 
@@ -83,23 +89,24 @@ We work with quarterly roadmaps in autonomous product teams.
 
 ### How do GitHub Issues get prioritized?
 
-Most GitHub issues (except smaller or more urgent issues) relate to our [current product roadmap items](https://github.com/orgs/gitpod-io/projects/27). Gitpod teams work against these roadmap items. Each Gitpod team has [its own project board](https://github.com/orgs/gitpod-io/projects) that follows a similar structure. You can find these project boards attached to [the GitHub organization](https://github.com/gitpod-io). Each team board has a "GroundWork" tab which shows current GitHub issues in progress. Each team project board also has an "inbox" where issues are sent for review by the team (and should be responded to within 48 hours). "Upvoting" by [reacting](https://docs.github.com/en/rest/reference/reactions) to GitHub issues helps signal to Gitpod that issues are important to you. If you are unsure of the status of an issue, please comment and a Gitpodder should respond to you shortly. For any other questions, please utilize the [Gitpod community](https://www.gitpod.io/community).
+Most GitHub issues (except smaller or more urgent issues) relate to our [current product roadmap items](https://github.com/orgs/gitpod-io/projects/27). Gitpod teams work against these roadmap items. Each Gitpod team has [its own project board](https://github.com/orgs/gitpod-io/projects) that follows a similar structure. You can find these project boards attached to [the GitHub organization](https://github.com/gitpod-io). Each team board has a "GroundWork" tab which shows current GitHub issues in progress. Each team project board also has an "inbox" where issues are sent for review by the team (and should be responded to within 48 hours). "Upvoting" by 👍 to GitHub issues helps signal to Gitpod that issues are important to you. If you are unsure of the status of an issue, please comment and a Gitpodder should respond to you shortly. For any other questions, please utilize the [Gitpod community](https://www.gitpod.io/community).
 
 ### Adding a new component to Gitpod
 
-For new Go projects, please update [gitpod-ws.code-workspace](./gitpod-ws.code-workspace) to include the folder. Why? This will make it so that [IntelliSense](https://code.visualstudio.com/docs/editor/intellisense) works with your project, without having to exclusively open the project in a separate context, e.g. `code components/<my-new-component>`. References [1](https://go.googlesource.com/tools/+/refs/heads/master/gopls/doc/workspace.md#multiple-workspace-folders)[2](https://code.visualstudio.com/docs/editor/multi-root-workspaces)
+For new Go projects, please update [`gitpod-ws.code-workspace`](./gitpod-ws.code-workspace) to include the folder. Why? This will make it so that [IntelliSense](https://code.visualstudio.com/docs/editor/intellisense) works with your project, without having to exclusively open the project in a separate context, e.g. `code components/<my-new-component>`. References [1](https://go.googlesource.com/tools/+/refs/heads/master/gopls/doc/workspace.md#multiple-workspace-folders)[2](https://code.visualstudio.com/docs/editor/multi-root-workspaces)
 
 ## Related Projects
 
 During the development of Gitpod, we also developed some of our own infrastructure toolings to make development easier and more efficient.
-To this end, we've developed a number of open source projects including:
+To this end, we've developed several open-source projects including:
 
 1. [**Werft**](https://github.com/csweichel/werft) - A Kubernetes native CI system
-1. [**Leeway**](https://github.com/gitpod-io/leeway) - A heavily caching build system
-1. [**Dazzle**](https://github.com/gitpod-io/dazzle/) - An experimental Docker image builder
-1. [**OpenVSCode Server**](https://github.com/gitpod-io/openvscode-server) - Run the latest VS Code on a remote machine accessed through a browser
+2. [**Leeway**](https://github.com/gitpod-io/leeway) - A heavily caching build system
+3. [**Dazzle**](https://github.com/gitpod-io/dazzle/) - An experimental Docker image builder
+4. [**OpenVSCode Server**](https://github.com/gitpod-io/openvscode-server) - Run the latest VS Code on a remote machine accessed through a browser
+5. [**Gitbot**](https://github.com/gitpod-io/gitbot) - A GitHub App for automating common tasks in the Gitpod organization.
 
 ## Code of Conduct
 
-We want to create a welcoming environment for everyone who is interested in contributing to Gitpod or participating in discussions with the Gitpod community.
+We want to create a welcoming environment for everyone interested in contributing to Gitpod or participating in discussions with the Gitpod community. You can learn more about it on our [Contribute Page](https://www.gitpod.io/docs/help/contribute).
 This project has adopted the [Contributor Covenant Code of Conduct](https://github.com/gitpod-io/.github/blob/main/CODE_OF_CONDUCT.md), [version 2.0](https://www.contributor-covenant.org/version/2/0/code_of_conduct/).


### PR DESCRIPTION
## Description
Revamp Product README. Will Do the incremental development for this. First changes looks good, we can improve more in follow-up PRs.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes: [Internal Conversastion](https://gitpod.slack.com/archives/C046Z4BBP2N/p1672905361077039)

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
