### PR TITLE
[db-sync] Remove remaining references

### DIFF
--- a/components/gitpod-db/go/oidc_client_config.go
+++ b/components/gitpod-db/go/oidc_client_config.go
@@ -24,7 +24,7 @@ type OIDCClientConfig struct {
 	Data EncryptedJSON[OIDCSpec] `gorm:"column:data;type:text;size:65535" json:"data"`
 
 	LastModified time.Time `gorm:"column:_lastModified;type:timestamp;default:CURRENT_TIMESTAMP(6);" json:"_lastModified"`
-	// deleted is reserved for use by db-sync.
+	// deleted is reserved for use by periodic deleter.
 	_ bool `gorm:"column:deleted;type:tinyint;default:0;" json:"deleted"`
 }
 

--- a/components/gitpod-db/go/personal_access_token.go
+++ b/components/gitpod-db/go/personal_access_token.go
@@ -26,7 +26,7 @@ type PersonalAccessToken struct {
 	CreatedAt      time.Time `gorm:"column:createdAt;type:timestamp;default:CURRENT_TIMESTAMP(6);" json:"createdAt"`
 	LastModified   time.Time `gorm:"column:_lastModified;type:timestamp;default:CURRENT_TIMESTAMP(6);" json:"_lastModified"`
 
-	// deleted is reserved for use by db-sync.
+	// deleted is reserved for use by periodic deleter.
 	_ bool `gorm:"column:deleted;type:tinyint;default:0;" json:"deleted"`
 }
 

--- a/components/gitpod-db/go/project.go
+++ b/components/gitpod-db/go/project.go
@@ -29,7 +29,7 @@ type Project struct {
 
 	MarkedDeleted bool `gorm:"column:markedDeleted;type:tinyint;default:0;" json:"markedDeleted"`
 
-	// deleted is reserved for use by db-sync
+	// deleted is reserved for use by periodic deleter
 	_ bool `gorm:"column:deleted;type:tinyint;default:0;" json:"deleted"`
 }
 

--- a/components/gitpod-db/go/stripe_customer.go
+++ b/components/gitpod-db/go/stripe_customer.go
@@ -20,7 +20,7 @@ type StripeCustomer struct {
 	Currency         string        `gorm:"column:currency;type:varchar;size:3;" json:"currency"`
 
 	LastModified time.Time `gorm:"->;column:_lastModified;type:timestamp;default:CURRENT_TIMESTAMP(6);" json:"_lastModified"`
-	// deleted is reserved for use by db-sync.
+	// deleted is reserved for use by periodic deleter
 	_ bool `gorm:"column:deleted;type:tinyint;default:0;" json:"deleted"`
 }
 

--- a/components/gitpod-db/go/team.go
+++ b/components/gitpod-db/go/team.go
@@ -20,7 +20,7 @@ type Team struct {
 
 	MarkedDeleted bool `gorm:"column:markedDeleted;type:tinyint;default:0;" json:"marked_deleted"`
 
-	// deleted is reserved for use by db-sync.
+	// deleted is reserved for use by periodic deleter
 	_ bool `gorm:"column:deleted;type:tinyint;default:0;" json:"deleted"`
 }
 

--- a/components/gitpod-db/go/team_membership.go
+++ b/components/gitpod-db/go/team_membership.go
@@ -25,7 +25,7 @@ type TeamMembership struct {
 	// Read-only (-> property).
 	LastModified time.Time `gorm:"->:column:_lastModified;type:timestamp;default:CURRENT_TIMESTAMP(6);" json:"_lastModified"`
 
-	// deleted column is reserved for use by db-sync
+	// deleted column is reserved for use by periodic deleter
 	_ bool `gorm:"column:deleted;type:tinyint;default:0;" json:"deleted"`
 }
 

