### PR TITLE
[ws-manager-mk2] Protect environment secrets

### DIFF
--- a/components/ws-manager-mk2/controllers/workspace_controller.go
+++ b/components/ws-manager-mk2/controllers/workspace_controller.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -182,6 +183,8 @@ func (r *WorkspaceReconciler) actOnStatus(ctx context.Context, workspace *worksp
 				}
 			}
 
+			r.deleteWorkspaceSecrets(ctx, workspace)
+
 			// Workspace might have already been in a deleting state,
 			// but not guaranteed, so try deleting anyway.
 			err := r.Client.Delete(ctx, workspace)
@@ -240,6 +243,9 @@ func (r *WorkspaceReconciler) actOnStatus(ctx context.Context, workspace *worksp
 		} else {
 			return ctrl.Result{Requeue: true}, err
 		}
+
+	case workspace.Status.Phase == workspacev1.WorkspacePhaseRunning:
+		r.deleteWorkspaceSecrets(ctx, workspace)
 
 	// we've disposed already - try to remove the finalizer and call it a day
 	case workspace.Status.Phase == workspacev1.WorkspacePhaseStopped:
@@ -329,6 +335,37 @@ func (r *WorkspaceReconciler) deleteWorkspacePod(ctx context.Context, pod *corev
 	}
 
 	return ctrl.Result{}, nil
+}
+
+func (r *WorkspaceReconciler) deleteWorkspaceSecrets(ctx context.Context, ws *workspacev1.Workspace) {
+	log := log.FromContext(ctx)
+
+	// if a secret cannot be deleted we do not return early because we want to attempt
+	// the deletion of the remaining secrets
+	err := r.deleteSecret(ctx, fmt.Sprintf("%s-%s", ws.Name, "env"), r.Config.Namespace)
+	if err != nil {
+		log.Error(err, "could not delete environment secret", "workspace", ws.Name)
+	}
+}
+
+func (r *WorkspaceReconciler) deleteSecret(ctx context.Context, name, namespace string) error {
+	var envSecret corev1.Secret
+	err := r.Client.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, &envSecret)
+	if errors.IsNotFound(err) {
+		// nothing to delete
+		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("could not retrieve secret %s: %w", name, err)
+	}
+
+	err = r.Client.Delete(ctx, &envSecret)
+	if err != nil && !errors.IsNotFound(err) {
+		return fmt.Errorf("could not delete secret %s: %w", name, err)
+	}
+
+	return nil
 }
 
 var (

--- a/components/ws-manager-mk2/controllers/workspace_controller.go
+++ b/components/ws-manager-mk2/controllers/workspace_controller.go
@@ -349,8 +349,8 @@ func (r *WorkspaceReconciler) deleteWorkspaceSecrets(ctx context.Context, ws *wo
 }
 
 func (r *WorkspaceReconciler) deleteSecret(ctx context.Context, name, namespace string) error {
-	var envSecret corev1.Secret
-	err := r.Client.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, &envSecret)
+	var secret corev1.Secret
+	err := r.Client.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, &secret)
 	if errors.IsNotFound(err) {
 		// nothing to delete
 		return nil
@@ -360,7 +360,7 @@ func (r *WorkspaceReconciler) deleteSecret(ctx context.Context, name, namespace 
 		return fmt.Errorf("could not retrieve secret %s: %w", name, err)
 	}
 
-	err = r.Client.Delete(ctx, &envSecret)
+	err = r.Client.Delete(ctx, &secret)
 	if err != nil && !errors.IsNotFound(err) {
 		return fmt.Errorf("could not delete secret %s: %w", name, err)
 	}

--- a/components/ws-manager-mk2/service/manager.go
+++ b/components/ws-manager-mk2/service/manager.go
@@ -319,24 +319,6 @@ func (wsm *WorkspaceManagerServer) createWorkspaceSecret(ctx context.Context, ow
 		return err
 	}
 
-	err = wait.PollWithContext(ctx, 100*time.Millisecond, 5*time.Second, func(c context.Context) (done bool, err error) {
-		var secret corev1.Secret
-		err = wsm.Client.Get(context.TODO(), types.NamespacedName{Namespace: namespace, Name: name}, &secret)
-		if errors.IsNotFound(err) {
-			return false, nil
-		}
-
-		if err != nil {
-			return false, err
-		}
-
-		return true, nil
-	})
-
-	if err != nil {
-		return err
-	}
-
 	return nil
 }
 

--- a/install/installer/pkg/components/ws-manager-mk2/role.go
+++ b/install/installer/pkg/components/ws-manager-mk2/role.go
@@ -122,6 +122,17 @@ func role(ctx *common.RenderContext) ([]runtime.Object, error) {
 						"patch",
 					},
 				},
+				{
+					APIGroups: []string{""},
+					Resources: []string{"secrets"},
+					Verbs: []string{
+						"create",
+						"delete",
+						"get",
+						"list",
+						"watch",
+					},
+				},
 			},
 		},
 	}, nil


### PR DESCRIPTION
## Description
Protect environment secrets

## Related Issue(s)
n.a.

## How to test
- Set environment variable in user preferences
- Create workspace
- Check that workspace CR contains reference to the secret
- Check that secret is deleted after workspace has started
- Check environment variables in workspace

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
None
```

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
