### PR TITLE
[stripe] Return NotFound for non-existent attribution IDs

### DIFF
--- a/components/server/ee/src/user/stripe-service.ts
+++ b/components/server/ee/src/user/stripe-service.ts
@@ -14,6 +14,8 @@ import {
     stripeClientRequestsCompletedDurationSeconds,
 } from "../../../src/prometheus-metrics";
 import { BillingServiceClient, BillingServiceDefinition } from "@gitpod/usage-api/lib/usage/v1/billing.pb";
+import { ResponseError } from "vscode-ws-jsonrpc";
+import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
 
 @injectable()
 export class StripeService {
@@ -57,7 +59,10 @@ export class StripeService {
     async getPortalUrlForAttributionId(attributionId: string, returnUrl: string): Promise<string> {
         const customerId = await this.findCustomerByAttributionId(attributionId);
         if (!customerId) {
-            throw new Error(`No Stripe Customer ID found for '${attributionId}'`);
+            throw new ResponseError(
+                ErrorCodes.NOT_FOUND,
+                `No Stripe Customer ID for attribution ID '${attributionId}'`,
+            );
         }
         const session = await reportStripeOutcome("portal_create_session", () => {
             return this.getStripe().billingPortal.sessions.create({


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Ensures the error returned is a UserError, rather than a ServerError. See [reported errors in grafana](https://grafana.gitpod.io/explore?orgId=1&left=%7B%22datasource%22:%22P4169E866C3094E38%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22datasource%22:%7B%22type%22:%22prometheus%22,%22uid%22:%22P4169E866C3094E38%22%7D,%22editorMode%22:%22code%22,%22expr%22:%22sum%28increase%28gitpod_server_api_calls_total%7Bmethod%3D%5C%22getStripePortalUrl%5C%22,%20statusCode%3D~%5C%225.%2A%5C%22%7D%5B10m%5D%29%29%20by%20%28statusCode%29%22,%22legendFormat%22:%22__auto%22,%22range%22:true,%22instant%22:true%7D%5D,%22range%22:%7B%22from%22:%22now-6h%22,%22to%22:%22now%22%7D%7D)

<img width="1610" alt="Screenshot 2023-02-28 at 10 43 32" src="https://user-images.githubusercontent.com/1419286/221814920-5057b7e6-c0ba-46b0-b975-97eacc971bd8.png">

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