--- a/components/gitpod-db/go/workspace.go
+++ b/components/gitpod-db/go/workspace.go
@@ -46,7 +46,7 @@ type Workspace struct {
 	SoftDeleted sql.NullString `gorm:"column:softDeleted;type:char;size:4;" json:"softDeleted"`
 	Pinned      bool           `gorm:"column:pinned;type:tinyint;default:0;" json:"pinned"`
 
-	// deleted is reserved for use by db-sync
+	// deleted is reserved for use by periodic deleter
 	_ int32 `gorm:"column:deleted;type:tinyint;default:0;" json:"deleted"`
 }
 

--- a/components/gitpod-db/go/workspace_instance.go
+++ b/components/gitpod-db/go/workspace_instance.go
@@ -44,7 +44,7 @@ type WorkspaceInstance struct {
 	Phase          sql.NullString `gorm:"->:column:phase;type:char;size:32;" json:"phase"`
 	PhasePersisted string         `gorm:"column:phasePersisted;type:char;size:32;" json:"phasePersisted"`
 
-	// deleted is restricted for use by db-sync
+	// deleted is restricted for use by periodic deleter
 	_ bool `gorm:"column:deleted;type:tinyint;default:0;" json:"deleted"`
 }
 

--- a/components/gitpod-db/src/typeorm/entity/db-blocked-repository.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-blocked-repository.ts
@@ -35,7 +35,7 @@ export class DBBlockedRepository implements BlockedRepository {
     })
     updatedAt: string;
 
-    // This column triggers the db-sync deletion mechanism. It's not intended for public consumption.
+    // This column triggers the periodic deleter deletion mechanism. It's not intended for public consumption.
     @Column()
     deleted: boolean;
 }

--- a/components/gitpod-db/src/typeorm/entity/db-pending-github-event.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-pending-github-event.ts
@@ -25,7 +25,7 @@ export class DBPendingGithubEvent implements PendingGithubEvent {
     @Column()
     event: string;
 
-    // This column triggers the db-sync deletion mechanism. It's not intended for public consumption.
+    // This column triggers the periodic deleter deletion mechanism. It's not intended for public consumption.
     @Column()
     deleted: boolean;
 }

--- a/components/gitpod-db/src/typeorm/entity/db-prebuild-info-entry.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-prebuild-info-entry.ts
@@ -32,7 +32,7 @@ export class DBPrebuildInfo {
     })
     info: PrebuildInfo;
 
-    // This column triggers the db-sync deletion mechanism. It's not intended for public consumption.
+    // This column triggers the periodic deleter deletion mechanism. It's not intended for public consumption.
     @Column()
     deleted?: boolean;
 }

--- a/components/gitpod-db/src/typeorm/entity/db-prebuilt-workspace-updatable.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-prebuilt-workspace-updatable.ts
@@ -60,7 +60,7 @@ export class DBPrebuiltWorkspaceUpdatable implements PrebuiltWorkspaceUpdatable 
     })
     label?: string;
 
-    // This column triggers the db-sync deletion mechanism. It's not intended for public consumption.
+    // This column triggers the periodic deleter deletion mechanism. It's not intended for public consumption.
     @Column()
     deleted?: boolean;
 }

--- a/components/gitpod-db/src/typeorm/entity/db-prebuilt-workspace.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-prebuilt-workspace.ts
@@ -78,7 +78,7 @@ export class DBPrebuiltWorkspace implements PrebuiltWorkspace {
     })
     statusVersion: number;
 
-    // This column triggers the db-sync deletion mechanism. It's not intended for public consumption.
+    // This column triggers the periodic deleter deletion mechanism. It's not intended for public consumption.
     @Column()
     deleted?: boolean;
 }

--- a/components/gitpod-db/src/typeorm/entity/db-project-env-vars.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-project-env-vars.ts
@@ -40,7 +40,7 @@ export class DBProjectEnvVar implements ProjectEnvVarWithValue {
     @Column("varchar")
     creationTime: string;
 
-    // This column triggers the db-sync deletion mechanism. It's not intended for public consumption.
+    // This column triggers the periodic deleter deletion mechanism. It's not intended for public consumption.
     @Column()
     deleted: boolean;
 }

--- a/components/gitpod-db/src/typeorm/entity/db-project-info.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-project-info.ts
@@ -35,7 +35,7 @@ export class DBProjectInfo {
     })
     overview: Project.Overview;
 
-    // This column triggers the db-sync deletion mechanism. It's not intended for public consumption.
+    // This column triggers the periodic deleter deletion mechanism. It's not intended for public consumption.
     @Column()
     deleted: boolean;
 }

--- a/components/gitpod-db/src/typeorm/entity/db-project-usage.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-project-usage.ts
@@ -20,7 +20,7 @@ export class DBProjectUsage {
     @Column("varchar")
     lastWorkspaceStart: string;
 
-    // This column triggers the db-sync deletion mechanism. It's not intended for public consumption.
+    // This column triggers the periodic deleter deletion mechanism. It's not intended for public consumption.
     @Column()
     deleted: boolean;
 }

--- a/components/gitpod-db/src/typeorm/entity/db-project.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-project.ts
@@ -48,7 +48,7 @@ export class DBProject {
     @Column("varchar")
     creationTime: string;
 
-    // This column triggers the db-sync deletion mechanism. It's not intended for public consumption.
+    // This column triggers the periodic deleter deletion mechanism. It's not intended for public consumption.
     @Column()
     deleted: boolean;
 

--- a/components/gitpod-db/src/typeorm/entity/db-team-membership-invite.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-team-membership-invite.ts
@@ -34,7 +34,7 @@ export class DBTeamMembershipInvite {
     })
     invitedEmail?: string;
 
-    // This column triggers the db-sync deletion mechanism. It's not intended for public consumption.
+    // This column triggers the periodic deleter deletion mechanism. It's not intended for public consumption.
     @Column()
     deleted: boolean;
 }

--- a/components/gitpod-db/src/typeorm/entity/db-team-membership.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-team-membership.ts
@@ -36,7 +36,7 @@ export class DBTeamMembership {
     })
     subscriptionId?: string;
 
-    // This column triggers the db-sync deletion mechanism. It's not intended for public consumption.
+    // This column triggers the periodic deleter deletion mechanism. It's not intended for public consumption.
     @Column()
     deleted: boolean;
 }

--- a/components/gitpod-db/src/typeorm/entity/db-team-subscription-2.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-team-subscription-2.ts
@@ -51,7 +51,7 @@ export class DBTeamSubscription2 implements TeamSubscription2 {
     })
     excludeFromMoreResources: boolean;
 
-    // This column triggers the db-sync deletion mechanism. It's not intended for public consumption.
+    // This column triggers the periodic deleter deletion mechanism. It's not intended for public consumption.
     @Column()
     deleted: boolean;
 }

--- a/components/gitpod-db/src/typeorm/entity/db-team.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-team.ts
@@ -31,7 +31,7 @@ export class DBTeam implements Team {
     @Column()
     markedDeleted?: boolean;
 
-    // This column triggers the db-sync deletion mechanism. It's not intended for public consumption.
+    // This column triggers the periodic deleter deletion mechanism. It's not intended for public consumption.
     @Column()
     deleted: boolean;
 }

--- a/components/gitpod-db/src/typeorm/entity/db-user-ssh-public-key.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-user-ssh-public-key.ts
@@ -50,7 +50,7 @@ export class DBUserSshPublicKey implements UserSSHPublicKey {
     })
     lastUsedTime?: string;
 
-    // This column triggers the db-sync deletion mechanism. It's not intended for public consumption.
+    // This column triggers the periodic deleter deletion mechanism. It's not intended for public consumption.
     @Column()
     deleted: boolean;
 }

--- a/components/gitpod-db/src/typeorm/entity/db-webhook-event.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-webhook-event.ts
@@ -80,7 +80,7 @@ export class DBWebhookEvent implements WebhookEvent {
     })
     commit?: string;
 
-    // This column triggers the db-sync deletion mechanism. It's not intended for public consumption.
+    // This column triggers the periodic deleter deletion mechanism. It's not intended for public consumption.
     @Column()
     deleted: boolean;
 }

--- a/components/gitpod-db/src/typeorm/entity/db-workspace-cluster.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-workspace-cluster.ts
@@ -100,7 +100,7 @@ export class DBWorkspaceCluster implements WorkspaceCluster {
     })
     region: WorkspaceRegion;
 
-    // This column triggers the db-sync deletion mechanism. It's not intended for public consumption.
+    // This column triggers the periodic deleter deletion mechanism. It's not intended for public consumption.
     @Column()
     deleted: boolean;
 }

--- a/components/gitpod-db/src/typeorm/entity/db-workspace-instance.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-workspace-instance.ts
@@ -84,7 +84,7 @@ export class DBWorkspaceInstance implements WorkspaceInstance {
     @Index("ind_phasePersisted")
     phasePersisted: WorkspaceInstancePhase;
 
-    // This column triggers the db-sync deletion mechanism. It's not intended for public consumption.
+    // This column triggers the periodic deleter deletion mechanism. It's not intended for public consumption.
     @Column()
     deleted?: boolean;
 

--- a/components/gitpod-db/src/typeorm/entity/db-workspace.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-workspace.ts
@@ -104,7 +104,7 @@ export class DBWorkspace implements Workspace {
     })
     contentDeletedTime?: string;
 
-    // This column triggers the db-sync deletion mechanism. It's not intended for public consumption.
+    // This column triggers the periodic deleter deletion mechanism. It's not intended for public consumption.
     @Column()
     deleted?: boolean;
 

--- a/components/gitpod-db/src/typeorm/workspace-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/workspace-db-impl.ts
@@ -914,8 +914,8 @@ export abstract class AbstractTypeORMWorkspaceDBImpl implements WorkspaceDB {
     }
 
     /**
-     * This *hard deletes* the workspace entry and all corresponding workspace-instances, by triggering a db-sync mechanism that purges it from the DB.
-     * Note: when this function returns that doesn't mean that the entries are actually gone yet, that might still take a short while until db-sync comes
+     * This *hard deletes* the workspace entry and all corresponding workspace-instances, by triggering a periodic deleter mechanism that purges it from the DB.
+     * Note: when this function returns that doesn't mean that the entries are actually gone yet, that might still take a short while until periodic deleter comes
      *       around to deleting them.
      */
     public async hardDeleteWorkspace(workspaceId: string): Promise<void> {

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -592,7 +592,7 @@ export interface GitpodToken {
     /** Created timestamp */
     created: string;
 
-    // token is deleted on the database and about to be collected by db-sync
+    // token is deleted on the database and about to be collected by periodic deleter
     deleted?: boolean;
 }
 
@@ -743,7 +743,7 @@ export interface Workspace {
     shareable?: boolean;
     pinned?: boolean;
 
-    // workspace is hard-deleted on the database and about to be collected by db-sync
+    // workspace is hard-deleted on the database and about to be collected by periodic deleter
     readonly deleted?: boolean;
 
     /**

--- a/components/gitpod-protocol/src/workspace-instance.ts
+++ b/components/gitpod-protocol/src/workspace-instance.ts
@@ -49,7 +49,7 @@ export interface WorkspaceInstance {
     //         values here.
     configuration?: WorkspaceInstanceConfiguration;
 
-    // instance is hard-deleted on the database and about to be collected by db-sync
+    // instance is hard-deleted on the database and about to be collected by periodic deleter
     readonly deleted?: boolean;
 
     /**

--- a/components/server/src/auth/bearer-authenticator.ts
+++ b/components/server/src/auth/bearer-authenticator.ts
@@ -52,7 +52,7 @@ export class BearerAuth {
                 if (isBearerAuthError(e)) {
                     // (AT) while investigating https://github.com/gitpod-io/gitpod/issues/8703 we
                     // came to the assumption that a workspace pod might start talking to a server pod
-                    // from the other cluster, which is not db-sync'd yet.
+                    // from the other cluster, which is not periodic delete'd yet.
                     // Logging this should allow us to test this assumption.
                     log.info("Bearer auth error.", e, { clientRegion: req.get("x-glb-client-region") });
                     res.status(401).send(e.message);

--- a/components/server/src/workspace/workspace-deletion-service.ts
+++ b/components/server/src/workspace/workspace-deletion-service.ts
@@ -46,8 +46,8 @@ export class WorkspaceDeletionService {
     }
 
     /**
-     * This *hard deletes* the workspace entry and all corresponding workspace-instances, by triggering a db-sync mechanism that purges it from the DB.
-     * Note: when this function returns that doesn't mean that the entries are actually gone yet, that might still take a short while until db-sync comes
+     * This *hard deletes* the workspace entry and all corresponding workspace-instances, by triggering a periodic deleter mechanism that purges it from the DB.
+     * Note: when this function returns that doesn't mean that the entries are actually gone yet, that might still take a short while until periodic deleter comes
      *       around to deleting them.
      * @param ctx
      * @param workspaceId

--- a/components/ws-manager-bridge/src/bridge.ts
+++ b/components/ws-manager-bridge/src/bridge.ts
@@ -246,7 +246,7 @@ export class WorkspaceManagerBridge implements Disposable {
                 this.prometheusExporter.statusUpdateReceived(this.cluster.name, true);
             } else {
                 // This scenario happens when the update for a WorkspaceInstance is picked up by a ws-manager-bridge in a different region,
-                // before db-sync finished running. This is because all ws-manager-bridge instances receive updates from all WorkspaceClusters.
+                // before periodic deleter finished running. This is because all ws-manager-bridge instances receive updates from all WorkspaceClusters.
                 // We ignore this update because we do not have anything to reconcile this update against, but also because we assume it is handled
                 // by another instance of ws-manager-bridge that is in the region where the WorkspaceInstance record was created.
                 this.prometheusExporter.statusUpdateReceived(this.cluster.name, false);

--- a/operations/observability/mixins/meta/dashboards/components/db.json
+++ b/operations/observability/mixins/meta/dashboards/components/db.json
@@ -1179,7 +1179,7 @@
         "allValue": null,
         "current": {},
         "datasource": "$datasource",
-        "definition": "label_values(container_cpu_usage_seconds_total{cluster=~\"$cluster\", pod=~\"db.*\", pod!~\"db-sync.*\"}, node)",
+        "definition": "label_values(container_cpu_usage_seconds_total{cluster=~\"$cluster\", pod=~\"db.*\"}, node)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -1189,7 +1189,7 @@
         "name": "node",
         "options": [],
         "query": {
-          "query": "label_values(container_cpu_usage_seconds_total{cluster=~\"$cluster\", pod=~\"db.*\", pod!~\"db-sync.*\"}, node)",
+          "query": "label_values(container_cpu_usage_seconds_total{cluster=~\"$cluster\", pod=~\"db.*\"}, node)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,
@@ -1205,7 +1205,7 @@
         "allValue": null,
         "current": {},
         "datasource": "$datasource",
-        "definition": "label_values(container_cpu_usage_seconds_total{cluster=~\"$cluster\", node=~\"$node\", pod=~\"db.*\", pod!~\"db-sync.*\"}, pod)",
+        "definition": "label_values(container_cpu_usage_seconds_total{cluster=~\"$cluster\", node=~\"$node\", pod=~\"db.*\"}, pod)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -1215,7 +1215,7 @@
         "name": "pod",
         "options": [],
         "query": {
-          "query": "label_values(container_cpu_usage_seconds_total{cluster=~\"$cluster\", node=~\"$node\", pod=~\"db.*\", pod!~\"db-sync.*\"}, pod)",
+          "query": "label_values(container_cpu_usage_seconds_total{cluster=~\"$cluster\", node=~\"$node\", pod=~\"db.*\"}, pod)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,

--- a/operations/observability/mixins/meta/dashboards/components/meta-services.json
+++ b/operations/observability/mixins/meta/dashboards/components/meta-services.json
@@ -398,7 +398,6 @@
             "content-service",
             "dashboard",
             "db",
-            "db-sync",
             "messagebus",
             "payment-endpoint",
             "proxy",
@@ -409,7 +408,6 @@
             "content-service",
             "dashboard",
             "db",
-            "db-sync",
             "messagebus",
             "payment-endpoint",
             "proxy",
@@ -447,11 +445,6 @@
           },
           {
             "selected": true,
-            "text": "db-sync",
-            "value": "db-sync"
-          },
-          {
-            "selected": true,
             "text": "messagebus",
             "value": "messagebus"
           },
@@ -486,7 +479,7 @@
             "value": "image-builder-mk3"
           }
         ],
-        "query": "content-service, dashboard, db, db-sync, messagebus, payment-endpoint, proxy, server, ws-manager-bridge, image-builder, image-builder-mk3",
+        "query": "content-service, dashboard, db, messagebus, payment-endpoint, proxy, server, ws-manager-bridge, image-builder, image-builder-mk3",
         "queryValue": "",
         "skipUrlSync": false,
         "type": "custom"

--- a/operations/observability/mixins/meta/rules/server.yaml
+++ b/operations/observability/mixins/meta/rules/server.yaml
@@ -71,20 +71,6 @@ spec:
         summary: The websocket connection rate is higher than usual. Investigation required.
         description: Websocket connection rate high
 
-    # TODO(gpl) This will be true for US all the time. Can we exclude that cluster somehow?
-    #
-    # - alert: db-sync not running
-    #   expr: sum (kube_pod_status_phase{pod=~"db-sync.*"}) by (pod) < 1
-    #   for: 5m
-    #   labels:
-    #     # sent to the team internal channel until we fine tuned it
-    #     severity: warning
-    #     team: webapp
-    #   annotations:
-    #     runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/DbSyncNotRunning.md
-    #     summary: The db-sync pod is not running. Investigation required.
-    #     description: db-sync pod not running
-
     - alert: MessagebusNotRunning
       expr: sum(up{job="messagebus"}) by (cluster) < 1
       for: 2m
@@ -113,7 +99,7 @@ spec:
 
     - alert: WebAppServicesCrashlooping
       # Reasoning: alert if any pod is restarting more than 3 times / 5 minutes.
-      expr: sum(increase(kube_pod_container_status_restarts_total{container!="POD", pod=~"(content-service|dashboard|db|db-sync|messagebus|payment-endpoint|proxy|server|ws-manager-bridge|usage)-.*"}[5m])) by (cluster) > 3
+      expr: sum(increase(kube_pod_container_status_restarts_total{container!="POD", pod=~"(content-service|dashboard|db|messagebus|payment-endpoint|proxy|server|ws-manager-bridge|usage)-.*"}[5m])) by (cluster) > 3
       for: 5m
       labels:
         # sent to the team internal channel until we fine tuned it


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Remove remaining references to db-sync, it's now gone.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
NONE
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

## Build Options:

- [ ] /werft with-github-actions
      Experimental feature to run the build with GitHub Actions (and not in Werft).
- [ ] leeway-no-cache
      leeway-target=components:all
- [ ] /werft no-test
      Run Leeway with `--dont-test`

<details>
<summary>Publish Options</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer Options</summary>

- [ ] with-ee-license
- [ ] with-slow-database
- [ ] with-dedicated-emulation
- [ ] with-ws-manager-mk2
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

#### Preview Environment Options:
- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [ ] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`
